### PR TITLE
Refactor shared product serialization helpers

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -13,6 +13,7 @@ import logging
 
 from core.database import get_session
 from services.product_service import ProductService
+from services.product_serialization import sanitize_specs, parse_legacy_images
 from models import Product, Tag, TagGroup, ProductTagLink
 from services.description_generator import DescriptionGeneratorService
 import httpx
@@ -68,26 +69,8 @@ def _map_product_to_response(
                 group_title=t.group.title if t.group else None
             ))
     
-    # Handle potentially string-encoded JSON fields
-    specs = product.specs
-    if isinstance(specs, str):
-        try:
-            # Replace single quotes with double quotes for valid JSON if needed, 
-            # but usually it's better to try literal_eval if it's a python repr
-            import ast
-            specs = ast.literal_eval(specs)
-        except Exception:
-            specs = {}  # Fallback if JSON parsing fails
-    if isinstance(specs, dict):
-        specs = {k: v for k, v in specs.items() if not str(k).startswith("__")}
-            
-    images = product.images
-    if isinstance(images, str):
-        try:
-            import ast
-            images = ast.literal_eval(images)
-        except Exception:
-            images = []  # Fallback if JSON parsing fails
+    specs = sanitize_specs(product.specs)
+    images = parse_legacy_images(product.images)
 
             
     # Map gallery images

--- a/services/product_serialization.py
+++ b/services/product_serialization.py
@@ -1,0 +1,36 @@
+"""Shared product serialization helpers used by API and service layers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import ast
+
+
+def sanitize_specs(specs: Any) -> Dict[str, Any]:
+    value = specs
+    if isinstance(value, str):
+        try:
+            value = ast.literal_eval(value)
+        except Exception:
+            value = {}
+    if not isinstance(value, dict):
+        return {}
+    return {k: v for k, v in value.items() if not str(k).startswith("__")}
+
+
+def parse_legacy_images(images: Any) -> List[str]:
+    value = images
+    if isinstance(value, str):
+        try:
+            value = ast.literal_eval(value)
+        except Exception:
+            value = []
+    if not isinstance(value, list):
+        return []
+    return value
+
+
+def to_web_path(path: str) -> str:
+    if path and not path.startswith("/"):
+        return f"/{path}"
+    return path

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -2,7 +2,6 @@
 Service Layer: Product business logic.
 """
 from typing import Optional, List, Dict, Any
-import ast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -12,6 +11,7 @@ from thefuzz import process
 from crud.product import ProductDAO
 from models import Product, Tag, TagGroup, ProductTagLink
 from services.spec_normalizer import normalize_specs
+from services.product_serialization import sanitize_specs, to_web_path
 
 
 ALLOWED_FILTER_GROUP_SLUGS = {"brand", "series", "expert-badge"}
@@ -31,18 +31,6 @@ def transliterate(text: str) -> str:
     for char in text.lower():
         result.append(TRANSLIT_MAP.get(char, char))
     return "".join(result)
-
-
-def _sanitize_specs(specs: Any) -> Dict[str, Any]:
-    value = specs
-    if isinstance(value, str):
-        try:
-            value = ast.literal_eval(value)
-        except Exception:
-            value = {}
-    if not isinstance(value, dict):
-        return {}
-    return {k: v for k, v in value.items() if not str(k).startswith("__")}
 
 
 class ProductService:
@@ -268,11 +256,6 @@ class ProductService:
             key=lambda item: (item.is_installation_photo, item.id),
         )
 
-        def to_web_path(path: str) -> str:
-            if path and not path.startswith("/"):
-                return f"/{path}"
-            return path
-
         data["images"] = [to_web_path(img.url) for img in gallery]
         data["gallery_images"] = [
             {
@@ -281,7 +264,7 @@ class ProductService:
             }
             for img in gallery
         ]
-        data["specs"] = _sanitize_specs(data.get("specs"))
+        data["specs"] = sanitize_specs(data.get("specs"))
         return data
 
     @staticmethod
@@ -340,7 +323,7 @@ class ProductService:
                     "main_image": p.main_image,
                     "is_published": p.is_published,
                     "created_at": p.created_at.isoformat() if p.created_at else None,
-                    "specs": _sanitize_specs(p.specs),
+                    "specs": sanitize_specs(p.specs),
                     "gallery_images": [
                         {
                             "id": img.id,


### PR DESCRIPTION
## Summary
- extract shared helpers for product serialization into `services/product_serialization.py`
- reuse shared helpers in `routers/api.py` and `services/product_service.py`
- remove duplicated parsing/sanitizing logic

## Scope
- [x] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation
- Local checks run:
  - [x] `docker compose exec -T app pytest -q tests/integration/test_catalog_api.py tests/unit/test_product_filtering_jsonb.py tests/integration/test_product_series_siblings.py`
- Manual checks:
  - [x] No behavior changes intended

## Deployment Notes
- [x] No special deploy steps

## Risk and Rollback
- Risk level: Low
- Rollback plan: revert this PR commit
