### PR TITLE
Refactor Belarus proxy endpoints into dedicated router

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -8,16 +8,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select, and_, func
 from typing import List, Optional
-from datetime import datetime, timedelta
 import logging
 
 from core.database import get_session
 from services.product_service import ProductService
 from services.product_serialization import sanitize_specs, parse_legacy_images
 from routers.api_content import router as content_router
+from routers.api_proxy import router as proxy_router
 from models import Product, Tag, TagGroup, ProductTagLink
 from services.description_generator import DescriptionGeneratorService
-import httpx
 from schemas import (
     CatalogResponse,
     Meta,
@@ -38,6 +37,7 @@ from fastapi import HTTPException
 
 router = APIRouter(prefix="/api", tags=["api"])
 router.include_router(content_router)
+router.include_router(proxy_router)
 logger = logging.getLogger(__name__)
 
 # --- HELPER FUNCTIONS ---
@@ -250,188 +250,6 @@ async def health_check(session: AsyncSession = Depends(get_session)):
         return {"status": "ok", "database": "online"}
     except Exception as e:
         return {"status": "error", "database": "offline", "detail": str(e)}
-
-# --- BELARUS API PROXIES ---
-
-@router.get("/admin/proxy/egr")
-async def proxy_egr(
-    unp: str,
-    username: str = Depends(get_current_username)
-):
-    """Proxy for Belarus EGR (Ministry of Taxes) API."""
-    url = f"http://grp.nalog.gov.by/api/grp-public/data?unp={unp}&type=json&charset=UTF-8"
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(url, timeout=10.0)
-            return response.json()
-        except Exception as e:
-            return {"error": str(e)}
-# Простой кэш в памяти, чтобы не долбить НБРБ при каждом клике
-# (В идеале можно использовать Redis, но для справочника банков это оверхед)
-BANK_CACHE = {
-    "data": [],
-    "last_updated": None
-}
-
-async def get_all_banks():
-    """Получает список банков с кэшированием на 72 часа"""
-    now = datetime.now()
-    if BANK_CACHE["data"] and BANK_CACHE["last_updated"]:
-        if now - BANK_CACHE["last_updated"] < timedelta(hours=72):
-            return BANK_CACHE["data"]
-            
-    url = "https://api.nbrb.by/bic"
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(url, timeout=5.0)
-            if response.status_code == 200:
-                data = response.json()
-                BANK_CACHE["data"] = data
-                BANK_CACHE["last_updated"] = now
-                return data
-        except Exception as e:
-            logger.error(f"Error fetching banks: {e}")
-            # Если ошибка сети, пробуем вернуть старый кэш
-            return BANK_CACHE["data"]
-    return []
-
-@router.get("/admin/proxy/bank")
-async def find_bank(
-    search: str = Query(None, description="BIC код или IBAN"),
-    username: str = Depends(get_current_username)
-):
-    """
-    Ищет банк локально в справочнике НБРБ.
-    Принимает:
-    - BIC (код банка, например '153001755')
-    - IBAN (вырезает код из строки вида BYxx [CODE] xxxx...)
-    """
-    
-    # 1. Нормализация запроса
-    if not search:
-        return await get_all_banks()
-
-    query = search.strip().replace(" ", "").upper()
-    target_bic = query
-
-    # 2. Если это IBAN (Беларусь = 28 символов, начинается на BY), вырезаем код
-    # Формат: BYxx [BICK] ... (символы с 5 по 8 - это код банка буквенный, но в API НБРБ коды цифровые)
-    # НО! В API НБРБ есть поле 'CdBic' (буквенный) и 'CdBank' (цифровой).
-    
-    # Если пользователь ввел короткий код (БИК)
-    banks = await get_all_banks()
-    
-    found_bank = None
-    
-    # Пытаемся найти по полному совпадению CDBank (SWIFT/BIC код вида OLMPBY2X) 
-    # или по префиксу банка из IBAN (символы 4-8, например 'OLMP' для Белгазпромбанка)
-    
-    bic_from_iban = None
-    if len(query) >= 8 and query.startswith("BY"):
-         bic_from_iban = query[4:8] # Вырезаем 4-буквенный код банка из IBAN
-    
-    for bank in banks:
-        # Данные в JSON НБРБ выглядят так:
-        # {"CDBank": "OLMPBY2X", "NmBankShort": "ОАО 'Белгазпромбанк'", "DtEnd": null, ...}
-        # CDBank - это SWIFT/BIC код банка (8-11 символов)
-        # DtEnd = null означает текущую (активную) запись
-        
-        cd_bank = bank.get("CDBank", "")
-        is_active = bank.get("DtEnd") is None
-        
-        # 1. Проверка по полному SWIFT/BIC коду (если ввели полный код, например "OLMPBY2X")
-        if cd_bank == target_bic:
-            # Если нашли активный банк - сразу возвращаем
-            if is_active:
-                found_bank = bank
-                break
-            # Иначе сохраняем как fallback
-            elif not found_bank:
-                found_bank = bank
-            
-        # 2. Проверка по 4-буквенному коду из IBAN (первые 4 символа CDBank)
-        if bic_from_iban and cd_bank.startswith(bic_from_iban):
-            # Если нашли активный банк - сразу возвращаем
-            if is_active:
-                found_bank = bank
-                break
-            # Иначе сохраняем как fallback
-            elif not found_bank:
-                found_bank = bank
-
-    if found_bank:
-        return {
-            "name": found_bank.get("NmBankShort"),
-            "address": found_bank.get("AdrBank"),
-            "bic": found_bank.get("CDBank"),     # SWIFT/BIC код
-            "swift": found_bank.get("CDBank")    # То же самое
-        }
-    
-    return {"error": "Банк не найден", "debug_bic": bic_from_iban or target_bic}
-
-# --- PUBLIC PROXIES (For Frontend Auto-fill) ---
-
-@router.get("/v1/proxy/egr")
-async def public_proxy_egr(unp: str):
-    """Public proxy for Belarus EGR (Ministry of Taxes) API."""
-    # Reusing the logic from admin proxy, strictly read-only
-    url = f"http://grp.nalog.gov.by/api/grp-public/data?unp={unp}&type=json&charset=UTF-8"
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(url, timeout=10.0)
-            return response.json()
-        except Exception as e:
-            return {"error": str(e)}
-
-@router.get("/v1/proxy/bank")
-async def public_find_bank(search: str = Query(None, description="BIC код или IBAN")):
-    """Public proxy to find bank details by IBAN/BIC."""
-    # Reuse the same logic as the admin endpoint
-    # Since find_bank logic is coupled with admin endpoint details, we'll just call the same logic helper if possible,
-    # but here I'll just copy the implementation to keep it clean and independent if admin logic changes.
-    # Actually, better to just call the implementation function if we extracted it, but for now duplicate the logic to separate concerns (admin vs public).
-    
-    # 1. Normalization
-    if not search:
-         return [] # Don't return full list to public to avoid data scraping, only search
-
-    query = search.strip().replace(" ", "").upper()
-    target_bic = query
-    
-    banks = await get_all_banks()
-    found_bank = None
-    
-    bic_from_iban = None
-    if len(query) >= 8 and query.startswith("BY"):
-         bic_from_iban = query[4:8]
-
-    for bank in banks:
-        cd_bank = bank.get("CDBank", "")
-        is_active = bank.get("DtEnd") is None
-        
-        if cd_bank == target_bic:
-            if is_active:
-                found_bank = bank
-                break
-            elif not found_bank:
-                found_bank = bank
-            
-        if bic_from_iban and cd_bank.startswith(bic_from_iban):
-            if is_active:
-                found_bank = bank
-                break
-            elif not found_bank:
-                found_bank = bank
-
-    if found_bank:
-        return {
-            "name": found_bank.get("NmBankShort"),
-            "address": found_bank.get("AdrBank"),
-            "bic": found_bank.get("CDBank"),
-            "swift": found_bank.get("CDBank")
-        }
-    
-    return {"error": "Банк не найден"}
 
 @router.post("/products/{product_id}/generate-description")
 async def generate_product_description(

--- a/routers/api_proxy.py
+++ b/routers/api_proxy.py
@@ -1,0 +1,159 @@
+"""Belarus proxy endpoints split from the main API router."""
+
+from datetime import datetime, timedelta
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, Query
+
+from core.security import get_current_username
+
+router = APIRouter(tags=["api"])
+logger = logging.getLogger(__name__)
+
+
+# Simple in-memory cache to avoid hammering NBRB on every request.
+BANK_CACHE = {
+    "data": [],
+    "last_updated": None,
+}
+
+
+async def get_all_banks():
+    """Fetch NBRB banks list with 72h cache."""
+    now = datetime.now()
+    if BANK_CACHE["data"] and BANK_CACHE["last_updated"]:
+        if now - BANK_CACHE["last_updated"] < timedelta(hours=72):
+            return BANK_CACHE["data"]
+
+    url = "https://api.nbrb.by/bic"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, timeout=5.0)
+            if response.status_code == 200:
+                data = response.json()
+                BANK_CACHE["data"] = data
+                BANK_CACHE["last_updated"] = now
+                return data
+        except Exception as e:
+            logger.error(f"Error fetching banks: {e}")
+            return BANK_CACHE["data"]
+    return []
+
+
+@router.get("/admin/proxy/egr")
+async def proxy_egr(
+    unp: str,
+    username: str = Depends(get_current_username),
+):
+    """Proxy for Belarus EGR (Ministry of Taxes) API."""
+    url = f"http://grp.nalog.gov.by/api/grp-public/data?unp={unp}&type=json&charset=UTF-8"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, timeout=10.0)
+            return response.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+
+@router.get("/admin/proxy/bank")
+async def find_bank(
+    search: str = Query(None, description="BIC код или IBAN"),
+    username: str = Depends(get_current_username),
+):
+    """Find bank in NBRB reference by BIC/IBAN."""
+    if not search:
+        return await get_all_banks()
+
+    query = search.strip().replace(" ", "").upper()
+    target_bic = query
+    banks = await get_all_banks()
+
+    found_bank = None
+    bic_from_iban = None
+    if len(query) >= 8 and query.startswith("BY"):
+        bic_from_iban = query[4:8]
+
+    for bank in banks:
+        cd_bank = bank.get("CDBank", "")
+        is_active = bank.get("DtEnd") is None
+
+        if cd_bank == target_bic:
+            if is_active:
+                found_bank = bank
+                break
+            if not found_bank:
+                found_bank = bank
+
+        if bic_from_iban and cd_bank.startswith(bic_from_iban):
+            if is_active:
+                found_bank = bank
+                break
+            if not found_bank:
+                found_bank = bank
+
+    if found_bank:
+        return {
+            "name": found_bank.get("NmBankShort"),
+            "address": found_bank.get("AdrBank"),
+            "bic": found_bank.get("CDBank"),
+            "swift": found_bank.get("CDBank"),
+        }
+
+    return {"error": "Банк не найден", "debug_bic": bic_from_iban or target_bic}
+
+
+@router.get("/v1/proxy/egr")
+async def public_proxy_egr(unp: str):
+    """Public proxy for Belarus EGR (Ministry of Taxes) API."""
+    url = f"http://grp.nalog.gov.by/api/grp-public/data?unp={unp}&type=json&charset=UTF-8"
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(url, timeout=10.0)
+            return response.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+
+@router.get("/v1/proxy/bank")
+async def public_find_bank(search: str = Query(None, description="BIC код или IBAN")):
+    """Public proxy to find bank details by IBAN/BIC."""
+    if not search:
+        return []
+
+    query = search.strip().replace(" ", "").upper()
+    target_bic = query
+    banks = await get_all_banks()
+    found_bank = None
+
+    bic_from_iban = None
+    if len(query) >= 8 and query.startswith("BY"):
+        bic_from_iban = query[4:8]
+
+    for bank in banks:
+        cd_bank = bank.get("CDBank", "")
+        is_active = bank.get("DtEnd") is None
+
+        if cd_bank == target_bic:
+            if is_active:
+                found_bank = bank
+                break
+            if not found_bank:
+                found_bank = bank
+
+        if bic_from_iban and cd_bank.startswith(bic_from_iban):
+            if is_active:
+                found_bank = bank
+                break
+            if not found_bank:
+                found_bank = bank
+
+    if found_bank:
+        return {
+            "name": found_bank.get("NmBankShort"),
+            "address": found_bank.get("AdrBank"),
+            "bic": found_bank.get("CDBank"),
+            "swift": found_bank.get("CDBank"),
+        }
+
+    return {"error": "Банк не найден"}


### PR DESCRIPTION
## Summary
- move Belarus proxy endpoints from `routers/api.py` to `routers/api_proxy.py`
- include proxy router via `router.include_router(...)` in main API router
- keep all existing endpoint paths unchanged (`/api/admin/proxy/*`, `/api/v1/proxy/*`)

## Scope
- [x] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation
- Local checks run:
  - [x] `docker compose exec -T app pytest -q`
- Manual checks:
  - [x] Refactor-only, behavior unchanged

## Deployment Notes
- [x] No special deploy steps

## Risk and Rollback
- Risk level: Low
- Rollback plan: revert this PR commit
