### PR TITLE
refactor: unify product dict mapping across services

### DIFF
--- a/services/favorite_service.py
+++ b/services/favorite_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from crud.favorite import FavoriteDAO
 from models import Product
+from services.product_dict_mapper import map_product_to_dict
 
 
 class FavoriteService:
@@ -30,6 +31,4 @@ class FavoriteService:
     @staticmethod
     def _to_dict(product: Product) -> Dict[str, Any]:
         """Convert Product to dict with bot-compatible format."""
-        data = product.model_dump()
-        data['categories'] = [t.title for t in product.tags]
-        return data
+        return map_product_to_dict(product)

--- a/services/product_dict_mapper.py
+++ b/services/product_dict_mapper.py
@@ -1,0 +1,49 @@
+"""Shared mappers for Product -> dict payloads used across services."""
+
+from typing import Any, Dict
+
+from models import Product
+from services.product_serialization import sanitize_specs, to_web_path
+
+
+def map_product_to_dict(
+    product: Product,
+    *,
+    include_tag_groups: bool = False,
+    include_media: bool = False,
+    sanitize_specs_payload: bool = False,
+) -> Dict[str, Any]:
+    data = product.model_dump()
+    tags = list(product.tags or [])
+    data["categories"] = [tag.title for tag in tags]
+
+    tags_data = []
+    for tag in tags:
+        tag_dict = tag.model_dump()
+        if include_tag_groups and tag.group:
+            tag_dict["group"] = tag.group.model_dump()
+        tags_data.append(tag_dict)
+    data["tags"] = tags_data
+
+    if include_media:
+        if data.get("main_image") and not data["main_image"].startswith("/"):
+            data["main_image"] = "/" + data["main_image"]
+
+        gallery = sorted(
+            list(product.gallery_images or []),
+            key=lambda item: (item.is_installation_photo, item.id),
+        )
+
+        data["images"] = [to_web_path(img.url) for img in gallery]
+        data["gallery_images"] = [
+            {
+                **img.model_dump(),
+                "url": to_web_path(img.url),
+            }
+            for img in gallery
+        ]
+
+    if sanitize_specs_payload:
+        data["specs"] = sanitize_specs(data.get("specs"))
+
+    return data

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -10,8 +10,9 @@ from thefuzz import process
 
 from crud.product import ProductDAO
 from models import Product, Tag, TagGroup, ProductTagLink
+from services.product_dict_mapper import map_product_to_dict
 from services.spec_normalizer import normalize_specs
-from services.product_serialization import sanitize_specs, to_web_path
+from services.product_serialization import sanitize_specs
 
 
 ALLOWED_FILTER_GROUP_SLUGS = {"brand", "series", "expert-badge"}
@@ -237,35 +238,12 @@ class ProductService:
 
     @staticmethod
     def _to_dict(product: Product) -> Dict[str, Any]:
-        data = product.model_dump()
-        data["categories"] = [t.title for t in product.tags]
-
-        tags_data = []
-        for tag in product.tags:
-            tag_dict = tag.model_dump()
-            if tag.group:
-                tag_dict["group"] = tag.group.model_dump()
-            tags_data.append(tag_dict)
-        data["tags"] = tags_data
-
-        if data.get("main_image") and not data["main_image"].startswith("/"):
-            data["main_image"] = "/" + data["main_image"]
-
-        gallery = sorted(
-            product.gallery_images,
-            key=lambda item: (item.is_installation_photo, item.id),
+        return map_product_to_dict(
+            product,
+            include_tag_groups=True,
+            include_media=True,
+            sanitize_specs_payload=True,
         )
-
-        data["images"] = [to_web_path(img.url) for img in gallery]
-        data["gallery_images"] = [
-            {
-                **img.model_dump(),
-                "url": to_web_path(img.url),
-            }
-            for img in gallery
-        ]
-        data["specs"] = sanitize_specs(data.get("specs"))
-        return data
 
     @staticmethod
     async def save_main_image(


### PR DESCRIPTION
## What
- add shared mapper `services/product_dict_mapper.py` for Product -> dict payloads
- make `ProductService._to_dict` delegate to shared mapper with full options
- make `FavoriteService._to_dict` delegate to shared mapper with lightweight defaults

## Validation
- `docker compose exec -T app pytest -q`