### PR TITLE
refactor: move admin API query logic to service layer

### DIFF
--- a/routers/api_admin.py
+++ b/routers/api_admin.py
@@ -2,12 +2,12 @@
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select, func
 from typing import List
 
 from core.database import get_session
 from core.security import get_current_username
-from models import Product, ProductTagLink, Service, Tag, TagGroup
+from services.admin_api_service import AdminApiService
+from services.product_service import ProductService
 
 router = APIRouter(tags=["api"])
 
@@ -19,8 +19,6 @@ async def search_products(
     session: AsyncSession = Depends(get_session),
 ):
     """Search products with fuzzy matching."""
-    from services.product_service import ProductService
-
     products = await ProductService.search(session, query=q, is_inverter=is_inverter)
     return {"items": products}
 
@@ -30,31 +28,7 @@ async def get_filterable_tags(
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):
-    stmt = (
-        select(TagGroup, Tag)
-        .join(Tag, Tag.group_id == TagGroup.id)
-        .where(Tag.is_filter == True)
-        .order_by(TagGroup.sort_order, TagGroup.title, Tag.sort_order, Tag.title)
-    )
-    result = await session.execute(stmt)
-
-    grouped = {}
-    for row in result:
-        group, tag = row
-        if group.title not in grouped:
-            grouped[group.title] = {
-                "group_label": group.title,
-                "tags": [],
-            }
-        grouped[group.title]["tags"].append(
-            {
-                "id": tag.id,
-                "title": tag.title,
-                "slug": tag.slug,
-            }
-        )
-
-    return list(grouped.values())
+    return await AdminApiService.get_filterable_tags(session)
 
 
 @router.get("/admin/products/search")
@@ -64,25 +38,7 @@ async def admin_search_products(
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):
-    stmt = select(Product)
-
-    if tag_ids:
-        tag_subquery = (
-            select(ProductTagLink.product_id)
-            .where(ProductTagLink.tag_id.in_(tag_ids))
-            .group_by(ProductTagLink.product_id)
-            .having(func.count(ProductTagLink.tag_id) == len(tag_ids))
-        )
-        stmt = stmt.where(Product.id.in_(tag_subquery))
-
-    if q:
-        pattern = f"%{q}%"
-        stmt = stmt.where((Product.title.ilike(pattern)) | (Product.description.ilike(pattern)))
-
-    stmt = stmt.limit(20)
-    result = await session.execute(stmt)
-    products = result.scalars().all()
-    return [{"id": p.id, "text": p.title, "price": p.price} for p in products]
+    return await AdminApiService.search_products(session, q=q, tag_ids=tag_ids)
 
 
 @router.get("/admin/services/search")
@@ -91,17 +47,10 @@ async def admin_search_services(
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):
-    stmt = select(Service).where(Service.title.ilike(f"%{q}%")).limit(20)
-    result = await session.execute(stmt)
-    services = result.scalars().all()
-    return [{"id": s.id, "text": s.title, "price": s.base_price} for s in services]
+    return await AdminApiService.search_services(session, q=q)
 
 
 @router.get("/health")
 async def health_check(session: AsyncSession = Depends(get_session)):
     """Check API and database availability."""
-    try:
-        await session.execute(select(1))
-        return {"status": "ok", "database": "online"}
-    except Exception as e:
-        return {"status": "error", "database": "offline", "detail": str(e)}
+    return await AdminApiService.health_check(session)

--- a/services/admin_api_service.py
+++ b/services/admin_api_service.py
@@ -1,0 +1,74 @@
+"""Service-layer helpers for admin/search/health API endpoints."""
+
+from typing import Any, Dict, List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import func, select
+
+from models import Product, ProductTagLink, Service, Tag, TagGroup
+
+
+class AdminApiService:
+    @staticmethod
+    async def get_filterable_tags(session: AsyncSession) -> List[Dict[str, Any]]:
+        stmt = (
+            select(TagGroup, Tag)
+            .join(Tag, Tag.group_id == TagGroup.id)
+            .where(Tag.is_filter == True)
+            .order_by(TagGroup.sort_order, TagGroup.title, Tag.sort_order, Tag.title)
+        )
+        result = await session.execute(stmt)
+
+        grouped = {}
+        for group, tag in result:
+            if group.title not in grouped:
+                grouped[group.title] = {
+                    "group_label": group.title,
+                    "tags": [],
+                }
+            grouped[group.title]["tags"].append(
+                {
+                    "id": tag.id,
+                    "title": tag.title,
+                    "slug": tag.slug,
+                }
+            )
+
+        return list(grouped.values())
+
+    @staticmethod
+    async def search_products(session: AsyncSession, q: str = "", tag_ids: List[int] | None = None) -> List[Dict[str, Any]]:
+        stmt = select(Product)
+
+        if tag_ids:
+            tag_subquery = (
+                select(ProductTagLink.product_id)
+                .where(ProductTagLink.tag_id.in_(tag_ids))
+                .group_by(ProductTagLink.product_id)
+                .having(func.count(ProductTagLink.tag_id) == len(tag_ids))
+            )
+            stmt = stmt.where(Product.id.in_(tag_subquery))
+
+        if q:
+            pattern = f"%{q}%"
+            stmt = stmt.where((Product.title.ilike(pattern)) | (Product.description.ilike(pattern)))
+
+        stmt = stmt.limit(20)
+        result = await session.execute(stmt)
+        products = result.scalars().all()
+        return [{"id": p.id, "text": p.title, "price": p.price} for p in products]
+
+    @staticmethod
+    async def search_services(session: AsyncSession, q: str = "") -> List[Dict[str, Any]]:
+        stmt = select(Service).where(Service.title.ilike(f"%{q}%")).limit(20)
+        result = await session.execute(stmt)
+        services = result.scalars().all()
+        return [{"id": s.id, "text": s.title, "price": s.base_price} for s in services]
+
+    @staticmethod
+    async def health_check(session: AsyncSession) -> Dict[str, str]:
+        try:
+            await session.execute(select(1))
+            return {"status": "ok", "database": "online"}
+        except Exception as exc:
+            return {"status": "error", "database": "offline", "detail": str(exc)}


### PR DESCRIPTION
## What
- move DB/query logic from `routers/api_admin.py` into `services/admin_api_service.py`
- keep `api_admin` router as thin transport layer
- preserve endpoint contracts for admin tags/products/services search and health

## Validation
- `docker compose exec -T app pytest -q`