### PR TITLE
refactor: move content API query logic to service layer

### DIFF
--- a/routers/api_content.py
+++ b/routers/api_content.py
@@ -2,12 +2,13 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 from typing import List
 
 from core.database import get_session
-from models import GlobalConfig, Service
 from schemas import ArticleResponse, ServiceResponse
+from services.article_service import ArticleService
+from services.content_api_service import ContentApiService
+from services.installation_service import InstallationService
 
 router = APIRouter(tags=["api"])
 
@@ -15,16 +16,12 @@ router = APIRouter(tags=["api"])
 @router.get("/v1/content/articles", response_model=List[ArticleResponse])
 async def get_articles(session: AsyncSession = Depends(get_session)):
     """Get list of published articles ordered by creation date (newest first)."""
-    from services.article_service import ArticleService
-
     return await ArticleService.get_all_published(session)
 
 
 @router.get("/v1/content/articles/{slug}", response_model=ArticleResponse)
 async def get_article(slug: str, session: AsyncSession = Depends(get_session)):
     """Get article details by slug. Returns 404 if not found or not published."""
-    from services.article_service import ArticleService
-
     article = await ArticleService.get_by_slug(session, slug)
     if not article:
         raise HTTPException(status_code=404, detail=f"Article with slug '{slug}' not found")
@@ -34,9 +31,7 @@ async def get_article(slug: str, session: AsyncSession = Depends(get_session)):
 @router.get("/v1/content/services", response_model=List[ServiceResponse])
 async def get_services(session: AsyncSession = Depends(get_session)):
     """Get list of all available services."""
-    stmt = select(Service).where(Service.is_active == True).order_by(Service.id)
-    result = await session.execute(stmt)
-    return result.scalars().all()
+    return await ContentApiService.get_active_services(session)
 
 
 @router.get("/v1/services/options", response_model=List[ServiceResponse])
@@ -45,21 +40,12 @@ async def get_service_options(
     session: AsyncSession = Depends(get_session),
 ):
     """Get rich installation options."""
-    stmt = (
-        select(Service)
-        .where(Service.is_active == True)
-        .where(Service.category == category)
-        .order_by(Service.base_price)
-    )
-    result = await session.execute(stmt)
-    return result.scalars().all()
+    return await ContentApiService.get_service_options(session, category=category)
 
 
 @router.get("/v1/installation-rates")
 async def get_installation_rates(session: AsyncSession = Depends(get_session)):
     """Get all installation rates."""
-    from services.installation_service import InstallationService
-
     return await InstallationService.get_all(session)
 
 
@@ -69,7 +55,4 @@ async def get_global_config(session: AsyncSession = Depends(get_session)):
     Get all global configuration parameters as a key-value dictionary.
     Example: {"phone": "+37529...", "email": "..."}
     """
-    stmt = select(GlobalConfig)
-    result = await session.execute(stmt)
-    configs = result.scalars().all()
-    return {c.key: c.value for c in configs}
+    return await ContentApiService.get_global_config_map(session)

--- a/services/content_api_service.py
+++ b/services/content_api_service.py
@@ -1,0 +1,37 @@
+"""Service-layer helpers for public content/services/config endpoints."""
+
+from typing import Dict, List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import GlobalConfig, Service
+
+
+class ContentApiService:
+    @staticmethod
+    async def get_active_services(session: AsyncSession) -> List[Service]:
+        stmt = select(Service).where(Service.is_active == True).order_by(Service.id)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def get_service_options(
+        session: AsyncSession,
+        category: str = "installation_option",
+    ) -> List[Service]:
+        stmt = (
+            select(Service)
+            .where(Service.is_active == True)
+            .where(Service.category == category)
+            .order_by(Service.base_price)
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def get_global_config_map(session: AsyncSession) -> Dict[str, str]:
+        stmt = select(GlobalConfig)
+        result = await session.execute(stmt)
+        configs = result.scalars().all()
+        return {config.key: config.value for config in configs}


### PR DESCRIPTION
## What
- move direct DB queries from `routers/api_content.py` into `services/content_api_service.py`
- keep content router as transport layer that orchestrates existing services
- preserve endpoint contracts for `/v1/content/services`, `/v1/services/options`, `/v1/config`

## Validation
- `docker compose exec -T app pytest -q`