### PR TITLE
refactor: move website order flow to service layer

### DIFF
--- a/routers/api_orders.py
+++ b/routers/api_orders.py
@@ -1,15 +1,13 @@
 """Public order endpoints split from the main API router."""
 
-import logging
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from schemas import OrderPayload, OrderResponse
+from services.website_order_service import WebsiteOrderService
 
 router = APIRouter(tags=["api"])
-logger = logging.getLogger(__name__)
 
 
 @router.post("/v1/orders", response_model=OrderResponse, operation_id="create_order")
@@ -18,102 +16,4 @@ async def create_order(payload: OrderPayload, session: AsyncSession = Depends(ge
     Create a new order from website.
     Accepts customer information and cart items.
     """
-    from models import LeadSource
-    from services.order_service import OrderService
-
-    logger.info(f"📦 Incoming order payload: customer={payload.customer.name}, items_count={len(payload.items)}")
-    for idx, item in enumerate(payload.items):
-        logger.info(
-            "   Item %s: product_id=%s, qty=%s, with_install=%s, install_price=%s",
-            idx,
-            item.product_id,
-            item.quantity,
-            getattr(item, "with_installation", "N/A"),
-            getattr(item, "installation_price", "N/A"),
-        )
-
-    items = [
-        {
-            "product_id": item.product_id,
-            "quantity": item.quantity,
-            "with_installation": item.with_installation,
-            "installation_price": item.installation_price,
-            "installation_meta": item.installation_meta,
-            "installation_options": item.installation_options,
-        }
-        for item in payload.items
-    ]
-
-    order = await OrderService.create_from_website(
-        session=session,
-        customer_name=payload.customer.name,
-        customer_phone=payload.customer.phone,
-        customer_email=payload.customer.email,
-        customer_address=payload.customer.address,
-        items=items,
-        lead_source=LeadSource.SITE,
-        comment=payload.comment,
-        customer_type=payload.customer.type,
-        customer_inn=payload.customer.inn,
-        customer_legal_name=payload.customer.full_legal_name,
-        customer_legal_address=payload.customer.legal_address,
-        customer_iban=payload.customer.iban,
-        customer_bic=payload.customer.bic,
-        customer_bank_name=payload.customer.bank_name,
-    )
-
-    from core.config import settings
-    from services.bot_service import BotService
-
-    if settings.admin_list:
-        await session.refresh(order, ["product_links", "service_links", "customer"])
-        for link in order.product_links:
-            await session.refresh(link, ["product"])
-
-        message_lines = [
-            f"🌐 <b>ЗАКАЗ С САЙТА #{order.id}</b>",
-            f"👤 {payload.customer.name}",
-            f"📱 {payload.customer.phone}",
-        ]
-
-        if payload.customer.email:
-            message_lines.append(f"📧 {payload.customer.email}")
-        if payload.customer.address:
-            message_lines.append(f"📍 {payload.customer.address}")
-        if payload.comment:
-            message_lines.append(f"💬 {payload.comment}")
-
-        message_lines.append("")
-        message_lines.append("🛒 <b>Товары:</b>")
-
-        for link in order.product_links:
-            product_name = link.product.title if link.product else f"Product #{link.product_id}"
-            line_total = link.price * link.quantity
-            message_lines.append(f"▫️ {product_name} x{link.quantity} — {line_total} р.")
-
-            if link.is_installation_included:
-                install_price = link.installation_price or 0
-                message_lines.append(f"   └ 🔧 Монтаж: {install_price} BYN")
-
-        if order.service_links:
-            for s_link in order.service_links:
-                title = s_link.title or "Услуга"
-                total = s_link.price * s_link.quantity
-                message_lines.append(f"🔧 {title} x{s_link.quantity} — {total} BYN")
-
-        message_lines.append("")
-        message_lines.append(f"💰 <b>Итого: {order.total_amount} руб.</b>")
-        admin_text = "\n".join(message_lines)
-
-        for admin_id in settings.admin_list:
-            try:
-                await BotService.send_message(admin_id, admin_text)
-            except Exception as e:
-                logger.warning(f"Failed to notify admin {admin_id}: {e}")
-
-    return OrderResponse(
-        id=order.id,
-        status=order.status,
-        total_amount=order.total_amount,
-        created_at=order.created_at,
-    )
+    return await WebsiteOrderService.create_order(session, payload)

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -1,0 +1,121 @@
+"""Service-layer orchestration for website checkout orders."""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from models import LeadSource, Order
+from schemas import OrderPayload, OrderResponse
+from services.bot_service import BotService
+from services.order_service import OrderService
+
+logger = logging.getLogger(__name__)
+
+
+class WebsiteOrderService:
+    @staticmethod
+    async def create_order(session: AsyncSession, payload: OrderPayload) -> OrderResponse:
+        logger.info(
+            "📦 Incoming order payload: customer=%s, items_count=%s",
+            payload.customer.name,
+            len(payload.items),
+        )
+        for idx, item in enumerate(payload.items):
+            logger.info(
+                "   Item %s: product_id=%s, qty=%s, with_install=%s, install_price=%s",
+                idx,
+                item.product_id,
+                item.quantity,
+                getattr(item, "with_installation", "N/A"),
+                getattr(item, "installation_price", "N/A"),
+            )
+
+        items = [
+            {
+                "product_id": item.product_id,
+                "quantity": item.quantity,
+                "with_installation": item.with_installation,
+                "installation_price": item.installation_price,
+                "installation_meta": item.installation_meta,
+                "installation_options": item.installation_options,
+            }
+            for item in payload.items
+        ]
+
+        order = await OrderService.create_from_website(
+            session=session,
+            customer_name=payload.customer.name,
+            customer_phone=payload.customer.phone,
+            customer_email=payload.customer.email,
+            customer_address=payload.customer.address,
+            items=items,
+            lead_source=LeadSource.SITE,
+            comment=payload.comment,
+            customer_type=payload.customer.type,
+            customer_inn=payload.customer.inn,
+            customer_legal_name=payload.customer.full_legal_name,
+            customer_legal_address=payload.customer.legal_address,
+            customer_iban=payload.customer.iban,
+            customer_bic=payload.customer.bic,
+            customer_bank_name=payload.customer.bank_name,
+        )
+
+        await WebsiteOrderService._notify_admins(session, order, payload)
+
+        return OrderResponse(
+            id=order.id,
+            status=order.status,
+            total_amount=order.total_amount,
+            created_at=order.created_at,
+        )
+
+    @staticmethod
+    async def _notify_admins(session: AsyncSession, order: Order, payload: OrderPayload) -> None:
+        if not settings.admin_list:
+            return
+
+        await session.refresh(order, ["product_links", "service_links", "customer"])
+        for link in order.product_links:
+            await session.refresh(link, ["product"])
+
+        message_lines = [
+            f"🌐 <b>ЗАКАЗ С САЙТА #{order.id}</b>",
+            f"👤 {payload.customer.name}",
+            f"📱 {payload.customer.phone}",
+        ]
+
+        if payload.customer.email:
+            message_lines.append(f"📧 {payload.customer.email}")
+        if payload.customer.address:
+            message_lines.append(f"📍 {payload.customer.address}")
+        if payload.comment:
+            message_lines.append(f"💬 {payload.comment}")
+
+        message_lines.append("")
+        message_lines.append("🛒 <b>Товары:</b>")
+
+        for link in order.product_links:
+            product_name = link.product.title if link.product else f"Product #{link.product_id}"
+            line_total = link.price * link.quantity
+            message_lines.append(f"▫️ {product_name} x{link.quantity} — {line_total} р.")
+
+            if link.is_installation_included:
+                install_price = link.installation_price or 0
+                message_lines.append(f"   └ 🔧 Монтаж: {install_price} BYN")
+
+        if order.service_links:
+            for service_link in order.service_links:
+                title = service_link.title or "Услуга"
+                total = service_link.price * service_link.quantity
+                message_lines.append(f"🔧 {title} x{service_link.quantity} — {total} BYN")
+
+        message_lines.append("")
+        message_lines.append(f"💰 <b>Итого: {order.total_amount} руб.</b>")
+        admin_text = "\n".join(message_lines)
+
+        for admin_id in settings.admin_list:
+            try:
+                await BotService.send_message(admin_id, admin_text)
+            except Exception as exc:
+                logger.warning("Failed to notify admin %s: %s", admin_id, exc)


### PR DESCRIPTION
## What
- extract website checkout orchestration from `routers/api_orders.py` into `services/website_order_service.py`
- move payload logging, item mapping, order creation call, and admin Telegram notifications into service layer
- keep order endpoint contract unchanged

## Validation
- `docker compose exec -T app pytest -q`