### PR TITLE
refactor: move manager doc generation flow to document service

### DIFF
--- a/routers/manager_orders.py
+++ b/routers/manager_orders.py
@@ -17,8 +17,6 @@ from services.order_service import OrderService
 
 router = APIRouter(prefix="/api/manager/orders", tags=["manager-orders"])
 
-ALLOWED_DOC_TYPES = {"contract", "invoice", "work_order", "act", "offer", "tn2", "ttn1"}
-
 
 @router.get("", response_model=ManagerOrderListResponse, operation_id="get_manager_orders")
 async def get_manager_orders(
@@ -87,15 +85,13 @@ async def generate_manager_order_document(
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
 ):
-    if doc_type not in ALLOWED_DOC_TYPES:
-        raise HTTPException(status_code=400, detail=f"Unsupported document type: {doc_type}")
     try:
-        doc = await DocumentService.create_or_get_document(session=session, order_id=order_id, doc_type=doc_type)
+        return await DocumentService.generate_manager_order_document(
+            session=session,
+            order_id=order_id,
+            doc_type=doc_type,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    return {
-        "doc_id": doc.id,
-        "doc_type": doc.doc_type,
-        "edit_url": doc.google_edit_url,
-    }

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -11,6 +11,8 @@ from services.documents.factory import DocumentFactory
 
 class DocumentService:
     """Сервис для работы с документами заказов через Google Drive"""
+
+    ALLOWED_DOC_TYPES = {"contract", "invoice", "work_order", "act", "offer", "tn2", "ttn1"}
     
     @staticmethod
     async def create_or_get_document(
@@ -43,6 +45,26 @@ class DocumentService:
         
         # 2. Создаем новый документ
         return await DocumentService._create_new_document(session, order_id, doc_type)
+
+    @staticmethod
+    async def generate_manager_order_document(
+        session: AsyncSession,
+        order_id: int,
+        doc_type: str,
+    ) -> dict:
+        if doc_type not in DocumentService.ALLOWED_DOC_TYPES:
+            raise ValueError(f"Unsupported document type: {doc_type}")
+
+        doc = await DocumentService.create_or_get_document(
+            session=session,
+            order_id=order_id,
+            doc_type=doc_type,
+        )
+        return {
+            "doc_id": doc.id,
+            "doc_type": doc.doc_type,
+            "edit_url": doc.google_edit_url,
+        }
     
     @staticmethod
     async def _create_new_document(


### PR DESCRIPTION
## What
- move manager order document generation flow from `routers/manager_orders.py` into `DocumentService`
- add `DocumentService.generate_manager_order_document(...)` with doc-type validation and response shaping
- keep router as transport layer with HTTP error mapping

## Validation
- `docker compose exec -T app pytest -q`