### PR TITLE
refactor: move manager image search logic to service layer

### DIFF
--- a/routers/manager_tools.py
+++ b/routers/manager_tools.py
@@ -28,13 +28,12 @@ from core.logger import logger
 from models import Product, ProductImage, Order, Customer
 from services.product_service import ProductService
 from services.customer_service import CustomerService
+from services.manager_media_service import ManagerMediaService
 from services.spec_normalizer import normalize_specs
 
 import httpx
 from PIL import Image
 from io import BytesIO
-from duckduckgo_search import DDGS
-
 router = APIRouter(prefix="/api/manager", tags=["manager"])
 
 @router.get("/me", operation_id="read_user_me")
@@ -57,38 +56,7 @@ async def search_images(
     """
     logger.info(f"Manager {username} searching images for: {q}")
     
-    try:
-        # DBGS is synchronous, run in executor
-        # Using updated approach for v6+
-        results = await asyncio.to_thread(
-            lambda: list(DDGS().images(q, max_results=max_results))
-        )
-        
-        # Extract relevant fields
-        images = []
-        for r in results:
-            if r.get('image'):
-                images.append({
-                    "image": r.get('image'),
-                    "width": r.get('width'),
-                    "height": r.get('height'),
-                    "thumbnail": r.get('thumbnail')
-                })
-        return images
-        
-    except Exception as e:
-        logger.error(f"Error searching images (DDG): {e}")
-        # Return empty list or specific error instead of 500
-        # Check if it is a rate limit or connection error
-        if "Ratelimit" in str(e) or "403" in str(e):
-             # Silently return empty list to not break UI, or handle specifically?
-             # User requested: "Better to return empty list [] or understandable error".
-             # Let's return empty list for graceful degradation.
-             logger.warning(f"DDG Ratelimit hit for query: {q}")
-             return []
-        
-        # For other errors, also fallback to empty list but log error
-        return []
+    return await ManagerMediaService.search_images(q, max_results=max_results)
 
 @router.post("/upload-image", operation_id="upload_image")
 async def upload_image(

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -1,0 +1,38 @@
+"""Service-layer helpers for manager media/search workflows."""
+
+import asyncio
+from typing import List
+
+from core.logger import logger
+from duckduckgo_search import DDGS
+
+
+class ManagerMediaService:
+    @staticmethod
+    async def search_images(query: str, max_results: int = 20) -> List[dict]:
+        """
+        Search images in DuckDuckGo and return normalized lightweight payload.
+        Returns empty list on provider errors/rate limits for graceful degradation.
+        """
+        try:
+            results = await asyncio.to_thread(
+                lambda: list(DDGS().images(query, max_results=max_results))
+            )
+        except Exception as exc:
+            logger.error(f"Error searching images (DDG): {exc}")
+            if "Ratelimit" in str(exc) or "403" in str(exc):
+                logger.warning(f"DDG Ratelimit hit for query: {query}")
+            return []
+
+        images = []
+        for result in results:
+            if result.get("image"):
+                images.append(
+                    {
+                        "image": result.get("image"),
+                        "width": result.get("width"),
+                        "height": result.get("height"),
+                        "thumbnail": result.get("thumbnail"),
+                    }
+                )
+        return images


### PR DESCRIPTION
## What
- extract DDG image search logic from `routers/manager_tools.py` into `services/manager_media_service.py`
- keep manager router transport-only for `/api/manager/search-images`
- preserve existing graceful fallback behavior (empty list on provider errors/rate-limit)

## Validation
- `docker compose exec -T app pytest -q`