### PR TITLE
refactor: move manager bulk local upload flow to media service

### DIFF
--- a/routers/manager_tools.py
+++ b/routers/manager_tools.py
@@ -329,28 +329,18 @@ async def bulk_upload_local_images(
         if content:
             file_payloads.append(content)
 
-    if not file_payloads:
-        raise HTTPException(status_code=400, detail="No valid files uploaded")
-
-    uploaded = 0
-    for product_id in unique_product_ids:
-        for idx, content in enumerate(file_payloads):
-            should_set_main = set_main and idx == 0 and not is_installation
-            await _save_image_from_bytes(
-                image_content=content,
-                product_id=product_id,
-                session=session,
-                set_main=should_set_main,
-                is_installation=is_installation,
-            )
-            uploaded += 1
-
-    return {
-        "message": "Bulk upload completed",
-        "products_count": len(unique_product_ids),
-        "files_count": len(file_payloads),
-        "uploaded_links": uploaded,
-    }
+    try:
+        return await ManagerMediaService.bulk_upload_local_images(
+            session=session,
+            product_ids=unique_product_ids,
+            file_payloads=file_payloads,
+            is_installation=is_installation,
+            set_main=set_main,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 @router.post("/gallery/bulk-delete-common", operation_id="bulk_delete_common_gallery_images")
 async def bulk_delete_common_gallery_images(

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -395,3 +395,45 @@ class ManagerMediaService:
             "products_count": len(unique_product_ids),
             "deleted_links": deleted_links,
         }
+
+    @staticmethod
+    async def bulk_upload_local_images(
+        session: AsyncSession,
+        *,
+        product_ids: List[int],
+        file_payloads: List[bytes],
+        is_installation: bool,
+        set_main: bool,
+    ) -> dict:
+        if not product_ids:
+            raise ValueError("product_ids is required")
+        if not file_payloads:
+            raise ValueError("No valid files uploaded")
+
+        unique_product_ids = list(dict.fromkeys(product_ids))
+
+        products_stmt = select(Product.id).where(Product.id.in_(unique_product_ids))
+        existing_product_ids = set((await session.execute(products_stmt)).scalars().all())
+        missing = sorted(set(unique_product_ids) - existing_product_ids)
+        if missing:
+            raise LookupError(f"Products not found: {missing}")
+
+        uploaded = 0
+        for product_id in unique_product_ids:
+            for idx, content in enumerate(file_payloads):
+                should_set_main = set_main and idx == 0 and not is_installation
+                await ManagerMediaService.save_image_from_bytes(
+                    image_content=content,
+                    product_id=product_id,
+                    session=session,
+                    set_main=should_set_main,
+                    is_installation=is_installation,
+                )
+                uploaded += 1
+
+        return {
+            "message": "Bulk upload completed",
+            "products_count": len(unique_product_ids),
+            "files_count": len(file_payloads),
+            "uploaded_links": uploaded,
+        }


### PR DESCRIPTION
## What
- move manager bulk local gallery upload flow from `routers/manager_tools.py` into `services/manager_media_service.py`
- add `ManagerMediaService.bulk_upload_local_images(...)` with validation and DB-side processing
- keep router endpoint as transport/parser wrapper for multipart form input

## Validation
- `docker compose exec -T app pytest -q`