### PR TITLE
refactor: move manager legacy specs normalization to service

### DIFF
--- a/routers/manager_tools.py
+++ b/routers/manager_tools.py
@@ -2,8 +2,6 @@ from typing import List, Optional, Set
 from datetime import datetime
 import asyncio
 import json
-import ast
-import re
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,9 +23,9 @@ from core.logger import logger
 from models import Product, ProductImage, Order, Customer
 from services.product_service import ProductService
 from services.customer_service import CustomerService
+from services.manager_legacy_specs_service import ManagerLegacySpecsService
 from services.manager_media_service import ManagerMediaService
 from services.manager_specs_service import ManagerSpecsService
-from services.spec_normalizer import normalize_specs
 
 router = APIRouter(prefix="/api/manager", tags=["manager"])
 
@@ -383,76 +381,6 @@ async def bulk_update_specs(
     
     return await ManagerSpecsService.bulk_update_specs(session, payload)
 
-# --- MIGRATION / NORMALIZATION TOOLS ---
-
-# Словарь перевода: Старый ключ (Onliner) -> Новый ключ (System)
-LEGACY_TO_SYSTEM_MAP = {
-    # Основное
-    "Тип кондиционера": "type",
-    "Дата выхода на рынок": "release_year",
-    "Тип внутреннего блока": "indoor_type",
-    "Режим работы": "modes",
-    "Цвет": "color",
-    "Wi-Fi": "wifi_ready",
-    "Инверторная технология": "inverter",
-    "Внутренний блок": "_delete_", # Мусорные поля помечаем на удаление
-    "Наружный блок": "_delete_",
-    "Пульт дистанционного управления": "_delete_", 
-
-    # Производительность
-    "Мощность охлаждения": "capacity_cooling_kw",
-    "Мощность обогрева": "capacity_heating_kw",
-    "Обслуживаемая площадь": "area_m2",
-    "Потребляемая мощность при охлаждении": "power_cons_cooling_kw",
-    "Потребляемая мощность при обогреве": "power_cons_heating_kw",
-    "Энергоэффективность при охлаждении (EER)": "eer",
-    "Энергоэффективность при обогреве (COP)": "cop",
-    "Максимальный расход воздуха внутреннего блока": "airflow_max",
-
-    # Трубы и монтаж
-    "Максимальная длина магистрали": "pipe_max_length",
-    "Перепад высот": "pipe_max_height",
-    "Хладагент (фреон)": "freon_type",
-    "Рабочая температура при охлаждении": "temp_range_cool",
-    "Рабочая температура при обогреве": "temp_range_heat",
-
-    # Шум
-    "Шум внутреннего блока": "noise_indoor",
-    "Шум наружного блока": "noise_outdoor",
-
-    # Габариты (Onliner style - раздельные)
-    "Ширина внутреннего блока": "width_indoor",
-    "Высота внутреннего блока": "height_indoor",
-    "Глубина внутреннего блока": "depth_indoor",
-    "Ширина наружного блока": "width_outdoor",
-    "Высота наружного блока": "height_outdoor",
-    "Глубина наружного блока": "depth_outdoor",
-    "Вес внутреннего блока": "weight_indoor",
-    "Вес наружного блока": "weight_outdoor",
-    
-    # MDV (если вдруг уже есть кириллица с сайта MDV)
-    "Модель внутреннего блока": "model_indoor",
-    "Модель наружного блока": "model_outdoor",
-}
-
-def _clean_legacy_value(key: str, value: any):
-    """Очищает значения (да -> True, удаление лишних единиц измерения)"""
-    if isinstance(value, str):
-        v_lower = value.lower().strip()
-        
-        # Булевы значения
-        if v_lower == "да":
-            return True
-        if v_lower == "нет":
-            return False
-            
-        # Чистка цифр (опционально, пока можно оставить строки для безопасности)
-        # Если захочешь превратить "3.4 кВт" в число 3.4, раскомментируй:
-        # if key in ["capacity_cooling_kw", "area_m2", "pipe_max_length"]:
-        #     return re.sub(r"[^\d\.,-]", "", value).strip()
-            
-    return value
-
 @router.post("/specs/normalize-legacy", operation_id="normalize_legacy_specs")
 async def normalize_legacy_specs(
     dry_run: bool = Query(True, description="Если True - не сохраняет изменения в БД, только показывает пример"),
@@ -464,83 +392,7 @@ async def normalize_legacy_specs(
     Переводит ключи Onliner (кириллица) в System (английский).
     """
     logger.info(f"Starting specs normalization (dry_run={dry_run}) by {username}")
-    
-    # Берем все товары, у которых есть specs
-    stmt = select(Product).where(Product.specs != None)
-    result = await session.execute(stmt)
-    products = result.scalars().all()
-    
-    updated_count = 0
-    preview_log = [] # Пример изменений для ответа
-    
-    for product in products:
-        try:
-            old_specs = product.specs
-            
-            # 1. Если это None - пропускаем
-            if old_specs is None:
-                continue
-
-            if isinstance(old_specs, str):
-                try:
-                    # Попытка 1: Честный JSON
-                    old_specs = json.loads(old_specs)
-                except json.JSONDecodeError:
-                    try:
-                        # Попытка 2: Python dict string (одинарные кавычки)
-                        old_specs = ast.literal_eval(old_specs)
-                    except (ValueError, SyntaxError):
-                        # Если совсем мусор
-                        logger.warning(f"Product {product.id} has invalid format: {old_specs}")
-                        continue
-
-            # 3. Если после всех попыток это все еще не словарь - пропускаем
-            if not isinstance(old_specs, dict):
-                continue
-                
-            # --- Дальше старая логика ---
-            new_specs = {}
-            changed = False
-            
-            for old_key, val in old_specs.items(): # Теперь здесь точно словарь!
-                new_key = LEGACY_TO_SYSTEM_MAP.get(old_key, old_key)
-                
-                if new_key == "_delete_":
-                    changed = True
-                    continue
-                
-                new_val = _clean_legacy_value(new_key, val)
-                
-                if new_key != old_key or new_val != val:
-                    changed = True
-                    
-                new_specs[new_key] = new_val
-                
-            if changed:
-                if not dry_run:
-                    product.specs = new_specs
-                    session.add(product)
-                updated_count += 1
-                if len(preview_log) < 5:
-                    preview_log.append({
-                        "id": product.id,
-                        "before_sample": list(old_specs.keys())[:2],
-                        "after_sample": list(new_specs.keys())[:2]
-                    })
-        except Exception as e:
-            logger.error(f"Error normalizing product {product.id}: {e}")
-            continue
-
-    if not dry_run:
-        await session.commit()
-        
-    return {
-        "message": "Normalization complete",
-        "dry_run": dry_run,
-        "products_processed": len(products),
-        "products_updated": updated_count,
-        "sample_changes": preview_log
-    }
+    return await ManagerLegacySpecsService.normalize_legacy_specs(session, dry_run=dry_run)
 
 # =============================================
 # Manager List Endpoints (Stitch Integration)

--- a/services/manager_legacy_specs_service.py
+++ b/services/manager_legacy_specs_service.py
@@ -1,0 +1,135 @@
+"""Service-layer helpers for one-off legacy specs normalization."""
+
+import ast
+import json
+from typing import Any
+
+from core.logger import logger
+from models import Product
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+
+LEGACY_TO_SYSTEM_MAP = {
+    "Тип кондиционера": "type",
+    "Дата выхода на рынок": "release_year",
+    "Тип внутреннего блока": "indoor_type",
+    "Режим работы": "modes",
+    "Цвет": "color",
+    "Wi-Fi": "wifi_ready",
+    "Инверторная технология": "inverter",
+    "Внутренний блок": "_delete_",
+    "Наружный блок": "_delete_",
+    "Пульт дистанционного управления": "_delete_",
+    "Мощность охлаждения": "capacity_cooling_kw",
+    "Мощность обогрева": "capacity_heating_kw",
+    "Обслуживаемая площадь": "area_m2",
+    "Потребляемая мощность при охлаждении": "power_cons_cooling_kw",
+    "Потребляемая мощность при обогреве": "power_cons_heating_kw",
+    "Энергоэффективность при охлаждении (EER)": "eer",
+    "Энергоэффективность при обогреве (COP)": "cop",
+    "Максимальный расход воздуха внутреннего блока": "airflow_max",
+    "Максимальная длина магистрали": "pipe_max_length",
+    "Перепад высот": "pipe_max_height",
+    "Хладагент (фреон)": "freon_type",
+    "Рабочая температура при охлаждении": "temp_range_cool",
+    "Рабочая температура при обогреве": "temp_range_heat",
+    "Шум внутреннего блока": "noise_indoor",
+    "Шум наружного блока": "noise_outdoor",
+    "Ширина внутреннего блока": "width_indoor",
+    "Высота внутреннего блока": "height_indoor",
+    "Глубина внутреннего блока": "depth_indoor",
+    "Ширина наружного блока": "width_outdoor",
+    "Высота наружного блока": "height_outdoor",
+    "Глубина наружного блока": "depth_outdoor",
+    "Вес внутреннего блока": "weight_indoor",
+    "Вес наружного блока": "weight_outdoor",
+    "Модель внутреннего блока": "model_indoor",
+    "Модель наружного блока": "model_outdoor",
+}
+
+
+def _clean_legacy_value(value: Any) -> Any:
+    if isinstance(value, str):
+        value_lower = value.lower().strip()
+        if value_lower == "да":
+            return True
+        if value_lower == "нет":
+            return False
+    return value
+
+
+class ManagerLegacySpecsService:
+    @staticmethod
+    async def normalize_legacy_specs(
+        session: AsyncSession,
+        *,
+        dry_run: bool = True,
+    ) -> dict:
+        stmt = select(Product).where(Product.specs != None)
+        result = await session.execute(stmt)
+        products = result.scalars().all()
+
+        updated_count = 0
+        preview_log = []
+
+        for product in products:
+            try:
+                old_specs = product.specs
+                if old_specs is None:
+                    continue
+
+                if isinstance(old_specs, str):
+                    try:
+                        old_specs = json.loads(old_specs)
+                    except json.JSONDecodeError:
+                        try:
+                            old_specs = ast.literal_eval(old_specs)
+                        except (ValueError, SyntaxError):
+                            logger.warning(f"Product {product.id} has invalid format: {old_specs}")
+                            continue
+
+                if not isinstance(old_specs, dict):
+                    continue
+
+                new_specs = {}
+                changed = False
+                for old_key, value in old_specs.items():
+                    new_key = LEGACY_TO_SYSTEM_MAP.get(old_key, old_key)
+                    if new_key == "_delete_":
+                        changed = True
+                        continue
+
+                    new_value = _clean_legacy_value(value)
+                    if new_key != old_key or new_value != value:
+                        changed = True
+
+                    new_specs[new_key] = new_value
+
+                if changed:
+                    if not dry_run:
+                        product.specs = new_specs
+                        session.add(product)
+                    updated_count += 1
+                    if len(preview_log) < 5:
+                        preview_log.append(
+                            {
+                                "id": product.id,
+                                "before_sample": list(old_specs.keys())[:2],
+                                "after_sample": list(new_specs.keys())[:2],
+                            }
+                        )
+            except Exception as exc:
+                logger.error(f"Error normalizing product {product.id}: {exc}")
+                continue
+
+        if not dry_run:
+            await session.commit()
+
+        return {
+            "message": "Normalization complete",
+            "dry_run": dry_run,
+            "products_processed": len(products),
+            "products_updated": updated_count,
+            "sample_changes": preview_log,
+        }


### PR DESCRIPTION
## Summary
- move /api/manager/specs/normalize-legacy business logic from router to service layer
- add ManagerLegacySpecsService with legacy key mapping, value cleanup, and dry-run/commit behavior
- keep endpoint contract unchanged while reducing router responsibilities

## Testing
- docker compose exec -T app pytest -q