### PR TITLE
refactor: move manager catalog endpoints orchestration to service

### DIFF
--- a/routers/manager_tools.py
+++ b/routers/manager_tools.py
@@ -21,8 +21,7 @@ from core.config import settings
 from core.security import get_current_username
 from core.logger import logger
 from models import Product, ProductImage, Order, Customer
-from services.product_service import ProductService
-from services.customer_service import CustomerService
+from services.manager_catalog_service import ManagerCatalogService
 from services.manager_legacy_specs_service import ManagerLegacySpecsService
 from services.manager_media_service import ManagerMediaService
 from services.manager_specs_service import ManagerSpecsService
@@ -415,8 +414,16 @@ async def list_products_for_manager(
     Paginated product list for manager UI.
     Unlike the public catalog, this can show unpublished products.
     """
-    return await ProductService.get_manager_list(
-        session, page, limit, search, is_published, area_min, area_max, is_inverter, sort
+    return await ManagerCatalogService.list_products(
+        session=session,
+        page=page,
+        limit=limit,
+        search=search,
+        is_published=is_published,
+        area_min=area_min,
+        area_max=area_max,
+        is_inverter=is_inverter,
+        sort=sort,
     )
 
 
@@ -434,7 +441,7 @@ async def list_customers_for_manager(
     Paginated customer list for manager UI.
     Includes order count per customer.
     """
-    return await CustomerService.list_for_manager(
+    return await ManagerCatalogService.list_customers(
         session=session,
         page=page,
         limit=limit,
@@ -454,10 +461,11 @@ async def update_product(
     """
     Update individual product fields.
     """
-    update_data = data.dict(exclude_unset=True)
-    tag_ids = update_data.pop("tag_ids", None)
-
-    result = await ProductService.update_product(session, product_id, update_data, tag_ids)
+    result = await ManagerCatalogService.update_product(
+        session=session,
+        product_id=product_id,
+        data=data,
+    )
 
     if not result:
         raise HTTPException(status_code=404, detail="Product not found")
@@ -474,10 +482,7 @@ async def bulk_round_price(
     """
     Round prices down to the nearest multiple of 50.
     """
-    if not request.product_ids:
-        return {"message": "No products selected", "updated_count": 0}
-
-    return await ProductService.bulk_round_prices(session, request.product_ids)
+    return await ManagerCatalogService.bulk_round_prices(session=session, request=request)
 
 
 @router.get("/tags/all", operation_id="get_all_tags")
@@ -488,4 +493,4 @@ async def get_all_tags(
     """
     Return all tags grouped by TagGroup for the product editor.
     """
-    return await ProductService.get_all_tags(session)
+    return await ManagerCatalogService.get_all_tags(session)

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, Optional
+
+from schemas import BulkRoundRequest, ProductUpdate
+from services.customer_service import CustomerService
+from services.product_service import ProductService
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ManagerCatalogService:
+    @staticmethod
+    async def list_products(
+        session: AsyncSession,
+        *,
+        page: int,
+        limit: int,
+        search: Optional[str],
+        is_published: Optional[bool],
+        area_min: Optional[int],
+        area_max: Optional[int],
+        is_inverter: Optional[bool],
+        sort: str,
+    ) -> Dict[str, Any]:
+        return await ProductService.get_manager_list(
+            session=session,
+            page=page,
+            limit=limit,
+            search=search,
+            is_published=is_published,
+            area_min=area_min,
+            area_max=area_max,
+            is_inverter=is_inverter,
+            sort=sort,
+        )
+
+    @staticmethod
+    async def list_customers(
+        session: AsyncSession,
+        *,
+        page: int,
+        limit: int,
+        search: Optional[str],
+        customer_type: Optional[str],
+        only_with_orders: bool,
+    ) -> Dict[str, Any]:
+        return await CustomerService.list_for_manager(
+            session=session,
+            page=page,
+            limit=limit,
+            search=search,
+            customer_type=customer_type,
+            only_with_orders=only_with_orders,
+        )
+
+    @staticmethod
+    async def update_product(
+        session: AsyncSession,
+        *,
+        product_id: int,
+        data: ProductUpdate,
+    ) -> Optional[Dict[str, Any]]:
+        update_data = data.dict(exclude_unset=True)
+        tag_ids = update_data.pop("tag_ids", None)
+        return await ProductService.update_product(session, product_id, update_data, tag_ids)
+
+    @staticmethod
+    async def bulk_round_prices(
+        session: AsyncSession,
+        *,
+        request: BulkRoundRequest,
+    ) -> Dict[str, Any]:
+        if not request.product_ids:
+            return {"message": "No products selected", "updated_count": 0}
+        return await ProductService.bulk_round_prices(session, request.product_ids)
+
+    @staticmethod
+    async def get_all_tags(session: AsyncSession):
+        return await ProductService.get_all_tags(session)


### PR DESCRIPTION
## Summary
- add ManagerCatalogService as service-layer orchestrator for manager product/customer catalog operations
- move request-shaping logic for update and bulk-round flows out of router
- switch manager routes to call ManagerCatalogService to keep routers thinner

## Testing
- docker compose exec -T app pytest -q