### PR TITLE
refactor: move manager bulk local media intake to orchestrator service

### DIFF
--- a/routers/manager_tools.py
+++ b/routers/manager_tools.py
@@ -1,11 +1,9 @@
 from typing import List, Optional
 from datetime import datetime
 import asyncio
-import json
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 from schemas import (
     BulkSpecUpdate,
     SpecsKeysResponse,
@@ -20,7 +18,6 @@ from core.database import get_session
 from core.config import settings
 from core.security import get_current_username
 from core.logger import logger
-from models import Product, ProductImage, Order, Customer
 from services.manager_catalog_service import ManagerCatalogService
 from services.manager_legacy_specs_service import ManagerLegacySpecsService
 from services.manager_media_orchestrator_service import ManagerMediaOrchestratorService
@@ -221,35 +218,10 @@ async def bulk_upload_local_images(
 ):
     """Upload local files once and attach to all selected products."""
     try:
-        product_ids = json.loads(product_ids_json)
-        if not isinstance(product_ids, list):
-            raise ValueError()
-        unique_product_ids = list(dict.fromkeys(int(pid) for pid in product_ids))
-    except Exception:
-        raise HTTPException(status_code=400, detail="Invalid product_ids_json")
-
-    if not unique_product_ids:
-        raise HTTPException(status_code=400, detail="product_ids is required")
-    if not files:
-        raise HTTPException(status_code=400, detail="files is required")
-
-    products_stmt = select(Product.id).where(Product.id.in_(unique_product_ids))
-    existing_product_ids = set((await session.execute(products_stmt)).scalars().all())
-    missing = sorted(set(unique_product_ids) - existing_product_ids)
-    if missing:
-        raise HTTPException(status_code=404, detail=f"Products not found: {missing}")
-
-    file_payloads: List[bytes] = []
-    for file in files:
-        content = await file.read()
-        if content:
-            file_payloads.append(content)
-
-    try:
-        return await ManagerMediaService.bulk_upload_local_images(
+        return await ManagerMediaOrchestratorService.bulk_upload_local_images(
             session=session,
-            product_ids=unique_product_ids,
-            file_payloads=file_payloads,
+            product_ids_json=product_ids_json,
+            files=files,
             is_installation=is_installation,
             set_main=set_main,
         )

--- a/services/manager_media_orchestrator_service.py
+++ b/services/manager_media_orchestrator_service.py
@@ -1,9 +1,11 @@
+import json
 from typing import Any, Dict, List
 
 from core.logger import logger
 from models import Product
 from services.manager_media_service import ManagerMediaService
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 from starlette.datastructures import UploadFile
 
 
@@ -81,4 +83,46 @@ class ManagerMediaOrchestratorService:
             session=session,
             set_main=False,
             is_installation=False,
+        )
+
+    @staticmethod
+    async def bulk_upload_local_images(
+        session: AsyncSession,
+        *,
+        product_ids_json: str,
+        files: List[UploadFile],
+        is_installation: bool,
+        set_main: bool,
+    ) -> Dict[str, Any]:
+        try:
+            product_ids = json.loads(product_ids_json)
+            if not isinstance(product_ids, list):
+                raise ValueError()
+            unique_product_ids = list(dict.fromkeys(int(pid) for pid in product_ids))
+        except Exception as exc:
+            raise ValueError("Invalid product_ids_json") from exc
+
+        if not unique_product_ids:
+            raise ValueError("product_ids is required")
+        if not files:
+            raise ValueError("files is required")
+
+        products_stmt = select(Product.id).where(Product.id.in_(unique_product_ids))
+        existing_product_ids = set((await session.execute(products_stmt)).scalars().all())
+        missing = sorted(set(unique_product_ids) - existing_product_ids)
+        if missing:
+            raise LookupError(f"Products not found: {missing}")
+
+        file_payloads: List[bytes] = []
+        for file in files:
+            content = await file.read()
+            if content:
+                file_payloads.append(content)
+
+        return await ManagerMediaService.bulk_upload_local_images(
+            session=session,
+            product_ids=unique_product_ids,
+            file_payloads=file_payloads,
+            is_installation=is_installation,
+            set_main=set_main,
         )


### PR DESCRIPTION
## Summary
- move /api/manager/gallery/bulk-upload-local intake/validation logic from router to ManagerMediaOrchestratorService
- keep products existence check and error messages in service layer
- simplify manager_tools by removing direct JSON/SQL parsing logic for this endpoint

## Testing
- python3 -m py_compile routers/manager_tools.py services/manager_media_orchestrator_service.py
- docker compose exec -T app pytest -q