### PR TITLE
refactor: aggregate manager routers behind single entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,12 +26,7 @@ from core.security import AdminAuthBackend
 from routers import admin as admin_router
 from routers import api as api_router
 from routers import auth as auth_router
-from routers import manager_catalog
-from routers import manager_media
-from routers import manager_specs
-from routers import manager_tools
-from routers import manager_orders
-from routers import manager_leads
+from routers import manager as manager_router
 from routers import system as system_router
 from admin import admin_views
 from starlette.responses import FileResponse
@@ -92,12 +87,7 @@ app.add_middleware(
 app.include_router(admin_router.router)
 app.include_router(auth_router.router)
 app.include_router(api_router.router)
-app.include_router(manager_catalog.router)
-app.include_router(manager_media.router)
-app.include_router(manager_specs.router)
-app.include_router(manager_tools.router)
-app.include_router(manager_orders.router)
-app.include_router(manager_leads.router)
+app.include_router(manager_router.router)
 app.include_router(system_router.router)
 
 # Static files

--- a/routers/manager.py
+++ b/routers/manager.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+
+from routers import manager_catalog
+from routers import manager_leads
+from routers import manager_media
+from routers import manager_orders
+from routers import manager_specs
+from routers import manager_tools
+
+
+router = APIRouter()
+router.include_router(manager_catalog.router)
+router.include_router(manager_media.router)
+router.include_router(manager_specs.router)
+router.include_router(manager_tools.router)
+router.include_router(manager_orders.router)
+router.include_router(manager_leads.router)


### PR DESCRIPTION
## Summary
- add routers/manager.py as a single manager API aggregator
- include manager catalog/media/specs/tools/orders/leads routers inside aggregator
- simplify main.py router wiring by replacing multiple manager includes with one

## Testing
- python3 -m py_compile main.py routers/manager.py
- docker compose exec -T app pytest -q