### PR TITLE
refactor: extract admin docs endpoints into dedicated router

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,16 +1,17 @@
 from fastapi import APIRouter, Request, Depends, HTTPException, UploadFile, File, Form
 from typing import Optional, List
-from fastapi.responses import RedirectResponse, StreamingResponse
-from services.document_service import DocumentService
+from fastapi.responses import RedirectResponse
 from services.importer_service import ImporterService
 from core.database import async_session_maker
 from core.security import get_current_username, check_admin_session
 from models import Product, Order
-from sqlmodel import select, func
+from routers import admin_docs
+from sqlmodel import select
 from sqlalchemy.orm import selectinload
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 importer_service = ImporterService()
+router.include_router(admin_docs.router)
 
 @router.get("/stats")
 async def get_dashboard_stats(
@@ -75,107 +76,6 @@ async def update_sync_mode(
         await ConfigService.set_config("sync_mode", str(new_mode))
             
     return RedirectResponse(url="/admin/", status_code=303)
-
-@router.get("/docs/generate/{doc_type}/{order_id}")
-async def generate_document(
-    doc_type: str,
-    order_id: int,
-    username: str = Depends(get_current_username)
-):
-    """
-    Универсальный роут для генерации документов.
-    doc_type: contract | offer | invoice | act | tn2 | ttn1
-    Возвращает ссылку на редактирование в Google Docs.
-    """
-    async with async_session_maker() as session:
-        try:
-            doc = await DocumentService.create_or_get_document(session, order_id, doc_type)
-            return RedirectResponse(url=doc.google_edit_url)
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-            return {"error": str(e)}
-
-@router.get("/docs/download/{doc_id}")
-async def download_document_pdf(
-    doc_id: int,
-    username: str = Depends(get_current_username)
-):
-    """
-    Скачивает документ в формате PDF из Google Drive.
-    """
-    from models import OrderDocument
-    from services.google_service import google_service
-    
-    async with async_session_maker() as session:
-        # 1. Находим документ в БД
-        result = await session.execute(
-            select(OrderDocument).where(OrderDocument.id == doc_id)
-        )
-        document = result.scalar_one_or_none()
-        
-        if not document:
-            raise HTTPException(status_code=404, detail="Document not found")
-        
-        # 2. Экспортируем из Google Drive
-        try:
-            pdf_content = google_service.export_file(document.google_file_id, mime_type='application/pdf')
-            
-            # 3. Возвращаем как StreamingResponse
-            # Используем URL encoding для кириллицы в имени файла (RFC 5987)
-            from urllib.parse import quote
-            filename = f"{document.number}.pdf"
-            filename_encoded = quote(filename)
-            
-            return StreamingResponse(
-                pdf_content,
-                media_type="application/pdf",
-                headers={
-                    "Content-Disposition": f"attachment; filename*=UTF-8''{filename_encoded}"
-                }
-            )
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error exporting PDF: {str(e)}")
-
-@router.get("/docs/delete/{doc_id}")
-async def delete_document(
-    doc_id: int,
-    username: str = Depends(get_current_username)
-):
-    """
-    Удаляет документ из БД и перемещает файл в корзину Google Drive.
-    """
-    from models import OrderDocument
-    from services.google_service import google_service
-    
-    async with async_session_maker() as session:
-        # 1. Находим документ
-        result = await session.execute(
-            select(OrderDocument).where(OrderDocument.id == doc_id)
-        )
-        document = result.scalar_one_or_none()
-        
-        if not document:
-            raise HTTPException(status_code=404, detail="Document not found")
-        
-        order_id = document.order_id
-        
-        # 2. Удаляем файл из Google Drive (если есть ID)
-        if document.google_file_id:
-            try:
-                google_service.delete_file(document.google_file_id)
-            except Exception as e:
-                print(f"Error deleting file from Drive: {e}")
-        
-        # 3. Удаляем запись из БД
-        await session.delete(document)
-        await session.commit()
-        
-        # 4. Редирект обратно на страницу заказа
-        return RedirectResponse(
-            url=f"/admin/order/edit/{order_id}", 
-            status_code=302
-        )
 
 from pydantic import BaseModel
 

--- a/routers/admin_docs.py
+++ b/routers/admin_docs.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import RedirectResponse, StreamingResponse
+from sqlmodel import select
+
+from core.database import async_session_maker
+from core.security import get_current_username
+from services.document_service import DocumentService
+
+
+router = APIRouter(tags=["admin-docs"])
+
+
+@router.get("/docs/generate/{doc_type}/{order_id}")
+async def generate_document(
+    doc_type: str,
+    order_id: int,
+    username: str = Depends(get_current_username)
+):
+    """
+    Универсальный роут для генерации документов.
+    doc_type: contract | offer | invoice | act | tn2 | ttn1
+    Возвращает ссылку на редактирование в Google Docs.
+    """
+    async with async_session_maker() as session:
+        try:
+            doc = await DocumentService.create_or_get_document(session, order_id, doc_type)
+            return RedirectResponse(url=doc.google_edit_url)
+        except Exception as exc:
+            import traceback
+            traceback.print_exc()
+            return {"error": str(exc)}
+
+
+@router.get("/docs/download/{doc_id}")
+async def download_document_pdf(
+    doc_id: int,
+    username: str = Depends(get_current_username)
+):
+    """
+    Скачивает документ в формате PDF из Google Drive.
+    """
+    from models import OrderDocument
+    from services.google_service import google_service
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(OrderDocument).where(OrderDocument.id == doc_id)
+        )
+        document = result.scalar_one_or_none()
+
+        if not document:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        try:
+            pdf_content = google_service.export_file(document.google_file_id, mime_type='application/pdf')
+
+            from urllib.parse import quote
+            filename = f"{document.number}.pdf"
+            filename_encoded = quote(filename)
+
+            return StreamingResponse(
+                pdf_content,
+                media_type="application/pdf",
+                headers={
+                    "Content-Disposition": f"attachment; filename*=UTF-8''{filename_encoded}"
+                }
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Error exporting PDF: {str(exc)}")
+
+
+@router.get("/docs/delete/{doc_id}")
+async def delete_document(
+    doc_id: int,
+    username: str = Depends(get_current_username)
+):
+    """
+    Удаляет документ из БД и перемещает файл в корзину Google Drive.
+    """
+    from models import OrderDocument
+    from services.google_service import google_service
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(OrderDocument).where(OrderDocument.id == doc_id)
+        )
+        document = result.scalar_one_or_none()
+
+        if not document:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        order_id = document.order_id
+
+        if document.google_file_id:
+            try:
+                google_service.delete_file(document.google_file_id)
+            except Exception as exc:
+                print(f"Error deleting file from Drive: {exc}")
+
+        await session.delete(document)
+        await session.commit()
+
+        return RedirectResponse(
+            url=f"/admin/order/edit/{order_id}",
+            status_code=302
+        )


### PR DESCRIPTION
## Summary
- move /admin/docs endpoints from routers/admin.py into new routers/admin_docs.py
- keep routers/admin.py as aggregator for docs subrouter and remaining admin endpoints
- preserve endpoint paths and behavior

## Testing
- python3 -m py_compile routers/admin.py routers/admin_docs.py
- docker compose exec -T app pytest -q