### PR TITLE
refactor: extract admin media endpoints into dedicated router

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,15 +1,16 @@
-from fastapi import APIRouter, Request, Depends, HTTPException, UploadFile, File, Form
-from typing import Optional, List
+from fastapi import APIRouter, Request, Depends
 from fastapi.responses import RedirectResponse
 from services.importer_service import ImporterService
 from core.database import async_session_maker
 from core.security import get_current_username, check_admin_session
 from routers import admin_docs
+from routers import admin_media
 from routers import admin_schedule
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 importer_service = ImporterService()
 router.include_router(admin_docs.router)
+router.include_router(admin_media.router)
 router.include_router(admin_schedule.router)
 
 @router.get("/stats")
@@ -111,54 +112,3 @@ async def move_order_status(
             return {"success": success}
         except Exception as e:
             return {"success": False, "error": str(e)}
-
-@router.post("/api/upload_images")
-async def upload_images(
-    files: List[UploadFile],
-    slug: Optional[str] = Form(None),
-    username: str = Depends(get_current_username)
-):
-    """
-    Bulk upload images for articles/products.
-    Returns list of web-accessible URLs.
-    """
-    from services.image_service import ImageService
-    uploaded_urls = []
-    
-    # Default to 'uploads' if no slug provided (e.g. new article)
-    effective_slug = slug or "uploads"
-    
-    # Determine entity type based on context - defaulting to 'articles' for now 
-    # as this is primarily for article editor.
-    # Could be made dynamic if needed.
-    entity_type = "articles" 
-    
-    for file in files:
-        file_bytes = await file.read()
-        filename = file.filename or "image.jpg"
-        
-        db_path = await ImageService.save_image(
-            file_bytes=file_bytes,
-            entity_type=entity_type,
-            slug=effective_slug,
-            filename=filename
-        )
-        
-        web_path = ImageService.get_web_path(db_path)
-        uploaded_urls.append(web_path)
-        
-    return {"urls": uploaded_urls}
-
-@router.get("/api/article_images/{slug}")
-async def list_article_images(
-    slug: str,
-    username: str = Depends(get_current_username)
-):
-    """
-    List all images associated with an article slug.
-    """
-    from services.image_service import ImageService
-    
-    # We assume 'articles' entity type
-    urls = await ImageService.list_images("articles", slug)
-    return {"urls": urls}

--- a/routers/admin_media.py
+++ b/routers/admin_media.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Form, UploadFile
+
+from core.security import get_current_username
+
+
+router = APIRouter(tags=["admin-media"])
+
+
+@router.post("/api/upload_images")
+async def upload_images(
+    files: List[UploadFile],
+    slug: Optional[str] = Form(None),
+    username: str = Depends(get_current_username)
+):
+    """
+    Bulk upload images for articles/products.
+    Returns list of web-accessible URLs.
+    """
+    from services.image_service import ImageService
+
+    uploaded_urls = []
+    effective_slug = slug or "uploads"
+    entity_type = "articles"
+
+    for file in files:
+        file_bytes = await file.read()
+        filename = file.filename or "image.jpg"
+
+        db_path = await ImageService.save_image(
+            file_bytes=file_bytes,
+            entity_type=entity_type,
+            slug=effective_slug,
+            filename=filename
+        )
+
+        web_path = ImageService.get_web_path(db_path)
+        uploaded_urls.append(web_path)
+
+    return {"urls": uploaded_urls}
+
+
+@router.get("/api/article_images/{slug}")
+async def list_article_images(
+    slug: str,
+    username: str = Depends(get_current_username)
+):
+    """
+    List all images associated with an article slug.
+    """
+    from services.image_service import ImageService
+
+    urls = await ImageService.list_images("articles", slug)
+    return {"urls": urls}


### PR DESCRIPTION
## Summary
- move admin media endpoints from routers/admin.py to routers/admin_media.py
- extracted endpoints:
  - POST /admin/api/upload_images
  - GET /admin/api/article_images/{slug}
- keep routers/admin.py as aggregator by including admin_media router
- preserve endpoint paths and behavior

## Testing
- python3 -m py_compile routers/admin.py routers/admin_media.py routers/admin_docs.py routers/admin_schedule.py
- docker compose exec -T app pytest -q