### PR TITLE
refactor: extract admin order move endpoint into dedicated router

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -5,12 +5,14 @@ from core.database import async_session_maker
 from core.security import get_current_username, check_admin_session
 from routers import admin_docs
 from routers import admin_media
+from routers import admin_orders
 from routers import admin_schedule
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 importer_service = ImporterService()
 router.include_router(admin_docs.router)
 router.include_router(admin_media.router)
+router.include_router(admin_orders.router)
 router.include_router(admin_schedule.router)
 
 @router.get("/stats")
@@ -76,39 +78,3 @@ async def update_sync_mode(
         await ConfigService.set_config("sync_mode", str(new_mode))
             
     return RedirectResponse(url="/admin/", status_code=303)
-
-from pydantic import BaseModel
-
-class OrderStatusUpdate(BaseModel):
-    order_id: int
-    new_status: str
-
-@router.post("/api/order/move")
-async def move_order_status(
-    data: OrderStatusUpdate,
-    username: str = Depends(get_current_username)
-):
-    """
-    API for Kanban drag-and-drop.
-    """
-    from services.order_service import OrderService
-    
-    async with async_session_maker() as session:
-        # Validate status
-        try:
-            # Check if status exists in Enum
-            from models import OrderStatus
-            # Allow case-insensitive match or direct match
-            status_enum = None
-            for s in OrderStatus:
-                if s.value == data.new_status:
-                    status_enum = s
-                    break
-            
-            if not status_enum:
-                return {"success": False, "error": f"Invalid status: {data.new_status}"}
-
-            success = await OrderService.update_status(session, data.order_id, status_enum)
-            return {"success": success}
-        except Exception as e:
-            return {"success": False, "error": str(e)}

--- a/routers/admin_orders.py
+++ b/routers/admin_orders.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from core.database import async_session_maker
+from core.security import get_current_username
+
+
+router = APIRouter(tags=["admin-orders"])
+
+
+class OrderStatusUpdate(BaseModel):
+    order_id: int
+    new_status: str
+
+
+@router.post("/api/order/move")
+async def move_order_status(
+    data: OrderStatusUpdate,
+    username: str = Depends(get_current_username)
+):
+    """
+    API for Kanban drag-and-drop.
+    """
+    from services.order_service import OrderService
+    from models import OrderStatus
+
+    async with async_session_maker() as session:
+        try:
+            status_enum = None
+            for status in OrderStatus:
+                if status.value == data.new_status:
+                    status_enum = status
+                    break
+
+            if not status_enum:
+                return {"success": False, "error": f"Invalid status: {data.new_status}"}
+
+            success = await OrderService.update_status(session, data.order_id, status_enum)
+            return {"success": success}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}


### PR DESCRIPTION
## Summary
- move admin order move endpoint from routers/admin.py to routers/admin_orders.py
- extracted endpoint:
  - POST /admin/api/order/move
- keep routers/admin.py as aggregator by including admin_orders router
- preserve endpoint path and behavior

## Testing
- python3 -m py_compile routers/admin.py routers/admin_orders.py routers/admin_docs.py routers/admin_media.py routers/admin_schedule.py
- docker compose exec -T app pytest -q