### PR TITLE
refactor: extract admin import and sync endpoints into dedicated router

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,16 +1,15 @@
 from fastapi import APIRouter, Request, Depends
-from fastapi.responses import RedirectResponse
-from services.importer_service import ImporterService
 from core.database import async_session_maker
-from core.security import get_current_username, check_admin_session
+from core.security import check_admin_session
 from routers import admin_docs
+from routers import admin_import
 from routers import admin_media
 from routers import admin_orders
 from routers import admin_schedule
 
 router = APIRouter(prefix="/admin", tags=["admin"])
-importer_service = ImporterService()
 router.include_router(admin_docs.router)
+router.include_router(admin_import.router)
 router.include_router(admin_media.router)
 router.include_router(admin_orders.router)
 router.include_router(admin_schedule.router)
@@ -26,55 +25,3 @@ async def get_dashboard_stats(
     from services.analytics_service import AnalyticsService
     async with async_session_maker() as session:
         return await AnalyticsService.get_dashboard_stats(session)
-
-@router.post("/import_onliner")
-async def import_process(
-    request: Request,
-    username: str = Depends(get_current_username)
-):
-    form = await request.form()
-    raw_urls = form.get("url", "")
-    with_related = bool(form.get("with_related"))
-    
-    # Split by newlines, remove \r, and filter empty
-    urls = [u.strip().replace('\r', '') for u in str(raw_urls).splitlines() if u.strip()]
-    
-    if not urls:
-        return RedirectResponse(url="/admin/product/list", status_code=303)
-        
-    try:
-        results = await importer_service.import_products_bulk(urls, with_related=with_related)
-        success_count = len(results["success"])
-        error_count = len(results["errors"])
-        
-        if success_count == 1 and error_count == 0:
-            msg = f"Product imported successfully!"
-        else:
-            msg = f"Import complete: {success_count} success, {error_count} errors."
-            
-        if error_count > 0:
-            msg += " Check logs for details."
-        
-        return RedirectResponse(
-            url=f"/admin/product/list?msg={msg}&type=success",
-            status_code=303
-        )
-    except Exception as e:
-        print(f"Import error: {e}")
-        return RedirectResponse(
-            url=f"/admin/product/list?msg=Error: {str(e)}&type=danger", 
-            status_code=303
-        )
-
-@router.post("/update_sync_mode")
-async def update_sync_mode(
-    request: Request,
-    username: str = Depends(get_current_username)
-):
-    form = await request.form()
-    new_mode = form.get("mode")
-    if new_mode is not None:
-        from services.config_service import ConfigService
-        await ConfigService.set_config("sync_mode", str(new_mode))
-            
-    return RedirectResponse(url="/admin/", status_code=303)

--- a/routers/admin_import.py
+++ b/routers/admin_import.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import RedirectResponse
+
+from core.security import get_current_username
+from services.importer_service import ImporterService
+
+
+router = APIRouter(tags=["admin-import"])
+importer_service = ImporterService()
+
+
+@router.post("/import_onliner")
+async def import_process(
+    request: Request,
+    username: str = Depends(get_current_username)
+):
+    form = await request.form()
+    raw_urls = form.get("url", "")
+    with_related = bool(form.get("with_related"))
+
+    urls = [url.strip().replace("\r", "") for url in str(raw_urls).splitlines() if url.strip()]
+    if not urls:
+        return RedirectResponse(url="/admin/product/list", status_code=303)
+
+    try:
+        results = await importer_service.import_products_bulk(urls, with_related=with_related)
+        success_count = len(results["success"])
+        error_count = len(results["errors"])
+
+        if success_count == 1 and error_count == 0:
+            msg = "Product imported successfully!"
+        else:
+            msg = f"Import complete: {success_count} success, {error_count} errors."
+        if error_count > 0:
+            msg += " Check logs for details."
+
+        return RedirectResponse(
+            url=f"/admin/product/list?msg={msg}&type=success",
+            status_code=303
+        )
+    except Exception as exc:
+        print(f"Import error: {exc}")
+        return RedirectResponse(
+            url=f"/admin/product/list?msg=Error: {str(exc)}&type=danger",
+            status_code=303
+        )
+
+
+@router.post("/update_sync_mode")
+async def update_sync_mode(
+    request: Request,
+    username: str = Depends(get_current_username)
+):
+    form = await request.form()
+    new_mode = form.get("mode")
+    if new_mode is not None:
+        from services.config_service import ConfigService
+        await ConfigService.set_config("sync_mode", str(new_mode))
+
+    return RedirectResponse(url="/admin/", status_code=303)


### PR DESCRIPTION
## Summary
- move import/sync admin endpoints from routers/admin.py to routers/admin_import.py
- extracted endpoints:
  - POST /admin/import_onliner
  - POST /admin/update_sync_mode
- keep routers/admin.py as aggregator by including admin_import router
- preserve endpoint paths and behavior

## Testing
- python3 -m py_compile routers/admin.py routers/admin_import.py routers/admin_docs.py routers/admin_media.py routers/admin_orders.py routers/admin_schedule.py
- docker compose exec -T app pytest -q