### PR TITLE
refactor: extract admin dashboard stats endpoint into dedicated router

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,6 +1,5 @@
-from fastapi import APIRouter, Request, Depends
-from core.database import async_session_maker
-from core.security import check_admin_session
+from fastapi import APIRouter
+from routers import admin_analytics
 from routers import admin_docs
 from routers import admin_import
 from routers import admin_media
@@ -8,20 +7,9 @@ from routers import admin_orders
 from routers import admin_schedule
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+router.include_router(admin_analytics.router)
 router.include_router(admin_docs.router)
 router.include_router(admin_import.router)
 router.include_router(admin_media.router)
 router.include_router(admin_orders.router)
 router.include_router(admin_schedule.router)
-
-@router.get("/stats")
-async def get_dashboard_stats(
-    request: Request,
-    authenticated: bool = Depends(check_admin_session)
-):
-    """
-    Dashboard stats endpoint - uses session-based auth (called from admin panel AJAX).
-    """
-    from services.analytics_service import AnalyticsService
-    async with async_session_maker() as session:
-        return await AnalyticsService.get_dashboard_stats(session)

--- a/routers/admin_analytics.py
+++ b/routers/admin_analytics.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends, Request
+
+from core.database import async_session_maker
+from core.security import check_admin_session
+
+
+router = APIRouter(tags=["admin-analytics"])
+
+
+@router.get("/stats")
+async def get_dashboard_stats(
+    request: Request,
+    authenticated: bool = Depends(check_admin_session),
+):
+    """
+    Dashboard stats endpoint - uses session-based auth (called from admin panel AJAX).
+    """
+    from services.analytics_service import AnalyticsService
+
+    async with async_session_maker() as session:
+        return await AnalyticsService.get_dashboard_stats(session)


### PR DESCRIPTION
## Summary
- move admin dashboard stats endpoint from routers/admin.py to routers/admin_analytics.py
- extracted endpoint:
  - GET /admin/stats
- keep routers/admin.py as aggregator by including admin_analytics router
- preserve endpoint path and behavior

## Testing
- python3 -m py_compile routers/admin.py routers/admin_analytics.py routers/admin_import.py routers/admin_docs.py routers/admin_media.py routers/admin_orders.py routers/admin_schedule.py
- docker compose exec -T app pytest -q