### PR TITLE
refactor: extract sentry init from main

### DIFF
--- a/core/app_observability.py
+++ b/core/app_observability.py
@@ -1,0 +1,13 @@
+import sentry_sdk
+
+from core.config import settings
+
+
+def init_sentry() -> None:
+    if settings.SENTRY_DSN:
+        sentry_sdk.init(
+            dsn=settings.SENTRY_DSN,
+            traces_sample_rate=1.0,
+            profiles_sample_rate=1.0,
+            environment=settings.ENVIRONMENT,
+        )

--- a/main.py
+++ b/main.py
@@ -4,19 +4,13 @@ from fastapi import FastAPI
 from admin.bootstrap import configure_sqladmin
 from core.app_http import configure_http
 from core.app_lifespan import app_lifespan
+from core.app_observability import init_sentry
 from core.app_static import mount_manager_assets, mount_static_and_media
 from core.database import engine
 from core.app_routing import register_app_routers
 from core.config import settings
-import sentry_sdk
 
-if settings.SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        traces_sample_rate=1.0,
-        profiles_sample_rate=1.0,
-        environment=settings.ENVIRONMENT
-    )
+init_sentry()
 
 from routers.manager_spa import create_manager_spa_router
 


### PR DESCRIPTION
## Summary
- move Sentry initialization from main.py to core/app_observability.py
- keep behavior unchanged via init_sentry() call in main.py

## Validation
- python3 -m py_compile main.py core/app_observability.py
- docker compose exec -T app pytest -q (45 passed)
