### PR TITLE
refactor: introduce app factory for main bootstrap

### DIFF
--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+
+from admin.bootstrap import configure_sqladmin
+from core.app_http import configure_http
+from core.app_lifespan import app_lifespan
+from core.app_observability import init_sentry
+from core.app_paths import get_base_dir, get_manager_dist
+from core.app_routing import register_app_routers
+from core.app_static import mount_manager_assets, mount_static_and_media
+from core.database import engine
+from core.config import settings
+from routers.manager_spa import create_manager_spa_router
+
+
+def create_app() -> FastAPI:
+    init_sentry()
+
+    base_dir = get_base_dir()
+    manager_dist = get_manager_dist(base_dir)
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    configure_http(app)
+    register_app_routers(app)
+    mount_static_and_media(app, base_dir)
+    mount_manager_assets(app, manager_dist)
+    app.include_router(create_manager_spa_router(manager_dist))
+
+    configure_sqladmin(
+        app=app,
+        engine=engine,
+        base_dir=base_dir,
+        secret_key=settings.SECRET_KEY,
+    )
+
+    return app

--- a/core/app_paths.py
+++ b/core/app_paths.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def get_base_dir() -> str:
+    return str(Path(__file__).resolve().parent.parent)
+
+
+def get_manager_dist(base_dir: str) -> str:
+    return str(Path(base_dir) / "manager_frontend" / "dist")

--- a/main.py
+++ b/main.py
@@ -1,40 +1,4 @@
-import os
-from fastapi import FastAPI
+from core.app_factory import create_app
 
-from admin.bootstrap import configure_sqladmin
-from core.app_http import configure_http
-from core.app_lifespan import app_lifespan
-from core.app_observability import init_sentry
-from core.app_static import mount_manager_assets, mount_static_and_media
-from core.database import engine
-from core.app_routing import register_app_routers
-from core.config import settings
 
-init_sentry()
-
-from routers.manager_spa import create_manager_spa_router
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-app = FastAPI(lifespan=app_lifespan)
-
-# --- MIDDLEWARE & ERROR HANDLING ---
-configure_http(app)
-
-# Include routers
-register_app_routers(app)
-
-# Static files
-mount_static_and_media(app, BASE_DIR)
-
-# Manager Dashboard SPA
-# 1. Mount assets explicitly to bypass the catch-all
-manager_dist = os.path.join(BASE_DIR, "manager_frontend", "dist")
-
-mount_manager_assets(app, manager_dist)
-
-# 2. Catch-all + root routes for manager SPA
-app.include_router(create_manager_spa_router(manager_dist))
-
-# Setup SQLAdmin with authentication
-configure_sqladmin(app=app, engine=engine, base_dir=BASE_DIR, secret_key=settings.SECRET_KEY)
+app = create_app()


### PR DESCRIPTION
## Summary
- introduce core/app_factory.py with create_app() to wire app bootstrap in one place
- introduce core/app_paths.py for base and manager dist path helpers
- simplify main.py to a minimal entrypoint: `app = create_app()`

## Validation
- python3 -m py_compile main.py core/app_factory.py core/app_paths.py
- docker compose exec -T app pytest -q (45 passed)
