### PR TITLE
refactor: standardize app path handling with pathlib

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from fastapi import FastAPI
 from sqladmin import Admin
@@ -9,11 +9,13 @@ from core.security import AdminAuthBackend
 
 
 def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: str, secret_key: str) -> Admin:
+    templates_dir = Path(base_dir) / "templates"
+
     admin = Admin(
         app,
         engine,
         title="AirCon Admin",
-        templates_dir=os.path.join(base_dir, "templates"),
+        templates_dir=str(templates_dir),
         authentication_backend=AdminAuthBackend(secret_key=secret_key),
     )
 

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from pathlib import Path
 
 from admin.bootstrap import configure_sqladmin
 from core.app_http import configure_http
@@ -15,8 +16,8 @@ from routers.manager_spa import create_manager_spa_router
 def create_app() -> FastAPI:
     init_sentry()
 
-    base_dir = get_base_dir()
-    manager_dist = get_manager_dist(base_dir)
+    base_dir: Path = get_base_dir()
+    manager_dist: Path = get_manager_dist(base_dir)
 
     app = FastAPI(lifespan=app_lifespan)
 
@@ -24,12 +25,12 @@ def create_app() -> FastAPI:
     register_app_routers(app)
     mount_static_and_media(app, base_dir)
     mount_manager_assets(app, manager_dist)
-    app.include_router(create_manager_spa_router(manager_dist))
+    app.include_router(create_manager_spa_router(str(manager_dist)))
 
     configure_sqladmin(
         app=app,
         engine=engine,
-        base_dir=base_dir,
+        base_dir=str(base_dir),
         secret_key=settings.SECRET_KEY,
     )
 

--- a/core/app_paths.py
+++ b/core/app_paths.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 
-def get_base_dir() -> str:
-    return str(Path(__file__).resolve().parent.parent)
+def get_base_dir() -> Path:
+    return Path(__file__).resolve().parent.parent
 
 
-def get_manager_dist(base_dir: str) -> str:
-    return str(Path(base_dir) / "manager_frontend" / "dist")
+def get_manager_dist(base_dir: Path) -> Path:
+    return base_dir / "manager_frontend" / "dist"

--- a/core/app_static.py
+++ b/core/app_static.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -7,26 +7,26 @@ from core.config import settings
 from core.logger import logger
 
 
-def mount_static_and_media(app: FastAPI, base_dir: str) -> None:
+def mount_static_and_media(app: FastAPI, base_dir: Path) -> None:
     app.mount(
         f"/{settings.STATIC_DIR}",
-        StaticFiles(directory=os.path.join(base_dir, settings.STATIC_DIR)),
+        StaticFiles(directory=base_dir / settings.STATIC_DIR),
         name="static",
     )
 
-    media_dir = os.path.join(base_dir, "media")
-    if not os.path.exists(media_dir):
-        os.makedirs(media_dir, exist_ok=True)
+    media_dir = base_dir / "media"
+    if not media_dir.exists():
+        media_dir.mkdir(parents=True, exist_ok=True)
     app.mount("/media", StaticFiles(directory=media_dir), name="media")
 
 
-def mount_manager_assets(app: FastAPI, manager_dist: str) -> None:
-    logger.info(f"Manager Dist Path: {manager_dist}, Exists: {os.path.exists(manager_dist)}")
+def mount_manager_assets(app: FastAPI, manager_dist: Path) -> None:
+    logger.info(f"Manager Dist Path: {manager_dist}, Exists: {manager_dist.exists()}")
 
-    if os.path.exists(manager_dist):
+    if manager_dist.exists():
         app.mount(
             "/manager/assets",
-            StaticFiles(directory=os.path.join(manager_dist, "assets")),
+            StaticFiles(directory=manager_dist / "assets"),
             name="manager_assets",
         )
     else:

--- a/routers/manager_spa.py
+++ b/routers/manager_spa.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from fastapi import APIRouter
 from fastapi.responses import FileResponse, JSONResponse
@@ -6,19 +6,20 @@ from fastapi.responses import FileResponse, JSONResponse
 
 def create_manager_spa_router(manager_dist: str) -> APIRouter:
     router = APIRouter()
+    manager_dist_path = Path(manager_dist)
+    index_path = manager_dist_path / "index.html"
+
+    def _render_index_or_404():
+        if index_path.exists():
+            return FileResponse(str(index_path))
+        return JSONResponse(status_code=404, content={"message": "Dashboard not built"})
 
     @router.get("/manager/{full_path:path}")
     async def serve_manager_app(full_path: str):
-        index_path = os.path.join(manager_dist, "index.html")
-        if os.path.exists(index_path):
-            return FileResponse(index_path)
-        return JSONResponse(status_code=404, content={"message": "Dashboard not built"})
+        return _render_index_or_404()
 
     @router.get("/manager", include_in_schema=False)
     async def serve_manager_root():
-        index_path = os.path.join(manager_dist, "index.html")
-        if os.path.exists(index_path):
-            return FileResponse(index_path)
-        return JSONResponse(status_code=404, content={"message": "Dashboard not built"})
+        return _render_index_or_404()
 
     return router


### PR DESCRIPTION
## Summary
- switch app bootstrap path handling to pathlib in core/app_paths.py and core/app_static.py
- keep app_factory wiring unchanged while passing normalized paths
- refactor routers/manager_spa.py to reuse one helper for index-or-404 rendering
- simplify admin/bootstrap.py templates path construction via pathlib

## Validation
- python3 -m py_compile core/app_paths.py core/app_factory.py core/app_static.py admin/bootstrap.py routers/manager_spa.py main.py
- docker compose exec -T app pytest -q (45 passed)
