### PR TITLE
refactor: align bootstrap interfaces to pathlib Path

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -8,8 +8,8 @@ from admin import admin_views
 from core.security import AdminAuthBackend
 
 
-def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: str, secret_key: str) -> Admin:
-    templates_dir = Path(base_dir) / "templates"
+def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: Path, secret_key: str) -> Admin:
+    templates_dir = base_dir / "templates"
 
     admin = Admin(
         app,

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -25,12 +25,12 @@ def create_app() -> FastAPI:
     register_app_routers(app)
     mount_static_and_media(app, base_dir)
     mount_manager_assets(app, manager_dist)
-    app.include_router(create_manager_spa_router(str(manager_dist)))
+    app.include_router(create_manager_spa_router(manager_dist))
 
     configure_sqladmin(
         app=app,
         engine=engine,
-        base_dir=str(base_dir),
+        base_dir=base_dir,
         secret_key=settings.SECRET_KEY,
     )
 

--- a/routers/manager_spa.py
+++ b/routers/manager_spa.py
@@ -4,10 +4,9 @@ from fastapi import APIRouter
 from fastapi.responses import FileResponse, JSONResponse
 
 
-def create_manager_spa_router(manager_dist: str) -> APIRouter:
+def create_manager_spa_router(manager_dist: Path) -> APIRouter:
     router = APIRouter()
-    manager_dist_path = Path(manager_dist)
-    index_path = manager_dist_path / "index.html"
+    index_path = manager_dist / "index.html"
 
     def _render_index_or_404():
         if index_path.exists():


### PR DESCRIPTION
## Summary
- align bootstrap interfaces to use pathlib `Path` where path objects are passed around
- update `admin/bootstrap.py` to accept `base_dir: Path`
- update `routers/manager_spa.py` to accept `manager_dist: Path`
- remove redundant str conversion in `core/app_factory.py`

## Validation
- python3 -m py_compile core/app_factory.py admin/bootstrap.py routers/manager_spa.py main.py
- docker compose exec -T app pytest -q (45 passed)
