### PR TITLE
refactor: extract manager SPA bootstrap wiring

### DIFF
--- a/core/app_constants.py
+++ b/core/app_constants.py
@@ -1,0 +1,3 @@
+MANAGER_ASSETS_ROUTE = "/manager/assets"
+MANAGER_ASSETS_DIRNAME = "assets"
+MANAGER_NOT_BUILT_MESSAGE = "Dashboard not built"

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from admin.bootstrap import configure_sqladmin
 from core.app_http import configure_http
 from core.app_lifespan import app_lifespan
+from core.app_manager import setup_manager_spa
 from core.app_observability import init_sentry
 from core.app_paths import get_base_dir, get_manager_dist
 from core.app_routing import register_app_routers
-from core.app_static import mount_manager_assets, mount_static_and_media
+from core.app_static import mount_static_and_media
 from core.database import engine
 from core.config import settings
-from routers.manager_spa import create_manager_spa_router
 
 
 def create_app() -> FastAPI:
@@ -24,8 +24,7 @@ def create_app() -> FastAPI:
     configure_http(app)
     register_app_routers(app)
     mount_static_and_media(app, base_dir)
-    mount_manager_assets(app, manager_dist)
-    app.include_router(create_manager_spa_router(manager_dist))
+    setup_manager_spa(app, manager_dist)
 
     configure_sqladmin(
         app=app,

--- a/core/app_manager.py
+++ b/core/app_manager.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from core.app_static import mount_manager_assets
+from routers.manager_spa import create_manager_spa_router
+
+
+def setup_manager_spa(app: FastAPI, manager_dist: Path) -> None:
+    mount_manager_assets(app, manager_dist)
+    app.include_router(create_manager_spa_router(manager_dist))

--- a/core/app_static.py
+++ b/core/app_static.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
+from core.app_constants import MANAGER_ASSETS_DIRNAME, MANAGER_ASSETS_ROUTE
 from core.config import settings
 from core.logger import logger
 
@@ -25,8 +26,8 @@ def mount_manager_assets(app: FastAPI, manager_dist: Path) -> None:
 
     if manager_dist.exists():
         app.mount(
-            "/manager/assets",
-            StaticFiles(directory=manager_dist / "assets"),
+            MANAGER_ASSETS_ROUTE,
+            StaticFiles(directory=manager_dist / MANAGER_ASSETS_DIRNAME),
             name="manager_assets",
         )
     else:

--- a/routers/manager_spa.py
+++ b/routers/manager_spa.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from fastapi import APIRouter
 from fastapi.responses import FileResponse, JSONResponse
 
+from core.app_constants import MANAGER_NOT_BUILT_MESSAGE
+
 
 def create_manager_spa_router(manager_dist: Path) -> APIRouter:
     router = APIRouter()
@@ -11,7 +13,7 @@ def create_manager_spa_router(manager_dist: Path) -> APIRouter:
     def _render_index_or_404():
         if index_path.exists():
             return FileResponse(str(index_path))
-        return JSONResponse(status_code=404, content={"message": "Dashboard not built"})
+        return JSONResponse(status_code=404, content={"message": MANAGER_NOT_BUILT_MESSAGE})
 
     @router.get("/manager/{full_path:path}")
     async def serve_manager_app(full_path: str):


### PR DESCRIPTION
## Summary
- extract manager SPA bootstrap wiring into `core/app_manager.py`
- add `core/app_constants.py` for manager assets route/dirname and not-built message
- update `core/app_factory.py` to use `setup_manager_spa(...)`
- update `core/app_static.py` and `routers/manager_spa.py` to consume shared constants

## Validation
- python3 -m py_compile core/app_factory.py core/app_manager.py core/app_constants.py core/app_static.py routers/manager_spa.py main.py
- docker compose exec -T app pytest -q (45 passed)
