### PR TITLE
refactor: structure app factory bootstrap steps

### DIFF
--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -5,6 +5,7 @@ from sqladmin import Admin
 from sqlalchemy.engine import Engine
 
 from admin import admin_views
+from core.app_constants import ADMIN_TITLE
 from core.security import AdminAuthBackend
 
 
@@ -14,7 +15,7 @@ def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: Path, secret_key:
     admin = Admin(
         app,
         engine,
-        title="AirCon Admin",
+        title=ADMIN_TITLE,
         templates_dir=str(templates_dir),
         authentication_backend=AdminAuthBackend(secret_key=secret_key),
     )

--- a/core/app_constants.py
+++ b/core/app_constants.py
@@ -1,3 +1,5 @@
+ADMIN_TITLE = "AirCon Admin"
+
 MANAGER_ASSETS_ROUTE = "/manager/assets"
 MANAGER_ASSETS_DIRNAME = "assets"
 MANAGER_NOT_BUILT_MESSAGE = "Dashboard not built"

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -1,36 +1,39 @@
 from fastapi import FastAPI
-from pathlib import Path
 
 from admin.bootstrap import configure_sqladmin
 from core.app_http import configure_http
 from core.app_lifespan import app_lifespan
 from core.app_manager import setup_manager_spa
 from core.app_observability import init_sentry
-from core.app_paths import get_base_dir, get_manager_dist
+from core.app_paths import AppPaths, get_app_paths
 from core.app_routing import register_app_routers
 from core.app_static import mount_static_and_media
 from core.database import engine
 from core.config import settings
 
 
-def create_app() -> FastAPI:
-    init_sentry()
-
-    base_dir: Path = get_base_dir()
-    manager_dist: Path = get_manager_dist(base_dir)
-
-    app = FastAPI(lifespan=app_lifespan)
-
+def _configure_app_layers(app: FastAPI, paths: AppPaths) -> None:
     configure_http(app)
     register_app_routers(app)
-    mount_static_and_media(app, base_dir)
-    setup_manager_spa(app, manager_dist)
+    mount_static_and_media(app, paths.base_dir)
+    setup_manager_spa(app, paths.manager_dist)
 
+
+def _configure_admin(app: FastAPI, paths: AppPaths) -> None:
     configure_sqladmin(
         app=app,
         engine=engine,
-        base_dir=base_dir,
+        base_dir=paths.base_dir,
         secret_key=settings.SECRET_KEY,
     )
+
+
+def create_app() -> FastAPI:
+    init_sentry()
+
+    paths = get_app_paths()
+    app = FastAPI(lifespan=app_lifespan)
+    _configure_app_layers(app, paths)
+    _configure_admin(app, paths)
 
     return app

--- a/core/app_paths.py
+++ b/core/app_paths.py
@@ -1,4 +1,11 @@
 from pathlib import Path
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AppPaths:
+    base_dir: Path
+    manager_dist: Path
 
 
 def get_base_dir() -> Path:
@@ -7,3 +14,8 @@ def get_base_dir() -> Path:
 
 def get_manager_dist(base_dir: Path) -> Path:
     return base_dir / "manager_frontend" / "dist"
+
+
+def get_app_paths() -> AppPaths:
+    base_dir = get_base_dir()
+    return AppPaths(base_dir=base_dir, manager_dist=get_manager_dist(base_dir))


### PR DESCRIPTION
## Summary
- add `AppPaths` dataclass and `get_app_paths()` in `core/app_paths.py`
- split bootstrap flow in `core/app_factory.py` into focused internal steps (`_configure_app_layers`, `_configure_admin`)
- centralize admin title into `core/app_constants.py` and consume it in `admin/bootstrap.py`

## Validation
- python3 -m py_compile core/app_paths.py core/app_factory.py core/app_constants.py admin/bootstrap.py main.py
- docker compose exec -T app pytest -q (45 passed)
