### PR TITLE
refactor: tidy admin bootstrap and tag formatter helpers

### DIFF
--- a/admin/base.py
+++ b/admin/base.py
@@ -1,27 +1,33 @@
 from markupsafe import Markup
 from models import Tag
 
+
+def _resolve_tags(model) -> list[Tag]:
+    if isinstance(model, Tag):
+        return [model]
+    return model.tags if hasattr(model, "tags") else []
+
+
 def format_tags_shared(model, context, hide_group: bool = False):
     """Shared formatter for Tag badges"""
-    html = ""
-    # Support both direct tag list and models with .tags
-    tags = model.tags if hasattr(model, "tags") else []
-    if not tags and isinstance(model, Tag):
-        tags = [model]
-        
+    badges: list[str] = []
+    tags = _resolve_tags(model)
+
     for tag in tags:
         color = "secondary"
         if tag.group:
             color = tag.group.color
-        
+
         # If tag is not public, use an outlined/muted style
         opacity = "1" if tag.is_public else "0.5"
         border = "1px solid #ccc" if not tag.is_public else "none"
-        
+
         # Include group name in small text if available, unless hidden
         group_prefix = ""
         if not hide_group and tag.group:
             group_prefix = f'<small style="opacity: 0.7;">{tag.group.title}:</small> '
-        
-        html += f'<span class="badge bg-{color}" style="margin-right: 5px; opacity: {opacity}; border: {border};">{group_prefix}{tag.title}</span>'
-    return Markup(html)
+
+        badges.append(
+            f'<span class="badge bg-{color}" style="margin-right: 5px; opacity: {opacity}; border: {border};">{group_prefix}{tag.title}</span>'
+        )
+    return Markup("".join(badges))

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -1,18 +1,18 @@
 from pathlib import Path
+from typing import Iterable
 
 from fastapi import FastAPI
 from sqladmin import Admin
 from sqlalchemy.engine import Engine
+from sqladmin.models import ModelView
 
 from admin import admin_views
 from core.app_constants import ADMIN_TITLE
 from core.security import AdminAuthBackend
 
 
-def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: Path, secret_key: str) -> Admin:
-    templates_dir = base_dir / "templates"
-
-    admin = Admin(
+def _create_admin(app: FastAPI, engine: Engine, templates_dir: Path, secret_key: str) -> Admin:
+    return Admin(
         app,
         engine,
         title=ADMIN_TITLE,
@@ -20,7 +20,15 @@ def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: Path, secret_key:
         authentication_backend=AdminAuthBackend(secret_key=secret_key),
     )
 
-    for view in admin_views:
+
+def _register_admin_views(admin: Admin, views: Iterable[type[ModelView]]) -> None:
+    for view in views:
         admin.add_view(view)
+
+
+def configure_sqladmin(app: FastAPI, engine: Engine, base_dir: Path, secret_key: str) -> Admin:
+    templates_dir = base_dir / "templates"
+    admin = _create_admin(app, engine, templates_dir, secret_key)
+    _register_admin_views(admin, admin_views)
 
     return admin

--- a/admin/config.py
+++ b/admin/config.py
@@ -1,16 +1,17 @@
 from sqladmin import ModelView
 from models import GlobalConfig
 
+
 class GlobalConfigAdmin(ModelView, model=GlobalConfig):
     name = "Настройка"
     name_plural = "Настройки сайта"
     icon = "fa-solid fa-gears"
-    
+
     column_list = [GlobalConfig.key, GlobalConfig.value, GlobalConfig.description]
     column_labels = {
         "key": "Ключ (код)",
         "value": "Значение",
-        "description": "Описание"
+        "description": "Описание",
     }
-    
+
     form_columns = [GlobalConfig.key, GlobalConfig.value, GlobalConfig.description]


### PR DESCRIPTION
## Summary
- split admin bootstrap into focused helpers in `admin/bootstrap.py`:
  - `_create_admin(...)`
  - `_register_admin_views(...)`
- refactor `admin/base.py` tag rendering with `_resolve_tags(...)` and list-join output building
- apply small style cleanup in `admin/config.py` (no behavior changes)

## Validation
- python3 -m py_compile admin/bootstrap.py admin/base.py admin/config.py main.py
- docker compose exec -T app pytest -q (45 passed)
