### PR TITLE
refactor: streamline core app bootstrap helpers

### DIFF
--- a/core/app_constants.py
+++ b/core/app_constants.py
@@ -1,5 +1,9 @@
 ADMIN_TITLE = "AirCon Admin"
 
+ADMIN_ROUTE_PREFIX = "/admin"
+INTERNAL_SERVER_ERROR_TITLE = "Internal Server Error"
+INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error"
+
 MANAGER_ASSETS_ROUTE = "/manager/assets"
 MANAGER_ASSETS_DIRNAME = "assets"
 MANAGER_NOT_BUILT_MESSAGE = "Dashboard not built"

--- a/core/app_http.py
+++ b/core/app_http.py
@@ -4,23 +4,40 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.sessions import SessionMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
+from core.app_constants import (
+    ADMIN_ROUTE_PREFIX,
+    INTERNAL_SERVER_ERROR_MESSAGE,
+    INTERNAL_SERVER_ERROR_TITLE,
+)
 from core.config import settings
 from core.logger import logger
+
+
+def _is_admin_path(path: str) -> bool:
+    return path.startswith(ADMIN_ROUTE_PREFIX)
+
+
+def _admin_error_response(detail: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content={"error": INTERNAL_SERVER_ERROR_TITLE, "detail": detail},
+    )
+
+
+def _public_error_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content={"message": INTERNAL_SERVER_ERROR_MESSAGE},
+    )
 
 
 async def global_exception_handler(request: Request, exc: Exception):
     logger.exception(f"Unhandled exception at {request.url}: {exc}")
 
-    if str(request.url.path).startswith("/admin"):
-        return JSONResponse(
-            status_code=500,
-            content={"error": "Internal Server Error", "detail": str(exc)},
-        )
+    if _is_admin_path(str(request.url.path)):
+        return _admin_error_response(str(exc))
 
-    return JSONResponse(
-        status_code=500,
-        content={"message": "Internal server error"},
-    )
+    return _public_error_response()
 
 
 def configure_http(app: FastAPI) -> None:

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -8,22 +8,28 @@ from core.database import async_session_maker, init_db
 from core.logger import logger
 
 
-@asynccontextmanager
-async def app_lifespan(app: FastAPI):
-    logger.info("Starting Application...")
-
-    await init_db()
-
+async def _seed_installation_defaults() -> None:
     from services.installation_service import InstallationService
 
     async with async_session_maker() as session:
         await InstallationService.seed_defaults(session)
 
+
+def _start_scheduler_loop() -> None:
     from services.scheduler_service import scheduler_service
 
     asyncio.create_task(
         scheduler_service.start_loop(interval_hours=settings.SCHEDULER_INTERVAL)
     )
+
+
+@asynccontextmanager
+async def app_lifespan(app: FastAPI):
+    logger.info("Starting Application...")
+
+    await init_db()
+    await _seed_installation_defaults()
+    _start_scheduler_loop()
 
     yield
 

--- a/core/app_routing.py
+++ b/core/app_routing.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 
 from routers import admin as admin_router
 from routers import api as api_router
@@ -6,10 +6,15 @@ from routers import auth as auth_router
 from routers import manager as manager_router
 from routers import system as system_router
 
+APP_ROUTERS: tuple[APIRouter, ...] = (
+    admin_router.router,
+    auth_router.router,
+    api_router.router,
+    manager_router.router,
+    system_router.router,
+)
+
 
 def register_app_routers(app: FastAPI) -> None:
-    app.include_router(admin_router.router)
-    app.include_router(auth_router.router)
-    app.include_router(api_router.router)
-    app.include_router(manager_router.router)
-    app.include_router(system_router.router)
+    for router in APP_ROUTERS:
+        app.include_router(router)


### PR DESCRIPTION
## Summary
- refactor `core/app_http.py` with small internal helpers for admin/public 500 responses
- move generic error strings and admin route prefix into `core/app_constants.py`
- refactor `core/app_lifespan.py` startup flow into focused helpers
- simplify `core/app_routing.py` via `APP_ROUTERS` tuple + loop

## Validation
- python3 -m py_compile core/app_constants.py core/app_http.py core/app_lifespan.py core/app_routing.py main.py
- docker compose exec -T app pytest -q (45 passed)
