### PR TITLE
refactor: split admin view registry and config constants

### DIFF
--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -9,23 +9,4 @@ from .calendar import CalendarAdmin
 from .google_auth import GoogleAuthView
 
 from .config import GlobalConfigAdmin
-
-# Export all views for easy registration in main.py
-admin_views = [
-    KanbanView,
-    CalendarAdmin,
-    OrderAdmin,
-    ProductAdmin,
-    ServiceAdmin,
-    CustomerAdmin,
-    ArticleAdmin,
-    TagAdmin,
-    TagGroupAdmin,
-    OrderProductLinkAdmin,
-    OrderServiceLinkAdmin,
-    BulkTagsView,
-    GoogleAuthView, # Settings (Bottom)
-    InstallerAdmin,
-    GlobalConfigAdmin,
-    InstallationRateAdmin
-]
+from .registry import admin_views

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -6,7 +6,7 @@ from sqladmin import Admin
 from sqlalchemy.engine import Engine
 from sqladmin.models import ModelView
 
-from admin import admin_views
+from admin.registry import admin_views
 from core.app_constants import ADMIN_TITLE
 from core.security import AdminAuthBackend
 

--- a/admin/config.py
+++ b/admin/config.py
@@ -1,17 +1,20 @@
 from sqladmin import ModelView
 from models import GlobalConfig
 
+from admin.view_constants import (
+    GLOBAL_CONFIG_COLUMN_LABELS,
+    GLOBAL_CONFIG_ICON,
+    GLOBAL_CONFIG_NAME,
+    GLOBAL_CONFIG_NAME_PLURAL,
+)
+
 
 class GlobalConfigAdmin(ModelView, model=GlobalConfig):
-    name = "Настройка"
-    name_plural = "Настройки сайта"
-    icon = "fa-solid fa-gears"
+    name = GLOBAL_CONFIG_NAME
+    name_plural = GLOBAL_CONFIG_NAME_PLURAL
+    icon = GLOBAL_CONFIG_ICON
 
     column_list = [GlobalConfig.key, GlobalConfig.value, GlobalConfig.description]
-    column_labels = {
-        "key": "Ключ (код)",
-        "value": "Значение",
-        "description": "Описание",
-    }
+    column_labels = GLOBAL_CONFIG_COLUMN_LABELS
 
     form_columns = [GlobalConfig.key, GlobalConfig.value, GlobalConfig.description]

--- a/admin/registry.py
+++ b/admin/registry.py
@@ -1,0 +1,28 @@
+from .calendar import CalendarAdmin
+from .catalog import BulkTagsView, InstallationRateAdmin, ProductAdmin, TagAdmin, TagGroupAdmin
+from .config import GlobalConfigAdmin
+from .content import ArticleAdmin
+from .customers import CustomerAdmin
+from .google_auth import GoogleAuthView
+from .installers import InstallerAdmin
+from .kanban import KanbanView
+from .orders import OrderAdmin, OrderProductLinkAdmin, OrderServiceLinkAdmin, ServiceAdmin
+
+admin_views = [
+    KanbanView,
+    CalendarAdmin,
+    OrderAdmin,
+    ProductAdmin,
+    ServiceAdmin,
+    CustomerAdmin,
+    ArticleAdmin,
+    TagAdmin,
+    TagGroupAdmin,
+    OrderProductLinkAdmin,
+    OrderServiceLinkAdmin,
+    BulkTagsView,
+    GoogleAuthView,
+    InstallerAdmin,
+    GlobalConfigAdmin,
+    InstallationRateAdmin,
+]

--- a/admin/view_constants.py
+++ b/admin/view_constants.py
@@ -1,0 +1,9 @@
+GLOBAL_CONFIG_NAME = "Настройка"
+GLOBAL_CONFIG_NAME_PLURAL = "Настройки сайта"
+GLOBAL_CONFIG_ICON = "fa-solid fa-gears"
+
+GLOBAL_CONFIG_COLUMN_LABELS = {
+    "key": "Ключ (код)",
+    "value": "Значение",
+    "description": "Описание",
+}


### PR DESCRIPTION
## Summary
- extract SQLAdmin view list into `admin/registry.py`
- keep `admin/__init__.py` as a light re-export + `admin_views` import
- update `admin/bootstrap.py` to import `admin_views` from registry
- extract `GlobalConfigAdmin` UI text/labels into `admin/view_constants.py`

## Validation
- python3 -m py_compile admin/__init__.py admin/registry.py admin/bootstrap.py admin/config.py admin/view_constants.py main.py
- docker compose exec -T app pytest -q (45 passed)
