### PR TITLE
chore: enforce manager-first policy and legacy admin guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,11 @@
   - [ ] Main user flow verified
   - [ ] No visible regressions in touched areas
 
+## Legacy Admin Check
+
+- [ ] This PR changes `admin/*` (legacy SQLAdmin)
+- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)
+
 ## Deployment Notes
 
 - [ ] No special deploy steps
@@ -40,4 +45,3 @@ If special steps required, describe exact commands:
 - Rollback plan:
 
 ## Screenshots / Logs (optional)
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ This file defines practical workflows and commands for contributors and coding a
   - persistence access belongs in `crud/`.
 - Reuse existing normalization logic in `services/spec_normalizer.py` instead of duplicating key/value cleanup.
 - Prefer small, targeted changes and run relevant tests/scripts before handoff.
+- Manager-first policy:
+  - New product functionality must be implemented in `manager_frontend/` + `routers/manager_*`.
+  - Legacy SQLAdmin (`admin/`) is compatibility-only: bugfixes, regressions, and required maintenance.
+  - Do not introduce net-new business features in legacy admin unless explicitly approved.
 
 ## Commands
 
@@ -106,6 +110,10 @@ Use this after large catalog imports or when unknown spec keys appear.
    - update backend schemas/routes,
    - refresh typed client with `npm run gen:api` in `manager_frontend/`,
    - verify photo/spec bulk-edit flows end-to-end.
+5. Legacy admin freeze:
+   - keep SQLAdmin routes/views working for existing operations,
+   - avoid adding new user workflows there,
+   - route new UX requirements to manager views first.
 
 ### 5) Leads Funnel Workflow
 

--- a/admin/bootstrap.py
+++ b/admin/bootstrap.py
@@ -10,6 +10,9 @@ from admin.registry import admin_views
 from core.app_constants import ADMIN_TITLE
 from core.security import AdminAuthBackend
 
+# Legacy compatibility note:
+# SQLAdmin is retained for backward-compatible operations only.
+# New product workflows should be implemented in manager routes/UI first.
 
 def _create_admin(app: FastAPI, engine: Engine, templates_dir: Path, secret_key: str) -> Admin:
     return Admin(

--- a/admin/registry.py
+++ b/admin/registry.py
@@ -8,6 +8,10 @@ from .installers import InstallerAdmin
 from .kanban import KanbanView
 from .orders import OrderAdmin, OrderProductLinkAdmin, OrderServiceLinkAdmin, ServiceAdmin
 
+# Legacy compatibility note:
+# Keep this registry focused on existing SQLAdmin capabilities.
+# New feature development should target manager views/routes.
+
 admin_views = [
     KanbanView,
     CalendarAdmin,

--- a/docs/process.md
+++ b/docs/process.md
@@ -8,6 +8,18 @@
 
 - `docs/git-workflow.md`
 
+## Manager-first policy (active)
+
+1. Main product development target:
+   - `manager_frontend/` + `routers/manager_*`.
+2. Legacy SQLAdmin target:
+   - compatibility and maintenance only.
+   - allowed: bugfixes, regressions, required compat updates.
+   - disallowed by default: net-new product workflows/features.
+3. Any PR touching `admin/*` must include justification:
+   - why legacy change is required now,
+   - why this is not implemented in manager flow.
+
 ## API-роутеры после декомпозиции
 
 Основной входной модуль API: `routers/api.py` (компоновщик).


### PR DESCRIPTION
## Summary
- codify manager-first / frozen-legacy policy in `AGENTS.md`
- add explicit policy section to `docs/process.md`
- add legacy compatibility guardrail comments in `admin/bootstrap.py` and `admin/registry.py`
- extend PR template with legacy-admin justification checklist

## Validation
- python3 -m py_compile admin/bootstrap.py admin/registry.py main.py
- docker compose exec -T app pytest -q (45 passed)
