### PR TITLE
refactor: split content models into dedicated module

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,6 +9,7 @@ from .common import (
 )
 from .customer import Customer, Lead
 from .cart import Cart, CartItem
+from .content import Article, GlobalConfig
 from .order import (
     Installer,
     Order,
@@ -19,9 +20,7 @@ from .order import (
     Service,
 )
 from .product import (
-    Article,
     Favorite,
-    GlobalConfig,
     InstallationRate,
     Product,
     ProductImage,

--- a/models/content.py
+++ b/models/content.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Article(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    slug: str = Field(unique=True, index=True)
+    content: str
+    main_image: Optional[str] = None
+    cover_image: Optional[str] = None
+    is_published: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    @property
+    def main_image_file(self) -> Any:
+        return getattr(self, "_temp_main_image_file", None)
+
+    @main_image_file.setter
+    def main_image_file(self, value: Any):
+        self._temp_main_image_file = value
+
+    @property
+    def cover_image_file(self) -> Any:
+        return getattr(self, "_temp_cover_image_file", None)
+
+    @cover_image_file.setter
+    def cover_image_file(self, value: Any):
+        self._temp_cover_image_file = value
+
+    def __str__(self):
+        return self.title
+
+
+class GlobalConfig(SQLModel, table=True):
+    __tablename__ = "global_config"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    key: str = Field(unique=True, index=True)
+    value: str
+    description: Optional[str] = None
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    def __str__(self):
+        return f"{self.key}: {self.value}"

--- a/models/product.py
+++ b/models/product.py
@@ -110,36 +110,6 @@ class ProductImage(SQLModel, table=True):
         return f"{photo_type} photo for product #{self.product_id}"
 
 
-class Article(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    title: str
-    slug: str = Field(unique=True, index=True)
-    content: str
-    main_image: Optional[str] = None
-    cover_image: Optional[str] = None
-    is_published: bool = Field(default=True)
-    created_at: datetime = Field(default_factory=datetime.now)
-
-    @property
-    def main_image_file(self) -> Any:
-        return getattr(self, "_temp_main_image_file", None)
-
-    @main_image_file.setter
-    def main_image_file(self, value: Any):
-        self._temp_main_image_file = value
-
-    @property
-    def cover_image_file(self) -> Any:
-        return getattr(self, "_temp_cover_image_file", None)
-
-    @cover_image_file.setter
-    def cover_image_file(self, value: Any):
-        self._temp_cover_image_file = value
-
-    def __str__(self):
-        return self.title
-
-
 class Favorite(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     user_id: int = Field(index=True)
@@ -147,18 +117,6 @@ class Favorite(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.now)
 
     product: Optional[Product] = Relationship()
-
-
-class GlobalConfig(SQLModel, table=True):
-    __tablename__ = "global_config"
-    id: Optional[int] = Field(default=None, primary_key=True)
-    key: str = Field(unique=True, index=True)
-    value: str
-    description: Optional[str] = None
-    updated_at: datetime = Field(default_factory=datetime.now)
-
-    def __str__(self):
-        return f"{self.key}: {self.value}"
 
 
 class InstallationRate(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- continue models package refactor by extracting content-oriented models into `models/content.py`
- move `Article` and `GlobalConfig` out of `models/product.py`
- keep external compatibility through `models/__init__.py` re-exports

## Validation
- python3 -m py_compile models/__init__.py models/common.py models/customer.py models/cart.py models/order.py models/product.py models/content.py main.py
- docker compose exec -T app pytest -q (45 passed)
