### PR TITLE
refactor: extract manager product methods into dedicated service

### DIFF
--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -1,0 +1,93 @@
+"""Manager-facing product service operations."""
+
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from crud.product import ProductDAO
+from services.product_serialization import sanitize_specs
+
+
+class ProductManagerService:
+    @staticmethod
+    async def get_manager_list(
+        session: AsyncSession,
+        page: int = 1,
+        limit: int = 40,
+        search: Optional[str] = None,
+        is_published: Optional[bool] = None,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        is_inverter: Optional[bool] = None,
+        sort: str = "newest",
+    ) -> Dict[str, Any]:
+        items, total = await ProductDAO.get_for_manager(
+            session, page, limit, search, is_published, area_min, area_max, is_inverter, sort
+        )
+
+        formatted_items = []
+        for p in items:
+            formatted_items.append(
+                {
+                    "id": p.id,
+                    "title": p.title,
+                    "slug": p.slug,
+                    "price": p.price,
+                    "old_price": p.old_price,
+                    "area": p.area,
+                    "is_inverter": p.is_inverter,
+                    "power_cooling": p.power_cooling,
+                    "main_image": p.main_image,
+                    "is_published": p.is_published,
+                    "created_at": p.created_at.isoformat() if p.created_at else None,
+                    "specs": sanitize_specs(p.specs),
+                    "gallery_images": [
+                        {
+                            "id": img.id,
+                            "url": img.url,
+                            "is_installation_photo": img.is_installation_photo,
+                        }
+                        for img in (p.gallery_images or [])
+                    ],
+                    "tags": [
+                        {
+                            "id": t.id,
+                            "title": t.title,
+                            "slug": t.slug,
+                            "group_title": t.group.title if t.group else None,
+                            "group_color": t.group.color if t.group else "secondary",
+                        }
+                        for t in (p.tags or [])
+                    ],
+                }
+            )
+
+        return {
+            "items": formatted_items,
+            "meta": {
+                "page": page,
+                "limit": limit,
+                "total": total,
+                "pages": (total + limit - 1) // limit if limit else 1,
+            },
+        }
+
+    @staticmethod
+    async def get_all_tags(session: AsyncSession) -> List[Dict[str, Any]]:
+        from crud.tag import TagDAO
+
+        groups = await TagDAO.get_all_grouped(session)
+        return [
+            {
+                "id": g.id,
+                "title": g.title,
+                "slug": g.slug,
+                "color": g.color,
+                "allow_multiple": g.allow_multiple,
+                "tags": [
+                    {"id": t.id, "title": t.title, "slug": t.slug}
+                    for t in sorted(g.tags, key=lambda item: (item.sort_order, item.title))
+                ],
+            }
+            for g in groups
+        ]

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -2,98 +2,13 @@
 
 Read/filter methods are inherited from ProductReadService.
 Write/mutation methods are inherited from ProductWriteService.
+Manager-facing methods are inherited from ProductManagerService.
 """
 
-from typing import Any, Dict, List, Optional
-
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from crud.product import ProductDAO
+from services.product_manager_service import ProductManagerService
 from services.product_read_service import ProductReadService
 from services.product_write_service import ProductWriteService
-from services.product_serialization import sanitize_specs
 
 
-class ProductService(ProductReadService, ProductWriteService):
-    @staticmethod
-    async def get_manager_list(
-        session: AsyncSession,
-        page: int = 1,
-        limit: int = 40,
-        search: Optional[str] = None,
-        is_published: Optional[bool] = None,
-        area_min: Optional[int] = None,
-        area_max: Optional[int] = None,
-        is_inverter: Optional[bool] = None,
-        sort: str = "newest",
-    ) -> Dict[str, Any]:
-        items, total = await ProductDAO.get_for_manager(
-            session, page, limit, search, is_published, area_min, area_max, is_inverter, sort
-        )
-
-        formatted_items = []
-        for p in items:
-            formatted_items.append(
-                {
-                    "id": p.id,
-                    "title": p.title,
-                    "slug": p.slug,
-                    "price": p.price,
-                    "old_price": p.old_price,
-                    "area": p.area,
-                    "is_inverter": p.is_inverter,
-                    "power_cooling": p.power_cooling,
-                    "main_image": p.main_image,
-                    "is_published": p.is_published,
-                    "created_at": p.created_at.isoformat() if p.created_at else None,
-                    "specs": sanitize_specs(p.specs),
-                    "gallery_images": [
-                        {
-                            "id": img.id,
-                            "url": img.url,
-                            "is_installation_photo": img.is_installation_photo,
-                        }
-                        for img in (p.gallery_images or [])
-                    ],
-                    "tags": [
-                        {
-                            "id": t.id,
-                            "title": t.title,
-                            "slug": t.slug,
-                            "group_title": t.group.title if t.group else None,
-                            "group_color": t.group.color if t.group else "secondary",
-                        }
-                        for t in (p.tags or [])
-                    ],
-                }
-            )
-
-        return {
-            "items": formatted_items,
-            "meta": {
-                "page": page,
-                "limit": limit,
-                "total": total,
-                "pages": (total + limit - 1) // limit if limit else 1,
-            },
-        }
-
-    @staticmethod
-    async def get_all_tags(session: AsyncSession) -> List[Dict[str, Any]]:
-        from crud.tag import TagDAO
-
-        groups = await TagDAO.get_all_grouped(session)
-        return [
-            {
-                "id": g.id,
-                "title": g.title,
-                "slug": g.slug,
-                "color": g.color,
-                "allow_multiple": g.allow_multiple,
-                "tags": [
-                    {"id": t.id, "title": t.title, "slug": t.slug}
-                    for t in sorted(g.tags, key=lambda item: (item.sort_order, item.title))
-                ],
-            }
-            for g in groups
-        ]
+class ProductService(ProductReadService, ProductWriteService, ProductManagerService):
+    """Backward-compatible facade that combines product service specializations."""


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Scope

- [ ] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation

- Local checks run:
  - [ ] `pytest -q` (or targeted tests)
  - [ ] `cd web && npm run build` (if touched)
  - [ ] `cd manager_frontend && npm run build` (if touched)
- Manual checks:
  - [ ] Main user flow verified
  - [ ] No visible regressions in touched areas

## Legacy Admin Check

- [ ] This PR changes `admin/*` (legacy SQLAdmin)
- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)

## Deployment Notes

- [ ] No special deploy steps
- [ ] Requires Alembic migration
- [ ] Requires post-deploy script/manual data operation

If special steps required, describe exact commands:

```bash
# Example
# docker compose exec app alembic upgrade head
```

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:

## Screenshots / Logs (optional)
