### PR TITLE
refactor: add explicit manager response contracts

### DIFF
--- a/routers/manager_auth.py
+++ b/routers/manager_auth.py
@@ -1,12 +1,13 @@
 from fastapi import APIRouter, Depends
 
 from core.security import get_current_username
+from schemas import ManagerAuthStatusResponse
 
 
 router = APIRouter(prefix="/api/manager", tags=["manager"])
 
 
-@router.get("/me", operation_id="read_user_me")
+@router.get("/me", response_model=ManagerAuthStatusResponse, operation_id="read_user_me")
 async def check_auth_status(username: str = Depends(get_current_username)):
     """
     Check if current user is authenticated.

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -5,14 +5,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.security import get_current_username
-from schemas import BulkRoundRequest, ProductUpdate
+from schemas import (
+    BulkRoundRequest,
+    ManagerActionMessageResponse,
+    ManagerBulkRoundPriceResponse,
+    ManagerCatalogCustomerListResponse,
+    ManagerCatalogProductListResponse,
+    ManagerTagGroupResponse,
+    ProductUpdate,
+)
 from services.manager_catalog_service import ManagerCatalogService
 
 
 router = APIRouter(prefix="/api/manager", tags=["manager"])
 
 
-@router.get("/products/list", operation_id="get_manager_products")
+@router.get(
+    "/products/list",
+    response_model=ManagerCatalogProductListResponse,
+    operation_id="get_manager_products",
+)
 async def list_products_for_manager(
     page: int = Query(1, ge=1),
     limit: int = Query(40, ge=1, le=100),
@@ -42,7 +54,11 @@ async def list_products_for_manager(
     )
 
 
-@router.get("/customers", operation_id="get_manager_customers")
+@router.get(
+    "/customers",
+    response_model=ManagerCatalogCustomerListResponse,
+    operation_id="get_manager_customers",
+)
 async def list_customers_for_manager(
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
@@ -66,7 +82,11 @@ async def list_customers_for_manager(
     )
 
 
-@router.patch("/products/{product_id}", operation_id="update_product")
+@router.patch(
+    "/products/{product_id}",
+    response_model=ManagerActionMessageResponse,
+    operation_id="update_product",
+)
 async def update_product(
     product_id: int,
     data: ProductUpdate,
@@ -88,7 +108,11 @@ async def update_product(
     return result
 
 
-@router.post("/products/bulk-round-price", operation_id="bulk_round_price")
+@router.post(
+    "/products/bulk-round-price",
+    response_model=ManagerBulkRoundPriceResponse,
+    operation_id="bulk_round_price",
+)
 async def bulk_round_price(
     request: BulkRoundRequest,
     session: AsyncSession = Depends(get_session),
@@ -100,7 +124,11 @@ async def bulk_round_price(
     return await ManagerCatalogService.bulk_round_prices(session=session, request=request)
 
 
-@router.get("/tags/all", operation_id="get_all_tags")
+@router.get(
+    "/tags/all",
+    response_model=list[ManagerTagGroupResponse],
+    operation_id="get_all_tags",
+)
 async def get_all_tags(
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),

--- a/routers/manager_specs.py
+++ b/routers/manager_specs.py
@@ -4,7 +4,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.logger import logger
 from core.security import get_current_username
-from schemas import BulkSpecUpdate
+from schemas import (
+    BulkSpecUpdate,
+    ManagerBulkSpecsResponse,
+    ManagerNormalizeLegacySpecsResponse,
+)
 from services.manager_legacy_specs_service import ManagerLegacySpecsService
 from services.manager_specs_service import ManagerSpecsService
 
@@ -12,7 +16,11 @@ from services.manager_specs_service import ManagerSpecsService
 router = APIRouter(prefix="/api/manager", tags=["manager"])
 
 
-@router.post("/specs/bulk-update", operation_id="bulk_update_specs")
+@router.post(
+    "/specs/bulk-update",
+    response_model=ManagerBulkSpecsResponse,
+    operation_id="bulk_update_specs",
+)
 async def bulk_update_specs(
     payload: BulkSpecUpdate,
     session: AsyncSession = Depends(get_session),
@@ -26,7 +34,11 @@ async def bulk_update_specs(
     return await ManagerSpecsService.bulk_update_specs(session, payload)
 
 
-@router.post("/specs/normalize-legacy", operation_id="normalize_legacy_specs")
+@router.post(
+    "/specs/normalize-legacy",
+    response_model=ManagerNormalizeLegacySpecsResponse,
+    operation_id="normalize_legacy_specs",
+)
 async def normalize_legacy_specs(
     dry_run: bool = Query(True, description="Если True - не сохраняет изменения в БД, только показывает пример"),
     session: AsyncSession = Depends(get_session),

--- a/schemas.py
+++ b/schemas.py
@@ -337,6 +337,98 @@ class LeadQualifyResponse(BaseModel):
     order_id: int
 
 
+class ManagerAuthStatusResponse(BaseModel):
+    username: str
+    status: str
+
+
+class ManagerCatalogProductImageResponse(BaseModel):
+    id: int
+    url: str
+    is_installation_photo: bool
+
+
+class ManagerCatalogProductTagResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+    group_title: Optional[str]
+    group_color: Optional[str]
+
+
+class ManagerCatalogProductItemResponse(BaseModel):
+    id: int
+    title: str
+    slug: Optional[str]
+    price: int
+    old_price: Optional[int]
+    area: int
+    is_inverter: bool
+    power_cooling: Optional[float]
+    main_image: Optional[str]
+    is_published: bool
+    created_at: datetime
+    specs: Dict[str, Any]
+    gallery_images: List[ManagerCatalogProductImageResponse]
+    tags: List[ManagerCatalogProductTagResponse]
+
+
+class ManagerCatalogProductListResponse(BaseModel):
+    items: List[ManagerCatalogProductItemResponse]
+    meta: Meta
+
+
+class ManagerCatalogCustomerItemResponse(BaseModel):
+    id: int
+    name: Optional[str]
+    phone: Optional[str]
+    email: Optional[str]
+    type: str
+    inn: Optional[str]
+    full_legal_name: Optional[str]
+    created_at: Optional[datetime]
+    order_count: int
+
+
+class ManagerCatalogCustomerListResponse(BaseModel):
+    items: List[ManagerCatalogCustomerItemResponse]
+    meta: Meta
+
+
+class ManagerTagOptionResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+
+
+class ManagerTagGroupResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+    color: str
+    allow_multiple: bool
+    tags: List[ManagerTagOptionResponse]
+
+
+class ManagerActionMessageResponse(BaseModel):
+    message: str
+
+
+class ManagerBulkRoundPriceResponse(ManagerActionMessageResponse):
+    updated_count: int
+
+
+class ManagerBulkSpecsResponse(ManagerActionMessageResponse):
+    operation: str
+
+
+class ManagerNormalizeLegacySpecsResponse(ManagerActionMessageResponse):
+    dry_run: bool
+    products_processed: int
+    products_updated: int
+    sample_changes: List[Dict[str, Any]]
+
+
 class ProductUpdate(BaseModel):
     title: Optional[str] = None
     price: Optional[int] = None


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Scope

- [ ] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation

- Local checks run:
  - [ ] `pytest -q` (or targeted tests)
  - [ ] `cd web && npm run build` (if touched)
  - [ ] `cd manager_frontend && npm run build` (if touched)
- Manual checks:
  - [ ] Main user flow verified
  - [ ] No visible regressions in touched areas

## Legacy Admin Check

- [ ] This PR changes `admin/*` (legacy SQLAdmin)
- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)

## Deployment Notes

- [ ] No special deploy steps
- [ ] Requires Alembic migration
- [ ] Requires post-deploy script/manual data operation

If special steps required, describe exact commands:

```bash
# Example
# docker compose exec app alembic upgrade head
```

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:

## Screenshots / Logs (optional)
