### PR TITLE
ci: enforce manager api client sync with openapi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,18 @@ jobs:
             sleep 1
           done
 
+      - name: Verify Manager API Client Is Up To Date
+        run: |
+          docker compose exec -T app python3 scripts/legacy/extract_openapi.py
+          cd manager_frontend
+          npm run gen:api
+          cd ..
+          git diff --exit-code -- openapi.json manager_frontend/src/client || (
+            echo "Manager API client is out of sync."
+            echo "Run: python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api"
+            exit 1
+          )
+
       - name: Run Pytest
         # using the 'app' service where the code lives
         run: docker compose exec -T app pytest -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,9 @@ Use this after large catalog imports or when unknown spec keys appear.
    - migrate broader admin entities and flows from legacy SQLAdmin UX to Vue-based reactive UX.
 4. When API contracts change:
    - update backend schemas/routes,
+   - regenerate OpenAPI (`python3 scripts/legacy/extract_openapi.py`),
    - refresh typed client with `npm run gen:api` in `manager_frontend/`,
+   - commit generated artifacts (`openapi.json`, `manager_frontend/src/client/*`) when changed,
    - verify photo/spec bulk-edit flows end-to-end.
 5. Legacy admin freeze:
    - keep SQLAdmin routes/views working for existing operations,

--- a/docs/process.md
+++ b/docs/process.md
@@ -20,6 +20,22 @@
    - why legacy change is required now,
    - why this is not implemented in manager flow.
 
+## Manager API Client Sync Policy
+
+When changing manager API contracts (`routers/manager_*`, `schemas.py`, OpenAPI-affecting dependencies):
+
+1. Regenerate OpenAPI schema:
+   - `python3 scripts/legacy/extract_openapi.py`
+2. Regenerate typed manager client:
+   - `cd manager_frontend && npm run gen:api`
+3. Validate manager build:
+   - `cd manager_frontend && npm run build`
+4. Commit updated artifacts when changed:
+   - `openapi.json`
+   - `manager_frontend/src/client/*`
+
+CI enforces this sync and fails if generated artifacts differ from committed files.
+
 ## API-роутеры после декомпозиции
 
 Основной входной модуль API: `routers/api.py` (компоновщик).


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Scope

- [ ] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation

- Local checks run:
  - [ ] `pytest -q` (or targeted tests)
  - [ ] `cd web && npm run build` (if touched)
  - [ ] `cd manager_frontend && npm run build` (if touched)
- Manual checks:
  - [ ] Main user flow verified
  - [ ] No visible regressions in touched areas

## Legacy Admin Check

- [ ] This PR changes `admin/*` (legacy SQLAdmin)
- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)

## Deployment Notes

- [ ] No special deploy steps
- [ ] Requires Alembic migration
- [ ] Requires post-deploy script/manual data operation

If special steps required, describe exact commands:

```bash
# Example
# docker compose exec app alembic upgrade head
```

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:

## Screenshots / Logs (optional)
