### PR TITLE
Manager: unify product-form API error handling and remove blocking alerts

### DIFF
--- a/manager_frontend/src/components/BulkSpecsModal.vue
+++ b/manager_frontend/src/components/BulkSpecsModal.vue
@@ -2,6 +2,7 @@
 import { ref, watch } from 'vue';
 import { api } from '../api';
 import { X, Plus, Trash2, Save, AlertTriangle } from 'lucide-vue-next';
+import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 
 const props = defineProps<{
     modelValue: boolean; // isOpen
@@ -16,6 +17,8 @@ const emit = defineEmits<{
 const specs = ref<{ key: string; value: string }[]>([{ key: '', value: '' }]);
 const operation = ref<'merge' | 'replace' | 'delete_keys'>('merge');
 const loading = ref(false);
+const formMessage = ref('');
+const formServerErrors = ref<Record<string, string>>({});
 const knownKeys = ref<string[]>([]);
 const keysLoading = ref(false);
 
@@ -34,6 +37,8 @@ const fetchKeys = async () => {
 
 watch(() => props.modelValue, (val) => {
     if (val) {
+        formMessage.value = '';
+        formServerErrors.value = {};
         if (knownKeys.value.length === 0) fetchKeys();
         // Reset form
         specs.value = [{ key: '', value: '' }];
@@ -55,6 +60,8 @@ const close = () => {
 
 const save = async () => {
     if (props.selectedProductIds.length === 0) return;
+    formMessage.value = '';
+    formServerErrors.value = {};
     
     // Validate
     const validSpecs: Record<string, string> = {};
@@ -67,15 +74,16 @@ const save = async () => {
     // Logic for validation
     if (Object.keys(validSpecs).length === 0) {
          if (operation.value === 'delete_keys') {
-              alert('Please specify at least one specification key');
+              formMessage.value = 'Укажите хотя бы один ключ характеристики';
               return;
          }
          // For merge/replace, empty might mean clear all or nothing
          if (operation.value === 'replace') {
              // If manual clear (no rows or empty rows)
-             if (!confirm('This will clear ALL specs for selected products. Continue?')) return;
+             if (!confirm('Будут очищены все характеристики у выбранных товаров. Продолжить?')) return;
          } else {
              // Merge with empty = do nothing
+             formMessage.value = 'Нет изменений для применения';
              return;
          }
     }
@@ -85,10 +93,11 @@ const save = async () => {
         await api.bulkUpdateSpecs(props.selectedProductIds, validSpecs, operation.value);
         emit('success');
         close();
-        alert('Specs updated successfully');
     } catch (e) {
         console.error(e);
-        alert('Failed to update specs');
+        const parsed = parseApiFieldErrors(e, ['product_ids', 'specs', 'operation']);
+        formServerErrors.value = parsed.fieldErrors;
+        formMessage.value = parsed.message || `Не удалось обновить характеристики: ${getApiErrorMessage(e)}`;
     } finally {
         loading.value = false;
     }
@@ -107,8 +116,14 @@ const save = async () => {
                     <X class="w-5 h-5" />
                 </button>
             </header>
+            <div v-if="formMessage" class="mx-6 mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                {{ formMessage }}
+            </div>
             
             <div class="p-6 overflow-y-auto flex-1">
+                <div v-if="Object.keys(formServerErrors).length" class="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                    <p v-for="(message, field) in formServerErrors" :key="`bulk-${field}`">{{ field }}: {{ message }}</p>
+                </div>
                 <!-- Operation Selector -->
                 <div class="mb-6">
                     <label class="block text-sm font-medium text-gray-700 mb-2">Operation</label>

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -2,6 +2,7 @@
 import { ref, watch, computed } from 'vue';
 import { api, type Product } from '../api';
 import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag } from 'lucide-vue-next';
+import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 
 interface TagItem {
     id: number;
@@ -39,6 +40,8 @@ const form = ref<any>({
 const specs = ref<{ key: string; value: string }[]>([]);
 const selectedTagIds = ref<Set<number>>(new Set());
 const loading = ref(false);
+const formMessage = ref('');
+const formServerErrors = ref<Record<string, string>>({});
 const knownKeys = ref<string[]>([]);
 const tagGroups = ref<TagGroupItem[]>([]);
 const tagsLoading = ref(false);
@@ -103,6 +106,8 @@ const getSelectedColorClasses = (color: string) => selectedColorClasses[color] |
 
 watch(() => props.modelValue, (val) => {
     if (val && props.product) {
+        formMessage.value = '';
+        formServerErrors.value = {};
         form.value = {
             title: props.product.title,
             slug: props.product.slug,
@@ -145,6 +150,8 @@ const save = async () => {
     }
 
     loading.value = true;
+    formMessage.value = '';
+    formServerErrors.value = {};
     try {
         const updateData = {
             ...form.value,
@@ -155,7 +162,17 @@ const save = async () => {
         emit('success');
         close();
     } catch (e) {
-        alert('Ошибка при сохранении');
+        const parsed = parseApiFieldErrors(e, [
+            'title',
+            'slug',
+            'price',
+            'old_price',
+            'is_published',
+            'specs',
+            'tag_ids',
+        ]);
+        formServerErrors.value = parsed.fieldErrors;
+        formMessage.value = parsed.message || `Ошибка при сохранении: ${getApiErrorMessage(e)}`;
         console.error(e);
     } finally {
         loading.value = false;
@@ -181,6 +198,9 @@ const save = async () => {
                     <X class="w-5 h-5" />
                 </button>
             </header>
+            <div v-if="formMessage" class="mx-6 mt-4 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                {{ formMessage }}
+            </div>
             
             <div class="flex-1 overflow-y-auto p-6">
                 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -193,9 +213,11 @@ const save = async () => {
                             <input 
                                 v-model="form.title" 
                                 type="text"
-                                class="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-gray-900 font-medium text-sm"
+                                class="w-full px-3 py-2 bg-gray-50 border rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-gray-900 font-medium text-sm"
+                                :class="formServerErrors.title ? 'border-red-400 focus:border-red-500' : 'border-gray-200'"
                                 placeholder="Напр: LG ARTCOOL Gallery"
                             />
+                            <p v-if="formServerErrors.title" class="mt-1 text-xs text-red-600">{{ formServerErrors.title }}</p>
                         </div>
 
                         <div>
@@ -206,9 +228,11 @@ const save = async () => {
                             <input 
                                 v-model="form.slug" 
                                 type="text"
-                                class="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-sm font-mono text-gray-600"
+                                class="w-full px-3 py-2 bg-gray-50 border rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-sm font-mono text-gray-600"
+                                :class="formServerErrors.slug ? 'border-red-400 focus:border-red-500' : 'border-gray-200'"
                                 placeholder="lg-artcool-gallery"
                             />
+                            <p v-if="formServerErrors.slug" class="mt-1 text-xs text-red-600">{{ formServerErrors.slug }}</p>
                         </div>
 
                         <div class="grid grid-cols-2 gap-3">
@@ -218,10 +242,12 @@ const save = async () => {
                                     <input 
                                         v-model.number="form.price" 
                                         type="number"
-                                        class="w-full pl-3 pr-10 py-2 bg-gray-50 border border-gray-200 rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all font-bold text-teal-700 text-sm"
+                                        class="w-full pl-3 pr-10 py-2 bg-gray-50 border rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all font-bold text-teal-700 text-sm"
+                                        :class="formServerErrors.price ? 'border-red-400 focus:border-red-500' : 'border-gray-200'"
                                     />
                                     <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs">руб.</span>
                                 </div>
+                                <p v-if="formServerErrors.price" class="mt-1 text-xs text-red-600">{{ formServerErrors.price }}</p>
                             </div>
                             <div>
                                 <label class="block text-sm font-semibold text-gray-700 mb-1 line-through decoration-gray-400">Старая цена</label>
@@ -229,10 +255,12 @@ const save = async () => {
                                     <input 
                                         v-model.number="form.old_price" 
                                         type="number"
-                                        class="w-full pl-3 pr-10 py-2 bg-gray-50 border border-gray-200 rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-gray-500 text-sm"
+                                        class="w-full pl-3 pr-10 py-2 bg-gray-50 border rounded-xl focus:bg-white focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-gray-500 text-sm"
+                                        :class="formServerErrors.old_price ? 'border-red-400 focus:border-red-500' : 'border-gray-200'"
                                     />
                                     <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs">руб.</span>
                                 </div>
+                                <p v-if="formServerErrors.old_price" class="mt-1 text-xs text-red-600">{{ formServerErrors.old_price }}</p>
                             </div>
                         </div>
 

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -4,6 +4,7 @@ import { api, type Product } from '../api';
 import { Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images, Settings } from 'lucide-vue-next';
 import BulkSpecsModal from '../components/BulkSpecsModal.vue';
 import ProductEditModal from '../components/ProductEditModal.vue';
+import { getApiErrorMessage } from '../utils/api-errors';
 
 // Product state
 const products = ref<Product[]>([]);
@@ -24,6 +25,14 @@ const reuseResults = ref<any[]>([]);
 const activeTab = ref<'search' | 'reuse' | 'upload'>('search');
 const uploadDragActive = ref(false);
 const fileInput = ref<HTMLInputElement | null>(null);
+const toast = ref('');
+
+const setToast = (message: string) => {
+    toast.value = message;
+    window.setTimeout(() => {
+        if (toast.value === message) toast.value = '';
+    }, 3000);
+};
 
 // Bulk Actions
 const selectedProductIds = ref<Set<number>>(new Set());
@@ -136,16 +145,16 @@ const uploadFiles = async (files: FileList) => {
     try {
         if (isBulkMode.value) {
             const res = await api.bulkUploadLocalImages(selectedIdsArray.value, files);
-            alert(`Uploaded ${res.uploaded_links} links`);
+            setToast(`Загружено ссылок: ${res.uploaded_links}`);
             await loadCommonGallery();
         } else {
             const res = await api.uploadLocalImages(selectedProduct.value!.id, files);
-            alert(`Uploaded ${res.uploaded} images`);
+            setToast(`Загружено изображений: ${res.uploaded}`);
             refreshSelectedProduct();
         }
         await loadProducts();
     } catch (e) {
-        alert('Upload failed');
+        setToast(`Ошибка загрузки: ${getApiErrorMessage(e)}`);
         console.error(e);
     } finally {
         searchLoading.value = false;
@@ -223,7 +232,7 @@ const cancelEditingPrice = () => {
 const savePrice = async (product: Product) => {
     const newPrice = parseInt(priceBuffer.value);
     if (isNaN(newPrice)) {
-        alert('Некорректная цена');
+        setToast('Некорректная цена');
         return;
     }
     if (newPrice === product.price) {
@@ -236,7 +245,7 @@ const savePrice = async (product: Product) => {
         product.price = newPrice;
         cancelEditingPrice();
     } catch (e) {
-        alert('Ошибка при сохранении цены');
+        setToast(`Ошибка при сохранении цены: ${getApiErrorMessage(e)}`);
         console.error(e);
     }
 };
@@ -259,8 +268,9 @@ const handleBulkRoundPrices = async () => {
         await api.bulkRoundPrices(selectedIdsArray.value);
         await loadProducts();
         selectedProductIds.value.clear();
+        setToast('Цены округлены');
     } catch (e) {
-        alert('Ошибка при округлении');
+        setToast(`Ошибка при округлении: ${getApiErrorMessage(e)}`);
         console.error(e);
     } finally {
         bulkRoundLoading.value = false;
@@ -301,7 +311,7 @@ const handleImageSearch = async () => {
         const results = await api.searchImages(imageQuery.value);
         imageSearchResults.value = results;
     } catch (e) {
-        alert('Search failed');
+        setToast(`Ошибка поиска: ${getApiErrorMessage(e)}`);
     } finally {
         searchLoading.value = false;
     }
@@ -329,15 +339,15 @@ const addToGallery = async (url: string) => {
     try {
         if (isBulkMode.value) {
             await bulkAddFromUrls([url], false);
-            alert('Added to selected products');
+            setToast('Изображение добавлено выбранным товарам');
         } else {
             await api.linkSearchResult(selectedProduct.value!.id, url);
             await loadProducts();
             refreshSelectedProduct();
-            alert('Added to gallery');
+            setToast('Изображение добавлено в галерею');
         }
     } catch (e) {
-        alert('Failed to add');
+        setToast(`Ошибка добавления: ${getApiErrorMessage(e)}`);
     } finally {
         uploadingImageId.value = null;
     }
@@ -348,8 +358,9 @@ const triggerCleanup = async () => {
     try {
         const res = await api.cleanupMedia(false);
         cleanupStats.value = res;
+        setToast('Очистка завершена');
     } catch (e) {
-        alert('Cleanup failed');
+        setToast(`Ошибка очистки: ${getApiErrorMessage(e)}`);
     } finally {
         cleanupLoading.value = false;
     }
@@ -369,23 +380,27 @@ const reuseImage = async (sourceUrl: string) => {
     try {
         if (isBulkMode.value) {
             await bulkAddFromUrls([sourceUrl], false);
-            alert('Image reused for selected products');
+            setToast('Изображение применено к выбранным товарам');
         } else {
             await api.reuseImage(selectedProduct.value!.id, sourceUrl);
-            alert('Image reused');
+            setToast('Изображение применено');
             await loadProducts();
             refreshSelectedProduct();
         }
-    } catch (e) { alert('Failed'); }
+    } catch (e) {
+        setToast(`Ошибка повторного использования: ${getApiErrorMessage(e)}`);
+    }
 };
 
 const setAsMain = async (id: number) => {
     try {
         await api.setMainImage(id);
-        alert('Updated');
+        setToast('Главное изображение обновлено');
         await loadProducts();
         refreshSelectedProduct();
-    } catch (e) { alert('Failed'); }
+    } catch (e) {
+        setToast(`Ошибка обновления: ${getApiErrorMessage(e)}`);
+    }
 };
 
 const confirmDeleteId = ref<number | null>(null);
@@ -403,7 +418,10 @@ const removeFromGallery = async (id: number) => {
         await api.deleteGalleryImage(id);
         await loadProducts();
         refreshSelectedProduct();
-    } catch (e) { alert('Failed'); }
+        setToast('Изображение удалено');
+    } catch (e) {
+        setToast(`Ошибка удаления: ${getApiErrorMessage(e)}`);
+    }
 };
 
 const removeCommonImage = async (url: string) => {
@@ -422,7 +440,7 @@ const removeCommonImage = async (url: string) => {
         await loadProducts();
         await loadCommonGallery();
     } catch (e) {
-        alert('Failed');
+        setToast(`Ошибка удаления: ${getApiErrorMessage(e)}`);
     }
 };
 
@@ -434,7 +452,7 @@ const selectImage = async (url: string) => {
     try {
         if (isBulkMode.value) {
             await bulkAddFromUrls([url], true);
-            alert('Set as main for selected products');
+            setToast('Главное изображение обновлено для выбранных товаров');
         } else {
             const response = await api.uploadImage(selectedProduct.value!.id, url);
             if (response && response.url) {
@@ -442,11 +460,11 @@ const selectImage = async (url: string) => {
                  refreshSelectedProduct();
                  showModal.value = false;
             } else {
-                 alert('Upload succeeded but no URL returned');
+                 setToast('Изображение загружено, но URL не вернулся');
             }
         }
     } catch (e) {
-        alert('Upload failed');
+        setToast(`Ошибка загрузки: ${getApiErrorMessage(e)}`);
     } finally {
         uploadingImageId.value = null;
     }
@@ -509,6 +527,9 @@ onMounted(() => {
           </button>
       </div>
     </header>
+    <p v-if="toast" class="mb-4 rounded-lg border border-teal-200 bg-teal-50 px-4 py-2 text-sm text-teal-800">
+      {{ toast }}
+    </p>
 
     <!-- Filters -->
     <div class="bg-white p-4 rounded-xl shadow-sm border border-gray-200 mb-6 flex flex-wrap gap-4 items-end">


### PR DESCRIPTION
## Summary
Unify error UX in remaining manager product forms so they behave like leads/orders (field-level + human-readable message), and remove blocking browser alerts.

### Included
- `ProductEditModal.vue`
  - replace `alert(...)` with `parseApiFieldErrors(...)` + inline error message block
  - highlight invalid fields (`title`, `slug`, `price`, `old_price`)
- `BulkSpecsModal.vue`
  - replace `alert(...)` with inline message + parsed server field errors (`product_ids`, `specs`, `operation`)
  - keep replace-all confirmation, localized text
- `ProductsView.vue`
  - replace all remaining `alert(...)` calls with unified toast banner + `getApiErrorMessage(...)`
  - success/failure messages for upload/reuse/delete/rounding/search flows

## Why
- consistent manager UX for API failures (`400/422`) and action feedback
- no browser blocking alerts during workflow
- easier triage when backend returns field-specific validation errors

## Verification
- `cd manager_frontend && npm run build`
