### PR TITLE
Manager orders: improve drawer validation and add patch error regression test

### DIFF
--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
   order: ManagerOrderDetailResponse | null;
   serverErrors?: Record<string, string>;
   formError?: string;
+  saving?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -36,6 +37,8 @@ const isPaid = ref(false);
 
 const productLines = ref<Array<{ product_id: number; quantity: number; price: number; cost: number }>>([]);
 const serviceLines = ref<Array<{ service_id?: number | null; title: string; quantity: number; price: number; cost: number }>>([]);
+const localServerErrors = ref<Record<string, string>>({});
+const localFormError = ref('');
 
 const totalPreview = computed(() => {
   const pTotal = productLines.value.reduce((sum, line) => sum + line.price * line.quantity, 0);
@@ -60,6 +63,8 @@ const loadProductOptions = async (q = '') => {
 
 const initForm = async (order: ManagerOrderDetailResponse | null) => {
   if (!order) return;
+  localServerErrors.value = {};
+  localFormError.value = '';
   status.value = order.status;
   nextFollowupDate.value = toLocalDateTimeInput(order.next_followup_date);
   assessmentDate.value = toLocalDateTimeInput(order.assessment_date);
@@ -132,6 +137,38 @@ const removeServiceLine = (index: number) => {
 
 const handleSave = () => {
   if (!props.order) return;
+  localServerErrors.value = {};
+  localFormError.value = '';
+
+  const errors: Record<string, string> = {};
+  if (!status.value) {
+    errors.status = 'Укажите статус';
+  }
+
+  if (assessmentDate.value && installationDate.value && installationDate.value < assessmentDate.value) {
+    errors.installation_date = 'Дата монтажа не может быть раньше даты замера';
+  }
+
+  if (productLines.value.some((line) => line.quantity <= 0)) {
+    errors.products = 'Количество товара должно быть больше 0';
+  } else if (productLines.value.some((line) => line.price < 0)) {
+    errors.products = 'Цена товара не может быть отрицательной';
+  }
+
+  if (serviceLines.value.some((line) => line.quantity <= 0)) {
+    errors.services = 'Количество услуги должно быть больше 0';
+  } else if (serviceLines.value.some((line) => line.price < 0)) {
+    errors.services = 'Цена услуги не может быть отрицательной';
+  } else if (serviceLines.value.some((line) => !line.title?.trim())) {
+    errors.services = 'Для услуги укажите название';
+  }
+
+  if (Object.keys(errors).length) {
+    localServerErrors.value = errors;
+    localFormError.value = 'Исправьте ошибки в форме';
+    return;
+  }
+
   const payload: ManagerOrderUpdatePayload = {
     status: status.value,
     next_followup_date: fromLocalDateTimeInput(nextFollowupDate.value),
@@ -160,7 +197,8 @@ const handleSave = () => {
 
 const closeDrawer = () => emit('update:modelValue', false);
 
-const getFieldError = (field: string): string => props.serverErrors?.[field] || '';
+const getFieldError = (field: string): string => localServerErrors.value[field] || props.serverErrors?.[field] || '';
+const displayFormError = computed(() => localFormError.value || props.formError || '');
 </script>
 
 <template>
@@ -172,8 +210,8 @@ const getFieldError = (field: string): string => props.serverErrors?.[field] || 
         <button class="btn-mini-outline" @click="closeDrawer">Закрыть</button>
       </header>
 
-      <p v-if="formError" class="mb-4 rounded-xl border border-red-500/40 bg-red-900/30 px-3 py-2 text-sm text-red-200">
-        {{ formError }}
+      <p v-if="displayFormError" class="mb-4 rounded-xl border border-red-500/40 bg-red-900/30 px-3 py-2 text-sm text-red-200">
+        {{ displayFormError }}
       </p>
 
       <section class="grid gap-3 md:grid-cols-2">
@@ -260,8 +298,10 @@ const getFieldError = (field: string): string => props.serverErrors?.[field] || 
       </section>
 
       <footer class="mt-6 flex justify-end gap-2">
-        <button class="btn-mini-outline" @click="closeDrawer">Отмена</button>
-        <button class="btn-mini" @click="handleSave">Сохранить</button>
+        <button class="btn-mini-outline" :disabled="saving" @click="closeDrawer">Отмена</button>
+        <button class="btn-mini" :disabled="saving" @click="handleSave">
+          {{ saving ? 'Сохраняем...' : 'Сохранить' }}
+        </button>
       </footer>
     </aside>
   </div>

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -303,6 +303,7 @@ watch(drawerOpen, (isOpen) => {
       :order="selectedOrder"
       :server-errors="orderServerErrors"
       :form-error="orderFormError"
+      :saving="saving"
       @save="saveOrder"
     />
 

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -197,6 +197,27 @@ async def test_manager_order_patch_lines_preserves_installers(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_order_patch_validation_errors(async_client, db):
+    customer = Customer(name="Validation", phone="+375299999999", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    payload = {
+        "products": [{"product_id": 1, "quantity": 0, "price": 100, "cost": 10}],
+    }
+    response = await async_client.patch(f"/api/manager/orders/{order.id}", json=payload, headers=headers)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Product quantity must be > 0"
+
+
+@pytest.mark.asyncio
 async def test_manager_order_generate_document(async_client, db, monkeypatch):
     customer = Customer(name="Doc", phone="+375297777777", type=CustomerType.individual)
     db.add(customer)


### PR DESCRIPTION
## Summary
- improve manager order edit UX with client-side validation in `OrderEditDrawer`
- keep server-side validation mapping in `OrdersDashboard` as fallback
- add integration regression test for invalid `PATCH /api/manager/orders/{id}` payload

## Changes
1. `manager_frontend/src/components/orders/OrderEditDrawer.vue`
- local validation before submit:
  - status required
  - installation date cannot be earlier than assessment date
  - product line quantity > 0
  - product line price >= 0
  - service line quantity > 0
  - service line price >= 0
  - service line title required
- local field/form errors are shown with same UI pattern as server errors
- save/cancel buttons disabled while saving and save button text shows progress

2. `manager_frontend/src/components/orders/OrdersDashboard.vue`
- pass `saving` state down to drawer

3. `tests/integration/test_manager_orders_api.py`
- add `test_manager_order_patch_validation_errors`
- verifies backend returns `400` with expected message for invalid line quantity

## Verification
- `cd manager_frontend && npm run build`
- `python3 -m py_compile tests/integration/test_manager_orders_api.py`
