### PR TITLE
fix: restore missing product specs and gallery in manager UI

### DIFF
--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -212,6 +212,7 @@ async def get_all_tags(
 
 @router.get(
     "/products/smart-search",
+    response_model=ManagerCatalogProductListResponse,
     operation_id=SMART_SEARCH_PRODUCTS,
 )
 async def smart_search_products(

--- a/schemas.py
+++ b/schemas.py
@@ -488,7 +488,7 @@ class ManagerCatalogProductItemResponse(BaseModel):
 
 
 class ManagerCatalogProductListResponse(BaseModel):
-    items: List[ProductListResponse]
+    items: List[ManagerCatalogProductItemResponse]
     meta: Meta
 
 

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -57,7 +57,10 @@ class ProductManagerService:
 
         stmt = (
             select(Product)
-            .options(selectinload(Product.tags))
+            .options(
+                selectinload(Product.tags).selectinload(Tag.group),
+                selectinload(Product.gallery_images)
+            )
             .where(Product.is_published.is_(True))
         )
 
@@ -97,11 +100,23 @@ class ProductManagerService:
                 "power_cooling": p.power_cooling,
                 "main_image": p.main_image,
                 "is_published": p.is_published,
+                "created_at": p.created_at.isoformat() if p.created_at else None,
+                "specs": sanitize_specs(p.specs),
+                "gallery_images": [
+                    {
+                        "id": img.id,
+                        "url": img.url,
+                        "is_installation_photo": img.is_installation_photo,
+                    }
+                    for img in (p.gallery_images or [])
+                ],
                 "tags": [
                     {
                         "id": t.id,
                         "title": t.title,
                         "slug": t.slug,
+                        "group_title": t.group.title if t.group else None,
+                        "group_color": t.group.color if t.group else "secondary",
                     }
                     for t in (p.tags or [])
                 ],


### PR DESCRIPTION
## Summary

- What changed:
- Why:

## Scope

- [ ] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation

- Local checks run:
  - [ ] `pytest -q` (or targeted tests)
  - [ ] `cd web && npm run build` (if touched)
  - [ ] `cd manager_frontend && npm run build` (if touched)
- Manual checks:
  - [ ] Main user flow verified
  - [ ] No visible regressions in touched areas

## Legacy Admin Check

- [ ] This PR changes `admin/*` (legacy SQLAdmin)
- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)

## Deployment Notes

- [ ] No special deploy steps
- [ ] Requires Alembic migration
- [ ] Requires post-deploy script/manual data operation

If special steps required, describe exact commands:

```bash
# Example
# docker compose exec app alembic upgrade head
```

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:

## Screenshots / Logs (optional)
