### PR TITLE
fix(ui): remove leftover delete CTA on product cards

### DIFF
--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -759,9 +759,6 @@ watchDebounced(
                     <button @click="openEditModal(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
                         <Settings class="w-4 h-4 text-teal-600" /> Изменить
                     </button>
-                    <button @click.stop="deleteProduct(product)" :disabled="isDeletingProduct === product.id" class="mt-2 bg-red-600/90 text-white px-4 py-2 rounded-full flex items-center gap-2 hover:bg-red-700 text-sm font-medium transition-colors w-36 justify-center">
-                        <span class="material-icons-round text-[16px]">delete</span> {{ isDeletingProduct === product.id ? 'Удаление...' : 'Удалить' }}
-                    </button>
                 </div>
             </div>
             <div class="p-3.5">


### PR DESCRIPTION
## What\n- remove leftover large red `Удалить` CTA from product card hover overlay\n\n## Why\n- users still see old delete block on local/prod; compact icon delete remains\n\n## Notes\n- BYN margin + availability fixes are already in `main` via #210\n- this PR only removes remaining UI tail