### PR TITLE
feat(bot): inline stock-aware search and availability badges

### DIFF
--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -1,8 +1,9 @@
 import html
 import logging
+import re
 
 from aiogram import Router, types, F
-from aiogram.filters import Command
+from aiogram.filters import Command, StateFilter
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
 from core.config import settings
@@ -14,6 +15,58 @@ from ..states import ShopState
 
 router = Router()
 logger = logging.getLogger(__name__)
+
+
+def _is_inline_search_query(text: str) -> bool:
+    if not text:
+        return False
+    # 1..3 tokens, each token contains only latin letters/digits.
+    return bool(re.fullmatch(r"[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+){0,2}", text.strip()))
+
+
+def _is_in_stock_product(product: dict) -> bool:
+    availability = str(product.get("availability_status") or "").strip().lower()
+    vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+    minsk_qty = int(product.get("minsk_qty") or 0)
+    if vitebsk_qty > 0 or minsk_qty > 0:
+        return True
+    return availability in {"in_stock_now", "available_2_3_days"}
+
+
+def _choose_search_products(products: list[dict]) -> tuple[list[dict], str | None]:
+    in_stock = [p for p in products if _is_in_stock_product(p)]
+    if in_stock:
+        return in_stock, None
+    if products:
+        return (
+            products,
+            "⚠️ По вашему запросу сейчас нет товаров в наличии на складах.\n"
+            "Показываю доступные модели, но лучше уточнить сроки поставки у менеджера.",
+        )
+    return [], None
+
+
+async def _render_search_results(message: types.Message, query: str, products: list[dict]) -> None:
+    selected_products, warning_text = _choose_search_products(products)
+    if not selected_products:
+        await message.answer(
+            f"К сожалению, по запросу «{html.escape(query)}» ничего не найдено. "
+            "Попробуйте ввести бренд и мощность, например: Midea 12",
+            parse_mode="HTML",
+        )
+        return
+
+    if warning_text:
+        await message.answer(warning_text)
+
+    await message.answer(
+        f"🔎 Нашел {len(selected_products)} вариантов по запросу «{html.escape(query)}».",
+        parse_mode="HTML",
+    )
+    is_admin = message.from_user.id == settings.ADMIN_ID if message.from_user else False
+    for product in selected_products:
+        await send_product_card(message, product, is_admin)
+
 
 # ==================== УМНЫЙ ПОДБОР ====================
 
@@ -165,19 +218,26 @@ async def search_process(message: types.Message, state: FSMContext):
             sample,
         )
 
-    if not products:
-        await message.answer(
-            f"К сожалению, по запросу «{html.escape(query)}» ничего не найдено. "
-            "Попробуйте ввести бренд и мощность, например: Midea 12",
-            parse_mode="HTML",
-        )
-    else:
-        await message.answer(
-            f"🔎 Нашел {len(products)} вариантов по запросу «{html.escape(query)}».",
-            parse_mode="HTML",
-        )
-        is_admin = message.from_user.id == settings.ADMIN_ID if message.from_user else False
-        for product in products:
-            await send_product_card(message, product, is_admin)
+    await _render_search_results(message, query, products)
 
     await state.clear()
+
+
+@router.message(StateFilter(None), F.text)
+async def auto_search_process(message: types.Message):
+    query = (message.text or "").strip()
+    user_id = message.from_user.id if message.from_user else None
+    if not _is_inline_search_query(query):
+        return
+
+    async with async_session_maker() as session:
+        products = await ProductService.search_products(session, query=query, limit=5)
+        sample = [f"{item.get('id')}:{(item.get('title') or '')[:40]}" for item in products[:3]]
+        logger.info(
+            "BOT_AUTO_SEARCH_RESULT user_id=%s query=%r found=%s sample=%s",
+            user_id,
+            query,
+            len(products),
+            sample,
+        )
+    await _render_search_results(message, query, products)

--- a/bot_app/utils.py
+++ b/bot_app/utils.py
@@ -7,6 +7,25 @@ from core.database import async_session_maker
 from services.favorite_service import FavoriteService
 from .keyboards import get_product_keyboard
 
+
+def _availability_badge(product: dict) -> str:
+    has_supply_fields = any(
+        key in product for key in ("availability_status", "vitebsk_qty", "minsk_qty")
+    )
+    if not has_supply_fields:
+        return ""
+
+    availability = str(product.get("availability_status") or "").strip().lower()
+    vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+    minsk_qty = int(product.get("minsk_qty") or 0)
+    in_stock = (
+        vitebsk_qty > 0
+        or minsk_qty > 0
+        or availability in {"in_stock_now", "available_2_3_days"}
+    )
+    return "✅ <b>В наличии</b>\n" if in_stock else "⛔ <b>Нет в наличии</b>\n"
+
+
 def format_caption(product):
     # Пытаемся достать характеристики
     specs_str = ""
@@ -16,6 +35,7 @@ def format_caption(product):
     
     return (
         f"❄️ <b>{product['title']}</b>\n"
+        f"{_availability_badge(product)}"
         f"💰 <b>{product['price']} руб.</b>\n"
         f"🏠 Площадь: {product.get('area', '-')} м²\n"
         f"{specs_str}"

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -10,6 +10,7 @@ from models import Product
 from services.product_dict_mapper import map_product_to_dict
 from services.product_filter_service import ProductFilterService
 from services.product_series_service import ProductSeriesService
+from services.product_supply_metrics_service import ProductSupplyMetricsService
 
 
 class ProductReadService(ProductFilterService, ProductSeriesService):
@@ -153,13 +154,28 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             sort="area_asc",
             limit=limit,
         )
-        return [ProductReadService._to_dict(p) for p in products]
+        supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, list(products))
+
+        items = [ProductReadService._to_dict(p) for p in products]
+        for item in items:
+            pid = item.get("id")
+            metrics = supply_metrics.get(pid, {})
+            item["vitebsk_qty"] = metrics.get("vitebsk_qty", 0)
+            item["minsk_qty"] = metrics.get("minsk_qty", 0)
+            item["availability_status"] = metrics.get("availability_status", "out_of_stock")
+        return items
 
     @staticmethod
     async def get_by_id(session: AsyncSession, product_id: int) -> Optional[Dict[str, Any]]:
         product = await ProductDAO.get_by_id(session, product_id)
         if product:
-            return ProductReadService._to_dict(product)
+            item = ProductReadService._to_dict(product)
+            supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, [product])
+            metrics = supply_metrics.get(product.id, {})
+            item["vitebsk_qty"] = metrics.get("vitebsk_qty", 0)
+            item["minsk_qty"] = metrics.get("minsk_qty", 0)
+            item["availability_status"] = metrics.get("availability_status", "out_of_stock")
+            return item
         return None
 
     @staticmethod

--- a/tests/unit/test_bot_auto_search_query.py
+++ b/tests/unit/test_bot_auto_search_query.py
@@ -1,0 +1,44 @@
+from bot_app.handlers.catalog import _choose_search_products, _is_inline_search_query
+from bot_app.utils import _availability_badge
+
+
+def test_inline_search_accepts_1_to_3_latin_or_digit_tokens():
+    assert _is_inline_search_query("lg")
+    assert _is_inline_search_query("lg 9")
+    assert _is_inline_search_query("chigo black 12")
+    assert _is_inline_search_query("123")
+
+
+def test_inline_search_rejects_non_matching_messages():
+    assert not _is_inline_search_query("привет")
+    assert not _is_inline_search_query("is chigo 12 good?")
+    assert not _is_inline_search_query("midea 12 inverter black")  # 4 tokens
+    assert not _is_inline_search_query("lg-9")  # punctuation
+
+
+def test_choose_search_products_prefers_in_stock():
+    products = [
+        {"id": 1, "availability_status": "out_of_stock", "vitebsk_qty": 0, "minsk_qty": 0},
+        {"id": 2, "availability_status": "in_stock_now", "vitebsk_qty": 0, "minsk_qty": 0},
+        {"id": 3, "availability_status": "available_2_3_days", "vitebsk_qty": 0, "minsk_qty": 1},
+    ]
+    selected, warning = _choose_search_products(products)
+    assert [p["id"] for p in selected] == [2, 3]
+    assert warning is None
+
+
+def test_choose_search_products_fallback_with_warning_when_no_stock():
+    products = [
+        {"id": 1, "availability_status": "out_of_stock", "vitebsk_qty": 0, "minsk_qty": 0},
+        {"id": 2, "availability_status": "check_availability", "vitebsk_qty": 0, "minsk_qty": 0},
+    ]
+    selected, warning = _choose_search_products(products)
+    assert [p["id"] for p in selected] == [1, 2]
+    assert warning is not None
+
+
+def test_availability_badge():
+    assert _availability_badge({"availability_status": "in_stock_now"}) == "✅ <b>В наличии</b>\n"
+    assert _availability_badge({"availability_status": "out_of_stock"}) == "⛔ <b>Нет в наличии</b>\n"
+    assert _availability_badge({"vitebsk_qty": 1}) == "✅ <b>В наличии</b>\n"
+    assert _availability_badge({"title": "No supply fields"}) == ""


### PR DESCRIPTION
## Summary
- added inline auto-search in bot messages without entering menu mode
- auto-search trigger rule: 1..3 tokens, latin letters/digits only (`lg 9`, `chigo black 12`)
- excluded non-search phrases like Cyrillic/free text/question-like messages
- search results are now stock-aware:
  - show only in-stock models first
  - if none are in stock, show fallback models with warning to уточнить сроки поставки
- product cards now include availability badge between title and price:
  - `✅ В наличии`
  - `⛔ Нет в наличии`
- enriched `get_curated`/`get_by_id` payloads with supply fields (`availability_status`, `vitebsk_qty`, `minsk_qty`) for consistent badges

## Bot UX impact
- managers/admins can type query directly in chat and get results instantly
- search now prioritizes actionable inventory-ready models
- visual stock status appears on each card

## Validation
- `python3 -m py_compile bot_app/handlers/catalog.py bot_app/utils.py services/product_read_service.py tests/unit/test_bot_auto_search_query.py`
- `pytest -q tests/unit/test_bot_auto_search_query.py tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_admin_handler.py tests/unit/test_notification_service.py` (12 passed)
- local bot container rebuilt/restarted via `docker compose up -d --build bot`
