### PR TITLE
Hotfix: fix IntegrityError on product delete (supplier mappings)

### DIFF
--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -202,6 +202,7 @@ class ProductManagerService:
     async def delete_for_manager(session: AsyncSession, product_id: int) -> bool:
         from models.order import OrderProductLink
         from models.product import ProductImage, ProductTagLink
+        from models.supplier import ProductLocalStock, ProductSupplierMapping
         import sqlalchemy as sa
         
         product = await session.get(Product, product_id)
@@ -225,6 +226,14 @@ class ProductManagerService:
         # Delete tag links explicitly to avoid async lazy-load issues on relationship mutation.
         await session.execute(
             sa.delete(ProductTagLink).where(ProductTagLink.product_id == product_id)
+        )
+        
+        # Delete supplier mappings and local stock (both have NOT NULL product_id).
+        await session.execute(
+            sa.delete(ProductSupplierMapping).where(ProductSupplierMapping.product_id == product_id)
+        )
+        await session.execute(
+            sa.delete(ProductLocalStock).where(ProductLocalStock.product_id == product_id)
         )
         
         await session.delete(product)


### PR DESCRIPTION
## Проблема

Sentry: `5be2d66c1ca54763be35269020b410c5`

При удалении товара через `DELETE /api/manager/products/{id}` возникал `IntegrityError` — `NotNullViolationError` на колонке `product_id` таблицы `product_supplier_mapping`.

SQLAlchemy пытался выставить `product_id = NULL` в связанных записях `product_supplier_mapping` и `product_local_stock`, но колонка имеет ограничение `NOT NULL`.

## Исправление

Добавлено явное удаление связанных записей `ProductSupplierMapping` и `ProductLocalStock` перед удалением самого товара в `delete_for_manager()`.

## Проверка

- Unit-тесты: ✅ passed
- Миграции: не требуются
- Ручные шаги: не требуются