### PR TITLE
Hotfix: export OrderWorkStage from models package

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -20,6 +20,7 @@ from .order import (
     OrderProductLink,
     OrderServiceLink,
     OrderServiceLink,
+    OrderWorkStage,
     Payment,
     Service,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "OrderProductLink",
     "OrderServiceLink",
     "OrderStatus",
+    "OrderWorkStage",
     "Product",
     "ProductImage",
     "ProductImage",


### PR DESCRIPTION
## Проблема

Sentry: `ca6a4c504c264aa5907dc9db4b6dd275`

При создании этапа монтажа `POST /api/manager/orders/{order_id}/stages` возникал `ImportError`:

```
cannot import name 'OrderWorkStage' from 'models' (/app/models/__init__.py)
```

Модель `OrderWorkStage` определена в `models/order.py`, но не была добавлена в re-export из `models/__init__.py`.

## Исправление

Добавлен `OrderWorkStage` в импорт и `__all__` в `models/__init__.py`.

## Проверка

- Миграции: не требуются
- Ручные шаги: не требуются