### PR TITLE
feat: create order directly from customer card

### DIFF
--- a/manager_frontend/src/components/CreateOrderModal.vue
+++ b/manager_frontend/src/components/CreateOrderModal.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { api } from '../api';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+const props = defineProps<{
+  customerId: number;
+  customerName: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'created', orderId: number): void;
+}>();
+
+const requestText = ref('');
+const loading = ref(false);
+const error = ref('');
+
+const handleCreate = async () => {
+  const text = requestText.value.trim();
+  if (!text) return;
+
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const result = await api.createManagerOrder({
+      customer_id: props.customerId,
+      source: 'manager',
+      request_text: text,
+    });
+    emit('created', result.id);
+  } catch (e) {
+    error.value = getApiErrorMessage(e);
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleClose = () => {
+  if (!loading.value) emit('close');
+};
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal-fade">
+      <div
+        class="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+        @click.self="handleClose"
+      >
+        <div
+          class="w-full max-w-md rounded-2xl bg-[#1e293b] border border-slate-700/60 shadow-2xl flex flex-col overflow-hidden"
+          style="max-height: 90vh"
+        >
+          <!-- Header -->
+          <div class="flex items-center justify-between px-6 py-4 border-b border-slate-700/50">
+            <div class="flex items-center gap-3">
+              <span class="material-icons-round text-teal-400 text-2xl">add_shopping_cart</span>
+              <div>
+                <h2 class="text-lg font-bold text-white">Новый заказ</h2>
+                <p class="text-xs text-slate-400 mt-0.5">{{ customerName }}</p>
+              </div>
+            </div>
+            <button
+              @click="handleClose"
+              :disabled="loading"
+              class="text-slate-400 hover:text-white transition-colors disabled:opacity-40"
+            >
+              <span class="material-icons-round text-xl">close</span>
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="px-6 py-5 space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-slate-300 mb-2">
+                Описание запроса
+                <span class="text-slate-500 font-normal ml-1">— что нужно клиенту</span>
+              </label>
+              <textarea
+                v-model="requestText"
+                :disabled="loading"
+                rows="4"
+                placeholder="Кондиционер в комнату 25 м², монтаж с закладкой трассы..."
+                class="w-full rounded-xl border border-slate-600 bg-slate-900 text-slate-100 placeholder-slate-600 text-sm px-4 py-3 resize-none outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all disabled:opacity-50"
+                @keydown.meta.enter="handleCreate"
+                @keydown.ctrl.enter="handleCreate"
+              />
+            </div>
+
+            <p class="text-xs text-slate-500">
+              Заказ будет создан в статусе <span class="text-teal-400 font-medium">Переговоры</span>
+            </p>
+
+            <!-- Error -->
+            <div v-if="error" class="rounded-xl border border-red-500/40 bg-red-900/20 px-4 py-3 text-sm text-red-300">
+              {{ error }}
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="px-6 py-4 border-t border-slate-700/50 flex justify-end gap-3">
+            <button
+              @click="handleClose"
+              :disabled="loading"
+              class="px-4 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-700 transition-colors disabled:opacity-40"
+            >
+              Отмена
+            </button>
+            <button
+              @click="handleCreate"
+              :disabled="loading || !requestText.trim()"
+              class="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold bg-teal-600 hover:bg-teal-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-teal-900/30"
+            >
+              <span
+                v-if="loading"
+                class="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin"
+              />
+              <span class="material-icons-round text-base" v-else>add</span>
+              {{ loading ? 'Создаём...' : 'Создать заказ' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
-import { ArrowLeft, Building2, Mail, Phone, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
+import { ArrowLeft, Building2, Mail, Phone, Plus, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
+import CreateOrderModal from '../components/CreateOrderModal.vue';
 import { api } from '../api';
 import { ManagerService, type ManagerCatalogCustomerItemResponse, type ManagerCustomerDocumentItem } from '../client';
 import { useBelarusPhoneMask } from '../composables/useBelarusPhoneMask';
@@ -43,6 +44,7 @@ const saveError = ref('');
 const success = ref('');
 const toast = ref('');
 const editMode = ref(false);
+const showCreateOrder = ref(false);
 const serverErrors = ref<Record<string, string>>({});
 
 const documents = ref<ManagerCustomerDocumentItem[]>([]);
@@ -213,6 +215,12 @@ const openOrders = () => {
     ? `/manager/orders/kanban?search=${encodeURIComponent(search)}`
     : '/manager/orders/kanban';
   window.history.pushState({}, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+const onOrderCreated = (orderId: number) => {
+  showCreateOrder.value = false;
+  window.history.pushState({}, '', `/manager/orders/kanban?orderId=${orderId}`);
   window.dispatchEvent(new PopStateEvent('popstate'));
 };
 
@@ -399,6 +407,10 @@ onMounted(() => {
         <button v-if="customer" class="btn-mini" type="button" @click="openOrders">
           Сделки клиента
         </button>
+        <button v-if="customer && !editMode" class="btn-mini" type="button" @click="showCreateOrder = true">
+          <Plus class="h-4 w-4" />
+          Новый заказ
+        </button>
         <button v-if="customer && !editMode" class="btn-mini" type="button" @click="startEdit">
           Редактировать
         </button>
@@ -554,6 +566,14 @@ onMounted(() => {
         </section>
 
       </div>
+
+      <CreateOrderModal
+        v-if="showCreateOrder && customer"
+        :customer-id="customer.id"
+        :customer-name="customer.full_legal_name || customer.name || `Клиент #${customer.id}`"
+        @close="showCreateOrder = false"
+        @created="onOrderCreated"
+      />
     </div>
   </div>
 </template>

--- a/manager_frontend/src/views/CustomersView.vue
+++ b/manager_frontend/src/views/CustomersView.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from 'vue';
-import { Search, Users, ChevronLeft, ChevronRight, Phone, Mail, Building } from 'lucide-vue-next';
+import { Search, Users, ChevronLeft, ChevronRight, Phone, Mail, Building, Plus } from 'lucide-vue-next';
 import { api } from '../api';
 import type { ManagerCatalogCustomerItemResponse } from '../client';
 import { CUSTOMER_UPDATED_EVENT, type CustomerUpdatedEventPayload } from '../utils/customer-events';
+import CreateOrderModal from '../components/CreateOrderModal.vue';
 
 // --- State ---
 const customers = ref<ManagerCatalogCustomerItemResponse[]>([]);
@@ -16,6 +17,20 @@ const meta = ref({ total: 0, pages: 1, limit: 20 });
 const recentlyUpdated = ref<Record<number, number>>({});
 const cleanupTimers = new Map<number, number>();
 const toast = ref('');
+const showCreateOrder = ref(false);
+const createOrderCustomer = ref<{ id: number; name: string } | null>(null);
+
+function openCreateOrder(customer: ManagerCatalogCustomerItemResponse) {
+  createOrderCustomer.value = { id: customer.id, name: customer.full_legal_name || customer.name || `Клиент #${customer.id}` };
+  showCreateOrder.value = true;
+}
+
+function onOrderCreated(orderId: number) {
+  showCreateOrder.value = false;
+  createOrderCustomer.value = null;
+  window.history.pushState({}, '', `/manager/orders/kanban?orderId=${orderId}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
 
 function setToast(msg: string) {
   toast.value = msg;
@@ -247,6 +262,9 @@ onUnmounted(() => {
           </div>
           <div class="footer-actions">
             <div class="date-added">{{ formatDate(customer.created_at) }}</div>
+            <button class="open-btn" @click="openCreateOrder(customer)" title="Создать заказ">
+              <Plus :size="14" />
+            </button>
             <button class="open-btn" @click="openCustomerProfile(customer.id)">Карточка</button>
           </div>
         </div>
@@ -263,6 +281,14 @@ onUnmounted(() => {
         <ChevronRight :size="16" />
       </button>
     </div>
+
+    <CreateOrderModal
+      v-if="showCreateOrder && createOrderCustomer"
+      :customer-id="createOrderCustomer.id"
+      :customer-name="createOrderCustomer.name"
+      @close="showCreateOrder = false; createOrderCustomer = null"
+      @created="onOrderCreated"
+    />
 
   </div>
 </template>

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -43,7 +43,11 @@ async def create_manager_order(
     try:
         from models import LeadSource, OrderStatus
         source_enum = LeadSource(payload.source) if payload.source else LeadSource.MANAGER
-        initial_status = OrderStatus.NEGOTIATION if payload.service_type == "maintenance" else OrderStatus.NEW_LEAD
+        # Orders from customer card (customer_id provided) or maintenance skip new_lead
+        if payload.customer_id or payload.service_type == "maintenance":
+            initial_status = OrderStatus.NEGOTIATION
+        else:
+            initial_status = OrderStatus.NEW_LEAD
         order = await OrderService.create_from_website(
             session=session,
             customer_name=payload.name or "Новый клиент",


### PR DESCRIPTION
- Add CreateOrderModal component for quick order creation
- Integrate into CustomerProfileView (header button) and CustomersView (card button)
- Orders from customer card start at 'negotiation' status (skip new_lead)
- Navigate to Kanban board after creation

## Summary

- What changed:
- Why:

## Scope

- [ ] Backend
- [ ] Storefront (`web/`)
- [ ] Manager frontend (`manager_frontend/`)
- [ ] Infra/CI/CD
- [ ] DB migration

## Validation

- Local checks run:
  - [ ] `pytest -q` (or targeted tests)
  - [ ] `cd web && npm run build` (if touched)
  - [ ] `cd manager_frontend && npm run build` (if touched)
- Manual checks:
  - [ ] Main user flow verified
  - [ ] No visible regressions in touched areas

## Legacy Admin Check

- [ ] This PR changes `admin/*` (legacy SQLAdmin)
- [ ] If yes, justification provided (why compat fix is needed and why not manager-first)

## Deployment Notes

- [ ] No special deploy steps
- [ ] Requires Alembic migration
- [ ] Requires post-deploy script/manual data operation

If special steps required, describe exact commands:

```bash
# Example
# docker compose exec app alembic upgrade head
```

## Risk and Rollback

- Risk level: Low / Medium / High
- Rollback plan:

## Screenshots / Logs (optional)
