### PR TITLE
CRM branches v1: report and safe backfill scripts (#257)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,14 @@ Production server intentionally runs from Docker images only (no git checkout in
 3. Manual commands on prod:
    - Report only:
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/report_legacy_tag_links.py`
+   - Report CRM branch candidates (orders grouped by customer/address):
+     - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/report_customer_branch_candidates.py --min-orders 2 --only-candidates`
+   - CRM branch backfill dry-run (safe default):
+     - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_customer_branches.py --min-orders 2`
+   - CRM branch backfill execute (manual-only):
+     - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_customer_branches.py --min-orders 2 --execute`
+   - CRM branch backfill for one customer (recommended first run):
+     - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_customer_branches.py --customer-id 123 --execute`
    - Normalize:
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/normalize_legacy.py`
    - Backfill brand/series:
@@ -170,6 +178,7 @@ Production server intentionally runs from Docker images only (no git checkout in
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/cleanup_legacy_tag_links.py --execute`
 4. Policy:
    - Cleanup is manual and explicit only.
+   - CRM branch backfill is manual-only and starts from dry-run.
    - Post-deploy smoke-check must pass (`/health`, `/api/v1/products?limit=5`, `/api/v1/filters/config`) before considering deploy successful.
 
 ## Notes

--- a/scripts/backfill_customer_branches.py
+++ b/scripts/backfill_customer_branches.py
@@ -1,0 +1,143 @@
+import argparse
+import asyncio
+import sys
+from collections import defaultdict
+from typing import Dict, Iterable, List, Optional, Set
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from models import CustomerBranch
+from scripts.customer_branch_backfill_common import (
+    BranchBackfillPlanItem,
+    build_backfill_plan,
+    fetch_customer_address_stats,
+    fetch_existing_branch_keys,
+    filter_stats_by_min_orders,
+)
+
+
+def _parse_customer_ids(raw_values: Optional[List[int]]) -> Optional[Set[int]]:
+    if not raw_values:
+        return None
+    return {int(value) for value in raw_values if int(value) > 0}
+
+
+def _print_plan(plan: Iterable[BranchBackfillPlanItem]) -> None:
+    grouped: Dict[int, List[BranchBackfillPlanItem]] = defaultdict(list)
+    for item in plan:
+        grouped[item.customer_id].append(item)
+
+    for customer_id in sorted(grouped.keys()):
+        entries = grouped[customer_id]
+        customer_name = entries[0].customer_name
+        print(f"\n[{customer_id}] {customer_name}")
+        for entry in entries:
+            default_mark = " default" if entry.is_default else ""
+            print(
+                "  - "
+                f"orders={entry.order_count:<3} linked={entry.linked_order_count:<3} "
+                f"address={entry.delivery_address}{default_mark}"
+            )
+
+
+async def run(*, execute: bool, min_orders: int, customer_ids: Optional[Set[int]]) -> None:
+    db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(db_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        stats_by_customer = await fetch_customer_address_stats(session)
+        stats_by_customer = filter_stats_by_min_orders(stats_by_customer, min_orders=min_orders)
+        existing_branches_by_customer = await fetch_existing_branch_keys(session)
+
+        if customer_ids:
+            stats_by_customer = {
+                customer_id: stats
+                for customer_id, stats in stats_by_customer.items()
+                if customer_id in customer_ids
+            }
+            existing_branches_by_customer = {
+                customer_id: entries
+                for customer_id, entries in existing_branches_by_customer.items()
+                if customer_id in customer_ids
+            }
+
+        plan = build_backfill_plan(
+            stats_by_customer=stats_by_customer,
+            existing_branches_by_customer=existing_branches_by_customer,
+        )
+
+        print("Customer Branch Backfill")
+        print(f"  min_orders={max(1, min_orders)}")
+        print(f"  scoped_customers={len(stats_by_customer)}")
+        print(f"  new_branches_planned={len(plan)}")
+        if customer_ids:
+            print(f"  customer_scope={sorted(customer_ids)}")
+
+        if not plan:
+            print("Nothing to backfill.")
+            await engine.dispose()
+            return
+
+        _print_plan(plan)
+
+        if not execute:
+            print("\nDry run only. Use --execute to persist branches.")
+            await engine.dispose()
+            return
+
+        for item in plan:
+            branch = CustomerBranch(
+                customer_id=item.customer_id,
+                delivery_address=item.delivery_address,
+                is_default=item.is_default,
+            )
+            session.add(branch)
+
+        await session.commit()
+        print(f"\nApplied. Created {len(plan)} customer branches.")
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create missing customer branches from historical order delivery addresses. "
+            "Default mode is dry-run."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist changes. Without this flag script only prints planned actions.",
+    )
+    parser.add_argument(
+        "--min-orders",
+        type=int,
+        default=2,
+        help="Minimum number of orders per address to consider branch candidate (default: 2).",
+    )
+    parser.add_argument(
+        "--customer-id",
+        action="append",
+        type=int,
+        default=None,
+        help="Limit backfill to specific customer id. Can be passed multiple times.",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run(
+            execute=args.execute,
+            min_orders=args.min_orders,
+            customer_ids=_parse_customer_ids(args.customer_id),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/customer_branch_backfill_common.py
+++ b/scripts/customer_branch_backfill_common.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import Customer, CustomerBranch, Order
+
+
+_SPACE_RE = re.compile(r"\s+")
+
+
+@dataclass
+class CustomerAddressStat:
+    customer_id: int
+    customer_name: str
+    normalized_address: str
+    address_key: str
+    order_count: int = 0
+    linked_order_count: int = 0
+    first_order_at: datetime | None = None
+    last_order_at: datetime | None = None
+
+
+@dataclass
+class BranchBackfillPlanItem:
+    customer_id: int
+    customer_name: str
+    delivery_address: str
+    address_key: str
+    order_count: int
+    linked_order_count: int
+    is_default: bool
+
+
+def normalize_address(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = _SPACE_RE.sub(" ", value.replace("\n", " ").replace("\r", " ")).strip(" ,;\t")
+    return normalized or None
+
+
+def address_key(value: str | None) -> str | None:
+    normalized = normalize_address(value)
+    if not normalized:
+        return None
+    return normalized.casefold()
+
+
+def _sort_stats(stats: Iterable[CustomerAddressStat]) -> List[CustomerAddressStat]:
+    return sorted(
+        stats,
+        key=lambda item: (
+            -item.order_count,
+            item.last_order_at or datetime.min,
+            item.normalized_address.casefold(),
+        ),
+    )
+
+
+def filter_stats_by_min_orders(
+    stats_by_customer: Dict[int, List[CustomerAddressStat]],
+    min_orders: int,
+) -> Dict[int, List[CustomerAddressStat]]:
+    min_threshold = max(1, int(min_orders))
+    filtered: Dict[int, List[CustomerAddressStat]] = {}
+    for customer_id, stats in stats_by_customer.items():
+        selected = [item for item in stats if item.order_count >= min_threshold]
+        if selected:
+            filtered[customer_id] = _sort_stats(selected)
+    return filtered
+
+
+async def fetch_customer_address_stats(session: AsyncSession) -> Dict[int, List[CustomerAddressStat]]:
+    stmt = (
+        select(
+            Order.customer_id,
+            Customer.name,
+            Order.delivery_address,
+            Order.created_at,
+            Order.customer_branch_id,
+        )
+        .join(Customer, Customer.id == Order.customer_id)
+        .where(
+            Order.customer_id.is_not(None),
+            Order.delivery_address.is_not(None),
+            func.length(func.trim(Order.delivery_address)) > 0,
+        )
+        .order_by(Order.customer_id.asc(), Order.created_at.asc(), Order.id.asc())
+    )
+    rows = (await session.execute(stmt)).all()
+
+    by_customer: Dict[int, Dict[str, CustomerAddressStat]] = {}
+    for customer_id_raw, customer_name_raw, delivery_address, created_at, customer_branch_id in rows:
+        normalized = normalize_address(delivery_address)
+        key = address_key(normalized)
+        if not normalized or not key:
+            continue
+
+        customer_id = int(customer_id_raw)
+        customer_name = str(customer_name_raw or f"Customer #{customer_id}")
+
+        customer_stats = by_customer.setdefault(customer_id, {})
+        stat = customer_stats.get(key)
+        if stat is None:
+            stat = CustomerAddressStat(
+                customer_id=customer_id,
+                customer_name=customer_name,
+                normalized_address=normalized,
+                address_key=key,
+            )
+            customer_stats[key] = stat
+
+        stat.order_count += 1
+        if customer_branch_id is not None:
+            stat.linked_order_count += 1
+
+        if created_at is not None:
+            if stat.first_order_at is None or created_at < stat.first_order_at:
+                stat.first_order_at = created_at
+            if stat.last_order_at is None or created_at > stat.last_order_at:
+                stat.last_order_at = created_at
+
+    result: Dict[int, List[CustomerAddressStat]] = {}
+    for customer_id, stats in by_customer.items():
+        result[customer_id] = _sort_stats(stats.values())
+    return result
+
+
+async def fetch_existing_branch_keys(session: AsyncSession) -> Dict[int, Dict[str, CustomerBranch]]:
+    stmt = (
+        select(CustomerBranch)
+        .where(CustomerBranch.customer_id.is_not(None))
+        .order_by(CustomerBranch.customer_id.asc(), CustomerBranch.created_at.asc(), CustomerBranch.id.asc())
+    )
+    branches = (await session.execute(stmt)).scalars().all()
+
+    by_customer: Dict[int, Dict[str, CustomerBranch]] = {}
+    for branch in branches:
+        key = address_key(branch.delivery_address)
+        if not key:
+            continue
+        customer_id = int(branch.customer_id)
+        customer_map = by_customer.setdefault(customer_id, {})
+        customer_map.setdefault(key, branch)
+    return by_customer
+
+
+def build_backfill_plan(
+    *,
+    stats_by_customer: Dict[int, List[CustomerAddressStat]],
+    existing_branches_by_customer: Dict[int, Dict[str, CustomerBranch]],
+) -> List[BranchBackfillPlanItem]:
+    plan: List[BranchBackfillPlanItem] = []
+
+    for customer_id in sorted(stats_by_customer.keys()):
+        stats = stats_by_customer[customer_id]
+        existing_map = dict(existing_branches_by_customer.get(customer_id, {}))
+        has_existing_branches = bool(existing_map)
+        has_default_branch = any(
+            bool(branch.is_default) for branch in existing_branches_by_customer.get(customer_id, {}).values()
+        )
+        created_for_customer = 0
+
+        for stat in stats:
+            if stat.address_key in existing_map:
+                continue
+            is_default = (not has_existing_branches) and (not has_default_branch) and (created_for_customer == 0)
+            plan.append(
+                BranchBackfillPlanItem(
+                    customer_id=stat.customer_id,
+                    customer_name=stat.customer_name,
+                    delivery_address=stat.normalized_address,
+                    address_key=stat.address_key,
+                    order_count=stat.order_count,
+                    linked_order_count=stat.linked_order_count,
+                    is_default=is_default,
+                )
+            )
+            existing_map[stat.address_key] = CustomerBranch(
+                customer_id=stat.customer_id,
+                delivery_address=stat.normalized_address,
+                is_default=is_default,
+            )
+            created_for_customer += 1
+
+    return sorted(
+        plan,
+        key=lambda item: (
+            item.customer_name.casefold(),
+            item.customer_id,
+            -item.order_count,
+            item.delivery_address.casefold(),
+        ),
+    )

--- a/scripts/report_customer_branch_candidates.py
+++ b/scripts/report_customer_branch_candidates.py
@@ -1,0 +1,137 @@
+import argparse
+import asyncio
+import sys
+from datetime import datetime
+from typing import Dict, List
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from scripts.customer_branch_backfill_common import (
+    CustomerAddressStat,
+    build_backfill_plan,
+    fetch_customer_address_stats,
+    fetch_existing_branch_keys,
+    filter_stats_by_min_orders,
+)
+
+
+def _fmt_dt(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.strftime("%Y-%m-%d")
+
+
+def _print_customer_block(
+    *,
+    customer_id: int,
+    customer_name: str,
+    stats: List[CustomerAddressStat],
+    existing_count: int,
+) -> None:
+    print(f"\n[{customer_id}] {customer_name}")
+    print(f"  existing_branches={existing_count}")
+    for stat in stats:
+        print(
+            "  - "
+            f"orders={stat.order_count:<3} "
+            f"linked={stat.linked_order_count:<3} "
+            f"first={_fmt_dt(stat.first_order_at)} "
+            f"last={_fmt_dt(stat.last_order_at)} "
+            f"address={stat.normalized_address}"
+        )
+
+
+async def run(*, min_orders: int, only_candidates: bool, max_customers: int | None) -> None:
+    db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(db_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        all_stats_by_customer = await fetch_customer_address_stats(session)
+        filtered_stats_by_customer = filter_stats_by_min_orders(
+            all_stats_by_customer,
+            min_orders=min_orders,
+        )
+        existing_branches_by_customer = await fetch_existing_branch_keys(session)
+        plan = build_backfill_plan(
+            stats_by_customer=filtered_stats_by_customer,
+            existing_branches_by_customer=existing_branches_by_customer,
+        )
+
+        customers_with_candidates = {item.customer_id for item in plan}
+        customer_ids = sorted(filtered_stats_by_customer.keys())
+        if only_candidates:
+            customer_ids = [customer_id for customer_id in customer_ids if customer_id in customers_with_candidates]
+        if max_customers is not None:
+            customer_ids = customer_ids[: max(0, max_customers)]
+
+        plan_count_by_customer: Dict[int, int] = {}
+        for item in plan:
+            plan_count_by_customer[item.customer_id] = plan_count_by_customer.get(item.customer_id, 0) + 1
+
+        print("Customer Branch Backfill Report")
+        print(f"  total_customers_with_addresses={len(all_stats_by_customer)}")
+        print(f"  customers_after_min_orders_filter={len(filtered_stats_by_customer)}")
+        print(f"  min_orders={max(1, min_orders)}")
+        print(f"  customers_with_new_branch_candidates={len(customers_with_candidates)}")
+        print(f"  new_branch_candidates_total={len(plan)}")
+        print(f"  printed_customers={len(customer_ids)}")
+
+        for customer_id in customer_ids:
+            stats = filtered_stats_by_customer.get(customer_id, [])
+            if not stats:
+                continue
+            customer_name = stats[0].customer_name
+            existing_count = len(existing_branches_by_customer.get(customer_id, {}))
+            _print_customer_block(
+                customer_id=customer_id,
+                customer_name=customer_name,
+                stats=stats,
+                existing_count=existing_count,
+            )
+            new_count = plan_count_by_customer.get(customer_id, 0)
+            if new_count:
+                print(f"    -> new_branch_candidates={new_count}")
+
+        print("\nTips:")
+        print("  - Use --only-candidates to focus only on customers with pending branch creation.")
+        print("  - Use scripts/backfill_customer_branches.py for dry-run/apply.")
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Report customer branch candidates from order delivery addresses.")
+    parser.add_argument(
+        "--min-orders",
+        type=int,
+        default=2,
+        help="Minimum number of orders per address to include candidate (default: 2).",
+    )
+    parser.add_argument(
+        "--only-candidates",
+        action="store_true",
+        help="Show only customers that still have new branch candidates.",
+    )
+    parser.add_argument(
+        "--max-customers",
+        type=int,
+        default=None,
+        help="Limit number of customers printed in report.",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run(
+            min_orders=args.min_orders,
+            only_candidates=args.only_candidates,
+            max_customers=args.max_customers,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/report_customer_branch_candidates.py` for report-only analysis of delivery addresses grouped by customer
- add `scripts/backfill_customer_branches.py` with dry-run by default and explicit `--execute`
- add shared aggregation/dedup module `scripts/customer_branch_backfill_common.py`
- update `AGENTS.md` with reproducible prod manual-only commands for report/backfill

## Safety
- no writes happen without `--execute`
- backfill deduplicates addresses against existing branches (normalized key)
- default branch is assigned only when customer has no existing branches

## Verification
- `python3 -m py_compile scripts/customer_branch_backfill_common.py scripts/report_customer_branch_candidates.py scripts/backfill_customer_branches.py`
- `python3 scripts/report_customer_branch_candidates.py --help`
- `python3 scripts/backfill_customer_branches.py --help`
- `docker compose exec -T app python3 scripts/report_customer_branch_candidates.py --min-orders 2 --only-candidates --max-customers 3`
- `docker compose exec -T app python3 scripts/backfill_customer_branches.py --min-orders 2`

Closes #257
