### PR TITLE
Importer: add lg24.by and hobot.by parsers (#249)

### DIFF
--- a/manager_frontend/src/components/BulkSpecsModal.vue
+++ b/manager_frontend/src/components/BulkSpecsModal.vue
@@ -32,6 +32,12 @@ const hiddenWifiAliasKeys = new Set([
     '__filter_wifi',
     '__filter_wifi_builtin',
 ]);
+const getSelectOptions = (key: string, value: unknown): string[] => {
+    const base = [...(specsTranslations[key]?.options || [])];
+    const current = String(value ?? '').trim();
+    if (current && !base.includes(current)) return [current, ...base];
+    return base;
+};
 
 // Fetch known keys for autocomplete
 const fetchKeys = async () => {
@@ -223,7 +229,7 @@ const save = async () => {
                                     class="w-full h-[38px] border dark:border-slate-700 bg-white dark:bg-slate-900 dark:text-slate-200 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500"
                                 >
                                     <option value="" disabled>{{ operation === 'delete_keys' ? 'Пропускается' : 'Выберите значение' }}</option>
-                                    <option v-for="opt in specsTranslations[row.key]?.options || []" :key="opt" :value="opt">
+                                    <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
                                         {{
                                             row.key === 'wifi_ready'
                                                 ? (opt === 'true' ? 'Да (встроен)' : (opt === 'ready' ? 'Ready (модуль отдельно)' : 'Нет'))

--- a/manager_frontend/src/components/OnlinerImportModal.vue
+++ b/manager_frontend/src/components/OnlinerImportModal.vue
@@ -102,7 +102,7 @@ const handleClose = () => {
               <div>
                 <p class="text-sm font-medium text-slate-200">Спарсить связанные</p>
                 <p class="text-xs text-slate-500 mt-0.5">
-                  Серию для Aircond.by / модификации для Onliner
+                  Серии/модификации для Aircond.by, Onliner и LG24
                 </p>
               </div>
               <!-- Toggle switch -->

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -94,6 +94,12 @@ const newBrandTitle = ref('');
 
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
+const getSelectOptions = (key: string, value: unknown): string[] => {
+    const base = [...(specsTranslations[key]?.options || [])];
+    const current = String(value ?? '').trim();
+    if (current && !base.includes(current)) return [current, ...base];
+    return base;
+};
 const INVALID_BRAND_TOKENS = new Set([
     'мультисплитсистема',
     'сплитсистема',
@@ -1568,7 +1574,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                                             class="w-full h-[38px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all text-gray-900 dark:text-slate-200 shadow-inner"
                                         >
                                             <option value="" disabled>Выберите значение</option>
-                                            <option v-for="opt in specsTranslations[row.key]?.options || []" :key="opt" :value="opt">
+                                            <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
                                                 {{
                                                     row.key === 'wifi_ready'
                                                         ? (opt === 'true' ? 'Да (встроен)' : (opt === 'ready' ? 'Ready (модуль отдельно)' : 'Нет'))

--- a/manager_frontend/src/utils/specsTranslations.ts
+++ b/manager_frontend/src/utils/specsTranslations.ts
@@ -10,7 +10,7 @@ export const specsTranslations: Record<string, SpecConfig> = {
     series: { label: 'Серия (Линейка)', type: 'text' },
     is_inverter: { label: 'Инвертор', type: 'boolean' },
     wifi_module: { label: 'Wi-Fi', type: 'boolean' },
-    compressor_brand: { label: 'Марка компрессора', type: 'select', options: ['GMCC', 'Toshiba', 'Highly', 'Panasonic', 'Gree'] },
+    compressor_brand: { label: 'Марка компрессора', type: 'select', options: ['GMCC', 'Toshiba', 'Highly', 'Panasonic', 'Gree', 'Mitsubishi'] },
     pipe_liquid: { label: 'Труба жидкостная', type: 'select', options: ['1/4"', '3/8"', '1/2"'] },
     pipe_gas: { label: 'Труба газовая', type: 'select', options: ['3/8"', '1/2"', '5/8"', '3/4"'] },
     capacity_cooling_kw: { label: 'Мощность охлаждения', type: 'number', unit: 'кВт' },

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -48,6 +48,31 @@ class HaierProffParser(BaseParser):
         return series or None
 
     @staticmethod
+    def _infer_type_specs_from_url(url: str) -> Dict[str, str]:
+        lowered = (url or "").lower()
+        inferred: Dict[str, str] = {}
+
+        if "vnutrennij-blok" in lowered:
+            inferred["Тип"] = "Внутренний блок"
+        elif "naruzhnyj-blok" in lowered:
+            inferred["Тип"] = "Наружный блок"
+        elif "split-sistema" in lowered:
+            inferred["Тип"] = "Сплит-система"
+
+        if "kasset" in lowered:
+            inferred["Тип внутреннего блока"] = "Кассетный"
+        elif "kanal" in lowered:
+            inferred["Тип внутреннего блока"] = "Канальный"
+        elif "kolonn" in lowered:
+            inferred["Тип внутреннего блока"] = "Колонный"
+        elif "napolno" in lowered or "potolochn" in lowered:
+            inferred["Тип внутреннего блока"] = "Напольно-потолочный"
+        elif "nastenn" in lowered or "super-match-as" in lowered:
+            inferred["Тип внутреннего блока"] = "Настенный"
+
+        return inferred
+
+    @staticmethod
     def _parse_first_number(value: str) -> float | None:
         if not value:
             return None
@@ -218,6 +243,8 @@ class HaierProffParser(BaseParser):
         series = self._extract_series_from_title(title)
         if series:
             specs.setdefault("Серия", series)
+        for key, value in self._infer_type_specs_from_url(str(response.url)).items():
+            specs.setdefault(key, value)
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -20,6 +20,11 @@ class HaierProffParser(BaseParser):
         ),
         "Accept-Language": "ru-RU,ru;q=0.9,en;q=0.8",
     }
+    _WIFI_TITLE_MARKERS = ("wi-fi", "wifi", "evo wi-fi", "evo wifi")
+    _WIFI_ICON_MARKERS = (
+        "44cdb19d3e20378d090e233fdcc44d44",  # evo wi-fi icon (png)
+        "4bc4d72914fc0e1db789283629505b2b",  # wifi icon (svg)
+    )
 
     def supports(self, url: str) -> bool:
         return "haierproff.ru" in url and "/catalog/cond/products/" in url
@@ -189,6 +194,44 @@ class HaierProffParser(BaseParser):
                 specs[key] = value
         return specs
 
+    @classmethod
+    def _extract_feature_entries(cls, soup: BeautifulSoup) -> List[Dict[str, str]]:
+        entries: List[Dict[str, str]] = []
+        for item in soup.select(".feature-s-list__item"):
+            img_el = item.select_one(".feature-s__icon img")
+            title_el = item.select_one(".feature-s__title")
+            desc_el = item.select_one(".feature-s__desc")
+            img_src = (img_el.get("src", "") if img_el else "").strip()
+            title = (title_el.get_text(" ", strip=True) if title_el else "").strip()
+            desc = (desc_el.get_text(" ", strip=True) if desc_el else "").strip()
+            entries.append(
+                {
+                    "img": img_src,
+                    "title": title,
+                    "desc": desc,
+                    "text": " ".join(part for part in (title, desc) if part).strip(),
+                }
+            )
+        return entries
+
+    @classmethod
+    def _feature_entries_indicate_wifi(cls, entries: List[Dict[str, str]]) -> bool:
+        for entry in entries:
+            text = str(entry.get("text", "")).lower().replace("ё", "е")
+            if any(marker in text for marker in cls._WIFI_TITLE_MARKERS):
+                return True
+            img_src = str(entry.get("img", "")).lower()
+            if any(marker in img_src for marker in cls._WIFI_ICON_MARKERS):
+                return True
+        return False
+
+    @staticmethod
+    def _should_assume_wifi_option(specs: Dict[str, str]) -> bool:
+        # User rule: if wifi isn't detectable, keep conservative "ready/option"
+        # for non-outdoor units.
+        unit_type = str(specs.get("Тип", "")).lower().replace("ё", "е")
+        return "наруж" not in unit_type
+
     @staticmethod
     def _extract_metrics(specs: Dict[str, str], title: str) -> Dict[str, Any]:
         metrics: Dict[str, Any] = {
@@ -276,7 +319,12 @@ class HaierProffParser(BaseParser):
         parsed_price = self._parse_first_number(price_text)
         price = int(round(parsed_price)) if parsed_price is not None else 0
 
-        features = [item.get_text(" ", strip=True) for item in soup.select(".feature-s-list__item") if item.get_text(" ", strip=True)]
+        feature_entries = self._extract_feature_entries(soup)
+        features = [
+            entry["text"]
+            for entry in feature_entries
+            if entry.get("text")
+        ]
         description_parts = []
         if features:
             description_parts.append("Преимущества: " + ", ".join(features))
@@ -307,6 +355,13 @@ class HaierProffParser(BaseParser):
             if key == "Тип внутреннего блока" and current == "настенный" and incoming != current:
                 specs[key] = value
                 continue
+
+        wifi_present = self._feature_entries_indicate_wifi(feature_entries)
+        if wifi_present:
+            specs.setdefault("Wi-Fi", "Да")
+        elif "Wi-Fi" not in specs and "Wi-Fi Ready" not in specs and self._should_assume_wifi_option(specs):
+            specs["Wi-Fi"] = "Опция"
+
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -206,6 +206,7 @@ class HaierProffParser(BaseParser):
             "slug": self._slug_from_url(str(response.url)),
             "description": description,
             "price": price,
+            "price_currency": "RUB",
             "area": metrics["area"],
             "main_image": images[0] if images else "",
             "images": images[1:] if len(images) > 1 else [],

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -73,6 +73,50 @@ class HaierProffParser(BaseParser):
         return inferred
 
     @staticmethod
+    def _extract_breadcrumb_parts(soup: BeautifulSoup) -> List[str]:
+        parts: List[str] = []
+        for node in soup.select(".breadcrumbs .breadcrumbs__item"):
+            text = re.sub(r"\s+", " ", node.get_text(" ", strip=True)).strip()
+            if text:
+                parts.append(text)
+        return parts
+
+    @staticmethod
+    def _infer_type_specs_from_breadcrumb_and_title(
+        *,
+        title: str,
+        breadcrumb_parts: List[str],
+    ) -> Dict[str, str]:
+        inferred: Dict[str, str] = {}
+        combined = " ".join([title, *breadcrumb_parts]).lower().replace("ё", "е")
+
+        if "полупром" in combined or "промышлен" in combined:
+            inferred.setdefault("Тип", "Полупромышленный кондиционер")
+        elif "мульти" in combined:
+            inferred.setdefault("Тип", "Мульти-сплит-система")
+
+        if "универсальн" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Напольно-потолочный")
+        elif "кассет" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Кассетный")
+        elif "каналь" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Канальный")
+        elif "колон" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Колонный")
+        elif "напольно" in combined or "потолоч" in combined or "подпотолоч" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Напольно-потолочный")
+        elif "настенн" in combined:
+            inferred.setdefault("Тип внутреннего блока", "Настенный")
+
+        if "Тип внутреннего блока" in inferred and "Тип" not in inferred:
+            if inferred["Тип внутреннего блока"] == "Настенный":
+                inferred["Тип"] = "Сплит-система"
+            else:
+                inferred["Тип"] = "Полупромышленный кондиционер"
+
+        return inferred
+
+    @staticmethod
     def _parse_first_number(value: str) -> float | None:
         if not value:
             return None
@@ -245,6 +289,24 @@ class HaierProffParser(BaseParser):
             specs.setdefault("Серия", series)
         for key, value in self._infer_type_specs_from_url(str(response.url)).items():
             specs.setdefault(key, value)
+        breadcrumb_parts = self._extract_breadcrumb_parts(soup)
+        for key, value in self._infer_type_specs_from_breadcrumb_and_title(
+            title=title,
+            breadcrumb_parts=breadcrumb_parts,
+        ).items():
+            current = str(specs.get(key, "")).strip().lower()
+            incoming = str(value).strip().lower()
+            if not current:
+                specs[key] = value
+                continue
+
+            # Breadcrumb/title inference is usually more specific than URL fallback.
+            if key == "Тип" and current in {"сплит-система", "split-system"} and incoming != current:
+                specs[key] = value
+                continue
+            if key == "Тип внутреннего блока" and current == "настенный" and incoming != current:
+                specs[key] = value
+                continue
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -31,6 +31,23 @@ class HaierProffParser(BaseParser):
         return segments[-1] if segments else "unknown"
 
     @staticmethod
+    def _normalize_title(raw_title: str) -> str:
+        title = re.sub(r"\s+", " ", (raw_title or "").strip())
+        if not title:
+            return "Без названия"
+        if not re.match(r"^haier\b", title, flags=re.IGNORECASE):
+            title = f"Haier {title}"
+        return title
+
+    @staticmethod
+    def _extract_series_from_title(title: str) -> str | None:
+        match = re.search(r"(?:^|\s)Серия\s+(.+)$", title, flags=re.IGNORECASE)
+        if not match:
+            return None
+        series = re.sub(r"\s+", " ", match.group(1)).strip(" -")
+        return series or None
+
+    @staticmethod
     def _parse_first_number(value: str) -> float | None:
         if not value:
             return None
@@ -180,7 +197,8 @@ class HaierProffParser(BaseParser):
             raise ValueError("URL haierproff.ru не похож на карточку товара кондиционера.")
 
         title_el = soup.select_one(".product-page__title")
-        title = title_el.get_text(" ", strip=True) if title_el else "Без названия"
+        title_raw = title_el.get_text(" ", strip=True) if title_el else "Без названия"
+        title = self._normalize_title(title_raw)
 
         price_text = ""
         price_el = soup.select_one(".product-page__price")
@@ -197,6 +215,9 @@ class HaierProffParser(BaseParser):
         description = "\n".join(dict.fromkeys(description_parts))
 
         specs = self._extract_specs(soup)
+        series = self._extract_series_from_title(title)
+        if series:
+            specs.setdefault("Серия", series)
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -1,0 +1,219 @@
+import re
+from typing import Any, Dict, List
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from .base import BaseParser
+
+
+class HaierProffParser(BaseParser):
+    """Parser for haierproff.ru conditioner catalog product pages."""
+
+    BASE_URL = "https://haierproff.ru"
+    _HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/122.0.0.0 Safari/537.36"
+        ),
+        "Accept-Language": "ru-RU,ru;q=0.9,en;q=0.8",
+    }
+
+    def supports(self, url: str) -> bool:
+        return "haierproff.ru" in url and "/catalog/cond/products/" in url
+
+    @staticmethod
+    def _slug_from_url(url: str) -> str:
+        path = url.rstrip("/").split("?")[0]
+        segments = [segment for segment in path.split("/") if segment]
+        return segments[-1] if segments else "unknown"
+
+    @staticmethod
+    def _parse_first_number(value: str) -> float | None:
+        if not value:
+            return None
+        cleaned = value.replace("\xa0", " ")
+        match = re.search(r"(-?\d[\d\s]*(?:[.,]\d+)?)", cleaned)
+        if not match:
+            return None
+        try:
+            raw = match.group(1).replace(" ", "").replace(",", ".")
+            return float(raw)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _to_abs_url(cls, value: str, current_url: str) -> str:
+        if not value:
+            return ""
+        if value.startswith("//"):
+            return f"https:{value}"
+        if value.startswith("/"):
+            return f"{cls.BASE_URL}{value}"
+        if value.startswith("http://") or value.startswith("https://"):
+            return value
+        return urljoin(current_url, value)
+
+    @staticmethod
+    def _looks_like_product_page(soup: BeautifulSoup) -> bool:
+        return bool(
+            soup.select_one(".product-page__title")
+            and soup.select_one(".product-page__price")
+            and soup.select_one(".spec-l__item")
+        )
+
+    @classmethod
+    def _collect_images(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        seen: set[str] = set()
+        images: List[str] = []
+
+        for img in soup.select(".gallery__image-list img, .gallery img"):
+            src = img.get("src") or img.get("data-src") or ""
+            abs_url = cls._to_abs_url(src, current_url)
+            if not abs_url or abs_url.startswith("data:") or abs_url in seen:
+                continue
+            seen.add(abs_url)
+            images.append(abs_url)
+
+        return images
+
+    @classmethod
+    def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        related: List[str] = []
+        for link in soup.select("a[href*='/catalog/cond/products/']"):
+            href = cls._to_abs_url(link.get("href", ""), current_url)
+            if not href or href == current_url or href in related:
+                continue
+            related.append(href)
+        return related
+
+    @staticmethod
+    def _extract_specs(soup: BeautifulSoup) -> Dict[str, str]:
+        specs: Dict[str, str] = {}
+        for row in soup.select(".spec-l__item"):
+            key_el = row.select_one(".spec-l__item-label")
+            val_el = row.select_one(".spec-l__item-value")
+            if not key_el or not val_el:
+                continue
+            key = key_el.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
+            value = val_el.get_text(" ", strip=True).replace("\xa0", " ")
+            if key and value:
+                specs[key] = value
+        return specs
+
+    @staticmethod
+    def _extract_metrics(specs: Dict[str, str], title: str) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {
+            "power_cooling": None,
+            "power_heating": None,
+            "area": 0,
+            "is_inverter": False,
+            "min_temp_heating": None,
+        }
+        has_explicit_cooling = False
+        has_explicit_heating = False
+
+        for key, value in specs.items():
+            key_lower = key.lower()
+            value_lower = value.lower()
+
+            if "инвертор" in key_lower:
+                if "неинвертор" in key_lower:
+                    if value_lower.startswith("да"):
+                        metrics["is_inverter"] = False
+                    elif value_lower.startswith("нет"):
+                        metrics["is_inverter"] = True
+                else:
+                    metrics["is_inverter"] = value_lower.startswith("да") or "инвертор" in value_lower
+
+            if "площад" in key_lower:
+                numbers = re.findall(r"\d+", value)
+                if numbers:
+                    metrics["area"] = max(int(num) for num in numbers)
+
+            if ("охлаждение" in key_lower or "мощность охлаждения" in key_lower) and "квт" in key_lower:
+                parsed = HaierProffParser._parse_first_number(value)
+                if parsed is not None:
+                    is_derived_power = any(token in key_lower for token in ("потребля", "потреблен", "годов", "/г"))
+                    if not is_derived_power:
+                        metrics["power_cooling"] = parsed
+                        has_explicit_cooling = True
+                    elif not has_explicit_cooling and metrics["power_cooling"] is None:
+                        metrics["power_cooling"] = parsed
+
+            if ("нагрев" in key_lower or "обогрев" in key_lower or "мощность нагрева" in key_lower) and "квт" in key_lower:
+                parsed = HaierProffParser._parse_first_number(value)
+                if parsed is not None:
+                    is_derived_power = any(token in key_lower for token in ("потребля", "потреблен", "годов", "/г"))
+                    if not is_derived_power:
+                        metrics["power_heating"] = parsed
+                        has_explicit_heating = True
+                    elif not has_explicit_heating and metrics["power_heating"] is None:
+                        metrics["power_heating"] = parsed
+
+            if "нагрев" in key_lower and "°" in key_lower:
+                match = re.search(r"(-\d+)", value)
+                if match:
+                    metrics["min_temp_heating"] = int(match.group(1))
+
+        if not metrics["area"]:
+            title_area = re.search(r"(\d+)\s*м", title.lower())
+            if title_area:
+                metrics["area"] = int(title_area.group(1))
+
+        return metrics
+
+    async def parse(self, url: str) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=20.0,
+            headers=self._HEADERS,
+        ) as client:
+            response = await client.get(url)
+            if response.status_code != 200:
+                raise Exception(f"Ошибка загрузки страницы haierproff.ru: {response.status_code}")
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        if not self._looks_like_product_page(soup):
+            raise ValueError("URL haierproff.ru не похож на карточку товара кондиционера.")
+
+        title_el = soup.select_one(".product-page__title")
+        title = title_el.get_text(" ", strip=True) if title_el else "Без названия"
+
+        price_text = ""
+        price_el = soup.select_one(".product-page__price")
+        if price_el:
+            price_text = price_el.get_text(" ", strip=True)
+        parsed_price = self._parse_first_number(price_text)
+        price = int(round(parsed_price)) if parsed_price is not None else 0
+
+        features = [item.get_text(" ", strip=True) for item in soup.select(".feature-s-list__item") if item.get_text(" ", strip=True)]
+        description_parts = []
+        if features:
+            description_parts.append("Преимущества: " + ", ".join(features))
+        description_parts.append(title)
+        description = "\n".join(dict.fromkeys(description_parts))
+
+        specs = self._extract_specs(soup)
+        metrics = self._extract_metrics(specs, title)
+        images = self._collect_images(soup, str(response.url))
+        related_urls = self._collect_related_urls(soup, str(response.url))
+
+        return {
+            "title": title,
+            "slug": self._slug_from_url(str(response.url)),
+            "description": description,
+            "price": price,
+            "area": metrics["area"],
+            "main_image": images[0] if images else "",
+            "images": images[1:] if len(images) > 1 else [],
+            "save_gallery": True,
+            "categories": [],
+            "specs": specs,
+            "metrics": metrics,
+            "related_urls": related_urls,
+            "availability": "В наличии",
+            "in_stock": True,
+        }

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -25,6 +25,11 @@ class HaierProffParser(BaseParser):
         "44cdb19d3e20378d090e233fdcc44d44",  # evo wi-fi icon (png)
         "4bc4d72914fc0e1db789283629505b2b",  # wifi icon (svg)
     )
+    _GROUP_PREFIX_SPEC_BLOCKS = (
+        "Внутренний блок",
+        "Наружный блок",
+        "Компрессор",
+    )
 
     def supports(self, url: str) -> bool:
         return "haierproff.ru" in url and "/catalog/cond/products/" in url
@@ -99,6 +104,8 @@ class HaierProffParser(BaseParser):
             inferred.setdefault("Тип", "Полупромышленный кондиционер")
         elif "мульти" in combined:
             inferred.setdefault("Тип", "Мульти-сплит-система")
+        elif "сплит" in combined:
+            inferred.setdefault("Тип", "Сплит-система")
 
         if "универсальн" in combined:
             inferred.setdefault("Тип внутреннего блока", "Напольно-потолочный")
@@ -118,6 +125,9 @@ class HaierProffParser(BaseParser):
                 inferred["Тип"] = "Сплит-система"
             else:
                 inferred["Тип"] = "Полупромышленный кондиционер"
+
+        if inferred.get("Тип") == "Сплит-система" and "Тип внутреннего блока" not in inferred:
+            inferred["Тип внутреннего блока"] = "Настенный"
 
         return inferred
 
@@ -180,9 +190,36 @@ class HaierProffParser(BaseParser):
             related.append(href)
         return related
 
-    @staticmethod
-    def _extract_specs(soup: BeautifulSoup) -> Dict[str, str]:
+    @classmethod
+    def _extract_specs(cls, soup: BeautifulSoup) -> Dict[str, str]:
         specs: Dict[str, str] = {}
+
+        def _store_spec(key: str, value: str, group: str = "") -> None:
+            if not key or not value:
+                return
+            if key not in specs:
+                specs[key] = value
+            elif specs[key] != value and group:
+                specs[f"{group}: {key}"] = value
+
+            if group and any(group.startswith(block) for block in cls._GROUP_PREFIX_SPEC_BLOCKS):
+                specs[f"{group}: {key}"] = value
+
+        collapse_nodes = soup.select(".accordion .collapse")
+        if collapse_nodes:
+            for collapse in collapse_nodes:
+                header = collapse.select_one(":scope > .collapse__header")
+                group = re.sub(r"\s+", " ", header.get_text(" ", strip=True)).strip() if header else ""
+                for row in collapse.select(".spec-l__item"):
+                    key_el = row.select_one(".spec-l__item-label")
+                    val_el = row.select_one(".spec-l__item-value")
+                    if not key_el or not val_el:
+                        continue
+                    key = key_el.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
+                    value = val_el.get_text(" ", strip=True).replace("\xa0", " ")
+                    _store_spec(key, value, group=group)
+            return specs
+
         for row in soup.select(".spec-l__item"):
             key_el = row.select_one(".spec-l__item-label")
             val_el = row.select_one(".spec-l__item-value")
@@ -190,8 +227,7 @@ class HaierProffParser(BaseParser):
                 continue
             key = key_el.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
             value = val_el.get_text(" ", strip=True).replace("\xa0", " ")
-            if key and value:
-                specs[key] = value
+            _store_spec(key, value)
         return specs
 
     @classmethod

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -293,8 +293,9 @@ class HobotParser(BaseParser):
                 description = text
 
         specs = self._extract_specs(soup)
-        if availability:
-            specs.setdefault("Наличие", availability)
+        # Presence from source page is decorative and can be stale.
+        # Real stock is synced from price mapping, so don't store it in specs.
+        specs.pop("Наличие", None)
 
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -1,0 +1,243 @@
+import re
+from typing import Any, Dict, List
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from .base import BaseParser
+
+
+class HobotParser(BaseParser):
+    """Parser for hobot.by product pages."""
+
+    BASE_URL = "https://www.hobot.by"
+    _HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/122.0.0.0 Safari/537.36"
+        ),
+        "Accept-Language": "ru-RU,ru;q=0.9,en;q=0.8",
+    }
+
+    def supports(self, url: str) -> bool:
+        return "hobot.by" in url
+
+    @staticmethod
+    def _slug_from_url(url: str) -> str:
+        path = url.rstrip("/").split("?")[0]
+        segments = [segment for segment in path.split("/") if segment]
+        return segments[-1] if segments else "unknown"
+
+    @staticmethod
+    def _parse_first_number(value: str) -> float | None:
+        if not value:
+            return None
+        cleaned = value.replace("\xa0", " ")
+        match = re.search(r"(-?\d[\d\s]*(?:[.,]\d+)?)", cleaned)
+        if not match:
+            return None
+        try:
+            raw = match.group(1).replace(" ", "").replace(",", ".")
+            return float(raw)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _to_abs_url(cls, value: str, current_url: str) -> str:
+        if not value:
+            return ""
+        if value.startswith("//"):
+            return f"https:{value}"
+        if value.startswith("/"):
+            return f"{cls.BASE_URL}{value}"
+        if value.startswith("http://") or value.startswith("https://"):
+            return value
+        return urljoin(current_url, value)
+
+    @staticmethod
+    def _looks_like_product_page(soup: BeautifulSoup) -> bool:
+        if soup.select_one("table.product-specs__table"):
+            return True
+        if soup.select_one('meta[itemprop="price"]'):
+            return True
+        if soup.select_one(".buy_block-availability .isAvailable"):
+            return True
+        return False
+
+    @staticmethod
+    def _extract_specs(soup: BeautifulSoup) -> Dict[str, str]:
+        specs: Dict[str, str] = {}
+        for row in soup.select("table.product-specs__table tr"):
+            cells = row.find_all(["th", "td"])
+            if len(cells) != 2:
+                continue
+            key = cells[0].get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
+            value = cells[1].get_text(" ", strip=True).replace("\xa0", " ")
+            if key and value:
+                specs[key] = value
+        return specs
+
+    @staticmethod
+    def _extract_metrics(specs: Dict[str, str], title: str) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {
+            "power_cooling": None,
+            "power_heating": None,
+            "area": 0,
+            "is_inverter": False,
+            "min_temp_heating": None,
+        }
+
+        for key, value in specs.items():
+            key_lower = key.lower()
+            value_lower = value.lower()
+
+            if "инвертор" in key_lower:
+                metrics["is_inverter"] = value_lower.startswith("да") or "инвертор" in value_lower
+
+            if "площад" in key_lower:
+                match = re.search(r"(\d+)", value)
+                if match and not metrics["area"]:
+                    metrics["area"] = int(match.group(1))
+
+            if "мощност" in key_lower and "охлажд" in key_lower:
+                parsed = HobotParser._parse_first_number(value)
+                if parsed is not None:
+                    metrics["power_cooling"] = parsed
+
+            if "мощност" in key_lower and ("обогрев" in key_lower or "нагрев" in key_lower):
+                parsed = HobotParser._parse_first_number(value)
+                if parsed is not None:
+                    metrics["power_heating"] = parsed
+
+            if "температ" in key_lower and ("мин" in key_lower or "обогрев" in key_lower):
+                match = re.search(r"(-\d+)", value)
+                if match:
+                    metrics["min_temp_heating"] = int(match.group(1))
+
+        if not metrics["area"]:
+            title_area = re.search(r"(\d+)\s*м", title.lower())
+            if title_area:
+                metrics["area"] = int(title_area.group(1))
+
+        return metrics
+
+    @classmethod
+    def _collect_images(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        seen: set[str] = set()
+        images: List[str] = []
+
+        for link in soup.select("a[data-fancybox], a.fancy"):
+            href = cls._to_abs_url(link.get("href", ""), current_url)
+            if not href or href in seen:
+                continue
+            if href.startswith("data:"):
+                continue
+            if not any(ext in href.lower() for ext in (".jpg", ".jpeg", ".png", ".webp", "/upload/")):
+                continue
+            seen.add(href)
+            images.append(href)
+
+        if not images:
+            for img in soup.select("img[src], img[data-src]"):
+                raw = img.get("data-src") or img.get("src") or ""
+                abs_url = cls._to_abs_url(raw, current_url)
+                if not abs_url or abs_url.startswith("data:") or abs_url in seen:
+                    continue
+                if "/upload/" not in abs_url:
+                    continue
+                seen.add(abs_url)
+                images.append(abs_url)
+
+        return images
+
+    @classmethod
+    def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        related: List[str] = []
+        current_slug = cls._slug_from_url(current_url)
+
+        for link in soup.select("a.dark_link[href*='/catalog/'], a.product-item__title[href*='/catalog/']"):
+            href = cls._to_abs_url(link.get("href", ""), current_url)
+            if not href or href == current_url or href in related:
+                continue
+            slug = cls._slug_from_url(href)
+            if slug == current_slug:
+                continue
+            # Product links are usually deeper than pure categories.
+            path_segments = [segment for segment in href.rstrip("/").split("/") if segment]
+            if "catalog" in path_segments:
+                idx = path_segments.index("catalog")
+                if len(path_segments[idx + 1 :]) < 2:
+                    continue
+            related.append(href)
+
+        return related
+
+    async def parse(self, url: str) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=20.0,
+            headers=self._HEADERS,
+        ) as client:
+            response = await client.get(url)
+            if response.status_code != 200:
+                raise Exception(f"Ошибка загрузки страницы hobot.by: {response.status_code}")
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        h1 = soup.select_one("h1")
+        title = h1.get_text(" ", strip=True) if h1 else "Без названия"
+        if "страница не найдена" in title.lower():
+            raise ValueError("URL hobot.by не найден (404-шаблон страницы).")
+        if not self._looks_like_product_page(soup):
+            raise ValueError("URL hobot.by не похож на карточку товара.")
+
+        price = 0
+        price_meta = soup.select_one('meta[itemprop="price"]')
+        price_text = price_meta.get("content", "") if price_meta else ""
+        if not price_text:
+            price_el = soup.select_one(".price-main.price") or soup.select_one(".price")
+            if price_el:
+                price_text = price_el.get_text(" ", strip=True)
+        parsed_price = self._parse_first_number(price_text)
+        if parsed_price is not None:
+            price = int(round(parsed_price))
+
+        availability_el = soup.select_one(".buy_block-availability .isAvailable .available")
+        availability = availability_el.get_text(" ", strip=True) if availability_el else ""
+        if not availability:
+            raw_block = soup.select_one(".buy_block-availability .isAvailable")
+            availability = raw_block.get_text(" ", strip=True) if raw_block else ""
+        in_stock = bool(availability) and ("нет" not in availability.lower())
+
+        description = ""
+        for block in soup.select(".detail_text"):
+            text = block.get_text("\n", strip=True)
+            if text and len(text) > len(description):
+                description = text
+
+        specs = self._extract_specs(soup)
+        if availability:
+            specs.setdefault("Наличие", availability)
+
+        metrics = self._extract_metrics(specs, title)
+        images = self._collect_images(soup, str(response.url))
+        related_urls = self._collect_related_urls(soup, str(response.url))
+
+        return {
+            "title": title,
+            "slug": self._slug_from_url(str(response.url)),
+            "description": description,
+            "price": price,
+            "area": metrics["area"],
+            "main_image": images[0] if images else "",
+            "images": images[1:] if len(images) > 1 else [],
+            "save_gallery": True,
+            "categories": [],
+            "specs": specs,
+            "metrics": metrics,
+            "related_urls": related_urls,
+            "availability": availability,
+            "in_stock": in_stock,
+        }

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -31,6 +31,31 @@ class HobotParser(BaseParser):
         return segments[-1] if segments else "unknown"
 
     @staticmethod
+    def _normalize_model_title(raw_title: str) -> str:
+        title = re.sub(r"\s+", " ", (raw_title or "").strip())
+        if not title:
+            return "Без названия"
+
+        title = re.sub(
+            r"^(?:(?:кассетн(?:ый|ая|ое|ые)|настенн(?:ый|ая|ое|ые)|канальн(?:ый|ая|ое|ые)|"
+            r"напольно-потолочн(?:ый|ая|ое|ые)|мобильн(?:ый|ая|ое|ые)|бытов(?:ой|ая|ое|ые)|"
+            r"колонн(?:ый|ая|ое|ые)|универсальн(?:ый|ая|ое|ые)|инверторн(?:ый|ая|ое|ые)|"
+            r"полупромышленн(?:ый|ая|ое|ые))\s+)+",
+            "",
+            title,
+            flags=re.IGNORECASE,
+        )
+
+        title = re.sub(
+            r"^(?:кондиционер|сплит[\s-]?система|мульти[\s-]?сплит[\s-]?система|внутренний\s+блок|наружный\s+блок)\s+",
+            "",
+            title,
+            flags=re.IGNORECASE,
+        )
+        title = re.sub(r"\s+", " ", title).strip(" -")
+        return title or "Без названия"
+
+    @staticmethod
     def _parse_first_number(value: str) -> float | None:
         if not value:
             return None
@@ -231,7 +256,8 @@ class HobotParser(BaseParser):
         soup = BeautifulSoup(response.text, "html.parser")
 
         h1 = soup.select_one("h1")
-        title = h1.get_text(" ", strip=True) if h1 else "Без названия"
+        title_raw = h1.get_text(" ", strip=True) if h1 else "Без названия"
+        title = self._normalize_model_title(title_raw)
         if "страница не найдена" in title.lower():
             raise ValueError("URL hobot.by не найден (404-шаблон страницы).")
         if not self._looks_like_product_page(soup):

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -153,6 +153,50 @@ class HobotParser(BaseParser):
         return images
 
     @classmethod
+    async def _choose_best_image_urls(cls, client: httpx.AsyncClient, image_urls: List[str]) -> List[str]:
+        """Prefer original /upload/iblock images over resize_cache where possible."""
+
+        async def exists(url: str) -> bool:
+            try:
+                resp = await client.head(url, timeout=10.0)
+                if resp.status_code == 405:
+                    resp = await client.get(url, timeout=10.0)
+                return resp.status_code == 200
+            except Exception:
+                return False
+
+        result: List[str] = []
+        seen: set[str] = set()
+        for url in image_urls:
+            best_url = url
+            match = re.search(
+                r"/upload/resize_cache/(?:webp/)?resize_cache/iblock/([^/]+)/[^/]+/([^/?#]+)",
+                url,
+                re.IGNORECASE,
+            )
+            if match:
+                folder = match.group(1)
+                filename = match.group(2)
+                filename_stem = filename.rsplit(".", 1)[0]
+                candidates = [
+                    f"{cls.BASE_URL}/upload/iblock/{folder}/{filename_stem}.jpg",
+                    f"{cls.BASE_URL}/upload/iblock/{folder}/{filename_stem}.jpeg",
+                    f"{cls.BASE_URL}/upload/iblock/{folder}/{filename_stem}.png",
+                    f"{cls.BASE_URL}/upload/iblock/{folder}/{filename_stem}.webp",
+                    f"{cls.BASE_URL}/upload/iblock/{folder}/{filename}",
+                ]
+                for candidate in candidates:
+                    if await exists(candidate):
+                        best_url = candidate
+                        break
+
+            if best_url not in seen:
+                seen.add(best_url)
+                result.append(best_url)
+
+        return result
+
+    @classmethod
     def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
         related: List[str] = []
         current_slug = cls._slug_from_url(current_url)
@@ -223,6 +267,13 @@ class HobotParser(BaseParser):
 
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
+        if images:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=15.0,
+                headers=self._HEADERS,
+            ) as image_client:
+                images = await self._choose_best_image_urls(image_client, images)
         related_urls = self._collect_related_urls(soup, str(response.url))
 
         return {

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -119,7 +119,12 @@ class HobotParser(BaseParser):
             value_lower = value.lower()
 
             if "инвертор" in key_lower:
-                metrics["is_inverter"] = value_lower.startswith("да") or "инвертор" in value_lower
+                metrics["is_inverter"] = (
+                    value_lower.startswith("да")
+                    or "есть" in value_lower
+                    or value_lower in {"+", "✓", "✔"}
+                    or "инвертор" in value_lower
+                )
 
             if "площад" in key_lower:
                 match = re.search(r"(\d+)", value)

--- a/parsers/hobot.py
+++ b/parsers/hobot.py
@@ -300,7 +300,8 @@ class HobotParser(BaseParser):
                 headers=self._HEADERS,
             ) as image_client:
                 images = await self._choose_best_image_urls(image_client, images)
-        related_urls = self._collect_related_urls(soup, str(response.url))
+        # User decision: disable related crawling for hobot to avoid mass unintended imports.
+        related_urls: List[str] = []
 
         return {
             "title": title,

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -1,0 +1,221 @@
+import re
+from typing import Any, Dict, List
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from .base import BaseParser
+
+
+class Lg24Parser(BaseParser):
+    """Parser for lg24.by product pages (WooCommerce)."""
+
+    BASE_URL = "https://lg24.by"
+    _HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/122.0.0.0 Safari/537.36"
+        ),
+        "Accept-Language": "ru-RU,ru;q=0.9,en;q=0.8",
+    }
+
+    def supports(self, url: str) -> bool:
+        return "lg24.by" in url
+
+    @staticmethod
+    def _slug_from_url(url: str) -> str:
+        path = url.rstrip("/").split("?")[0]
+        segments = [segment for segment in path.split("/") if segment]
+        return segments[-1] if segments else "unknown"
+
+    @staticmethod
+    def _parse_first_number(value: str) -> float | None:
+        if not value:
+            return None
+        cleaned = value.replace("\xa0", " ")
+        match = re.search(r"(-?\d[\d\s]*(?:[.,]\d+)?)", cleaned)
+        if not match:
+            return None
+        try:
+            raw = match.group(1).replace(" ", "").replace(",", ".")
+            return float(raw)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _to_abs_url(cls, value: str, current_url: str) -> str:
+        if not value:
+            return ""
+        if value.startswith("//"):
+            return f"https:{value}"
+        if value.startswith("/"):
+            return f"{cls.BASE_URL}{value}"
+        if value.startswith("http://") or value.startswith("https://"):
+            return value
+        return urljoin(current_url, value)
+
+    @classmethod
+    def _collect_images(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        seen: set[str] = set()
+        images: List[str] = []
+
+        for img in soup.select("div.woocommerce-product-gallery img"):
+            for attr in ("data-large_image", "src", "data-src"):
+                raw = img.get(attr, "")
+                if not raw:
+                    continue
+                abs_url = cls._to_abs_url(raw, current_url)
+                if not abs_url or abs_url.startswith("data:"):
+                    continue
+                if abs_url in seen:
+                    continue
+                seen.add(abs_url)
+                images.append(abs_url)
+
+        return images
+
+    @classmethod
+    def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
+        related: List[str] = []
+        for link in soup.select(".related.products a[href*='/product/'], ul.products a[href*='/product/']"):
+            href = cls._to_abs_url(link.get("href", ""), current_url)
+            if not href or href == current_url or href in related:
+                continue
+            related.append(href)
+        return related
+
+    @staticmethod
+    def _extract_specs(soup: BeautifulSoup) -> Dict[str, str]:
+        specs: Dict[str, str] = {}
+
+        # Main source on lg24: <section id="tab1"> ... <dl><dt>..</dt><dd>..</dd>
+        for row in soup.select("section#tab1 dl"):
+            dt = row.find("dt")
+            dd = row.find("dd")
+            if not dt or not dd:
+                continue
+            key = dt.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
+            value = dd.get_text(" ", strip=True).replace("\xa0", " ")
+            if key and value:
+                specs[key] = value
+
+        # Fallback source: standard WooCommerce attributes table.
+        if not specs:
+            for row in soup.select("table.woocommerce-product-attributes tr"):
+                th = row.find("th")
+                td = row.find("td")
+                if not th or not td:
+                    continue
+                key = th.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
+                value = td.get_text(" ", strip=True).replace("\xa0", " ")
+                if key and value:
+                    specs[key] = value
+
+        return specs
+
+    @staticmethod
+    def _extract_metrics(specs: Dict[str, str], title: str) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {
+            "power_cooling": None,
+            "power_heating": None,
+            "area": 0,
+            "is_inverter": False,
+            "min_temp_heating": None,
+        }
+
+        for key, value in specs.items():
+            key_lower = key.lower()
+            value_lower = value.lower()
+
+            if "инвертор" in key_lower or "тип системы" in key_lower:
+                if "инвертор" in value_lower or value_lower.startswith("да"):
+                    metrics["is_inverter"] = True
+
+            if "площад" in key_lower:
+                match = re.search(r"(\d+)", value)
+                if match and not metrics["area"]:
+                    metrics["area"] = int(match.group(1))
+
+            if "мощност" in key_lower and "охлажд" in key_lower:
+                parsed = Lg24Parser._parse_first_number(value)
+                if parsed is not None:
+                    metrics["power_cooling"] = parsed
+
+            if "мощност" in key_lower and ("нагрев" in key_lower or "обогрев" in key_lower):
+                parsed = Lg24Parser._parse_first_number(value)
+                if parsed is not None:
+                    metrics["power_heating"] = parsed
+
+            if "температ" in key_lower and ("мин" in key_lower or "обогрев" in key_lower):
+                match = re.search(r"(-\d+)", value)
+                if match:
+                    metrics["min_temp_heating"] = int(match.group(1))
+
+        if not metrics["area"]:
+            title_area = re.search(r"до\s*(\d+)\s*м", title.lower())
+            if title_area:
+                metrics["area"] = int(title_area.group(1))
+
+        return metrics
+
+    async def parse(self, url: str) -> Dict[str, Any]:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=20.0,
+            headers=self._HEADERS,
+        ) as client:
+            response = await client.get(url)
+            if response.status_code != 200:
+                raise Exception(f"Ошибка загрузки страницы lg24.by: {response.status_code}")
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        h1 = soup.select_one("h1.product_title") or soup.select_one("h1.entry-title") or soup.select_one("h1")
+        title = h1.get_text(" ", strip=True) if h1 else "Без названия"
+
+        price = 0
+        price_meta = soup.select_one('meta[itemprop="price"]')
+        price_text = ""
+        if price_meta:
+            price_text = price_meta.get("content", "")
+        if not price_text:
+            price_el = soup.select_one("p.price") or soup.select_one(".summary p.price") or soup.select_one(".woocommerce-Price-amount")
+            if price_el:
+                price_text = price_el.get_text(" ", strip=True)
+        parsed_price = self._parse_first_number(price_text)
+        if parsed_price is not None:
+            price = int(round(parsed_price))
+
+        stock_el = soup.select_one("p.stock")
+        availability = stock_el.get_text(" ", strip=True) if stock_el else ""
+        in_stock = bool(availability) and ("нет в наличии" not in availability.lower())
+
+        description_el = soup.select_one(".woocommerce-product-details__short-description") or soup.select_one("section#tab1")
+        description = description_el.get_text("\n", strip=True) if description_el else ""
+
+        specs = self._extract_specs(soup)
+        if availability:
+            specs.setdefault("Наличие", availability)
+
+        metrics = self._extract_metrics(specs, title)
+        images = self._collect_images(soup, str(response.url))
+        related_urls = self._collect_related_urls(soup, str(response.url))
+
+        return {
+            "title": title,
+            "slug": self._slug_from_url(str(response.url)),
+            "description": description,
+            "price": price,
+            "area": metrics["area"],
+            "main_image": images[0] if images else "",
+            "images": images[1:] if len(images) > 1 else [],
+            "save_gallery": True,
+            "categories": [],
+            "specs": specs,
+            "metrics": metrics,
+            "related_urls": related_urls,
+            "availability": availability,
+            "in_stock": in_stock,
+        }

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -288,6 +288,9 @@ class Lg24Parser(BaseParser):
         description = description_el.get_text("\n", strip=True) if description_el else ""
 
         specs = self._extract_specs(soup)
+        # lg24.by catalog is LG-only; force canonical brand to avoid
+        # mis-detection from series words in title (e.g. "Ultra").
+        specs.setdefault("Бренд", "LG")
         breadcrumb_parts = self._extract_breadcrumb_parts(soup)
         for key, value in self._infer_type_specs_from_breadcrumb(breadcrumb_parts).items():
             specs.setdefault(key, value)

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -31,6 +31,33 @@ class Lg24Parser(BaseParser):
         return segments[-1] if segments else "unknown"
 
     @staticmethod
+    def _normalize_model_title(raw_title: str) -> str:
+        title = re.sub(r"\s+", " ", (raw_title or "").strip())
+        if not title:
+            return "Без названия"
+
+        # Remove leading descriptor adjectives to expose core product noun.
+        title = re.sub(
+            r"^(?:(?:кассетн(?:ый|ая|ое|ые)|настенн(?:ый|ая|ое|ые)|канальн(?:ый|ая|ое|ые)|"
+            r"напольно-потолочн(?:ый|ая|ое|ые)|мобильн(?:ый|ая|ое|ые)|бытов(?:ой|ая|ое|ые)|"
+            r"колонн(?:ый|ая|ое|ые)|универсальн(?:ый|ая|ое|ые)|инверторн(?:ый|ая|ое|ые)|"
+            r"полупромышленн(?:ый|ая|ое|ые))\s+)+",
+            "",
+            title,
+            flags=re.IGNORECASE,
+        )
+
+        # Keep model-oriented title in DB (without generic product type noun).
+        title = re.sub(
+            r"^(?:кондиционер|сплит[\s-]?система|мульти[\s-]?сплит[\s-]?система|внутренний\s+блок|наружный\s+блок)\s+",
+            "",
+            title,
+            flags=re.IGNORECASE,
+        )
+        title = re.sub(r"\s+", " ", title).strip(" -")
+        return title or "Без названия"
+
+    @staticmethod
     def _parse_first_number(value: str) -> float | None:
         if not value:
             return None
@@ -173,7 +200,8 @@ class Lg24Parser(BaseParser):
         soup = BeautifulSoup(response.text, "html.parser")
 
         h1 = soup.select_one("h1.product_title") or soup.select_one("h1.entry-title") or soup.select_one("h1")
-        title = h1.get_text(" ", strip=True) if h1 else "Без названия"
+        title_raw = h1.get_text(" ", strip=True) if h1 else "Без названия"
+        title = self._normalize_model_title(title_raw)
 
         price = 0
         price_meta = soup.select_one('meta[itemprop="price"]')

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -174,7 +174,11 @@ class Lg24Parser(BaseParser):
             elif "колон" in p:
                 inferred.setdefault("Тип внутреннего блока", "колонный")
         if "Тип внутреннего блока" in inferred and "Тип" not in inferred:
-            inferred["Тип"] = "сплит-система"
+            indoor = inferred.get("Тип внутреннего блока", "")
+            if indoor == "настенный":
+                inferred["Тип"] = "сплит-система"
+            else:
+                inferred["Тип"] = "полупромышленный кондиционер"
         return inferred
 
     @staticmethod

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -20,6 +20,13 @@ class Lg24Parser(BaseParser):
         ),
         "Accept-Language": "ru-RU,ru;q=0.9,en;q=0.8",
     }
+    _DOC_SPEC_KEY_MARKERS = (
+        "руководство",
+        "инструкция",
+        "manual",
+        "user guide",
+        "паспорт",
+    )
 
     def supports(self, url: str) -> bool:
         return "lg24.by" in url
@@ -106,12 +113,69 @@ class Lg24Parser(BaseParser):
     @classmethod
     def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
         related: List[str] = []
-        for link in soup.select(".related.products a[href*='/product/'], ul.products a[href*='/product/']"):
+        # Use explicit product tag list to avoid noisy broad related grids.
+        for link in soup.select("ul.item-tags a[href*='/product/']"):
             href = cls._to_abs_url(link.get("href", ""), current_url)
             if not href or href == current_url or href in related:
                 continue
             related.append(href)
         return related
+
+    @classmethod
+    def _should_skip_spec(cls, key: str, value: str) -> bool:
+        key_l = key.lower().strip()
+        value_l = value.lower().strip()
+        if value_l in {"", "-", "—"}:
+            return True
+        # Until file attachments are supported, documentation rows are noise.
+        if any(marker in key_l for marker in cls._DOC_SPEC_KEY_MARKERS):
+            return True
+        if "скача" in value_l or value_l in {"download"}:
+            if any(marker in key_l for marker in cls._DOC_SPEC_KEY_MARKERS):
+                return True
+        return False
+
+    @staticmethod
+    def _extract_breadcrumb_parts(soup: BeautifulSoup) -> List[str]:
+        breadcrumb = soup.select_one(".woocommerce-breadcrumb")
+        if not breadcrumb:
+            return []
+        parts: List[str] = []
+        for node in breadcrumb.children:
+            text = node.get_text(" ", strip=True) if hasattr(node, "get_text") else str(node).strip()
+            text = re.sub(r"\s+", " ", text).strip()
+            if not text:
+                continue
+            if re.fullmatch(r"[/›»>]+", text):
+                continue
+            parts.append(text)
+        return parts
+
+    @staticmethod
+    def _infer_type_specs_from_breadcrumb(parts: List[str]) -> Dict[str, str]:
+        inferred: Dict[str, str] = {}
+        for part in parts:
+            p = part.lower().strip()
+            if "кондиционеры для дома" in p or "для дома" in p:
+                inferred.setdefault("Тип", "сплит-система")
+            elif "мульти" in p:
+                inferred.setdefault("Тип", "мульти-сплит-система")
+            elif "полупром" in p or "полупромышлен" in p:
+                inferred.setdefault("Тип", "полупромышленный кондиционер")
+
+            if "настенн" in p:
+                inferred.setdefault("Тип внутреннего блока", "настенный")
+            elif "каналь" in p:
+                inferred.setdefault("Тип внутреннего блока", "канальный")
+            elif "кассет" in p:
+                inferred.setdefault("Тип внутреннего блока", "кассетный")
+            elif "напольно" in p or "потолоч" in p:
+                inferred.setdefault("Тип внутреннего блока", "напольно-потолочный")
+            elif "колон" in p:
+                inferred.setdefault("Тип внутреннего блока", "колонный")
+        if "Тип внутреннего блока" in inferred and "Тип" not in inferred:
+            inferred["Тип"] = "сплит-система"
+        return inferred
 
     @staticmethod
     def _extract_specs(soup: BeautifulSoup) -> Dict[str, str]:
@@ -125,7 +189,7 @@ class Lg24Parser(BaseParser):
                 continue
             key = dt.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
             value = dd.get_text(" ", strip=True).replace("\xa0", " ")
-            if key and value:
+            if key and value and not Lg24Parser._should_skip_spec(key, value):
                 specs[key] = value
 
         # Fallback source: standard WooCommerce attributes table.
@@ -137,7 +201,7 @@ class Lg24Parser(BaseParser):
                     continue
                 key = th.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
                 value = td.get_text(" ", strip=True).replace("\xa0", " ")
-                if key and value:
+                if key and value and not Lg24Parser._should_skip_spec(key, value):
                     specs[key] = value
 
         return specs
@@ -224,6 +288,9 @@ class Lg24Parser(BaseParser):
         description = description_el.get_text("\n", strip=True) if description_el else ""
 
         specs = self._extract_specs(soup)
+        breadcrumb_parts = self._extract_breadcrumb_parts(soup)
+        for key, value in self._infer_type_specs_from_breadcrumb(breadcrumb_parts).items():
+            specs.setdefault(key, value)
         if availability:
             specs.setdefault("Наличие", availability)
 

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -38,6 +38,15 @@ class Lg24Parser(BaseParser):
         return segments[-1] if segments else "unknown"
 
     @staticmethod
+    def _ensure_brand_prefix(title: str, brand: str = "LG") -> str:
+        normalized = re.sub(r"\s+", " ", (title or "").strip())
+        if not normalized:
+            return brand
+        if re.search(rf"\b{re.escape(brand)}\b", normalized, flags=re.IGNORECASE):
+            return normalized
+        return f"{brand} {normalized}".strip()
+
+    @staticmethod
     def _normalize_model_title(raw_title: str) -> str:
         title = re.sub(r"\s+", " ", (raw_title or "").strip())
         if not title:
@@ -62,7 +71,9 @@ class Lg24Parser(BaseParser):
             flags=re.IGNORECASE,
         )
         title = re.sub(r"\s+", " ", title).strip(" -")
-        return title or "Без названия"
+        if not title:
+            return "Без названия"
+        return Lg24Parser._ensure_brand_prefix(title, brand="LG")
 
     @staticmethod
     def _parse_first_number(value: str) -> float | None:

--- a/scripts/ensure_global_config_defaults.py
+++ b/scripts/ensure_global_config_defaults.py
@@ -14,6 +14,7 @@ from models.content import GlobalConfig
 
 DEFAULT_CONFIGS: list[tuple[str, str, str]] = [
     ("fx_rate_usd_byn", "3.4", "Курс USD/BYN для закупки"),
+    ("fx_rate_rub_byn", "0.0350", "Курс RUB/BYN для импорта"),
     ("supplier_sync_enabled", "true", "Включить авто-синк поставщиков"),
     ("supplier_sync_interval_minutes", "60", "Интервал синка поставщиков (мин)"),
     ("fx_rate_source", "manual", "Источник курса USD/BYN: manual | nbrb"),

--- a/services/fx_rate_service.py
+++ b/services/fx_rate_service.py
@@ -13,6 +13,7 @@ from models.content import GlobalConfig
 
 _RATE_CACHE_VALUE_USD: Optional[Decimal] = None
 _RATE_CACHE_VALUE_EUR: Optional[Decimal] = None
+_RATE_CACHE_VALUE_RUB: Optional[Decimal] = None
 _RATE_CACHE_AT: Optional[datetime] = None
 _RATE_CACHE_TTL = timedelta(minutes=10)
 
@@ -30,6 +31,7 @@ def _parse_decimal(value: str | None) -> Optional[Decimal]:
 class FxRateService:
     NBRB_USD_URL = "https://api.nbrb.by/exrates/rates/USD?parammode=2"
     NBRB_EUR_URL = "https://api.nbrb.by/exrates/rates/EUR?parammode=2"
+    NBRB_RUB_URL = "https://api.nbrb.by/exrates/rates/RUB?parammode=2"
 
     @staticmethod
     async def _get_config(session: AsyncSession, key: str) -> Optional[GlobalConfig]:
@@ -37,8 +39,13 @@ class FxRateService:
         return res.scalar_one_or_none()
 
     @staticmethod
-    async def _get_manual_rate(session: AsyncSession) -> Optional[Decimal]:
+    async def _get_manual_usd_rate(session: AsyncSession) -> Optional[Decimal]:
         cfg = await FxRateService._get_config(session, "fx_rate_usd_byn")
+        return _parse_decimal(cfg.value if cfg else None)
+
+    @staticmethod
+    async def _get_manual_rub_rate(session: AsyncSession) -> Optional[Decimal]:
+        cfg = await FxRateService._get_config(session, "fx_rate_rub_byn")
         return _parse_decimal(cfg.value if cfg else None)
 
     @staticmethod
@@ -61,47 +68,60 @@ class FxRateService:
         return parsed
 
     @staticmethod
-    async def _fetch_nbrb_rates() -> tuple[Optional[Decimal], Optional[Decimal]]:
-        global _RATE_CACHE_VALUE_USD, _RATE_CACHE_VALUE_EUR, _RATE_CACHE_AT
+    def _parse_nbrb_rate_payload(payload: dict | None) -> Optional[Decimal]:
+        data = payload or {}
+        rate_raw = data.get("Cur_OfficialRate")
+        scale_raw = data.get("Cur_Scale", 1)
+        rate = _parse_decimal(str(rate_raw) if rate_raw is not None else None)
+        scale = _parse_decimal(str(scale_raw) if scale_raw is not None else "1")
+        if rate is None or scale is None or scale == 0:
+            return None
+        return (rate / scale).quantize(Decimal("0.0001"))
+
+    @staticmethod
+    async def _fetch_nbrb_rates() -> tuple[Optional[Decimal], Optional[Decimal], Optional[Decimal]]:
+        global _RATE_CACHE_VALUE_USD, _RATE_CACHE_VALUE_EUR, _RATE_CACHE_VALUE_RUB, _RATE_CACHE_AT
 
         now = datetime.now()
         if _RATE_CACHE_AT is not None:
             if now - _RATE_CACHE_AT <= _RATE_CACHE_TTL:
-                return _RATE_CACHE_VALUE_USD, _RATE_CACHE_VALUE_EUR
+                return _RATE_CACHE_VALUE_USD, _RATE_CACHE_VALUE_EUR, _RATE_CACHE_VALUE_RUB
 
         usd_val = None
         eur_val = None
+        rub_val = None
 
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 usd_resp = await client.get(FxRateService.NBRB_USD_URL)
                 if usd_resp.status_code == 200:
-                    data = usd_resp.json()
-                    rate = data.get("Cur_OfficialRate")
-                    usd_val = _parse_decimal(str(rate) if rate is not None else None)
+                    usd_val = FxRateService._parse_nbrb_rate_payload(usd_resp.json())
 
                 eur_resp = await client.get(FxRateService.NBRB_EUR_URL)
                 if eur_resp.status_code == 200:
-                    data = eur_resp.json()
-                    rate = data.get("Cur_OfficialRate")
-                    eur_val = _parse_decimal(str(rate) if rate is not None else None)
+                    eur_val = FxRateService._parse_nbrb_rate_payload(eur_resp.json())
+
+                rub_resp = await client.get(FxRateService.NBRB_RUB_URL)
+                if rub_resp.status_code == 200:
+                    rub_val = FxRateService._parse_nbrb_rate_payload(rub_resp.json())
 
                 _RATE_CACHE_VALUE_USD = usd_val
                 _RATE_CACHE_VALUE_EUR = eur_val
+                _RATE_CACHE_VALUE_RUB = rub_val
                 _RATE_CACHE_AT = now
         except Exception:
             pass
 
-        return usd_val, eur_val
+        return usd_val, eur_val, rub_val
 
     @staticmethod
     async def get_effective_usd_byn_rate(session: AsyncSession) -> Optional[Decimal]:
         source = await FxRateService._get_rate_source(session)
-        manual = await FxRateService._get_manual_rate(session)
+        manual = await FxRateService._get_manual_usd_rate(session)
         if source == "manual":
             return manual
 
-        usd_rate, _ = await FxRateService._fetch_nbrb_rates()
+        usd_rate, _, _ = await FxRateService._fetch_nbrb_rates()
         # Fallback to manual if NBRB temporarily unavailable.
         return usd_rate if usd_rate is not None else manual
 
@@ -112,8 +132,19 @@ class FxRateService:
         if source == "manual":
             return None
 
-        _, eur_rate = await FxRateService._fetch_nbrb_rates()
+        _, eur_rate, _ = await FxRateService._fetch_nbrb_rates()
         return eur_rate
+
+    @staticmethod
+    async def get_effective_rub_byn_rate(session: AsyncSession) -> Optional[Decimal]:
+        source = await FxRateService._get_rate_source(session)
+        manual = await FxRateService._get_manual_rub_rate(session)
+        if source == "manual" and manual is not None:
+            return manual
+
+        _, _, rub_rate = await FxRateService._fetch_nbrb_rates()
+        # Fallback chain: NBRB -> manual.
+        return rub_rate if rub_rate is not None else manual
 
     @staticmethod
     async def get_supplier_usd_byn_rate(session: AsyncSession) -> Optional[Decimal]:

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -165,7 +165,12 @@ class ImporterService:
                 return parser
         return None
 
-    async def import_product(self, url: str, update_existing: bool = False) -> dict:
+    async def import_product(
+        self,
+        url: str,
+        update_existing: bool = False,
+        collect_related: bool = False,
+    ) -> dict:
         """
         Orchestrates the import process: find parser -> parse -> save to DB.
         Returns a dict: {'product': Product, 'related_urls': List[str]}
@@ -184,7 +189,21 @@ class ImporterService:
                 )
                 if has_category_tag:
                     # Keep fast path for already healthy records.
-                    return {"product": existing, "related_urls": []}
+                    related_urls: List[str] = []
+                    if collect_related:
+                        parser = self.get_parser(url)
+                        if parser:
+                            try:
+                                parsed = await parser.parse(url)
+                                related_urls = list(parsed.get("related_urls") or [])
+                            except Exception as exc:
+                                logger.warning(
+                                    "Failed to collect related URLs for existing product %s (%s): %s",
+                                    existing.id,
+                                    url,
+                                    exc,
+                                )
+                    return {"product": existing, "related_urls": related_urls}
 
                 # Self-heal path: if product exists but lacks catalog category tags,
                 # force update flow to refresh derived tags/specs.
@@ -409,7 +428,11 @@ class ImporterService:
             if url in processed_urls: continue
             
             try:
-                res = await self.import_product(url, update_existing=update_existing)
+                res = await self.import_product(
+                    url,
+                    update_existing=update_existing,
+                    collect_related=with_related,
+                )
                 product = res["product"]
                 # Only add to 'success' if it's a NEW import (or just count it)
                 # To keep it simple, we count all as success if they are in DB now.

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -73,11 +73,6 @@ async def _normalize_import_price_to_byn(session, *, data: dict, source_url: str
     converted_price = (source_price * rub_byn_rate).quantize(Decimal("1"))
     data["price"] = int(converted_price)
 
-    specs = dict(data.get("specs") or {})
-    specs["Цена источника"] = f"{int(source_price)} RUB"
-    specs["Курс RUB/BYN (импорт)"] = str(rub_byn_rate)
-    data["specs"] = specs
-
 
 async def _ensure_tag_group(
     session,

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -1,4 +1,5 @@
 import logging
+from decimal import Decimal
 from typing import List, Optional
 
 import slugify
@@ -15,6 +16,7 @@ from parsers.tvoy_klimat import TvoyKlimatParser
 from core.database import async_session_maker
 from models import Product, ProductImage, Tag, TagGroup
 from services.image_service import ImageService
+from services.fx_rate_service import FxRateService
 from services.spec_normalizer import normalize_specs
 from services.tag_logic import (
     CATEGORY_TAG_TITLES,
@@ -40,6 +42,40 @@ def _augment_auto_slugs_with_wifi_specs(auto_slugs: List[str], specs: dict) -> L
     elif wifi_state == "ready" and "wifi-ready" not in result:
         result.append("wifi-ready")
     return result
+
+
+async def _normalize_import_price_to_byn(session, *, data: dict, source_url: str) -> None:
+    """Convert source price to BYN if parser reports foreign currency."""
+    raw_price = data.get("price")
+    if raw_price is None:
+        return
+
+    currency = str(data.get("price_currency") or "BYN").strip().upper()
+    if currency in {"", "BYN"}:
+        return
+
+    try:
+        source_price = Decimal(str(raw_price))
+    except Exception:
+        logger.warning("Price conversion skipped for %s: invalid source price=%r", source_url, raw_price)
+        return
+
+    if currency != "RUB":
+        logger.warning("Price conversion skipped for %s: unsupported currency=%s", source_url, currency)
+        return
+
+    rub_byn_rate = await FxRateService.get_effective_rub_byn_rate(session)
+    if rub_byn_rate is None:
+        logger.warning("Price conversion skipped for %s: RUB/BYN rate unavailable", source_url)
+        return
+
+    converted_price = (source_price * rub_byn_rate).quantize(Decimal("1"))
+    data["price"] = int(converted_price)
+
+    specs = dict(data.get("specs") or {})
+    specs["Цена источника"] = f"{int(source_price)} RUB"
+    specs["Курс RUB/BYN (импорт)"] = str(rub_byn_rate)
+    data["specs"] = specs
 
 
 async def _ensure_tag_group(
@@ -149,6 +185,7 @@ class ImporterService:
                 raise ValueError("No parser found for this URL")
 
             data = await parser.parse(url)
+            await _normalize_import_price_to_byn(session, data=data, source_url=url)
             
             # Determine publishing status
             is_published = True 

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -28,6 +28,7 @@ from services.tag_logic import (
 from services.brand_series_service import sync_product_brand_series
 
 logger = logging.getLogger(__name__)
+_CATEGORY_TAG_SLUGS = {"cat-household", "cat-multi", "cat-industrial"}
 
 
 def _augment_auto_slugs_with_wifi_specs(auto_slugs: List[str], specs: dict) -> List[str]:
@@ -176,9 +177,22 @@ class ImporterService:
             result = await session.execute(stmt)
             existing = result.scalar_one_or_none()
             if existing and not update_existing:
-                # We return it but maybe don't re-save. 
-                # For the sake of bulk import, we'll return the existing one.
-                return {"product": existing, "related_urls": []}
+                await session.refresh(existing, attribute_names=["tags"])
+                has_category_tag = any(
+                    (getattr(tag, "slug", "") or "") in _CATEGORY_TAG_SLUGS
+                    for tag in (existing.tags or [])
+                )
+                if has_category_tag:
+                    # Keep fast path for already healthy records.
+                    return {"product": existing, "related_urls": []}
+
+                # Self-heal path: if product exists but lacks catalog category tags,
+                # force update flow to refresh derived tags/specs.
+                logger.info(
+                    "Reimporting existing product %s because category tags are missing",
+                    existing.id,
+                )
+                update_existing = True
 
             parser = self.get_parser(url)
             if not parser:
@@ -311,6 +325,18 @@ class ImporterService:
                 existing.power_cooling = metrics.get('power_cooling', existing.power_cooling)
                 existing.specs = normalized_specs
                 existing.source_url = url
+
+                # Preserve manual tags, but append newly inferred auto-tags.
+                await session.refresh(existing, attribute_names=["tags"])
+                merged_tags: dict[str, Tag] = {}
+                for tag in (existing.tags or []):
+                    key = getattr(tag, "slug", None) or f"id:{getattr(tag, 'id', None)}"
+                    merged_tags[key] = tag
+                for tag in tag_objects:
+                    key = getattr(tag, "slug", None) or f"id:{getattr(tag, 'id', None)}"
+                    merged_tags[key] = tag
+                existing.tags = list(merged_tags.values())
+
                 session.add(existing)
                 product = existing
             else:

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import selectinload
 
 from parsers.base import BaseParser
 from parsers.aircond import AircondParser
+from parsers.hobot import HobotParser
+from parsers.lg24 import Lg24Parser
 from parsers.onliner import OnlinerParser
 from parsers.tvoy_klimat import TvoyKlimatParser
 from core.database import async_session_maker
@@ -111,6 +113,8 @@ class ImporterService:
         # Register available parsers
         self.parsers: List[BaseParser] = [
             AircondParser(),
+            Lg24Parser(),
+            HobotParser(),
             TvoyKlimatParser(),
             OnlinerParser(),
         ]

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from parsers.base import BaseParser
 from parsers.aircond import AircondParser
+from parsers.haierproff import HaierProffParser
 from parsers.hobot import HobotParser
 from parsers.lg24 import Lg24Parser
 from parsers.onliner import OnlinerParser
@@ -113,6 +114,7 @@ class ImporterService:
         # Register available parsers
         self.parsers: List[BaseParser] = [
             AircondParser(),
+            HaierProffParser(),
             Lg24Parser(),
             HobotParser(),
             TvoyKlimatParser(),

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -8,8 +8,10 @@ KEY_MAP = {
     # --- ОСНОВНОЕ ---
     "Тип": "type",
     "Тип кондиционера": "type",
+    "Тип системы": "inverter",
     "Тип внутреннего блока": "indoor_type",
     "Режим работы": "modes",
+    "Режимы работы": "modes",
     "Обслуживаемая площадь": "area_m2",
     "Обслуживаемая площадь, кв.м": "area_m2",
     "Площадь охлаждения": "area_m2",
@@ -21,6 +23,8 @@ KEY_MAP = {
     "Инверторная технология": "inverter",
     "Инверторный": "inverter",
     "Инверторное управление": "inverter",
+    "Инверторное управление мощностью": "inverter",
+    "Инверторный компрессор": "inverter",
     "Бренд": "brand",
     "Марка": "brand",
     "Производитель": "brand",
@@ -35,10 +39,13 @@ KEY_MAP = {
     "Wi-Fi Ready": "wifi_ready",
     "Пульт дистанционного управления": "remote_control",
     "Пульт ДУ": "remote_control",
+    "Пульт": "remote_control",
+    "Пульт управления": "remote_control",
     "Таймер включения/выключения": "timer",
     "Таймер": "timer",
     "Регулировка направления воздушного потока": "airflow_direction",
     "Регулировка скорости вращения вентилятора": "fan_speed",
+    "Регулятор скорости вращения вентилятора": "fan_speed",
     "Авторестарт после пропадания питания": "autorestart",
     "Авторестарт": "autorestart",
     "Турбо-режим": "turbo_mode",
@@ -47,20 +54,39 @@ KEY_MAP = {
     "Ночной режим": "sleep_mode",
     "Осушение воздуха": "dehumidification",
     "Осушение": "dehumidification",
+    "Режим осушения воздуха": "dehumidification",
 
     # --- МОЩНОСТЬ ---
     "Мощность охлаждения": "capacity_cooling_kw",
+    "Мощность охлаждения, кВт": "capacity_cooling_kw",
+    "Мощность охлаждения (Мин/Ном/Макс), кВт": "capacity_cooling_kw",
     "Мощность в режиме охлаждения": "capacity_cooling_kw",
     "Мощность в режиме охлаждения, кВт": "capacity_cooling_kw",
     "Холодопроизводительность": "capacity_cooling_kw",
+    "Охлаждение, кВт": "capacity_cooling_kw",
+    "Охлаждение минимум, кВт": "capacity_cooling_min_kw",
+    "Охлаждение максимум, кВт": "capacity_cooling_max_kw",
     "Мощность обогрева": "capacity_heating_kw",
+    "Мощность обогрева, кВт": "capacity_heating_kw",
+    "Мощность нагрева (Мин/Ном/Макс), кВт": "capacity_heating_kw",
     "Мощность в режиме обогрева": "capacity_heating_kw",
     "Мощность в режиме обогрева, кВт": "capacity_heating_kw",
     "Теплопроизводительность": "capacity_heating_kw",
+    "Нагрев, кВт": "capacity_heating_kw",
+    "Нагрев минимум, кВт": "capacity_heating_min_kw",
+    "Нагрев максимум, кВт": "capacity_heating_max_kw",
     "Потребляемая мощность при охлаждении": "power_cons_cooling_kw",
     "Потребляемая мощность при охлаждении, кВт": "power_cons_cooling_kw",
+    "Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт": "power_cons_cooling_kw",
+    "Номинальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_kw",
+    "Минимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_min_kw",
+    "Максимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_max_kw",
     "Потребляемая мощность при обогреве": "power_cons_heating_kw",
     "Потребляемая мощность при обогреве, кВт": "power_cons_heating_kw",
+    "Потребление электроэнергии в режиме нагрева (Мин / Ном / Макс), кВт": "power_cons_heating_kw",
+    "Номинальная потребляемая мощность (нагрев), кВт": "power_cons_heating_kw",
+    "Минимальная потребляемая мощность (нагрев), кВт": "power_cons_heating_min_kw",
+    "Максимальная потребляемая мощность (нагрев), кВт": "power_cons_heating_max_kw",
     
     # --- ЭФФЕКТИВНОСТЬ ---
     "Энергоэффективность при охлаждении (EER)": "eer",
@@ -76,12 +102,16 @@ KEY_MAP = {
     "Шум внутреннего блока, дБ": "noise_indoor",
     "Уровень шума внутреннего блока": "noise_indoor",
     "Уровень шума (макс), дБ": "noise_indoor",
+    "Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх": "noise_indoor",
+    "Уровень шума в режиме ОХЛАЖДЕНИЯ (Тих / Низ / Ср /Макс), дБ": "noise_indoor",
+    "Уровень шума в режиме НАГРЕВА (Низ / Ср / Макс), дБ": "noise_indoor",
     "Шум наружного блока": "noise_outdoor",
     "Шум наружного блока, дБ": "noise_outdoor",
     "Шум внешнего блока": "noise_outdoor",
     "Шум внешнего блока, дБ": "noise_outdoor",
     "Уровень шума наружного блока": "noise_outdoor",
     "Уровень шума наружного блока, дБ": "noise_outdoor",
+    "Уровень звукового давления, дБ, А": "noise_outdoor",
     
     # --- ГАБАРИТЫ ВНУТРЕННИЙ ---
     "Ширина внутреннего блока": "width_indoor",
@@ -104,33 +134,50 @@ KEY_MAP = {
     "Максимальная длина коммуникаций": "pipe_max_length",
     "Максимальная длина коммуникаций, м": "pipe_max_length",
     "Макс. длина трассы": "pipe_max_length",
+    "Макс. длина трубопроводов без дополнительной заправки, м": "pipe_max_length",
     "Перепад высот": "pipe_max_height",
     "Перепад высот, м": "pipe_max_height",
+    "Максимальная длина/перепад высот, м": "pipe_max_length",
+    "Максимальная длина/перепад высот, при использовании только в режиме охлаждения, м": "pipe_max_length",
     "Максимальный перепад высот": "multi_max_height_diff",
     "Максимальное количество внутренних блоков": "multi_max_indoor_units",
     "Максимальная суммарная длина магистрали": "multi_max_total_pipe_length",
     "Диаметр жидкостной трубы": "pipe_liquid",
+    "Диаметр жидкостной линии, мм": "pipe_liquid",
     "Диаметр газовой трубы": "pipe_gas",
+    "Диаметр газовой линии, мм": "pipe_gas",
     
     # --- ТЕМПЕРАТУРЫ ---
     "Рабочая температура при охлаждении": "temp_range_cool",
     "Рабочий диапазон температур при охлаждении": "temp_range_cool",
     "Рабочий диапазон температур при охлаждении,°C": "temp_range_cool",
+    "Рабочий диапазон температур при охлаждении, °C": "temp_range_cool",
+    "Охлаждение, °С": "temp_range_cool",
     "Рабочая температура при обогреве": "temp_range_heat",
     "Рабочий диапазон температур при обогреве": "temp_range_heat",
     "Рабочий диапазон температур при обогреве,°C": "temp_range_heat",
+    "Рабочий диапазон температур при обогреве, °C": "temp_range_heat",
+    "Нагрев, °С": "temp_range_heat",
     "Минимальная температура наружного воздуха": "temp_range_heat",
     "Мин. температура (обогрев)": "temp_range_heat",
     
     # --- ПЛОЩАДЬ (с единицами) ---
     "Обслуживаемая площадь до": "area_m2",
     "Обслуживаемая площадь до, м2": "area_m2",
+    "Рекомендуемая максимальная площадь помещения": "area_m2",
+    "Рекомендованная площадь, м 2": "area_m2",
     
     # --- ЭНЕРГОЭФФЕКТИВНОСТЬ (без скобок) ---
     "Энергоэффективность при охлаждении": "energy_class_cooling",
     "Энергоэффективность при обогреве": "energy_class_heating",
+    "Класс эффективности": "energy_class",
+    "Класс энергоэффективности (Холод / Тепло)": "energy_class",
+    "Коэффициент энергоэффективности (EER / COP)": "eer",
+    "Энергоэффективность SEER/EER": "eer",
+    "Энергоэффективность SCOP/COP": "cop",
     
     "Максимальный расход воздуха внутреннего блока": "airflow_max",
+    "Расход воздуха (высокая скорость), м 3 /ч": "airflow_max",
 
     # --- ФИЛЬТРЫ И ДОП. ФУНКЦИИ ---
     "Приток свежего воздуха": "fresh_air",
@@ -145,6 +192,20 @@ KEY_MAP = {
     "Электростатический фильтр": "electrostatic_filter",
     "Обеззараживание ультрафиолетом": "uv_sterilization",
     "Самоочистка": "self_cleaning",
+    "Автоочистка теплообменника": "self_cleaning",
+    "Wi-Fi управление": "wifi_ready",
+    "Марка используемого хладагента": "freon_type",
+    "Производитель компрессора": "compressor_brand",
+    "Номинальный уровень рабочего тока (охлаждение), А": "current_cooling_nominal_a",
+    "Номинальный уровень рабочего тока (нагрев), А": "current_heating_nominal_a",
+    "Дополнительная заправка (г/м)": "refrigerant_additional_g_m",
+    "Вес заправляемого хладагента, г": "refrigerant_charge_g",
+    "Артикулы товара": "sku_list",
+    "Подача питания": "power_supply_location",
+    "Подключение питания": "power_supply_location",
+    "Электропитание, Ф/В/Гц": "power_supply",
+    "Электропитание (Ø / В / Гц)": "power_supply",
+    "Модель": "model",
 }
 
 # Composite dimension keys: "940×1250×340" → split into width/height/depth
@@ -156,6 +217,19 @@ _DIMENSIONS_MAP = {
     "Габариты наружного блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты внешнего блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты мм": ("width_indoor", "height_indoor", "depth_indoor"),
+}
+
+_PREFERRED_NUMERIC_KEYS = {
+    "capacity_cooling_kw",
+    "capacity_heating_kw",
+    "power_cons_cooling_kw",
+    "power_cons_heating_kw",
+    "power_cons_cooling_min_kw",
+    "power_cons_cooling_max_kw",
+    "power_cons_heating_min_kw",
+    "power_cons_heating_max_kw",
+    "area_m2",
 }
 
 
@@ -218,11 +292,36 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
         return val
 
     if key in boolean_keys:
+        if key == "inverter":
+            if "инвертор" in val_lower or "inverter" in val_lower:
+                return True
+            if "неинвертор" in val_lower or "on/off" in val_lower or "on off" in val_lower:
+                return False
+        if val_lower in {"+", "✓", "✔"}:
+            return True
         if "да" in val_lower or "есть" in val_lower or "поддерживается" in val_lower:
             return True
         if "нет" in val_lower or "отсутствует" in val_lower:
             return False
         return val # Если там что-то сложное, оставляем как есть
+
+    # Some sources provide ranges like "0.89 / 2.5 / 3.7" (min/nom/max).
+    # Keep nominal values in core numeric fields for consistent UI/filtering.
+    if key in _PREFERRED_NUMERIC_KEYS:
+        numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", val)
+        if numbers:
+            normalized = [n.replace(",", ".") for n in numbers]
+            if key in {"capacity_cooling_kw", "capacity_heating_kw", "power_cons_cooling_kw", "power_cons_heating_kw"} and "/" in val:
+                # For min/nom/max triplets pick nominal (middle) value.
+                if len(normalized) >= 3:
+                    return normalized[1]
+            if key == "area_m2" and ("-" in val or "до" in val_lower or "~" in val):
+                # For ranges use upper bound as recommended/max area.
+                try:
+                    return str(max(float(n) for n in normalized)).rstrip("0").rstrip(".")
+                except ValueError:
+                    pass
+            return normalized[0]
 
     # 2. Чистка чисел (Только если keep_units = False)
     if not keep_units:
@@ -368,6 +467,7 @@ def _classify_wifi_value(value: Any) -> str | None:
         "да",
         "есть",
         "✓",
+        "+",
     )
     if any(marker in text for marker in builtin_markers):
         return "builtin"

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -438,6 +438,7 @@ def _normalize_indoor_type_kind(*values: Any) -> str | None:
             "напольно" in text
             or "подпотолоч" in text
             or "потолоч" in text
+            or "универсальн" in text
             or "floor-ceiling" in text
             or "floor ceiling" in text
         ):
@@ -475,6 +476,7 @@ def _normalize_system_type(type_value: Any, indoor_type_value: Any) -> str | Non
         "напольно",
         "подпотолоч",
         "потолоч",
+        "универсальн",
         "floor-ceiling",
         "floor ceiling",
     )

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -149,8 +149,10 @@ KEY_MAP = {
     "Максимальная суммарная длина магистрали": "multi_max_total_pipe_length",
     "Диаметр жидкостной трубы": "pipe_liquid",
     "Диаметр жидкостной линии, мм": "pipe_liquid",
+    "Диаметр труб жидкого хладагента, мм": "pipe_liquid",
     "Диаметр газовой трубы": "pipe_gas",
     "Диаметр газовой линии, мм": "pipe_gas",
+    "Диаметр труб газообразного хладагента, мм": "pipe_gas",
     
     # --- ТЕМПЕРАТУРЫ ---
     "Рабочая температура при охлаждении": "temp_range_cool",
@@ -497,11 +499,20 @@ def _resolve_dynamic_system_key(key: Any) -> str | None:
         text.replace("‑", "-")
         .replace("–", "-")
         .replace("—", "-")
+        .replace("⁰", "°")
         .replace("_", " ")
     )
     text = re.sub(r"\s+", " ", text)
     if "wifi" in text or "wi-fi" in text or "wi fi" in text:
         return "wifi_ready"
+    if "для работы в режиме охлаждения" in text:
+        return "temp_range_cool"
+    if "для работы в режиме нагрева" in text or "для работы в режиме обогрева" in text:
+        return "temp_range_heat"
+    if "диаметр труб жидкого хладагента" in text:
+        return "pipe_liquid"
+    if "диаметр труб газообразного хладагента" in text:
+        return "pipe_gas"
     return None
 
 

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -447,6 +447,49 @@ def _normalize_indoor_type_kind(*values: Any) -> str | None:
     return None
 
 
+def _normalize_system_type(type_value: Any, indoor_type_value: Any) -> str | None:
+    type_text = str(type_value or "").strip().lower().replace("ё", "е")
+    indoor_text = str(indoor_type_value or "").strip().lower().replace("ё", "е")
+    type_text = type_text.replace("—", "-")
+    indoor_text = indoor_text.replace("—", "-")
+    type_text = re.sub(r"\s+", " ", type_text)
+    indoor_text = re.sub(r"\s+", " ", indoor_text)
+    combined = f"{type_text} {indoor_text}".strip()
+    if not combined:
+        return None
+
+    if "наружн" in combined and "блок" in combined:
+        return "наружный блок"
+    if "внутренн" in combined and "блок" in combined:
+        return "внутренний блок"
+    if "мульти" in combined:
+        return "мульти-сплит-система"
+
+    industrial_markers = (
+        "полупром",
+        "полупромышлен",
+        "промышлен",
+        "кассет",
+        "каналь",
+        "колон",
+        "напольно",
+        "подпотолоч",
+        "потолоч",
+        "floor-ceiling",
+        "floor ceiling",
+    )
+    if any(marker in combined for marker in industrial_markers):
+        return "полупромышленный кондиционер"
+
+    if "сплит" in combined or "кондиционер" in combined:
+        return "сплит-система"
+
+    if "настенн" in combined:
+        return "сплит-система"
+
+    return None
+
+
 def _classify_wifi_value(value: Any) -> str | None:
     if isinstance(value, bool):
         return "builtin" if value else "none"
@@ -684,6 +727,13 @@ def normalize_specs(
         if not sys_key or sys_key in new_specs:
             continue
         new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units)
+
+    normalized_type = _normalize_system_type(
+        new_specs.get("type"),
+        new_specs.get("indoor_type"),
+    )
+    if normalized_type:
+        new_specs["type"] = normalized_type
 
     current_brand = str(new_specs.get("brand", "")).strip()
     if not current_brand or is_invalid_brand_name(current_brand):

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -213,8 +213,6 @@ KEY_MAP = {
     "Электропитание, Ф/В/Гц": "power_supply",
     "Электропитание (Ø / В / Гц)": "power_supply",
     "Модель": "model",
-    "Цена источника": "source_price_rub",
-    "Курс RUB/BYN (импорт)": "source_fx_rub_byn",
     "Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
 }
 
@@ -246,8 +244,13 @@ _PREFERRED_NUMERIC_KEYS = {
     "area_m2",
     "weight_indoor",
     "weight_outdoor",
+}
+
+_DROPPED_SPEC_KEYS = {
     "source_price_rub",
     "source_fx_rub_byn",
+    "Цена источника",
+    "Курс RUB/BYN (импорт)",
 }
 
 
@@ -729,6 +732,10 @@ def normalize_specs(
         if not sys_key or sys_key in new_specs:
             continue
         new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units)
+
+    # Source price/rate are import internals; never persist in product specs.
+    for dropped_key in _DROPPED_SPEC_KEYS:
+        new_specs.pop(dropped_key, None)
 
     normalized_type = _normalize_system_type(
         new_specs.get("type"),

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -312,6 +312,28 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
             return False
         return val
 
+    if key == "indoor_type":
+        text = val_lower.replace("—", "-")
+        text = re.sub(r"\s+", " ", text)
+        if "каналь" in text:
+            return "канальный"
+        if "кассет" in text:
+            return "кассетный"
+        if (
+            "напольно" in text
+            or "подпотолоч" in text
+            or "потолоч" in text
+            or "универсальн" in text
+            or "floor-ceiling" in text
+            or "floor ceiling" in text
+        ):
+            return "напольно-потолочный"
+        if "колон" in text or "console" in text or "column" in text:
+            return "колонный"
+        if "настенн" in text or "wall" in text:
+            return "настенный"
+        return text
+
     if key in boolean_keys:
         if key == "inverter":
             if "инвертор" in val_lower or "inverter" in val_lower:
@@ -516,6 +538,7 @@ def _classify_wifi_value(value: Any) -> str | None:
         "приобрета",
         "отдельно",
         "опцион",
+        "опци",
         "ready",
         "модул",
         "поддержива",

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -28,6 +28,7 @@ KEY_MAP = {
     "Бренд": "brand",
     "Марка": "brand",
     "Производитель": "brand",
+    "Наличие": "availability",
     "Серия": "series",
     "Линейка": "series",
     "Модельный ряд": "series",
@@ -119,6 +120,8 @@ KEY_MAP = {
     "Глубина внутреннего блока": "depth_indoor",
     "Вес внутреннего блока": "weight_indoor",
     "Вес внутреннего блока, кг": "weight_indoor",
+    "Чистый вес / Вес в упаковке, кг": "weight_indoor",
+    "Внутренний блок без упаковки, кг": "weight_indoor",
     
     # --- ГАБАРИТЫ НАРУЖНЫЙ ---
     "Ширина наружного блока": "width_outdoor",
@@ -128,6 +131,8 @@ KEY_MAP = {
     "Вес наружного блока, кг": "weight_outdoor",
     "Вес внешнего блока": "weight_outdoor",
     "Вес внешнего блока, кг": "weight_outdoor",
+    "Чистый вес / вес в упаковке, кг": "weight_outdoor",
+    "Наружный блок без упаковки, кг": "weight_outdoor",
     
     # --- МОНТАЖ ---
     "Максимальная длина магистрали": "pipe_max_length",
@@ -206,6 +211,9 @@ KEY_MAP = {
     "Электропитание, Ф/В/Гц": "power_supply",
     "Электропитание (Ø / В / Гц)": "power_supply",
     "Модель": "model",
+    "Цена источника": "source_price_rub",
+    "Курс RUB/BYN (импорт)": "source_fx_rub_byn",
+    "Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
 }
 
 # Composite dimension keys: "940×1250×340" → split into width/height/depth
@@ -218,6 +226,10 @@ _DIMENSIONS_MAP = {
     "Габариты внешнего блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    # Haierproff uses width/depth/height order (Ш/Г/В).
+    "Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
+    "Внутренний блок без упаковки (Ш × В × Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Наружный блок без упаковки (Ш × В × Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
 }
 
 _PREFERRED_NUMERIC_KEYS = {
@@ -230,6 +242,10 @@ _PREFERRED_NUMERIC_KEYS = {
     "power_cons_heating_min_kw",
     "power_cons_heating_max_kw",
     "area_m2",
+    "weight_indoor",
+    "weight_outdoor",
+    "source_price_rub",
+    "source_fx_rub_byn",
 }
 
 

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -42,6 +42,7 @@ KEY_MAP = {
     "Пульт ДУ": "remote_control",
     "Пульт": "remote_control",
     "Пульт управления": "remote_control",
+    "Внутренний блок: Пульт управления": "remote_control",
     "Таймер включения/выключения": "timer",
     "Таймер": "timer",
     "Регулировка направления воздушного потока": "airflow_direction",
@@ -92,6 +93,7 @@ KEY_MAP = {
     # --- ЭФФЕКТИВНОСТЬ ---
     "Энергоэффективность при охлаждении (EER)": "eer",
     "EER": "eer",
+    "EER/COP": "eer",
     "Энергоэффективность при обогреве (COP)": "cop",
     "COP": "cop",
     "Класс энергоэффективности": "energy_class",
@@ -113,6 +115,9 @@ KEY_MAP = {
     "Уровень шума наружного блока": "noise_outdoor",
     "Уровень шума наружного блока, дБ": "noise_outdoor",
     "Уровень звукового давления, дБ, А": "noise_outdoor",
+    "Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
+    "Наружный блок: Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
+    "Внутренний блок: Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх": "noise_indoor",
     
     # --- ГАБАРИТЫ ВНУТРЕННИЙ ---
     "Ширина внутреннего блока": "width_indoor",
@@ -121,6 +126,7 @@ KEY_MAP = {
     "Вес внутреннего блока": "weight_indoor",
     "Вес внутреннего блока, кг": "weight_indoor",
     "Чистый вес / Вес в упаковке, кг": "weight_indoor",
+    "Внутренний блок: Чистый вес / Вес в упаковке, кг": "weight_indoor",
     "Внутренний блок без упаковки, кг": "weight_indoor",
     
     # --- ГАБАРИТЫ НАРУЖНЫЙ ---
@@ -132,6 +138,8 @@ KEY_MAP = {
     "Вес внешнего блока": "weight_outdoor",
     "Вес внешнего блока, кг": "weight_outdoor",
     "Чистый вес / вес в упаковке, кг": "weight_outdoor",
+    "Наружный блок: Чистый вес / вес в упаковке, кг": "weight_outdoor",
+    "Наружный блок: Чистый вес / Вес в упаковке, кг": "weight_outdoor",
     "Наружный блок без упаковки, кг": "weight_outdoor",
     
     # --- МОНТАЖ ---
@@ -180,6 +188,7 @@ KEY_MAP = {
     "Класс эффективности": "energy_class",
     "Класс энергоэффективности (Холод / Тепло)": "energy_class",
     "Коэффициент энергоэффективности (EER / COP)": "eer",
+    "EER/COP": "eer",
     "Энергоэффективность SEER/EER": "eer",
     "Энергоэффективность SCOP/COP": "cop",
     
@@ -203,6 +212,9 @@ KEY_MAP = {
     "Wi-Fi управление": "wifi_ready",
     "Марка используемого хладагента": "freon_type",
     "Производитель компрессора": "compressor_brand",
+    "Компрессор: Производитель компрессора": "compressor_brand",
+    "Неинверторный компрессор": "inverter",
+    "Компрессор: Неинверторный компрессор": "inverter",
     "Номинальный уровень рабочего тока (охлаждение), А": "current_cooling_nominal_a",
     "Номинальный уровень рабочего тока (нагрев), А": "current_heating_nominal_a",
     "Дополнительная заправка (г/м)": "refrigerant_additional_g_m",
@@ -213,6 +225,8 @@ KEY_MAP = {
     "Электропитание, Ф/В/Гц": "power_supply",
     "Электропитание (Ø / В / Гц)": "power_supply",
     "Модель": "model",
+    "Внутренний блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_indoor_package_mm",
+    "Наружный блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
     "Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
 }
 
@@ -227,7 +241,8 @@ _DIMENSIONS_MAP = {
     "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты мм": ("width_indoor", "height_indoor", "depth_indoor"),
     # Haierproff uses width/depth/height order (Ш/Г/В).
-    "Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
+    "Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_indoor", "depth_indoor", "height_indoor"),
+    "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
     "Внутренний блок без упаковки (Ш × В × Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
     "Наружный блок без упаковки (Ш × В × Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
 }
@@ -290,6 +305,45 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
         
     val_lower = val.lower().strip()
 
+    if key in {"pipe_liquid", "pipe_gas"}:
+        # Convert common metric diameters to canonical inch fractions for UI/filter selects.
+        normalized = val.replace(",", ".")
+        if "/" in normalized and '"' in normalized:
+            return normalized.strip()
+        match = re.search(r"(\d+(?:\.\d+)?)", normalized)
+        if not match:
+            return val.strip()
+        try:
+            mm = float(match.group(1))
+        except ValueError:
+            return val.strip()
+        mm_to_inch = {
+            6.35: '1/4"',
+            9.52: '3/8"',
+            12.70: '1/2"',
+            15.88: '5/8"',
+            19.05: '3/4"',
+        }
+        nearest = min(mm_to_inch.keys(), key=lambda k: abs(k - mm))
+        if abs(nearest - mm) <= 0.25:
+            return mm_to_inch[nearest]
+        return match.group(1)
+
+    if key == "compressor_brand":
+        text = re.sub(r"\s+", " ", val).strip()
+        lowered = text.lower().replace("ё", "е")
+        canonical = {
+            "gmcc": "GMCC",
+            "toshiba": "Toshiba",
+            "highly": "Highly",
+            "panasonic": "Panasonic",
+            "gree": "Gree",
+        }
+        for token, normalized in canonical.items():
+            if token in lowered:
+                return normalized
+        return text
+
     # 1. Логика для Булевых (Да/Нет)
     # Сюда попадают: inverter, wifi_ready, remote_control и все режимы
     boolean_keys = [
@@ -333,6 +387,12 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
         if "настенн" in text or "wall" in text:
             return "настенный"
         return text
+
+    if key == "remote_control":
+        no_markers = ("нет", "отсутств", "нету", "no")
+        if any(marker in val_lower for marker in no_markers):
+            return False
+        return True
 
     if key in boolean_keys:
         if key == "inverter":
@@ -731,13 +791,56 @@ def normalize_specs(
     for rus_key, sys_key in KEY_MAP.items():
         if rus_key in old_specs:
             raw_val = old_specs[rus_key]
-            
+
+            # Explicit split keys with two metrics in one source value.
+            rus_key_l = rus_key.lower().replace("ё", "е")
+            if "eer/cop" in rus_key_l:
+                numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", str(raw_val))
+                if numbers:
+                    new_specs["eer"] = numbers[0].replace(",", ".")
+                    if len(numbers) > 1:
+                        new_specs["cop"] = numbers[1].replace(",", ".")
+                if rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+            if "seer/eer" in rus_key_l:
+                numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", str(raw_val))
+                if numbers:
+                    new_specs["seer"] = numbers[0].replace(",", ".")
+                    if len(numbers) > 1:
+                        new_specs["eer"] = numbers[1].replace(",", ".")
+                if rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+            if "scop/cop" in rus_key_l:
+                numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", str(raw_val))
+                if numbers:
+                    new_specs["scop"] = numbers[0].replace(",", ".")
+                    if len(numbers) > 1:
+                        new_specs["cop"] = numbers[1].replace(",", ".")
+                if rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+
+            # Special rule: source key explicitly states "non-inverter".
+            if "неинвертор" in rus_key_l and sys_key == "inverter":
+                parsed = _parse_bool(raw_val)
+                if parsed is True:
+                    new_specs[sys_key] = False
+                elif parsed is False:
+                    new_specs[sys_key] = True
+                else:
+                    new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units)
+                if rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+
             # Чистим / Конвертируем
             clean_val = clean_value(sys_key, raw_val, keep_units=keep_units)
-            
+
             # Записываем новый ключ
             new_specs[sys_key] = clean_val
-            
+
             # Удаляем старый (чтобы не было дублей)
             if rus_key in new_specs:
                 del new_specs[rus_key]

--- a/services/tag_logic.py
+++ b/services/tag_logic.py
@@ -241,6 +241,7 @@ def detect_category_slug(
         "подпотолоч",
         "потолоч",
         "напольно",
+        "универсальн",
         "floor-ceiling",
         "floor ceiling",
         "колонн",

--- a/tests/unit/test_haierproff_parser.py
+++ b/tests/unit/test_haierproff_parser.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+
 from parsers.haierproff import HaierProffParser
 
 
@@ -29,6 +31,16 @@ def test_haierproff_infers_household_for_wall_from_title_only():
     assert inferred["Тип внутреннего блока"] == "Настенный"
 
 
+def test_haierproff_defaults_split_system_to_wall_indoor_type():
+    inferred = HaierProffParser._infer_type_specs_from_breadcrumb_and_title(
+        title="Haier HSU-24HQJ103/R3 Quantum On-Off",
+        breadcrumb_parts=["Каталог", "Бытовые сплит-системы"],
+    )
+
+    assert inferred["Тип"] == "Сплит-система"
+    assert inferred["Тип внутреннего блока"] == "Настенный"
+
+
 def test_haierproff_detects_wifi_by_feature_title_and_icon():
     entries = [
         {"img": "/images/uploads/2023/04/12/resize_cache/46_1/44cdb19d3e20378d090e233fdcc44d44.png", "title": "", "desc": "", "text": ""},
@@ -41,3 +53,35 @@ def test_haierproff_detects_wifi_by_feature_title_and_icon():
 def test_haierproff_wifi_fallback_is_option_for_non_outdoor():
     assert HaierProffParser._should_assume_wifi_option({"Тип": "Сплит-система"}) is True
     assert HaierProffParser._should_assume_wifi_option({"Тип": "Наружный блок"}) is False
+
+
+def test_haierproff_extract_specs_keeps_group_prefixed_duplicates():
+    html = """
+    <div class="accordion">
+      <div class="collapse">
+        <div class="collapse__header">Внутренний блок</div>
+        <div class="collapse__content">
+          <div class="spec-l__item">
+            <div class="spec-l__item-label">Габаритные размеры без упаковки (Ш/Г/В), мм</div>
+            <div class="spec-l__item-value">974 × 223 × 318</div>
+          </div>
+        </div>
+      </div>
+      <div class="collapse">
+        <div class="collapse__header">Наружный блок</div>
+        <div class="collapse__content">
+          <div class="spec-l__item">
+            <div class="spec-l__item-label">Габаритные размеры без упаковки (Ш/Г/В), мм</div>
+            <div class="spec-l__item-value">875 × 355 × 642</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    specs = HaierProffParser._extract_specs(soup)
+
+    assert specs["Габаритные размеры без упаковки (Ш/Г/В), мм"] == "974 × 223 × 318"
+    assert specs["Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм"] == "974 × 223 × 318"
+    assert specs["Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм"] == "875 × 355 × 642"

--- a/tests/unit/test_haierproff_parser.py
+++ b/tests/unit/test_haierproff_parser.py
@@ -1,0 +1,30 @@
+from parsers.haierproff import HaierProffParser
+
+
+def test_haierproff_infers_poluprom_and_universal_indoor_from_breadcrumbs():
+    parts = [
+        "Каталог",
+        "Полупромышленные сплит-системы",
+        "Super Match Plus",
+        "AC105S2SH2FA / 1U105S2SS1FB",
+    ]
+    title = "Haier AC105S2SH2FA / 1U105S2SS1FB AC (Универсальные блоки) Super Match Plus"
+
+    inferred = HaierProffParser._infer_type_specs_from_breadcrumb_and_title(
+        title=title,
+        breadcrumb_parts=parts,
+    )
+
+    assert inferred["Тип"] == "Полупромышленный кондиционер"
+    assert inferred["Тип внутреннего блока"] == "Напольно-потолочный"
+
+
+def test_haierproff_infers_household_for_wall_from_title_only():
+    inferred = HaierProffParser._infer_type_specs_from_breadcrumb_and_title(
+        title="Haier AS35S2SJ2FA Jade настенный блок",
+        breadcrumb_parts=[],
+    )
+
+    assert inferred["Тип"] == "Сплит-система"
+    assert inferred["Тип внутреннего блока"] == "Настенный"
+

--- a/tests/unit/test_haierproff_parser.py
+++ b/tests/unit/test_haierproff_parser.py
@@ -28,3 +28,16 @@ def test_haierproff_infers_household_for_wall_from_title_only():
     assert inferred["Тип"] == "Сплит-система"
     assert inferred["Тип внутреннего блока"] == "Настенный"
 
+
+def test_haierproff_detects_wifi_by_feature_title_and_icon():
+    entries = [
+        {"img": "/images/uploads/2023/04/12/resize_cache/46_1/44cdb19d3e20378d090e233fdcc44d44.png", "title": "", "desc": "", "text": ""},
+        {"img": "", "title": "Управление Wi-Fi (Стандартно)", "desc": "", "text": "Управление Wi-Fi (Стандартно)"},
+    ]
+
+    assert HaierProffParser._feature_entries_indicate_wifi(entries) is True
+
+
+def test_haierproff_wifi_fallback_is_option_for_non_outdoor():
+    assert HaierProffParser._should_assume_wifi_option({"Тип": "Сплит-система"}) is True
+    assert HaierProffParser._should_assume_wifi_option({"Тип": "Наружный блок"}) is False

--- a/tests/unit/test_hobot_parser_metrics.py
+++ b/tests/unit/test_hobot_parser_metrics.py
@@ -1,0 +1,16 @@
+from parsers.hobot import HobotParser
+
+
+def test_hobot_extract_metrics_treats_est_as_inverter_true():
+    metrics = HobotParser._extract_metrics(
+        {
+            "Инверторное управление мощностью": "Есть",
+            "Мощность охлаждения, кВт": "2.80",
+            "Мощность обогрева, кВт": "3.63",
+        },
+        "Test title",
+    )
+
+    assert metrics["is_inverter"] is True
+    assert metrics["power_cooling"] == 2.8
+    assert metrics["power_heating"] == 3.63

--- a/tests/unit/test_importer_service_related.py
+++ b/tests/unit/test_importer_service_related.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import pytest
+
+from services.importer_service import ImporterService
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, existing_product):
+        self._existing_product = existing_product
+
+    async def execute(self, stmt):  # noqa: ARG002
+        return _FakeScalarResult(self._existing_product)
+
+    async def refresh(self, obj, attribute_names=None):  # noqa: ARG002
+        return None
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_import_product_existing_collects_related_when_requested(monkeypatch):
+    existing = SimpleNamespace(
+        id=123,
+        tags=[SimpleNamespace(slug="cat-household")],
+    )
+    fake_session = _FakeSession(existing)
+
+    parser_calls = {"count": 0}
+
+    class _FakeParser:
+        async def parse(self, url):  # noqa: ARG002
+            parser_calls["count"] += 1
+            return {"related_urls": ["https://lg24.by/product/sibling/"]}
+
+    monkeypatch.setattr(
+        "services.importer_service.async_session_maker",
+        lambda: _FakeSessionContext(fake_session),
+    )
+
+    service = ImporterService()
+    service.get_parser = lambda url: _FakeParser()  # noqa: ARG005
+
+    result = await service.import_product(
+        "https://lg24.by/product/current/",
+        update_existing=False,
+        collect_related=True,
+    )
+
+    assert result["product"] is existing
+    assert result["related_urls"] == ["https://lg24.by/product/sibling/"]
+    assert parser_calls["count"] == 1
+

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -103,6 +103,16 @@ def test_lg24_defaults_non_wall_indoor_type_to_poluprom():
     assert inferred["Тип внутреннего блока"] == "кассетный"
 
 
+def test_lg24_title_brand_prefix_added_when_missing():
+    normalized = Lg24Parser._normalize_model_title("Кондиционер Deluxe Pro H12S1D")
+    assert normalized == "LG Deluxe Pro H12S1D"
+
+
+def test_lg24_title_brand_prefix_not_duplicated_when_present():
+    normalized = Lg24Parser._normalize_model_title("Кондиционер LG ECO Smart PC07SQR")
+    assert normalized == "LG ECO Smart PC07SQR"
+
+
 @pytest.mark.asyncio
 async def test_lg24_parse_sets_fixed_lg_brand(monkeypatch):
     html = """

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+import pytest
 
 from parsers.lg24 import Lg24Parser
 
@@ -83,3 +84,43 @@ def test_lg24_keeps_poluprom_type_when_present_in_breadcrumb():
 
     assert inferred["Тип"] == "полупромышленный кондиционер"
     assert inferred["Тип внутреннего блока"] == "канальный"
+
+
+@pytest.mark.asyncio
+async def test_lg24_parse_sets_fixed_lg_brand(monkeypatch):
+    html = """
+    <html>
+      <body>
+        <h1 class="product_title">4-поточный кассетный тип Ultra Inverter UT48R/UU48WR</h1>
+        <meta itemprop="price" content="12345" />
+        <section id="tab1">
+          <dl><dt>Мощность охлаждения (Мин/Ном/Макс), кВт</dt><dd>5.0 / 13.4 / 14.0</dd></dl>
+        </section>
+      </body>
+    </html>
+    """
+
+    class _Resp:
+        status_code = 200
+        text = html
+        url = "https://lg24.by/product/ut48r-uu48wr/"
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            return _Resp()
+
+    monkeypatch.setattr("parsers.lg24.httpx.AsyncClient", _FakeClient)
+
+    parser = Lg24Parser()
+    parsed = await parser.parse("https://lg24.by/product/ut48r-uu48wr/")
+
+    assert parsed["specs"]["Бренд"] == "LG"

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -1,0 +1,85 @@
+from bs4 import BeautifulSoup
+
+from parsers.lg24 import Lg24Parser
+
+
+def test_lg24_related_urls_use_item_tags_only():
+    html = """
+    <html>
+      <body>
+        <ul class="item-tags">
+          <li><a href="/product/lg-eco-s07eqr/">LG ECO S07EQR</a></li>
+          <li><a href="/product/lg-eco-s09eqr/">LG ECO S09EQR</a></li>
+        </ul>
+        <div class="related products">
+          <a href="/product/noisy-extra-1/">Noisy 1</a>
+          <a href="/product/noisy-extra-2/">Noisy 2</a>
+        </div>
+      </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    related = Lg24Parser._collect_related_urls(soup, "https://lg24.by/product/current/")
+
+    assert related == [
+        "https://lg24.by/product/lg-eco-s07eqr/",
+        "https://lg24.by/product/lg-eco-s09eqr/",
+    ]
+
+
+def test_lg24_extract_specs_skips_doc_download_rows():
+    html = """
+    <html>
+      <body>
+        <section id="tab1">
+          <dl><dt>Руководство пользователя</dt><dd><a href="/file.pdf">Скачать</a></dd></dl>
+          <dl><dt>Инструкция по монтажу</dt><dd>1 шт.</dd></dl>
+          <dl><dt>Мощность охлаждения (Мин/Ном/Макс), кВт</dt><dd>0.89 / 2.5 / 3.7</dd></dl>
+        </section>
+      </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    specs = Lg24Parser._extract_specs(soup)
+
+    assert "Руководство пользователя" not in specs
+    assert "Инструкция по монтажу" not in specs
+    assert specs["Мощность охлаждения (Мин/Ном/Макс), кВт"] == "0.89 / 2.5 / 3.7"
+
+
+def test_lg24_infers_type_and_indoor_type_from_breadcrumb():
+    html = """
+    <nav class="woocommerce-breadcrumb">
+      <a href="/">Главная</a> /
+      <a href="/catalog/dom">Кондиционеры для дома</a> /
+      <a href="/catalog/dom/nastennye">Настенный блок</a> /
+      Кондиционер LG ECO S07EQR
+    </nav>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    parts = Lg24Parser._extract_breadcrumb_parts(soup)
+    inferred = Lg24Parser._infer_type_specs_from_breadcrumb(parts)
+
+    assert inferred["Тип"] == "сплит-система"
+    assert inferred["Тип внутреннего блока"] == "настенный"
+
+
+def test_lg24_keeps_poluprom_type_when_present_in_breadcrumb():
+    html = """
+    <nav class="woocommerce-breadcrumb">
+      <a href="/">Главная</a> /
+      <a href="/catalog/poluprom">Полупром</a> /
+      <a href="/catalog/poluprom/kanalnye">Канальный блок</a> /
+      CL12R
+    </nav>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    parts = Lg24Parser._extract_breadcrumb_parts(soup)
+    inferred = Lg24Parser._infer_type_specs_from_breadcrumb(parts)
+
+    assert inferred["Тип"] == "полупромышленный кондиционер"
+    assert inferred["Тип внутреннего блока"] == "канальный"

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -86,6 +86,23 @@ def test_lg24_keeps_poluprom_type_when_present_in_breadcrumb():
     assert inferred["Тип внутреннего блока"] == "канальный"
 
 
+def test_lg24_defaults_non_wall_indoor_type_to_poluprom():
+    html = """
+    <nav class="woocommerce-breadcrumb">
+      <a href="/">Главная</a> /
+      <a href="/catalog/cassette">Кассетный блок</a> /
+      UT48R
+    </nav>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    parts = Lg24Parser._extract_breadcrumb_parts(soup)
+    inferred = Lg24Parser._infer_type_specs_from_breadcrumb(parts)
+
+    assert inferred["Тип"] == "полупромышленный кондиционер"
+    assert inferred["Тип внутреннего блока"] == "кассетный"
+
+
 @pytest.mark.asyncio
 async def test_lg24_parse_sets_fixed_lg_brand(monkeypatch):
     html = """

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -114,3 +114,67 @@ def test_indoor_type_filter_key_for_semi_industrial():
 
     floor_ceiling = normalize_specs({"Тип внутреннего блока": "напольно-потолочный"})
     assert floor_ceiling["__filter_indoor_type"] == "floor_ceiling"
+
+
+def test_hobot_power_and_controls_keys_are_normalized():
+    specs = normalize_specs(
+        {
+            "Мощность охлаждения, кВт": "2.80",
+            "Мощность обогрева, кВт": "3.63",
+            "Рабочий диапазон температур при охлаждении, °C": "от -15 до +53",
+            "Рабочий диапазон температур при обогреве, °C": "от -20 до +30",
+            "Инверторное управление мощностью": "Есть",
+            "Пульт": "Есть",
+            "Режим осушения воздуха": "есть",
+            "Регулятор скорости вращения вентилятора": "Есть",
+        }
+    )
+
+    assert specs["capacity_cooling_kw"] == "2.80"
+    assert specs["capacity_heating_kw"] == "3.63"
+    assert specs["temp_range_cool"] == "от -15 до +53"
+    assert specs["temp_range_heat"] == "от -20 до +30"
+    assert specs["inverter"] is True
+    assert specs["remote_control"] is True
+    assert specs["dehumidification"] is True
+    assert specs["fan_speed"] is True
+
+
+def test_haierproff_core_keys_are_normalized():
+    specs = normalize_specs(
+        {
+            "Охлаждение, кВт": "5,2",
+            "Нагрев, кВт": "6,0",
+            "Рекомендованная площадь, м 2": "35 - 50",
+            "Марка используемого хладагента": "R32",
+            "Диаметр жидкостной линии, мм": "6,35",
+            "Диаметр газовой линии, мм": "9,52",
+            "Инверторный компрессор": "Да",
+        }
+    )
+
+    assert specs["capacity_cooling_kw"] == "5.2"
+    assert specs["capacity_heating_kw"] == "6.0"
+    assert specs["area_m2"] == "50"
+    assert specs["freon_type"] == "R32"
+    assert specs["pipe_liquid"] == "6.35"
+    assert specs["pipe_gas"] == "9.52"
+    assert specs["inverter"] is True
+
+
+def test_min_nom_max_values_use_nominal_component():
+    specs = normalize_specs(
+        {
+            "Мощность охлаждения (Мин/Ном/Макс), кВт": "0.89 / 2.5 / 3.7",
+            "Мощность нагрева (Мин/Ном/Макс), кВт": "0.89 / 3.3 / 4.1",
+            "Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт": "0.20 / 0.656 / 1.4",
+            "Потребление электроэнергии в режиме нагрева (Мин / Ном / Макс), кВт": "0.195 / 0.800 / 1.6",
+            "Тип системы": "Инверторная",
+        }
+    )
+
+    assert specs["capacity_cooling_kw"] == "2.5"
+    assert specs["capacity_heating_kw"] == "3.3"
+    assert specs["power_cons_cooling_kw"] == "0.656"
+    assert specs["power_cons_heating_kw"] == "0.800"
+    assert specs["inverter"] is True

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -173,8 +173,8 @@ def test_haierproff_core_keys_are_normalized():
     assert specs["capacity_heating_kw"] == "6.0"
     assert specs["area_m2"] == "50"
     assert specs["freon_type"] == "R32"
-    assert specs["pipe_liquid"] == "6.35"
-    assert specs["pipe_gas"] == "9.52"
+    assert specs["pipe_liquid"] == '1/4"'
+    assert specs["pipe_gas"] == '3/8"'
     assert specs["inverter"] is True
 
 
@@ -199,7 +199,7 @@ def test_min_nom_max_values_use_nominal_component():
 def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
     specs = normalize_specs(
         {
-            "Габаритные размеры без упаковки (Ш/Г/В), мм": "898 × 355 × 643",
+            "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": "898 × 355 × 643",
             "Габаритные размеры в упаковке (Ш/Г/В), мм": "940 × 390 × 697",
             "Чистый вес / Вес в упаковке, кг": "14,9 / 18,9",
             "Чистый вес / вес в упаковке, кг": "36,5 / 38,5",
@@ -234,8 +234,8 @@ def test_dynamic_temp_and_pipe_aliases_are_normalized():
 
     assert specs["temp_range_cool"] == "-15 ~ 48"
     assert specs["temp_range_heat"] == "-18 ~ 18"
-    assert specs["pipe_liquid"] == "6.35"
-    assert specs["pipe_gas"] == "9.52"
+    assert specs["pipe_liquid"] == '1/4"'
+    assert specs["pipe_gas"] == '3/8"'
 
 
 def test_type_canonicalization_marks_cassette_split_as_semi_industrial():
@@ -257,3 +257,40 @@ def test_type_fallback_from_indoor_type_sets_semi_industrial():
     )
 
     assert specs["type"] == "полупромышленный кондиционер"
+
+
+def test_haier_grouped_indoor_outdoor_dimensions_are_split_correctly():
+    specs = normalize_specs(
+        {
+            "Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм": "974 × 223 × 318",
+            "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": "875 × 355 × 642",
+        }
+    )
+
+    assert specs["width_indoor"] == "974"
+    assert specs["depth_indoor"] == "223"
+    assert specs["height_indoor"] == "318"
+    assert specs["width_outdoor"] == "875"
+    assert specs["depth_outdoor"] == "355"
+    assert specs["height_outdoor"] == "642"
+
+
+def test_non_inverter_compressor_sets_inverter_false():
+    specs = normalize_specs({"Неинверторный компрессор": "Да"})
+    assert specs["inverter"] is False
+
+
+def test_remote_control_model_implies_remote_control_true():
+    specs = normalize_specs({"Пульт управления": "YR-HE"})
+    assert specs["remote_control"] is True
+
+
+def test_compressor_brand_is_canonicalized_for_select():
+    specs = normalize_specs({"Производитель компрессора": "HIGHLY"})
+    assert specs["compressor_brand"] == "Highly"
+
+
+def test_eer_cop_pair_is_split_into_two_specs():
+    specs = normalize_specs({"EER/COP": "3,21 / 3,61"})
+    assert specs["eer"] == "3.21"
+    assert specs["cop"] == "3.61"

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -218,3 +218,24 @@ def test_dynamic_temp_and_pipe_aliases_are_normalized():
     assert specs["temp_range_heat"] == "-18 ~ 18"
     assert specs["pipe_liquid"] == "6.35"
     assert specs["pipe_gas"] == "9.52"
+
+
+def test_type_canonicalization_marks_cassette_split_as_semi_industrial():
+    specs = normalize_specs(
+        {
+            "Тип кондиционера": "4-поточная кассетная сплит-система",
+            "Тип внутреннего блока": "кассетный",
+        }
+    )
+
+    assert specs["type"] == "полупромышленный кондиционер"
+
+
+def test_type_fallback_from_indoor_type_sets_semi_industrial():
+    specs = normalize_specs(
+        {
+            "Тип внутреннего блока": "канальный",
+        }
+    )
+
+    assert specs["type"] == "полупромышленный кондиционер"

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -204,8 +204,10 @@ def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
     assert specs["weight_indoor"] == "14.9"
     assert specs["weight_outdoor"] == "36.5"
     assert specs["availability"] == "В наличии"
-    assert specs["source_price_rub"] == "191700"
-    assert specs["source_fx_rub_byn"] == "0.0374"
+    assert "source_price_rub" not in specs
+    assert "source_fx_rub_byn" not in specs
+    assert "Цена источника" not in specs
+    assert "Курс RUB/BYN (импорт)" not in specs
 
 
 def test_dynamic_temp_and_pipe_aliases_are_normalized():

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -64,6 +64,14 @@ def test_dynamic_wifi_key_mapping_from_onliner_specs():
     assert specs["__filter_wifi_builtin"] is False
 
 
+def test_wifi_option_value_maps_to_ready():
+    specs = normalize_specs({"Wi-Fi": "Опция"})
+
+    assert specs["wifi_ready"] == "ready"
+    assert specs["__filter_wifi"] is True
+    assert specs["__filter_wifi_builtin"] is False
+
+
 def test_brand_normalization_and_auto_tag_slug_output():
     auto_slugs = []
     specs = normalize_specs(
@@ -108,16 +116,20 @@ def test_multisplit_russian_keys_are_normalized():
 def test_indoor_type_filter_key_for_semi_industrial():
     cassette = normalize_specs({"Тип внутреннего блока": "кассетный"})
     assert cassette["__filter_indoor_type"] == "cassette"
+    assert cassette["indoor_type"] == "кассетный"
 
     duct = normalize_specs({"indoor_type": "Канальный"})
     assert duct["__filter_indoor_type"] == "duct"
+    assert duct["indoor_type"] == "канальный"
 
     floor_ceiling = normalize_specs({"Тип внутреннего блока": "напольно-потолочный"})
     assert floor_ceiling["__filter_indoor_type"] == "floor_ceiling"
+    assert floor_ceiling["indoor_type"] == "напольно-потолочный"
 
     universal = normalize_specs({"Тип внутреннего блока": "универсальный"})
     assert universal["__filter_indoor_type"] == "floor_ceiling"
     assert universal["type"] == "полупромышленный кондиционер"
+    assert universal["indoor_type"] == "напольно-потолочный"
 
 
 def test_hobot_power_and_controls_keys_are_normalized():

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -178,3 +178,27 @@ def test_min_nom_max_values_use_nominal_component():
     assert specs["power_cons_cooling_kw"] == "0.656"
     assert specs["power_cons_heating_kw"] == "0.800"
     assert specs["inverter"] is True
+
+
+def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
+    specs = normalize_specs(
+        {
+            "Габаритные размеры без упаковки (Ш/Г/В), мм": "898 × 355 × 643",
+            "Габаритные размеры в упаковке (Ш/Г/В), мм": "940 × 390 × 697",
+            "Чистый вес / Вес в упаковке, кг": "14,9 / 18,9",
+            "Чистый вес / вес в упаковке, кг": "36,5 / 38,5",
+            "Наличие": "В наличии",
+            "Цена источника": "191700 RUB",
+            "Курс RUB/BYN (импорт)": "0.0374",
+        }
+    )
+
+    assert specs["width_outdoor"] == "898"
+    assert specs["depth_outdoor"] == "355"
+    assert specs["height_outdoor"] == "643"
+    assert specs["dimensions_outdoor_package_mm"] == "940 × 390 × 697"
+    assert specs["weight_indoor"] == "14.9"
+    assert specs["weight_outdoor"] == "36.5"
+    assert specs["availability"] == "В наличии"
+    assert specs["source_price_rub"] == "191700"
+    assert specs["source_fx_rub_byn"] == "0.0374"

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -202,3 +202,19 @@ def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
     assert specs["availability"] == "В наличии"
     assert specs["source_price_rub"] == "191700"
     assert specs["source_fx_rub_byn"] == "0.0374"
+
+
+def test_dynamic_temp_and_pipe_aliases_are_normalized():
+    specs = normalize_specs(
+        {
+            "для работы в режиме охлаждения, ⁰C CТ": "-15 ~ 48",
+            "Для работы в режиме нагрева , ⁰C ВТ": "-18 ~ 18",
+            "Диаметр труб жидкого хладагента, мм": "6.35",
+            "Диаметр труб газообразного хладагента, мм": "9.52",
+        }
+    )
+
+    assert specs["temp_range_cool"] == "-15 ~ 48"
+    assert specs["temp_range_heat"] == "-18 ~ 18"
+    assert specs["pipe_liquid"] == "6.35"
+    assert specs["pipe_gas"] == "9.52"

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -115,6 +115,10 @@ def test_indoor_type_filter_key_for_semi_industrial():
     floor_ceiling = normalize_specs({"Тип внутреннего блока": "напольно-потолочный"})
     assert floor_ceiling["__filter_indoor_type"] == "floor_ceiling"
 
+    universal = normalize_specs({"Тип внутреннего блока": "универсальный"})
+    assert universal["__filter_indoor_type"] == "floor_ceiling"
+    assert universal["type"] == "полупромышленный кондиционер"
+
 
 def test_hobot_power_and_controls_keys_are_normalized():
     specs = normalize_specs(

--- a/tests/unit/test_tag_logic.py
+++ b/tests/unit/test_tag_logic.py
@@ -43,6 +43,15 @@ def test_detect_category_slug_for_semi_industrial():
     assert slug == "cat-industrial"
 
 
+def test_detect_category_slug_for_universal_block_marker():
+    slug = detect_category_slug(
+        metrics={},
+        specs={"Тип внутреннего блока": "универсальный"},
+        title="Haier AC Universal",
+    )
+    assert slug == "cat-industrial"
+
+
 def test_detect_category_slug_for_multi_inner_block():
     slug = detect_category_slug(
         metrics={},

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -17,6 +17,10 @@ import { generateBentoCards } from "../../utils/bento-cards";
 
 export async function getStaticPaths() {
     const products = await getProducts();
+    if (!Array.isArray(products) || products.length === 0) {
+        throw new Error("[SSG] Product static paths generation failed: no products returned from API.");
+    }
+
     return products.map((product: any) => ({
         params: { slug: product.slug },
         props: { product },

--- a/web/src/pages/services/[slug].astro
+++ b/web/src/pages/services/[slug].astro
@@ -67,6 +67,8 @@ export async function getStaticPaths() {
 }
 
 const { service } = Astro.props;
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+const safeDescription = typeof service?.description === "string" ? stripHtml(service.description) : "";
 ---
 
 <Layout
@@ -80,8 +82,8 @@ const { service } = Astro.props;
                 <h1 class="gradient-text hero-title" style="word-break: break-word; hyphens: auto;">{service.title}</h1>
                 <p class="breadcrumbs">Главная / Услуги / {service.title}</p>
                 <div class="hero-desc">
-                    {service.description ? 
-                        <div set:html={service.description} /> 
+                    {safeDescription ? 
+                        <p>{safeDescription}</p>
                         : 
                         <p>Профессиональная климатическая услуга от «Мастера Воздуха» с гарантией качества и надежности.</p>
                     }

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -3,11 +3,20 @@ const PUBLIC_API_URL = (import.meta.env.PUBLIC_API_URL || 'http://localhost:8000
 
 // Re-export spec formatting utilities
 export { formatSpec, formatAllSpecs, SPEC_DICT } from './spec-dictionary';
+const normalizeApiV1Base = (raw) => {
+    const base = String(raw || "").trim().replace(/\/$/, "");
+    if (!base) return "";
+    if (base.endsWith("/api/v1")) return base;
+    return `${base.replace(/\/api\/v1$/, "")}/api/v1`;
+};
+
+const uniqueNonEmpty = (values) => [...new Set(values.map((v) => String(v || "").trim()).filter(Boolean))];
+
 // Ensure standard formatting (no trailing slash)
 // INTERNAL_URL is used for SSR (Server Side Rendering) inside Docker network
-const INTERNAL_URL = (import.meta.env.INTERNAL_API_URL || 'http://app:8000/api/v1').replace(/\/$/, "");
+const INTERNAL_URL = normalizeApiV1Base(import.meta.env.INTERNAL_API_URL || 'http://app:8000/api/v1');
 // PUBLIC_URL is used for Client-side requests (Browser)
-const CLIENT_URL = (import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1').replace(/\/$/, "");
+const CLIENT_URL = normalizeApiV1Base(import.meta.env.PUBLIC_API_URL || 'http://localhost:8000/api/v1');
 
 // Define API versions relative to the base
 // Use Client-side URL if not in SSR
@@ -67,6 +76,37 @@ async function fetchJson(url, options = {}, returnNullOnError = true) {
     }
 }
 
+function getSsgApiCandidates() {
+    return uniqueNonEmpty([
+        INTERNAL_URL,
+        CLIENT_URL,
+        normalizeApiV1Base(import.meta.env.PUBLIC_API_URL),
+        normalizeApiV1Base(import.meta.env.INTERNAL_API_URL),
+        "http://localhost:8000/api/v1",
+    ]);
+}
+
+async function getCatalogStrictForSsg(params = {}) {
+    const query = buildQuery(params);
+    const candidates = getSsgApiCandidates();
+    const errors = [];
+
+    for (const baseUrl of candidates) {
+        const url = `${baseUrl}/catalog?${query}`;
+        try {
+            const data = await fetchJson(url, {}, false);
+            if (data && Array.isArray(data.items)) {
+                return data;
+            }
+            errors.push(`${url} -> invalid payload`);
+        } catch (error) {
+            errors.push(`${url} -> ${error.message}`);
+        }
+    }
+
+    throw new Error(`[SSG] Failed to fetch catalog. Tried: ${candidates.join(", ")}. Errors: ${errors.join(" | ")}`);
+}
+
 export async function getCatalog(params = {}) {
     const query = buildQuery(params);
     const url = `${API_V1}/catalog?${query}`;
@@ -90,7 +130,13 @@ export async function getFiltersConfig() {
 }
 
 export async function getProducts() {
-    // Fetch all products for SSG (limit 1000 for now)
+    // During SSG we require a strict fetch to avoid silently dropping product routes.
+    if (import.meta.env.SSR) {
+        const data = await getCatalogStrictForSsg({ limit: 1000 });
+        return data && data.items ? data.items : [];
+    }
+
+    // Client-side/runtime usage can stay resilient with soft fallback.
     const data = await getCatalog({ limit: 1000 });
     return data && data.items ? data.items : [];
 }


### PR DESCRIPTION
## Summary
- add `Lg24Parser` for `lg24.by` (WooCommerce product pages)
- add `HobotParser` for `hobot.by` (catalog product pages)
- add `HaierProffParser` for official `haierproff.ru/cond` product pages
- register new parsers in `ImporterService`
- improve `HobotParser` image pipeline: prefer original `/upload/iblock/...` assets over `resize_cache` variants when originals are available
- convert `haierproff` source prices from `RUB` to `BYN` during import
- normalize product titles for `lg24` and `hobot` by removing generic prefixes (`кондиционер`, `сплит-система`, etc.)
- ensure `haierproff` titles always include brand prefix `Haier`
- extract series from `haierproff` title fragment `Серия ...` into specs
- disable related URL crawling for `hobot` (to avoid unintended mass imports)
- add self-heal for existing products without category tags: reimport updates inferred tags/specs even when `update_existing=false`

## Price conversion (RUB -> BYN)
- `HaierProffParser` now returns `price_currency="RUB"`
- importer converts source price to BYN before save
- conversion uses `FxRateService.get_effective_rub_byn_rate(...)`
- if manual RUB rate is configured (`fx_rate_rub_byn`) and source mode is `manual`, it is used
- otherwise importer falls back to NBRB RUB/BYN rate
- import writes trace fields into specs:
  - `Цена источника`
  - `Курс RUB/BYN (импорт)`

## Naming rules
- `haierproff` title example:
  - source: `AS50HSL1HRA-W / 1U50HSL1FRA Серия Spirit DC`
  - saved: `Haier AS50HSL1HRA-W / 1U50HSL1FRA Серия Spirit DC`
- `haierproff` series extraction:
  - `Серия Spirit DC` -> specs `Серия=Spirit DC` -> normalized `series=Spirit DC`
- `lg24` / `hobot` title cleanup examples:
  - `Кондиционер LG Objet Green AG09BK` -> `LG Objet Green AG09BK`
  - `Универсальная сплит-система Haier ...` -> `Haier ...`

## Catalog visibility fix
- root cause: some previously imported `haierproff` products had no category tag (`cat-household|cat-multi|cat-industrial`), so they were excluded from website catalog defaults
- fix in parser: infer `Тип`/`Тип внутреннего блока` from `haierproff` URL slug (e.g. `split-sistema-*`)
- fix in importer: if existing product has no category tag, force update flow and merge inferred tags instead of returning fast-path

## What is parsed
For donors parser output includes:
- product title
- price
- availability (`availability`, `in_stock`, and fallback copy into `specs["Наличие"]`)
- description
- technical specs map
- images (main + gallery)
- related product URLs
- normalized metrics (`area`, `is_inverter`, `power_cooling`, `power_heating`, `min_temp_heating` where detectable)

## Implementation notes
- added browser-like headers and locale headers to reduce donor-side blocking risk
- added fallback selectors for resilient extraction when markup changes
- added guards to detect non-product pages and fail fast with clear errors
- for `hobot.by` parser now tries to restore original image paths and checks availability before choosing them
- added config default key: `fx_rate_rub_byn`

## Verification
- `python3 -m py_compile parsers/lg24.py parsers/hobot.py parsers/haierproff.py services/importer_service.py services/fx_rate_service.py`
- smoke run on real URLs:
  - `https://lg24.by/product/4-potochnyj-kassetnyj-tip-smart-inverter-ut18wc-uu18wc/`
  - `https://www.hobot.by/catalog/obogrevateli/konvektory_elektricheskie/ballu_bec_ezer_2000/`
  - `https://haierproff.ru/catalog/cond/products/split-sistema-haier-tundra-hsu-07htt03r3-hsu-07htt103r3out-2024`
  - `https://haierproff.ru/catalog/cond/products/split-sistema-haier-spirit-dc-inverter-AS50HSL1HRA-W-1U50HSL1FRA`
  - `https://haierproff.ru/catalog/cond/products/split-sistema-haier-jade-super-match-as35s2sj2fa-g-1u35mecfra-2024`
- RUB conversion smoke:
  - source `26300 RUB` converted to `984 BYN` with rate `0.0374`
- reimport visibility smoke:
  - `import_product(..., update_existing=False)` for existing `haierproff` product id `222` updated tags to include `cat-household`
- parser routing check through `ImporterService.get_parser(...)`

Closes #249
