### PR TITLE
feat(import): manuals links + shared media dedupe

### DIFF
--- a/alembic/versions/1f2e3d4c5b6a_add_product_attachments_and_import_media_cache.py
+++ b/alembic/versions/1f2e3d4c5b6a_add_product_attachments_and_import_media_cache.py
@@ -1,0 +1,92 @@
+"""add product attachments and import media cache
+
+Revision ID: 1f2e3d4c5b6a
+Revises: b7d8e9f0a1b2
+Create Date: 2026-04-20 15:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1f2e3d4c5b6a"
+down_revision: Union[str, Sequence[str], None] = "b7d8e9f0a1b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "product_attachment",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("product_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False, server_default=sa.text("'manual'")),
+        sa.Column("title", sa.String(), nullable=False, server_default=sa.text("'Инструкция'")),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["product_id"], ["product.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "product_id",
+            "kind",
+            "url",
+            name="uq_product_attachment_product_kind_url",
+        ),
+    )
+    op.create_index(
+        "ix_product_attachment_product_id",
+        "product_attachment",
+        ["product_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_product_attachment_kind",
+        "product_attachment",
+        ["kind"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_product_attachment_source",
+        "product_attachment",
+        ["source"],
+        unique=False,
+    )
+
+    op.create_table(
+        "import_media_cache",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("source_url", sa.String(), nullable=False),
+        sa.Column("local_url", sa.String(), nullable=False),
+        sa.Column("content_hash", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("source_url", name="uq_import_media_cache_source_url"),
+    )
+    op.create_index(
+        "ix_import_media_cache_source_url",
+        "import_media_cache",
+        ["source_url"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_import_media_cache_content_hash",
+        "import_media_cache",
+        ["content_hash"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_import_media_cache_content_hash", table_name="import_media_cache")
+    op.drop_index("ix_import_media_cache_source_url", table_name="import_media_cache")
+    op.drop_table("import_media_cache")
+
+    op.drop_index("ix_product_attachment_source", table_name="product_attachment")
+    op.drop_index("ix_product_attachment_kind", table_name="product_attachment")
+    op.drop_index("ix_product_attachment_product_id", table_name="product_attachment")
+    op.drop_table("product_attachment")

--- a/crud/product.py
+++ b/crud/product.py
@@ -25,6 +25,7 @@ class ProductDAO:
         stmt = select(Product).where(Product.id == product_id).options(
             selectinload(Product.tags).selectinload(Tag.group),
             selectinload(Product.gallery_images),
+            selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
@@ -34,6 +35,7 @@ class ProductDAO:
         stmt = select(Product).where(Product.slug == slug).options(
             selectinload(Product.tags).selectinload(Tag.group),
             selectinload(Product.gallery_images),
+            selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
@@ -43,6 +45,7 @@ class ProductDAO:
         stmt = select(Product).where(Product.is_published == True).options(
             selectinload(Product.tags).selectinload(Tag.group),
             selectinload(Product.gallery_images),
+            selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
@@ -52,7 +55,8 @@ class ProductDAO:
         if not product_ids:
             return []
         stmt = select(Product).where(Product.id.in_(product_ids)).options(
-            selectinload(Product.gallery_images)
+            selectinload(Product.gallery_images),
+            selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
@@ -260,6 +264,7 @@ class ProductDAO:
         stmt = select(Product).options(
             selectinload(Product.tags).selectinload(Tag.group),
             selectinload(Product.gallery_images),
+            selectinload(Product.attachments),
         )
 
         stmt = ProductDAO._apply_common_filters(
@@ -400,6 +405,7 @@ class ProductDAO:
         stmt = select(Product).options(
             selectinload(Product.gallery_images),
             selectinload(Product.tags).selectinload(Tag.group),
+            selectinload(Product.attachments),
         )
         count_stmt = select(func.count(Product.id))
 

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -59,6 +59,7 @@ export type { ManagerCatalogCustomerListResponse } from './models/ManagerCatalog
 export type { ManagerCatalogProductImageResponse } from './models/ManagerCatalogProductImageResponse';
 export type { ManagerCatalogProductItemResponse } from './models/ManagerCatalogProductItemResponse';
 export type { ManagerCatalogProductListResponse } from './models/ManagerCatalogProductListResponse';
+export type { ManagerCatalogProductManualResponse } from './models/ManagerCatalogProductManualResponse';
 export type { ManagerCatalogProductTagResponse } from './models/ManagerCatalogProductTagResponse';
 export type { ManagerCrmHealthReportResponse } from './models/ManagerCrmHealthReportResponse';
 export type { ManagerCustomerBranchCreatePayload } from './models/ManagerCustomerBranchCreatePayload';
@@ -127,6 +128,8 @@ export type { ProductAvailabilityLeadResponse } from './models/ProductAvailabili
 export type { ProductImageResponse } from './models/ProductImageResponse';
 export type { ProductLocalStockPayload } from './models/ProductLocalStockPayload';
 export type { ProductLocalStockResponse } from './models/ProductLocalStockResponse';
+export type { ProductManualPayload } from './models/ProductManualPayload';
+export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';
 export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';

--- a/manager_frontend/src/client/models/ManagerCatalogProductItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogProductItemResponse.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ManagerCatalogProductImageResponse } from './ManagerCatalogProductImageResponse';
+import type { ManagerCatalogProductManualResponse } from './ManagerCatalogProductManualResponse';
 import type { ManagerCatalogProductTagResponse } from './ManagerCatalogProductTagResponse';
 export type ManagerCatalogProductItemResponse = {
     id: number;
@@ -20,6 +21,7 @@ export type ManagerCatalogProductItemResponse = {
     created_at: string;
     specs: Record<string, any>;
     gallery_images: Array<ManagerCatalogProductImageResponse>;
+    manuals: Array<ManagerCatalogProductManualResponse>;
     tags: Array<ManagerCatalogProductTagResponse>;
     min_cost_byn?: (number | null);
     recommended_price_byn?: (number | null);

--- a/manager_frontend/src/client/models/ManagerCatalogProductManualResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogProductManualResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerCatalogProductManualResponse = {
+    id: number;
+    kind?: string;
+    title: string;
+    url: string;
+    source?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ProductManualPayload.ts
+++ b/manager_frontend/src/client/models/ProductManualPayload.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductManualPayload = {
+    kind?: string;
+    title: string;
+    url: string;
+    source?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ProductManualResponse.ts
+++ b/manager_frontend/src/client/models/ProductManualResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductManualResponse = {
+    id: number;
+    kind?: string;
+    title: string;
+    url: string;
+    source?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ProductResponse.ts
+++ b/manager_frontend/src/client/models/ProductResponse.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ProductImageResponse } from './ProductImageResponse';
+import type { ProductManualResponse } from './ProductManualResponse';
 import type { ProductSiblingResponse } from './ProductSiblingResponse';
 import type { TagResponse } from './TagResponse';
 export type ProductResponse = {
@@ -24,6 +25,7 @@ export type ProductResponse = {
     specs?: Record<string, any>;
     images?: Array<string>;
     gallery_images?: Array<ProductImageResponse>;
+    manuals?: Array<ProductManualResponse>;
     series_siblings?: Array<ProductSiblingResponse>;
 };
 

--- a/manager_frontend/src/client/models/ProductUpdate.ts
+++ b/manager_frontend/src/client/models/ProductUpdate.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductManualPayload } from './ProductManualPayload';
 export type ProductUpdate = {
     title?: (string | null);
     price?: (number | null);
@@ -12,5 +13,6 @@ export type ProductUpdate = {
     brand_id?: (number | null);
     series_id?: (number | null);
     tag_ids?: (Array<number> | null);
+    manuals?: Array<ProductManualPayload>;
 };
 

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -53,6 +53,7 @@ const form = ref<any>({
 });
 
 const specs = ref<{ key: string; value: string }[]>([]);
+const manuals = ref<{ title: string; url: string }[]>([]);
 const selectedTagIds = ref<Set<number>>(new Set());
 const loading = ref(false);
 const formMessage = ref('');
@@ -842,6 +843,12 @@ watch(() => props.modelValue, async (val) => {
             }
             return { key, value: sVal };
         });
+        manuals.value = (((props.product as any).manuals || []) as Array<any>)
+            .map((item) => ({
+                title: String(item?.title || 'Инструкция').trim() || 'Инструкция',
+                url: String(item?.url || '').trim(),
+            }))
+            .filter((item) => Boolean(item.url));
         compatibilityQuery.value = '';
         compatibilityResults.value = [];
         compatibilityInfo.value = '';
@@ -893,6 +900,8 @@ const loadSupplierOffers = async () => {
 
 const addRow = () => specs.value.push({ key: '', value: '' });
 const removeRow = (index: number) => specs.value.splice(index, 1);
+const addManualRow = () => manuals.value.push({ title: 'Инструкция', url: '' });
+const removeManualRow = (index: number) => manuals.value.splice(index, 1);
 
 const close = () => emit('update:modelValue', false);
 
@@ -969,11 +978,24 @@ const save = async () => {
     formMessage.value = '';
     formServerErrors.value = {};
     try {
+        const validManuals = manuals.value
+            .map((item) => ({
+                title: String(item.title || '').trim() || 'Инструкция',
+                url: String(item.url || '').trim(),
+            }))
+            .filter((item) => Boolean(item.url))
+            .map((item) => ({
+                ...item,
+                kind: 'manual',
+                source: 'manager',
+            }));
+
         const updateData = {
             ...form.value,
             brand_id: selectedBrandEntityId.value ?? null,
             specs: validSpecs,
             tag_ids: Array.from(selectedTagIds.value),
+            manuals: validManuals,
         };
         await api.updateProduct(props.product.id, updateData);
         emit('success');
@@ -988,6 +1010,7 @@ const save = async () => {
             'brand_id',
             'specs',
             'tag_ids',
+            'manuals',
         ]);
         formServerErrors.value = parsed.fieldErrors;
         formMessage.value = parsed.message || `Ошибка при сохранении: ${getApiErrorMessage(e)}`;
@@ -1526,6 +1549,39 @@ const unlinkSupplierOffer = async (offer: any) => {
 
                     <!-- Column 2: Specs -->
                     <section class="space-y-5">
+                        <div class="rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 space-y-2">
+                            <div class="flex justify-between items-center">
+                                <h3 class="text-xs font-bold text-gray-500 dark:text-slate-400 uppercase tracking-widest">
+                                    Инструкции и файлы
+                                </h3>
+                                <button @click="addManualRow" class="text-xs bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 px-2.5 py-1 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 text-teal-600 dark:text-teal-400 font-bold flex items-center gap-1 transition-colors shadow-sm">
+                                    <Plus class="w-3 h-3" /> Добавить
+                                </button>
+                            </div>
+                            <div class="space-y-2">
+                                <div v-for="(manual, idx) in manuals" :key="`manual-${idx}`" class="grid grid-cols-[160px_1fr_auto] gap-1.5 items-center">
+                                    <input
+                                        v-model="manual.title"
+                                        type="text"
+                                        placeholder="Название"
+                                        class="h-[34px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1.5 text-xs"
+                                    />
+                                    <input
+                                        v-model="manual.url"
+                                        type="url"
+                                        placeholder="https://..."
+                                        class="h-[34px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1.5 text-xs"
+                                    />
+                                    <button @click="removeManualRow(idx)" class="p-1.5 text-gray-300 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all">
+                                        <Trash2 class="w-3.5 h-3.5" />
+                                    </button>
+                                </div>
+                                <div v-if="manuals.length === 0" class="text-[11px] text-gray-400 dark:text-slate-500">
+                                    Ссылки на инструкции не добавлены.
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="flex justify-between items-center">
                             <h3 class="text-xs font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest flex items-center gap-1.5">
                                  Характеристики

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -29,8 +29,10 @@ from .order import (
 )
 from .product import (
     Favorite,
+    ImportMediaCache,
     InstallationRate,
     Product,
+    ProductAttachment,
     ProductImage,
     ProductTagLink,
     Tag,
@@ -56,6 +58,7 @@ __all__ = [
     "Favorite",
     "GlobalConfig",
     "InstallationRate",
+    "ImportMediaCache",
     "Installer",
     "Lead",
     "LeadIntakeSource",
@@ -73,6 +76,7 @@ __all__ = [
     "OrderWorkStage",
     "PaymentCurrency",
     "Product",
+    "ProductAttachment",
     "ProductImage",
     "ProductImage",
     "ProductSeries",

--- a/models/product.py
+++ b/models/product.py
@@ -70,6 +70,7 @@ class Product(SQLModel, table=True):
     main_image: Optional[str] = Field(default=None)
     images: List[str] = Field(default=[], sa_column=Column(JSON))
     gallery_images: List["ProductImage"] = Relationship(back_populates="product")
+    attachments: List["ProductAttachment"] = Relationship(back_populates="product")
 
     tags: List[Tag] = Relationship(back_populates="products", link_model=ProductTagLink)
     order_links: List["OrderProductLink"] = Relationship(back_populates="product")
@@ -114,6 +115,35 @@ class ProductImage(SQLModel, table=True):
     def __str__(self):
         photo_type = "Installation" if self.is_installation_photo else "Gallery"
         return f"{photo_type} photo for product #{self.product_id}"
+
+
+class ProductAttachment(SQLModel, table=True):
+    __tablename__ = "product_attachment"
+    __table_args__ = (
+        UniqueConstraint("product_id", "kind", "url", name="uq_product_attachment_product_kind_url"),
+    )
+    id: Optional[int] = Field(default=None, primary_key=True)
+    product_id: int = Field(foreign_key="product.id", index=True)
+    kind: str = Field(default="manual", index=True)
+    title: str = Field(default="Инструкция")
+    url: str
+    source: Optional[str] = Field(default=None, index=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    product: "Product" = Relationship(back_populates="attachments")
+
+    def __str__(self):
+        return f"{self.kind} attachment for product #{self.product_id}"
+
+
+class ImportMediaCache(SQLModel, table=True):
+    __tablename__ = "import_media_cache"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source_url: str = Field(sa_column=Column(String, unique=True, nullable=False, index=True))
+    local_url: str = Field(nullable=False)
+    content_hash: str = Field(index=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+    last_seen_at: datetime = Field(default_factory=datetime.now)
 
 
 class Favorite(SQLModel, table=True):

--- a/openapi.json
+++ b/openapi.json
@@ -9654,6 +9654,13 @@
             "type": "array",
             "title": "Gallery Images"
           },
+          "manuals": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerCatalogProductManualResponse"
+            },
+            "type": "array",
+            "title": "Manuals"
+          },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/ManagerCatalogProductTagResponse"
@@ -9736,6 +9743,7 @@
           "created_at",
           "specs",
           "gallery_images",
+          "manuals",
           "tags"
         ],
         "title": "ManagerCatalogProductItemResponse"
@@ -9759,6 +9767,45 @@
           "meta"
         ],
         "title": "ManagerCatalogProductListResponse"
+      },
+      "ManagerCatalogProductManualResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "manual"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "url"
+        ],
+        "title": "ManagerCatalogProductManualResponse"
       },
       "ManagerCatalogProductTagResponse": {
         "properties": {
@@ -13677,6 +13724,79 @@
         ],
         "title": "ProductLocalStockResponse"
       },
+      "ProductManualPayload": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "manual"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "url"
+        ],
+        "title": "ProductManualPayload"
+      },
+      "ProductManualResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "manual"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "url"
+        ],
+        "title": "ProductManualResponse"
+      },
       "ProductResponse": {
         "properties": {
           "id": {
@@ -13801,6 +13921,14 @@
             },
             "type": "array",
             "title": "Gallery Images",
+            "default": []
+          },
+          "manuals": {
+            "items": {
+              "$ref": "#/components/schemas/ProductManualResponse"
+            },
+            "type": "array",
+            "title": "Manuals",
             "default": []
           },
           "series_siblings": {
@@ -14001,6 +14129,13 @@
               }
             ],
             "title": "Tag Ids"
+          },
+          "manuals": {
+            "items": {
+              "$ref": "#/components/schemas/ProductManualPayload"
+            },
+            "type": "array",
+            "title": "Manuals"
           }
         },
         "type": "object",

--- a/parsers/haierproff.py
+++ b/parsers/haierproff.py
@@ -191,6 +191,33 @@ class HaierProffParser(BaseParser):
         return related
 
     @classmethod
+    def _extract_manuals(cls, soup: BeautifulSoup, current_url: str) -> List[Dict[str, str]]:
+        manuals: List[Dict[str, str]] = []
+        seen_urls: set[str] = set()
+
+        for link in soup.select(".icon-link-l-list a.icon-link-l[href]"):
+            href = cls._to_abs_url(link.get("href", ""), current_url)
+            if not href or href in seen_urls:
+                continue
+
+            title_el = link.select_one(".icon-link-l__text")
+            title = re.sub(r"\s+", " ", title_el.get_text(" ", strip=True)).strip() if title_el else ""
+            if not title:
+                title = "Документ"
+
+            seen_urls.add(href)
+            manuals.append(
+                {
+                    "kind": "manual",
+                    "title": title,
+                    "url": href,
+                    "source": "haierproff",
+                }
+            )
+
+        return manuals
+
+    @classmethod
     def _extract_specs(cls, soup: BeautifulSoup) -> Dict[str, str]:
         specs: Dict[str, str] = {}
 
@@ -401,6 +428,7 @@ class HaierProffParser(BaseParser):
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))
+        manuals = self._extract_manuals(soup, str(response.url))
 
         return {
             "title": title,
@@ -416,6 +444,7 @@ class HaierProffParser(BaseParser):
             "specs": specs,
             "metrics": metrics,
             "related_urls": related_urls,
+            "manuals": manuals,
             "availability": "В наличии",
             "in_stock": True,
         }

--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -221,6 +221,53 @@ class Lg24Parser(BaseParser):
 
         return specs
 
+    @classmethod
+    def _extract_manuals(cls, soup: BeautifulSoup, current_url: str) -> List[Dict[str, str]]:
+        manuals: List[Dict[str, str]] = []
+        seen: set[str] = set()
+
+        def collect_row(key_text: str, value_node) -> None:
+            key = (key_text or "").replace("\xa0", " ").strip().rstrip(":")
+            if not key:
+                return
+            key_l = key.lower()
+            if not any(marker in key_l for marker in cls._DOC_SPEC_KEY_MARKERS):
+                return
+
+            links = value_node.select("a[href]") if value_node else []
+            for link in links:
+                href = cls._to_abs_url(link.get("href", ""), current_url)
+                if not href or href in seen:
+                    continue
+                seen.add(href)
+                manuals.append(
+                    {
+                        "kind": "manual",
+                        "title": key,
+                        "url": href,
+                        "source": "lg24",
+                    }
+                )
+
+        for row in soup.select("section#tab1 dl"):
+            dt = row.find("dt")
+            dd = row.find("dd")
+            if not dt or not dd:
+                continue
+            collect_row(dt.get_text(" ", strip=True), dd)
+
+        if manuals:
+            return manuals
+
+        for row in soup.select("table.woocommerce-product-attributes tr"):
+            th = row.find("th")
+            td = row.find("td")
+            if not th or not td:
+                continue
+            collect_row(th.get_text(" ", strip=True), td)
+
+        return manuals
+
     @staticmethod
     def _extract_metrics(specs: Dict[str, str], title: str) -> Dict[str, Any]:
         metrics: Dict[str, Any] = {
@@ -315,6 +362,7 @@ class Lg24Parser(BaseParser):
         metrics = self._extract_metrics(specs, title)
         images = self._collect_images(soup, str(response.url))
         related_urls = self._collect_related_urls(soup, str(response.url))
+        manuals = self._extract_manuals(soup, str(response.url))
 
         return {
             "title": title,
@@ -329,6 +377,7 @@ class Lg24Parser(BaseParser):
             "specs": specs,
             "metrics": metrics,
             "related_urls": related_urls,
+            "manuals": manuals,
             "availability": availability,
             "in_stock": in_stock,
         }

--- a/schemas.py
+++ b/schemas.py
@@ -70,6 +70,21 @@ class ProductImageResponse(BaseModel):
     is_installation_photo: bool
 
 
+class ProductManualResponse(BaseModel):
+    id: int
+    kind: str = "manual"
+    title: str
+    url: str
+    source: Optional[str] = None
+
+
+class ProductManualPayload(BaseModel):
+    kind: str = "manual"
+    title: str
+    url: str
+    source: Optional[str] = None
+
+
 class ProductSiblingResponse(BaseModel):
     id: int
     title: str
@@ -89,6 +104,7 @@ class ProductResponse(ProductBase):
     specs: Dict[str, Any] = {}
     images: List[str] = [] # Legacy
     gallery_images: List[ProductImageResponse] = [] # New
+    manuals: List[ProductManualResponse] = []
     series_siblings: List[ProductSiblingResponse] = []
 
 
@@ -746,6 +762,14 @@ class ManagerCatalogProductImageResponse(BaseModel):
     is_installation_photo: bool
 
 
+class ManagerCatalogProductManualResponse(BaseModel):
+    id: int
+    kind: str = "manual"
+    title: str
+    url: str
+    source: Optional[str] = None
+
+
 class ManagerCatalogProductTagResponse(BaseModel):
     id: int
     title: str
@@ -770,6 +794,7 @@ class ManagerCatalogProductItemResponse(BaseModel):
     created_at: datetime
     specs: Dict[str, Any]
     gallery_images: List[ManagerCatalogProductImageResponse]
+    manuals: List[ManagerCatalogProductManualResponse]
     tags: List[ManagerCatalogProductTagResponse]
     min_cost_byn: Optional[float] = None
     recommended_price_byn: Optional[float] = None
@@ -1121,6 +1146,7 @@ class ProductUpdate(BaseModel):
     brand_id: Optional[int] = None
     series_id: Optional[int] = None
     tag_ids: Optional[List[int]] = None
+    manuals: List[ProductManualPayload] = Field(default_factory=list)
 
 
 class SupplierResponse(BaseModel):

--- a/scripts/dedupe_product_media.py
+++ b/scripts/dedupe_product_media.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Deduplicate product media URLs into shared hash-based WEBP storage.
+
+Default mode is dry-run.
+Use --execute to persist DB updates and delete unreferenced old files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from PIL import Image
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from models import ImportMediaCache, Product, ProductImage
+
+
+@dataclass
+class UrlPlan:
+    old_url: str
+    canonical_url: str
+    old_path: Path
+    canonical_path: Path
+    webp_content: bytes
+    old_size: int
+
+
+def _url_to_path(url: str) -> Path:
+    return Path(url.lstrip("/"))
+
+
+def _to_webp(content: bytes) -> bytes:
+    img = Image.open(BytesIO(content))
+    if img.mode in ("RGBA", "P"):
+        img = img.convert("RGB")
+    output = BytesIO()
+    img.save(output, format="WEBP", quality=85)
+    return output.getvalue()
+
+
+async def _build_plan(url: str) -> Optional[UrlPlan]:
+    if not url or not str(url).startswith("/media/"):
+        return None
+
+    old_path = _url_to_path(url)
+    if not old_path.exists() or not old_path.is_file():
+        return None
+
+    old_bytes = await asyncio.to_thread(old_path.read_bytes)
+    webp_content = await asyncio.to_thread(_to_webp, old_bytes)
+    content_hash = hashlib.sha256(webp_content).hexdigest()
+    canonical_url = f"/media/products/shared/{content_hash}.webp"
+    canonical_path = _url_to_path(canonical_url)
+
+    if canonical_url == url:
+        return None
+
+    return UrlPlan(
+        old_url=url,
+        canonical_url=canonical_url,
+        old_path=old_path,
+        canonical_path=canonical_path,
+        webp_content=webp_content,
+        old_size=len(old_bytes),
+    )
+
+
+async def _collect_media_urls(session: AsyncSession) -> List[str]:
+    urls: List[str] = []
+
+    main_rows = await session.execute(select(Product.main_image).where(Product.main_image.is_not(None)))
+    urls.extend([u for u in main_rows.scalars().all() if u and str(u).startswith("/media/")])
+
+    gallery_rows = await session.execute(select(ProductImage.url))
+    urls.extend([u for u in gallery_rows.scalars().all() if u and str(u).startswith("/media/")])
+
+    unique: Dict[str, None] = {}
+    for url in urls:
+        unique[str(url)] = None
+    return list(unique.keys())
+
+
+async def _count_refs(session: AsyncSession, url: str) -> int:
+    main_refs = (
+        await session.execute(select(func.count()).select_from(Product).where(Product.main_image == url))
+    ).scalar_one()
+    gallery_refs = (
+        await session.execute(select(func.count()).select_from(ProductImage).where(ProductImage.url == url))
+    ).scalar_one()
+    cache_refs = (
+        await session.execute(select(func.count()).select_from(ImportMediaCache).where(ImportMediaCache.local_url == url))
+    ).scalar_one()
+    return int(main_refs or 0) + int(gallery_refs or 0) + int(cache_refs or 0)
+
+
+async def run(*, execute: bool) -> None:
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        async with session_factory() as session:
+            urls = await _collect_media_urls(session)
+            plans: List[UrlPlan] = []
+            skipped = 0
+            for url in urls:
+                try:
+                    plan = await _build_plan(url)
+                except Exception as exc:
+                    skipped += 1
+                    print(f"[warn] skip {url}: {exc}")
+                    continue
+                if plan is None:
+                    continue
+                plans.append(plan)
+
+            if not plans:
+                print("No replaceable media duplicates found.")
+                return
+
+            replace_map = {plan.old_url: plan.canonical_url for plan in plans}
+            total_old_bytes = sum(plan.old_size for plan in plans)
+            groups: Dict[str, List[UrlPlan]] = {}
+            for plan in plans:
+                groups.setdefault(plan.canonical_url, []).append(plan)
+            duplicate_groups = {k: v for k, v in groups.items() if len(v) > 1}
+            potential_reclaimed = sum(plan.old_size for plan in plans)
+            print(f"Candidates: {len(plans)} unique media URLs")
+            print(f"Approx source size: {total_old_bytes} bytes")
+            print(f"Potential reclaim (after canonical rewrite): {potential_reclaimed} bytes")
+            print(f"Hash groups: {len(groups)} (duplicate groups: {len(duplicate_groups)})")
+            print(f"Skipped unreadable files: {skipped}")
+            if duplicate_groups:
+                print("Top duplicate hash groups:")
+                ranked = sorted(
+                    duplicate_groups.items(),
+                    key=lambda item: (len(item[1]), sum(p.old_size for p in item[1])),
+                    reverse=True,
+                )
+                for canonical_url, group_plans in ranked[:10]:
+                    group_size = sum(item.old_size for item in group_plans)
+                    print(f"  {canonical_url}: {len(group_plans)} files, {group_size} bytes")
+
+            print("URLs to rewrite:")
+            for sample in plans:
+                print(f"  {sample.old_url} -> {sample.canonical_url}")
+
+            if not execute:
+                print("\nDry run only. Re-run with --execute to apply.")
+                return
+
+            # 1) Ensure canonical files exist.
+            for plan in plans:
+                plan.canonical_path.parent.mkdir(parents=True, exist_ok=True)
+                if not plan.canonical_path.exists():
+                    await asyncio.to_thread(plan.canonical_path.write_bytes, plan.webp_content)
+
+            # 2) Rewrite DB URLs to canonical shared paths.
+            for old_url, canonical_url in replace_map.items():
+                await session.execute(
+                    update(Product).where(Product.main_image == old_url).values(main_image=canonical_url)
+                )
+                await session.execute(
+                    update(ProductImage).where(ProductImage.url == old_url).values(url=canonical_url)
+                )
+                await session.execute(
+                    update(ImportMediaCache).where(ImportMediaCache.local_url == old_url).values(local_url=canonical_url)
+                )
+            await session.commit()
+
+            # 3) Remove old files if truly unreferenced.
+            deleted = 0
+            reclaimed = 0
+            for plan in plans:
+                refs = await _count_refs(session, plan.old_url)
+                if refs > 0:
+                    continue
+                if not plan.old_path.exists():
+                    continue
+                try:
+                    size = plan.old_path.stat().st_size
+                    await asyncio.to_thread(os.remove, plan.old_path)
+                    deleted += 1
+                    reclaimed += int(size)
+                except Exception as exc:
+                    print(f"[warn] failed to delete {plan.old_path}: {exc}")
+
+            print("\nApplied successfully.")
+            print(f"Updated URLs: {len(plans)}")
+            print(f"Deleted orphan files: {deleted}")
+            print(f"Reclaimed bytes: {reclaimed}")
+    finally:
+        await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Deduplicate product media to canonical shared WEBP files."
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Apply DB updates and remove orphan files. Default: dry-run.",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(execute=args.execute))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/catalog.py
+++ b/services/catalog.py
@@ -33,6 +33,7 @@ class CatalogService:
             .options(
                 selectinload(Product.tags).selectinload(Tag.group),
                 selectinload(Product.gallery_images),
+                selectinload(Product.attachments),
             )
             .where(
                 Product.is_published.is_(True),
@@ -44,4 +45,3 @@ class CatalogService:
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
-

--- a/services/import_media_service.py
+++ b/services/import_media_service.py
@@ -1,0 +1,157 @@
+"""Shared-media ingestion helpers for importer pipelines."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from datetime import datetime
+from io import BytesIO
+from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from PIL import Image
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import ImportMediaCache
+
+logger = logging.getLogger(__name__)
+_FILE_WRITE_LOCK = asyncio.Lock()
+
+
+class ImportMediaService:
+    @staticmethod
+    def normalize_source_url(value: str) -> str:
+        raw = str(value or "").strip()
+        if not raw:
+            return ""
+        parts = urlsplit(raw)
+        if not parts.scheme and not parts.netloc:
+            return raw
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+
+    @staticmethod
+    async def _to_webp_bytes(content: bytes) -> bytes:
+        def process(payload: bytes) -> bytes:
+            img = Image.open(BytesIO(payload))
+            if img.mode in ("RGBA", "P"):
+                img = img.convert("RGB")
+            output = BytesIO()
+            img.save(output, format="WEBP", quality=85)
+            return output.getvalue()
+
+        return await asyncio.to_thread(process, content)
+
+    @staticmethod
+    async def _save_shared_file(content: bytes) -> tuple[str, str]:
+        webp_content = await ImportMediaService._to_webp_bytes(content)
+        content_hash = hashlib.sha256(webp_content).hexdigest()
+
+        shared_dir = os.path.join("media", "products", "shared")
+        os.makedirs(shared_dir, exist_ok=True)
+        filename = f"{content_hash}.webp"
+        file_path = os.path.join(shared_dir, filename)
+
+        if not os.path.exists(file_path):
+            async with _FILE_WRITE_LOCK:
+                if not os.path.exists(file_path):
+                    with open(file_path, "wb") as f:
+                        f.write(webp_content)
+
+        return f"/media/products/shared/{filename}", content_hash
+
+    @staticmethod
+    async def _upsert_cache_row(
+        session: AsyncSession,
+        *,
+        source_url: str,
+        local_url: str,
+        content_hash: str,
+    ) -> None:
+        existing = (
+            await session.execute(
+                select(ImportMediaCache).where(ImportMediaCache.source_url == source_url)
+            )
+        ).scalar_one_or_none()
+        now = datetime.now()
+        if existing:
+            existing.local_url = local_url
+            existing.content_hash = content_hash
+            existing.last_seen_at = now
+            session.add(existing)
+            return
+
+        session.add(
+            ImportMediaCache(
+                source_url=source_url,
+                local_url=local_url,
+                content_hash=content_hash,
+                created_at=now,
+                last_seen_at=now,
+            )
+        )
+
+    @staticmethod
+    async def resolve_or_download(
+        session: AsyncSession,
+        *,
+        source_url: str,
+    ) -> Optional[str]:
+        normalized_url = ImportMediaService.normalize_source_url(source_url)
+        if not normalized_url:
+            return None
+
+        existing = (
+            await session.execute(
+                select(ImportMediaCache).where(ImportMediaCache.source_url == normalized_url)
+            )
+        ).scalar_one_or_none()
+        if existing and existing.local_url:
+            existing.last_seen_at = datetime.now()
+            session.add(existing)
+            return existing.local_url
+
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=15.0,
+                headers={"User-Agent": "Mozilla/5.0 (Codex Importer)"},
+            ) as client:
+                response = await client.get(normalized_url)
+        except Exception as exc:
+            logger.warning("Import image download failed for %s: %s", normalized_url, exc)
+            return None
+
+        if response.status_code != 200:
+            logger.warning(
+                "Import image download failed for %s: status=%s",
+                normalized_url,
+                response.status_code,
+            )
+            return None
+
+        try:
+            local_url, content_hash = await ImportMediaService._save_shared_file(response.content)
+        except Exception as exc:
+            logger.warning("Import image processing failed for %s: %s", normalized_url, exc)
+            return None
+
+        resolved_url = ImportMediaService.normalize_source_url(str(response.url))
+        await ImportMediaService._upsert_cache_row(
+            session,
+            source_url=normalized_url,
+            local_url=local_url,
+            content_hash=content_hash,
+        )
+        if resolved_url and resolved_url != normalized_url:
+            await ImportMediaService._upsert_cache_row(
+                session,
+                source_url=resolved_url,
+                local_url=local_url,
+                content_hash=content_hash,
+            )
+
+        return local_url

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -15,8 +15,9 @@ from parsers.onliner import OnlinerParser
 from parsers.tvoy_klimat import TvoyKlimatParser
 from core.database import async_session_maker
 from models import Product, ProductImage, Tag, TagGroup
-from services.image_service import ImageService
 from services.fx_rate_service import FxRateService
+from services.import_media_service import ImportMediaService
+from services.product_attachment_service import replace_manuals
 from services.spec_normalizer import normalize_specs
 from services.tag_logic import (
     CATEGORY_TAG_TITLES,
@@ -317,17 +318,18 @@ class ImporterService:
             # Main Image
             main_image_url = data.get('main_image')
             local_main_image = None
-            if main_image_url and not (existing and update_existing):
-                local_main_image = await ImageService.download_and_save_image(
-                    main_image_url, 'products', slug
+            if main_image_url:
+                local_main_image = await ImportMediaService.resolve_or_download(
+                    session,
+                    source_url=main_image_url,
                 )
             
             # --- Gallery images ---
             # Phase 48: Onliner gallery download disabled (manual via Manager).
-            # Aircond.by returns save_gallery=True → persist to ProductImage.
+            # Other donors may return save_gallery=True → persist to ProductImage.
             save_gallery = data.get("save_gallery", False)
             gallery_image_urls: List[str] = []
-            if save_gallery and not (existing and update_existing):
+            if save_gallery:
                 gallery_image_urls = data.get("images", [])
 
             if existing and update_existing:
@@ -339,6 +341,8 @@ class ImporterService:
                 existing.power_cooling = metrics.get('power_cooling', existing.power_cooling)
                 existing.specs = normalized_specs
                 existing.source_url = url
+                if local_main_image and not existing.main_image:
+                    existing.main_image = local_main_image
 
                 # Preserve manual tags, but append newly inferred auto-tags.
                 await session.refresh(existing, attribute_names=["tags"])
@@ -381,26 +385,42 @@ class ImporterService:
             await session.commit()
             await session.refresh(product)
 
-            # Persist gallery images into ProductImage (aircond.by)
+            if "manuals" in data:
+                await replace_manuals(
+                    session,
+                    product_id=product.id,
+                    manuals=data.get("manuals") or [],
+                )
+
+            # Persist gallery images into ProductImage
             if gallery_image_urls and product.id:
+                existing_gallery_urls = set(
+                    (
+                        await session.execute(
+                            select(ProductImage.url).where(ProductImage.product_id == product.id)
+                        )
+                    ).scalars().all()
+                )
                 for img_url in gallery_image_urls:
                     try:
-                        local_path = await ImageService.download_and_save_image(
-                            img_url, "products", product.slug or slug
+                        local_path = await ImportMediaService.resolve_or_download(
+                            session,
+                            source_url=img_url,
                         )
-                        if local_path:
+                        if local_path and local_path not in existing_gallery_urls:
                             pi = ProductImage(
                                 product_id=product.id,
                                 url=local_path,
                                 is_installation_photo=False,
                             )
                             session.add(pi)
+                            existing_gallery_urls.add(local_path)
                     except Exception as exc:
                         logger.warning(
                             "Gallery image save failed for %s: %s", img_url, exc
                         )
-                if session.new:
-                    await session.commit()
+            if "manuals" in data or gallery_image_urls:
+                await session.commit()
 
             return {"product": product, "related_urls": data.get('related_urls', [])}
 

--- a/services/product_attachment_service.py
+++ b/services/product_attachment_service.py
@@ -1,0 +1,92 @@
+"""Helpers for product attachment normalization and persistence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+from urllib.parse import urlsplit, urlunsplit
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import ProductAttachment
+
+
+def _normalize_url(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    parts = urlsplit(raw)
+    if not parts.scheme and not parts.netloc:
+        return raw
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+
+
+def normalize_manuals(raw_manuals: Iterable[Dict[str, Any]] | None) -> List[Dict[str, str]]:
+    """Normalize parser/UI manuals payload into deduplicated canonical rows."""
+    if not raw_manuals:
+        return []
+
+    result: List[Dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for raw in raw_manuals:
+        if not isinstance(raw, dict):
+            continue
+
+        url = _normalize_url(raw.get("url") or raw.get("href"))
+        if not url:
+            continue
+
+        title = str(raw.get("title") or "Инструкция").strip() or "Инструкция"
+        kind = str(raw.get("kind") or "manual").strip().lower() or "manual"
+        source = str(raw.get("source") or "").strip()
+
+        key = (kind, url)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(
+            {
+                "kind": kind,
+                "title": title,
+                "url": url,
+                "source": source,
+            }
+        )
+
+    return result
+
+
+async def replace_manuals(
+    session: AsyncSession,
+    *,
+    product_id: int,
+    manuals: Iterable[Dict[str, Any]] | None,
+) -> None:
+    normalized = normalize_manuals(manuals)
+    await session.execute(
+        delete(ProductAttachment).where(
+            ProductAttachment.product_id == product_id,
+            ProductAttachment.kind == "manual",
+        )
+    )
+    for item in normalized:
+        session.add(
+            ProductAttachment(
+                product_id=product_id,
+                kind=item["kind"],
+                title=item["title"],
+                url=item["url"],
+                source=item["source"] or None,
+            )
+        )
+
+
+async def list_manuals(session: AsyncSession, *, product_id: int) -> List[ProductAttachment]:
+    rows = await session.execute(
+        select(ProductAttachment).where(
+            ProductAttachment.product_id == product_id,
+            ProductAttachment.kind == "manual",
+        )
+    )
+    return list(rows.scalars().all())

--- a/services/product_dict_mapper.py
+++ b/services/product_dict_mapper.py
@@ -42,6 +42,17 @@ def map_product_to_dict(
             }
             for img in gallery
         ]
+        data["manuals"] = [
+            {
+                "id": item.id,
+                "kind": item.kind,
+                "title": item.title,
+                "url": item.url,
+                "source": item.source,
+            }
+            for item in (product.attachments or [])
+            if item.kind == "manual"
+        ]
 
     if sanitize_specs_payload:
         data["specs"] = sanitize_specs(data.get("specs"))

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -21,6 +21,20 @@ from models.product_constants import BTU_MAPPING
 
 class ProductManagerService:
     @staticmethod
+    def _serialize_manuals(product: Product) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": item.id,
+                "kind": item.kind,
+                "title": item.title,
+                "url": item.url,
+                "source": item.source,
+            }
+            for item in (product.attachments or [])
+            if item.kind == "manual"
+        ]
+
+    @staticmethod
     async def smart_search(
         session: AsyncSession,
         q: str,
@@ -48,7 +62,8 @@ class ProductManagerService:
             select(Product)
             .options(
                 selectinload(Product.tags).selectinload(Tag.group),
-                selectinload(Product.gallery_images)
+                selectinload(Product.gallery_images),
+                selectinload(Product.attachments),
             )
             .where(Product.is_published.is_(True))
         )
@@ -93,6 +108,7 @@ class ProductManagerService:
                     }
                     for img in (p.gallery_images or [])
                 ],
+                "manuals": ProductManagerService._serialize_manuals(p),
                 "tags": [
                     {
                         "id": t.id,
@@ -168,6 +184,7 @@ class ProductManagerService:
                         }
                         for img in (p.gallery_images or [])
                     ],
+                    "manuals": ProductManagerService._serialize_manuals(p),
                     "tags": [
                         {
                             "id": t.id,
@@ -228,7 +245,7 @@ class ProductManagerService:
     @staticmethod
     async def delete_for_manager(session: AsyncSession, product_id: int) -> bool:
         from models.order import OrderProductLink
-        from models.product import ProductImage, ProductTagLink
+        from models.product import ProductAttachment, ProductImage, ProductTagLink
         from models.supplier import ProductLocalStock, ProductSupplierMapping
         import sqlalchemy as sa
         
@@ -248,6 +265,9 @@ class ProductManagerService:
         # Delete gallery images
         await session.execute(
             sa.delete(ProductImage).where(ProductImage.product_id == product_id)
+        )
+        await session.execute(
+            sa.delete(ProductAttachment).where(ProductAttachment.product_id == product_id)
         )
         
         # Delete tag links explicitly to avoid async lazy-load issues on relationship mutation.

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from models import Product
 from schemas import (
     ProductImageResponse,
+    ProductManualResponse,
     ProductResponse,
     ProductSiblingResponse,
     TagGroupResponse,
@@ -68,6 +69,18 @@ def map_product_to_response(
         for item in (series_siblings or [])
     ]
 
+    manuals_payload = [
+        ProductManualResponse(
+            id=item.id,
+            kind=item.kind,
+            title=item.title,
+            url=item.url,
+            source=item.source,
+        )
+        for item in (product.attachments or [])
+        if item.kind == "manual"
+    ]
+
     return ProductResponse(
         id=product.id,
         title=product.title,
@@ -87,5 +100,6 @@ def map_product_to_response(
         specs=specs or {},
         images=images or [],
         gallery_images=gallery,
+        manuals=manuals_payload,
         series_siblings=siblings_payload,
     )

--- a/services/product_write_service.py
+++ b/services/product_write_service.py
@@ -9,6 +9,7 @@ from sqlmodel import select
 from crud.product import ProductDAO
 from models import Product, ProductImage, Tag
 from services.brand_series_service import sync_product_brand_series
+from services.product_attachment_service import replace_manuals
 from services.spec_normalizer import normalize_specs
 
 
@@ -46,6 +47,7 @@ class ProductWriteService:
         tag_ids: Optional[List[int]] = None,
     ) -> Optional[Dict[str, Any]]:
         payload = dict(update_data)
+        manuals_payload = payload.pop("manuals", None)
         wifi_tag_slugs: Optional[List[str]] = None
         selected_tags: Optional[List[Tag]] = None
         if tag_ids is not None:
@@ -78,6 +80,13 @@ class ProductWriteService:
         product = await ProductDAO.update_full(session, product_id, payload, tag_ids)
         if not product:
             return None
+
+        if manuals_payload is not None:
+            await replace_manuals(
+                session,
+                product_id=product_id,
+                manuals=manuals_payload,
+            )
 
         explicit_brand_override = "brand_id" in payload
         explicit_brand_id = payload.get("brand_id") if explicit_brand_override else None

--- a/tests/unit/test_haierproff_parser.py
+++ b/tests/unit/test_haierproff_parser.py
@@ -85,3 +85,37 @@ def test_haierproff_extract_specs_keeps_group_prefixed_duplicates():
     assert specs["Габаритные размеры без упаковки (Ш/Г/В), мм"] == "974 × 223 × 318"
     assert specs["Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм"] == "974 × 223 × 318"
     assert specs["Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм"] == "875 × 355 × 642"
+
+
+def test_haierproff_extract_manuals_from_icon_link_list():
+    html = """
+    <div class="icon-link-l-list">
+      <a class="icon-link-l" href="/lfm_files/35/Flexis/certificate.pdf" target="_blank">
+        <div class="icon-link-l__text">Сертификат соответствия</div>
+      </a>
+      <a class="icon-link-l" href="/lfm_files/shares/Quantum/manual.pdf" target="_blank">
+        <div class="icon-link-l__text">Руководство пользователя</div>
+      </a>
+    </div>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    manuals = HaierProffParser._extract_manuals(
+        soup,
+        "https://haierproff.ru/catalog/cond/products/sample-model",
+    )
+
+    assert manuals == [
+        {
+            "kind": "manual",
+            "title": "Сертификат соответствия",
+            "url": "https://haierproff.ru/lfm_files/35/Flexis/certificate.pdf",
+            "source": "haierproff",
+        },
+        {
+            "kind": "manual",
+            "title": "Руководство пользователя",
+            "url": "https://haierproff.ru/lfm_files/shares/Quantum/manual.pdf",
+            "source": "haierproff",
+        },
+    ]

--- a/tests/unit/test_import_media_service.py
+++ b/tests/unit/test_import_media_service.py
@@ -1,0 +1,126 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel import select
+
+from models import ImportMediaCache
+from services.import_media_service import ImportMediaService
+
+
+def _png_bytes(color: tuple[int, int, int] = (20, 120, 200)) -> bytes:
+    image = Image.new("RGB", (8, 8), color)
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, content: bytes, url: str):
+        self.status_code = status_code
+        self.content = content
+        self.url = url
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "import_media_test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_import_media_service_reuses_cached_url(sqlite_session, monkeypatch):
+    calls = {"count": 0}
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            calls["count"] += 1
+            return _FakeResponse(
+                status_code=200,
+                content=_png_bytes(),
+                url=url,
+            )
+
+    monkeypatch.setattr("services.import_media_service.httpx.AsyncClient", _FakeClient)
+
+    first = await ImportMediaService.resolve_or_download(
+        sqlite_session,
+        source_url="https://example.com/image-1.png#fragment",
+    )
+    await sqlite_session.commit()
+    second = await ImportMediaService.resolve_or_download(
+        sqlite_session,
+        source_url="https://example.com/image-1.png",
+    )
+    await sqlite_session.commit()
+
+    assert first
+    assert second == first
+    assert calls["count"] == 1
+
+    rows = (
+        await sqlite_session.execute(
+            select(ImportMediaCache).where(ImportMediaCache.source_url == "https://example.com/image-1.png")
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].local_url == first
+
+
+@pytest.mark.asyncio
+async def test_import_media_service_dedupes_same_content_for_different_urls(sqlite_session, monkeypatch):
+    calls = {"count": 0}
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            calls["count"] += 1
+            return _FakeResponse(
+                status_code=200,
+                content=_png_bytes((10, 200, 20)),
+                url=url,
+            )
+
+    monkeypatch.setattr("services.import_media_service.httpx.AsyncClient", _FakeClient)
+
+    first = await ImportMediaService.resolve_or_download(sqlite_session, source_url="https://example.com/image-a.png")
+    second = await ImportMediaService.resolve_or_download(sqlite_session, source_url="https://cdn.example.com/image-b.png")
+    await sqlite_session.commit()
+
+    assert first
+    assert second
+    assert first == second
+    assert calls["count"] == 2
+
+    rows = (await sqlite_session.execute(select(ImportMediaCache))).scalars().all()
+    assert len(rows) == 2
+    assert rows[0].local_url == rows[1].local_url

--- a/tests/unit/test_importer_service_media_and_manuals.py
+++ b/tests/unit/test_importer_service_media_and_manuals.py
@@ -1,0 +1,140 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel import select
+
+from models import ImportMediaCache, Product, ProductAttachment
+from services.importer_service import ImporterService
+
+
+def _png_bytes(color=(40, 80, 160)) -> bytes:
+    image = Image.new("RGB", (12, 12), color)
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, content: bytes, url: str):
+        self.status_code = status_code
+        self.content = content
+        self.url = url
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "importer_media_manuals.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_importer_saves_manuals_and_reuses_image_cache_on_update(sqlite_session, monkeypatch):
+    image_calls = {"count": 0}
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            image_calls["count"] += 1
+            return _FakeResponse(
+                status_code=200,
+                content=_png_bytes(),
+                url=url,
+            )
+
+    class _FakeParser:
+        async def parse(self, url):  # noqa: ARG002
+            return {
+                "title": "LG Test Import",
+                "slug": "lg-test-import",
+                "description": "Test description",
+                "price": 1234,
+                "area": 25,
+                "main_image": "https://img.example.com/lg-test-import.png",
+                "images": [],
+                "save_gallery": True,
+                "categories": [],
+                "specs": {"Бренд": "LG", "Тип": "сплит-система"},
+                "metrics": {"area": 25, "is_inverter": True, "power_cooling": 2.6},
+                "related_urls": [],
+                "manuals": [
+                    {
+                        "kind": "manual",
+                        "title": "Руководство пользователя",
+                        "url": "https://img.example.com/manual.pdf",
+                        "source": "lg24",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr("services.import_media_service.httpx.AsyncClient", _FakeClient)
+    monkeypatch.setattr(
+        "services.importer_service.async_session_maker",
+        lambda: _FakeSessionContext(sqlite_session),
+    )
+
+    service = ImporterService()
+    service.get_parser = lambda url: _FakeParser()  # noqa: ARG005
+
+    first = await service.import_product(
+        "https://example.com/product/lg-test-import",
+        update_existing=False,
+        collect_related=False,
+    )
+    second = await service.import_product(
+        "https://example.com/product/lg-test-import",
+        update_existing=True,
+        collect_related=False,
+    )
+
+    assert first["product"].id == second["product"].id
+    assert image_calls["count"] == 1
+
+    product = (await sqlite_session.execute(select(Product).where(Product.slug == "lg-test-import"))).scalar_one()
+    assert product.main_image
+    assert product.main_image.startswith("/media/products/shared/")
+
+    manuals = (
+        await sqlite_session.execute(
+            select(ProductAttachment).where(
+                ProductAttachment.product_id == product.id,
+                ProductAttachment.kind == "manual",
+            )
+        )
+    ).scalars().all()
+    assert len(manuals) == 1
+    assert manuals[0].url == "https://img.example.com/manual.pdf"
+
+    cache_rows = (await sqlite_session.execute(select(ImportMediaCache))).scalars().all()
+    assert len(cache_rows) == 1

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -50,6 +50,37 @@ def test_lg24_extract_specs_skips_doc_download_rows():
     assert specs["Мощность охлаждения (Мин/Ном/Макс), кВт"] == "0.89 / 2.5 / 3.7"
 
 
+def test_lg24_extract_manuals_from_doc_rows():
+    html = """
+    <html>
+      <body>
+        <section id="tab1">
+          <dl><dt>Руководство пользователя</dt><dd><a href="/manuals/user-guide.pdf">Скачать</a></dd></dl>
+          <dl><dt>Инструкция по монтажу</dt><dd><a href="https://cdn.example.com/mount.pdf">PDF</a></dd></dl>
+        </section>
+      </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    manuals = Lg24Parser._extract_manuals(soup, "https://lg24.by/product/model-1/")
+
+    assert manuals == [
+        {
+            "kind": "manual",
+            "title": "Руководство пользователя",
+            "url": "https://lg24.by/manuals/user-guide.pdf",
+            "source": "lg24",
+        },
+        {
+            "kind": "manual",
+            "title": "Инструкция по монтажу",
+            "url": "https://cdn.example.com/mount.pdf",
+            "source": "lg24",
+        },
+    ]
+
+
 def test_lg24_infers_type_and_indoor_type_from_breadcrumb():
     html = """
     <nav class="woocommerce-breadcrumb">

--- a/tests/unit/test_product_manuals_payloads.py
+++ b/tests/unit/test_product_manuals_payloads.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from crud.product import ProductDAO
+from models import Product
+from services.product_manager_service import ProductManagerService
+from services.product_response_mapper import map_product_to_response
+from services.product_write_service import ProductWriteService
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "product_manuals_payloads.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_manuals_are_serialized_for_public_and_manager_payloads(sqlite_session):
+    product = Product(
+        title="Haier Flexis Test",
+        slug="haier-flexis-manual-test",
+        description="desc",
+        price=3999,
+        area=35,
+        is_inverter=True,
+        is_published=True,
+        specs={"brand": "Haier", "type": "сплит-система"},
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+
+    result = await ProductWriteService.update_product(
+        sqlite_session,
+        product.id,
+        update_data={
+            "manuals": [
+                {
+                    "kind": "manual",
+                    "title": "Руководство пользователя",
+                    "url": "https://haier.example/manual-user.pdf",
+                    "source": "manager",
+                },
+                {
+                    "kind": "manual",
+                    "title": "Инструкция монтажа",
+                    "url": "https://haier.example/manual-install.pdf",
+                    "source": "manager",
+                },
+            ]
+        },
+        tag_ids=None,
+    )
+    assert result == {"message": "Product updated", "id": product.id}
+
+    refreshed = await ProductDAO.get_by_id(sqlite_session, product.id)
+    assert refreshed is not None
+    public_payload = map_product_to_response(refreshed)
+    assert len(public_payload.manuals) == 2
+    assert {item.title for item in public_payload.manuals} == {
+        "Руководство пользователя",
+        "Инструкция монтажа",
+    }
+
+    manager_payload = await ProductManagerService.get_manager_list(
+        sqlite_session,
+        page=1,
+        limit=20,
+        search=None,
+        is_published=True,
+        area_min=None,
+        area_max=None,
+        is_inverter=None,
+        category_slug=None,
+        sort="newest",
+    )
+    item = next((row for row in manager_payload["items"] if row["id"] == product.id), None)
+    assert item is not None
+    assert len(item["manuals"]) == 2

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -41,6 +41,12 @@ if (!product) {
 }
 
 const specs = product.specs || {};
+const manuals = (product.manuals || [])
+    .map((item: any) => ({
+        title: String(item?.title || "Инструкция").trim() || "Инструкция",
+        url: String(item?.url || "").trim(),
+    }))
+    .filter((item: any) => Boolean(item.url));
 const galleryUrls = product.gallery_images?.length
     ? product.gallery_images.map((img: any) => img.url)
     : [];
@@ -282,6 +288,31 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
                         )
                     }
                 </div>
+
+                {
+                    manuals.length > 0 && (
+                        <section class="manuals-card">
+                            <h3>
+                                <span class="material-icons-round">
+                                    description
+                                </span>
+                                Инструкции и файлы
+                            </h3>
+                            <ul>
+                                {
+                                    manuals.map((item: any) => (
+                                        <li>
+                                            <a href={item.url} target="_blank" rel="noopener noreferrer">
+                                                <span class="material-icons-round">download</span>
+                                                <span>{item.title}</span>
+                                            </a>
+                                        </li>
+                                    ))
+                                }
+                            </ul>
+                        </section>
+                    )
+                }
 
                 <FeaturesBentoGrid client:visible cards={bentoCards} />
 
@@ -1423,6 +1454,63 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
         color: var(--text-muted);
         font-size: 0.88rem;
         line-height: 1.45;
+    }
+
+    .manuals-card {
+        margin-top: 1.25rem;
+        border: 1px solid var(--panel-chip-border);
+        background: var(--panel-glass-bg);
+        border-radius: 16px;
+        padding: 1rem 1.1rem;
+        display: grid;
+        gap: 0.7rem;
+    }
+    .manuals-card h3 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 800;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+    }
+    .manuals-card h3 .material-icons-round {
+        font-size: 1.05rem;
+        color: var(--primary);
+    }
+    .manuals-card ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        scrollbar-width: thin;
+        gap: 0.45rem;
+    }
+    .manuals-card li {
+        flex: 0 0 auto;
+    }
+    .manuals-card a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        color: var(--text);
+        text-decoration: none;
+        border: 1px solid var(--panel-chip-border);
+        border-radius: 10px;
+        padding: 0.45rem 0.55rem;
+        background: var(--panel-chip-bg);
+        font-size: 0.92rem;
+        transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+    }
+    .manuals-card a:hover {
+        color: var(--primary);
+        border-color: var(--panel-chip-hover-border);
+        background: color-mix(in srgb, var(--primary) 8%, var(--panel-chip-bg));
+    }
+    .manuals-card a .material-icons-round {
+        font-size: 1rem;
+        opacity: 0.8;
     }
 
     /* Spoiler */


### PR DESCRIPTION
## Что сделано
- Добавлена поддержка вложений товара (manual links): модель, схемы API, сохранение в импорте и редактирование в manager UI.
- На витрине добавлен блок «Инструкции и файлы» на карточке товара.
- Импорт изображений переведен на shared hash-storage (`/media/products/shared/{sha256}.webp`) с URL-кэшем `import_media_cache`.
- Добавлен скрипт `scripts/dedupe_product_media.py` для dry-run/execute очистки legacy-дублей.
- Добавлен парсинг manuals для `lg24` и `haierproff`.
- Список ссылок manuals на витрине переведен в горизонтальный flex-ряд по оси X.

## Тесты и проверки
- `pytest -q tests/unit/test_haierproff_parser.py tests/unit/test_lg24_parser.py tests/unit/test_importer_service_media_and_manuals.py`
- `pytest -q tests/unit/test_import_media_service.py tests/unit/test_product_manuals_payloads.py`
- `npm run build` в `manager_frontend`
- `npm run build` в `web`
