### PR TITLE
[codex] Auto-approve orders moved to execution

### DIFF
--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -161,7 +161,8 @@ const DOCUMENT_TYPES = [
 ];
 
 const isCompanyOrder = computed(() => props.order.customer?.type === 'company' || !!props.order.customer?.inn);
-const hasContract = computed(() => isCompanyOrder.value ? !!selectedCustomerContractId.value : documents.value.some(d => d.doc_type === 'contract'));
+const hasOrderContract = computed(() => documents.value.some(d => d.doc_type === 'contract'));
+const hasContract = computed(() => (isCompanyOrder.value ? !!selectedCustomerContractId.value : false) || hasOrderContract.value);
 const datedDocumentTypes = new Set(['contract', 'act', 'tn2', 'ttn1']);
 const getDocumentDateForType = (type: string) => (
   datedDocumentTypes.has(type) && documentDate.value ? `${documentDate.value}T00:00:00` : undefined
@@ -523,7 +524,7 @@ watch(() => props.order.id, () => {
                 Создать открытый договор
               </button>
             </div>
-            <p v-else-if="!selectedCustomerContractId" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужно выбрать открытый договор.</p>
+            <p v-else-if="!selectedCustomerContractId && !hasOrderContract" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужен открытый договор или разовый договор заказа.</p>
           </div>
 
           <div v-if="documents.length" class="space-y-3">

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1141,10 +1141,6 @@ const handleSave = () => {
       localFormError.value = 'Требуется замер: заполните результат замера';
       return;
     }
-    if (proposalStatus.value !== 'approved') {
-      localFormError.value = 'Проект должен быть согласован с клиентом';
-      return;
-    }
   }
 
   if (enableCurrency.value) {
@@ -1195,7 +1191,7 @@ const handleSave = () => {
     measurement_required: measurementRequired.value,
     measurer_id: measurerId.value,
     measurement_result: measurementResult.value,
-    proposal_status: proposalStatus.value,
+    proposal_status: status.value === 'execution' ? 'approved' : proposalStatus.value,
     target_currency: enableCurrency.value ? (targetCurrency.value || null) : null,
     target_currency_amount: enableCurrency.value && targetCurrencyAmount.value ? Number(String(targetCurrencyAmount.value).replace(',', '.')) : null,
   };

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -408,7 +408,8 @@ const handleFileUpload = async (event: Event) => {
 };
 
 const isCompanyOrder = computed(() => props.order?.customer?.type === 'company' || !!props.order?.customer?.inn);
-const hasContract = computed(() => isCompanyOrder.value ? !!selectedCustomerContractId.value : documents.value.some(d => d.doc_type === 'contract'));
+const hasOrderContract = computed(() => documents.value.some(d => d.doc_type === 'contract'));
+const hasContract = computed(() => (isCompanyOrder.value ? !!selectedCustomerContractId.value : false) || hasOrderContract.value);
 
 const DOCUMENT_TYPES = [
   { type: 'contract', label: 'Договор' },
@@ -1810,7 +1811,7 @@ watch(
               Создать открытый договор
             </button>
           </div>
-          <p v-else-if="!selectedCustomerContractId" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужно выбрать открытый договор.</p>
+          <p v-else-if="!selectedCustomerContractId && !hasOrderContract" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужен открытый договор или разовый договор заказа.</p>
         </div>
 
         <div v-if="documents.length" class="space-y-3 mt-3">

--- a/schemas.py
+++ b/schemas.py
@@ -426,7 +426,7 @@ class ManagerOrderListItemResponse(BaseModel):
     @computed_field
     @property
     def ready_for_execution(self) -> bool:
-        return self.proposal_status == "approved"
+        return self.status == "execution" or self.proposal_status == "approved"
 
     # Financials
     total_payments: float = 0.0

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -268,17 +268,17 @@ class DocumentService:
             order = order_result.scalars().first()
             if not order:
                 raise ValueError("Order not found")
+            contract_query = select(OrderDocument).where(
+                OrderDocument.order_id == order_id,
+                OrderDocument.doc_type == "contract"
+            )
+            result = await session.execute(contract_query)
+            has_one_time_contract = result.scalars().first() is not None
             if order.customer and order.customer.type == CustomerType.company:
-                if not order.customer_contract_id:
-                    raise ValueError("Невозможно создать акт/накладную: выберите открытый договор клиента")
-            else:
-                contract_query = select(OrderDocument).where(
-                    OrderDocument.order_id == order_id,
-                    OrderDocument.doc_type == "contract"
-                )
-                result = await session.execute(contract_query)
-                if not result.scalars().first():
-                    raise ValueError("Невозможно создать акт/накладную: отсутствует договор")
+                if not order.customer_contract_id and not has_one_time_contract:
+                    raise ValueError("Невозможно создать акт/накладную: выберите открытый договор клиента или создайте договор заказа")
+            elif not has_one_time_contract:
+                raise ValueError("Невозможно создать акт/накладную: отсутствует договор")
 
         # 1. Получаем template_id (используем переданный или дефолтный)
         if not template_id:

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1298,6 +1298,8 @@ class OrderService:
             order.proposal_status = payload.proposal_status
         if "proposal_sent_at" in fields_set:
             order.proposal_sent_at = OrderService._normalize_naive_datetime(payload.proposal_sent_at)
+        if order.status == OrderStatus.EXECUTION and order.proposal_status != "approved":
+            order.proposal_status = "approved"
         
         # Equipment & Installation
         if "equipment_status" in fields_set and payload.equipment_status is not None:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -165,6 +165,36 @@ async def test_manager_order_patch_scalar_fields(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_order_execution_auto_approves_proposal(async_client, db):
+    customer = Customer(name="Execution", phone="+375295555556", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEGOTIATION,
+        proposal_status="draft",
+        total_amount=100,
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"status": "execution", "proposal_status": "draft"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "execution"
+    assert data["proposal_status"] == "approved"
+    assert data["ready_for_execution"] is True
+
+
+@pytest.mark.asyncio
 async def test_manager_order_patch_customer_branch_validation(async_client, db):
     c1 = Customer(name="Branch C1", phone="+375295511111", type=CustomerType.individual)
     c2 = Customer(name="Branch C2", phone="+375295522222", type=CustomerType.individual)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -293,6 +293,25 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
 
     monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
 
+    one_time_order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(one_time_order)
+    await db.commit()
+    await db.refresh(one_time_order)
+    db.add(
+        OrderDocument(
+            order_id=one_time_order.id,
+            doc_type="contract",
+            number="Д-2026-999",
+            google_file_id="one-time-contract",
+            google_edit_url="https://docs.google.com/document/d/one-time-contract/edit",
+        )
+    )
+    await db.commit()
+
+    one_time_act = await async_client.post(f"/api/manager/orders/{one_time_order.id}/documents/act", headers=headers)
+    assert one_time_act.status_code == 200
+    assert captured_replacements[-1]["{{act_number}}"] == "1"
+
     first_act = await async_client.post(f"/api/manager/orders/{order.id}/documents/act", headers=headers)
     assert first_act.status_code == 200
     assert captured_replacements[-1]["{{act_number}}"] == "1"


### PR DESCRIPTION
## Summary
- Treat moving an order to `execution` as implicit client approval.
- Remove the manager UI blocker that required manually setting proposal status to `approved` before saving an execution order.
- Normalize execution orders to `proposal_status = approved` on the backend and keep `ready_for_execution` true for execution status.
- Add a regression test for moving a draft proposal order into execution.

## Validation
- `python3 -m compileall services/order_service.py schemas.py tests/integration/test_manager_orders_api.py`
- `cd manager_frontend && npm run build`

## Notes
- This is a follow-up hotfix after #277 was merged.