### PR TITLE
[codex] Add favorite customers in manager

### DIFF
--- a/alembic/versions/6a7b8c9d0e1f_add_customer_is_favorite.py
+++ b/alembic/versions/6a7b8c9d0e1f_add_customer_is_favorite.py
@@ -1,0 +1,34 @@
+"""add_customer_is_favorite
+
+Revision ID: 6a7b8c9d0e1f
+Revises: 9c2d1f8a7b64
+Create Date: 2026-04-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6a7b8c9d0e1f"
+down_revision: Union[str, Sequence[str], None] = "9c2d1f8a7b64"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("customer", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("is_favorite", sa.Boolean(), nullable=False, server_default=sa.text("false"))
+        )
+        batch_op.create_index(batch_op.f("ix_customer_is_favorite"), ["is_favorite"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("customer", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_customer_is_favorite"))
+        batch_op.drop_column("is_favorite")

--- a/manager_frontend/src/client/models/ManagerCatalogCustomerItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogCustomerItemResponse.ts
@@ -23,6 +23,7 @@ export type ManagerCatalogCustomerItemResponse = {
     last_delivery_address?: (string | null);
     created_at: (string | null);
     order_count: number;
+    is_favorite?: boolean;
     branches?: Array<ManagerCustomerBranchItemResponse>;
 };
 

--- a/manager_frontend/src/client/models/ManagerCustomerUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerUpdatePayload.ts
@@ -18,5 +18,6 @@ export type ManagerCustomerUpdatePayload = {
     signer_position?: (string | null);
     signer_name?: (string | null);
     acting_basis?: (string | null);
+    is_favorite?: (boolean | null);
 };
 

--- a/manager_frontend/src/views/CustomersView.vue
+++ b/manager_frontend/src/views/CustomersView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch } from 'vue';
-import { Search, Users, ChevronLeft, ChevronRight, Phone, Mail, Building, Plus } from 'lucide-vue-next';
+import { Search, Users, ChevronLeft, ChevronRight, Phone, Mail, Building, Plus, Star } from 'lucide-vue-next';
 import { api } from '../api';
 import type { ManagerCatalogCustomerItemResponse } from '../client';
 import { CUSTOMER_UPDATED_EVENT, type CustomerUpdatedEventPayload } from '../utils/customer-events';
@@ -15,14 +15,49 @@ const onlyWithOrders = ref(false);
 const page = ref(1);
 const meta = ref({ total: 0, pages: 1, limit: 20 });
 const recentlyUpdated = ref<Record<number, number>>({});
+const favoriteSaving = ref<Record<number, boolean>>({});
 const cleanupTimers = new Map<number, number>();
 const toast = ref('');
 const showCreateOrder = ref(false);
 const createOrderCustomer = ref<{ id: number; name: string } | null>(null);
 
+function sortCustomerItems(items: ManagerCatalogCustomerItemResponse[]) {
+  return [...items].sort((a, b) => {
+    const favoriteDiff = Number(Boolean(b.is_favorite)) - Number(Boolean(a.is_favorite));
+    if (favoriteDiff !== 0) return favoriteDiff;
+    return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+  });
+}
+
 function openCreateOrder(customer: ManagerCatalogCustomerItemResponse) {
   createOrderCustomer.value = { id: customer.id, name: customer.full_legal_name || customer.name || `Клиент #${customer.id}` };
   showCreateOrder.value = true;
+}
+
+async function toggleFavorite(customer: ManagerCatalogCustomerItemResponse) {
+  if (favoriteSaving.value[customer.id]) return;
+
+  const nextFavorite = !customer.is_favorite;
+  favoriteSaving.value = { ...favoriteSaving.value, [customer.id]: true };
+  customers.value = sortCustomerItems(customers.value.map((item) => (
+    item.id === customer.id ? { ...item, is_favorite: nextFavorite } : item
+  )));
+
+  try {
+    const updated = await api.patchManagerCustomer(customer.id, { is_favorite: nextFavorite });
+    customers.value = sortCustomerItems(customers.value.map((item) => (item.id === updated.id ? { ...item, ...updated } : item)));
+    setToast(nextFavorite ? 'Клиент добавлен в избранное' : 'Клиент убран из избранного');
+  } catch (e) {
+    console.error('Failed to toggle customer favorite', e);
+    customers.value = sortCustomerItems(customers.value.map((item) => (
+      item.id === customer.id ? { ...item, is_favorite: !nextFavorite } : item
+    )));
+    setToast('Не удалось обновить избранное');
+  } finally {
+    const nextSaving = { ...favoriteSaving.value };
+    delete nextSaving[customer.id];
+    favoriteSaving.value = nextSaving;
+  }
 }
 
 function onOrderCreated(orderId: number) {
@@ -55,7 +90,7 @@ async function loadCustomers() {
       typeFilter.value || undefined,
       onlyWithOrders.value,
     );
-    customers.value = data.items;
+    customers.value = sortCustomerItems(data.items);
     meta.value = data.meta;
   } catch (e) {
     console.error('Failed to load customers', e);
@@ -262,6 +297,15 @@ onUnmounted(() => {
           </div>
           <div class="footer-actions">
             <div class="date-added">{{ formatDate(customer.created_at) }}</div>
+            <button
+              class="favorite-btn"
+              :class="{ active: customer.is_favorite }"
+              :disabled="favoriteSaving[customer.id]"
+              :title="customer.is_favorite ? 'Убрать из избранного' : 'Добавить в избранное'"
+              @click="toggleFavorite(customer)"
+            >
+              <Star :size="15" :fill="customer.is_favorite ? 'currentColor' : 'none'" />
+            </button>
             <button class="open-btn" @click="openCreateOrder(customer)" title="Создать заказ">
               <Plus :size="14" />
             </button>
@@ -552,6 +596,32 @@ onUnmounted(() => {
   background: var(--mv-bg);
 }
 
+.favorite-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--mv-border);
+  background: var(--mv-surface);
+  border-radius: 8px;
+  color: var(--mv-text-muted);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.favorite-btn:hover:not(:disabled),
+.favorite-btn.active {
+  border-color: rgba(245, 158, 11, 0.55);
+  background: rgba(245, 158, 11, 0.12);
+  color: #d97706;
+}
+
+.favorite-btn:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
 .drawer-overlay {
   position: fixed;
   inset: 0;
@@ -731,6 +801,7 @@ onUnmounted(() => {
 
 :global(.dark) .customers-view .open-btn,
 :global(.dark) .customers-view .icon-btn,
+:global(.dark) .customers-view .favorite-btn,
 :global(.dark) .customers-view .page-btn {
   background: #0f172a;
   border-color: #334155;
@@ -740,6 +811,13 @@ onUnmounted(() => {
 :global(.dark) .customers-view .open-btn:hover,
 :global(.dark) .customers-view .icon-btn:hover {
   background: #253246;
+}
+
+:global(.dark) .customers-view .favorite-btn:hover:not(:disabled),
+:global(.dark) .customers-view .favorite-btn.active {
+  border-color: rgba(251, 191, 36, 0.55);
+  background: rgba(251, 191, 36, 0.14);
+  color: #fbbf24;
 }
 
 /* :global(.dark) .customers-view .view-header h1 {
@@ -801,6 +879,7 @@ onUnmounted(() => {
 
 :global(.dark) .customers-view .open-btn,
 :global(.dark) .customers-view .icon-btn,
+:global(.dark) .customers-view .favorite-btn,
 :global(.dark) .customers-view .page-btn {
   background: #0f172a;
   border-color: #334155;

--- a/models/customer.py
+++ b/models/customer.py
@@ -31,6 +31,7 @@ class Customer(SQLModel, table=True):
 
     created_at: datetime = Field(default_factory=datetime.now)
     is_archived: bool = Field(default=False, index=True)
+    is_favorite: bool = Field(default=False, index=True)
 
     orders: List["Order"] = Relationship(back_populates="customer")
     contracts: List["CustomerContract"] = Relationship(

--- a/openapi.json
+++ b/openapi.json
@@ -10938,6 +10938,11 @@
             "type": "integer",
             "title": "Order Count"
           },
+          "is_favorite": {
+            "type": "boolean",
+            "title": "Is Favorite",
+            "default": false
+          },
           "branches": {
             "items": {
               "$ref": "#/components/schemas/ManagerCustomerBranchItemResponse"
@@ -12009,6 +12014,17 @@
               }
             ],
             "title": "Acting Basis"
+          },
+          "is_favorite": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Favorite"
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -843,6 +843,7 @@ class ManagerCatalogCustomerItemResponse(BaseModel):
     last_delivery_address: Optional[str] = None
     created_at: Optional[datetime]
     order_count: int
+    is_favorite: bool = False
     branches: List["ManagerCustomerBranchItemResponse"] = Field(default_factory=list)
 
 
@@ -964,6 +965,7 @@ class ManagerCustomerUpdatePayload(BaseModel):
     signer_position: Optional[str] = None
     signer_name: Optional[str] = None
     acting_basis: Optional[str] = None
+    is_favorite: Optional[bool] = None
 
     @field_validator("name")
     @classmethod

--- a/services/customer_service.py
+++ b/services/customer_service.py
@@ -58,6 +58,7 @@ class CustomerService:
             "created_at": customer.created_at.isoformat() if customer.created_at else None,
             "order_count": order_count,
             "is_archived": customer.is_archived,
+            "is_favorite": customer.is_favorite,
             "branches": branches or [],
         }
 
@@ -259,6 +260,9 @@ class CustomerService:
         if "type" in payload and payload["type"]:
             customer.type = CustomerType(str(payload["type"]).strip().lower())
 
+        if "is_favorite" in payload and payload["is_favorite"] is not None:
+            customer.is_favorite = bool(payload["is_favorite"])
+
         for field in optional_text_fields:
             if field not in payload:
                 continue
@@ -311,7 +315,7 @@ class CustomerService:
             stmt = stmt.where(Customer.type == customer_type)
             count_stmt = count_stmt.where(Customer.type == customer_type)
 
-        stmt = stmt.order_by(Customer.created_at.desc())
+        stmt = stmt.order_by(Customer.is_favorite.desc(), Customer.created_at.desc())
         stmt = stmt.offset((page - 1) * limit).limit(limit)
 
         result = await session.execute(stmt)

--- a/tests/integration/test_manager_customers_api.py
+++ b/tests/integration/test_manager_customers_api.py
@@ -123,6 +123,62 @@ async def test_manager_customer_patch_updates_requisites(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_customer_favorite_patch_and_sort(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    regular_customer = Customer(
+        name="ООО Обычный клиент",
+        phone="+375291110000",
+        type=CustomerType.company,
+        created_at=datetime(2026, 1, 10, 10, 0, 0),
+    )
+    favorite_customer = Customer(
+        name="ООО Частый клиент",
+        phone="+375291110001",
+        type=CustomerType.company,
+        created_at=datetime(2026, 1, 1, 10, 0, 0),
+    )
+    db.add(regular_customer)
+    db.add(favorite_customer)
+    await db.commit()
+    await db.refresh(regular_customer)
+    await db.refresh(favorite_customer)
+
+    db.add(
+        Order(
+            customer_id=regular_customer.id,
+            status=OrderStatus.NEW_LEAD,
+            title="Обычная сделка",
+        )
+    )
+    db.add(
+        Order(
+            customer_id=favorite_customer.id,
+            status=OrderStatus.NEW_LEAD,
+            title="Частая сделка",
+        )
+    )
+    await db.commit()
+
+    patch_resp = await async_client.patch(
+        f"/api/manager/customers/{favorite_customer.id}",
+        headers=headers,
+        json={"is_favorite": True},
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["is_favorite"] is True
+
+    list_resp = await async_client.get(
+        "/api/manager/customers?only_with_orders=true&limit=10",
+        headers=headers,
+    )
+    assert list_resp.status_code == 200
+    items = list_resp.json()["items"]
+    assert items[0]["id"] == favorite_customer.id
+    assert items[0]["is_favorite"] is True
+
+
+@pytest.mark.asyncio
 async def test_manager_customer_patch_rejects_invalid_iban(async_client, db):
     headers = await _auth_headers(async_client)
 


### PR DESCRIPTION
## Summary
- Add a persisted `is_favorite` flag to customers with an Alembic migration.
- Return and update the flag through the manager customer API and regenerated manager client.
- Add a star action in the manager customers list and sort favorite customers first.

## Why
Managers often work with a small set of frequent customers, and legal names can be hard to scan. Marking customers as favorites keeps those accounts at the top of the clients page for faster order creation.

## Validation
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_customers_api.py -q`
- `npm run build` in `manager_frontend/`

## Notes
- The local test server 500 was caused by the new code running before the migration was applied. Applying `alembic upgrade head` adds `customer.is_favorite` and resolves it.