### PR TITLE
[codex] Improve catalog ranking and filters

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -5,18 +5,29 @@ All methods accept AsyncSession as first argument for DI/transaction control.
 """
 from typing import Optional, List, Dict, Any
 
-from sqlalchemy import Integer, Boolean, String, cast, func, and_, or_, exists
+from sqlalchemy import Integer, Boolean, String, case, cast, func, and_, or_, exists
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Product, Tag, TagGroup, ProductTagLink
+from models import Brand, Product, Tag, TagGroup, ProductTagLink
 from models.product_constants import BTU_MAPPING
+from models.supplier import ProductLocalStock, ProductSupplierMapping, SupplierOffer
 
 
 ALLOWED_FILTER_GROUP_SLUGS = {"brand", "series", "expert-badge", "type", "category"}
 ALLOWED_INDOOR_TYPE_FILTERS = {"duct", "cassette", "floor_ceiling", "column"}
+CATALOG_RANKING_WEIGHTS = {
+    "availability": 100,
+    "out_of_stock": -100,
+    "area_to_25": 50,
+    "area_to_35": 30,
+    "area_large": 10,
+    "analytics_clicks": 0,
+    "analytics_cart_adds": 0,
+    "analytics_views": 0,
+}
 
 
 class ProductDAO:
@@ -96,6 +107,7 @@ class ProductDAO:
         has_fresh_air: Optional[bool] = None,
         indoor_types: Optional[List[str]] = None,
         tag_slugs: Optional[List[str]] = None,
+        brand_slugs: Optional[List[str]] = None,
         is_published: Optional[bool] = True,
     ):
         if is_published is not None:
@@ -197,6 +209,16 @@ class ProductDAO:
                 # Backcompat: unknown/legacy slugs should be ignored (not zero-result).
                 stmt = stmt.where(or_(~exists(group_slug_exists), Product.id.in_(group_subq)))
 
+        if brand_slugs:
+            normalized_brand_slugs = [
+                slug.strip().lower()
+                for slug in brand_slugs
+                if slug and slug.strip()
+            ]
+            if normalized_brand_slugs:
+                brand_subq = select(Brand.id).where(Brand.slug.in_(normalized_brand_slugs))
+                stmt = stmt.where(Product.brand_id.in_(brand_subq))
+
         return stmt
 
     @staticmethod
@@ -241,6 +263,111 @@ class ProductDAO:
         return stmt
 
     @staticmethod
+    def _catalog_recommendation_score_expr(area_max: Optional[int] = None):
+        local_stock_exists = exists(
+            select(ProductLocalStock.id).where(
+                ProductLocalStock.product_id == Product.id,
+                ProductLocalStock.qty > 0,
+            )
+        )
+        supplier_stock_exists = exists(
+            select(ProductSupplierMapping.id)
+            .join(
+                SupplierOffer,
+                and_(
+                    ProductSupplierMapping.supplier_id == SupplierOffer.supplier_id,
+                    ProductSupplierMapping.external_id == SupplierOffer.external_id,
+                ),
+            )
+            .where(
+                ProductSupplierMapping.product_id == Product.id,
+                ProductSupplierMapping.is_active.is_(True),
+                SupplierOffer.is_active.is_(True),
+                SupplierOffer.qty > 0,
+            )
+        )
+
+        availability_score = case(
+            (
+                or_(local_stock_exists, supplier_stock_exists),
+                CATALOG_RANKING_WEIGHTS["availability"],
+            ),
+            else_=CATALOG_RANKING_WEIGHTS["out_of_stock"],
+        )
+        area_threshold = int(area_max) if area_max else None
+        if area_threshold and area_threshold > 35:
+            if area_threshold <= 50:
+                area_score = case(
+                    (
+                        and_(Product.area > 35, Product.area <= area_threshold),
+                        CATALOG_RANKING_WEIGHTS["area_to_25"],
+                    ),
+                    (
+                        and_(Product.area > 25, Product.area <= 35),
+                        CATALOG_RANKING_WEIGHTS["area_to_35"],
+                    ),
+                    (Product.area <= 25, CATALOG_RANKING_WEIGHTS["area_large"]),
+                    else_=0,
+                )
+            elif area_threshold <= 70:
+                area_score = case(
+                    (
+                        and_(Product.area > 50, Product.area <= area_threshold),
+                        CATALOG_RANKING_WEIGHTS["area_to_25"],
+                    ),
+                    (
+                        and_(Product.area > 35, Product.area <= 50),
+                        CATALOG_RANKING_WEIGHTS["area_to_35"],
+                    ),
+                    (
+                        and_(Product.area > 25, Product.area <= 35),
+                        CATALOG_RANKING_WEIGHTS["area_large"],
+                    ),
+                    (Product.area <= 25, 5),
+                    else_=0,
+                )
+            else:
+                area_score = case(
+                    (
+                        and_(Product.area > 70, Product.area <= area_threshold),
+                        CATALOG_RANKING_WEIGHTS["area_to_25"],
+                    ),
+                    (
+                        and_(Product.area > 50, Product.area <= 70),
+                        CATALOG_RANKING_WEIGHTS["area_to_35"],
+                    ),
+                    (Product.area <= 50, CATALOG_RANKING_WEIGHTS["area_large"]),
+                    else_=0,
+                )
+        elif area_threshold and area_threshold > 25:
+            area_score = case(
+                (
+                    and_(Product.area > 25, Product.area <= area_threshold),
+                    CATALOG_RANKING_WEIGHTS["area_to_25"],
+                ),
+                (Product.area <= 25, CATALOG_RANKING_WEIGHTS["area_to_35"]),
+                else_=0,
+            )
+        else:
+            area_score = case(
+                (Product.area <= 25, CATALOG_RANKING_WEIGHTS["area_to_25"]),
+                (Product.area <= 35, CATALOG_RANKING_WEIGHTS["area_to_35"]),
+                (Product.area > 35, CATALOG_RANKING_WEIGHTS["area_large"]),
+                else_=0,
+            )
+
+        return availability_score + area_score
+
+    @staticmethod
+    def _catalog_brand_priority_expr():
+        brand_sort_order = (
+            select(Brand.sort_order)
+            .where(Brand.id == Product.brand_id)
+            .scalar_subquery()
+        )
+        return func.coalesce(brand_sort_order, 999)
+
+    @staticmethod
     async def get_filtered(
         session: AsyncSession,
         *,
@@ -254,8 +381,9 @@ class ProductDAO:
         has_fresh_air: Optional[bool] = None,
         indoor_types: Optional[List[str]] = None,
         tag_slugs: Optional[List[str]] = None,
+        brand_slugs: Optional[List[str]] = None,
         is_published: Optional[bool] = True,
-        sort: str = "newest",
+        sort: str = "recommended",
         page: int = 1,
         limit: int = 20,
         faceted_tag_ids: Optional[dict[int, list[int]]] = None,
@@ -280,6 +408,7 @@ class ProductDAO:
             has_fresh_air=has_fresh_air,
             indoor_types=indoor_types,
             tag_slugs=tag_slugs,
+            brand_slugs=brand_slugs,
             is_published=is_published,
         )
         if search_query:
@@ -294,8 +423,15 @@ class ProductDAO:
             stmt = stmt.order_by(Product.area.asc())
         elif sort == "area_desc":
             stmt = stmt.order_by(Product.area.desc())
+        elif sort == "newest":
+            stmt = stmt.order_by(Product.created_at.desc(), Product.id.desc())
         else:
-            stmt = stmt.order_by(Product.created_at.desc())
+            stmt = stmt.order_by(
+                ProductDAO._catalog_recommendation_score_expr(area_max=area_max).desc(),
+                ProductDAO._catalog_brand_priority_expr().asc(),
+                Product.created_at.desc(),
+                Product.id.desc(),
+            )
 
         offset = (page - 1) * limit
         stmt = stmt.offset(offset).limit(limit)
@@ -316,6 +452,7 @@ class ProductDAO:
         has_fresh_air: Optional[bool] = None,
         indoor_types: Optional[List[str]] = None,
         tag_slugs: Optional[List[str]] = None,
+        brand_slugs: Optional[List[str]] = None,
         is_published: Optional[bool] = True,
         faceted_tag_ids: Optional[dict[int, list[int]]] = None,
         search_query: Optional[str] = None,
@@ -334,6 +471,7 @@ class ProductDAO:
             has_fresh_air=has_fresh_air,
             indoor_types=indoor_types,
             tag_slugs=tag_slugs,
+            brand_slugs=brand_slugs,
             is_published=is_published,
         )
         stmt = ProductDAO._apply_faceted_filters(stmt, faceted_tag_ids)

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -302,7 +302,7 @@ export class ApiService {
     public static getProductsV1(
         page: number = 1,
         limit: number = 20,
-        sort: string = 'newest',
+        sort: string = 'recommended',
         minPrice?: (number | null),
         maxPrice?: (number | null),
         areaMin?: (number | null),
@@ -361,7 +361,7 @@ export class ApiService {
     public static getProducts(
         page: number = 1,
         limit: number = 20,
-        sort: string = 'newest',
+        sort: string = 'recommended',
         minPrice?: (number | null),
         maxPrice?: (number | null),
         areaMin?: (number | null),

--- a/openapi.json
+++ b/openapi.json
@@ -1127,7 +1127,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "newest",
+              "default": "recommended",
               "title": "Sort"
             }
           },
@@ -1377,7 +1377,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "newest",
+              "default": "recommended",
               "title": "Sort"
             }
           },

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -48,7 +48,7 @@ async def generate_product_description(
 async def get_catalog(
     page: int = 1,
     limit: int = 20,
-    sort: str = "newest",
+    sort: str = "recommended",
     min_price: Optional[int] = None,
     max_price: Optional[int] = None,
     area_min: Optional[int] = None,

--- a/services/product_filter_service.py
+++ b/services/product_filter_service.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import func, select
 
-from models import Product, Tag, TagGroup
+from models import Brand, Product, Tag, TagGroup
 from services.tag_logic import is_invalid_brand_name, is_invalid_brand_slug
 
 
@@ -48,11 +48,12 @@ class ProductFilterService:
         area_min, area_max = area_q.one()
 
         brands_stmt = (
-            select(Tag)
-            .join(TagGroup, Tag.group_id == TagGroup.id)
-            .where(Tag.is_public == True)
-            .where(TagGroup.slug == "brand")
-            .order_by(Tag.sort_order, Tag.title)
+            select(Brand)
+            .join(Product, Product.brand_id == Brand.id)
+            .where(Brand.is_published == True)
+            .where(Product.is_published == True)
+            .group_by(Brand.id)
+            .order_by(Brand.sort_order, Brand.title)
         )
         expert_stmt = (
             select(Tag)
@@ -64,15 +65,15 @@ class ProductFilterService:
 
         brands = list((await session.execute(brands_stmt)).scalars().all())
         brands = [
-            t
-            for t in brands
-            if not is_invalid_brand_name(t.title) and not is_invalid_brand_slug(t.slug)
+            brand
+            for brand in brands
+            if not is_invalid_brand_name(brand.title) and not is_invalid_brand_slug(brand.slug)
         ]
         expert_tags = list((await session.execute(expert_stmt)).scalars().all())
 
         return {
             "price": {"min": price_min, "max": price_max},
             "area": {"min": area_min, "max": area_max},
-            "brands": [{"id": t.id, "title": t.title, "slug": t.slug} for t in brands],
+            "brands": [{"id": brand.id, "title": brand.title, "slug": brand.slug} for brand in brands],
             "expert_tags": [{"id": t.id, "title": t.title, "slug": t.slug} for t in expert_tags],
         }

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from crud.product import ProductDAO
-from models import Product
+from models import Brand, Product
 from services.product_dict_mapper import map_product_to_dict
 from services.product_filter_service import ProductFilterService
 from services.product_series_service import ProductSeriesService
@@ -54,7 +54,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
         *,
         page: int = 1,
         limit: int = 20,
-        sort: str = "newest",
+        sort: str = "recommended",
         min_price: Optional[int] = None,
         max_price: Optional[int] = None,
         area_min: Optional[int] = None,
@@ -68,8 +68,16 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
         search: Optional[str] = None,
     ) -> Dict[str, Any]:
         faceted_tag_ids = None
+        brand_slugs = []
+        facet_slugs = tag_slugs or []
         if tag_slugs:
-            faceted_tag_ids = await ProductReadService.resolve_slugs_to_grouped_ids(session, tag_slugs)
+            brand_rows = (
+                await session.execute(select(Brand.slug).where(Brand.slug.in_(tag_slugs)))
+            ).scalars().all()
+            brand_slugs = [slug for slug in brand_rows if slug]
+            brand_slug_set = set(brand_slugs)
+            facet_slugs = [slug for slug in tag_slugs if slug not in brand_slug_set]
+            faceted_tag_ids = await ProductReadService.resolve_slugs_to_grouped_ids(session, facet_slugs)
 
         items = await ProductDAO.get_filtered(
             session,
@@ -83,6 +91,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             indoor_types=indoor_types,
             is_inverter=is_inverter,
             tag_slugs=None,
+            brand_slugs=brand_slugs,
             faceted_tag_ids=faceted_tag_ids,
             sort=sort,
             page=page,
@@ -102,6 +111,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             indoor_types=indoor_types,
             is_inverter=is_inverter,
             tag_slugs=None,
+            brand_slugs=brand_slugs,
             faceted_tag_ids=faceted_tag_ids,
             is_published=True,
             search_query=search,

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -1,6 +1,8 @@
 import pytest
 from httpx import AsyncClient
-from models import Product
+from datetime import datetime, timedelta
+from models import Brand, Product
+from crud.supplier import ProductLocalStockDAO
 from services.spec_normalizer import normalize_specs
 
 @pytest.fixture
@@ -52,6 +54,73 @@ async def test_product_not_found(async_client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_catalog_default_sort_uses_recommendation_score(async_client: AsyncClient, db):
+    now = datetime.now()
+    apartment = Product(
+        title="Apartment in stock",
+        slug="apartment-in-stock",
+        price=1500,
+        area=25,
+        is_published=True,
+        created_at=now - timedelta(days=3),
+    )
+    mid_area = Product(
+        title="Mid area in stock",
+        slug="mid-area-in-stock",
+        price=1700,
+        area=35,
+        is_published=True,
+        created_at=now - timedelta(days=2),
+    )
+    large_area = Product(
+        title="Large area in stock",
+        slug="large-area-in-stock",
+        price=2200,
+        area=50,
+        is_published=True,
+        created_at=now - timedelta(days=1),
+    )
+    unavailable_new = Product(
+        title="Unavailable new",
+        slug="unavailable-new",
+        price=1200,
+        area=20,
+        is_published=True,
+        created_at=now,
+    )
+    db.add_all([apartment, mid_area, large_area, unavailable_new])
+    await db.commit()
+
+    for product in (apartment, mid_area, large_area):
+        await ProductLocalStockDAO.upsert(
+            session=db,
+            product_id=product.id,
+            qty=1,
+            updated_by="test",
+            warehouse_code="vitebsk",
+        )
+
+    response = await async_client.get("/api/v1/products?limit=4")
+    assert response.status_code == 200
+    slugs = [item["slug"] for item in response.json()["items"]]
+    assert slugs == [
+        "apartment-in-stock",
+        "mid-area-in-stock",
+        "large-area-in-stock",
+        "unavailable-new",
+    ]
+
+    response = await async_client.get("/api/v1/products?limit=4&area_max=50")
+    assert response.status_code == 200
+    slugs = [item["slug"] for item in response.json()["items"]]
+    assert slugs[:3] == [
+        "large-area-in-stock",
+        "mid-area-in-stock",
+        "apartment-in-stock",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_catalog_filters_by_wifi_and_heating(async_client: AsyncClient, db):
     good = Product(
         title="Good",
@@ -82,6 +151,35 @@ async def test_catalog_filters_by_wifi_and_heating(async_client: AsyncClient, db
     assert "good" in slugs
     assert "weak" not in slugs
     assert all(not key.startswith("__") for key in payload["items"][0]["specs"].keys())
+
+
+@pytest.mark.asyncio
+async def test_catalog_filters_by_brand_entity_slug(async_client: AsyncClient, db):
+    mdv = Brand(title="MDV", slug="mdv", is_published=True, sort_order=10)
+    haier = Brand(title="Haier", slug="haier", is_published=True, sort_order=40)
+    db.add_all([mdv, haier])
+    await db.flush()
+
+    db.add_all(
+        [
+            Product(title="MDV product", slug="mdv-product", price=1000, area=25, brand_id=mdv.id, is_published=True),
+            Product(
+                title="Haier product",
+                slug="haier-product",
+                price=1000,
+                area=25,
+                brand_id=haier.id,
+                is_published=True,
+            ),
+        ]
+    )
+    await db.commit()
+
+    response = await async_client.get("/api/v1/products?tag_slugs=mdv")
+    assert response.status_code == 200
+    slugs = [item["slug"] for item in response.json()["items"]]
+    assert "mdv-product" in slugs
+    assert "haier-product" not in slugs
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_filters_config_api.py
+++ b/tests/integration/test_filters_config_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from models import Product, Tag, TagGroup
+from models import Brand, Product, Tag, TagGroup
 
 
 @pytest.mark.asyncio
@@ -16,17 +16,23 @@ async def test_filters_config_returns_ranges_and_allowed_tags(async_client, db):
     await db.refresh(expert_group)
     await db.refresh(technical_group)
 
-    brand = Tag(title="Haier", slug="haier", group_id=brand_group.id, is_public=True)
+    brand = Brand(title="Haier", slug="haier", is_published=True, sort_order=10)
+    priority_brand = Brand(title="MDV", slug="mdv", is_published=True, sort_order=0)
     expert = Tag(title="Хит", slug="hit", group_id=expert_group.id, is_public=True)
     technical = Tag(title="Wi-Fi", slug="wifi-builtin", group_id=technical_group.id, is_public=True)
     db.add(brand)
+    db.add(priority_brand)
     db.add(expert)
     db.add(technical)
 
-    p1 = Product(title="A", slug="a", price=1000, area=20, is_published=True)
+    await db.flush()
+
+    p1 = Product(title="A", slug="a", price=1000, area=20, brand_id=brand.id, is_published=True)
     p2 = Product(title="B", slug="b", price=2400, area=55, is_published=True)
+    p3 = Product(title="C", slug="c", price=1600, area=35, brand_id=priority_brand.id, is_published=True)
     db.add(p1)
     db.add(p2)
+    db.add(p3)
     await db.commit()
 
     response = await async_client.get("/api/v1/filters/config")
@@ -35,7 +41,7 @@ async def test_filters_config_returns_ranges_and_allowed_tags(async_client, db):
 
     assert data["price"] == {"min": 1000, "max": 2400}
     assert data["area"] == {"min": 20, "max": 55}
-    assert [item["slug"] for item in data["brands"]] == ["haier"]
+    assert [item["slug"] for item in data["brands"]] == ["mdv", "haier"]
     assert [item["slug"] for item in data["expert_tags"]] == ["hit"]
     assert "wifi-builtin" not in [item["slug"] for item in data["expert_tags"]]
 
@@ -47,16 +53,16 @@ async def test_filters_config_hides_obvious_pseudo_brands(async_client, db):
     await db.commit()
     await db.refresh(brand_group)
 
-    valid_brand = Tag(title="TCL", slug="tcl", group_id=brand_group.id, is_public=True)
-    pseudo_brand = Tag(
+    valid_brand = Brand(title="TCL", slug="tcl", is_published=True)
+    pseudo_brand = Brand(
         title="Мульти-сплит-система",
         slug="multi-split-sistema",
-        group_id=brand_group.id,
-        is_public=True,
+        is_published=True,
     )
     db.add(valid_brand)
     db.add(pseudo_brand)
-    db.add(Product(title="A", slug="cfg-brand-a", price=1000, area=20, is_published=True))
+    await db.flush()
+    db.add(Product(title="A", slug="cfg-brand-a", price=1000, area=20, brand_id=valid_brand.id, is_published=True))
     await db.commit()
 
     response = await async_client.get("/api/v1/filters/config")

--- a/web/src/components/CatalogApp.vue
+++ b/web/src/components/CatalogApp.vue
@@ -5,6 +5,8 @@ import { getCatalog, getFiltersConfig } from '../utils/api';
 import { getBrandConfig } from '../utils/brands';
 
 const BASE_LIMIT = 20;
+const POPULAR_LIMIT = 80;
+const CATALOG_DEFAULT_SORT = 'recommended';
 const CATEGORY_SLUG_LIST = ['cat-household', 'cat-multi', 'cat-industrial'];
 const POWER_PRESETS = [
   { key: 'area-20', title: 'до 20 м²', min: null, max: 20 },
@@ -30,6 +32,14 @@ const props = defineProps({
     type: Object,
     default: () => ({ total: 0, page: 1, limit: BASE_LIMIT, pages: 1 })
   },
+  initialPopularProducts: {
+    type: Array,
+    default: () => []
+  },
+  initialFilters: {
+    type: Object,
+    default: () => ({})
+  },
   forcedTitle: {
     type: String,
     default: ''
@@ -41,29 +51,37 @@ const props = defineProps({
   lockedInitialFilters: {
     type: Object,
     default: null
+  },
+  initialCategorySlug: {
+    type: String,
+    default: 'cat-household'
   }
 });
 
+const initialActiveTags = Array.isArray(props.lockedInitialFilters?.tag_slugs)
+  ? [...props.lockedInitialFilters.tag_slugs]
+  : [props.initialCategorySlug || 'cat-household'];
 const products = ref(props.initialProducts || []);
+const popularProducts = ref(props.initialPopularProducts || []);
 const meta = ref(props.initialMeta || { total: 0, page: 1, limit: BASE_LIMIT, pages: 1 });
 
 const loadingInitial = ref(false);
 const loadingMore = ref(false);
 const loadingBrands = ref(false);
 
-const activeTags = ref([]);
+const activeTags = ref([...new Set(initialActiveTags)]);
 const searchQuery = ref('');
-const sort = ref('newest');
+const sort = ref(props.initialFilters?.sort || CATALOG_DEFAULT_SORT);
 const mobileSearchOpen = ref(false);
 const advancedFiltersOpen = ref(false);
 
-const currentAreaMin = ref(null);
-const currentAreaMax = ref(null);
-const currentIsInverter = ref(null);
-const currentHasWifi = ref(null);
-const currentHasFreshAir = ref(null);
-const currentHeatingMin = ref(null);
-const currentIndoorTypes = ref([]);
+const currentAreaMin = ref(props.initialFilters?.area_min ?? null);
+const currentAreaMax = ref(props.initialFilters?.area_max ?? null);
+const currentIsInverter = ref(props.initialFilters?.is_inverter ?? null);
+const currentHasWifi = ref(props.initialFilters?.has_wifi ?? null);
+const currentHasFreshAir = ref(props.initialFilters?.has_fresh_air ?? null);
+const currentHeatingMin = ref(props.initialFilters?.heating_min ?? null);
+const currentIndoorTypes = ref([...(props.initialFilters?.indoor_types || [])]);
 const selectedOutdoorSlug = ref('');
 const selectedIndoorQuantities = ref({});
 
@@ -77,6 +95,12 @@ const activeBrandSlug = computed(() => activeTags.value.find((slug) => knownBran
 const isHouseholdCategory = computed(() => activeCategorySlug.value === 'cat-household');
 const isIndustrialCategory = computed(() => activeCategorySlug.value === 'cat-industrial');
 const isMultiCategory = computed(() => activeCategorySlug.value === 'cat-multi');
+
+const isCatalogAvailable = (product) => {
+  const status = String(product?.availability_status || '');
+  const qty = Number(product?.vitebsk_qty || 0) + Number(product?.minsk_qty || 0);
+  return qty > 0 || status === 'in_stock_now' || status === 'available_2_3_days';
+};
 
 const getSpecValue = (product, keys = []) => {
   if (!product) return null;
@@ -218,6 +242,72 @@ const getProductBrand = (product) => {
   const brandTag = (product?.tags || []).find((tag) => (tag.group?.slug || tag.group_slug) === 'brand');
   return brandTag?.title || '';
 };
+
+const getProductBrandSlug = (product) => {
+  const brandTag = (product?.tags || []).find((tag) => (tag.group?.slug || tag.group_slug) === 'brand');
+  if (brandTag?.slug) return String(brandTag.slug).trim().toLowerCase();
+  const brandTitle = getProductBrand(product);
+  const matched = availableBrands.value.find((brand) => isSameBrand(brand.title, brandTitle));
+  return matched?.slug || normalizeBrand(brandTitle);
+};
+
+const brandPriorityIndex = (brandSlug) => {
+  const configuredIndex = availableBrands.value.findIndex((brand) => brand.slug === brandSlug);
+  return configuredIndex >= 0 ? configuredIndex : availableBrands.value.length + 50;
+};
+
+const popularAreaLimit = computed(() => {
+  const selectedMax = Number(currentAreaMax.value || 0);
+  return selectedMax > 0 ? selectedMax : 35;
+});
+
+const diversifyPopularModels = (items, limit = 8) => {
+  const candidates = items.filter((product) => (
+    isCatalogAvailable(product) && Number(product?.area || 0) <= popularAreaLimit.value
+  ));
+  const groups = new Map();
+  candidates.forEach((product) => {
+    const brandSlug = getProductBrandSlug(product) || 'unknown';
+    const compressor = product?.is_inverter ? 'inverter' : 'onoff';
+    const key = `${brandSlug}:${compressor}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        brandSlug,
+        compressor,
+        items: [],
+      });
+    }
+    groups.get(key).items.push(product);
+  });
+
+  const compressorOrder = { onoff: 0, inverter: 1 };
+  const orderedGroups = [...groups.values()].sort((a, b) => (
+    brandPriorityIndex(a.brandSlug) - brandPriorityIndex(b.brandSlug)
+    || (compressorOrder[a.compressor] ?? 9) - (compressorOrder[b.compressor] ?? 9)
+    || a.brandSlug.localeCompare(b.brandSlug, 'ru')
+  ));
+
+  const result = [];
+  let cursor = 0;
+  while (result.length < limit && orderedGroups.some((group) => cursor < group.items.length)) {
+    orderedGroups.forEach((group) => {
+      if (result.length < limit && group.items[cursor]) {
+        result.push(group.items[cursor]);
+      }
+    });
+    cursor += 1;
+  }
+  return result;
+};
+
+const popularModels = computed(() => diversifyPopularModels(popularProducts.value, 8));
+
+const showPopularModels = computed(() => (
+  isHouseholdCategory.value
+  && !loadingInitial.value
+  && popularModels.value.length >= 3
+));
 
 const getCoolingKw = (product) => parseNumber(getSpecValue(product, ['capacity_cooling_kw', 'Мощность охлаждения']));
 const getIndoorCapacityClass = (product) => {
@@ -475,7 +565,7 @@ const activePowerPresetKey = computed(() => {
 });
 
 const hasActiveAdvancedFilters = computed(() => (
-  sort.value !== 'newest'
+  sort.value !== CATALOG_DEFAULT_SORT
   || currentIsInverter.value !== null
   || currentHasWifi.value !== null
   || currentHasFreshAir.value !== null
@@ -522,7 +612,7 @@ const getParamsFromUrl = () => {
 
   return {
     page: Number.parseInt(sp.get('page') || '1', 10) || 1,
-    sort: sp.get('sort') || 'newest',
+    sort: sp.get('sort') || CATALOG_DEFAULT_SORT,
     q: sp.get('q') || '',
     tag_slugs: tags,
     area_min: sp.get('area_min') || null,
@@ -577,8 +667,9 @@ const applyLockedFilters = (params) => {
 };
 
 const syncStateFromUrl = () => {
-  const params = getParamsFromUrl();
-  if (!params) return;
+  const rawParams = getParamsFromUrl();
+  if (!rawParams) return;
+  const params = applyLockedFilters(rawParams);
 
   activeTags.value = [...params.tag_slugs];
   searchQuery.value = params.q;
@@ -621,6 +712,13 @@ const buildApiParams = (page = 1) => {
   return applyLockedFilters(base);
 };
 
+const buildPopularApiParams = () => ({
+  ...buildApiParams(1),
+  page: 1,
+  limit: POPULAR_LIMIT,
+  sort: CATALOG_DEFAULT_SORT,
+});
+
 const syncUrlFromState = (page = 1, { replace = false } = {}) => {
   if (typeof window === 'undefined') return;
 
@@ -631,7 +729,7 @@ const syncUrlFromState = (page = 1, { replace = false } = {}) => {
     sp.set('tag_slugs', params.tag_slugs.join(','));
   }
   if (page > 1) sp.set('page', String(page));
-  if (params.sort && params.sort !== 'newest') sp.set('sort', params.sort);
+  if (params.sort && params.sort !== CATALOG_DEFAULT_SORT) sp.set('sort', params.sort);
   if (params.q) sp.set('q', params.q);
 
   if (params.area_min !== undefined) sp.set('area_min', String(params.area_min));
@@ -662,7 +760,12 @@ const fetchProducts = async ({ page = 1, append = false } = {}) => {
 
   try {
     const apiParams = buildApiParams(page);
-    const data = await getCatalog(apiParams);
+    const [data, popularData] = append
+      ? [await getCatalog(apiParams), null]
+      : await Promise.all([
+        getCatalog(apiParams),
+        getCatalog(buildPopularApiParams()),
+      ]);
 
     const incomingItems = data.items || [];
     if (append) {
@@ -677,6 +780,7 @@ const fetchProducts = async ({ page = 1, append = false } = {}) => {
       products.value = merged;
     } else {
       products.value = incomingItems;
+      popularProducts.value = popularData?.items || incomingItems;
     }
 
     syncMultiSelectionState();
@@ -854,7 +958,7 @@ const setHeatingMin = async (value) => {
 };
 
 const resetAdvancedFilters = async () => {
-  sort.value = 'newest';
+  sort.value = CATALOG_DEFAULT_SORT;
   currentIsInverter.value = null;
   currentHasWifi.value = null;
   currentHasFreshAir.value = null;
@@ -956,38 +1060,6 @@ onMounted(async () => {
         Как выбрать тип полупромышленного кондиционера
       </a>
     </header>
-
-    <section class="glass-panel brand-panel">
-      <div class="section-head">
-        <div class="section-label">Бренд</div>
-        <div v-if="loadingBrands" class="label-hint">Обновляем список...</div>
-      </div>
-      <div class="brand-strip">
-        <button
-          class="brand-pill"
-          :class="{ active: activeBrandSlug === null }"
-          @click="toggleBrand('__all__')"
-        >
-          Все бренды
-        </button>
-
-        <button
-          v-for="brand in availableBrands"
-          :key="brand.slug"
-          class="brand-pill"
-          :class="{ active: activeBrandSlug === brand.slug }"
-          @click="toggleBrand(brand.slug)"
-        >
-          <img
-            v-if="getBrandConfig(brand.slug).logo"
-            :src="getBrandConfig(brand.slug).logo"
-            :alt="brand.title"
-            class="brand-pill-logo"
-          />
-          <span>{{ brand.title }}</span>
-        </button>
-      </div>
-    </section>
 
     <section v-if="isHouseholdCategory" class="glass-panel quick-power-panel">
       <div class="section-label">Мощность</div>
@@ -1144,8 +1216,41 @@ onMounted(async () => {
     <transition name="fade-up">
       <section v-if="advancedFiltersOpen" class="glass-panel advanced-panel">
         <div class="advanced-row">
+          <div class="section-head">
+            <div class="control-label">Бренд</div>
+            <div v-if="loadingBrands" class="label-hint">Обновляем список...</div>
+          </div>
+          <div class="brand-strip">
+            <button
+              class="brand-pill"
+              :class="{ active: activeBrandSlug === null }"
+              @click="toggleBrand('__all__')"
+            >
+              Все бренды
+            </button>
+
+            <button
+              v-for="brand in availableBrands"
+              :key="brand.slug"
+              class="brand-pill"
+              :class="{ active: activeBrandSlug === brand.slug }"
+              @click="toggleBrand(brand.slug)"
+            >
+              <img
+                v-if="getBrandConfig(brand.slug).logo"
+                :src="getBrandConfig(brand.slug).logo"
+                :alt="brand.title"
+                class="brand-pill-logo"
+              />
+              <span>{{ brand.title }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="advanced-row">
           <label class="control-label" for="catalog-sort">Сортировка</label>
           <select id="catalog-sort" v-model="sort" class="filters-select" @change="onSortChange">
+            <option value="recommended">Рекомендуемые</option>
             <option value="newest">Сначала новые</option>
             <option value="price_asc">Сначала дешевле</option>
             <option value="price_desc">Сначала дороже</option>
@@ -1217,14 +1322,33 @@ onMounted(async () => {
     </div>
 
     <div v-else-if="products.length > 0" class="catalog-content">
-      <transition-group name="fade-up" tag="div" class="grid">
-        <ProductCard
-          v-for="product in products"
-          :key="product.id"
-          :product="product"
-          :showInstallation="true"
-        />
-      </transition-group>
+      <section v-if="showPopularModels" class="popular-section" aria-labelledby="popular-models-title">
+        <div class="catalog-section-head">
+          <h2 id="popular-models-title">Популярные модели</h2>
+        </div>
+        <transition-group name="fade-up" tag="div" class="grid popular-grid">
+          <ProductCard
+            v-for="product in popularModels"
+            :key="`popular-${product.id}`"
+            :product="product"
+            :showInstallation="true"
+          />
+        </transition-group>
+      </section>
+
+      <section class="all-products-section" aria-labelledby="all-products-title">
+        <div class="catalog-section-head">
+          <h2 id="all-products-title">Все модели</h2>
+        </div>
+        <transition-group name="fade-up" tag="div" class="grid">
+          <ProductCard
+            v-for="product in products"
+            :key="product.id"
+            :product="product"
+            :showInstallation="true"
+          />
+        </transition-group>
+      </section>
 
       <div v-if="loadingMore" class="grid skeleton-grid skeleton-grid-more">
         <div v-for="i in 4" :key="`skeleton-more-${i}`" class="skeleton-card" />
@@ -1242,6 +1366,24 @@ onMounted(async () => {
       <h3>Товары не найдены</h3>
       <p>Попробуйте выбрать другой бренд или категорию.</p>
     </div>
+
+    <section class="catalog-seo-block">
+      <h2>Как выбрать кондиционер для квартиры</h2>
+      <p>
+        Для жилых комнат чаще всего подходят настенные сплит-системы до 25–35 м²: они закрывают типовые спальни,
+        детские и гостиные без переплаты за лишнюю мощность. При выборе стоит учитывать площадь, солнечную сторону,
+        высоту потолков и теплопритоки от техники.
+      </p>
+      <p>
+        Если кондиционер нужен для ежедневного использования, обратите внимание на инверторные модели, уровень шума
+        внутреннего блока и наличие сервисной поддержки. Для больших помещений и коммерческих объектов лучше выбирать
+        модель с запасом по производительности и заранее продумать место установки.
+      </p>
+      <p>
+        В каталоге MVN собраны кондиционеры для квартир, домов и офисов в Витебске. Умная сортировка поднимает выше
+        доступные модели подходящей мощности, чтобы быстрее найти практичный вариант с монтажом.
+      </p>
+    </section>
   </div>
 </template>
 
@@ -1729,6 +1871,32 @@ onMounted(async () => {
   gap: 1.4rem;
 }
 
+.popular-section,
+.all-products-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.catalog-section-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.catalog-section-head h2,
+.catalog-seo-block h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.35rem;
+  line-height: 1.2;
+}
+
+.popular-grid {
+  padding-bottom: 0.15rem;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -1809,6 +1977,19 @@ onMounted(async () => {
   font-size: 4rem;
   color: var(--text-muted);
   opacity: 0.55;
+}
+
+.catalog-seo-block {
+  margin-top: 2.2rem;
+  padding-top: 1.6rem;
+  border-top: 1px solid var(--panel-glass-border);
+  color: var(--text-muted);
+}
+
+.catalog-seo-block p {
+  max-width: 880px;
+  margin: 0.75rem 0 0;
+  line-height: 1.7;
 }
 
 @media (max-width: 980px) {

--- a/web/src/components/CatalogGrid.vue
+++ b/web/src/components/CatalogGrid.vue
@@ -64,7 +64,7 @@ const fetchProducts = async () => {
         tag_slugs: tags,
         page: params.page || 1,
         limit: 12,
-        sort: params.sort || 'newest'
+        sort: params.sort || 'recommended'
     };
     
     // Remove legacy params if they exist in URL but handled via tags now

--- a/web/src/config/virtual-categories.ts
+++ b/web/src/config/virtual-categories.ts
@@ -1,4 +1,5 @@
 export type CatalogSort =
+    | "recommended"
     | "newest"
     | "price_asc"
     | "price_desc"
@@ -32,8 +33,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Инверторные кондиционеры в Витебске",
         intro: "Подбор инверторных сплит-систем с монтажом и гарантией в Витебске.",
         filters: {
+            tag_slugs: ["cat-household"],
             is_inverter: true,
-            sort: "newest",
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -45,8 +47,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Кондиционеры с Wi-Fi в Витебске",
         intro: "Подберем сплит-системы с управлением через приложение и голосовые ассистенты.",
         filters: {
+            tag_slugs: ["cat-household"],
             has_wifi: true,
-            sort: "newest",
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -58,8 +61,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Кондиционеры для обогрева зимой в Витебске",
         intro: "Модели для межсезонья и зимней эксплуатации с профессиональным монтажом.",
         filters: {
+            tag_slugs: ["cat-household"],
             heating_min: -20,
-            sort: "newest",
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -71,8 +75,22 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Тихие кондиционеры в Витебске",
         intro: "Подбор малошумных моделей для комфортного сна и работы.",
         filters: {
-            tag_slugs: ["noise-silent"],
-            sort: "newest",
+            tag_slugs: ["cat-household", "noise-silent"],
+            sort: "recommended",
+        },
+        indexable: true,
+    },
+    {
+        slug: "do-25m2",
+        seoTitle: "Купить кондиционер до 25 м² в Витебске",
+        seoDescription:
+            "Кондиционеры для комнат до 25 м² в Витебске: модели для спальни, детской и небольшой гостиной.",
+        h1: "Кондиционеры до 25 м² в Витебске",
+        intro: "Подбор компактных сплит-систем для квартирных комнат с доставкой и монтажом.",
+        filters: {
+            tag_slugs: ["cat-household"],
+            area_max: 25,
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -84,9 +102,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Кондиционеры до 35 м² в Витебске",
         intro: "Подбор сплит-систем для квартир, спален и небольших офисов до 35 м².",
         filters: {
-            area_min: 30,
-            area_max: 39,
-            sort: "newest",
+            tag_slugs: ["cat-household"],
+            area_max: 35,
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -98,9 +116,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Кондиционеры до 50 м² в Витебске",
         intro: "Подбор кондиционеров для гостиных, студий и офисов площадью до 50 м².",
         filters: {
-            area_min: 40,
-            area_max: 59,
-            sort: "newest",
+            tag_slugs: ["cat-household"],
+            area_max: 50,
+            sort: "recommended",
         },
         indexable: true,
     },
@@ -112,9 +130,9 @@ export const VIRTUAL_CATEGORIES: VirtualCategoryConfig[] = [
         h1: "Кондиционеры до 70 м² в Витебске",
         intro: "Решения для просторных помещений и коммерческих зон до 70 м².",
         filters: {
-            area_min: 60,
+            tag_slugs: ["cat-household"],
             area_max: 70,
-            sort: "newest",
+            sort: "recommended",
         },
         indexable: true,
     },

--- a/web/src/pages/catalog.astro
+++ b/web/src/pages/catalog.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import CatalogApp from "../components/CatalogApp.vue";
 import { getCatalog } from "../utils/api";
+import { buildCatalogItemListSchema } from "../utils/catalog-seo";
 import { matchVirtualCategoryByFilters } from "../utils/virtual-category";
 import {
     VIRTUAL_CATEGORIES,
@@ -11,8 +12,9 @@ import {
 const { searchParams } = Astro.url;
 const hasQueryParams = Array.from(searchParams.keys()).length > 0;
 const page = searchParams.get("page") || "1";
-const sortRaw = searchParams.get("sort") || "newest";
+const sortRaw = searchParams.get("sort") || "recommended";
 const allowedSorts: CatalogSort[] = [
+    "recommended",
     "newest",
     "price_asc",
     "price_desc",
@@ -21,7 +23,7 @@ const allowedSorts: CatalogSort[] = [
 ];
 const sort: CatalogSort = allowedSorts.includes(sortRaw as CatalogSort)
     ? (sortRaw as CatalogSort)
-    : "newest";
+    : "recommended";
 const tagSlugsRaw = searchParams.getAll("tag_slugs");
 const isInverterRaw = searchParams.get("is_inverter");
 const hasWifiRaw = searchParams.get("has_wifi");
@@ -62,6 +64,8 @@ const parsedIndoorTypes = indoorTypesRaw
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean);
 const hasIndustrialCategory = tag_slugs.includes("cat-industrial");
+const initialCategorySlug =
+    tag_slugs.find((slug) => categorySlugs.has(slug)) || "cat-household";
 
 let canonicalPath = "/catalog";
 let robotsValue: string | undefined;
@@ -85,6 +89,7 @@ if (hasQueryParams) {
 }
 
 interface Product {
+    id?: number;
     title: string;
     price: number;
     slug: string;
@@ -108,7 +113,7 @@ interface Product {
     }>;
 }
 
-const data = await getCatalog({
+const catalogParams = {
     page,
     limit: 20,
     sort,
@@ -122,9 +127,30 @@ const data = await getCatalog({
         hasIndustrialCategory && parsedIndoorTypes.length > 0
             ? parsedIndoorTypes
             : undefined,
+};
+const data = await getCatalog(catalogParams);
+const popularData = await getCatalog({
+    ...catalogParams,
+    page: 1,
+    limit: 80,
+    sort: "recommended",
 });
 const products = (data.items || []) as Product[];
+const popularProducts = (popularData.items || []) as Product[];
 const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
+const catalogSchema = buildCatalogItemListSchema(products, Astro.url.origin);
+const initialFilters = {
+    sort,
+    area_min: parsedAreaMin ?? null,
+    area_max: parsedAreaMax ?? null,
+    is_inverter: parsedIsInverter ?? null,
+    has_wifi: parsedHasWifi ?? null,
+    heating_min: parsedHeatingMin ?? null,
+    indoor_types:
+        hasIndustrialCategory && parsedIndoorTypes.length > 0
+            ? parsedIndoorTypes
+            : [],
+};
 ---
 
 <Layout
@@ -132,8 +158,16 @@ const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
     canonical={canonicalPath}
     robots={robotsValue}
 >
+    <script type="application/ld+json" set:html={JSON.stringify(catalogSchema)} />
     <div class="container catalog-page">
-        <CatalogApp client:load initialProducts={products} initialMeta={meta} />
+        <CatalogApp
+            client:load
+            initialProducts={products}
+            initialMeta={meta}
+            initialPopularProducts={popularProducts}
+            initialFilters={initialFilters}
+            initialCategorySlug={initialCategorySlug}
+        />
     </div>
     <script is:inline define:vars={{ virtualCategories: VIRTUAL_CATEGORIES }}>
         (() => {
@@ -153,17 +187,19 @@ const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
                 return tags;
             };
 
-            const normalizeTags = (tags) => [...new Set(tags)].sort();
+            const technicalDefaultTags = new Set(["cat-household"]);
+            const normalizeTags = (tags) => [...new Set(tags.filter((tag) => !technicalDefaultTags.has(tag)))].sort();
 
-            const sortRaw = sp.get("sort") || "newest";
+            const sortRaw = sp.get("sort") || "recommended";
             const allowedSorts = [
+                "recommended",
                 "newest",
                 "price_asc",
                 "price_desc",
                 "area_asc",
                 "area_desc",
             ];
-            const sort = allowedSorts.includes(sortRaw) ? sortRaw : "newest";
+            const sort = allowedSorts.includes(sortRaw) ? sortRaw : "recommended";
 
             const toNumber = (value) => {
                 if (!value) return undefined;
@@ -200,7 +236,7 @@ const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
 
             const matched = virtualCategories.find((category) => {
                 const normalizedCategory = {
-                    sort: category.filters.sort || "newest",
+                    sort: category.filters.sort || "recommended",
                     tag_slugs: normalizeTags(category.filters.tag_slugs || []),
                     is_inverter:
                         typeof category.filters.is_inverter === "boolean"

--- a/web/src/pages/catalog/[virtual].astro
+++ b/web/src/pages/catalog/[virtual].astro
@@ -4,6 +4,7 @@ import CatalogApp from "../../components/CatalogApp.vue";
 import type { VirtualCategoryConfig } from "../../config/virtual-categories";
 import { VIRTUAL_CATEGORIES } from "../../config/virtual-categories";
 import { getCatalog } from "../../utils/api";
+import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 import { buildCatalogQueryFromVirtual } from "../../utils/virtual-category";
 
 export async function getStaticPaths() {
@@ -14,11 +15,15 @@ export async function getStaticPaths() {
 }
 
 interface Product {
+    id?: number;
     title: string;
     price: number;
     slug: string;
     main_image?: string;
     description?: string;
+    vitebsk_qty?: number;
+    minsk_qty?: number;
+    availability_status?: string | null;
     is_inverter?: boolean;
     area?: number;
     badges?: Array<{ text: string; class?: string }>;
@@ -45,9 +50,21 @@ if (!category) {
 
 const query = buildCatalogQueryFromVirtual(category);
 const data = await getCatalog(query);
+const popularData = await getCatalog({
+    ...query,
+    page: 1,
+    limit: 80,
+    sort: "recommended",
+});
 const products = (data.items || []) as Product[];
+const popularProducts = (popularData.items || []) as Product[];
 const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
 const robotsValue = category.indexable === false ? "noindex,follow" : undefined;
+const catalogSchema = buildCatalogItemListSchema(products, Astro.url.origin);
+const initialCategorySlug =
+    category.filters.tag_slugs?.find((slug) =>
+        ["cat-household", "cat-multi", "cat-industrial"].includes(slug),
+    ) || "cat-household";
 ---
 
 <Layout
@@ -56,14 +73,18 @@ const robotsValue = category.indexable === false ? "noindex,follow" : undefined;
     canonical={`/catalog/${category.slug}`}
     robots={robotsValue}
 >
+    <script type="application/ld+json" set:html={JSON.stringify(catalogSchema)} />
     <div class="container catalog-page">
         <CatalogApp
             client:load
             initialProducts={products}
             initialMeta={meta}
+            initialPopularProducts={popularProducts}
+            initialFilters={category.filters}
             forcedTitle={category.h1}
             forcedDescription={category.intro || category.seoDescription}
             lockedInitialFilters={category.filters}
+            initialCategorySlug={initialCategorySlug}
         />
     </div>
 </Layout>

--- a/web/src/utils/catalog-seo.ts
+++ b/web/src/utils/catalog-seo.ts
@@ -1,0 +1,53 @@
+type CatalogSeoProduct = {
+    id?: number;
+    title: string;
+    slug?: string | null;
+    price?: number | null;
+    main_image?: string | null;
+    availability_status?: string | null;
+    vitebsk_qty?: number | null;
+    minsk_qty?: number | null;
+};
+
+function absoluteUrl(path: string | null | undefined, origin: string) {
+    if (!path) return undefined;
+    if (/^https?:\/\//i.test(path)) return path;
+    return new URL(path.startsWith("/") ? path : `/${path}`, origin).toString();
+}
+
+export function getSchemaAvailability(product: CatalogSeoProduct) {
+    const status = product.availability_status || "";
+    const stockQty = Number(product.vitebsk_qty || 0) + Number(product.minsk_qty || 0);
+
+    if (status === "out_of_stock") return "https://schema.org/OutOfStock";
+    if (status === "check_availability") return "https://schema.org/LimitedAvailability";
+    if (stockQty > 0 || status === "in_stock_now" || status === "available_2_3_days") {
+        return "https://schema.org/InStock";
+    }
+    return "https://schema.org/OutOfStock";
+}
+
+export function buildCatalogItemListSchema(products: CatalogSeoProduct[], origin: string) {
+    return {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        itemListElement: products.slice(0, 20).map((product, index) => ({
+            "@type": "ListItem",
+            position: index + 1,
+            item: {
+                "@type": "Product",
+                name: product.title,
+                url: absoluteUrl(product.slug ? `/product/${product.slug}` : undefined, origin),
+                image: absoluteUrl(product.main_image, origin),
+                sku: product.id ? String(product.id) : undefined,
+                offers: {
+                    "@type": "Offer",
+                    price: Number(product.price || 0),
+                    priceCurrency: "BYN",
+                    availability: getSchemaAvailability(product),
+                    url: absoluteUrl(product.slug ? `/product/${product.slug}` : undefined, origin),
+                },
+            },
+        })),
+    };
+}

--- a/web/src/utils/virtual-category.ts
+++ b/web/src/utils/virtual-category.ts
@@ -26,8 +26,8 @@ interface NormalizedFilters {
     area_max?: number;
 }
 
-const DEFAULT_SORT: CatalogSort = "newest";
-const TECHNICAL_DEFAULT_TAGS = new Set<string>();
+const DEFAULT_SORT: CatalogSort = "recommended";
+const TECHNICAL_DEFAULT_TAGS = new Set<string>(["cat-household"]);
 
 function normalizeTags(tags: string[] = []): string[] {
     const clean = tags


### PR DESCRIPTION
## What changed

- Replaced newest-first catalog defaults with recommended ranking that prioritizes availability, area relevance, and brand sort order.
- Moved brand filters to real `Brand` entities and made storefront brand priority follow `Brand.sort_order` from the manager/admin UI.
- Split the catalog into diversified popular models and the full sorted listing, with power presets influencing both ranking and the popular block.
- Added SEO support for filter landing pages, catalog bottom copy, and Product/Offer JSON-LD.
- Synced OpenAPI and the generated manager client after the catalog default sort change.

## Why

The old date-based ordering buried sellable, relevant apartment models and made the catalog look like a raw import list. Power presets also appeared ineffective because ranking continued to prefer small-room models even after selecting larger room sizes.

## Validation

- `python3 -m compileall crud/product.py services/product_read_service.py services/product_filter_service.py tests/integration/test_catalog_api.py tests/integration/test_filters_config_api.py`
- `npm run build` in `web/`
- `npm run audit:theme` in `web/` (passes with existing unrelated warnings)
- Browser/API smoke checks for `area_max=25`, `area_max=50`, and `area_max=70`

## Notes

Local integration pytest still cannot connect to `db_test` in this environment, so those tests were added/updated but not fully executed locally.