### PR TITLE
[codex] manager product catalog filters

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -21,6 +21,7 @@ ALLOWED_INDOOR_TYPE_FILTERS = {"duct", "cassette", "floor_ceiling", "column"}
 CATALOG_RANKING_WEIGHTS = {
     "availability": 100,
     "out_of_stock": -100,
+    "manager_favorite": 80,
     "area_to_25": 50,
     "area_to_35": 30,
     "area_large": 10,
@@ -264,6 +265,14 @@ class ProductDAO:
 
     @staticmethod
     def _catalog_recommendation_score_expr(area_max: Optional[int] = None):
+        favorite_tag_exists = exists(
+            select(ProductTagLink.product_id)
+            .join(Tag, ProductTagLink.tag_id == Tag.id)
+            .where(
+                ProductTagLink.product_id == Product.id,
+                Tag.slug == "manager-favorite",
+            )
+        )
         local_stock_exists = exists(
             select(ProductLocalStock.id).where(
                 ProductLocalStock.product_id == Product.id,
@@ -293,6 +302,10 @@ class ProductDAO:
                 CATALOG_RANKING_WEIGHTS["availability"],
             ),
             else_=CATALOG_RANKING_WEIGHTS["out_of_stock"],
+        )
+        favorite_score = case(
+            (favorite_tag_exists, CATALOG_RANKING_WEIGHTS["manager_favorite"]),
+            else_=0,
         )
         area_threshold = int(area_max) if area_max else None
         if area_threshold and area_threshold > 35:
@@ -356,7 +369,7 @@ class ProductDAO:
                 else_=0,
             )
 
-        return availability_score + area_score
+        return availability_score + favorite_score + area_score
 
     @staticmethod
     def _catalog_brand_priority_expr():
@@ -537,8 +550,12 @@ class ProductDAO:
         area_min: Optional[int] = None,
         area_max: Optional[int] = None,
         is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
-        sort: str = "newest",
+        sort: str = "recommended",
     ) -> tuple[List[Product], int]:
         stmt = select(Product).options(
             selectinload(Product.gallery_images),
@@ -547,38 +564,31 @@ class ProductDAO:
         )
         count_stmt = select(func.count(Product.id))
 
-        if is_published is not None:
-            stmt = stmt.where(Product.is_published == is_published)
-            count_stmt = count_stmt.where(Product.is_published == is_published)
-
-        if area_min is not None:
-            stmt = stmt.where(Product.area >= area_min)
-            count_stmt = count_stmt.where(Product.area >= area_min)
-
-        if area_max is not None:
-            stmt = stmt.where(Product.area <= area_max)
-            count_stmt = count_stmt.where(Product.area <= area_max)
-
-        if is_inverter is not None:
-            stmt = stmt.where(Product.is_inverter == is_inverter)
-            count_stmt = count_stmt.where(Product.is_inverter == is_inverter)
+        common_filter_kwargs = {
+            "area_min": area_min,
+            "area_max": area_max,
+            "heating_min": heating_min,
+            "has_wifi": has_wifi,
+            "has_fresh_air": has_fresh_air,
+            "is_inverter": is_inverter,
+            "tag_slugs": [category_slug] if category_slug else None,
+            "brand_slugs": brand_slugs,
+            "is_published": is_published,
+        }
+        stmt = ProductDAO._apply_common_filters(
+            session=session,
+            stmt=stmt,
+            **common_filter_kwargs,
+        )
+        count_stmt = ProductDAO._apply_common_filters(
+            session=session,
+            stmt=count_stmt,
+            **common_filter_kwargs,
+        )
 
         if search:
             stmt = stmt.where(Product.title.ilike(f"%{search}%"))
             count_stmt = count_stmt.where(Product.title.ilike(f"%{search}%"))
-
-        if category_slug:
-            normalized_category = str(category_slug).strip().lower()
-            if normalized_category:
-                category_subq = (
-                    select(ProductTagLink.product_id)
-                    .join(Tag, ProductTagLink.tag_id == Tag.id)
-                    .join(TagGroup, Tag.group_id == TagGroup.id)
-                    .where(TagGroup.slug == "category")
-                    .where(Tag.slug == normalized_category)
-                )
-                stmt = stmt.where(Product.id.in_(category_subq))
-                count_stmt = count_stmt.where(Product.id.in_(category_subq))
 
         if sort == "price_asc":
             stmt = stmt.order_by(Product.price.asc())
@@ -586,6 +596,13 @@ class ProductDAO:
             stmt = stmt.order_by(Product.price.desc())
         elif sort == "title":
             stmt = stmt.order_by(Product.title.asc())
+        elif sort == "recommended":
+            stmt = stmt.order_by(
+                ProductDAO._catalog_recommendation_score_expr(area_max=area_max).desc(),
+                ProductDAO._catalog_brand_priority_expr().asc(),
+                Product.created_at.desc(),
+                Product.id.desc(),
+            )
         else:
             stmt = stmt.order_by(Product.id.desc())
 

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -115,6 +115,15 @@ export interface ManagerBrandUpdatePayload {
     sort_order?: number | null;
 }
 
+export interface ManagerProductFilterOptions {
+    heatingMin?: number;
+    hasWifi?: boolean;
+    hasFreshAir?: boolean;
+    brandSlugs?: string[];
+    areaMin?: number;
+    areaMax?: number;
+}
+
 export const api = {
     async login(username: string, password: string) {
         return await LoginService.loginAccessToken({ username, password });
@@ -439,7 +448,8 @@ export const api = {
         areaMax?: number,
         isInverter?: boolean,
         categorySlug?: string,
-        sort = 'newest',
+        sort = 'recommended',
+        filters: ManagerProductFilterOptions = {},
     ) {
         return await ManagerService.getManagerProducts(
             page,
@@ -449,6 +459,10 @@ export const api = {
             areaMin ?? undefined,
             areaMax ?? undefined,
             isInverter ?? undefined,
+            filters.heatingMin ?? undefined,
+            filters.hasWifi ?? undefined,
+            filters.hasFreshAir ?? undefined,
+            filters.brandSlugs ?? undefined,
             categorySlug ?? undefined,
             sort,
         );
@@ -502,6 +516,26 @@ export const api = {
         return await ManagerService.getAllTags();
     },
 
+    async createTagGroup(payload: {
+        title: string;
+        slug?: string;
+        is_public?: boolean;
+        color?: string;
+        allow_multiple?: boolean;
+    }) {
+        return await ManagerTagsService.createManagerTagGroup(payload);
+    },
+
+    async createTag(payload: {
+        group_id: number;
+        title: string;
+        slug?: string;
+        is_public?: boolean;
+        is_filter?: boolean;
+    }) {
+        return await ManagerTagsService.createManagerTag(payload);
+    },
+
     async searchProducts(q: string) {
         return await ApiService.adminSearchProductsApiAdminProductsSearchGet(q);
     },
@@ -512,8 +546,20 @@ export const api = {
         isInverter?: boolean,
         hasWifi?: boolean,
         categorySlug?: string,
+        filters: ManagerProductFilterOptions = {},
     ): Promise<Product[]> {
-        const res = await ManagerService.smartSearchProducts(q, limit, isInverter, hasWifi, categorySlug);
+        const res = await ManagerService.smartSearchProducts(
+            q,
+            limit,
+            isInverter,
+            filters.areaMin ?? undefined,
+            filters.areaMax ?? undefined,
+            filters.heatingMin ?? undefined,
+            hasWifi ?? filters.hasWifi ?? undefined,
+            filters.hasFreshAir ?? undefined,
+            filters.brandSlugs ?? undefined,
+            categorySlug,
+        );
         return res.items;
     },
 

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -72,6 +72,10 @@ export class ManagerService {
      * @param areaMin
      * @param areaMax
      * @param isInverter
+     * @param heatingMin
+     * @param hasWifi
+     * @param hasFreshAir
+     * @param brandSlugs Brand slugs to include
      * @param categorySlug Category tag slug: cat-household/cat-multi/cat-industrial
      * @param sort
      * @returns ManagerCatalogProductListResponse Successful Response
@@ -85,8 +89,12 @@ export class ManagerService {
         areaMin?: (number | null),
         areaMax?: (number | null),
         isInverter?: (boolean | null),
+        heatingMin?: (number | null),
+        hasWifi?: (boolean | null),
+        hasFreshAir?: (boolean | null),
+        brandSlugs?: (Array<string> | null),
         categorySlug?: (string | null),
-        sort: string = 'newest',
+        sort: string = 'recommended',
     ): CancelablePromise<ManagerCatalogProductListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
@@ -99,6 +107,10 @@ export class ManagerService {
                 'area_min': areaMin,
                 'area_max': areaMax,
                 'is_inverter': isInverter,
+                'heating_min': heatingMin,
+                'has_wifi': hasWifi,
+                'has_fresh_air': hasFreshAir,
+                'brand_slugs': brandSlugs,
                 'category_slug': categorySlug,
                 'sort': sort,
             },
@@ -406,7 +418,12 @@ export class ManagerService {
      * @param q Free-text search query, e.g. 'mdv loft 18'
      * @param limit
      * @param isInverter
+     * @param areaMin
+     * @param areaMax
+     * @param heatingMin
      * @param hasWifi
+     * @param hasFreshAir
+     * @param brandSlugs Brand slugs to include
      * @param categorySlug Category tag slug: cat-household/cat-multi/cat-industrial
      * @returns ManagerCatalogProductListResponse Successful Response
      * @throws ApiError
@@ -415,7 +432,12 @@ export class ManagerService {
         q: string,
         limit: number = 40,
         isInverter?: (boolean | null),
+        areaMin?: (number | null),
+        areaMax?: (number | null),
+        heatingMin?: (number | null),
         hasWifi?: (boolean | null),
+        hasFreshAir?: (boolean | null),
+        brandSlugs?: (Array<string> | null),
         categorySlug?: (string | null),
     ): CancelablePromise<ManagerCatalogProductListResponse> {
         return __request(OpenAPI, {
@@ -425,7 +447,12 @@ export class ManagerService {
                 'q': q,
                 'limit': limit,
                 'is_inverter': isInverter,
+                'area_min': areaMin,
+                'area_max': areaMax,
+                'heating_min': heatingMin,
                 'has_wifi': hasWifi,
+                'has_fresh_air': hasFreshAir,
+                'brand_slugs': brandSlugs,
                 'category_slug': categorySlug,
             },
             errors: {

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, watch, computed } from 'vue';
 import { watchDebounced } from '@vueuse/core';
-import { api, type Product } from '../api';
-import { Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images, Settings, ArrowLeft, LayoutGrid, List, Package, Link2, ExternalLink } from 'lucide-vue-next';
+import { api, type ManagerBrand, type Product } from '../api';
+import { Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images, Settings, ArrowLeft, LayoutGrid, List, Package, Link2, ExternalLink, Star, SlidersHorizontal, X } from 'lucide-vue-next';
 import BulkSpecsModal from '../components/BulkSpecsModal.vue';
 import BulkCompatibilityModal from '../components/BulkCompatibilityModal.vue';
 import ProductEditModal from '../components/ProductEditModal.vue';
@@ -131,8 +131,20 @@ const searchQuery = ref('');
 const areaMin = ref<number | undefined>();
 const areaMax = ref<number | undefined>();
 const isInverter = ref<boolean | undefined>();
+const heatingMin = ref<number | undefined>();
+const hasWifi = ref<boolean | undefined>();
+const hasFreshAir = ref<boolean | undefined>();
+const selectedBrandSlug = ref<string | null>(null);
+const brands = ref<ManagerBrand[]>([]);
+const loadingBrands = ref(false);
+const filtersOpen = ref(false);
 const viewType = ref<'grid' | 'table'>('grid');
 const SMART_SEARCH_LIMIT = 100;
+const sortMode = ref<'recommended' | 'newest' | 'price_asc' | 'price_desc' | 'title'>('recommended');
+const FAVORITE_TAG_SLUG = 'manager-favorite';
+const FAVORITE_TAG_TITLE = 'Избранное';
+const FAVORITE_TAG_GROUP_SLUG = 'manager-flags';
+const FAVORITE_TAG_GROUP_TITLE = 'Метки менеджера';
 const hasSearchQuery = computed(() => searchQuery.value.trim().length > 0);
 const categorySlug = ref<'cat-household' | 'cat-multi' | 'cat-industrial'>('cat-household');
 const CATEGORY_FILTER_TABS: Array<{ slug: 'cat-household' | 'cat-multi' | 'cat-industrial'; title: string }> = [
@@ -140,18 +152,176 @@ const CATEGORY_FILTER_TABS: Array<{ slug: 'cat-household' | 'cat-multi' | 'cat-i
     { slug: 'cat-multi', title: 'Мульти-сплит' },
     { slug: 'cat-industrial', title: 'Полупром' },
 ];
+const favoriteTagId = ref<number | null>(null);
+const favoriteUpdatingIds = ref<Set<number>>(new Set());
+const availableBrands = computed(() => (
+    [...brands.value]
+        .filter((brand) => brand.products_count > 0)
+        .sort((left, right) => (left.sort_order - right.sort_order) || left.title.localeCompare(right.title))
+));
+const hasAdvancedFilters = computed(() => (
+    areaMin.value !== undefined
+    || areaMax.value !== undefined
+    || isInverter.value !== undefined
+    || heatingMin.value !== undefined
+    || hasWifi.value !== undefined
+    || hasFreshAir.value !== undefined
+    || selectedBrandSlug.value !== null
+    || sortMode.value !== 'recommended'
+));
 
 const applyFilters = () => {
     page.value = 1;
     loadProducts();
 };
 
-const setCategoryFilter = (slug: 'cat-household' | 'cat-multi' | 'cat-industrial') => {
-    if (categorySlug.value === slug) return;
-    categorySlug.value = slug;
+const onCategoryChange = () => {
     selectedProductIds.value.clear();
     page.value = 1;
     loadProducts();
+};
+
+const resetFilters = () => {
+    searchQuery.value = '';
+    areaMin.value = undefined;
+    areaMax.value = undefined;
+    isInverter.value = undefined;
+    heatingMin.value = undefined;
+    hasWifi.value = undefined;
+    hasFreshAir.value = undefined;
+    selectedBrandSlug.value = null;
+    sortMode.value = 'recommended';
+    categorySlug.value = 'cat-household';
+    selectedProductIds.value.clear();
+    page.value = 1;
+    loadProducts();
+};
+
+const getManagerProductFilters = () => ({
+    heatingMin: heatingMin.value,
+    hasWifi: hasWifi.value,
+    hasFreshAir: hasFreshAir.value,
+    brandSlugs: selectedBrandSlug.value ? [selectedBrandSlug.value] : undefined,
+    areaMin: areaMin.value,
+    areaMax: areaMax.value,
+});
+
+const toggleBrand = (slug: string | null) => {
+    selectedBrandSlug.value = selectedBrandSlug.value === slug ? null : slug;
+    applyFilters();
+};
+
+const setCompressorFilter = (value: boolean) => {
+    isInverter.value = isInverter.value === value ? undefined : value;
+    applyFilters();
+};
+
+const toggleWifiFilter = () => {
+    hasWifi.value = hasWifi.value === true ? undefined : true;
+    applyFilters();
+};
+
+const toggleFreshAirFilter = () => {
+    hasFreshAir.value = hasFreshAir.value === true ? undefined : true;
+    applyFilters();
+};
+
+const setHeatingFilter = (value: number) => {
+    heatingMin.value = heatingMin.value === value ? undefined : value;
+    applyFilters();
+};
+
+const filterChipClass = (active: boolean) => (
+    active
+        ? 'bg-teal-600 text-white border-teal-600 shadow-sm'
+        : 'bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-200 border-gray-300 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700'
+);
+
+const loadBrands = async () => {
+    loadingBrands.value = true;
+    try {
+        const response = await api.listManagerBrands();
+        brands.value = response.items || [];
+    } catch (e) {
+        setToast(`Ошибка загрузки брендов: ${getApiErrorMessage(e)}`);
+        console.error(e);
+    } finally {
+        loadingBrands.value = false;
+    }
+};
+
+const isFavoriteProduct = (product: Product) => (
+    ((product as any).tags || []).some((tag: any) => tag.slug === FAVORITE_TAG_SLUG)
+);
+
+const setFavoriteUpdating = (productId: number, isUpdating: boolean) => {
+    const next = new Set(favoriteUpdatingIds.value);
+    if (isUpdating) {
+        next.add(productId);
+    } else {
+        next.delete(productId);
+    }
+    favoriteUpdatingIds.value = next;
+};
+
+const ensureFavoriteTag = async () => {
+    if (favoriteTagId.value) return favoriteTagId.value;
+
+    let groups = await api.getAllTags();
+    let group = groups.find((item: any) => item.slug === FAVORITE_TAG_GROUP_SLUG);
+    if (!group) {
+        group = await api.createTagGroup({
+            title: FAVORITE_TAG_GROUP_TITLE,
+            slug: FAVORITE_TAG_GROUP_SLUG,
+            is_public: false,
+            color: 'warning',
+            allow_multiple: true,
+        });
+        groups = await api.getAllTags();
+        group = groups.find((item: any) => item.slug === FAVORITE_TAG_GROUP_SLUG) || group;
+    }
+
+    let tag = (group.tags || []).find((item: any) => item.slug === FAVORITE_TAG_SLUG);
+    if (!tag) {
+        tag = await api.createTag({
+            group_id: group.id,
+            title: FAVORITE_TAG_TITLE,
+            slug: FAVORITE_TAG_SLUG,
+            is_public: false,
+            is_filter: false,
+        });
+    }
+
+    favoriteTagId.value = tag.id;
+    return tag.id;
+};
+
+const toggleFavoriteProduct = async (product: Product) => {
+    if (favoriteUpdatingIds.value.has(product.id)) return;
+    setFavoriteUpdating(product.id, true);
+
+    try {
+        const tagId = await ensureFavoriteTag();
+        const currentIds = new Set<number>(
+            ((product as any).tags || [])
+                .map((tag: any) => Number(tag.id))
+                .filter((tagId: number) => Number.isFinite(tagId)),
+        );
+        if (isFavoriteProduct(product)) {
+            currentIds.delete(tagId);
+        } else {
+            currentIds.add(tagId);
+        }
+        const willBeFavorite = !isFavoriteProduct(product);
+        await api.updateProduct(product.id, { tag_ids: Array.from(currentIds) });
+        setToast(willBeFavorite ? 'Товар добавлен в избранные' : 'Товар убран из избранных');
+        await loadProducts();
+    } catch (e) {
+        setToast(`Ошибка избранного: ${getApiErrorMessage(e)}`);
+        console.error(e);
+    } finally {
+        setFavoriteUpdating(product.id, false);
+    }
 };
 
 
@@ -272,6 +442,12 @@ watch(showModal, (val) => {
   }
 });
 
+watch(filtersOpen, (isOpen) => {
+    if (isOpen && brands.value.length === 0 && !loadingBrands.value) {
+        loadBrands();
+    }
+});
+
 const loadProducts = async () => {
   loading.value = true;
   page.value = 1;
@@ -280,17 +456,12 @@ const loadProducts = async () => {
       const smartResults = await api.smartSearchProducts(
           searchQuery.value.trim(),
           SMART_SEARCH_LIMIT,
-          undefined,
-          undefined,
+          isInverter.value,
+          hasWifi.value,
           categorySlug.value,
+          getManagerProductFilters(),
       );
-      const filtered = smartResults.filter((product) => {
-        if (areaMin.value !== undefined && product.area < areaMin.value) return false;
-        if (areaMax.value !== undefined && product.area > areaMax.value) return false;
-        if (isInverter.value !== undefined && product.is_inverter !== isInverter.value) return false;
-        return true;
-      });
-      products.value = filtered;
+      products.value = smartResults;
       hasMore.value = false;
     } else {
       const data = await api.getManagerProducts(
@@ -302,6 +473,8 @@ const loadProducts = async () => {
           areaMax.value,
           isInverter.value,
           categorySlug.value,
+          sortMode.value,
+          getManagerProductFilters(),
       );
       products.value = data.items ? data.items : (Array.isArray(data) ? data : []);
       hasMore.value = products.value.length >= limit;
@@ -341,6 +514,8 @@ const loadMore = async () => {
             areaMax.value, 
             isInverter.value,
             categorySlug.value,
+            sortMode.value,
+            getManagerProductFilters(),
         );
         const newItems = data.items ? data.items : (Array.isArray(data) ? data : []);
         if (newItems.length < limit) {
@@ -627,6 +802,7 @@ onMounted(() => {
             searchQuery.value = String(pendingEditProductId.value);
         }
     }
+    loadBrands();
     loadProducts();
 
     const observer = new IntersectionObserver((entries) => {
@@ -676,8 +852,8 @@ watchDebounced(
 <template>
   <div class="p-6">
     <!-- Header -->
-    <header class="mb-6 flex justify-between items-center">
-      <div class="flex items-center gap-4">
+    <header class="mb-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+      <div class="flex flex-wrap items-center gap-4">
           <button
             v-if="pendingReturnTo"
             @click="navigateBackFromProducts"
@@ -690,6 +866,22 @@ watchDebounced(
             <span class="material-icons-round text-teal-600 dark:text-teal-400">inventory_2</span>
             Товары
           </h1>
+
+          <div class="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 shadow-sm">
+            <label class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400" for="manager-product-category">
+              Категория
+            </label>
+            <select
+              id="manager-product-category"
+              v-model="categorySlug"
+              class="min-w-[150px] bg-transparent text-sm font-semibold text-gray-900 dark:text-slate-100 outline-none"
+              @change="onCategoryChange"
+            >
+              <option v-for="tab in CATEGORY_FILTER_TABS" :key="tab.slug" :value="tab.slug">
+                {{ tab.title }}
+              </option>
+            </select>
+          </div>
           
           <div class="flex bg-gray-100 dark:bg-slate-800 p-1 rounded-lg ml-2">
             <button 
@@ -733,7 +925,7 @@ watchDebounced(
               <button @click="selectedProductIds.clear()" class="text-xs text-teal-600 hover:text-teal-800 underline ml-1">Сбросить</button>
           </div>
       </div>
-      <div class="flex gap-2">
+      <div class="flex flex-wrap gap-2">
           <button @click="toggleSelectAll" class="px-3 py-2 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 flex items-center gap-2 text-gray-700 dark:text-slate-200 text-sm transition-colors">
               <CheckSquare v-if="allSelected" class="w-4 h-4 text-teal-600" />
               <Square v-else class="w-4 h-4 text-gray-400" />
@@ -763,70 +955,189 @@ watchDebounced(
       </Transition>
 
     <!-- Filters -->
-    <div class="bg-white dark:bg-slate-800 p-4 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 mb-6 flex flex-wrap gap-4 items-end">
-        <div class="w-full">
-            <label class="block text-xs font-medium text-gray-500 mb-1">Категория каталога</label>
+    <div class="bg-white dark:bg-slate-800 p-4 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 mb-6 space-y-4">
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-end">
+            <div class="flex-1 min-w-[240px]">
+                <label class="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1">Поиск по модели</label>
+                <div class="relative">
+                    <Search class="w-4 h-4 text-gray-400 dark:text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
+                    <input
+                        v-model="searchQuery"
+                        @keyup.enter="applyFilters"
+                        placeholder="Например: ARTCOOL..."
+                        class="w-full pl-9 pr-4 py-2.5 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 focus:border-transparent outline-none shadow-inner"
+                    />
+                </div>
+            </div>
+
             <div class="flex flex-wrap gap-2">
                 <button
-                    v-for="tab in CATEGORY_FILTER_TABS"
-                    :key="tab.slug"
                     type="button"
-                    class="px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors"
-                    :class="categorySlug === tab.slug
+                    class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border text-sm font-semibold transition-colors"
+                    :class="filtersOpen
                         ? 'bg-teal-600 text-white border-teal-600'
-                        : 'bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 border-gray-300 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700'"
-                    @click="setCategoryFilter(tab.slug)"
+                        : 'bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-200 border-gray-300 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700'"
+                    @click="filtersOpen = !filtersOpen"
                 >
-                    {{ tab.title }}
+                    <SlidersHorizontal class="w-4 h-4" />
+                    Фильтры
+                    <span
+                        v-if="hasAdvancedFilters"
+                        class="inline-flex h-2 w-2 rounded-full"
+                        :class="filtersOpen ? 'bg-white' : 'bg-teal-500'"
+                    ></span>
+                </button>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm font-semibold text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+                    @click="resetFilters"
+                >
+                    <X class="w-4 h-4" />
+                    Сбросить фильтры
                 </button>
             </div>
         </div>
 
-        <div class="flex-1 min-w-[200px]">
-            <label class="block text-xs font-medium text-gray-500 mb-1">Поиск по модели</label>
-            <div class="relative">
-                <Search class="w-4 h-4 text-gray-400 dark:text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
-                <input 
-                    v-model="searchQuery" 
-                    @keyup.enter="applyFilters"
-                    placeholder="Например: ARTCOOL..." 
-                    class="w-full pl-9 pr-4 py-2 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 focus:border-transparent outline-none shadow-inner"
-                />
+        <Transition name="fade">
+            <div v-if="filtersOpen" class="space-y-4 border-t border-gray-100 dark:border-slate-700 pt-4">
+                <div>
+                    <div class="mb-2 flex items-center gap-2">
+                        <span class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Бренд</span>
+                        <span v-if="loadingBrands" class="text-xs text-gray-400 dark:text-slate-500">обновляем...</span>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                            :class="filterChipClass(selectedBrandSlug === null)"
+                            @click="toggleBrand(null)"
+                        >
+                            Все бренды
+                        </button>
+                        <button
+                            v-for="brand in availableBrands"
+                            :key="brand.slug"
+                            type="button"
+                            class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                            :class="filterChipClass(selectedBrandSlug === brand.slug)"
+                            @click="toggleBrand(brand.slug)"
+                        >
+                            {{ brand.title }}
+                        </button>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 lg:grid-cols-[minmax(220px,320px)_1fr] lg:items-end">
+                    <div>
+                        <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-2" for="manager-products-sort">
+                            Сортировка
+                        </label>
+                        <select
+                            id="manager-products-sort"
+                            v-model="sortMode"
+                            class="w-full px-3 py-2.5 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 outline-none shadow-inner"
+                            @change="applyFilters"
+                        >
+                            <option value="recommended">Рекомендуемые</option>
+                            <option value="price_asc">Сначала дешевле</option>
+                            <option value="price_desc">Сначала дороже</option>
+                            <option value="newest">Сначала новые</option>
+                            <option value="title">По названию</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="grid gap-4 lg:grid-cols-[minmax(220px,320px)_1fr]">
+                    <div>
+                        <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-2">Площадь (м²)</label>
+                        <div class="flex gap-2 items-center">
+                            <input
+                                v-model.number="areaMin"
+                                type="number"
+                                placeholder="От"
+                                class="w-full px-3 py-2.5 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 outline-none shadow-inner"
+                            />
+                            <span class="text-gray-400">-</span>
+                            <input
+                                v-model.number="areaMax"
+                                type="number"
+                                placeholder="До"
+                                class="w-full px-3 py-2.5 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 outline-none shadow-inner"
+                            />
+                            <button
+                                type="button"
+                                @click="applyFilters"
+                                class="px-4 py-2.5 bg-teal-600 dark:bg-teal-600 text-white rounded-lg hover:bg-teal-700 dark:hover:bg-teal-700 font-medium text-sm transition-colors shadow-sm"
+                            >
+                                OK
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-3">
+                        <div>
+                            <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Тип компрессора</div>
+                            <div class="flex flex-wrap gap-2">
+                                <button
+                                    type="button"
+                                    class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                                    :class="filterChipClass(isInverter === true)"
+                                    @click="setCompressorFilter(true)"
+                                >
+                                    Инвертор
+                                </button>
+                                <button
+                                    type="button"
+                                    class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                                    :class="filterChipClass(isInverter === false)"
+                                    @click="setCompressorFilter(false)"
+                                >
+                                    On/Off
+                                </button>
+                            </div>
+                        </div>
+
+                        <div>
+                            <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Дополнительно</div>
+                            <div class="flex flex-wrap gap-2">
+                                <button
+                                    type="button"
+                                    class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                                    :class="filterChipClass(hasWifi === true)"
+                                    @click="toggleWifiFilter"
+                                >
+                                    Wi-Fi
+                                </button>
+                                <button
+                                    type="button"
+                                    class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                                    :class="filterChipClass(hasFreshAir === true)"
+                                    @click="toggleFreshAirFilter"
+                                >
+                                    Приток воздуха
+                                </button>
+                            </div>
+                        </div>
+
+                        <div>
+                            <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Обогрев</div>
+                            <div class="flex flex-wrap gap-2">
+                                <button
+                                    v-for="value in [-15, -20, -25, -30]"
+                                    :key="value"
+                                    type="button"
+                                    class="rounded-lg border px-3 py-2 text-sm font-semibold transition-colors"
+                                    :class="filterChipClass(heatingMin === value)"
+                                    @click="setHeatingFilter(value)"
+                                >
+                                    до {{ value }}°C
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </div>
-
-        <div class="w-[180px]">
-             <label class="block text-xs font-medium text-gray-500 mb-1">Площадь (м²)</label>
-             <div class="flex gap-2 items-center">
-                 <input 
-                    v-model.number="areaMin"
-                    type="number" 
-                    placeholder="От" 
-                    class="w-full px-3 py-2 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 outline-none shadow-inner"
-                 />
-                 <span class="text-gray-400">-</span>
-                 <input 
-                    v-model.number="areaMax"
-                    type="number" 
-                    placeholder="До" 
-                    class="w-full px-3 py-2 border border-gray-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-gray-900 dark:text-slate-100 dark:placeholder-slate-500 rounded-lg text-sm focus:ring-2 focus:ring-teal-500 outline-none shadow-inner"
-                 />
-             </div>
-        </div>
-
-        <div class="flex items-center gap-2 pb-2">
-            <label class="flex items-center gap-2 cursor-pointer bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors select-none">
-                <input type="checkbox" v-model="isInverter" class="w-4 h-4 text-teal-600 dark:text-teal-500 bg-white dark:bg-slate-900 border-gray-300 dark:border-slate-700 rounded focus:ring-teal-500" />
-                <span class="text-sm text-gray-700 dark:text-slate-300">Только инвертор</span>
-            </label>
-        </div>
-
-        <button 
-            @click="applyFilters"
-            class="px-6 py-2 bg-teal-600 dark:bg-teal-600 text-white rounded-lg hover:bg-teal-700 dark:hover:bg-teal-700 font-medium text-sm transition-colors shadow-sm"
-        >
-            Применить
-        </button>
+        </Transition>
     </div>
     
     <!-- Product Grid -->
@@ -851,6 +1162,19 @@ watchDebounced(
                      <Square v-else class="w-5 h-5 text-gray-400" />
                  </button>
              </div>
+             <div class="absolute top-2.5 right-2.5 z-20">
+                 <button
+                    @click.stop="toggleFavoriteProduct(product)"
+                    :disabled="favoriteUpdatingIds.has(product.id)"
+                    class="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-md shadow-sm hover:bg-white dark:hover:bg-slate-700 p-1 transition-colors disabled:opacity-50"
+                    :title="isFavoriteProduct(product) ? 'Убрать из избранных' : 'В избранное'"
+                 >
+                    <Star
+                        class="w-5 h-5"
+                        :class="isFavoriteProduct(product) ? 'fill-amber-400 text-amber-500' : 'text-gray-400 hover:text-amber-500'"
+                    />
+                 </button>
+             </div>
             <div class="aspect-video bg-gray-100 dark:bg-slate-700 relative">
                 <img v-if="product.main_image" :src="getImageUrl(product.main_image)" class="w-full h-full object-cover" />
                 <div v-else class="w-full h-full flex items-center justify-center text-gray-300">
@@ -862,7 +1186,7 @@ watchDebounced(
                     <button
                       @click.stop="deleteProduct(product)"
                       :disabled="isDeletingProduct === product.id"
-                      class="absolute top-2.5 right-2.5 flex h-7 w-7 items-center justify-center rounded-full bg-red-600/90 text-white shadow-sm transition-colors hover:bg-red-700 disabled:opacity-50"
+                      class="absolute top-2.5 right-11 flex h-7 w-7 items-center justify-center rounded-full bg-red-600/90 text-white shadow-sm transition-colors hover:bg-red-700 disabled:opacity-50"
                       title="Удалить"
                     >
                       <span class="material-icons-round text-[16px] leading-none">close</span>
@@ -999,6 +1323,15 @@ watchDebounced(
               </td>
               <td class="p-4 text-right">
                 <div class="flex justify-end gap-2 text-gray-400">
+                  <button
+                    @click="toggleFavoriteProduct(product)"
+                    :disabled="favoriteUpdatingIds.has(product.id)"
+                    class="p-2 transition-colors disabled:opacity-50"
+                    :class="isFavoriteProduct(product) ? 'text-amber-500 hover:text-amber-600' : 'hover:text-amber-500'"
+                    :title="isFavoriteProduct(product) ? 'Убрать из избранных' : 'В избранное'"
+                  >
+                    <Star class="w-4 h-4" :class="{ 'fill-amber-400': isFavoriteProduct(product) }" />
+                  </button>
                   <button @click="copyPublicProductLink(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" :title="product.slug ? 'Скопировать ссылку на сайт' : 'У товара нет публичного slug'" :disabled="!product.slug">
                     <Link2 class="w-4 h-4" />
                   </button>

--- a/openapi.json
+++ b/openapi.json
@@ -2296,6 +2296,75 @@
             }
           },
           {
+            "name": "heating_min",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Heating Min"
+            }
+          },
+          {
+            "name": "has_wifi",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Wifi"
+            }
+          },
+          {
+            "name": "has_fresh_air",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Fresh Air"
+            }
+          },
+          {
+            "name": "brand_slugs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Brand slugs to include",
+              "title": "Brand Slugs"
+            },
+            "description": "Brand slugs to include"
+          },
+          {
             "name": "category_slug",
             "in": "query",
             "required": false,
@@ -2319,7 +2388,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "newest",
+              "default": "recommended",
               "title": "Sort"
             }
           }
@@ -3100,6 +3169,54 @@
             }
           },
           {
+            "name": "area_min",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Area Min"
+            }
+          },
+          {
+            "name": "area_max",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Area Max"
+            }
+          },
+          {
+            "name": "heating_min",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Heating Min"
+            }
+          },
+          {
             "name": "has_wifi",
             "in": "query",
             "required": false,
@@ -3114,6 +3231,43 @@
               ],
               "title": "Has Wifi"
             }
+          },
+          {
+            "name": "has_fresh_air",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Fresh Air"
+            }
+          },
+          {
+            "name": "brand_slugs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Brand slugs to include",
+              "title": "Brand Slugs"
+            },
+            "description": "Brand slugs to include"
           },
           {
             "name": "category_slug",

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -69,8 +69,12 @@ async def list_products_for_manager(
     area_min: Optional[int] = Query(None),
     area_max: Optional[int] = Query(None),
     is_inverter: Optional[bool] = Query(None),
+    heating_min: Optional[int] = Query(None),
+    has_wifi: Optional[bool] = Query(None),
+    has_fresh_air: Optional[bool] = Query(None),
+    brand_slugs: Optional[List[str]] = Query(None, description="Brand slugs to include"),
     category_slug: Optional[str] = Query(None, description="Category tag slug: cat-household/cat-multi/cat-industrial"),
-    sort: str = Query("newest"),
+    sort: str = Query("recommended"),
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),
 ):
@@ -87,6 +91,10 @@ async def list_products_for_manager(
         area_min=area_min,
         area_max=area_max,
         is_inverter=is_inverter,
+        heating_min=heating_min,
+        has_wifi=has_wifi,
+        has_fresh_air=has_fresh_air,
+        brand_slugs=brand_slugs,
         category_slug=category_slug,
         sort=sort,
     )
@@ -440,7 +448,12 @@ async def smart_search_products(
     q: str = Query(..., min_length=1, description="Free-text search query, e.g. 'mdv loft 18'"),
     limit: int = Query(40, ge=1, le=100),
     is_inverter: Optional[bool] = Query(None),
+    area_min: Optional[int] = Query(None),
+    area_max: Optional[int] = Query(None),
+    heating_min: Optional[int] = Query(None),
     has_wifi: Optional[bool] = Query(None),
+    has_fresh_air: Optional[bool] = Query(None),
+    brand_slugs: Optional[List[str]] = Query(None, description="Brand slugs to include"),
     category_slug: Optional[str] = Query(None, description="Category tag slug: cat-household/cat-multi/cat-industrial"),
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),
@@ -457,7 +470,12 @@ async def smart_search_products(
         q=q,
         limit=limit,
         is_inverter=is_inverter,
+        area_min=area_min,
+        area_max=area_max,
+        heating_min=heating_min,
         has_wifi=has_wifi,
+        has_fresh_air=has_fresh_air,
+        brand_slugs=brand_slugs,
         category_slug=category_slug,
     )
 

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from schemas import (
     BulkRoundRequest,
@@ -179,7 +179,12 @@ class ManagerCatalogService:
         q: str,
         limit: int = 40,
         is_inverter: Optional[bool] = None,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        heating_min: Optional[int] = None,
         has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
     ):
         return await ProductManagerService.smart_search(
@@ -187,6 +192,11 @@ class ManagerCatalogService:
             q=q,
             limit=limit,
             is_inverter=is_inverter,
+            area_min=area_min,
+            area_max=area_max,
+            heating_min=heating_min,
             has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            brand_slugs=brand_slugs,
             category_slug=category_slug,
         )

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -25,6 +25,10 @@ class ManagerCatalogService:
         area_min: Optional[int],
         area_max: Optional[int],
         is_inverter: Optional[bool],
+        heating_min: Optional[int],
+        has_wifi: Optional[bool],
+        has_fresh_air: Optional[bool],
+        brand_slugs: Optional[list[str]],
         category_slug: Optional[str],
         sort: str,
     ) -> Dict[str, Any]:
@@ -37,6 +41,10 @@ class ManagerCatalogService:
             area_min=area_min,
             area_max=area_max,
             is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            brand_slugs=brand_slugs,
             category_slug=category_slug,
             sort=sort,
         )

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -40,7 +40,12 @@ class ProductManagerService:
         q: str,
         limit: int = 40,
         is_inverter: Optional[bool] = None,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
+        heating_min: Optional[int] = None,
         has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Parse a free-text query and return matching products.
@@ -73,9 +78,14 @@ class ProductManagerService:
         stmt = ProductDAO._apply_common_filters(
             session=session,
             stmt=stmt,
+            area_min=area_min,
+            area_max=area_max,
+            heating_min=heating_min,
             is_inverter=is_inverter,
             has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
             tag_slugs=[category_slug] if category_slug else None,
+            brand_slugs=brand_slugs,
             is_published=None,
         )
 
@@ -150,11 +160,28 @@ class ProductManagerService:
         area_min: Optional[int] = None,
         area_max: Optional[int] = None,
         is_inverter: Optional[bool] = None,
+        heating_min: Optional[int] = None,
+        has_wifi: Optional[bool] = None,
+        has_fresh_air: Optional[bool] = None,
+        brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
-        sort: str = "newest",
+        sort: str = "recommended",
     ) -> Dict[str, Any]:
         items, total = await ProductDAO.get_for_manager(
-            session, page, limit, search, is_published, area_min, area_max, is_inverter, category_slug, sort
+            session,
+            page=page,
+            limit=limit,
+            search=search,
+            is_published=is_published,
+            area_min=area_min,
+            area_max=area_max,
+            is_inverter=is_inverter,
+            heating_min=heating_min,
+            has_wifi=has_wifi,
+            has_fresh_air=has_fresh_air,
+            brand_slugs=brand_slugs,
+            category_slug=category_slug,
+            sort=sort,
         )
         supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, list(items))
 

--- a/tests/integration/test_manager_products_category_filter_api.py
+++ b/tests/integration/test_manager_products_category_filter_api.py
@@ -2,7 +2,8 @@ import pytest
 from sqlmodel import select
 
 from core.config import settings
-from models import Product, ProductTagLink, Tag, TagGroup
+from crud.supplier import ProductLocalStockDAO
+from models import Brand, Product, ProductTagLink, Tag, TagGroup
 
 
 async def _auth_headers(async_client):
@@ -116,3 +117,160 @@ async def test_manager_products_smart_search_respects_category_slug(async_client
     ids = {item["id"] for item in items}
     assert p_multi.id in ids
     assert p_house.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_manager_products_recommended_sort_boosts_favorites(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    household_tag = await _get_or_create_category_tag(db, "cat-household", "Бытовые")
+    favorite_tag = (await db.execute(select(Tag).where(Tag.slug == "manager-favorite"))).scalar_one_or_none()
+    if favorite_tag is None:
+        favorite_group = TagGroup(
+            title="Метки менеджера",
+            slug="manager-flags-test",
+            color="warning",
+            is_public=False,
+            allow_multiple=True,
+        )
+        db.add(favorite_group)
+        await db.commit()
+        await db.refresh(favorite_group)
+        favorite_tag = Tag(
+            title="Избранное",
+            slug="manager-favorite",
+            group_id=favorite_group.id,
+            is_public=False,
+            is_filter=False,
+        )
+        db.add(favorite_tag)
+        await db.commit()
+        await db.refresh(favorite_tag)
+
+    marker = "UNITFAV789"
+    regular = Product(
+        title=f"{marker} Regular",
+        slug=f"{marker.lower()}-regular",
+        price=1000,
+        area=25,
+        is_published=True,
+    )
+    favorite = Product(
+        title=f"{marker} Favorite",
+        slug=f"{marker.lower()}-favorite",
+        price=1100,
+        area=35,
+        is_published=True,
+    )
+    db.add_all([regular, favorite])
+    await db.commit()
+    await db.refresh(regular)
+    await db.refresh(favorite)
+
+    db.add_all(
+        [
+            ProductTagLink(product_id=regular.id, tag_id=household_tag.id),
+            ProductTagLink(product_id=favorite.id, tag_id=household_tag.id),
+            ProductTagLink(product_id=favorite.id, tag_id=favorite_tag.id),
+        ]
+    )
+    await db.commit()
+
+    for product in (regular, favorite):
+        await ProductLocalStockDAO.upsert(
+            session=db,
+            product_id=product.id,
+            qty=1,
+            updated_by="test",
+            warehouse_code="vitebsk",
+        )
+
+    resp = await async_client.get(
+        "/api/manager/products/list",
+        headers=headers,
+        params={
+            "search": marker,
+            "category_slug": "cat-household",
+            "sort": "recommended",
+            "limit": 10,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    slugs = [item["slug"] for item in resp.json()["items"]]
+    assert slugs[:2] == [favorite.slug, regular.slug]
+
+
+@pytest.mark.asyncio
+async def test_manager_products_list_supports_catalog_style_filters(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    household_tag = await _get_or_create_category_tag(db, "cat-household", "Бытовые")
+    mdv = Brand(title="MDV Filter", slug="mdv-filter", is_published=True, sort_order=0)
+    haier = Brand(title="Haier Filter", slug="haier-filter", is_published=True, sort_order=2)
+    db.add_all([mdv, haier])
+    await db.commit()
+    await db.refresh(mdv)
+    await db.refresh(haier)
+
+    marker = "UNITFILTER321"
+    matched = Product(
+        title=f"{marker} MDV On-Off WiFi Fresh",
+        slug=f"{marker.lower()}-matched",
+        price=1000,
+        area=25,
+        is_inverter=False,
+        brand_id=mdv.id,
+        is_published=True,
+        specs={"__filter_wifi": True, "fresh_air": True, "__filter_min_heat": -25},
+    )
+    wrong_brand = Product(
+        title=f"{marker} Haier On-Off WiFi Fresh",
+        slug=f"{marker.lower()}-wrong-brand",
+        price=1000,
+        area=25,
+        is_inverter=False,
+        brand_id=haier.id,
+        is_published=True,
+        specs={"__filter_wifi": True, "fresh_air": True, "__filter_min_heat": -25},
+    )
+    wrong_compressor = Product(
+        title=f"{marker} MDV Inverter WiFi Fresh",
+        slug=f"{marker.lower()}-wrong-compressor",
+        price=1000,
+        area=25,
+        is_inverter=True,
+        brand_id=mdv.id,
+        is_published=True,
+        specs={"__filter_wifi": True, "fresh_air": True, "__filter_min_heat": -25},
+    )
+    db.add_all([matched, wrong_brand, wrong_compressor])
+    await db.commit()
+    for product in (matched, wrong_brand, wrong_compressor):
+        await db.refresh(product)
+
+    db.add_all(
+        [
+            ProductTagLink(product_id=matched.id, tag_id=household_tag.id),
+            ProductTagLink(product_id=wrong_brand.id, tag_id=household_tag.id),
+            ProductTagLink(product_id=wrong_compressor.id, tag_id=household_tag.id),
+        ]
+    )
+    await db.commit()
+
+    resp = await async_client.get(
+        "/api/manager/products/list",
+        headers=headers,
+        params={
+            "search": marker,
+            "category_slug": "cat-household",
+            "brand_slugs": ["mdv-filter"],
+            "is_inverter": "false",
+            "has_wifi": "true",
+            "has_fresh_air": "true",
+            "heating_min": -20,
+            "limit": 10,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    slugs = [item["slug"] for item in resp.json()["items"]]
+    assert slugs == [matched.slug]


### PR DESCRIPTION
## Что изменилось

- Перестроен фильтр товаров в менеджере: категория вынесена в шапку, расширенные фильтры открываются под кнопкой `Фильтры`.
- Добавлены фильтры по брендам, типу компрессора (`Инвертор` / `On/Off`), Wi-Fi, притоку воздуха, обогреву и сортировке.
- Добавлена звездочка избранного товара через тег `manager-favorite` без новой сущности.
- Избранные товары получают дополнительный вес в рекомендованной сортировке.
- Manager API и smart-search теперь принимают catalog-style query-параметры: brand slugs, heating, Wi-Fi, fresh air, area, inverter.
- Обновлены OpenAPI и сгенерированный manager client.
- Добавлены интеграционные тесты для избранного ранжирования и новых фильтров менеджера.

## Почему

Менеджеру нужно быстро собирать витрину по тем же практичным признакам, что и на сайте, и вручную поднимать приоритетные к продаже модели без добавления новых сущностей.

## Проверки

- `npm run build` в `manager_frontend/` — проходит в основной рабочей копии.
- `python3 -m compileall crud/product.py routers/manager_catalog.py services/manager_catalog_service.py services/product_manager_service.py` — проходит.
- `git diff --check` — проходит.
- Browser smoke на `http://localhost:8000/manager/products`: фильтры открываются, бренды видны, консоль без ошибок.
- `pytest tests/integration/test_manager_products_category_filter_api.py -q` — не дошел до тестов локально: окружение не резолвит `db_test`.
