### PR TITLE
[codex] add document role overrides

### DIFF
--- a/alembic/versions/8f2a6d7c1b34_add_document_role_type.py
+++ b/alembic/versions/8f2a6d7c1b34_add_document_role_type.py
@@ -1,0 +1,48 @@
+"""add_document_role_type
+
+Revision ID: 8f2a6d7c1b34
+Revises: 6a7b8c9d0e1f
+Create Date: 2026-04-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision: str = "8f2a6d7c1b34"
+down_revision: Union[str, Sequence[str], None] = "6a7b8c9d0e1f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    order_columns = {column["name"] for column in inspector.get_columns("order")}
+    if "document_role_type" not in order_columns:
+        with op.batch_alter_table("order", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("document_role_type", sa.String(), nullable=True))
+
+    contract_columns = {column["name"] for column in inspector.get_columns("customer_contract")}
+    if "document_role_type" not in contract_columns:
+        with op.batch_alter_table("customer_contract", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("document_role_type", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    contract_columns = {column["name"] for column in inspector.get_columns("customer_contract")}
+    if "document_role_type" in contract_columns:
+        with op.batch_alter_table("customer_contract", schema=None) as batch_op:
+            batch_op.drop_column("document_role_type")
+
+    order_columns = {column["name"] for column in inspector.get_columns("order")}
+    if "document_role_type" in order_columns:
+        with op.batch_alter_table("order", schema=None) as batch_op:
+            batch_op.drop_column("document_role_type")

--- a/core/app_static.py
+++ b/core/app_static.py
@@ -2,10 +2,31 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from starlette.responses import Response
 
 from core.app_constants import MANAGER_ASSETS_DIRNAME, MANAGER_ASSETS_ROUTE
 from core.config import settings
 from core.logger import logger
+
+
+MANAGER_NO_CACHE_HEADERS = {
+    "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
+
+def apply_manager_no_cache_headers(response: Response) -> Response:
+    response.headers.update(MANAGER_NO_CACHE_HEADERS)
+    return response
+
+
+class ManagerAssetsStaticFiles(StaticFiles):
+    async def get_response(self, path: str, scope) -> Response:
+        response = await super().get_response(path, scope)
+        if response.status_code == 200 and path.endswith((".js", ".css")):
+            apply_manager_no_cache_headers(response)
+        return response
 
 
 def mount_static_and_media(app: FastAPI, base_dir: Path) -> None:
@@ -27,7 +48,7 @@ def mount_manager_assets(app: FastAPI, manager_dist: Path) -> None:
     if manager_dist.exists():
         app.mount(
             MANAGER_ASSETS_ROUTE,
-            StaticFiles(directory=manager_dist / MANAGER_ASSETS_DIRNAME),
+            ManagerAssetsStaticFiles(directory=manager_dist / MANAGER_ASSETS_DIRNAME),
             name="manager_assets",
         )
     else:

--- a/docs/document-placeholders.md
+++ b/docs/document-placeholders.md
@@ -1,0 +1,22 @@
+# Document Placeholders
+
+## Object Address
+
+Use `{{object_address}}` in document templates when the act or another document needs the work site address.
+
+The value is resolved from the order address first, then from the selected customer branch address. If neither is filled, the generator inserts an empty string.
+
+## Contract Party Roles
+
+Templates for acts and invoices may keep normal Russian role words:
+
+- `продавец`
+- `покупатель`
+
+For acts and invoices only, the generator can replace these words and their common case forms according to the selected role type:
+
+- `seller_buyer`: no replacement
+- `executor_customer`: продавец -> исполнитель, покупатель -> заказчик
+- `contractor_customer`: продавец -> подрядчик, покупатель -> заказчик
+
+The role type can come from the contract template default, the open customer contract, or the order override.

--- a/manager_frontend/src/client/models/Body_upload_manager_customer_contract.ts
+++ b/manager_frontend/src/client/models/Body_upload_manager_customer_contract.ts
@@ -6,6 +6,7 @@ export type Body_upload_manager_customer_contract = {
     number: string;
     contract_date: string;
     valid_until: string;
+    document_role_type?: (string | null);
     file: Blob;
 };
 

--- a/manager_frontend/src/client/models/DocumentTemplateItem.ts
+++ b/manager_frontend/src/client/models/DocumentTemplateItem.ts
@@ -5,5 +5,6 @@
 export type DocumentTemplateItem = {
     id: string;
     name: string;
+    document_role_type?: string;
 };
 

--- a/manager_frontend/src/client/models/ManagerCustomerContractCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerContractCreatePayload.ts
@@ -5,6 +5,7 @@
 export type ManagerCustomerContractCreatePayload = {
     number?: (string | null);
     template_id?: (string | null);
+    document_role_type?: (string | null);
     contract_date?: (string | null);
     valid_until?: (string | null);
 };

--- a/manager_frontend/src/client/models/ManagerCustomerContractItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerContractItemResponse.ts
@@ -10,6 +10,7 @@ export type ManagerCustomerContractItemResponse = {
     valid_until: string;
     status: string;
     template_id?: (string | null);
+    document_role_type?: string;
     edit_url?: (string | null);
     created_at: string;
     updated_at?: (string | null);

--- a/manager_frontend/src/client/models/ManagerCustomerContractUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerContractUpdatePayload.ts
@@ -5,6 +5,7 @@
 export type ManagerCustomerContractUpdatePayload = {
     number?: (string | null);
     template_id?: (string | null);
+    document_role_type?: (string | null);
     contract_date?: (string | null);
     valid_until?: (string | null);
     status?: (string | null);

--- a/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
@@ -31,6 +31,8 @@ export type ManagerOrderDetailResponse = {
     customer_branch?: (OrderCustomerBranchBrief | null);
     customer_contract_id?: (number | null);
     customer_contract?: (OrderCustomerContractBrief | null);
+    document_role_type?: (string | null);
+    effective_document_role_type?: string;
     installer_id?: (number | null);
     installer?: (ManagerInstallerResponse | null);
     equipment_status?: string;

--- a/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
@@ -26,6 +26,8 @@ export type ManagerOrderListItemResponse = {
     customer_branch?: (OrderCustomerBranchBrief | null);
     customer_contract_id?: (number | null);
     customer_contract?: (OrderCustomerContractBrief | null);
+    document_role_type?: (string | null);
+    effective_document_role_type?: string;
     installer_id?: (number | null);
     installer?: (ManagerInstallerResponse | null);
     equipment_status?: string;

--- a/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
@@ -29,6 +29,7 @@ export type ManagerOrderUpdatePayload = {
     customer_id?: (number | null);
     customer_branch_id?: (number | null);
     customer_contract_id?: (number | null);
+    document_role_type?: (string | null);
     customer_type?: (string | null);
     customer_name?: (string | null);
     customer_phone?: (string | null);

--- a/manager_frontend/src/client/models/OrderCustomerContractBrief.ts
+++ b/manager_frontend/src/client/models/OrderCustomerContractBrief.ts
@@ -9,6 +9,7 @@ export type OrderCustomerContractBrief = {
     valid_from: string;
     valid_until: string;
     status: string;
+    document_role_type?: (string | null);
     edit_url?: (string | null);
 };
 

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { ManagerOrdersService, ManagerDocsService, ManagerContractsService } from '../../client';
-import type { ManagerCustomerContractItemResponse, ManagerOrderDetailResponse, ManagerOrderDocumentItem } from '../../client';
+import type { DocumentTemplateItem, ManagerCustomerContractItemResponse, ManagerOrderDetailResponse, ManagerOrderDocumentItem } from '../../client';
 import { formatMoney } from './order-utils';
 import DateTimeField from '../ui/DateTimeField.vue';
 import { getApiErrorMessage } from '../../utils/api-errors';
@@ -148,11 +148,27 @@ const docDropdownOpen = ref(false);
 const isUploadingDoc = ref(false);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 
-const contractTemplates = ref<{id: string; name: string}[]>([]);
+type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
+const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
+  { value: 'seller_buyer', label: 'Продавец / Покупатель' },
+  { value: 'executor_customer', label: 'Исполнитель / Заказчик' },
+  { value: 'contractor_customer', label: 'Подрядчик / Заказчик' },
+];
+const normalizeRoleType = (value: unknown): DocumentRoleType => {
+  const raw = String(value || '').trim();
+  if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
+  return 'seller_buyer';
+};
+const getRoleLabel = (value?: string | null) => (
+  DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
+);
+
+const contractTemplates = ref<DocumentTemplateItem[]>([]);
 const selectedContractTemplateId = ref<string>('');
 const documentDate = ref(new Date().toISOString().slice(0, 10));
 const customerContracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const selectedCustomerContractId = ref<number | null>(props.order.customer_contract_id || null);
+const selectedDocumentRoleType = ref<string | null>(props.order.document_role_type || null);
 const ONE_TIME_CONTRACT_VALUE = 'one-time-contract';
 
 const DOCUMENT_TYPES = [
@@ -184,6 +200,22 @@ const selectedContractBinding = computed({
   },
   set: (value: string) => {
     void updateContractBinding(value);
+  },
+});
+const selectedContractTemplate = computed(() => contractTemplates.value.find((template) => template.id === selectedContractTemplateId.value) || null);
+const selectedOpenContract = computed(() => (
+  customerContracts.value.find((contract) => contract.id === selectedCustomerContractId.value) || null
+));
+const inheritedDocumentRoleType = computed(() => normalizeRoleType(
+  selectedDocumentRoleType.value
+    || selectedOpenContract.value?.document_role_type
+    || selectedContractTemplate.value?.document_role_type
+    || props.order.effective_document_role_type
+));
+const selectedDocumentRoleBinding = computed({
+  get: () => selectedDocumentRoleType.value || '',
+  set: (value: string) => {
+    void updateDocumentRoleBinding(value);
   },
 });
 
@@ -222,6 +254,19 @@ const updateContractBinding = async (value: string) => {
     emit('refresh');
   } catch (error) {
     setToast(`Ошибка выбора договора: ${getApiErrorMessage(error)}`, 'error');
+  }
+};
+
+const updateDocumentRoleBinding = async (value: string) => {
+  const nextRole = value ? normalizeRoleType(value) : null;
+  try {
+    selectedDocumentRoleType.value = nextRole;
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      document_role_type: nextRole,
+    });
+    emit('refresh');
+  } catch (error) {
+    setToast(`Ошибка выбора ролей: ${getApiErrorMessage(error)}`, 'error');
   }
 };
 
@@ -329,6 +374,7 @@ watch(() => props.order.id, () => {
   loadContractTemplates();
   loadCustomerContracts();
   selectedCustomerContractId.value = props.order.customer_contract_id || null;
+  selectedDocumentRoleType.value = props.order.document_role_type || null;
 }, { immediate: true });
 </script>
 
@@ -558,6 +604,19 @@ watch(() => props.order.id, () => {
               </button>
             </div>
             <p v-else-if="!selectedCustomerContractId && !hasOrderContract" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужен открытый договор или разовый договор заказа.</p>
+          </div>
+
+          <div class="mb-3 rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700/50 dark:bg-slate-900/40 dark:shadow-none">
+            <label class="mb-1 block text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Роли сторон в актах и счетах</label>
+            <select
+              v-model="selectedDocumentRoleBinding"
+              class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500/50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+            >
+              <option value="">По договору / шаблону · {{ getRoleLabel(inheritedDocumentRoleType) }}</option>
+              <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
           </div>
 
           <div v-if="documents.length" class="space-y-3">

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -18,6 +18,7 @@ import type {
   PaymentResponse,
   PaymentCurrency,
   FxRateResponse,
+  DocumentTemplateItem,
 } from '../../client';
 import { ManagerDocsService, ManagerOrdersService, ManagerContractsService, ManagerSettingsService } from '../../client';
 import { formatMoney } from './order-utils';
@@ -53,6 +54,7 @@ type ProductOption = {
 };
 type ProductLine = { product_id: number; product_query: string; quantity: number; price: number; cost: number };
 type ServiceLine = { service_id?: number | null; title: string; quantity: number; price: number; cost: number };
+type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
 
 type OrderDrawerDraft = {
   productLines: ProductLine[];
@@ -420,11 +422,26 @@ const DOCUMENT_TYPES = [
   { type: 'ttn1', label: 'ТТН-1' },
 ];
 
-const contractTemplates = ref<{id: string; name: string}[]>([]);
+const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
+  { value: 'seller_buyer', label: 'Продавец / Покупатель' },
+  { value: 'executor_customer', label: 'Исполнитель / Заказчик' },
+  { value: 'contractor_customer', label: 'Подрядчик / Заказчик' },
+];
+const normalizeRoleType = (value: unknown): DocumentRoleType => {
+  const raw = String(value || '').trim();
+  if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
+  return 'seller_buyer';
+};
+const getRoleLabel = (value?: string | null) => (
+  DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
+);
+
+const contractTemplates = ref<DocumentTemplateItem[]>([]);
 const selectedContractTemplateId = ref<string>('');
 const documentDate = ref(new Date().toISOString().slice(0, 10));
 const customerContracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const selectedCustomerContractId = ref<number | null>(null);
+const selectedDocumentRoleType = ref<string | null>(null);
 const ONE_TIME_CONTRACT_VALUE = 'one-time-contract';
 const datedDocumentTypes = new Set(['contract', 'act', 'tn2', 'ttn1']);
 const getDocumentDateForType = (type: string) => (
@@ -435,6 +452,22 @@ const oneTimeContractDocument = computed(() => (
     .filter((doc) => doc.doc_type === 'contract')
     .sort((a, b) => b.id - a.id)[0] || null
 ));
+const selectedContractTemplate = computed(() => contractTemplates.value.find((template) => template.id === selectedContractTemplateId.value) || null);
+const selectedOpenContract = computed(() => (
+  customerContracts.value.find((contract) => contract.id === selectedCustomerContractId.value) || null
+));
+const inheritedDocumentRoleType = computed(() => normalizeRoleType(
+  selectedDocumentRoleType.value
+    || selectedOpenContract.value?.document_role_type
+    || selectedContractTemplate.value?.document_role_type
+    || props.order?.effective_document_role_type
+));
+const selectedDocumentRoleBinding = computed({
+  get: () => selectedDocumentRoleType.value || '',
+  set: (value: string) => {
+    void updateDocumentRoleBinding(value);
+  },
+});
 const selectedContractBinding = computed({
   get: () => {
     if (selectedCustomerContractId.value) return `open:${selectedCustomerContractId.value}`;
@@ -503,6 +536,20 @@ const updateContractBinding = async (value: string) => {
     emit('reload', props.order.id);
   } catch (error) {
     setToast(`Ошибка выбора договора: ${getApiErrorMessage(error)}`, 'error');
+  }
+};
+
+const updateDocumentRoleBinding = async (value: string) => {
+  if (!props.order?.id) return;
+  const nextRole = value ? normalizeRoleType(value) : null;
+  try {
+    selectedDocumentRoleType.value = nextRole;
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      document_role_type: nextRole,
+    });
+    emit('reload', props.order.id);
+  } catch (error) {
+    setToast(`Ошибка выбора ролей: ${getApiErrorMessage(error)}`, 'error');
   }
 };
 
@@ -899,6 +946,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   loadDocuments(order.id);
   loadContractTemplates();
   selectedCustomerContractId.value = order.customer_contract_id || null;
+  selectedDocumentRoleType.value = order.document_role_type || null;
 
   const customerId = order.customer?.id;
   if (customerId) {
@@ -1845,6 +1893,19 @@ watch(
             </button>
           </div>
           <p v-else-if="!selectedCustomerContractId && !hasOrderContract" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов и накладных нужен открытый договор или разовый договор заказа.</p>
+        </div>
+
+        <div class="mb-3 rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700/50 dark:bg-slate-900/40 dark:shadow-none">
+          <label class="mb-1 block text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Роли сторон в актах и счетах</label>
+          <select
+            v-model="selectedDocumentRoleBinding"
+            class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500/50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+          >
+            <option value="">По договору / шаблону · {{ getRoleLabel(inheritedDocumentRoleType) }}</option>
+            <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
         </div>
 
         <div v-if="documents.length" class="space-y-3 mt-3">

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { ArrowLeft, Building2, Mail, Phone, Plus, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
 import CreateOrderModal from '../components/CreateOrderModal.vue';
 import { api } from '../api';
-import { ManagerContractsService, ManagerService, type ManagerCatalogCustomerItemResponse, type ManagerCustomerContractItemResponse, type ManagerCustomerDocumentItem } from '../client';
+import { ManagerContractsService, ManagerDocsService, ManagerService, type DocumentTemplateItem, type ManagerCatalogCustomerItemResponse, type ManagerCustomerContractItemResponse, type ManagerCustomerDocumentItem } from '../client';
 import { useBelarusPhoneMask } from '../composables/useBelarusPhoneMask';
 import { useB2BLookup } from '../composables/useB2BLookup';
 import { dispatchCustomerUpdated } from '../utils/customer-events';
@@ -56,6 +56,23 @@ const contractUploadSaving = ref(false);
 const showContractForm = ref(false);
 const showContractUploadForm = ref(false);
 const OPEN_CONTRACT_TEMPLATE_ID = '1x-pL1j9g-NzLSpPTLVYXSsmutGExPgfDqzi2VLq9thI';
+type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
+const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
+  { value: 'seller_buyer', label: 'Продавец / Покупатель' },
+  { value: 'executor_customer', label: 'Исполнитель / Заказчик' },
+  { value: 'contractor_customer', label: 'Подрядчик / Заказчик' },
+];
+const contractTemplates = ref<DocumentTemplateItem[]>([]);
+
+const normalizeRoleType = (value: unknown): DocumentRoleType => {
+  const raw = String(value || '').trim();
+  if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
+  return 'seller_buyer';
+};
+
+const getRoleLabel = (value?: string | null) => (
+  DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
+);
 
 const phoneError = ref('');
 const emailError = ref('');
@@ -119,11 +136,13 @@ const buildDefaultContractForm = () => {
   const start = new Date();
   const end = new Date(start);
   end.setFullYear(end.getFullYear() + 1);
+  const defaultTemplate = contractTemplates.value[0];
   return {
     number: '',
     contract_date: toInputDate(start),
     valid_until: toInputDate(end),
-    template_id: OPEN_CONTRACT_TEMPLATE_ID,
+    template_id: defaultTemplate?.id || OPEN_CONTRACT_TEMPLATE_ID,
+    document_role_type: normalizeRoleType(defaultTemplate?.document_role_type),
   };
 };
 
@@ -132,6 +151,7 @@ const contractUploadForm = ref({
   number: '',
   contract_date: buildDefaultContractForm().contract_date,
   valid_until: buildDefaultContractForm().valid_until,
+  document_role_type: buildDefaultContractForm().document_role_type,
   file: null as File | null,
 });
 
@@ -253,6 +273,20 @@ const loadCustomerContracts = async () => {
   }
 };
 
+const loadContractTemplates = async () => {
+  try {
+    const res = await ManagerDocsService.getDocTemplates('contract');
+    contractTemplates.value = res.items;
+  } catch (e) {
+    console.warn('Failed to load contract templates', e);
+  }
+};
+
+const syncContractRoleFromTemplate = () => {
+  const template = contractTemplates.value.find((item) => item.id === contractForm.value.template_id);
+  contractForm.value.document_role_type = normalizeRoleType(template?.document_role_type);
+};
+
 const openContractForm = () => {
   contractForm.value = buildDefaultContractForm();
   showContractUploadForm.value = false;
@@ -265,6 +299,7 @@ const openContractUploadForm = () => {
     number: '',
     contract_date: defaults.contract_date,
     valid_until: defaults.valid_until,
+    document_role_type: defaults.document_role_type,
     file: null,
   };
   showContractForm.value = false;
@@ -301,6 +336,7 @@ const createContract = async () => {
     const payload = {
       number: contractForm.value.number.trim() || null,
       template_id: contractForm.value.template_id.trim() || OPEN_CONTRACT_TEMPLATE_ID,
+      document_role_type: contractForm.value.document_role_type,
       contract_date: contractForm.value.contract_date ? `${contractForm.value.contract_date}T00:00:00` : null,
       valid_until: contractForm.value.valid_until ? `${contractForm.value.valid_until}T00:00:00` : null,
     };
@@ -331,6 +367,7 @@ const uploadContract = async () => {
       number: contractUploadForm.value.number.trim(),
       contract_date: `${contractUploadForm.value.contract_date}T00:00:00`,
       valid_until: `${contractUploadForm.value.valid_until}T00:00:00`,
+      document_role_type: contractUploadForm.value.document_role_type,
       file: contractUploadForm.value.file,
     });
     showContractUploadForm.value = false;
@@ -549,12 +586,14 @@ watch(customerId, () => {
   void loadCustomer();
   void loadCustomerDocs();
   void loadCustomerContracts();
+  void loadContractTemplates();
 });
 
 onMounted(() => {
   void loadCustomer();
   void loadCustomerDocs();
   void loadCustomerContracts();
+  void loadContractTemplates();
 });
 </script>
 
@@ -718,7 +757,17 @@ onMounted(() => {
               <input v-model="contractForm.number" class="field-input" type="text" placeholder="Номер, если уже известен" />
               <input v-model="contractForm.contract_date" class="field-input" type="date" @change="syncContractValidUntil" />
               <input v-model="contractForm.valid_until" class="field-input" type="date" />
-              <input v-model="contractForm.template_id" class="field-input" type="text" placeholder="Template ID" />
+              <select v-model="contractForm.template_id" class="field-input" @change="syncContractRoleFromTemplate">
+                <option v-for="template in contractTemplates" :key="template.id" :value="template.id">
+                  {{ template.name }}
+                </option>
+                <option v-if="!contractTemplates.length" :value="OPEN_CONTRACT_TEMPLATE_ID">Договор по умолчанию</option>
+              </select>
+              <select v-model="contractForm.document_role_type" class="field-input md:col-span-2">
+                <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
             </div>
             <div class="mt-3 flex justify-end gap-2">
               <button class="btn-mini-outline" type="button" @click="showContractForm = false">Отмена</button>
@@ -733,6 +782,11 @@ onMounted(() => {
               <input v-model="contractUploadForm.number" class="field-input" type="text" placeholder="Номер договора" required />
               <input v-model="contractUploadForm.contract_date" class="field-input" type="date" required @change="syncUploadContractValidUntil" />
               <input v-model="contractUploadForm.valid_until" class="field-input" type="date" required />
+              <select v-model="contractUploadForm.document_role_type" class="field-input">
+                <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
               <input class="field-input" type="file" accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" required @change="onContractUploadFileChange" />
             </div>
             <div class="mt-3 flex justify-end gap-2">
@@ -761,6 +815,9 @@ onMounted(() => {
                   </div>
                   <p class="mt-2 text-[13px] leading-none text-slate-500 dark:text-slate-400">
                     {{ formatDateOnly(contract.valid_from) }} - {{ formatDateOnly(contract.valid_until) }}
+                  </p>
+                  <p class="mt-2 text-[12px] leading-none text-slate-500 dark:text-slate-400">
+                    Роли: {{ getRoleLabel(contract.document_role_type) }}
                   </p>
                 </div>
               </div>

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -13,6 +13,18 @@ const toastType = ref<'success' | 'error'>('success');
 
 // A set to keep track of which settings are currently being saved
 const savingKeys = ref<Set<string>>(new Set());
+type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
+interface ContractTemplateForm {
+    id: string;
+    name: string;
+    document_role_type: DocumentRoleType;
+}
+const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
+    { value: 'seller_buyer', label: 'Продавец / Покупатель' },
+    { value: 'executor_customer', label: 'Исполнитель / Заказчик' },
+    { value: 'contractor_customer', label: 'Подрядчик / Заказчик' },
+];
+const contractTemplateDrafts = ref<Record<string, ContractTemplateForm[]>>({});
 
 // Create form
 const showCreateForm = ref(false);
@@ -87,11 +99,70 @@ const loadSettings = async () => {
     try {
         const res = await api.listManagerSettings();
         settings.value = res.items;
+        contractTemplateDrafts.value = Object.fromEntries(
+            res.items
+                .filter((setting) => setting.key === 'contract_templates')
+                .map((setting) => [setting.key, parseContractTemplates(setting.value)]),
+        );
     } catch (e) {
         error.value = getApiErrorMessage(e);
     } finally {
         loading.value = false;
     }
+};
+
+const normalizeRoleType = (value: unknown): DocumentRoleType => {
+    const raw = String(value || '').trim();
+    if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
+    return 'seller_buyer';
+};
+
+const parseContractTemplates = (raw: string): ContractTemplateForm[] => {
+    try {
+        const items = JSON.parse(raw || '[]');
+        if (!Array.isArray(items)) return [];
+        return items
+            .filter((item) => item && typeof item === 'object')
+            .map((item) => ({
+                id: String(item.id || '').trim(),
+                name: String(item.name || '').trim(),
+                document_role_type: normalizeRoleType(item.document_role_type),
+            }))
+            .filter((item) => item.id || item.name);
+    } catch {
+        return [];
+    }
+};
+
+const ensureContractTemplateDraft = (setting: ManagerSettingResponse) => {
+    if (!contractTemplateDrafts.value[setting.key]) {
+        contractTemplateDrafts.value[setting.key] = parseContractTemplates(setting.value);
+    }
+    return contractTemplateDrafts.value[setting.key] ?? [];
+};
+
+const addContractTemplateRow = (setting: ManagerSettingResponse) => {
+    ensureContractTemplateDraft(setting).push({
+        id: '',
+        name: '',
+        document_role_type: 'seller_buyer',
+    });
+};
+
+const removeContractTemplateRow = (setting: ManagerSettingResponse, index: number) => {
+    ensureContractTemplateDraft(setting).splice(index, 1);
+};
+
+const saveContractTemplates = async (setting: ManagerSettingResponse) => {
+    const rows = ensureContractTemplateDraft(setting)
+        .map((row) => ({
+            id: row.id.trim(),
+            name: row.name.trim(),
+            document_role_type: normalizeRoleType(row.document_role_type),
+        }))
+        .filter((row) => row.id && row.name);
+    setting.value = JSON.stringify(rows, null, 2);
+    await saveSetting(setting);
 };
 
 const saveSetting = async (setting: ManagerSettingResponse) => {
@@ -346,7 +417,63 @@ onMounted(() => {
                     </div>
                 </div>
                 
-                <div class="flex-1 w-full space-y-3">
+                <div v-if="setting.key === 'contract_templates'" class="flex-[2] w-full space-y-3">
+                    <div class="flex items-center justify-between gap-3">
+                        <label class="block text-xs font-medium text-gray-500 dark:text-slate-400">Шаблоны договоров</label>
+                        <button
+                            type="button"
+                            class="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-teal-700 bg-teal-50 hover:bg-teal-100 dark:bg-teal-500/10 dark:text-teal-300 dark:hover:bg-teal-500/20 rounded-lg"
+                            @click="addContractTemplateRow(setting)"
+                        >
+                            <span class="material-icons-round text-[16px]">add</span>
+                            Добавить шаблон
+                        </button>
+                    </div>
+                    <div class="space-y-2">
+                        <div
+                            v-for="(template, index) in ensureContractTemplateDraft(setting)"
+                            :key="`${setting.key}-${index}`"
+                            class="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1.4fr_220px_auto] md:items-center"
+                        >
+                            <input
+                                v-model="template.name"
+                                type="text"
+                                class="w-full bg-gray-50 dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors shadow-sm text-sm"
+                                placeholder="Название для менеджера"
+                                :disabled="savingKeys.has(setting.key)"
+                            />
+                            <input
+                                v-model="template.id"
+                                type="text"
+                                class="w-full bg-gray-50 dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors shadow-sm text-sm font-mono"
+                                placeholder="Google Template ID"
+                                :disabled="savingKeys.has(setting.key)"
+                            />
+                            <select
+                                v-model="template.document_role_type"
+                                class="w-full bg-gray-50 dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors shadow-sm text-sm"
+                                :disabled="savingKeys.has(setting.key)"
+                            >
+                                <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+                                    {{ option.label }}
+                                </option>
+                            </select>
+                            <button
+                                type="button"
+                                class="flex h-10 w-10 items-center justify-center rounded-lg text-red-500 transition-colors hover:bg-red-500/10"
+                                title="Удалить шаблон"
+                                :disabled="savingKeys.has(setting.key)"
+                                @click="removeContractTemplateRow(setting, index)"
+                            >
+                                <span class="material-icons-round text-[20px]">delete</span>
+                            </button>
+                        </div>
+                    </div>
+                    <p v-if="!ensureContractTemplateDraft(setting).length" class="text-sm text-gray-500 dark:text-slate-400">
+                        Шаблоны еще не добавлены.
+                    </p>
+                </div>
+                <div v-else class="flex-1 w-full space-y-3">
                     <div>
                         <label class="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1">Значение</label>
                         <input
@@ -370,7 +497,7 @@ onMounted(() => {
                 
                 <div class="md:w-32 flex-shrink-0 flex justify-end w-full md:block">
                     <button
-                        @click="saveSetting(setting)"
+                        @click="setting.key === 'contract_templates' ? saveContractTemplates(setting) : saveSetting(setting)"
                         class="w-full flex justify-center items-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-teal-600 hover:bg-teal-500 active:bg-teal-700 transition-colors rounded-lg disabled:opacity-50 shadow-sm"
                         :disabled="savingKeys.has(setting.key)"
                     >

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,6 @@
 from .common import (
     CustomerType,
+    DocumentRoleType,
     LeadIntakeSource,
     LeadLossReason,
     LeadSegmentHint,
@@ -60,6 +61,7 @@ __all__ = [
     "CustomerBranch",
     "CustomerContract",
     "CustomerType",
+    "DocumentRoleType",
     "Favorite",
     "GlobalConfig",
     "InstallationRate",

--- a/models/common.py
+++ b/models/common.py
@@ -73,6 +73,12 @@ class PaymentCurrency(str, Enum):
     EUR = "EUR"
 
 
+class DocumentRoleType(str, Enum):
+    SELLER_BUYER = "seller_buyer"
+    EXECUTOR_CUSTOMER = "executor_customer"
+    CONTRACTOR_CUSTOMER = "contractor_customer"
+
+
 class OrderStageStatus(str, Enum):
     PLANNED = "planned"
     IN_PROGRESS = "in_progress"

--- a/models/customer.py
+++ b/models/customer.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from sqlalchemy import Column, String
 from sqlmodel import Field, Relationship, SQLModel
 
-from .common import CustomerType, LeadIntakeSource, LeadLossReason, LeadSegmentHint, LeadStatus
+from .common import CustomerType, DocumentRoleType, LeadIntakeSource, LeadLossReason, LeadSegmentHint, LeadStatus
 
 
 class Customer(SQLModel, table=True):
@@ -65,6 +65,7 @@ class CustomerContract(SQLModel, table=True):
     status: str = Field(default="active", sa_column=Column(String, index=True))
 
     template_id: Optional[str] = None
+    document_role_type: Optional[DocumentRoleType] = Field(default=None, sa_column=Column(String, nullable=True))
     google_file_id: Optional[str] = None
     google_edit_url: Optional[str] = None
 

--- a/models/order.py
+++ b/models/order.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import BigInteger, Column, JSON, String
 from sqlmodel import Field, Relationship, SQLModel
 
-from .common import ClosingResult, EquipmentStatus, LeadSource, OrderStageStatus, OrderStatus, PaymentCurrency, PaymentType
+from .common import ClosingResult, DocumentRoleType, EquipmentStatus, LeadSource, OrderStageStatus, OrderStatus, PaymentCurrency, PaymentType
 
 class Installer(SQLModel, table=True):
     __tablename__ = "installers"
@@ -224,6 +224,7 @@ class Order(SQLModel, table=True):
     customer_contract_id: Optional[int] = Field(default=None, foreign_key="customer_contract.id", index=True)
 
     delivery_address: Optional[str] = None
+    document_role_type: Optional[DocumentRoleType] = Field(default=None, sa_column=Column(String, nullable=True))
 
     user_id: Optional[int] = Field(default=None, index=True)
 

--- a/openapi.json
+++ b/openapi.json
@@ -8777,6 +8777,17 @@
             "format": "date-time",
             "title": "Valid Until"
           },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
+          },
           "file": {
             "type": "string",
             "format": "binary",
@@ -9405,6 +9416,11 @@
           "name": {
             "type": "string",
             "title": "Name"
+          },
+          "document_role_type": {
+            "type": "string",
+            "title": "Document Role Type",
+            "default": "seller_buyer"
           }
         },
         "type": "object",
@@ -11606,6 +11622,17 @@
             ],
             "title": "Template Id"
           },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
+          },
           "contract_date": {
             "anyOf": [
               {
@@ -11672,6 +11699,11 @@
               }
             ],
             "title": "Template Id"
+          },
+          "document_role_type": {
+            "type": "string",
+            "title": "Document Role Type",
+            "default": "seller_buyer"
           },
           "edit_url": {
             "anyOf": [
@@ -11753,6 +11785,17 @@
               }
             ],
             "title": "Template Id"
+          },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
           },
           "contract_date": {
             "anyOf": [
@@ -13108,6 +13151,22 @@
               }
             ]
           },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
+          },
+          "effective_document_role_type": {
+            "type": "string",
+            "title": "Effective Document Role Type",
+            "default": "seller_buyer"
+          },
           "installer_id": {
             "anyOf": [
               {
@@ -13565,6 +13624,22 @@
                 "type": "null"
               }
             ]
+          },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
+          },
+          "effective_document_role_type": {
+            "type": "string",
+            "title": "Effective Document Role Type",
+            "default": "seller_buyer"
           },
           "installer_id": {
             "anyOf": [
@@ -14136,6 +14211,17 @@
               }
             ],
             "title": "Customer Contract Id"
+          },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
           },
           "customer_type": {
             "anyOf": [
@@ -15840,6 +15926,17 @@
           "status": {
             "type": "string",
             "title": "Status"
+          },
+          "document_role_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Role Type"
           },
           "edit_url": {
             "anyOf": [

--- a/routers/manager_contracts.py
+++ b/routers/manager_contracts.py
@@ -91,6 +91,7 @@ async def upload_manager_customer_contract(
     number: str = Form(...),
     contract_date: datetime = Form(...),
     valid_until: datetime = Form(...),
+    document_role_type: str | None = Form(None),
     file: UploadFile = File(...),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
@@ -102,6 +103,7 @@ async def upload_manager_customer_contract(
             number=number,
             contract_date=contract_date,
             valid_until=valid_until,
+            document_role_type=document_role_type,
             file=file,
         )
     except ValueError as exc:

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -142,7 +142,11 @@ async def get_doc_templates(
     items = await DocumentService.get_available_templates(session, doc_type)
     return {
         "items": [
-            DocumentTemplateItem(id=t["id"], name=t["name"])
+            DocumentTemplateItem(
+                id=t["id"],
+                name=t["name"],
+                document_role_type=t.get("document_role_type"),
+            )
             for t in items
         ]
     }

--- a/routers/manager_spa.py
+++ b/routers/manager_spa.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 from fastapi.responses import FileResponse, JSONResponse
 
 from core.app_constants import MANAGER_NOT_BUILT_MESSAGE
+from core.app_static import apply_manager_no_cache_headers
 
 
 def create_manager_spa_router(manager_dist: Path) -> APIRouter:
@@ -12,7 +13,7 @@ def create_manager_spa_router(manager_dist: Path) -> APIRouter:
 
     def _render_index_or_404():
         if index_path.exists():
-            return FileResponse(str(index_path))
+            return apply_manager_no_cache_headers(FileResponse(str(index_path)))
         return JSONResponse(status_code=404, content={"message": MANAGER_NOT_BUILT_MESSAGE})
 
     @router.get("/manager/{full_path:path}", include_in_schema=False)

--- a/schemas.py
+++ b/schemas.py
@@ -339,6 +339,7 @@ class OrderCustomerContractBrief(BaseModel):
     valid_from: datetime
     valid_until: datetime
     status: str
+    document_role_type: Optional[str] = None
     edit_url: Optional[str] = None
 
 
@@ -383,6 +384,8 @@ class ManagerOrderListItemResponse(BaseModel):
     customer_branch: Optional[OrderCustomerBranchBrief] = None
     customer_contract_id: Optional[int] = None
     customer_contract: Optional[OrderCustomerContractBrief] = None
+    document_role_type: Optional[str] = None
+    effective_document_role_type: str = "seller_buyer"
     installer_id: Optional[int] = None
     installer: Optional[ManagerInstallerResponse] = None
     # New fields
@@ -575,6 +578,7 @@ class ManagerOrderUpdatePayload(BaseModel):
     customer_id: Optional[int] = None
     customer_branch_id: Optional[int] = None
     customer_contract_id: Optional[int] = None
+    document_role_type: Optional[str] = None
     customer_type: Optional[str] = None
     customer_name: Optional[str] = None
     customer_phone: Optional[str] = None
@@ -622,6 +626,7 @@ class ManagerOrderDocumentResponse(BaseModel):
 class DocumentTemplateItem(BaseModel):
     id: str
     name: str
+    document_role_type: str = "seller_buyer"
 
 
 class DocumentTemplateListResponse(BaseModel):
@@ -871,6 +876,7 @@ class ManagerCustomerContractItemResponse(BaseModel):
     valid_until: datetime
     status: str
     template_id: Optional[str] = None
+    document_role_type: str = "seller_buyer"
     edit_url: Optional[str] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
@@ -883,6 +889,7 @@ class ManagerCustomerContractListResponse(BaseModel):
 class ManagerCustomerContractCreatePayload(BaseModel):
     number: Optional[str] = None
     template_id: Optional[str] = None
+    document_role_type: Optional[str] = None
     contract_date: Optional[datetime] = None
     valid_until: Optional[datetime] = None
 
@@ -890,6 +897,7 @@ class ManagerCustomerContractCreatePayload(BaseModel):
 class ManagerCustomerContractUpdatePayload(BaseModel):
     number: Optional[str] = None
     template_id: Optional[str] = None
+    document_role_type: Optional[str] = None
     contract_date: Optional[datetime] = None
     valid_until: Optional[datetime] = None
     status: Optional[str] = None

--- a/services/customer_contract_service.py
+++ b/services/customer_contract_service.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -5,7 +6,8 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import Customer, CustomerContract, CustomerType, Order
+from models import Customer, CustomerContract, CustomerType, GlobalConfig, Order
+from services.document_role_service import DocumentRoleService
 from services.google_service import get_google_service
 
 
@@ -43,6 +45,7 @@ class CustomerContractService:
             "valid_until": contract.valid_until,
             "status": contract.status,
             "template_id": contract.template_id,
+            "document_role_type": DocumentRoleService.normalize_role_type(contract.document_role_type),
             "edit_url": contract.google_edit_url,
             "created_at": contract.created_at,
             "updated_at": contract.updated_at,
@@ -59,6 +62,7 @@ class CustomerContractService:
             "valid_from": contract.valid_from,
             "valid_until": contract.valid_until,
             "status": contract.status,
+            "document_role_type": DocumentRoleService.normalize_role_type(contract.document_role_type),
             "edit_url": contract.google_edit_url,
         }
 
@@ -83,6 +87,7 @@ class CustomerContractService:
             "{{contract_date}}": CustomerContractService._format_date(contract.valid_from),
             "{{contract_valid_from}}": CustomerContractService._format_date(contract.valid_from),
             "{{contract_valid_until}}": CustomerContractService._format_date(contract.valid_until),
+            "{{document_role_type}}": DocumentRoleService.normalize_role_type(contract.document_role_type),
         }
 
     @staticmethod
@@ -116,6 +121,23 @@ class CustomerContractService:
         return f"ОД-{year}-{next_num:03d}"
 
     @staticmethod
+    async def _get_template_role_type(session: AsyncSession, template_id: Optional[str]) -> str:
+        if not template_id:
+            return DocumentRoleService.normalize_role_type(None)
+        try:
+            result = await session.execute(select(GlobalConfig).where(GlobalConfig.key == "contract_templates"))
+            config = result.scalars().first()
+            items = json.loads(config.value) if config and config.value else []
+        except Exception:
+            return DocumentRoleService.normalize_role_type(None)
+        if not isinstance(items, list):
+            return DocumentRoleService.normalize_role_type(None)
+        for item in items:
+            if isinstance(item, dict) and str(item.get("id") or "").strip() == template_id:
+                return DocumentRoleService.normalize_role_type(item.get("document_role_type"))
+        return DocumentRoleService.normalize_role_type(None)
+
+    @staticmethod
     async def create_for_customer(
         session: AsyncSession,
         *,
@@ -132,6 +154,9 @@ class CustomerContractService:
         valid_until = CustomerContractService._normalize_naive_datetime(payload.get("valid_until")) or CustomerContractService._default_valid_until(contract_date)
         number = str(payload.get("number") or "").strip() or await CustomerContractService._get_next_number(session, contract_date)
         template_id = str(payload.get("template_id") or "").strip() or OPEN_SERVICE_CONTRACT_TEMPLATE_ID
+        document_role_type = DocumentRoleService.normalize_role_type(
+            payload.get("document_role_type") or await CustomerContractService._get_template_role_type(session, template_id)
+        )
 
         contract = CustomerContract(
             customer_id=customer_id,
@@ -140,6 +165,7 @@ class CustomerContractService:
             valid_until=valid_until,
             status=CustomerContractService.ACTIVE_STATUS,
             template_id=template_id,
+            document_role_type=document_role_type,
         )
 
         title = f"Открытый договор {number} {customer.name}"
@@ -164,6 +190,7 @@ class CustomerContractService:
         number: str,
         contract_date: datetime,
         valid_until: datetime,
+        document_role_type: Optional[str] = None,
         file: "Any",
     ) -> Optional[Dict[str, Any]]:
         import os
@@ -208,6 +235,7 @@ class CustomerContractService:
                 valid_until=valid_until_value,
                 status=CustomerContractService.ACTIVE_STATUS,
                 template_id=None,
+                document_role_type=DocumentRoleService.normalize_role_type(document_role_type),
                 google_file_id=file_id,
                 google_edit_url=f"https://drive.google.com/file/d/{file_id}/view?usp=sharing",
             )
@@ -239,6 +267,8 @@ class CustomerContractService:
         if "template_id" in payload:
             template_id = str(payload.get("template_id") or "").strip()
             contract.template_id = template_id or None
+        if "document_role_type" in payload:
+            contract.document_role_type = DocumentRoleService.normalize_role_type(payload.get("document_role_type"))
         if "contract_date" in payload and payload.get("contract_date") is not None:
             contract.valid_from = CustomerContractService._normalize_naive_datetime(payload.get("contract_date"))
         if "valid_until" in payload and payload.get("valid_until") is not None:
@@ -249,7 +279,7 @@ class CustomerContractService:
                 raise ValueError("Некорректный статус договора")
             contract.status = status
 
-        if contract.google_file_id and any(field in payload for field in {"number", "contract_date", "valid_until"}):
+        if contract.google_file_id and any(field in payload for field in {"number", "contract_date", "valid_until", "document_role_type"}):
             customer = await session.get(Customer, customer_id)
             if customer:
                 get_google_service().replace_placeholders(

--- a/services/document_role_service.py
+++ b/services/document_role_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+from models import DocumentRoleType
+
+
+DEFAULT_DOCUMENT_ROLE_TYPE = DocumentRoleType.SELLER_BUYER.value
+
+
+@dataclass(frozen=True)
+class RoleForms:
+    nom: str
+    gen: str
+    dat: str
+    acc: str
+    ins: str
+    prep: str
+
+    def values(self) -> tuple[str, str, str, str, str, str]:
+        return (self.nom, self.gen, self.dat, self.acc, self.ins, self.prep)
+
+
+SELLER_FORMS = RoleForms("продавец", "продавца", "продавцу", "продавца", "продавцом", "продавце")
+BUYER_FORMS = RoleForms("покупатель", "покупателя", "покупателю", "покупателя", "покупателем", "покупателе")
+
+ROLE_FORMS: Dict[str, tuple[RoleForms, RoleForms]] = {
+    DocumentRoleType.SELLER_BUYER.value: (SELLER_FORMS, BUYER_FORMS),
+    DocumentRoleType.EXECUTOR_CUSTOMER.value: (
+        RoleForms("исполнитель", "исполнителя", "исполнителю", "исполнителя", "исполнителем", "исполнителе"),
+        RoleForms("заказчик", "заказчика", "заказчику", "заказчика", "заказчиком", "заказчике"),
+    ),
+    DocumentRoleType.CONTRACTOR_CUSTOMER.value: (
+        RoleForms("подрядчик", "подрядчика", "подрядчику", "подрядчика", "подрядчиком", "подрядчике"),
+        RoleForms("заказчик", "заказчика", "заказчику", "заказчика", "заказчиком", "заказчике"),
+    ),
+}
+
+ROLE_LABELS: Dict[str, str] = {
+    DocumentRoleType.SELLER_BUYER.value: "Продавец / Покупатель",
+    DocumentRoleType.EXECUTOR_CUSTOMER.value: "Исполнитель / Заказчик",
+    DocumentRoleType.CONTRACTOR_CUSTOMER.value: "Подрядчик / Заказчик",
+}
+
+
+class DocumentRoleService:
+    @staticmethod
+    def normalize_role_type(raw: Optional[Any]) -> str:
+        value = raw.value if hasattr(raw, "value") else raw
+        value = str(value or "").strip()
+        return value if value in ROLE_FORMS else DEFAULT_DOCUMENT_ROLE_TYPE
+
+    @staticmethod
+    def nullable_role_type(raw: Optional[Any]) -> Optional[str]:
+        if raw is None:
+            return None
+        value = raw.value if hasattr(raw, "value") else raw
+        value = str(value or "").strip()
+        if not value:
+            return None
+        if value not in ROLE_FORMS:
+            raise ValueError("Некорректный тип ролей сторон")
+        return value
+
+    @staticmethod
+    def effective_role_type(order: Any) -> str:
+        order_role = DocumentRoleService.normalize_role_type(getattr(order, "document_role_type", None))
+        if getattr(order, "document_role_type", None):
+            return order_role
+        contract = getattr(order, "customer_contract", None)
+        return DocumentRoleService.normalize_role_type(getattr(contract, "document_role_type", None))
+
+    @staticmethod
+    def role_options() -> list[dict[str, str]]:
+        return [{"value": value, "label": label} for value, label in ROLE_LABELS.items()]
+
+    @staticmethod
+    def role_label(raw: Optional[Any]) -> str:
+        return ROLE_LABELS[DocumentRoleService.normalize_role_type(raw)]
+
+    @staticmethod
+    def _with_capitalized_forms(words: Iterable[str]) -> list[str]:
+        result: list[str] = []
+        for word in words:
+            result.append(word)
+            result.append(word[:1].upper() + word[1:])
+        return result
+
+    @staticmethod
+    def build_word_replacements(raw_role_type: Optional[Any]) -> Dict[str, str]:
+        role_type = DocumentRoleService.normalize_role_type(raw_role_type)
+        if role_type == DEFAULT_DOCUMENT_ROLE_TYPE:
+            return {}
+
+        seller_target, buyer_target = ROLE_FORMS[role_type]
+        replacements: Dict[str, str] = {}
+        for source, target in zip(
+            DocumentRoleService._with_capitalized_forms(SELLER_FORMS.values()),
+            DocumentRoleService._with_capitalized_forms(seller_target.values()),
+        ):
+            replacements[source] = target
+        for source, target in zip(
+            DocumentRoleService._with_capitalized_forms(BUYER_FORMS.values()),
+            DocumentRoleService._with_capitalized_forms(buyer_target.values()),
+        ):
+            replacements[source] = target
+        return replacements

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -10,6 +10,7 @@ from models import CustomerType, OrderDocument, Order, GlobalConfig
 from services.google_service import get_google_service
 from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
+from services.document_role_service import DocumentRoleService
 
 
 class DocumentService:
@@ -38,14 +39,48 @@ class DocumentService:
                 if config and config.value:
                     items = json.loads(config.value)
                     if isinstance(items, list) and len(items) > 0:
-                        return items
+                        normalized_items = []
+                        for item in items:
+                            if not isinstance(item, dict):
+                                continue
+                            normalized_item = DocumentService._normalize_template_item(item)
+                            if normalized_item:
+                                normalized_items.append(normalized_item)
+                        if normalized_items:
+                            return normalized_items
             except Exception:
                 pass
 
         # Fallback: единственный шаблон по умолчанию
         if default_id:
-            return [{"id": default_id, "name": f"{default_name} (по умолчанию)"}]
+            return [{
+                "id": default_id,
+                "name": f"{default_name} (по умолчанию)",
+                "document_role_type": DocumentRoleService.normalize_role_type(None),
+            }]
         return []
+
+    @staticmethod
+    def _normalize_template_item(item: dict) -> dict:
+        template_id = str(item.get("id") or "").strip()
+        name = str(item.get("name") or "").strip() or template_id
+        if not template_id:
+            return {}
+        return {
+            "id": template_id,
+            "name": name,
+            "document_role_type": DocumentRoleService.normalize_role_type(item.get("document_role_type")),
+        }
+
+    @staticmethod
+    async def _get_contract_template_role_type(session: AsyncSession, template_id: Optional[str]) -> str:
+        if not template_id:
+            return DocumentRoleService.normalize_role_type(None)
+        templates = await DocumentService.get_available_templates(session, "contract")
+        for template in templates:
+            if template.get("id") == template_id:
+                return DocumentRoleService.normalize_role_type(template.get("document_role_type"))
+        return DocumentRoleService.normalize_role_type(None)
     
     @staticmethod
     async def create_or_get_document(
@@ -300,6 +335,8 @@ class DocumentService:
         strategy = DocumentFactory.get_strategy(doc_type, session, order_id)
         await strategy.fetch_order()
         if doc_type == "contract" and strategy.order:
+            if not strategy.order.document_role_type:
+                strategy.order.document_role_type = await DocumentService._get_contract_template_role_type(session, template_id)
             strategy.order.contract_date = effective_doc_date
             session.add(strategy.order)
         replacements = await strategy._prepare_base_variables(
@@ -354,6 +391,12 @@ class DocumentService:
             
             # 6. Заменяем плейсхолдеры в документе
             get_google_service().replace_placeholders(file_id, replacements)
+            if doc_type in {"act", "invoice"} and strategy.order:
+                role_replacements = DocumentRoleService.build_word_replacements(
+                    DocumentRoleService.effective_role_type(strategy.order)
+                )
+                if role_replacements:
+                    get_google_service().replace_placeholders(file_id, role_replacements)
             
             # 7. Заполняем таблицу (если есть данные)
             table_data = strategy._prepare_table_data() if hasattr(strategy, '_prepare_table_data') else []
@@ -382,7 +425,8 @@ class DocumentService:
             order = await session.get(Order, order_id)
             if order and order.status in ["new_lead", "measurement"]:
                 from models.common import OrderStatus
-                order.status = OrderStatus.PROPOSAL
+                order.status = OrderStatus.NEGOTIATION
+                order.proposal_status = "sent"
                 session.add(order)
 
         await session.commit()

--- a/services/documents/base.py
+++ b/services/documents/base.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 from num2words import num2words
 
 from models import Order, OrderProductLink, OrderServiceLink, CustomerType
+from services.document_role_service import DocumentRoleService
 
 # Template IDs
 TEMPLATES = {
@@ -39,6 +40,7 @@ class BaseDocumentStrategy(ABC):
     async def fetch_order(self) -> None:
         query = select(Order).where(Order.id == self.order_id).options(
             selectinload(Order.customer),
+            selectinload(Order.customer_branch),
             selectinload(Order.customer_contract),
             selectinload(Order.product_links).selectinload(OrderProductLink.product),
             selectinload(Order.service_links).selectinload(OrderServiceLink.service)
@@ -101,6 +103,7 @@ class BaseDocumentStrategy(ABC):
             "{{date}}": effective_date.strftime("%d.%m.%Y"),
             "{{total_amount}}": f"{order.total_amount:.2f}",
             "{{total_amount_in_words}}": self._amount_in_words(order.total_amount), 
+            "{{object_address}}": order.delivery_address or (order.customer_branch.delivery_address if order.customer_branch else "") or "",
             
             # Defaults
             "{{client_name}}": "Клиент",
@@ -123,6 +126,7 @@ class BaseDocumentStrategy(ABC):
             "{{contract_valid_until}}": "-",
             "{{act_number}}": "1",
             "{{act_sequence_number}}": "1",
+            "{{document_role_type}}": DocumentRoleService.effective_role_type(order),
         }
 
         # A one-time contract document must always use its own generated number/date,

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -10,6 +10,7 @@ from crud.order import OrderDAO
 from crud.product import ProductDAO
 from models import Order, OrderProductLink, OrderServiceLink, Customer, CustomerBranch, CustomerContract, CustomerType, OrderStatus, PaymentCurrency, Product, LeadSource, Service, OrderInstaller, OrderWorkStage
 from services.customer_contract_service import CustomerContractService
+from services.document_role_service import DocumentRoleService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
 
 logger = logging.getLogger(__name__)
@@ -1005,6 +1006,10 @@ class OrderService:
             "comment": order.comment,
             "delivery_address": order.delivery_address,
             "customer_contract_id": order.customer_contract_id,
+            "document_role_type": (
+                order.document_role_type.value if hasattr(order.document_role_type, "value") else order.document_role_type
+            ),
+            "effective_document_role_type": DocumentRoleService.effective_role_type(order),
             "closing_result": order.closing_result,
             "reject_reason": order.reject_reason,
             "is_on_hold": bool(order.is_on_hold),
@@ -1279,6 +1284,8 @@ class OrderService:
             order.is_paid = payload.is_paid
         if "customer_delivery_address" in fields_set:
             order.delivery_address = payload.customer_delivery_address
+        if "document_role_type" in fields_set:
+            order.document_role_type = DocumentRoleService.nullable_role_type(payload.document_role_type)
         # New fields
         if "closing_result" in fields_set:
             order.closing_result = payload.closing_result

--- a/tests/integration/test_manager_customers_api.py
+++ b/tests/integration/test_manager_customers_api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from sqlmodel import select
 
 from core.config import settings
-from models import Customer, CustomerBranch, CustomerContract, CustomerType, Order, OrderStatus
+from models import Customer, CustomerBranch, CustomerContract, CustomerType, GlobalConfig, Order, OrderStatus
 
 
 async def _auth_headers(async_client):
@@ -287,6 +287,13 @@ async def test_manager_customer_contract_create_and_dashboard_notice(async_clien
         legal_address="Минск, Победителей 1",
     )
     db.add(customer)
+    db.add(
+        GlobalConfig(
+            key="contract_templates",
+            value='[{"id":"service-template","name":"Сервис","document_role_type":"executor_customer"}]',
+            description="Contract templates",
+        )
+    )
     await db.commit()
     await db.refresh(customer)
 
@@ -296,6 +303,7 @@ async def test_manager_customer_contract_create_and_dashboard_notice(async_clien
         json={
             "contract_date": "2026-01-15T00:00:00",
             "valid_until": "2027-01-15T00:00:00",
+            "template_id": "service-template",
         },
     )
     assert create_resp.status_code == 200
@@ -303,9 +311,10 @@ async def test_manager_customer_contract_create_and_dashboard_notice(async_clien
     assert created["number"].startswith("ОД-2026-")
     assert created["status"] == "active"
     assert created["edit_url"].endswith("/edit")
-    assert captured["template_id"] == "1x-pL1j9g-NzLSpPTLVYXSsmutGExPgfDqzi2VLq9thI"
+    assert captured["template_id"] == "service-template"
     assert captured["replacements"]["{{contract_valid_until}}"] == "15.01.2027"
     assert captured["replacements"]["{{contract_number}}"] == created["number"]
+    assert created["document_role_type"] == "executor_customer"
 
     list_resp = await async_client.get(f"/api/manager/customers/{customer.id}/contracts", headers=headers)
     assert list_resp.status_code == 200

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -8,6 +8,7 @@ from models import (
     CustomerBranch,
     CustomerContract,
     CustomerType,
+    GlobalConfig,
     Installer,
     Order,
     OrderDocument,
@@ -105,7 +106,7 @@ async def test_manager_order_detail_uses_snapshot_prices(async_client, db):
     await db.refresh(customer)
     await db.refresh(product)
 
-    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD, delivery_address="Минск, объект 1")
     db.add(order)
     await db.commit()
     await db.refresh(order)
@@ -254,7 +255,7 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
         google_file_id="fake",
         google_edit_url="https://docs.google.com/document/d/fake/edit",
     )
-    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD, delivery_address="Минск, объект 1")
     db.add(contract)
     db.add(order)
     await db.commit()
@@ -326,6 +327,7 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
     assert first_act.status_code == 200
     assert captured_replacements[-1]["{{act_number}}"] == "1"
     assert captured_replacements[-1]["{{act_sequence_number}}"] == "1"
+    assert captured_replacements[-1]["{{object_address}}"] == "Минск, объект 1"
 
     second_order = Order(customer_id=customer.id, customer_contract_id=contract.id, status=OrderStatus.NEW_LEAD)
     db.add(second_order)
@@ -336,6 +338,98 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
     assert second_act.status_code == 200
     assert captured_replacements[-1]["{{act_number}}"] == "2"
     assert captured_replacements[-1]["{{act_sequence_number}}"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_manager_document_roles_from_template_contract_and_order_override(async_client, db, monkeypatch):
+    headers = await _auth_headers(async_client)
+    db.add(
+        GlobalConfig(
+            key="contract_templates",
+            value='[{"id":"tpl-service","name":"Услуги","document_role_type":"executor_customer"},{"id":"tpl-old","name":"Старый"}]',
+            description="Contract templates",
+        )
+    )
+    customer = Customer(name="Role Customer", phone="+375296009988", type=CustomerType.company, inn="123456789")
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    templates_resp = await async_client.get("/api/manager/docs/templates/contract", headers=headers)
+    assert templates_resp.status_code == 200
+    templates = templates_resp.json()["items"]
+    assert next(item for item in templates if item["id"] == "tpl-service")["document_role_type"] == "executor_customer"
+    assert next(item for item in templates if item["id"] == "tpl-old")["document_role_type"] == "seller_buyer"
+
+    captured_replacements = []
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            return {
+                "file_id": f"role-fake-{len(captured_replacements) + 1}",
+                "edit_url": f"https://docs.google.com/document/d/role-fake-{len(captured_replacements) + 1}/edit",
+            }
+
+        def replace_placeholders(self, file_id, replacements):
+            captured_replacements.append(dict(replacements))
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    one_time_order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD, delivery_address="Витебск, объект")
+    db.add(one_time_order)
+    await db.commit()
+    await db.refresh(one_time_order)
+
+    contract_resp = await async_client.post(
+        f"/api/manager/orders/{one_time_order.id}/documents/contract",
+        headers=headers,
+        params={"template_id": "tpl-service", "contract_date": "2026-04-27T00:00:00"},
+    )
+    assert contract_resp.status_code == 200
+    assert all("продавцом" not in replacements for replacements in captured_replacements)
+    refreshed_order = await db.get(Order, one_time_order.id)
+    assert refreshed_order.document_role_type == "executor_customer"
+
+    act_resp = await async_client.post(f"/api/manager/orders/{one_time_order.id}/documents/act", headers=headers)
+    assert act_resp.status_code == 200
+    assert captured_replacements[-2]["{{object_address}}"] == "Витебск, объект"
+    assert captured_replacements[-1]["продавцом"] == "исполнителем"
+    assert captured_replacements[-1]["покупателя"] == "заказчика"
+
+    contract = CustomerContract(
+        customer_id=customer.id,
+        number="ОД-2026-555",
+        valid_from=datetime(2026, 1, 1),
+        valid_until=datetime(2026, 12, 31),
+        status="active",
+        document_role_type="executor_customer",
+        google_file_id="fake-contract",
+        google_edit_url="https://docs.google.com/document/d/fake-contract/edit",
+    )
+    override_order = Order(
+        customer_id=customer.id,
+        customer_contract_id=None,
+        status=OrderStatus.NEW_LEAD,
+        document_role_type="contractor_customer",
+    )
+    db.add(contract)
+    db.add(override_order)
+    await db.commit()
+    await db.refresh(contract)
+    override_order.customer_contract_id = contract.id
+    db.add(override_order)
+    await db.commit()
+    await db.refresh(override_order)
+
+    invoice_resp = await async_client.post(f"/api/manager/orders/{override_order.id}/documents/invoice", headers=headers)
+    assert invoice_resp.status_code == 200, invoice_resp.text
+    assert captured_replacements[-1]["продавцом"] == "подрядчиком"
+
+    offer_resp = await async_client.post(f"/api/manager/orders/{override_order.id}/documents/offer", headers=headers)
+    assert offer_resp.status_code == 200
+    assert "продавцом" not in captured_replacements[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_document_role_service.py
+++ b/tests/unit/test_document_role_service.py
@@ -1,0 +1,21 @@
+from services.document_role_service import DocumentRoleService
+
+
+def test_executor_customer_role_replacements():
+    replacements = DocumentRoleService.build_word_replacements("executor_customer")
+
+    assert replacements["продавцом"] == "исполнителем"
+    assert replacements["покупателя"] == "заказчика"
+    assert replacements["Продавец"] == "Исполнитель"
+
+
+def test_contractor_customer_role_replacements():
+    replacements = DocumentRoleService.build_word_replacements("contractor_customer")
+
+    assert replacements["продавцом"] == "подрядчиком"
+    assert replacements["покупателем"] == "заказчиком"
+
+
+def test_seller_buyer_role_replacements_are_empty():
+    assert DocumentRoleService.build_word_replacements("seller_buyer") == {}
+    assert DocumentRoleService.build_word_replacements(None) == {}

--- a/tests/unit/test_manager_spa_cache_headers.py
+++ b/tests/unit/test_manager_spa_cache_headers.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core.app_static import mount_manager_assets
+from routers.manager_spa import create_manager_spa_router
+
+
+@pytest.fixture()
+async def manager_client(tmp_path: Path):
+    dist = tmp_path / "dist"
+    assets = dist / "assets"
+    assets.mkdir(parents=True)
+    (dist / "index.html").write_text('<script src="/manager/assets/index-test.js"></script>')
+    (assets / "index-test.js").write_text("import('./OrdersKanbanView-test.js')")
+    (assets / "OrdersKanbanView-test.js").write_text("export default {}")
+    (assets / "index-test.css").write_text("body{}")
+    (assets / "logo.svg").write_text("<svg></svg>")
+
+    app = FastAPI()
+    mount_manager_assets(app, dist)
+    app.include_router(create_manager_spa_router(dist))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_manager_index_disables_cache(manager_client):
+    response = await manager_client.get("/manager/")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+    assert response.headers["pragma"] == "no-cache"
+    assert response.headers["expires"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_manager_js_and_css_chunks_disable_cache(manager_client):
+    js_response = await manager_client.get("/manager/assets/index-test.js")
+    css_response = await manager_client.get("/manager/assets/index-test.css")
+
+    assert js_response.status_code == 200
+    assert css_response.status_code == 200
+    assert js_response.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+    assert css_response.headers["cache-control"] == "no-store, no-cache, must-revalidate, max-age=0"
+
+
+@pytest.mark.asyncio
+async def test_manager_other_assets_keep_default_cache_headers(manager_client):
+    response = await manager_client.get("/manager/assets/logo.svg")
+
+    assert response.status_code == 200
+    assert "cache-control" not in response.headers


### PR DESCRIPTION
## Summary

- add `document_role_type` for orders and customer open contracts with seller/buyer fallback
- resolve role defaults from contract templates and allow order-level overrides for acts/invoices
- add role word-form replacements for act/invoice only, plus `{{object_address}}`
- add manager UI for contract template role defaults, contract role selection, and order override/reset
- disable stale manager SPA JS/CSS caching so rebuilt lazy chunks do not break orders/customers

## Validation

- `python3 -m py_compile core/app_static.py routers/manager_spa.py services/document_role_service.py services/document_service.py services/customer_contract_service.py services/documents/base.py services/order_service.py`
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin DATABASE_URL=sqlite+aiosqlite:///./test.db python3 -m pytest tests/unit/test_document_role_service.py tests/unit/test_manager_spa_cache_headers.py -q`
- `npm run build` in `manager_frontend`
- `docker compose exec -T -e POSTGRES_PASSWORD=securepass -e TEST_DB_HOST=db_test -e TEST_DB_PORT=5432 app pytest tests/unit/test_document_role_service.py tests/unit/test_manager_spa_cache_headers.py tests/integration/test_manager_orders_api.py tests/integration/test_manager_customers_api.py -q`

## Notes

The local manager outage during testing was caused by the new DB columns not being migrated yet; `alembic upgrade head` fixed the local schema.
