### PR TITLE
[codex] create open contracts from flagged templates

### DIFF
--- a/manager_frontend/src/client/models/Body_upload_manager_customer_contract.ts
+++ b/manager_frontend/src/client/models/Body_upload_manager_customer_contract.ts
@@ -6,6 +6,7 @@ export type Body_upload_manager_customer_contract = {
     number: string;
     contract_date: string;
     valid_until: string;
+    template_id?: (string | null);
     document_role_type?: (string | null);
     file: Blob;
 };

--- a/manager_frontend/src/client/models/DocumentTemplateItem.ts
+++ b/manager_frontend/src/client/models/DocumentTemplateItem.ts
@@ -6,5 +6,6 @@ export type DocumentTemplateItem = {
     id: string;
     name: string;
     document_role_type?: string;
+    is_open_contract?: boolean;
 };
 

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -290,9 +290,9 @@ const loadDocuments = async () => {
 const loadContractTemplates = async () => {
   try {
     const res = await ManagerDocsService.getDocTemplates('contract');
-    contractTemplates.value = res.items;
-    if (res.items.length > 0 && res.items[0]) {
-      selectedContractTemplateId.value = res.items[0].id;
+    contractTemplates.value = res.items.filter((template) => !template.is_open_contract);
+    if (contractTemplates.value.length > 0 && contractTemplates.value[0]) {
+      selectedContractTemplateId.value = contractTemplates.value[0].id;
     }
   } catch (e) {
     console.warn('Failed to load contract templates', e);

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -482,9 +482,9 @@ const selectedContractBinding = computed({
 const loadContractTemplates = async () => {
   try {
     const res = await ManagerDocsService.getDocTemplates('contract');
-    contractTemplates.value = res.items;
-    if (res.items.length > 0 && res.items[0]) {
-      selectedContractTemplateId.value = res.items[0].id;
+    contractTemplates.value = res.items.filter((template) => !template.is_open_contract);
+    if (contractTemplates.value.length > 0 && contractTemplates.value[0]) {
+      selectedContractTemplateId.value = contractTemplates.value[0].id;
     }
   } catch (e) {
     console.warn('Failed to load contract templates', e);

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -53,11 +53,8 @@ const contracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const contractsLoading = ref(false);
 const contractSaving = ref(false);
 const contractUploadSaving = ref(false);
-const contractRoleSavingId = ref<number | null>(null);
-const contractRoleErrors = ref<Record<number, string>>({});
 const showContractForm = ref(false);
 const showContractUploadForm = ref(false);
-const OPEN_CONTRACT_TEMPLATE_ID = '1x-pL1j9g-NzLSpPTLVYXSsmutGExPgfDqzi2VLq9thI';
 type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
 const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
   { value: 'seller_buyer', label: 'Продавец / Покупатель' },
@@ -65,11 +62,21 @@ const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> =
   { value: 'contractor_customer', label: 'Подрядчик / Заказчик' },
 ];
 const contractTemplates = ref<DocumentTemplateItem[]>([]);
+const openContractTemplates = computed(() => contractTemplates.value.filter((template) => template.is_open_contract));
 
 const normalizeRoleType = (value: unknown): DocumentRoleType => {
   const raw = String(value || '').trim();
   if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
   return 'seller_buyer';
+};
+
+const getRoleLabel = (value?: string | null) => (
+  DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
+);
+
+const getTemplateRoleLabel = (templateId?: string | null) => {
+  const template = contractTemplates.value.find((item) => item.id === templateId);
+  return getRoleLabel(template?.document_role_type);
 };
 
 const phoneError = ref('');
@@ -134,13 +141,12 @@ const buildDefaultContractForm = () => {
   const start = new Date();
   const end = new Date(start);
   end.setFullYear(end.getFullYear() + 1);
-  const defaultTemplate = contractTemplates.value[0];
+  const defaultTemplate = openContractTemplates.value[0];
   return {
     number: '',
     contract_date: toInputDate(start),
     valid_until: toInputDate(end),
-    template_id: defaultTemplate?.id || OPEN_CONTRACT_TEMPLATE_ID,
-    document_role_type: normalizeRoleType(defaultTemplate?.document_role_type),
+    template_id: defaultTemplate?.id || '',
   };
 };
 
@@ -149,7 +155,7 @@ const contractUploadForm = ref({
   number: '',
   contract_date: buildDefaultContractForm().contract_date,
   valid_until: buildDefaultContractForm().valid_until,
-  document_role_type: buildDefaultContractForm().document_role_type,
+  template_id: buildDefaultContractForm().template_id,
   file: null as File | null,
 });
 
@@ -280,24 +286,27 @@ const loadContractTemplates = async () => {
   }
 };
 
-const syncContractRoleFromTemplate = () => {
-  const template = contractTemplates.value.find((item) => item.id === contractForm.value.template_id);
-  contractForm.value.document_role_type = normalizeRoleType(template?.document_role_type);
-};
-
 const openContractForm = () => {
+  if (!openContractTemplates.value.length) {
+    setToast('В настройках нет шаблонов, отмеченных как открытый договор');
+    return;
+  }
   contractForm.value = buildDefaultContractForm();
   showContractUploadForm.value = false;
   showContractForm.value = true;
 };
 
 const openContractUploadForm = () => {
+  if (!openContractTemplates.value.length) {
+    setToast('В настройках нет шаблонов, отмеченных как открытый договор');
+    return;
+  }
   const defaults = buildDefaultContractForm();
   contractUploadForm.value = {
     number: '',
     contract_date: defaults.contract_date,
     valid_until: defaults.valid_until,
-    document_role_type: defaults.document_role_type,
+    template_id: defaults.template_id,
     file: null,
   };
   showContractForm.value = false;
@@ -329,12 +338,15 @@ const onContractUploadFileChange = (event: Event) => {
 
 const createContract = async () => {
   if (!customerId.value) return;
+  if (!contractForm.value.template_id.trim()) {
+    setToast('Выберите шаблон открытого договора');
+    return;
+  }
   contractSaving.value = true;
   try {
     const payload = {
       number: contractForm.value.number.trim() || null,
-      template_id: contractForm.value.template_id.trim() || OPEN_CONTRACT_TEMPLATE_ID,
-      document_role_type: contractForm.value.document_role_type,
+      template_id: contractForm.value.template_id.trim(),
       contract_date: contractForm.value.contract_date ? `${contractForm.value.contract_date}T00:00:00` : null,
       valid_until: contractForm.value.valid_until ? `${contractForm.value.valid_until}T00:00:00` : null,
     };
@@ -359,13 +371,17 @@ const uploadContract = async () => {
     setToast('Выберите файл договора');
     return;
   }
+  if (!contractUploadForm.value.template_id.trim()) {
+    setToast('Выберите шаблон открытого договора');
+    return;
+  }
   contractUploadSaving.value = true;
   try {
     await ManagerContractsService.uploadManagerCustomerContract(customerId.value, {
       number: contractUploadForm.value.number.trim(),
       contract_date: `${contractUploadForm.value.contract_date}T00:00:00`,
       valid_until: `${contractUploadForm.value.valid_until}T00:00:00`,
-      document_role_type: contractUploadForm.value.document_role_type,
+      template_id: contractUploadForm.value.template_id.trim(),
       file: contractUploadForm.value.file,
     });
     showContractUploadForm.value = false;
@@ -376,40 +392,6 @@ const uploadContract = async () => {
   } finally {
     contractUploadSaving.value = false;
   }
-};
-
-const updateContractRole = async (contract: ManagerCustomerContractItemResponse, roleType: string) => {
-  if (!customerId.value) return;
-  const nextRole = normalizeRoleType(roleType);
-  const previousRole = normalizeRoleType(contract.document_role_type);
-  if (nextRole === previousRole) return;
-
-  contract.document_role_type = nextRole;
-  contractRoleSavingId.value = contract.id;
-  contractRoleErrors.value = { ...contractRoleErrors.value, [contract.id]: '' };
-  try {
-    const updated = await ManagerContractsService.patchManagerCustomerContract(
-      customerId.value,
-      contract.id,
-      { document_role_type: nextRole },
-    );
-    contracts.value = contracts.value.map((item) => (item.id === contract.id ? updated : item));
-    setToast('Роли договора обновлены');
-  } catch (e) {
-    contract.document_role_type = previousRole;
-    const message = `Не удалось сохранить роли: ${getApiErrorMessage(e)}`;
-    contractRoleErrors.value = { ...contractRoleErrors.value, [contract.id]: message };
-    setToast(message);
-  } finally {
-    if (contractRoleSavingId.value === contract.id) {
-      contractRoleSavingId.value = null;
-    }
-  }
-};
-
-const onContractRoleChange = (contract: ManagerCustomerContractItemResponse, event: Event) => {
-  const select = event.target as HTMLSelectElement;
-  void updateContractRole(contract, select.value);
 };
 
 const archiveContract = async (contract: ManagerCustomerContractItemResponse) => {
@@ -789,17 +771,14 @@ onMounted(() => {
               <input v-model="contractForm.number" class="field-input" type="text" placeholder="Номер, если уже известен" />
               <input v-model="contractForm.contract_date" class="field-input" type="date" @change="syncContractValidUntil" />
               <input v-model="contractForm.valid_until" class="field-input" type="date" />
-              <select v-model="contractForm.template_id" class="field-input" @change="syncContractRoleFromTemplate">
-                <option v-for="template in contractTemplates" :key="template.id" :value="template.id">
+              <select v-model="contractForm.template_id" class="field-input">
+                <option v-for="template in openContractTemplates" :key="template.id" :value="template.id">
                   {{ template.name }}
                 </option>
-                <option v-if="!contractTemplates.length" :value="OPEN_CONTRACT_TEMPLATE_ID">Договор по умолчанию</option>
               </select>
-              <select v-model="contractForm.document_role_type" class="field-input md:col-span-2">
-                <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
-                  {{ option.label }}
-                </option>
-              </select>
+              <p class="md:col-span-4 text-xs text-[var(--mv-text-muted)]">
+                Роли берутся из выбранного шаблона: {{ getTemplateRoleLabel(contractForm.template_id) }}
+              </p>
             </div>
             <div class="mt-3 flex justify-end gap-2">
               <button class="btn-mini-outline" type="button" @click="showContractForm = false">Отмена</button>
@@ -814,12 +793,15 @@ onMounted(() => {
               <input v-model="contractUploadForm.number" class="field-input" type="text" placeholder="Номер договора" required />
               <input v-model="contractUploadForm.contract_date" class="field-input" type="date" required @change="syncUploadContractValidUntil" />
               <input v-model="contractUploadForm.valid_until" class="field-input" type="date" required />
-              <select v-model="contractUploadForm.document_role_type" class="field-input">
-                <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
-                  {{ option.label }}
+              <select v-model="contractUploadForm.template_id" class="field-input">
+                <option v-for="template in openContractTemplates" :key="template.id" :value="template.id">
+                  {{ template.name }}
                 </option>
               </select>
               <input class="field-input" type="file" accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" required @change="onContractUploadFileChange" />
+              <p class="md:col-span-4 text-xs text-[var(--mv-text-muted)]">
+                Роли загруженного договора будут взяты из выбранного шаблона: {{ getTemplateRoleLabel(contractUploadForm.template_id) }}
+              </p>
             </div>
             <div class="mt-3 flex justify-end gap-2">
               <button class="btn-mini-outline" type="button" @click="showContractUploadForm = false">Отмена</button>
@@ -848,27 +830,8 @@ onMounted(() => {
                   <p class="mt-2 text-[13px] leading-none text-slate-500 dark:text-slate-400">
                     {{ formatDateOnly(contract.valid_from) }} - {{ formatDateOnly(contract.valid_until) }}
                   </p>
-                  <div class="mt-2 flex flex-wrap items-center gap-2">
-                    <label class="text-[12px] leading-none text-slate-500 dark:text-slate-400" :for="`contract-role-${contract.id}`">
-                      Роли:
-                    </label>
-                    <select
-                      :id="`contract-role-${contract.id}`"
-                      class="field-input max-w-[260px] py-1 text-[12px]"
-                      :disabled="contractRoleSavingId === contract.id"
-                      :value="normalizeRoleType(contract.document_role_type)"
-                      @change="onContractRoleChange(contract, $event)"
-                    >
-                      <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
-                        {{ option.label }}
-                      </option>
-                    </select>
-                    <span v-if="contractRoleSavingId === contract.id" class="text-[12px] text-slate-500 dark:text-slate-400">
-                      Сохраняем...
-                    </span>
-                  </div>
-                  <p v-if="contractRoleErrors[contract.id]" class="mt-1 text-[12px] text-red-500">
-                    {{ contractRoleErrors[contract.id] }}
+                  <p class="mt-2 text-[12px] leading-none text-slate-500 dark:text-slate-400">
+                    Роли: {{ getRoleLabel(contract.document_role_type) }}
                   </p>
                 </div>
               </div>

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -53,6 +53,8 @@ const contracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const contractsLoading = ref(false);
 const contractSaving = ref(false);
 const contractUploadSaving = ref(false);
+const contractRoleSavingId = ref<number | null>(null);
+const contractRoleErrors = ref<Record<number, string>>({});
 const showContractForm = ref(false);
 const showContractUploadForm = ref(false);
 const OPEN_CONTRACT_TEMPLATE_ID = '1x-pL1j9g-NzLSpPTLVYXSsmutGExPgfDqzi2VLq9thI';
@@ -69,10 +71,6 @@ const normalizeRoleType = (value: unknown): DocumentRoleType => {
   if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
   return 'seller_buyer';
 };
-
-const getRoleLabel = (value?: string | null) => (
-  DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
-);
 
 const phoneError = ref('');
 const emailError = ref('');
@@ -378,6 +376,40 @@ const uploadContract = async () => {
   } finally {
     contractUploadSaving.value = false;
   }
+};
+
+const updateContractRole = async (contract: ManagerCustomerContractItemResponse, roleType: string) => {
+  if (!customerId.value) return;
+  const nextRole = normalizeRoleType(roleType);
+  const previousRole = normalizeRoleType(contract.document_role_type);
+  if (nextRole === previousRole) return;
+
+  contract.document_role_type = nextRole;
+  contractRoleSavingId.value = contract.id;
+  contractRoleErrors.value = { ...contractRoleErrors.value, [contract.id]: '' };
+  try {
+    const updated = await ManagerContractsService.patchManagerCustomerContract(
+      customerId.value,
+      contract.id,
+      { document_role_type: nextRole },
+    );
+    contracts.value = contracts.value.map((item) => (item.id === contract.id ? updated : item));
+    setToast('Роли договора обновлены');
+  } catch (e) {
+    contract.document_role_type = previousRole;
+    const message = `Не удалось сохранить роли: ${getApiErrorMessage(e)}`;
+    contractRoleErrors.value = { ...contractRoleErrors.value, [contract.id]: message };
+    setToast(message);
+  } finally {
+    if (contractRoleSavingId.value === contract.id) {
+      contractRoleSavingId.value = null;
+    }
+  }
+};
+
+const onContractRoleChange = (contract: ManagerCustomerContractItemResponse, event: Event) => {
+  const select = event.target as HTMLSelectElement;
+  void updateContractRole(contract, select.value);
 };
 
 const archiveContract = async (contract: ManagerCustomerContractItemResponse) => {
@@ -816,8 +848,27 @@ onMounted(() => {
                   <p class="mt-2 text-[13px] leading-none text-slate-500 dark:text-slate-400">
                     {{ formatDateOnly(contract.valid_from) }} - {{ formatDateOnly(contract.valid_until) }}
                   </p>
-                  <p class="mt-2 text-[12px] leading-none text-slate-500 dark:text-slate-400">
-                    Роли: {{ getRoleLabel(contract.document_role_type) }}
+                  <div class="mt-2 flex flex-wrap items-center gap-2">
+                    <label class="text-[12px] leading-none text-slate-500 dark:text-slate-400" :for="`contract-role-${contract.id}`">
+                      Роли:
+                    </label>
+                    <select
+                      :id="`contract-role-${contract.id}`"
+                      class="field-input max-w-[260px] py-1 text-[12px]"
+                      :disabled="contractRoleSavingId === contract.id"
+                      :value="normalizeRoleType(contract.document_role_type)"
+                      @change="onContractRoleChange(contract, $event)"
+                    >
+                      <option v-for="option in DOCUMENT_ROLE_OPTIONS" :key="option.value" :value="option.value">
+                        {{ option.label }}
+                      </option>
+                    </select>
+                    <span v-if="contractRoleSavingId === contract.id" class="text-[12px] text-slate-500 dark:text-slate-400">
+                      Сохраняем...
+                    </span>
+                  </div>
+                  <p v-if="contractRoleErrors[contract.id]" class="mt-1 text-[12px] text-red-500">
+                    {{ contractRoleErrors[contract.id] }}
                   </p>
                 </div>
               </div>

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -18,6 +18,7 @@ interface ContractTemplateForm {
     id: string;
     name: string;
     document_role_type: DocumentRoleType;
+    is_open_contract: boolean;
 }
 const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> = [
     { value: 'seller_buyer', label: 'Продавец / Покупатель' },
@@ -127,6 +128,7 @@ const parseContractTemplates = (raw: string): ContractTemplateForm[] => {
                 id: String(item.id || '').trim(),
                 name: String(item.name || '').trim(),
                 document_role_type: normalizeRoleType(item.document_role_type),
+                is_open_contract: item.is_open_contract === true,
             }))
             .filter((item) => item.id || item.name);
     } catch {
@@ -146,6 +148,7 @@ const addContractTemplateRow = (setting: ManagerSettingResponse) => {
         id: '',
         name: '',
         document_role_type: 'seller_buyer',
+        is_open_contract: false,
     });
 };
 
@@ -159,6 +162,7 @@ const saveContractTemplates = async (setting: ManagerSettingResponse) => {
             id: row.id.trim(),
             name: row.name.trim(),
             document_role_type: normalizeRoleType(row.document_role_type),
+            is_open_contract: row.is_open_contract === true,
         }))
         .filter((row) => row.id && row.name);
     setting.value = JSON.stringify(rows, null, 2);
@@ -433,7 +437,7 @@ onMounted(() => {
                         <div
                             v-for="(template, index) in ensureContractTemplateDraft(setting)"
                             :key="`${setting.key}-${index}`"
-                            class="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1.4fr_220px_auto] md:items-center"
+                            class="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1.4fr_220px_150px_auto] md:items-center"
                         >
                             <input
                                 v-model="template.name"
@@ -458,6 +462,15 @@ onMounted(() => {
                                     {{ option.label }}
                                 </option>
                             </select>
+                            <label class="flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-gray-50 px-3 text-sm text-gray-700 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200">
+                                <input
+                                    v-model="template.is_open_contract"
+                                    type="checkbox"
+                                    class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                                    :disabled="savingKeys.has(setting.key)"
+                                />
+                                <span>Открытый</span>
+                            </label>
                             <button
                                 type="button"
                                 class="flex h-10 w-10 items-center justify-center rounded-lg text-red-500 transition-colors hover:bg-red-500/10"

--- a/openapi.json
+++ b/openapi.json
@@ -8931,6 +8931,17 @@
             "format": "date-time",
             "title": "Valid Until"
           },
+          "template_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Id"
+          },
           "document_role_type": {
             "anyOf": [
               {
@@ -9575,6 +9586,11 @@
             "type": "string",
             "title": "Document Role Type",
             "default": "seller_buyer"
+          },
+          "is_open_contract": {
+            "type": "boolean",
+            "title": "Is Open Contract",
+            "default": false
           }
         },
         "type": "object",

--- a/routers/manager_contracts.py
+++ b/routers/manager_contracts.py
@@ -91,6 +91,7 @@ async def upload_manager_customer_contract(
     number: str = Form(...),
     contract_date: datetime = Form(...),
     valid_until: datetime = Form(...),
+    template_id: str | None = Form(None),
     document_role_type: str | None = Form(None),
     file: UploadFile = File(...),
     _: str = Depends(get_current_username),
@@ -103,6 +104,7 @@ async def upload_manager_customer_contract(
             number=number,
             contract_date=contract_date,
             valid_until=valid_until,
+            template_id=template_id,
             document_role_type=document_role_type,
             file=file,
         )

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -146,6 +146,7 @@ async def get_doc_templates(
                 id=t["id"],
                 name=t["name"],
                 document_role_type=t.get("document_role_type"),
+                is_open_contract=bool(t.get("is_open_contract")),
             )
             for t in items
         ]

--- a/schemas.py
+++ b/schemas.py
@@ -627,6 +627,7 @@ class DocumentTemplateItem(BaseModel):
     id: str
     name: str
     document_role_type: str = "seller_buyer"
+    is_open_contract: bool = False
 
 
 class DocumentTemplateListResponse(BaseModel):

--- a/services/customer_contract_service.py
+++ b/services/customer_contract_service.py
@@ -122,20 +122,57 @@ class CustomerContractService:
 
     @staticmethod
     async def _get_template_role_type(session: AsyncSession, template_id: Optional[str]) -> str:
-        if not template_id:
-            return DocumentRoleService.normalize_role_type(None)
+        template = await CustomerContractService._get_contract_template(session, template_id)
+        if template:
+            return DocumentRoleService.normalize_role_type(template.get("document_role_type"))
+        return DocumentRoleService.normalize_role_type(None)
+
+    @staticmethod
+    async def _get_contract_templates(session: AsyncSession) -> list[dict]:
         try:
             result = await session.execute(select(GlobalConfig).where(GlobalConfig.key == "contract_templates"))
             config = result.scalars().first()
             items = json.loads(config.value) if config and config.value else []
         except Exception:
-            return DocumentRoleService.normalize_role_type(None)
+            return []
         if not isinstance(items, list):
-            return DocumentRoleService.normalize_role_type(None)
+            return []
+
+        from services.document_service import DocumentService
+
+        templates = []
         for item in items:
-            if isinstance(item, dict) and str(item.get("id") or "").strip() == template_id:
-                return DocumentRoleService.normalize_role_type(item.get("document_role_type"))
-        return DocumentRoleService.normalize_role_type(None)
+            if not isinstance(item, dict):
+                continue
+            normalized = DocumentService._normalize_template_item(item)
+            if normalized:
+                templates.append(normalized)
+        return templates
+
+    @staticmethod
+    async def _get_contract_template(session: AsyncSession, template_id: Optional[str]) -> Optional[dict]:
+        cleaned_id = str(template_id or "").strip()
+        if not cleaned_id:
+            return None
+        templates = await CustomerContractService._get_contract_templates(session)
+        return next((template for template in templates if template.get("id") == cleaned_id), None)
+
+    @staticmethod
+    async def _resolve_open_contract_template(session: AsyncSession, template_id: Optional[str]) -> dict:
+        templates = await CustomerContractService._get_contract_templates(session)
+        cleaned_id = str(template_id or "").strip()
+        if cleaned_id:
+            template = next((item for item in templates if item.get("id") == cleaned_id), None)
+            if not template:
+                raise ValueError("Шаблон договора не найден")
+            if not template.get("is_open_contract"):
+                raise ValueError("Выберите шаблон, отмеченный как открытый договор")
+            return template
+
+        template = next((item for item in templates if item.get("is_open_contract")), None)
+        if not template:
+            raise ValueError("В настройках нет шаблонов, отмеченных как открытый договор")
+        return template
 
     @staticmethod
     async def create_for_customer(
@@ -153,10 +190,9 @@ class CustomerContractService:
         contract_date = CustomerContractService._normalize_naive_datetime(payload.get("contract_date")) or datetime.now()
         valid_until = CustomerContractService._normalize_naive_datetime(payload.get("valid_until")) or CustomerContractService._default_valid_until(contract_date)
         number = str(payload.get("number") or "").strip() or await CustomerContractService._get_next_number(session, contract_date)
-        template_id = str(payload.get("template_id") or "").strip() or OPEN_SERVICE_CONTRACT_TEMPLATE_ID
-        document_role_type = DocumentRoleService.normalize_role_type(
-            payload.get("document_role_type") or await CustomerContractService._get_template_role_type(session, template_id)
-        )
+        template = await CustomerContractService._resolve_open_contract_template(session, payload.get("template_id"))
+        template_id = str(template.get("id") or "").strip()
+        document_role_type = DocumentRoleService.normalize_role_type(template.get("document_role_type"))
 
         contract = CustomerContract(
             customer_id=customer_id,
@@ -190,6 +226,7 @@ class CustomerContractService:
         number: str,
         contract_date: datetime,
         valid_until: datetime,
+        template_id: Optional[str] = None,
         document_role_type: Optional[str] = None,
         file: "Any",
     ) -> Optional[Dict[str, Any]]:
@@ -210,6 +247,11 @@ class CustomerContractService:
         valid_until_value = CustomerContractService._normalize_naive_datetime(valid_until)
         if not valid_until_value:
             raise ValueError("Дата окончания договора обязательна")
+
+        template = await CustomerContractService._resolve_open_contract_template(session, template_id)
+        resolved_role_type = DocumentRoleService.normalize_role_type(
+            document_role_type or template.get("document_role_type")
+        )
 
         original_filename = file.filename or f"open-contract-{cleaned_number}.pdf"
         _, suffix = os.path.splitext(original_filename)
@@ -234,8 +276,8 @@ class CustomerContractService:
                 valid_from=valid_from,
                 valid_until=valid_until_value,
                 status=CustomerContractService.ACTIVE_STATUS,
-                template_id=None,
-                document_role_type=DocumentRoleService.normalize_role_type(document_role_type),
+                template_id=str(template.get("id") or "").strip() or None,
+                document_role_type=resolved_role_type,
                 google_file_id=file_id,
                 google_edit_url=f"https://drive.google.com/file/d/{file_id}/view?usp=sharing",
             )

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -57,8 +57,17 @@ class DocumentService:
                 "id": default_id,
                 "name": f"{default_name} (по умолчанию)",
                 "document_role_type": DocumentRoleService.normalize_role_type(None),
+                "is_open_contract": False,
             }]
         return []
+
+    @staticmethod
+    def _normalize_template_bool(value: object) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
     @staticmethod
     def _normalize_template_item(item: dict) -> dict:
@@ -70,6 +79,7 @@ class DocumentService:
             "id": template_id,
             "name": name,
             "document_role_type": DocumentRoleService.normalize_role_type(item.get("document_role_type")),
+            "is_open_contract": DocumentService._normalize_template_bool(item.get("is_open_contract")),
         }
 
     @staticmethod

--- a/tests/integration/test_manager_customers_api.py
+++ b/tests/integration/test_manager_customers_api.py
@@ -290,7 +290,7 @@ async def test_manager_customer_contract_create_and_dashboard_notice(async_clien
     db.add(
         GlobalConfig(
             key="contract_templates",
-            value='[{"id":"service-template","name":"Сервис","document_role_type":"executor_customer"}]',
+            value='[{"id":"service-template","name":"Сервис","document_role_type":"executor_customer","is_open_contract":true}]',
             description="Contract templates",
         )
     )

--- a/tests/integration/test_manager_customers_api.py
+++ b/tests/integration/test_manager_customers_api.py
@@ -357,6 +357,13 @@ async def test_manager_customer_contract_upload_and_delete(async_client, db, mon
         inn="123456789",
     )
     db.add(customer)
+    db.add(
+        GlobalConfig(
+            key="contract_templates",
+            value='[{"id":"uploaded-template","name":"Загрузка","document_role_type":"executor_customer","is_open_contract":true}]',
+            description="Contract templates",
+        )
+    )
     await db.commit()
     await db.refresh(customer)
 
@@ -367,6 +374,7 @@ async def test_manager_customer_contract_upload_and_delete(async_client, db, mon
             "number": "EXT-2026-001",
             "contract_date": "2026-02-10T00:00:00",
             "valid_until": "2027-02-10T00:00:00",
+            "template_id": "uploaded-template",
         },
         files={"file": ("external-contract.pdf", b"%PDF-contract", "application/pdf")},
     )
@@ -374,6 +382,8 @@ async def test_manager_customer_contract_upload_and_delete(async_client, db, mon
     uploaded = upload_resp.json()
     assert uploaded["number"] == "EXT-2026-001"
     assert uploaded["status"] == "active"
+    assert uploaded["template_id"] == "uploaded-template"
+    assert uploaded["document_role_type"] == "executor_customer"
     assert uploaded["edit_url"].endswith("/view?usp=sharing")
     assert "EXT-2026-001" in captured["filename"]
     assert captured["mime_type"] == "application/pdf"

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -346,7 +346,7 @@ async def test_manager_document_roles_from_template_contract_and_order_override(
     db.add(
         GlobalConfig(
             key="contract_templates",
-            value='[{"id":"tpl-service","name":"Услуги","document_role_type":"executor_customer"},{"id":"tpl-old","name":"Старый"}]',
+            value='[{"id":"tpl-service","name":"Услуги","document_role_type":"executor_customer","is_open_contract":true},{"id":"tpl-old","name":"Старый"}]',
             description="Contract templates",
         )
     )
@@ -359,7 +359,9 @@ async def test_manager_document_roles_from_template_contract_and_order_override(
     assert templates_resp.status_code == 200
     templates = templates_resp.json()["items"]
     assert next(item for item in templates if item["id"] == "tpl-service")["document_role_type"] == "executor_customer"
+    assert next(item for item in templates if item["id"] == "tpl-service")["is_open_contract"] is True
     assert next(item for item in templates if item["id"] == "tpl-old")["document_role_type"] == "seller_buyer"
+    assert next(item for item in templates if item["id"] == "tpl-old")["is_open_contract"] is False
 
     captured_replacements = []
 


### PR DESCRIPTION
## Summary
- add an “open contract” flag to contract template settings
- use only open-marked templates when creating/uploading customer open contracts
- keep roles driven by the selected template instead of editing existing contracts manually
- hide open-contract templates from one-time order contract generation

## Validation
- npm run build in manager_frontend
- python3 -m py_compile services/document_service.py services/customer_contract_service.py routers/manager_contracts.py routers/manager_docs.py schemas.py
- BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin POSTGRES_PASSWORD=securepass TEST_DB_HOST=localhost TEST_DB_PORT=5433 python3 -m pytest tests/integration/test_manager_customers_api.py::test_manager_customer_contract_create_and_dashboard_notice tests/integration/test_manager_orders_api.py::test_manager_document_roles_from_template_contract_and_order_override -q
- browser-use check on /manager/settings and /manager/customers/profile?customerId=76