### PR TITLE
[codex] Fix backend audit findings

### DIFF
--- a/manager_frontend/src/client/services/ManagerLeadsInboxService.ts
+++ b/manager_frontend/src/client/services/ManagerLeadsInboxService.ts
@@ -28,17 +28,23 @@ export class ManagerLeadsInboxService {
      * scope=active  → new_lead + assessment, sorted by is_new DESC then created_at DESC.
      * scope=archive → canceled.
      * @param scope
+     * @param page
+     * @param limit
      * @returns LeadsInboxListResponse Successful Response
      * @throws ApiError
      */
     public static getManagerLeadsInbox(
         scope: string = 'active',
+        page: number = 1,
+        limit: number = 50,
     ): CancelablePromise<LeadsInboxListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/manager/leads/inbox',
             query: {
                 'scope': scope,
+                'page': page,
+                'limit': limit,
             },
             errors: {
                 422: `Validation Error`,

--- a/openapi.json
+++ b/openapi.json
@@ -5255,6 +5255,29 @@
               "default": "active",
               "title": "Scope"
             }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
           }
         ],
         "responses": {

--- a/routers/admin_orders.py
+++ b/routers/admin_orders.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from core.database import async_session_maker
+from core.database import get_session
 from core.security import get_current_username
+from services.order_service import OrderService
 
 
 router = APIRouter(tags=["admin-orders"])
@@ -16,26 +18,10 @@ class OrderStatusUpdate(BaseModel):
 @router.post("/api/order/move")
 async def move_order_status(
     data: OrderStatusUpdate,
-    username: str = Depends(get_current_username)
+    username: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
 ):
     """
     API for Kanban drag-and-drop.
     """
-    from services.order_service import OrderService
-    from models import OrderStatus
-
-    async with async_session_maker() as session:
-        try:
-            status_enum = None
-            for status in OrderStatus:
-                if status.value == data.new_status:
-                    status_enum = status
-                    break
-
-            if not status_enum:
-                return {"success": False, "error": f"Invalid status: {data.new_status}"}
-
-            success = await OrderService.update_status(session, data.order_id, status_enum)
-            return {"success": success}
-        except Exception as exc:
-            return {"success": False, "error": str(exc)}
+    return await OrderService.update_status_from_admin(session, data.order_id, data.new_status)

--- a/routers/admin_schedule.py
+++ b/routers/admin_schedule.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends
-from sqlalchemy.orm import selectinload
-from sqlmodel import select
 
-from core.database import async_session_maker
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
 from core.security import get_current_username
+from services.admin_schedule_service import AdminScheduleService
 
 
 router = APIRouter(tags=["admin-schedule"])
@@ -14,91 +15,23 @@ router = APIRouter(tags=["admin-schedule"])
 @router.get("/api/admin/installers/search")
 async def search_installers(
     q: str = "",
-    username: str = Depends(get_current_username)
+    username: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
 ):
     """
     Search installers for Select2.
     """
-    from models import Installer
-
-    async with async_session_maker() as session:
-        stmt = select(Installer).where(Installer.is_active == True)
-        if q:
-            stmt = stmt.where(Installer.name.ilike(f"%{q}%"))
-
-        result = await session.execute(stmt)
-        installers = result.scalars().all()
-
-        return [
-            {
-                "id": installer.id,
-                "text": f"{installer.name} (TG: {installer.telegram_id or '-'})",
-                "default_rate": installer.default_rate or 0
-            }
-            for installer in installers
-        ]
+    return await AdminScheduleService.search_installers(session, q=q)
 
 
 @router.get("/calendar/events")
 async def get_calendar_events(
     start: Optional[str] = None,
     end: Optional[str] = None,
-    username: str = Depends(get_current_username)
+    username: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
 ):
     """
     Get events for FullCalendar (Orders with Installation or Assessment dates).
     """
-    from models import Order, OrderStatus, OrderInstaller
-    from sqlalchemy import or_
-
-    async with async_session_maker() as session:
-        stmt = select(Order).options(
-            selectinload(Order.installers).selectinload(OrderInstaller.installer)
-        ).where(
-            or_(
-                Order.installation_date.is_not(None),
-                Order.measurement_date.is_not(None)
-            )
-        )
-
-        if start:
-            # Placeholder for future explicit date window filtering.
-            pass
-
-        result = await session.execute(stmt)
-        orders = result.scalars().all()
-
-        events = []
-        for order in orders:
-            if order.measurement_date:
-                events.append({
-                    "id": f"assess_{order.id}",
-                    "title": f"🔍 Замер: {order.delivery_address or 'Без адреса'}",
-                    "start": order.measurement_date.isoformat(),
-                    "color": "#3b82f6",
-                    "extendedProps": {"order_id": order.id}
-                })
-
-            if order.installation_date:
-                color = "#22c55e"
-                if order.status == OrderStatus.CLOSED:
-                    if order.closing_result == "won":
-                        color = "#6b7280"
-                    elif order.closing_result == "lost":
-                        color = "#ef4444"
-
-                installers_str = ""
-                if order.installers:
-                    installers_str = " (" + ", ".join(
-                        [installer.installer.name for installer in order.installers if installer.installer]
-                    ) + ")"
-
-                events.append({
-                    "id": f"install_{order.id}",
-                    "title": f"🛠️ Монтаж: {order.delivery_address or 'Без адреса'}{installers_str}",
-                    "start": order.installation_date.isoformat(),
-                    "color": color,
-                    "extendedProps": {"order_id": order.id}
-                })
-
-        return events
+    return await AdminScheduleService.get_calendar_events(session, start=start, end=end)

--- a/routers/manager_leads_inbox.py
+++ b/routers/manager_leads_inbox.py
@@ -31,6 +31,8 @@ async def get_leads_counter(
 @router.get("/inbox", response_model=LeadsInboxListResponse, operation_id=GET_MANAGER_LEADS_INBOX)
 async def get_leads_inbox(
     scope: str = Query("active", pattern="^(active|archive)$"),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=100),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
 ) -> LeadsInboxListResponse:
@@ -39,4 +41,4 @@ async def get_leads_inbox(
     scope=active  → new_lead + assessment, sorted by is_new DESC then created_at DESC.
     scope=archive → canceled.
     """
-    return await OrderService.get_leads_inbox(session, scope=scope)
+    return await OrderService.get_leads_inbox(session, scope=scope, page=page, limit=limit)

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -41,51 +41,7 @@ async def create_manager_order(
     session: AsyncSession = Depends(get_session),
 ):
     try:
-        from models import LeadSource, OrderStatus
-        source_enum = LeadSource(payload.source) if payload.source else LeadSource.MANAGER
-        # Orders from customer card (customer_id provided) or maintenance skip new_lead
-        if payload.customer_id or payload.service_type == "maintenance":
-            initial_status = OrderStatus.NEGOTIATION
-        else:
-            initial_status = OrderStatus.NEW_LEAD
-        order = await OrderService.create_from_website(
-            session=session,
-            customer_name=payload.name or "Новый клиент",
-            customer_phone=payload.phone or "",
-            customer_email=None,
-            customer_address=payload.address,
-            items=[],
-            lead_source=source_enum,
-            initial_status=initial_status,
-            comment=payload.request_text,
-            customer_id=payload.customer_id,
-            customer_type=payload.customer_type,
-            customer_inn=payload.customer_inn,
-            customer_full_legal_name=payload.customer_full_legal_name,
-        )
-        # Apply target_date if maintenance
-        if payload.service_type == "maintenance" and payload.target_date:
-            raw_order_date = await session.get(type(order), order.id)
-            if raw_order_date is not None:
-                raw_order_date.installation_date = payload.target_date.replace(tzinfo=None)
-                session.add(raw_order_date)
-                await session.commit()
-                await session.refresh(raw_order_date)
-                order = raw_order_date
-        # Save optional service_type into technical_meta
-        if payload.service_type:
-            from sqlalchemy.orm import Session
-            from sqlalchemy.orm.attributes import flag_modified
-            raw_order = await session.get(type(order), order.id)
-            if raw_order is not None:
-                raw_order.technical_meta = dict(raw_order.technical_meta or {})
-                raw_order.technical_meta["service_type"] = payload.service_type
-                flag_modified(raw_order, "technical_meta")
-                session.add(raw_order)
-                await session.commit()
-                await session.refresh(raw_order)
-                order = raw_order
-        data = await OrderService.get_order_detail_for_manager(session, order.id)
+        data = await OrderService.create_manager_order(session=session, payload=payload)
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,

--- a/services/admin_schedule_service.py
+++ b/services/admin_schedule_service.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models import Installer, Order, OrderInstaller, OrderStatus
+
+
+class AdminScheduleService:
+    @staticmethod
+    async def search_installers(session: AsyncSession, q: str = "") -> List[Dict[str, Any]]:
+        stmt = select(Installer).where(Installer.is_active == True)
+        if q:
+            stmt = stmt.where(Installer.name.ilike(f"%{q}%"))
+
+        result = await session.execute(stmt)
+        installers = result.scalars().all()
+
+        return [
+            {
+                "id": installer.id,
+                "text": f"{installer.name} (TG: {installer.telegram_id or '-'})",
+                "default_rate": installer.default_rate or 0,
+            }
+            for installer in installers
+        ]
+
+    @staticmethod
+    async def get_calendar_events(
+        session: AsyncSession,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        # `start`/`end` are accepted for FullCalendar compatibility; legacy
+        # behavior returned all dated orders, so filtering stays unchanged.
+        stmt = (
+            select(Order)
+            .options(selectinload(Order.installers).selectinload(OrderInstaller.installer))
+            .where(
+                or_(
+                    Order.installation_date.is_not(None),
+                    Order.measurement_date.is_not(None),
+                )
+            )
+        )
+
+        result = await session.execute(stmt)
+        orders = result.scalars().all()
+
+        events = []
+        for order in orders:
+            if order.measurement_date:
+                events.append(
+                    {
+                        "id": f"assess_{order.id}",
+                        "title": f"🔍 Замер: {order.delivery_address or 'Без адреса'}",
+                        "start": order.measurement_date.isoformat(),
+                        "color": "#3b82f6",
+                        "extendedProps": {"order_id": order.id},
+                    }
+                )
+
+            if order.installation_date:
+                color = "#22c55e"
+                if order.status == OrderStatus.CLOSED:
+                    if order.closing_result == "won":
+                        color = "#6b7280"
+                    elif order.closing_result == "lost":
+                        color = "#ef4444"
+
+                installers_str = ""
+                if order.installers:
+                    installers_str = " (" + ", ".join(
+                        [installer.installer.name for installer in order.installers if installer.installer]
+                    ) + ")"
+
+                events.append(
+                    {
+                        "id": f"install_{order.id}",
+                        "title": f"🛠️ Монтаж: {order.delivery_address or 'Без адреса'}{installers_str}",
+                        "start": order.installation_date.isoformat(),
+                        "color": color,
+                        "extendedProps": {"order_id": order.id},
+                    }
+                )
+
+        return events

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -189,6 +189,51 @@ class OrderService:
         return order
 
     @staticmethod
+    async def create_manager_order(session: AsyncSession, payload: Any) -> Optional[Dict[str, Any]]:
+        source_enum = LeadSource(payload.source) if payload.source else LeadSource.MANAGER
+        initial_status = (
+            OrderStatus.NEGOTIATION
+            if payload.customer_id or payload.service_type == "maintenance"
+            else OrderStatus.NEW_LEAD
+        )
+
+        order = await OrderService.create_from_website(
+            session=session,
+            customer_name=payload.name or "Новый клиент",
+            customer_phone=payload.phone or "",
+            customer_email=None,
+            customer_address=payload.address,
+            items=[],
+            lead_source=source_enum,
+            initial_status=initial_status,
+            comment=payload.request_text,
+            customer_id=payload.customer_id,
+            customer_type=payload.customer_type,
+            customer_inn=payload.customer_inn,
+            customer_full_legal_name=payload.customer_full_legal_name,
+        )
+
+        changed = False
+        if payload.service_type == "maintenance" and payload.target_date:
+            order.installation_date = OrderService._normalize_naive_datetime(payload.target_date)
+            changed = True
+
+        if payload.service_type:
+            from sqlalchemy.orm.attributes import flag_modified
+
+            order.technical_meta = dict(order.technical_meta or {})
+            order.technical_meta["service_type"] = payload.service_type
+            flag_modified(order, "technical_meta")
+            changed = True
+
+        if changed:
+            session.add(order)
+            await session.commit()
+            await session.refresh(order)
+
+        return await OrderService.get_order_detail_for_manager(session, int(order.id))
+
+    @staticmethod
     async def create_from_website(
         session: AsyncSession,
         customer_name: str,
@@ -952,6 +997,23 @@ class OrderService:
         return await OrderDAO.update_status(session, order_id, new_status)
 
     @staticmethod
+    async def update_status_from_admin(
+        session: AsyncSession,
+        order_id: int,
+        new_status: str,
+    ) -> Dict[str, Any]:
+        try:
+            status_enum = OrderStatus(new_status)
+        except ValueError:
+            return {"success": False, "error": f"Invalid status: {new_status}"}
+
+        try:
+            success = await OrderService.update_status(session, order_id, status_enum)
+            return {"success": success}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    @staticmethod
     def _map_customer_brief(customer: Optional[Customer]) -> Optional[Dict[str, Any]]:
         if not customer:
             return None
@@ -1040,7 +1102,7 @@ class OrderService:
     @staticmethod
     def _map_product_line(link: OrderProductLink) -> Dict[str, Any]:
         product_title = link.product.title if link.product else f"Товар #{link.product_id}"
-        line_total = (link.price + (link.installation_price or 0)) * link.quantity
+        line_total = link.price * link.quantity
         return {
             "id": link.id,
             "product_id": link.product_id,
@@ -1657,7 +1719,12 @@ class OrderService:
         return count, count > 0
 
     @staticmethod
-    async def get_leads_inbox(session: AsyncSession, scope: str = "active"):
+    async def get_leads_inbox(
+        session: AsyncSession,
+        scope: str = "active",
+        page: int = 1,
+        limit: int = 50,
+    ):
         """Return triage inbox items based on scope.
 
         scope="active"  → new_lead + assessment
@@ -1667,17 +1734,23 @@ class OrderService:
         from schemas import LeadsInboxItemResponse, LeadsInboxListResponse
         from sqlalchemy import case as sa_case
 
+        page = max(1, int(page or 1))
+        limit = min(100, max(1, int(limit or 50)))
         stmt = select(Order).options(selectinload(Order.customer))
+        count_stmt = select(func.count(Order.id))
 
         if scope == "archive":
             # Archived leads are just closed/lost leads
-            stmt = stmt.where(
+            scope_filters = (
                 Order.status == OrderStatus.CLOSED,
                 Order.closing_result == "lost"
             )
         else:
             active_statuses = [OrderStatus.NEW_LEAD]
-            stmt = stmt.where(Order.status.in_(active_statuses))
+            scope_filters = (Order.status.in_(active_statuses),)
+
+        stmt = stmt.where(*scope_filters)
+        count_stmt = count_stmt.where(*scope_filters)
 
         if scope == "active":
             # new_lead orders float to top, then newest first
@@ -1689,6 +1762,10 @@ class OrderService:
         else:
             stmt = stmt.order_by(Order.created_at.desc())
 
+        total_result = await session.execute(count_stmt)
+        total = int(total_result.scalar() or 0)
+
+        stmt = stmt.offset((page - 1) * limit).limit(limit)
         result = await session.execute(stmt)
         orders: list[Order] = list(result.scalars().all())
 
@@ -1721,7 +1798,7 @@ class OrderService:
             for order in orders
         ]
 
-        return LeadsInboxListResponse(items=items, total=len(items))
+        return LeadsInboxListResponse(items=items, total=total)
 
     @staticmethod
     async def delete_order(session: AsyncSession, order_id: int) -> bool:

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -33,7 +33,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
 
     @staticmethod
     async def get_public_spec_keys(session: AsyncSession) -> Dict[str, Any]:
-        stmt = select(Product.specs)
+        stmt = select(Product.specs).where(Product.is_published.is_(True))
         result = await session.execute(stmt)
         all_specs = result.scalars().all()
 

--- a/services/product_supply_metrics_service.py
+++ b/services/product_supply_metrics_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
+from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -57,15 +58,20 @@ class ProductSupplyMetricsService:
             }
 
         keys = {(m.supplier_id, m.external_id) for m in mappings}
+        offer_clauses = [
+            and_(
+                SupplierOffer.supplier_id == supplier_id,
+                SupplierOffer.external_id == external_id,
+            )
+            for supplier_id, external_id in keys
+        ]
         offers_res = await session.execute(
             select(SupplierOffer).where(
                 SupplierOffer.is_active.is_(True),
-                SupplierOffer.supplier_id.in_([k[0] for k in keys]),
+                or_(*offer_clauses),
             )
         )
-        offers = [
-            o for o in offers_res.scalars().all() if (o.supplier_id, o.external_id) in keys
-        ]
+        offers = list(offers_res.scalars().all())
         offer_map = {(o.supplier_id, o.external_id): o for o in offers}
 
         source_res = await session.execute(

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List
+from typing import Any, Dict, List
 from sqlmodel import select
 from core.config import settings
 from core.database import async_session_maker
@@ -57,38 +57,68 @@ class SchedulerService:
             if mode == 1:
                 # Только товары с тегом "hit" (Хит продаж)
                 from models import Tag
-                stmt = select(Product).join(Product.tags).where(Tag.slug == "hit", Product.source_url != None)
+                stmt = (
+                    select(
+                        Product.id.label("id"),
+                        Product.title.label("title"),
+                        Product.source_url.label("source_url"),
+                        Product.price.label("price"),
+                    )
+                    .join(Product.tags)
+                    .where(Tag.slug == "hit", Product.source_url != None)
+                )
             else:
                 # Все товары с URL
-                stmt = select(Product).where(Product.source_url != None)
-            
-            result = await session.execute(stmt)
-            products = result.scalars().unique().all()
-            
-            updated_count = 0
-            for product in products:
-                try:
-                    logger.info(f"Checking price for: {product.title}")
-                    data = await self.parser.parse(product.source_url)
-                    new_price = data.get('price')
-                    
-                    if new_price and new_price != product.price:
-                        logger.info(f"Price updated for {product.title}: {product.price} -> {new_price}")
-                        product.old_price = product.price
-                        product.price = new_price
-                        session.add(product)
-                        updated_count += 1
-                    
-                    # Sleep to avoid rate limiting
-                    await asyncio.sleep(2)
-                except Exception as e:
-                    logger.error(f"Error updating price for {product.title}: {e}")
+                stmt = select(
+                    Product.id.label("id"),
+                    Product.title.label("title"),
+                    Product.source_url.label("source_url"),
+                    Product.price.label("price"),
+                ).where(Product.source_url != None)
 
-            if updated_count > 0:
-                await session.commit()
-                logger.info(f"Finished price update. {updated_count} products updated.")
-            else:
-                logger.info("Finished price update. No changes found.")
+            result = await session.execute(stmt)
+            product_rows = [dict(row) for row in result.mappings().unique().all()]
+
+        updates: List[Dict[str, Any]] = []
+        for product in product_rows:
+            try:
+                logger.info(f"Checking price for: {product['title']}")
+                data = await self.parser.parse(product["source_url"])
+                new_price = data.get("price")
+
+                if new_price and new_price != product["price"]:
+                    logger.info(
+                        f"Price updated for {product['title']}: {product['price']} -> {new_price}"
+                    )
+                    updates.append(
+                        {
+                            "id": product["id"],
+                            "old_price": product["price"],
+                            "new_price": new_price,
+                        }
+                    )
+
+                # Sleep to avoid rate limiting
+                await asyncio.sleep(2)
+            except Exception as e:
+                logger.error(f"Error updating price for {product['title']}: {e}")
+
+        if updates:
+            updated_count = 0
+            async with async_session_maker() as session:
+                for item in updates:
+                    product = await session.get(Product, item["id"])
+                    if not product:
+                        continue
+                    product.old_price = item["old_price"]
+                    product.price = item["new_price"]
+                    session.add(product)
+                    updated_count += 1
+                if updated_count:
+                    await session.commit()
+            logger.info(f"Finished price update. {updated_count} products updated.")
+        else:
+            logger.info("Finished price update. No changes found.")
 
     async def start_loop(self, interval_hours: int = 6):
         """

--- a/services/supplier_sync_service.py
+++ b/services/supplier_sync_service.py
@@ -119,10 +119,15 @@ class SupplierSyncService:
             if not supplier or not supplier.spreadsheet_id:
                 raise ValueError("Supplier spreadsheet is not configured")
 
+            spreadsheet_id = supplier.spreadsheet_id
+            sheet_name = source.sheet_name
+            range_a1 = source.range_a1
+            await session.commit()
+
             values = get_google_service().read_sheet_values(
-                spreadsheet_id=supplier.spreadsheet_id,
-                sheet_name=source.sheet_name,
-                range_a1=source.range_a1,
+                spreadsheet_id=spreadsheet_id,
+                sheet_name=sheet_name,
+                range_a1=range_a1,
             )
 
             # Do not hard-skip first row; rely on logical row validation instead.

--- a/tests/integration/test_cart_api.py
+++ b/tests/integration/test_cart_api.py
@@ -58,3 +58,7 @@ async def test_checkout_flow(async_client: AsyncClient, cart_product):
     # 2000 * 2 + 250 * 2 = 4000 + 500 = 4500
     expected_total = (cart_product.price * 2) + (250 * 2)
     assert data["total_amount"] == expected_total
+    assert "margin" not in data
+    assert "total_cost" not in data
+    assert "technical_meta" not in data
+    assert "cost" not in data

--- a/tests/unit/test_order_service_leads_inbox.py
+++ b/tests/unit/test_order_service_leads_inbox.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from models import Customer, LeadSource, Order, OrderStatus
+from services.order_service import OrderService
+
+
+@pytest.mark.asyncio
+async def test_leads_inbox_is_paginated(db):
+    now = datetime.now()
+    for idx in range(3):
+        customer = Customer(name=f"Lead {idx}", phone=f"+37529000000{idx}")
+        db.add(customer)
+        await db.flush()
+        db.add(
+            Order(
+                customer_id=customer.id,
+                status=OrderStatus.NEW_LEAD,
+                lead_source=LeadSource.MANAGER,
+                created_at=now + timedelta(minutes=idx),
+            )
+        )
+    await db.commit()
+
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=2)
+
+    assert response.total == 3
+    assert len(response.items) == 2
+    assert [item.customer_name for item in response.items] == ["Lead 2", "Lead 1"]

--- a/tests/unit/test_router_service_boundaries.py
+++ b/tests/unit/test_router_service_boundaries.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_refactored_routers_do_not_perform_direct_db_work():
+    repo_root = Path(__file__).resolve().parents[2]
+    router_paths = [
+        repo_root / "routers" / "manager_orders_write.py",
+        repo_root / "routers" / "admin_schedule.py",
+        repo_root / "routers" / "admin_orders.py",
+    ]
+    forbidden = (
+        "async_session_maker",
+        "session.add",
+        "session.commit",
+        "session.delete",
+        "session.execute",
+        "select(",
+    )
+
+    for path in router_paths:
+        source = path.read_text()
+        for token in forbidden:
+            assert token not in source, f"{path.name} contains direct DB token {token!r}"

--- a/tests/unit/test_snapshot_pricing.py
+++ b/tests/unit/test_snapshot_pricing.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlmodel import select
 from services.order_service import OrderService
-from models import Product, OrderProductLink, LeadSource, OrderStatus
+from models import Product, OrderProductLink, OrderServiceLink, LeadSource, OrderStatus
 
 async def test_snapshot_pricing(db):
     # 1. Create test product
@@ -43,13 +43,17 @@ async def test_snapshot_pricing(db):
     result = await db.execute(stmt)
     link = result.scalar_one()
     
-    # 4. Verify total calculation
-    expected_total = (link.price + link.installation_price) * link.quantity
+    service_result = await db.execute(select(OrderServiceLink).where(OrderServiceLink.order_id == order.id))
+    service_link = service_result.scalar_one()
+
+    # 4. Verify total calculation uses product/service snapshots.
+    expected_total = (link.price * link.quantity) + (service_link.price * service_link.quantity)
     
     assert link.is_installation_included is True
     assert link.installation_price == 260
     assert link.installation_details is not None
     assert link.installation_details.get("source") == "web_calculator"
+    assert service_link.price == 260
     assert order.total_amount == expected_total
 
 async def test_order_without_installation(db):
@@ -124,3 +128,37 @@ async def test_create_from_website_supports_negotiation_status_and_preserves_che
     assert link.product_id == product.id
     assert link.is_installation_included is True
     assert link.installation_price == 300
+
+
+async def test_order_detail_does_not_double_count_installation_in_product_line(db):
+    product = Product(id=65, title="Line Total Product", slug="line-total-product", price=2000, area=25)
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    order = await OrderService.create_from_website(
+        session=db,
+        customer_name="Клиент детализации",
+        customer_phone="+375447770012",
+        customer_email=None,
+        customer_address="г. Минск",
+        items=[
+            {
+                "product_id": product.id,
+                "quantity": 2,
+                "with_installation": True,
+                "installation_price": 300,
+                "installation_meta": {"source": "checkout"},
+            }
+        ],
+        lead_source=LeadSource.SITE,
+        initial_status=OrderStatus.NEGOTIATION,
+        comment=None,
+    )
+
+    detail = await OrderService.get_order_detail_for_manager(db, order.id)
+
+    assert detail["total_amount"] == 4600
+    assert detail["product_lines"][0]["installation_price"] == 300
+    assert detail["product_lines"][0]["line_total"] == 4000
+    assert detail["service_lines"][0]["line_total"] == 600


### PR DESCRIPTION
## What changed
- Moved remaining manager/admin router business logic into service-layer methods.
- Added a schedule service for legacy admin schedule endpoints.
- Shortened DB session lifetimes in scheduler price sync and supplier sheet sync.
- Added pagination to manager leads inbox and narrowed public spec key reads to published products.
- Optimized supplier offer lookup for supply metrics.
- Fixed order detail product line totals so installation snapshots are not double-counted.
- Updated OpenAPI/generated manager leads inbox client for `page` and `limit` query params.

## Why
This addresses the backend audit findings around service-layer boundaries, session management, listing scalability, public/internal schema separation checks, and snapshot pricing consistency.

## Validation
- `python3 -m py_compile ...` on touched Python files passed.
- `pytest tests/unit/test_router_service_boundaries.py -q` passed.
- DB-backed targeted pytest was attempted, but local `db_test` is not resolvable in this environment (`socket.gaierror`).