### PR TITLE
Refactor Astro storefront SEO islands and stabilize manager views

### DIFF
--- a/web/src/components/CatalogApp.vue
+++ b/web/src/components/CatalogApp.vue
@@ -55,6 +55,10 @@ const props = defineProps({
   initialCategorySlug: {
     type: String,
     default: 'cat-household'
+  },
+  initialBrands: {
+    type: Array,
+    default: () => []
   }
 });
 
@@ -68,6 +72,7 @@ const meta = ref(props.initialMeta || { total: 0, page: 1, limit: BASE_LIMIT, pa
 const loadingInitial = ref(false);
 const loadingMore = ref(false);
 const loadingBrands = ref(false);
+const dynamicActive = ref(false);
 
 const activeTags = ref([...new Set(initialActiveTags)]);
 const searchQuery = ref('');
@@ -85,7 +90,10 @@ const currentIndoorTypes = ref([...(props.initialFilters?.indoor_types || [])]);
 const selectedOutdoorSlug = ref('');
 const selectedIndoorQuantities = ref({});
 
-const availableBrands = ref([]);
+const availableBrands = ref((props.initialBrands || []).map((brand) => ({
+  ...brand,
+  sort_order: brand.sort_order ?? 999,
+})));
 let searchDebounceTimeout = null;
 
 const lockedFilters = computed(() => props.lockedInitialFilters || null);
@@ -693,6 +701,29 @@ const syncStateFromUrl = () => {
   }
 };
 
+const hasUrlQueryParams = () => {
+  if (typeof window === 'undefined') return false;
+  return Array.from(new URLSearchParams(window.location.search).keys()).length > 0;
+};
+
+const getUrlPage = () => {
+  if (typeof window === 'undefined') return 1;
+  const parsed = Number.parseInt(new URLSearchParams(window.location.search).get('page') || '1', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+};
+
+const syncStaticHeaderFromState = () => {
+  if (typeof document === 'undefined') return;
+
+  const header = document.querySelector('.catalog-page > .catalog-header');
+  if (!header) return;
+
+  const title = header.querySelector('h1');
+  const description = header.querySelector('.header-description');
+  if (title) title.textContent = pageTitle.value;
+  if (description) description.textContent = pageDescription.value;
+};
+
 const buildApiParams = (page = 1) => {
   const base = {
     page,
@@ -751,7 +782,13 @@ const syncUrlFromState = (page = 1, { replace = false } = {}) => {
   }
 };
 
+const activateDynamicResults = () => {
+  dynamicActive.value = true;
+};
+
 const fetchProducts = async ({ page = 1, append = false } = {}) => {
+  activateDynamicResults();
+  syncStaticHeaderFromState();
   if (append) {
     loadingMore.value = true;
   } else {
@@ -822,6 +859,10 @@ const updateBrandsFallbackFromProducts = () => {
 };
 
 const loadBrands = async () => {
+  if (availableBrands.value.length > 0) {
+    updateBrandsFallbackFromProducts();
+    return;
+  }
   loadingBrands.value = true;
   try {
     const filters = await getFiltersConfig();
@@ -987,59 +1028,20 @@ const onSearchInput = () => {
 
 onMounted(async () => {
   syncStateFromUrl();
+  syncStaticHeaderFromState();
   await loadBrands();
-
-  const currentMetaLimit = Number(props.initialMeta?.limit || BASE_LIMIT);
-  const urlPage = Number(getParamsFromUrl()?.page || 1);
-  const hasUrlQuery = typeof window !== 'undefined'
-    ? Array.from(new URLSearchParams(window.location.search).keys()).length > 0
-    : false;
-
-  if (
-    hasUrlQuery
-    || !props.initialProducts?.length
-    || currentMetaLimit !== BASE_LIMIT
-    || urlPage > 1
-  ) {
-    await fetchProducts({ page: Math.max(1, urlPage), append: false });
-  }
   syncMultiSelectionState();
+  if (hasUrlQueryParams()) {
+    await fetchProducts({ page: getUrlPage(), append: false });
+  }
 });
 </script>
 
 <template>
   <div class="catalog-shell">
-    <header class="catalog-header">
-      <div class="header-top">
-        <div class="breadcrumb">
-          <a href="/">Главная</a>
-          <span class="sep">/</span>
-          <span>Каталог</span>
-        </div>
-
-        <div class="search-input-wrapper header-search catalog-desktop-only">
-          <span class="material-icons-round search-icon">search</span>
-          <input
-            v-model="searchQuery"
-            type="text"
-            class="search-input"
-            placeholder="Поиск по модели, бренду, характеристике"
-            @input="onSearchInput"
-          />
-        </div>
-
-        <button
-          class="search-toggle catalog-mobile-only"
-          :class="{ active: mobileSearchOpen }"
-          @click="mobileSearchOpen = !mobileSearchOpen"
-          aria-label="Открыть поиск"
-          type="button"
-        >
-          <span class="material-icons-round">{{ mobileSearchOpen ? 'close' : 'search' }}</span>
-        </button>
-      </div>
-
-      <div v-if="mobileSearchOpen" class="search-input-wrapper header-search catalog-mobile-only mobile-search">
+    <section class="catalog-controls" aria-label="Фильтры каталога">
+      <div class="controls-top">
+        <div class="search-input-wrapper header-search">
         <span class="material-icons-round search-icon">search</span>
         <input
           v-model="searchQuery"
@@ -1049,17 +1051,15 @@ onMounted(async () => {
           @input="onSearchInput"
         />
       </div>
-
-      <h1 class="gradient-text">{{ pageTitle }}</h1>
-      <p class="header-description">{{ pageDescription }}</p>
-      <a
-        v-if="isIndustrialCategory"
-        :href="semiGuideUrl"
-        class="semi-guide-link"
-      >
-        Как выбрать тип полупромышленного кондиционера
-      </a>
-    </header>
+        <a
+          v-if="isIndustrialCategory"
+          :href="semiGuideUrl"
+          class="semi-guide-link"
+        >
+          Как выбрать тип полупромышленного кондиционера
+        </a>
+      </div>
+    </section>
 
     <section v-if="isHouseholdCategory" class="glass-panel quick-power-panel">
       <div class="section-label">Мощность</div>
@@ -1317,11 +1317,21 @@ onMounted(async () => {
       </section>
     </transition>
 
-    <div v-if="loadingInitial" class="grid skeleton-grid">
+    <div v-if="!dynamicActive" class="catalog-static-slot">
+      <slot />
+    </div>
+
+    <div v-if="!dynamicActive && hasMore" class="load-more-wrap">
+      <button class="load-more-btn" :disabled="loadingMore" @click="loadMore">
+        {{ loadingMore ? 'Загружаем...' : 'Показать еще' }}
+      </button>
+    </div>
+
+    <div v-if="dynamicActive && loadingInitial" class="grid skeleton-grid">
       <div v-for="i in 8" :key="`skeleton-${i}`" class="skeleton-card" />
     </div>
 
-    <div v-else-if="products.length > 0" class="catalog-content">
+    <div v-else-if="dynamicActive && products.length > 0" class="catalog-content">
       <section v-if="showPopularModels" class="popular-section" aria-labelledby="popular-models-title">
         <div class="catalog-section-head">
           <h2 id="popular-models-title">Популярные модели</h2>
@@ -1332,6 +1342,7 @@ onMounted(async () => {
             :key="`popular-${product.id}`"
             :product="product"
             :showInstallation="true"
+            :refreshProductOnMount="false"
           />
         </transition-group>
       </section>
@@ -1346,6 +1357,7 @@ onMounted(async () => {
             :key="product.id"
             :product="product"
             :showInstallation="true"
+            :refreshProductOnMount="false"
           />
         </transition-group>
       </section>
@@ -1361,35 +1373,29 @@ onMounted(async () => {
       </div>
     </div>
 
-    <div v-else class="empty-status card">
+    <div v-else-if="dynamicActive" class="empty-status card">
       <span class="material-icons-round large">search_off</span>
       <h3>Товары не найдены</h3>
       <p>Попробуйте выбрать другой бренд или категорию.</p>
     </div>
-
-    <section class="catalog-seo-block">
-      <h2>Как выбрать кондиционер для квартиры</h2>
-      <p>
-        Для жилых комнат чаще всего подходят настенные сплит-системы до 25–35 м²: они закрывают типовые спальни,
-        детские и гостиные без переплаты за лишнюю мощность. При выборе стоит учитывать площадь, солнечную сторону,
-        высоту потолков и теплопритоки от техники.
-      </p>
-      <p>
-        Если кондиционер нужен для ежедневного использования, обратите внимание на инверторные модели, уровень шума
-        внутреннего блока и наличие сервисной поддержки. Для больших помещений и коммерческих объектов лучше выбирать
-        модель с запасом по производительности и заранее продумать место установки.
-      </p>
-      <p>
-        В каталоге MVN собраны кондиционеры для квартир, домов и офисов в Витебске. Умная сортировка поднимает выше
-        доступные модели подходящей мощности, чтобы быстрее найти практичный вариант с монтажом.
-      </p>
-    </section>
   </div>
 </template>
 
 <style scoped>
 .catalog-header {
   margin-bottom: 1.5rem;
+}
+
+.catalog-controls {
+  margin-bottom: 1rem;
+}
+
+.controls-top {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .header-top {
@@ -1432,7 +1438,7 @@ onMounted(async () => {
 
 .header-search {
   width: min(620px, 58vw);
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .search-toggle {
@@ -1999,6 +2005,10 @@ onMounted(async () => {
 }
 
 @media (max-width: 768px) {
+  .controls-top {
+    align-items: stretch;
+  }
+
   .header-top {
     align-items: center;
     margin-bottom: 0.8rem;
@@ -2010,6 +2020,10 @@ onMounted(async () => {
 
   .catalog-mobile-only {
     display: flex !important;
+  }
+
+  .header-search {
+    width: 100%;
   }
 
   .breadcrumb {

--- a/web/src/components/PriceWithToggle.vue
+++ b/web/src/components/PriceWithToggle.vue
@@ -22,7 +22,10 @@ const props = defineProps({
   area: { type: Number, default: 0 },
   vitebskQty: { type: Number, default: 0 },
   minskQty: { type: Number, default: 0 },
-  availabilityStatus: { type: String, default: null }
+  availabilityStatus: { type: String, default: null },
+  installationRates: { type: Array, default: null },
+  installDiscount: { type: Number, default: null },
+  refreshProductOnMount: { type: Boolean, default: true }
 });
 
 const isInstalled = ref(false);
@@ -48,13 +51,17 @@ const liveMinskQty = ref(Number(props.minskQty) || 0);
 
 onMounted(async () => {
     try {
+        const shouldUseProvidedRates = Array.isArray(props.installationRates) && props.installationRates.length > 0;
+        const shouldUseProvidedDiscount = props.installDiscount !== null && props.installDiscount !== undefined;
         const [ratesData, configData, freshProduct] = await Promise.all([
-            getInstallationRates(),
-            getGlobalConfig(),
-            props.productId ? getProductById(props.productId) : Promise.resolve(null)
+            shouldUseProvidedRates ? Promise.resolve(props.installationRates) : getInstallationRates(),
+            shouldUseProvidedDiscount ? Promise.resolve(null) : getGlobalConfig(),
+            props.refreshProductOnMount && props.productId ? getProductById(props.productId) : Promise.resolve(null)
         ]);
         rates.value = ratesData || [];
-        if (configData && configData.install_discount) {
+        if (shouldUseProvidedDiscount) {
+            discount.value = Number(props.installDiscount) || 0;
+        } else if (configData && configData.install_discount) {
             discount.value = parseInt(configData.install_discount, 10) || 0;
         }
         if (freshProduct && freshProduct.price !== undefined) {

--- a/web/src/components/ProductCard.astro
+++ b/web/src/components/ProductCard.astro
@@ -31,6 +31,9 @@ interface Props {
   variant?: "default" | "hero" | "small" | "minimal";
   showInstallation?: boolean;
   baseInstallationPrice?: number;
+  installationRates?: any[] | null;
+  installDiscount?: number | null;
+  refreshProductOnMount?: boolean;
 }
 
 const {
@@ -38,7 +41,19 @@ const {
   variant = "default",
   showInstallation = false,
   baseInstallationPrice = 360,
+  installationRates = null,
+  installDiscount = null,
+  refreshProductOnMount = false,
 } = Astro.props;
+
+const pricingProps = {
+  ...(Array.isArray(installationRates) && installationRates.length > 0
+    ? { installationRates }
+    : {}),
+  ...(installDiscount !== null && installDiscount !== undefined
+    ? { installDiscount }
+    : {}),
+};
 
 const formatPrice = (price: number) => price.toLocaleString();
 
@@ -188,6 +203,8 @@ const showAreaBadge = !!product.area;
             vitebskQty={product.vitebsk_qty}
             minskQty={product.minsk_qty}
             availabilityStatus={product.availability_status}
+            refreshProductOnMount={refreshProductOnMount}
+            {...pricingProps}
           />
         </div>
       </div>
@@ -250,6 +267,8 @@ const showAreaBadge = !!product.area;
             vitebskQty={product.vitebsk_qty}
             minskQty={product.minsk_qty}
             availabilityStatus={product.availability_status}
+            refreshProductOnMount={refreshProductOnMount}
+            {...pricingProps}
           />
         </div>
       </div>

--- a/web/src/components/ProductCard.vue
+++ b/web/src/components/ProductCard.vue
@@ -19,6 +19,18 @@ const props = defineProps({
   baseInstallationPrice: {
     type: Number,
     default: 360
+  },
+  installationRates: {
+    type: Array,
+    default: null
+  },
+  installDiscount: {
+    type: Number,
+    default: null
+  },
+  refreshProductOnMount: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -149,6 +161,9 @@ const showAreaBadge = computed(() => Boolean(props.product.area));
           :vitebskQty="product.vitebsk_qty"
           :minskQty="product.minsk_qty"
           :availabilityStatus="product.availability_status"
+          :installationRates="installationRates"
+          :installDiscount="installDiscount"
+          :refreshProductOnMount="refreshProductOnMount"
         />
     </div>
   </div>

--- a/web/src/components/ProductGroup.astro
+++ b/web/src/components/ProductGroup.astro
@@ -86,6 +86,7 @@ if (vitebskFeatured) {
                         product={product}
                         variant="default"
                         showInstallation={true}
+                        refreshProductOnMount={false}
                     />
                 ))}
             </div>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -174,7 +174,7 @@ const address = config["address"] || SITE_CONFIG.address;
 				</div>
 
 				<div class="nav-actions">
-					<MobileMenu client:load />
+					<MobileMenu client:media="(max-width: 980px)" />
 					<button
 						id="theme-toggle"
 						class="icon-btn"

--- a/web/src/pages/catalog.astro
+++ b/web/src/pages/catalog.astro
@@ -1,7 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import CatalogApp from "../components/CatalogApp.vue";
-import { getCatalog } from "../utils/api";
+import ProductCard from "../components/ProductCard.astro";
+import { getCatalog, getFiltersConfig } from "../utils/api";
 import { buildCatalogItemListSchema } from "../utils/catalog-seo";
 import { matchVirtualCategoryByFilters } from "../utils/virtual-category";
 import {
@@ -137,8 +138,32 @@ const popularData = await getCatalog({
 });
 const products = (data.items || []) as Product[];
 const popularProducts = (popularData.items || []) as Product[];
+const filtersConfig = await getFiltersConfig();
 const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
 const catalogSchema = buildCatalogItemListSchema(products, Astro.url.origin);
+const isCatalogAvailable = (product: Product) => {
+    const status = String(product?.availability_status || "");
+    const qty = Number(product?.vitebsk_qty || 0) + Number(product?.minsk_qty || 0);
+    return qty > 0 || status === "in_stock_now" || status === "available_2_3_days";
+};
+const pageTitle =
+    initialCategorySlug === "cat-multi"
+        ? "Мульти-сплит системы"
+        : initialCategorySlug === "cat-industrial"
+          ? "Полупромышленные кондиционеры"
+          : "Бытовые кондиционеры";
+const pageDescription =
+    initialCategorySlug === "cat-multi"
+        ? "Системы с одним наружным блоком и несколькими внутренними для гибкого зонирования."
+        : initialCategorySlug === "cat-industrial"
+          ? "Кассетные, канальные и напольно-потолочные решения для коммерческих и сложных объектов."
+          : "Настенные сплит-системы для квартиры и дома с удобной фильтрацией по брендам.";
+const staticPopularProducts =
+    initialCategorySlug === "cat-household"
+        ? popularProducts
+              .filter((product) => isCatalogAvailable(product) && Number(product.area || 0) <= Number(parsedAreaMax || 35))
+              .slice(0, 8)
+        : [];
 const initialFilters = {
     sort,
     area_min: parsedAreaMin ?? null,
@@ -159,15 +184,138 @@ const initialFilters = {
     robots={robotsValue}
 >
     <script type="application/ld+json" set:html={JSON.stringify(catalogSchema)} />
+    <script is:inline>
+        (() => {
+            if (typeof window === "undefined") return;
+
+            const sp = new URLSearchParams(window.location.search);
+            if (Array.from(sp.keys()).length === 0) return;
+
+            const tags = sp
+                .getAll("tag_slugs")
+                .flatMap((raw) => raw.split(","))
+                .map((tag) => tag.trim())
+                .filter(Boolean);
+            const category = tags.find((tag) =>
+                ["cat-household", "cat-multi", "cat-industrial"].includes(tag),
+            );
+            const copy = {
+                "cat-multi": {
+                    title: "Мульти-сплит системы",
+                    description:
+                        "Системы с одним наружным блоком и несколькими внутренними для гибкого зонирования.",
+                },
+                "cat-industrial": {
+                    title: "Полупромышленные кондиционеры",
+                    description:
+                        "Кассетные, канальные и напольно-потолочные решения для коммерческих и сложных объектов.",
+                },
+            }[category || ""];
+
+            if (!copy) return;
+            document.documentElement.classList.add("catalog-query-mode");
+
+            const applyCopy = () => {
+                const header = document.querySelector(".catalog-page > .catalog-header");
+                if (!header) return;
+                const title = header.querySelector("h1");
+                const description = header.querySelector(".header-description");
+                if (title) title.textContent = copy.title;
+                if (description) description.textContent = copy.description;
+            };
+
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", applyCopy, { once: true });
+            } else {
+                applyCopy();
+            }
+        })();
+    </script>
     <div class="container catalog-page">
+        <header class="catalog-header">
+            <div class="breadcrumb">
+                <a href="/">Главная</a>
+                <span class="sep">/</span>
+                <span>Каталог</span>
+            </div>
+            <h1 class="gradient-text">{pageTitle}</h1>
+            <p class="header-description">{pageDescription}</p>
+        </header>
         <CatalogApp
-            client:load
+            client:idle
             initialProducts={products}
             initialMeta={meta}
             initialPopularProducts={popularProducts}
             initialFilters={initialFilters}
             initialCategorySlug={initialCategorySlug}
-        />
+            initialBrands={filtersConfig?.brands || []}
+        >
+            <div class="catalog-static-content">
+                {
+                    staticPopularProducts.length >= 3 && (
+                        <section class="catalog-section popular-section" aria-labelledby="static-popular-models-title">
+                            <div class="catalog-section-head">
+                                <h2 id="static-popular-models-title">Популярные модели</h2>
+                            </div>
+                            <div class="catalog-grid popular-grid">
+                                {staticPopularProducts.map((product) => (
+                                    <ProductCard
+                                        product={product}
+                                        variant="default"
+                                        showInstallation={true}
+                                        refreshProductOnMount={false}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    )
+                }
+
+                {
+                    products.length > 0 ? (
+                        <section class="catalog-section all-products-section" aria-labelledby="static-all-products-title">
+                            <div class="catalog-section-head">
+                                <h2 id="static-all-products-title">Все модели</h2>
+                            </div>
+                            <div class="catalog-grid">
+                                {products.map((product) => (
+                                    <ProductCard
+                                        product={product}
+                                        variant="default"
+                                        showInstallation={true}
+                                        refreshProductOnMount={false}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    ) : (
+                        <div class="empty-status card">
+                            <span class="material-icons-round large">search_off</span>
+                            <h3>Товары не найдены</h3>
+                            <p>Попробуйте выбрать другой бренд или категорию.</p>
+                        </div>
+                    )
+                }
+
+                <section class="catalog-seo-block">
+                    <h2>Как выбрать кондиционер для квартиры</h2>
+                    <p>
+                        Для жилых комнат чаще всего подходят настенные сплит-системы до 25–35 м²: они закрывают типовые спальни,
+                        детские и гостиные без переплаты за лишнюю мощность. При выборе стоит учитывать площадь, солнечную сторону,
+                        высоту потолков и теплопритоки от техники.
+                    </p>
+                    <p>
+                        Если кондиционер нужен для ежедневного использования, обратите внимание на инверторные модели, уровень шума
+                        внутреннего блока и наличие сервисной поддержки. Для больших помещений и коммерческих объектов лучше выбирать
+                        модель с запасом по производительности и заранее продумать место установки.
+                    </p>
+                    <p>
+                        В каталоге MVN собраны кондиционеры для квартир, домов и офисов в Витебске. Умная сортировка поднимает выше
+                        доступные модели подходящей мощности, чтобы быстрее найти практичный вариант с монтажом.
+                    </p>
+                </section>
+            </div>
+        </CatalogApp>
     </div>
     <script is:inline define:vars={{ virtualCategories: VIRTUAL_CATEGORIES }}>
         (() => {
@@ -325,6 +473,67 @@ const initialFilters = {
         margin-bottom: 0.5rem;
         font-weight: 800;
         line-height: 1.1;
+    }
+    .header-description {
+        max-width: 760px;
+        color: var(--text-muted);
+        margin: 0;
+        line-height: 1.65;
+    }
+    .catalog-static-content,
+    .catalog-section {
+        display: flex;
+        flex-direction: column;
+        gap: 1.4rem;
+    }
+    :global(html.catalog-query-mode .catalog-static-slot) {
+        display: none;
+    }
+    .catalog-section + .catalog-section {
+        margin-top: 1.4rem;
+    }
+    .catalog-section-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+    .catalog-section-head h2,
+    .catalog-seo-block h2 {
+        margin: 0;
+        color: var(--text);
+        font-family: "Space Grotesk", sans-serif;
+        font-size: 1.35rem;
+        line-height: 1.2;
+    }
+    .catalog-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 1.3rem;
+    }
+    .empty-status {
+        text-align: center;
+        padding: 4rem 1rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+    }
+    .large {
+        font-size: 4rem;
+        color: var(--text-muted);
+        opacity: 0.55;
+    }
+    .catalog-seo-block {
+        margin-top: 2.2rem;
+        padding-top: 1.6rem;
+        border-top: 1px solid var(--panel-glass-border);
+        color: var(--text-muted);
+    }
+    .catalog-seo-block p {
+        max-width: 880px;
+        margin: 0.75rem 0 0;
+        line-height: 1.7;
     }
     .count {
         font-weight: 700;

--- a/web/src/pages/catalog/[virtual].astro
+++ b/web/src/pages/catalog/[virtual].astro
@@ -1,9 +1,10 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import CatalogApp from "../../components/CatalogApp.vue";
+import ProductCard from "../../components/ProductCard.astro";
 import type { VirtualCategoryConfig } from "../../config/virtual-categories";
 import { VIRTUAL_CATEGORIES } from "../../config/virtual-categories";
-import { getCatalog } from "../../utils/api";
+import { getCatalog, getFiltersConfig } from "../../utils/api";
 import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 import { buildCatalogQueryFromVirtual } from "../../utils/virtual-category";
 
@@ -58,6 +59,7 @@ const popularData = await getCatalog({
 });
 const products = (data.items || []) as Product[];
 const popularProducts = (popularData.items || []) as Product[];
+const filtersConfig = await getFiltersConfig();
 const meta = data.meta || { total: 0, page: 1, limit: 20, pages: 1 };
 const robotsValue = category.indexable === false ? "noindex,follow" : undefined;
 const catalogSchema = buildCatalogItemListSchema(products, Astro.url.origin);
@@ -65,6 +67,17 @@ const initialCategorySlug =
     category.filters.tag_slugs?.find((slug) =>
         ["cat-household", "cat-multi", "cat-industrial"].includes(slug),
     ) || "cat-household";
+const isCatalogAvailable = (product: Product) => {
+    const status = String(product?.availability_status || "");
+    const qty = Number(product?.vitebsk_qty || 0) + Number(product?.minsk_qty || 0);
+    return qty > 0 || status === "in_stock_now" || status === "available_2_3_days";
+};
+const staticPopularProducts =
+    initialCategorySlug === "cat-household"
+        ? popularProducts
+              .filter((product) => isCatalogAvailable(product) && Number(product.area || 0) <= Number(category.filters.area_max || 35))
+              .slice(0, 8)
+        : [];
 ---
 
 <Layout
@@ -75,8 +88,19 @@ const initialCategorySlug =
 >
     <script type="application/ld+json" set:html={JSON.stringify(catalogSchema)} />
     <div class="container catalog-page">
+        <header class="catalog-header">
+            <div class="breadcrumb">
+                <a href="/">Главная</a>
+                <span class="sep">/</span>
+                <a href="/catalog">Каталог</a>
+                <span class="sep">/</span>
+                <span>{category.h1}</span>
+            </div>
+            <h1 class="gradient-text">{category.h1}</h1>
+            <p class="header-description">{category.intro || category.seoDescription}</p>
+        </header>
         <CatalogApp
-            client:load
+            client:idle
             initialProducts={products}
             initialMeta={meta}
             initialPopularProducts={popularProducts}
@@ -85,7 +109,65 @@ const initialCategorySlug =
             forcedDescription={category.intro || category.seoDescription}
             lockedInitialFilters={category.filters}
             initialCategorySlug={initialCategorySlug}
-        />
+            initialBrands={filtersConfig?.brands || []}
+        >
+            <div class="catalog-static-content">
+                {
+                    staticPopularProducts.length >= 3 && (
+                        <section class="catalog-section popular-section" aria-labelledby="static-popular-models-title">
+                            <div class="catalog-section-head">
+                                <h2 id="static-popular-models-title">Популярные модели</h2>
+                            </div>
+                            <div class="catalog-grid popular-grid">
+                                {staticPopularProducts.map((product) => (
+                                    <ProductCard
+                                        product={product}
+                                        variant="default"
+                                        showInstallation={true}
+                                        refreshProductOnMount={false}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    )
+                }
+
+                {
+                    products.length > 0 ? (
+                        <section class="catalog-section all-products-section" aria-labelledby="static-all-products-title">
+                            <div class="catalog-section-head">
+                                <h2 id="static-all-products-title">Все модели</h2>
+                            </div>
+                            <div class="catalog-grid">
+                                {products.map((product) => (
+                                    <ProductCard
+                                        product={product}
+                                        variant="default"
+                                        showInstallation={true}
+                                        refreshProductOnMount={false}
+                                    />
+                                ))}
+                            </div>
+                        </section>
+                    ) : (
+                        <div class="empty-status card">
+                            <span class="material-icons-round large">search_off</span>
+                            <h3>Товары не найдены</h3>
+                            <p>Попробуйте выбрать другой бренд или категорию.</p>
+                        </div>
+                    )
+                }
+
+                <section class="catalog-seo-block">
+                    <h2>{category.h1}: выбор и монтаж в Витебске</h2>
+                    <p>{category.intro || category.seoDescription}</p>
+                    <p>
+                        В каталоге можно сравнить модели по мощности, типу компрессора, наличию Wi-Fi, режимам обогрева
+                        и доступности. Для точного подбора учитывайте площадь помещения, теплопритоки и место установки.
+                    </p>
+                </section>
+            </div>
+        </CatalogApp>
     </div>
 </Layout>
 
@@ -94,5 +176,88 @@ const initialCategorySlug =
         padding: 2rem 1.5rem;
         max-width: 1400px;
         margin: 0 auto;
+    }
+    .catalog-header {
+        margin-bottom: 2rem;
+    }
+    .breadcrumb {
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        margin-bottom: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-weight: 500;
+        flex-wrap: wrap;
+    }
+    .breadcrumb a:hover {
+        color: var(--primary);
+    }
+    .sep {
+        opacity: 0.5;
+    }
+    .catalog-header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        font-weight: 800;
+        line-height: 1.1;
+    }
+    .header-description {
+        max-width: 760px;
+        color: var(--text-muted);
+        margin: 0;
+        line-height: 1.65;
+    }
+    .catalog-static-content,
+    .catalog-section {
+        display: flex;
+        flex-direction: column;
+        gap: 1.4rem;
+    }
+    .catalog-section + .catalog-section {
+        margin-top: 1.4rem;
+    }
+    .catalog-section-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+    .catalog-section-head h2,
+    .catalog-seo-block h2 {
+        margin: 0;
+        color: var(--text);
+        font-family: "Space Grotesk", sans-serif;
+        font-size: 1.35rem;
+        line-height: 1.2;
+    }
+    .catalog-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 1.3rem;
+    }
+    .empty-status {
+        text-align: center;
+        padding: 4rem 1rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+    }
+    .large {
+        font-size: 4rem;
+        color: var(--text-muted);
+        opacity: 0.55;
+    }
+    .catalog-seo-block {
+        margin-top: 2.2rem;
+        padding-top: 1.6rem;
+        border-top: 1px solid var(--panel-glass-border);
+        color: var(--text-muted);
+    }
+    .catalog-seo-block p {
+        max-width: 880px;
+        margin: 0.75rem 0 0;
+        line-height: 1.7;
     }
 </style>

--- a/web/src/pages/contacts.astro
+++ b/web/src/pages/contacts.astro
@@ -67,7 +67,7 @@ const workHours = config["work_hours"] || "Пн-Пт: 9:00 - 18:00";
             </div>
 
             <div class="contact-form-wrapper">
-                <ContactForm client:load />
+                <ContactForm client:visible />
             </div>
         </div>
     </section>

--- a/web/src/pages/kak-vybrat-konditsioner.astro
+++ b/web/src/pages/kak-vybrat-konditsioner.astro
@@ -16,7 +16,7 @@ import PowerCalculator from "../components/PowerCalculator.vue";
 
     <section class="container selection-grid">
         <div class="calculator-wrapper">
-            <PowerCalculator client:load />
+            <PowerCalculator client:visible />
         </div>
 
         <div class="content prose">

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -72,7 +72,7 @@ const publicSpecsSummary = buildPublicSpecsSummary(specs);
 const bentoCards = generateBentoCards(product);
 
 const publicTags = (product.tags || []).filter((t: any) => t.is_public);
----
+	---
 
 <Layout
     title={product.title}
@@ -200,6 +200,7 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
                         vitebskQty={product.vitebsk_qty}
                         minskQty={product.minsk_qty}
                         availabilityStatus={product.availability_status}
+                        refreshProductOnMount={false}
                     />
                 </div>
 

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -182,9 +182,18 @@ export async function refreshProductPrices(ids) {
     return results.filter(Boolean);
 }
 
+let _globalConfigPromise = null;
+
 export async function getGlobalConfig() {
-    const data = await fetchJson(`${API_V1}/config`);
-    return data || {};
+    if (!_globalConfigPromise) {
+        _globalConfigPromise = fetchJson(`${API_V1}/config`)
+            .catch(err => {
+                console.error('[API] Failed to fetch global config:', err);
+                _globalConfigPromise = null;
+                return {};
+            });
+    }
+    return _globalConfigPromise.then(res => res || {});
 }
 
 /**


### PR DESCRIPTION
## Summary
- Reworked the Astro storefront to keep catalog SEO content server-rendered while hydrating only the interactive parts
- Reduced eager Vue hydration across catalog, contact, and calculator surfaces
- Optimized catalog price/install handling to avoid redundant product and config fetches
- Updated manager frontend views and API usage to align with the current data flow

## Testing
- `web` build completed successfully
- Local browser smoke checks confirmed catalog category switching, SEO headings, and product grids render correctly
- Theme audit still reports only pre-existing hardcoded surface colors in unrelated files