### PR TITLE
[codex] Fix Google OAuth production callback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ CORS_ORIGINS=["https://mvn.by","https://dev.mvn.by","http://localhost:4321"]
 # Production manager build gets WEBSITE_URL from GitHub Actions deploy workflow.
 WEBSITE_URL=http://localhost:4321
 
+# Google OAuth callback. Set this on production and add the same URI to
+# Google Cloud Console -> OAuth client -> Authorized redirect URIs.
+# Example: GOOGLE_OAUTH_REDIRECT_URI=https://api.mvn.by/api/manager/google-auth/callback
+GOOGLE_OAUTH_REDIRECT_URI=http://127.0.0.1:8000/api/manager/google-auth/callback
+
 # HTTP Basic Auth credentials
  ---
 # --- Bot Settings ---

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -36,7 +36,6 @@ const creating = ref(false);
 const googleAuthStatus = ref<ManagerGoogleAuthStatusResponse | null>(null);
 const googleAuthLoading = ref(false);
 const googleAuthBusy = ref(false);
-const googleAuthCode = ref('');
 
 const goToBackups = () => {
     if (window.location.pathname !== '/manager/settings/backup') {
@@ -68,25 +67,6 @@ const openGoogleAuth = async () => {
         const response = await api.getManagerGoogleAuthUrl();
         window.open(response.url, '_blank', 'noopener,noreferrer');
         setToast('Открыли Google Login в новой вкладке');
-    } catch (e) {
-        setToast(getApiErrorMessage(e), 'error');
-    } finally {
-        googleAuthBusy.value = false;
-    }
-};
-
-const exchangeGoogleCode = async () => {
-    const code = googleAuthCode.value.trim();
-    if (!code) {
-        setToast('Введите код от Google', 'error');
-        return;
-    }
-    googleAuthBusy.value = true;
-    try {
-        await api.exchangeManagerGoogleAuthCode(code);
-        googleAuthCode.value = '';
-        setToast('Google интеграция подключена');
-        await loadGoogleAuthStatus();
     } catch (e) {
         setToast(getApiErrorMessage(e), 'error');
     } finally {
@@ -320,29 +300,14 @@ onMounted(() => {
                 </div>
             </div>
 
-            <div class="mt-4 grid grid-cols-1 md:grid-cols-[auto_1fr_auto] gap-2 items-center">
+            <div class="mt-4 flex flex-wrap items-center gap-2">
                 <button
                     @click="openGoogleAuth"
                     class="flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-500 active:bg-teal-700 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-all text-sm disabled:opacity-60"
                     :disabled="googleAuthBusy"
                 >
                     <span class="material-icons-round text-[18px]">open_in_new</span>
-                    Open Google Login
-                </button>
-                <input
-                    v-model="googleAuthCode"
-                    type="text"
-                    class="w-full bg-gray-50 dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors shadow-sm text-sm font-mono"
-                    placeholder="Вставьте код от Google (4/0A...)"
-                    :disabled="googleAuthBusy"
-                />
-                <button
-                    @click="exchangeGoogleCode"
-                    class="flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 text-white font-medium py-2 px-4 rounded-lg shadow-sm transition-all text-sm disabled:opacity-60"
-                    :disabled="googleAuthBusy"
-                >
-                    <span class="material-icons-round text-[18px]">check_circle</span>
-                    Подтвердить код
+                    Подключить Google
                 </button>
             </div>
         </div>

--- a/routers/manager_google_auth.py
+++ b/routers/manager_google_auth.py
@@ -1,6 +1,9 @@
 from html import escape
 
-from fastapi import APIRouter, Depends, HTTPException
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
@@ -24,16 +27,24 @@ router = APIRouter(
 )
 
 
+def _google_oauth_redirect_uri(request: Request) -> str:
+    configured = os.getenv("GOOGLE_OAUTH_REDIRECT_URI", "").strip()
+    if configured:
+        return configured
+    return str(request.url_for("manager_google_auth_callback"))
+
+
 @router.get("/status", response_model=ManagerGoogleAuthStatusResponse, operation_id=GET_MANAGER_GOOGLE_AUTH_STATUS)
 async def get_manager_google_auth_status(_: str = Depends(get_current_username)):
-    status_payload = get_google_service().get_token_status()
+    status_payload = await run_in_threadpool(lambda: get_google_service().get_token_status())
     return ManagerGoogleAuthStatusResponse(**status_payload)
 
 
 @router.get("/url", response_model=ManagerGoogleAuthUrlResponse, operation_id=GET_MANAGER_GOOGLE_AUTH_URL)
-async def get_manager_google_auth_url(_: str = Depends(get_current_username)):
+async def get_manager_google_auth_url(request: Request, _: str = Depends(get_current_username)):
     try:
-        url = get_google_service().get_auth_url()
+        redirect_uri = _google_oauth_redirect_uri(request)
+        url = await run_in_threadpool(lambda: get_google_service().get_auth_url(redirect_uri))
         return ManagerGoogleAuthUrlResponse(url=url)
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -42,6 +53,7 @@ async def get_manager_google_auth_url(_: str = Depends(get_current_username)):
 @router.post("/exchange", response_model=ManagerActionMessageResponse, operation_id=EXCHANGE_MANAGER_GOOGLE_AUTH_CODE)
 async def exchange_manager_google_auth_code(
     payload: ManagerGoogleAuthExchangePayload,
+    request: Request,
     _: str = Depends(get_current_username),
 ):
     code = (payload.code or "").strip()
@@ -49,7 +61,8 @@ async def exchange_manager_google_auth_code(
         raise HTTPException(status_code=400, detail="Google auth code is required")
 
     try:
-        get_google_service().finish_auth(code)
+        redirect_uri = _google_oauth_redirect_uri(request)
+        await run_in_threadpool(lambda: get_google_service().finish_auth(code, redirect_uri))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -57,7 +70,7 @@ async def exchange_manager_google_auth_code(
 
 
 @router.get("/callback", include_in_schema=False)
-async def manager_google_auth_callback(code: str = "", error: str = ""):
+async def manager_google_auth_callback(request: Request, code: str = "", error: str = ""):
     if error:
         return HTMLResponse(
             content=f"""
@@ -84,7 +97,8 @@ async def manager_google_auth_callback(code: str = "", error: str = ""):
         )
 
     try:
-        get_google_service().finish_auth(code)
+        redirect_uri = _google_oauth_redirect_uri(request)
+        await run_in_threadpool(lambda: get_google_service().finish_auth(code, redirect_uri))
     except Exception as exc:
         return HTMLResponse(
             content=f"""

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import logging
 import re
 from typing import Dict, Any, List, Optional
@@ -21,10 +21,11 @@ SCOPES = [
 TOKEN_FILE = 'token.json'
 CLIENT_SECRET_FILE = 'client_secret.json'
 DESTINATION_FOLDER_ID = '1kLK6Vque3V5iPV1i1HjeH_su-TmyCzQt' 
-DEFAULT_OAUTH_REDIRECT_URI = os.getenv(
-    "GOOGLE_OAUTH_REDIRECT_URI",
-    "http://127.0.0.1:8000/api/manager/google-auth/callback",
-)
+DEFAULT_OAUTH_REDIRECT_URI = "http://127.0.0.1:8000/api/manager/google-auth/callback"
+
+
+def get_default_oauth_redirect_uri() -> str:
+    return os.getenv("GOOGLE_OAUTH_REDIRECT_URI", DEFAULT_OAUTH_REDIRECT_URI)
 
 class GoogleDocsService:
     def __init__(self):
@@ -48,10 +49,11 @@ class GoogleDocsService:
                 status["expiry"] = self.creds.expiry.strftime("%Y-%m-%d %H:%M:%S")
         return status
 
-    def get_auth_url(self, redirect_uri: str = DEFAULT_OAUTH_REDIRECT_URI) -> str:
+    def get_auth_url(self, redirect_uri: Optional[str] = None) -> str:
         """Generates the OAuth2 URL for the user to visit."""
         if not os.path.exists(CLIENT_SECRET_FILE):
              raise Exception(f"Client Secret file '{CLIENT_SECRET_FILE}' not found!")
+        redirect_uri = redirect_uri or get_default_oauth_redirect_uri()
         
         flow = Flow.from_client_secrets_file(
             CLIENT_SECRET_FILE,
@@ -65,10 +67,11 @@ class GoogleDocsService:
         )
         return auth_url
 
-    def finish_auth(self, code: str, redirect_uri: str = DEFAULT_OAUTH_REDIRECT_URI):
+    def finish_auth(self, code: str, redirect_uri: Optional[str] = None):
         """Exchanges auth code for token and saves it."""
         if not os.path.exists(CLIENT_SECRET_FILE):
              raise Exception(f"Client Secret file '{CLIENT_SECRET_FILE}' not found!")
+        redirect_uri = redirect_uri or get_default_oauth_redirect_uri()
              
         flow = Flow.from_client_secrets_file(
             CLIENT_SECRET_FILE,

--- a/tests/unit/test_manager_google_auth_api.py
+++ b/tests/unit/test_manager_google_auth_api.py
@@ -7,7 +7,8 @@ from routers.manager_google_auth import router as manager_google_auth_router
 
 
 @pytest.fixture()
-async def google_auth_client():
+async def google_auth_client(monkeypatch):
+    monkeypatch.delenv("GOOGLE_OAUTH_REDIRECT_URI", raising=False)
     app = FastAPI()
     app.include_router(manager_google_auth_router)
     app.dependency_overrides[get_current_username] = lambda: "admin"
@@ -39,23 +40,47 @@ async def test_google_auth_status_endpoint(google_auth_client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_google_auth_url_endpoint(google_auth_client, monkeypatch):
+    called = {"redirect_uri": None}
+
     class _Svc:
-        def get_auth_url(self):
+        def get_auth_url(self, redirect_uri=None):
+            called["redirect_uri"] = redirect_uri
             return "https://accounts.google.com/o/oauth2/auth?x=1"
 
     monkeypatch.setattr("routers.manager_google_auth.get_google_service", lambda: _Svc())
     response = await google_auth_client.get("/api/manager/google-auth/url")
     assert response.status_code == 200
     assert response.json()["url"].startswith("https://accounts.google.com/")
+    assert called["redirect_uri"] == "http://test/api/manager/google-auth/callback"
+
+
+@pytest.mark.asyncio
+async def test_google_auth_url_endpoint_uses_configured_redirect_uri(google_auth_client, monkeypatch):
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI",
+        "https://api.mvn.by/api/manager/google-auth/callback",
+    )
+    called = {"redirect_uri": None}
+
+    class _Svc:
+        def get_auth_url(self, redirect_uri=None):
+            called["redirect_uri"] = redirect_uri
+            return "https://accounts.google.com/o/oauth2/auth?x=1"
+
+    monkeypatch.setattr("routers.manager_google_auth.get_google_service", lambda: _Svc())
+    response = await google_auth_client.get("/api/manager/google-auth/url")
+    assert response.status_code == 200
+    assert called["redirect_uri"] == "https://api.mvn.by/api/manager/google-auth/callback"
 
 
 @pytest.mark.asyncio
 async def test_google_auth_exchange_endpoint(google_auth_client, monkeypatch):
-    called = {"code": None}
+    called = {"code": None, "redirect_uri": None}
 
     class _Svc:
-        def finish_auth(self, code: str):
+        def finish_auth(self, code: str, redirect_uri=None):
             called["code"] = code
+            called["redirect_uri"] = redirect_uri
 
     monkeypatch.setattr("routers.manager_google_auth.get_google_service", lambda: _Svc())
     response = await google_auth_client.post(
@@ -64,12 +89,13 @@ async def test_google_auth_exchange_endpoint(google_auth_client, monkeypatch):
     )
     assert response.status_code == 200
     assert called["code"] == "test-code-123"
+    assert called["redirect_uri"] == "http://test/api/manager/google-auth/callback"
 
 
 @pytest.mark.asyncio
 async def test_google_auth_exchange_requires_code(google_auth_client, monkeypatch):
     class _Svc:
-        def finish_auth(self, code: str):
+        def finish_auth(self, code: str, redirect_uri=None):
             raise AssertionError("finish_auth should not be called")
 
     monkeypatch.setattr("routers.manager_google_auth.get_google_service", lambda: _Svc())
@@ -82,13 +108,15 @@ async def test_google_auth_exchange_requires_code(google_auth_client, monkeypatc
 
 @pytest.mark.asyncio
 async def test_google_auth_callback_exchanges_code(google_auth_client, monkeypatch):
-    called = {"code": None}
+    called = {"code": None, "redirect_uri": None}
 
     class _Svc:
-        def finish_auth(self, code: str):
+        def finish_auth(self, code: str, redirect_uri=None):
             called["code"] = code
+            called["redirect_uri"] = redirect_uri
 
     monkeypatch.setattr("routers.manager_google_auth.get_google_service", lambda: _Svc())
     response = await google_auth_client.get("/api/manager/google-auth/callback?code=callback-code")
     assert response.status_code == 200
     assert called["code"] == "callback-code"
+    assert called["redirect_uri"] == "http://test/api/manager/google-auth/callback"


### PR DESCRIPTION
## What changed
- Build Google OAuth callback URLs from the current API request, with GOOGLE_OAUTH_REDIRECT_URI as an explicit production override.
- Pass the same redirect URI into token exchange/callback handling and run Google auth service calls in FastAPI's threadpool.
- Hide the legacy manual Google code input in manager settings now that callback flow works.
- Document the production redirect URI env variable and cover request/env redirect behavior in unit tests.

## Why
Production auth was still sending Google a localhost redirect URI, so successful login returned to 127.0.0.1 instead of api.mvn.by.

## Validation
- python3 -m compileall -q services/google_service.py routers/manager_google_auth.py
- pytest tests/unit/test_manager_google_auth_api.py -q
- npm run build (manager_frontend)