### PR TITLE
[codex] Add manager order titles and labels

### DIFF
--- a/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
@@ -16,6 +16,8 @@ export type ManagerOrderDetailResponse = {
     id: number;
     status: string;
     lead_source?: (string | null);
+    title?: (string | null);
+    manager_labels?: Array<string>;
     created_at: string;
     updated_at?: (string | null);
     next_followup_date?: (string | null);

--- a/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
@@ -11,6 +11,8 @@ export type ManagerOrderListItemResponse = {
     id: number;
     status: string;
     lead_source?: (string | null);
+    title?: (string | null);
+    manager_labels?: Array<string>;
     created_at: string;
     updated_at?: (string | null);
     next_followup_date?: (string | null);

--- a/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
@@ -7,6 +7,8 @@ import type { ManagerOrderServiceLinePayload } from './ManagerOrderServiceLinePa
 import type { PaymentCurrency } from './PaymentCurrency';
 export type ManagerOrderUpdatePayload = {
     status?: (string | null);
+    title?: (string | null);
+    manager_labels?: (Array<string> | null);
     next_followup_date?: (string | null);
     measurement_date?: (string | null);
     installation_date?: (string | null);

--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { ManagerOrderListItemResponse } from '../../client';
 import { STATUS_LABELS, formatMoney, isOverdue } from './order-utils';
 
@@ -16,6 +17,15 @@ const emit = defineEmits<{
 const onDragStart = () => {
   emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
 };
+
+const customerName = computed(() => props.order.customer?.full_legal_name || props.order.customer?.name || `Заказ #${props.order.id}`);
+const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
+const secondaryLine = computed(() => {
+  const parts = [];
+  if (props.order.title?.trim()) parts.push(customerName.value);
+  if (props.order.delivery_address) parts.push(props.order.delivery_address);
+  return parts.join(' · ');
+});
 </script>
 
 <template>
@@ -26,12 +36,23 @@ const onDragStart = () => {
     @dragstart="onDragStart"
   >
     <header class="mb-3 flex items-start justify-between gap-3">
-      <div>
-        <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ order.customer?.full_legal_name || order.customer?.name || `Заказ #${order.id}` }}</p>
+      <div class="min-w-0">
+        <p class="truncate text-lg font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+        <p v-if="secondaryLine" class="mt-0.5 break-words text-sm text-gray-500 dark:text-slate-400">{{ secondaryLine }}</p>
         <p class="text-sm text-gray-500 dark:text-slate-400">УНП: {{ order.customer?.inn || '—' }}</p>
       </div>
       <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-1 text-xs text-gray-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
     </header>
+
+    <div v-if="order.manager_labels?.length" class="mb-3 flex flex-wrap gap-1">
+      <span
+        v-for="label in order.manager_labels"
+        :key="label"
+        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+      >
+        {{ label }}
+      </span>
+    </div>
 
     <div class="mb-3 flex flex-wrap gap-1">
       <span v-if="order.needs_attention" class="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🔴 Внимание (замер)</span>

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { ManagerOrderListItemResponse } from '../../client';
 import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
 
@@ -16,6 +17,15 @@ const emit = defineEmits<{
 const onDragStart = () => {
   emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
 };
+
+const customerName = computed(() => props.order.customer?.name || `Заказ #${props.order.id}`);
+const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
+const secondaryLine = computed(() => {
+  const parts = [];
+  if (props.order.title?.trim()) parts.push(customerName.value);
+  if (props.order.delivery_address) parts.push(props.order.delivery_address);
+  return parts.join(' · ');
+});
 </script>
 
 <template>
@@ -26,12 +36,23 @@ const onDragStart = () => {
     @dragstart="onDragStart"
   >
     <header class="mb-3 flex items-start justify-between gap-3">
-      <div>
-        <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ order.customer?.name || `Заказ #${order.id}` }}</p>
+      <div class="min-w-0">
+        <p class="truncate text-lg font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+        <p v-if="secondaryLine" class="mt-0.5 break-words text-sm text-gray-500 dark:text-slate-400">{{ secondaryLine }}</p>
         <p class="text-sm text-gray-500 dark:text-slate-400">{{ formatPhone(order.customer?.phone) }}</p>
       </div>
       <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-1 text-xs text-gray-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
     </header>
+
+    <div v-if="order.manager_labels?.length" class="mb-3 flex flex-wrap gap-1">
+      <span
+        v-for="label in order.manager_labels"
+        :key="label"
+        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+      >
+        {{ label }}
+      </span>
+    </div>
 
     <div class="mb-3 flex flex-wrap gap-1">
       <span v-if="order.needs_attention" class="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🔴 Внимание (замер)</span>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -68,6 +68,9 @@ const toast = ref('');
 let productSearchRequestId = 0;
 
 const status = ref('new_lead');
+const orderTitle = ref('');
+const managerLabels = ref<string[]>([]);
+const managerLabelDraft = ref('');
 const nextFollowupDate = ref('');
 const assessmentDate = ref('');
 const installationDate = ref('');
@@ -303,6 +306,20 @@ const setToast = (message: string, type: 'success' | 'error' = 'success') => {
   window.setTimeout(() => {
     if (toast.value === message) toast.value = '';
   }, 3000);
+};
+
+const normalizeManagerLabel = (value: string) => value.trim().replace(/\s+/g, ' ');
+
+const addManagerLabel = () => {
+  const label = normalizeManagerLabel(managerLabelDraft.value);
+  if (!label) return;
+  const exists = managerLabels.value.some((item) => item.toLocaleLowerCase('ru-RU') === label.toLocaleLowerCase('ru-RU'));
+  if (!exists) managerLabels.value.push(label);
+  managerLabelDraft.value = '';
+};
+
+const removeManagerLabel = (label: string) => {
+  managerLabels.value = managerLabels.value.filter((item) => item !== label);
 };
 
 const formatDateTime = (value?: string | null) => {
@@ -881,6 +898,9 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   localServerErrors.value = {};
   localFormError.value = '';
   status.value = order.status;
+  orderTitle.value = order.title ?? '';
+  managerLabels.value = [...(order.manager_labels ?? [])];
+  managerLabelDraft.value = '';
   nextFollowupDate.value = toLocalDateTimeInput(order.next_followup_date);
   assessmentDate.value = toLocalDateTimeInput(order.measurement_date);
   installationDate.value = toLocalDateTimeInput(order.installation_date);
@@ -1244,6 +1264,8 @@ const handleSave = () => {
   clearDraft();
   const payload: ManagerOrderUpdatePayload = {
     status: status.value,
+    title: orderTitle.value,
+    manager_labels: managerLabels.value,
     next_followup_date: fromLocalDateTimeInput(nextFollowupDate.value),
     measurement_date: fromLocalDateTimeInput(assessmentDate.value),
     installation_date: fromLocalDateTimeInput(installationDate.value),
@@ -1343,7 +1365,7 @@ watch(
       <header class="mb-4 flex items-start justify-between border-b border-gray-100 pb-4">
         <div class="flex-1">
           <div class="flex items-center gap-3 mb-1">
-            <h2 class="text-xl font-semibold font-['Space_Grotesk'] text-gray-900">№{{ order?.id }} {{ customer?.full_legal_name || customer?.name || 'Без имени' }}</h2>
+            <h2 class="text-xl font-semibold font-['Space_Grotesk'] text-gray-900">№{{ order?.id }} {{ orderTitle || customer?.full_legal_name || customer?.name || 'Без имени' }}</h2>
             <span
               v-if="isWebsiteOrder"
               class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-emerald-700"
@@ -1380,6 +1402,53 @@ watch(
       <p v-if="displayFormError" class="mb-4 rounded-xl border border-red-500/40 bg-red-50 px-3 py-2 text-sm text-red-700">
         {{ displayFormError }}
       </p>
+
+      <section class="mb-6 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="field-label md:col-span-2">
+            Внутреннее название
+            <input
+              v-model="orderTitle"
+              class="field-input"
+              placeholder="Например: Монтаж магазина в Дубровно"
+              maxlength="160"
+            />
+            <span v-if="getFieldError('title')" class="text-xs text-red-300">{{ getFieldError('title') }}</span>
+          </label>
+
+          <div class="md:col-span-2">
+            <p class="mb-1 text-xs font-medium uppercase tracking-[0.08em] text-slate-500">Метки</p>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="label in managerLabels"
+                :key="label"
+                class="inline-flex items-center gap-1 rounded-full border border-teal-200 bg-teal-50 px-2.5 py-1 text-xs font-medium text-teal-800"
+              >
+                {{ label }}
+                <button
+                  type="button"
+                  class="flex h-4 w-4 items-center justify-center rounded-full text-teal-500 hover:bg-teal-100 hover:text-teal-800"
+                  :aria-label="`Удалить метку ${label}`"
+                  @click="removeManagerLabel(label)"
+                >
+                  <span class="material-icons-round text-[14px]">close</span>
+                </button>
+              </span>
+              <span v-if="!managerLabels.length" class="text-sm text-slate-500">Метки не добавлены</span>
+            </div>
+            <div class="mt-2 flex flex-col gap-2 sm:flex-row">
+              <input
+                v-model="managerLabelDraft"
+                class="field-input sm:flex-1"
+                placeholder="срочно, ждём адрес, уточнить оплату"
+                @keydown.enter.prevent="addManagerLabel"
+              />
+              <button type="button" class="btn-mini whitespace-nowrap" @click="addManagerLabel">Добавить метку</button>
+            </div>
+            <span v-if="getFieldError('manager_labels')" class="text-xs text-red-300">{{ getFieldError('manager_labels') }}</span>
+          </div>
+        </div>
+      </section>
 
       <section v-if="isWebsiteOrder" class="mb-6 rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 via-white to-teal-50 p-4 shadow-sm">
         <div class="mb-4 flex flex-wrap items-start justify-between gap-3">

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -220,6 +220,8 @@ const saveOrder = async (payload: { orderId: number; data: ManagerOrderUpdatePay
     console.error(error);
     const parsed = parseApiFieldErrors(error, [
       'status',
+      'title',
+      'manager_labels',
       'next_followup_date',
       'measurement_date',
       'installation_date',

--- a/manager_frontend/src/components/orders/OrdersListTable.vue
+++ b/manager_frontend/src/components/orders/OrdersListTable.vue
@@ -19,6 +19,14 @@ const toggleSort = (key: string) => {
   if (props.sort === `${key}_desc`) emit('update:sort', `${key}_asc`);
   else emit('update:sort', `${key}_desc`);
 };
+
+const customerName = (order: ManagerOrderListItemResponse) => (
+  props.segment === 'b2b'
+    ? (order.customer?.full_legal_name || order.customer?.name || '—')
+    : (order.customer?.name || '—')
+);
+
+const displayTitle = (order: ManagerOrderListItemResponse) => order.title?.trim() || `#${order.id}`;
 </script>
 
 <template>
@@ -53,14 +61,26 @@ const toggleSort = (key: string) => {
           class="border-t border-gray-100"
           :class="isOverdue(order) ? 'bg-red-50' : ''"
         >
-          <td class="px-3 py-3 font-semibold">#{{ order.id }}</td>
+          <td class="px-3 py-3">
+            <p class="max-w-[260px] truncate font-semibold text-gray-900">{{ displayTitle(order) }}</p>
+            <p v-if="order.title?.trim()" class="max-w-[260px] truncate text-xs text-gray-500">#{{ order.id }} · {{ customerName(order) }}</p>
+            <div v-if="order.manager_labels?.length" class="mt-1 flex max-w-[260px] flex-wrap gap-1">
+              <span
+                v-for="label in order.manager_labels"
+                :key="label"
+                class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+              >
+                {{ label }}
+              </span>
+            </div>
+          </td>
           <td class="px-3 py-3">
             <template v-if="segment === 'b2b'">
-              <p>{{ order.customer?.full_legal_name || order.customer?.name || '—' }}</p>
+              <p>{{ customerName(order) }}</p>
               <p class="text-xs text-gray-500">УНП: {{ order.customer?.inn || '—' }}</p>
             </template>
             <template v-else>
-              <p>{{ order.customer?.name || '—' }}</p>
+              <p>{{ customerName(order) }}</p>
               <p class="text-xs text-gray-500">{{ formatPhone(order.customer?.phone) }}</p>
             </template>
           </td>

--- a/openapi.json
+++ b/openapi.json
@@ -13212,6 +13212,24 @@
             ],
             "title": "Lead Source"
           },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "manager_labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Manager Labels"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13686,6 +13704,24 @@
             ],
             "title": "Lead Source"
           },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "manager_labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Manager Labels"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -14159,6 +14195,31 @@
               }
             ],
             "title": "Status"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "manager_labels": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manager Labels"
           },
           "next_followup_date": {
             "anyOf": [

--- a/schemas.py
+++ b/schemas.py
@@ -369,6 +369,8 @@ class ManagerOrderListItemResponse(BaseModel):
     id: int
     status: str
     lead_source: Optional[str] = None
+    title: Optional[str] = None
+    manager_labels: List[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: Optional[datetime] = None
     next_followup_date: Optional[datetime] = None
@@ -545,6 +547,8 @@ class ManagerOrderServiceLinePayload(BaseModel):
 
 class ManagerOrderUpdatePayload(BaseModel):
     status: Optional[str] = None
+    title: Optional[str] = None
+    manager_labels: Optional[List[str]] = None
     next_followup_date: Optional[datetime] = None
     measurement_date: Optional[datetime] = None
     installation_date: Optional[datetime] = None

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -16,6 +16,94 @@ from services.product_supply_metrics_service import ProductSupplyMetricsService
 logger = logging.getLogger(__name__)
 
 class OrderService:
+    MANAGER_LABELS_META_KEY = "manager_labels"
+    LEGACY_WEBSITE_TITLE_PREFIX = "Заказ с сайта от "
+    SERVICE_TYPE_TITLE_MAP = {
+        "turnkey": "Продажа + монтаж",
+        "install_only": "Монтаж",
+        "pre_install": "Закладка трассы",
+        "maintenance": "Обслуживание",
+        "repair": "Ремонт",
+        "dismantling": "Демонтаж",
+    }
+
+    @staticmethod
+    def _clean_order_title(raw: Any) -> Optional[str]:
+        title = " ".join(str(raw or "").split())
+        return title or None
+
+    @staticmethod
+    def _display_order_title(order: Order) -> Optional[str]:
+        title = OrderService._clean_order_title(order.title)
+        if title and title.startswith(OrderService.LEGACY_WEBSITE_TITLE_PREFIX):
+            return None
+        return title
+
+    @staticmethod
+    def _build_default_order_title(
+        *,
+        service_type: Optional[str] = None,
+        comment: Optional[str] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[str]:
+        if service_type:
+            mapped = OrderService.SERVICE_TYPE_TITLE_MAP.get(str(service_type))
+            if mapped:
+                return mapped
+
+        text = str(comment or "").casefold()
+        if any(marker in text for marker in ("обслуж", "сервис", " то ", "техобслуж")):
+            return "Обслуживание"
+        if any(marker in text for marker in ("ремонт", "чинит", "не работает", "ошибк")):
+            return "Ремонт"
+        if "демонтаж" in text:
+            return "Демонтаж"
+        if any(marker in text for marker in ("монтаж", "установ")):
+            return "Монтаж"
+        if any(marker in text for marker in ("заклад", "трасс")):
+            return "Закладка трассы"
+        if any(marker in text for marker in ("куп", "покуп", "продаж", "кондиционер")):
+            return "Продажа"
+
+        if items:
+            has_installation = any(bool(item.get("with_installation")) for item in items)
+            return "Продажа + монтаж" if has_installation else "Продажа"
+
+        return None
+
+    @staticmethod
+    def _normalize_manager_labels(raw_labels: Any) -> List[str]:
+        if not isinstance(raw_labels, list):
+            return []
+
+        labels: List[str] = []
+        seen: set[str] = set()
+        for raw in raw_labels:
+            label = " ".join(str(raw or "").split())
+            if not label:
+                continue
+            key = label.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            labels.append(label)
+        return labels
+
+    @staticmethod
+    def _get_manager_labels(order: Order) -> List[str]:
+        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+        return OrderService._normalize_manager_labels(meta.get(OrderService.MANAGER_LABELS_META_KEY))
+
+    @staticmethod
+    def _set_manager_labels(order: Order, raw_labels: Any) -> None:
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        labels = OrderService._normalize_manager_labels(raw_labels)
+        if labels:
+            meta[OrderService.MANAGER_LABELS_META_KEY] = labels
+        else:
+            meta.pop(OrderService.MANAGER_LABELS_META_KEY, None)
+        order.technical_meta = meta
+
     @staticmethod
     def _normalize_payment_currency(raw: Any) -> PaymentCurrency:
         if isinstance(raw, PaymentCurrency):
@@ -214,6 +302,14 @@ class OrderService:
         )
 
         changed = False
+        default_title = OrderService._build_default_order_title(
+            service_type=payload.service_type,
+            comment=payload.request_text,
+        )
+        if default_title:
+            order.title = default_title
+            changed = True
+
         if payload.service_type == "maintenance" and payload.target_date:
             order.installation_date = OrderService._normalize_naive_datetime(payload.target_date)
             changed = True
@@ -336,13 +432,14 @@ class OrderService:
             session.add(customer)
 
         # 2. Create order with lead_source
+        default_title = OrderService._build_default_order_title(comment=comment, items=items)
         order = Order(
             customer_id=customer.id,
             delivery_address=customer_address,
             status=initial_status,
             lead_source=lead_source,
             comment=comment,
-            title=f"Заказ с сайта от {datetime.now().strftime('%d.%m %H:%M')}",
+            title=default_title,
             created_at=datetime.now()
         )
         session.add(order)
@@ -1054,6 +1151,8 @@ class OrderService:
                 if order.lead_source and hasattr(order.lead_source, "value")
                 else (str(order.lead_source) if order.lead_source else None)
             ),
+            "title": OrderService._display_order_title(order),
+            "manager_labels": OrderService._get_manager_labels(order),
             "created_at": order.created_at,
             "updated_at": order.updated_at,
             "next_followup_date": order.next_followup_date,
@@ -1187,6 +1286,8 @@ class OrderService:
                 Customer.phone.ilike(like),
                 Customer.full_legal_name.ilike(like),
                 Customer.inn.ilike(like),
+                Order.title.ilike(like),
+                cast(Order.technical_meta, String).ilike(like),
                 cast(Order.id, String).ilike(like),
             )
             base_stmt = base_stmt.where(search_clause)
@@ -1334,6 +1435,10 @@ class OrderService:
                 order.status = OrderStatus(payload.status)
             except ValueError as exc:
                 raise ValueError(f"Invalid status: {payload.status}") from exc
+        if "title" in fields_set:
+            order.title = OrderService._clean_order_title(payload.title)
+        if "manager_labels" in fields_set:
+            OrderService._set_manager_labels(order, payload.manager_labels)
         if "next_followup_date" in fields_set:
             order.next_followup_date = OrderService._normalize_naive_datetime(payload.next_followup_date)
         if "measurement_date" in fields_set:

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,6 +71,21 @@ class OrderService:
             return "Продажа + монтаж" if has_installation else "Продажа"
 
         return None
+
+    @staticmethod
+    def _json_text_search_variants(raw: str) -> List[str]:
+        text = str(raw or "").strip()
+        if not text:
+            return []
+
+        variants = [text]
+        escaped = json.dumps(text, ensure_ascii=True)[1:-1]
+        if escaped and escaped not in variants:
+            variants.append(escaped)
+            like_escaped = escaped.replace("\\", "\\\\")
+            if like_escaped not in variants:
+                variants.append(like_escaped)
+        return variants
 
     @staticmethod
     def _normalize_manager_labels(raw_labels: Any) -> List[str]:
@@ -1279,15 +1295,22 @@ class OrderService:
             except ValueError as exc:
                 raise ValueError(f"Invalid status: {status}") from exc
 
-        if search:
-            like = f"%{search.strip()}%"
+        if search and search.strip():
+            search_text = search.strip()
+            like = f"%{search_text}%"
+            technical_meta_search = or_(
+                *[
+                    cast(Order.technical_meta, String).ilike(f"%{variant}%")
+                    for variant in OrderService._json_text_search_variants(search_text)
+                ]
+            )
             search_clause = or_(
                 Customer.name.ilike(like),
                 Customer.phone.ilike(like),
                 Customer.full_legal_name.ilike(like),
                 Customer.inn.ilike(like),
                 Order.title.ilike(like),
-                cast(Order.technical_meta, String).ilike(like),
+                technical_meta_search,
                 cast(Order.id, String).ilike(like),
             )
             base_stmt = base_stmt.where(search_clause)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -166,6 +166,38 @@ async def test_manager_order_patch_scalar_fields(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_order_patch_title_and_labels_search(async_client, db):
+    customer = Customer(name="Patch Labels", phone="+375295555557", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    payload = {
+        "title": "  Монтаж магазина  ",
+        "manager_labels": [" срочно ", "СРОЧНО", "ждём адрес"],
+    }
+    response = await async_client.patch(f"/api/manager/orders/{order.id}", json=payload, headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Монтаж магазина"
+    assert data["manager_labels"] == ["срочно", "ждём адрес"]
+
+    by_title = await async_client.get("/api/manager/orders?segment=b2c&search=магазина", headers=headers)
+    assert by_title.status_code == 200
+    assert [item["id"] for item in by_title.json()["items"]] == [order.id]
+
+    by_label = await async_client.get("/api/manager/orders?segment=b2c&search=адрес", headers=headers)
+    assert by_label.status_code == 200
+    assert [item["id"] for item in by_label.json()["items"]] == [order.id]
+
+
+@pytest.mark.asyncio
 async def test_manager_order_execution_auto_approves_proposal(async_client, db):
     customer = Customer(name="Execution", phone="+375295555556", type=CustomerType.individual)
     db.add(customer)

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -6,6 +6,22 @@ from schemas import ManagerOrderUpdatePayload
 from services.order_service import OrderService
 
 
+def test_service_default_order_title_inference():
+    assert OrderService._build_default_order_title(service_type="maintenance", comment="что угодно") == "Обслуживание"
+    assert OrderService._build_default_order_title(comment="Нужен монтаж с закладкой трассы") == "Монтаж"
+    assert OrderService._build_default_order_title(comment="Купить кондиционер") == "Продажа"
+    assert OrderService._build_default_order_title(items=[{"product_id": 1, "with_installation": True}]) == "Продажа + монтаж"
+    assert OrderService._build_default_order_title(items=[{"product_id": 1}]) == "Продажа"
+
+
+def test_service_display_order_title_hides_legacy_site_title():
+    order = Order(title="Заказ с сайта от 03.05 12:00")
+    assert OrderService._display_order_title(order) is None
+
+    order.title = "Монтаж магазина"
+    assert OrderService._display_order_title(order) == "Монтаж магазина"
+
+
 @pytest.mark.asyncio
 async def test_service_get_orders_for_manager_segment_and_search(db):
     c1 = Customer(name="Alice", phone="+375291111111", type=CustomerType.individual)
@@ -27,6 +43,32 @@ async def test_service_get_orders_for_manager_segment_and_search(db):
     b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20, search="999000111")
     assert len(b2b["items"]) == 1
     assert b2b["items"][0]["customer"]["name"] == "Acme LLC"
+
+
+@pytest.mark.asyncio
+async def test_service_get_orders_for_manager_title_and_labels(db):
+    customer = Customer(name="Labels", phone="+375291111112", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    db.add(
+        Order(
+            customer_id=customer.id,
+            status=OrderStatus.NEW_LEAD,
+            title="Монтаж магазина в Дубровно",
+            technical_meta={"manager_labels": ["срочно", "уточнить оплату"]},
+        )
+    )
+    await db.commit()
+
+    by_title = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="Дубровно")
+    assert len(by_title["items"]) == 1
+    assert by_title["items"][0]["title"] == "Монтаж магазина в Дубровно"
+    assert by_title["items"][0]["manager_labels"] == ["срочно", "уточнить оплату"]
+
+    by_label = await OrderService.get_orders_for_manager(db, "b2c", page=1, limit=20, search="оплату")
+    assert len(by_label["items"]) == 1
 
 
 @pytest.mark.asyncio
@@ -86,6 +128,38 @@ async def test_service_update_order_for_manager_line_sync(db):
     assert data["status"] == "negotiation"
     assert len(data["product_lines"]) == 1
     assert data["total_amount"] == 2800
+
+
+@pytest.mark.asyncio
+async def test_service_update_order_for_manager_title_and_labels(db):
+    customer = Customer(name="Meta", phone="+375294444445", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    payload = ManagerOrderUpdatePayload(
+        title="  Монтаж   магазина  ",
+        manager_labels=[" срочно ", "Срочно", "", "ждём оплату"],
+    )
+
+    data = await OrderService.update_order_for_manager(db, order.id, payload)
+    assert data is not None
+    assert data["title"] == "Монтаж магазина"
+    assert data["manager_labels"] == ["срочно", "ждём оплату"]
+
+    cleared = await OrderService.update_order_for_manager(
+        db,
+        order.id,
+        ManagerOrderUpdatePayload(title="", manager_labels=[]),
+    )
+    assert cleared is not None
+    assert cleared["title"] is None
+    assert cleared["manager_labels"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -22,6 +22,14 @@ def test_service_display_order_title_hides_legacy_site_title():
     assert OrderService._display_order_title(order) == "Монтаж магазина"
 
 
+def test_service_json_text_search_variants_include_escaped_cyrillic():
+    assert OrderService._json_text_search_variants("адрес") == [
+        "адрес",
+        "\\u0430\\u0434\\u0440\\u0435\\u0441",
+        "\\\\u0430\\\\u0434\\\\u0440\\\\u0435\\\\u0441",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_service_get_orders_for_manager_segment_and_search(db):
     c1 = Customer(name="Alice", phone="+375291111111", type=CustomerType.individual)


### PR DESCRIPTION
## What changed

- Added manager-facing order title and manager label fields to order list/detail/update API schemas.
- Store MVP labels in `Order.technical_meta["manager_labels"]` with trimming, whitespace collapse, empty-value removal, and case-insensitive dedupe.
- Extended manager order search to include internal order titles and technical metadata labels.
- Updated Manager UI cards, table, and edit drawer to display/edit internal titles and compact label badges.
- Stopped surfacing legacy autogenerated titles like `Заказ с сайта от ...` as Manager UI titles.
- Added service-aware default internal titles for new orders, such as `Продажа`, `Монтаж`, `Обслуживание`, `Ремонт`, and `Демонтаж`.
- Regenerated `openapi.json` and the manager frontend API client.

## Why

Issue #295 needs a lightweight internal naming and marking layer for orders before improving kanban cards, mobile order cards, and grouping. While verifying the UI, we found that old website-generated technical titles had started appearing as primary card titles, so this PR also hides those legacy defaults and uses more meaningful defaults for newly created orders.

## Validation

- `python3 scripts/legacy/extract_openapi.py`
- `cd manager_frontend && npm run gen:api`
- `python3 -m py_compile schemas.py services/order_service.py tests/unit/test_order_service_manager.py tests/integration/test_manager_orders_api.py`
- `cd manager_frontend && npm run build`
- `git diff --check`
- Browser check on `http://localhost:8000/manager/orders?segment=b2b&view=kanban`

## Notes

Full pytest could not run locally because the test database connection is not currently usable in this environment (`db_test` DNS/password errors).