### PR TITLE
Make kanban order cards compact and expandable

### DIFF
--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
-import { STATUS_LABELS, formatMoney, isOverdue } from './order-utils';
+import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
 
 const props = defineProps<{
   order: ManagerOrderListItemResponse;
+  expanded: boolean;
   draggableDisabled?: boolean;
 }>();
 
@@ -12,68 +14,146 @@ const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
+  toggleExpanded: [orderId: number];
 }>();
 
+const isDragging = ref(false);
+
 const onDragStart = () => {
+  isDragging.value = true;
   emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
 };
 
+const onDragEnd = () => {
+  window.setTimeout(() => {
+    isDragging.value = false;
+  }, 0);
+};
+
+const onCardClick = () => {
+  if (isDragging.value) return;
+  emit('toggleExpanded', props.order.id);
+};
+
 const customerName = computed(() => props.order.customer?.full_legal_name || props.order.customer?.name || `Заказ #${props.order.id}`);
+const hasCustomTitle = computed(() => Boolean(props.order.title?.trim()));
 const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
-const secondaryLine = computed(() => {
-  const parts = [];
-  if (props.order.title?.trim()) parts.push(customerName.value);
+const objectLine = computed(() => {
+  const parts: string[] = [];
+  if (hasCustomTitle.value) parts.push(customerName.value);
   if (props.order.delivery_address) parts.push(props.order.delivery_address);
   return parts.join(' · ');
 });
+const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
+const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
+const dateSummary = computed(() => {
+  if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
+  if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.measurement_date) return { label: 'Замер', value: formatDate(props.order.measurement_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.installation_date) return { label: 'Монтаж', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
+  return null;
+});
+const statusFlags = computed(() => [
+  props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
+  props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
+  props.order.client_thinking ? { label: 'Думают', className: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300' } : null,
+  props.order.ready_for_execution ? { label: 'Согласовано', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
+].filter(Boolean) as { label: string; className: string }[]);
+const hasComment = computed(() => Boolean(props.order.comment?.trim()));
 </script>
 
 <template>
   <article
-    class="rounded-[2rem] border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 shadow-lg"
-    :class="isOverdue(order) ? 'ring-2 ring-red-500/70' : 'ring-1 ring-transparent'"
+    class="group cursor-pointer rounded-2xl border bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:bg-slate-800"
+    :class="[
+      expanded ? 'border-teal-300 ring-2 ring-teal-500/20 dark:border-teal-500' : 'border-gray-200 dark:border-slate-700',
+      isOverdue(order) ? 'ring-2 ring-red-500/60' : '',
+    ]"
     :draggable="!draggableDisabled"
+    @click="onCardClick"
     @dragstart="onDragStart"
+    @dragend="onDragEnd"
   >
-    <header class="mb-3 flex items-start justify-between gap-3">
-      <div class="min-w-0">
-        <p class="truncate text-lg font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
-        <p v-if="secondaryLine" class="mt-0.5 break-words text-sm text-gray-500 dark:text-slate-400">{{ secondaryLine }}</p>
-        <p class="text-sm text-gray-500 dark:text-slate-400">УНП: {{ order.customer?.inn || '—' }}</p>
+    <header class="flex items-start gap-2">
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 items-center gap-2">
+          <p class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+          <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+        </div>
+        <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>
       </div>
-      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-1 text-xs text-gray-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+      <button
+        type="button"
+        class="shrink-0 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
+        :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
+        @click.stop="emit('toggleExpanded', order.id)"
+      >
+        <ChevronUp v-if="expanded" class="h-4 w-4" />
+        <ChevronDown v-else class="h-4 w-4" />
+      </button>
     </header>
 
-    <div v-if="order.manager_labels?.length" class="mb-3 flex flex-wrap gap-1">
+    <div v-if="compactLabels.length || hiddenLabelsCount" class="mt-2 flex flex-wrap gap-1">
       <span
-        v-for="label in order.manager_labels"
+        v-for="label in compactLabels"
         :key="label"
-        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200"
       >
         {{ label }}
       </span>
+      <span v-if="hiddenLabelsCount" class="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-600 dark:bg-slate-700 dark:text-slate-300">+{{ hiddenLabelsCount }}</span>
     </div>
 
-    <div class="mb-3 flex flex-wrap gap-1">
-      <span v-if="order.needs_attention" class="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🔴 Внимание (замер)</span>
-      <span v-if="order.awaiting_measurement" class="rounded-full bg-blue-100 text-blue-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🕒 Замер</span>
-      <span v-if="order.client_thinking" class="rounded-full bg-amber-100 text-amber-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">⏳ Думают</span>
-      <span v-if="order.ready_for_execution" class="rounded-full bg-green-100 text-green-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">✅ Согласовано</span>
+    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+      <span
+        v-for="flag in statusFlags"
+        :key="flag.label"
+        class="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+        :class="flag.className"
+      >
+        {{ flag.label }}
+      </span>
+      <span v-if="dateSummary" class="text-[11px] font-medium" :class="dateSummary.className">{{ dateSummary.label }}: {{ dateSummary.value }}</span>
+      <span class="text-[11px] text-gray-500 dark:text-slate-400">Маржа: {{ formatMoney(order.margin) }}</span>
     </div>
 
-    <div class="space-y-1 text-sm text-gray-700 dark:text-slate-300">
-      <p>
-        Счет:
-        <span :class="order.is_paid ? 'text-emerald-300' : 'text-amber-300'">{{ order.is_paid ? 'Оплачен' : 'Ожидает оплаты' }}</span>
-      </p>
-      <p class="font-semibold" :class="order.margin > 0 ? 'text-teal-700 dark:text-teal-400' : 'text-gray-400 dark:text-slate-500'">Маржа: {{ formatMoney(order.margin) }}</p>
-      <p v-if="isOverdue(order)" class="font-semibold text-red-400">Просрочено касание</p>
-    </div>
+    <Transition name="fade">
+      <section v-if="expanded" class="mt-3 border-t border-gray-100 pt-3 dark:border-slate-700">
+        <div class="space-y-2 text-xs text-gray-600 dark:text-slate-300">
+          <p v-if="order.delivery_address"><span class="font-semibold text-gray-800 dark:text-white">Объект:</span> {{ order.delivery_address }}</p>
+          <p v-if="order.customer?.phone"><span class="font-semibold text-gray-800 dark:text-white">Телефон:</span> {{ formatPhone(order.customer.phone) }}</p>
+          <p v-if="order.customer?.inn"><span class="font-semibold text-gray-800 dark:text-white">УНП:</span> {{ order.customer.inn }}</p>
+          <p v-if="hasComment" class="max-h-20 overflow-hidden"><span class="font-semibold text-gray-800 dark:text-white">Комментарий:</span> {{ order.comment }}</p>
+        </div>
 
-    <footer class="mt-4 flex flex-wrap gap-2">
-      <button class="btn-mini" @click="emit('generate', { orderId: order.id, docType: 'invoice' })">Счет</button>
-      <button class="btn-mini" @click="emit('generate', { orderId: order.id, docType: 'contract' })">Договор</button>
-      <button class="btn-mini-outline" @click="emit('open', order.id)">Открыть</button>
-    </footer>
+        <div class="mt-3 grid grid-cols-2 gap-2 text-xs">
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Сумма: <span class="font-semibold">{{ formatMoney(order.total_amount) }}</span></p>
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Маржа: <span class="font-semibold">{{ formatMoney(order.margin) }}</span></p>
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Счет: <span :class="order.is_paid ? 'text-emerald-600 dark:text-emerald-300' : 'text-amber-600 dark:text-amber-300'">{{ order.is_paid ? 'Оплачен' : 'Ожидает' }}</span></p>
+          <p v-if="order.next_followup_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Касание: <span class="font-semibold">{{ formatDate(order.next_followup_date) }}</span></p>
+          <p v-if="order.measurement_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Замер: <span class="font-semibold">{{ formatDate(order.measurement_date) }}</span></p>
+          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Монтаж: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
+        </div>
+
+        <div v-if="order.manager_labels?.length" class="mt-3 flex flex-wrap gap-1">
+          <span
+            v-for="label in order.manager_labels"
+            :key="label"
+            class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200"
+          >
+            {{ label }}
+          </span>
+        </div>
+
+        <footer class="mt-3 flex flex-wrap gap-2">
+          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'invoice' })">Счет</button>
+          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'contract' })">Договор</button>
+          <button type="button" class="btn-mini-outline inline-flex items-center gap-1" @click.stop="emit('open', order.id)">
+            <ExternalLink class="h-3.5 w-3.5" />
+            Открыть заказ
+          </button>
+        </footer>
+      </section>
+    </Transition>
   </article>
 </template>

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
 import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
 
 const props = defineProps<{
   order: ManagerOrderListItemResponse;
+  expanded: boolean;
   draggableDisabled?: boolean;
 }>();
 
@@ -12,66 +14,145 @@ const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
+  toggleExpanded: [orderId: number];
 }>();
 
+const isDragging = ref(false);
+
 const onDragStart = () => {
+  isDragging.value = true;
   emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
 };
 
+const onDragEnd = () => {
+  window.setTimeout(() => {
+    isDragging.value = false;
+  }, 0);
+};
+
+const onCardClick = () => {
+  if (isDragging.value) return;
+  emit('toggleExpanded', props.order.id);
+};
+
 const customerName = computed(() => props.order.customer?.name || `Заказ #${props.order.id}`);
+const hasCustomTitle = computed(() => Boolean(props.order.title?.trim()));
 const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
-const secondaryLine = computed(() => {
-  const parts = [];
-  if (props.order.title?.trim()) parts.push(customerName.value);
+const objectLine = computed(() => {
+  const parts: string[] = [];
+  if (hasCustomTitle.value) parts.push(customerName.value);
   if (props.order.delivery_address) parts.push(props.order.delivery_address);
   return parts.join(' · ');
 });
+const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
+const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
+const dateSummary = computed(() => {
+  if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
+  if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.measurement_date) return { label: 'Замер', value: formatDate(props.order.measurement_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.installation_date) return { label: 'Монтаж', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
+  return null;
+});
+const statusFlags = computed(() => [
+  props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
+  props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
+  props.order.client_thinking ? { label: 'Думают', className: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300' } : null,
+  props.order.ready_for_execution ? { label: 'Согласовано', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
+].filter(Boolean) as { label: string; className: string }[]);
+const hasComment = computed(() => Boolean(props.order.comment?.trim()));
 </script>
 
 <template>
   <article
-    class="rounded-[2rem] border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5 shadow-lg"
-    :class="isOverdue(order) ? 'ring-2 ring-red-500/70' : 'ring-1 ring-transparent'"
+    class="group cursor-pointer rounded-2xl border bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:bg-slate-800"
+    :class="[
+      expanded ? 'border-teal-300 ring-2 ring-teal-500/20 dark:border-teal-500' : 'border-gray-200 dark:border-slate-700',
+      isOverdue(order) ? 'ring-2 ring-red-500/60' : '',
+    ]"
     :draggable="!draggableDisabled"
+    @click="onCardClick"
     @dragstart="onDragStart"
+    @dragend="onDragEnd"
   >
-    <header class="mb-3 flex items-start justify-between gap-3">
-      <div class="min-w-0">
-        <p class="truncate text-lg font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
-        <p v-if="secondaryLine" class="mt-0.5 break-words text-sm text-gray-500 dark:text-slate-400">{{ secondaryLine }}</p>
-        <p class="text-sm text-gray-500 dark:text-slate-400">{{ formatPhone(order.customer?.phone) }}</p>
+    <header class="flex items-start gap-2">
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 items-center gap-2">
+          <p class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+          <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+        </div>
+        <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>
       </div>
-      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-1 text-xs text-gray-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+      <button
+        type="button"
+        class="shrink-0 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
+        :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
+        @click.stop="emit('toggleExpanded', order.id)"
+      >
+        <ChevronUp v-if="expanded" class="h-4 w-4" />
+        <ChevronDown v-else class="h-4 w-4" />
+      </button>
     </header>
 
-    <div v-if="order.manager_labels?.length" class="mb-3 flex flex-wrap gap-1">
+    <div v-if="compactLabels.length || hiddenLabelsCount" class="mt-2 flex flex-wrap gap-1">
       <span
-        v-for="label in order.manager_labels"
+        v-for="label in compactLabels"
         :key="label"
-        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200"
       >
         {{ label }}
       </span>
+      <span v-if="hiddenLabelsCount" class="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-600 dark:bg-slate-700 dark:text-slate-300">+{{ hiddenLabelsCount }}</span>
     </div>
 
-    <div class="mb-3 flex flex-wrap gap-1">
-      <span v-if="order.needs_attention" class="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🔴 Внимание (замер)</span>
-      <span v-if="order.awaiting_measurement" class="rounded-full bg-blue-100 text-blue-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">🕒 Замер</span>
-      <span v-if="order.client_thinking" class="rounded-full bg-amber-100 text-amber-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">⏳ Думают</span>
-      <span v-if="order.ready_for_execution" class="rounded-full bg-green-100 text-green-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider">✅ Согласовано</span>
+    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+      <span
+        v-for="flag in statusFlags"
+        :key="flag.label"
+        class="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+        :class="flag.className"
+      >
+        {{ flag.label }}
+      </span>
+      <span v-if="dateSummary" class="text-[11px] font-medium" :class="dateSummary.className">{{ dateSummary.label }}: {{ dateSummary.value }}</span>
+      <span class="text-[11px] text-gray-500 dark:text-slate-400">Маржа: {{ formatMoney(order.margin) }}</span>
     </div>
 
-    <div class="space-y-1 text-sm text-gray-700 dark:text-slate-300">
-      <p>Замер: {{ formatDate(order.measurement_date) }}</p>
-      <p>Монтаж: {{ formatDate(order.installation_date) }}</p>
-      <p class="font-semibold" :class="order.margin > 0 ? 'text-teal-700 dark:text-teal-400' : 'text-gray-400 dark:text-slate-500'">Маржа: {{ formatMoney(order.margin) }}</p>
-      <p v-if="isOverdue(order)" class="font-semibold text-red-400">Просрочено касание</p>
-    </div>
+    <Transition name="fade">
+      <section v-if="expanded" class="mt-3 border-t border-gray-100 pt-3 dark:border-slate-700">
+        <div class="space-y-2 text-xs text-gray-600 dark:text-slate-300">
+          <p v-if="order.delivery_address"><span class="font-semibold text-gray-800 dark:text-white">Адрес:</span> {{ order.delivery_address }}</p>
+          <p v-if="order.customer?.phone"><span class="font-semibold text-gray-800 dark:text-white">Телефон:</span> {{ formatPhone(order.customer.phone) }}</p>
+          <p v-if="hasComment" class="max-h-20 overflow-hidden"><span class="font-semibold text-gray-800 dark:text-white">Комментарий:</span> {{ order.comment }}</p>
+        </div>
 
-    <footer class="mt-4 flex flex-wrap gap-2">
-      <button class="btn-mini" @click="emit('generate', { orderId: order.id, docType: 'work_order' })">Наряд на монтаж</button>
-      <button class="btn-mini" @click="emit('generate', { orderId: order.id, docType: 'act' })">Акт</button>
-      <button class="btn-mini-outline" @click="emit('open', order.id)">Открыть</button>
-    </footer>
+        <div class="mt-3 grid grid-cols-2 gap-2 text-xs">
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Сумма: <span class="font-semibold">{{ formatMoney(order.total_amount) }}</span></p>
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Маржа: <span class="font-semibold">{{ formatMoney(order.margin) }}</span></p>
+          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Оплата: <span :class="order.is_paid ? 'text-emerald-600 dark:text-emerald-300' : 'text-amber-600 dark:text-amber-300'">{{ order.is_paid ? 'Оплачено' : 'Ожидает' }}</span></p>
+          <p v-if="order.next_followup_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Касание: <span class="font-semibold">{{ formatDate(order.next_followup_date) }}</span></p>
+          <p v-if="order.measurement_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Замер: <span class="font-semibold">{{ formatDate(order.measurement_date) }}</span></p>
+          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Монтаж: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
+        </div>
+
+        <div v-if="order.manager_labels?.length" class="mt-3 flex flex-wrap gap-1">
+          <span
+            v-for="label in order.manager_labels"
+            :key="label"
+            class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-200"
+          >
+            {{ label }}
+          </span>
+        </div>
+
+        <footer class="mt-3 flex flex-wrap gap-2">
+          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'work_order' })">Наряд</button>
+          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'act' })">Акт</button>
+          <button type="button" class="btn-mini-outline inline-flex items-center gap-1" @click.stop="emit('open', order.id)">
+            <ExternalLink class="h-3.5 w-3.5" />
+            Открыть заказ
+          </button>
+        </footer>
+      </section>
+    </Transition>
   </article>
 </template>

--- a/manager_frontend/src/components/orders/OrderColumn.vue
+++ b/manager_frontend/src/components/orders/OrderColumn.vue
@@ -10,6 +10,7 @@ defineProps<{
   orders: ManagerOrderListItemResponse[];
   segment: Segment;
   movingOrderIds: number[];
+  expandedOrderId: number | null;
 }>();
 
 const emit = defineEmits<{
@@ -17,6 +18,7 @@ const emit = defineEmits<{
   generate: [payload: { orderId: number; docType: string }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   dropTo: [status: string];
+  toggleExpanded: [orderId: number];
 }>();
 
 const onDrop = (event: DragEvent, status: string) => {
@@ -27,7 +29,7 @@ const onDrop = (event: DragEvent, status: string) => {
 
 <template>
   <section
-    class="min-h-[220px] w-[320px] md:w-[350px] lg:w-[380px] shrink-0 rounded-[2rem] border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4"
+    class="min-h-[220px] w-[calc(100vw-2rem)] max-w-[320px] shrink-0 rounded-2xl border border-gray-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800 sm:w-[320px] md:w-[350px] md:max-w-[350px] lg:w-[380px] lg:max-w-[380px]"
     @dragover.prevent
     @drop="(event) => onDrop(event, status)"
   >
@@ -42,10 +44,12 @@ const onDrop = (event: DragEvent, status: string) => {
         v-for="order in orders"
         :key="order.id"
         :order="order"
+        :expanded="expandedOrderId === order.id"
         :draggable-disabled="movingOrderIds.includes(order.id)"
         @open="(orderId) => emit('open', orderId)"
         @generate="(payload) => emit('generate', payload)"
         @drag-start="(payload) => emit('dragStart', payload)"
+        @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
       />
     </div>
   </section>

--- a/manager_frontend/src/components/orders/OrderKanbanBoard.vue
+++ b/manager_frontend/src/components/orders/OrderKanbanBoard.vue
@@ -18,6 +18,11 @@ const emit = defineEmits<{
 }>();
 
 const dragContext = ref<{ orderId: number; oldStatus: string } | null>(null);
+const expandedOrderId = ref<number | null>(null);
+
+const onToggleExpanded = (orderId: number) => {
+  expandedOrderId.value = expandedOrderId.value === orderId ? null : orderId;
+};
 
 const onDropTo = (newStatus: string) => {
   if (!dragContext.value) return;
@@ -48,10 +53,12 @@ const onDragStart = (payload: { orderId: number; oldStatus: string }) => {
       :orders="groupedOrders[status] || []"
       :segment="segment"
       :moving-order-ids="movingOrderIds"
+      :expanded-order-id="expandedOrderId"
       @open="(orderId) => emit('open', orderId)"
       @generate="(payload) => emit('generate', payload)"
       @drag-start="(payload) => onDragStart(payload)"
       @drop-to="(dropStatus) => onDropTo(dropStatus)"
+      @toggle-expanded="onToggleExpanded"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Added a single expanded-card state for the orders kanban so only one card is open at a time.
- Reworked B2B and B2C order cards into a compact default layout with an explicit expand/collapse control.
- Moved detailed order data, document actions, and the primary open action into the expanded state.
- Kept drag-and-drop behavior intact while making the kanban denser and easier to scan.

## Testing
- `cd manager_frontend && npm run build` passed.
- Verified the kanban in the browser for B2B and B2C: compact rendering, single-card expansion, collapse behavior, and opening the full order drawer from the expanded state.