### PR TITLE
[codex] Group manager orders by customer

### DIFF
--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
 import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
+import OrderTitleEditor from './OrderTitleEditor.vue';
 
 const props = defineProps<{
   order: ManagerOrderListItemResponse;
@@ -15,6 +16,7 @@ const emit = defineEmits<{
   generate: [payload: { orderId: number; docType: string }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   toggleExpanded: [orderId: number];
+  renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
 
 const isDragging = ref(false);
@@ -37,7 +39,6 @@ const onCardClick = () => {
 
 const customerName = computed(() => props.order.customer?.full_legal_name || props.order.customer?.name || `Заказ #${props.order.id}`);
 const hasCustomTitle = computed(() => Boolean(props.order.title?.trim()));
-const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
 const objectLine = computed(() => {
   const parts: string[] = [];
   if (hasCustomTitle.value) parts.push(customerName.value);
@@ -77,7 +78,14 @@ const hasComment = computed(() => Boolean(props.order.comment?.trim()));
     <header class="flex items-start gap-2">
       <div class="min-w-0 flex-1">
         <div class="flex min-w-0 items-center gap-2">
-          <p class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+          <OrderTitleEditor
+            class="min-w-0 flex-1"
+            :order-id="order.id"
+            :title="order.title"
+            :fallback-title="customerName"
+            text-class="text-sm"
+            @rename="(payload) => emit('renameOrder', payload)"
+          />
           <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
         </div>
         <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
 import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
+import OrderTitleEditor from './OrderTitleEditor.vue';
 
 const props = defineProps<{
   order: ManagerOrderListItemResponse;
@@ -15,6 +16,7 @@ const emit = defineEmits<{
   generate: [payload: { orderId: number; docType: string }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   toggleExpanded: [orderId: number];
+  renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
 
 const isDragging = ref(false);
@@ -37,7 +39,6 @@ const onCardClick = () => {
 
 const customerName = computed(() => props.order.customer?.name || `Заказ #${props.order.id}`);
 const hasCustomTitle = computed(() => Boolean(props.order.title?.trim()));
-const displayTitle = computed(() => props.order.title?.trim() || customerName.value);
 const objectLine = computed(() => {
   const parts: string[] = [];
   if (hasCustomTitle.value) parts.push(customerName.value);
@@ -77,7 +78,14 @@ const hasComment = computed(() => Boolean(props.order.comment?.trim()));
     <header class="flex items-start gap-2">
       <div class="min-w-0 flex-1">
         <div class="flex min-w-0 items-center gap-2">
-          <p class="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">{{ displayTitle }}</p>
+          <OrderTitleEditor
+            class="min-w-0 flex-1"
+            :order-id="order.id"
+            :title="order.title"
+            :fallback-title="customerName"
+            text-class="text-sm"
+            @rename="(payload) => emit('renameOrder', payload)"
+          />
           <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
         </div>
         <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>

--- a/manager_frontend/src/components/orders/OrderColumn.vue
+++ b/manager_frontend/src/components/orders/OrderColumn.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
-import type { ManagerOrderListItemResponse } from '../../client';
 import type { Segment } from '../../api';
+import type { OrderRenderItem } from './order-utils';
 import OrderCardB2B from './OrderCardB2B.vue';
 import OrderCardB2C from './OrderCardB2C.vue';
+import OrderCustomerGroupCard from './OrderCustomerGroupCard.vue';
 
-defineProps<{
+const props = defineProps<{
   status: string;
   label: string;
-  orders: ManagerOrderListItemResponse[];
+  items: OrderRenderItem[];
   segment: Segment;
   movingOrderIds: number[];
   expandedOrderId: number | null;
+  expandedGroupIds: string[];
 }>();
 
 const emit = defineEmits<{
@@ -19,7 +21,12 @@ const emit = defineEmits<{
   dragStart: [payload: { orderId: number; oldStatus: string }];
   dropTo: [status: string];
   toggleExpanded: [orderId: number];
+  toggleGroup: [groupId: string];
+  renameCustomer: [payload: { customerId: number; alias: string | null }];
+  renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
+
+const orderCount = () => props.items.reduce((total, item) => total + (item.type === 'group' ? item.group.orders.length : 1), 0);
 
 const onDrop = (event: DragEvent, status: string) => {
   event.preventDefault();
@@ -35,22 +42,39 @@ const onDrop = (event: DragEvent, status: string) => {
   >
     <header class="mb-3 flex items-center justify-between">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-slate-400">{{ label }}</h3>
-      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-0.5 text-xs text-gray-700 dark:text-slate-300">{{ orders.length }}</span>
+      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-0.5 text-xs text-gray-700 dark:text-slate-300">{{ orderCount() }}</span>
     </header>
 
     <div class="space-y-3">
-      <component
-        :is="segment === 'b2b' ? OrderCardB2B : OrderCardB2C"
-        v-for="order in orders"
-        :key="order.id"
-        :order="order"
-        :expanded="expandedOrderId === order.id"
-        :draggable-disabled="movingOrderIds.includes(order.id)"
-        @open="(orderId) => emit('open', orderId)"
-        @generate="(payload) => emit('generate', payload)"
-        @drag-start="(payload) => emit('dragStart', payload)"
-        @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
-      />
+      <template v-for="item in items" :key="item.type === 'group' ? item.group.id : item.order.id">
+        <OrderCustomerGroupCard
+          v-if="item.type === 'group'"
+          :group="item.group"
+          :segment="segment"
+          :expanded="expandedGroupIds.includes(item.group.id)"
+          :moving-order-ids="movingOrderIds"
+          :expanded-order-id="expandedOrderId"
+          @open="(orderId) => emit('open', orderId)"
+          @generate="(payload) => emit('generate', payload)"
+          @drag-start="(payload) => emit('dragStart', payload)"
+          @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
+          @toggle-group="(groupId) => emit('toggleGroup', groupId)"
+          @rename-customer="(payload) => emit('renameCustomer', payload)"
+          @rename-order="(payload) => emit('renameOrder', payload)"
+        />
+        <component
+          :is="segment === 'b2b' ? OrderCardB2B : OrderCardB2C"
+          v-else
+          :order="item.order"
+          :expanded="expandedOrderId === item.order.id"
+          :draggable-disabled="movingOrderIds.includes(item.order.id)"
+          @open="(orderId) => emit('open', orderId)"
+          @generate="(payload) => emit('generate', payload)"
+          @drag-start="(payload) => emit('dragStart', payload)"
+          @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
+          @rename-order="(payload) => emit('renameOrder', payload)"
+        />
+      </template>
     </div>
   </section>
 </template>

--- a/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { Check, ChevronDown, ChevronUp, X } from 'lucide-vue-next';
+import type { Segment } from '../../api';
+import type { CustomerOrderGroup } from './order-utils';
+import { formatMoney, formatOrderCount } from './order-utils';
+import OrderCardB2B from './OrderCardB2B.vue';
+import OrderCardB2C from './OrderCardB2C.vue';
+
+const props = defineProps<{
+  group: CustomerOrderGroup;
+  segment: Segment;
+  expanded: boolean;
+  movingOrderIds: number[];
+  expandedOrderId: number | null;
+}>();
+
+const emit = defineEmits<{
+  open: [orderId: number];
+  generate: [payload: { orderId: number; docType: string }];
+  dragStart: [payload: { orderId: number; oldStatus: string }];
+  toggleExpanded: [orderId: number];
+  toggleGroup: [groupId: string];
+  renameCustomer: [payload: { customerId: number; alias: string | null }];
+  renameOrder: [payload: { orderId: number; title: string | null }];
+}>();
+
+const editing = ref(false);
+const aliasDraft = ref(props.group.customerName);
+
+watch(
+  () => props.group.customerName,
+  (value) => {
+    if (!editing.value) aliasDraft.value = value;
+  },
+);
+
+const startEditing = () => {
+  editing.value = true;
+  aliasDraft.value = props.group.customerName;
+};
+
+const saveAlias = () => {
+  const trimmed = aliasDraft.value.trim();
+  emit('renameCustomer', { customerId: props.group.customerId, alias: trimmed || null });
+  editing.value = false;
+};
+
+const cancelEditing = () => {
+  editing.value = false;
+  aliasDraft.value = props.group.customerName;
+};
+
+const onGroupClick = () => {
+  if (!editing.value) emit('toggleGroup', props.group.id);
+};
+</script>
+
+<template>
+  <article
+    class="rounded-2xl border bg-slate-50 p-3 shadow-sm transition dark:border-slate-700 dark:bg-slate-900/40"
+    :class="group.hasOverdue ? 'border-red-200 ring-2 ring-red-500/40' : 'border-slate-200'"
+  >
+    <div
+      class="flex w-full items-start gap-2 text-left"
+      :aria-expanded="expanded"
+      role="button"
+      tabindex="0"
+      @click="onGroupClick"
+      @keydown.enter.prevent="onGroupClick"
+      @keydown.space.prevent="onGroupClick"
+    >
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 flex-wrap items-center gap-2">
+          <div class="min-w-0 flex-1" @click.stop>
+            <div v-if="editing" class="flex min-w-0 items-center gap-1">
+              <input
+                v-model="aliasDraft"
+                class="min-w-0 flex-1 rounded-lg border border-teal-200 bg-white px-2 py-1 text-sm font-semibold text-slate-900 outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+                :placeholder="group.originalCustomerName"
+                autofocus
+                @blur="saveAlias"
+                @keydown.enter.prevent="saveAlias"
+                @keydown.esc.prevent="cancelEditing"
+              />
+              <button type="button" class="rounded-full p-1 text-teal-700 hover:bg-teal-50" @mousedown.prevent @click.stop="saveAlias">
+                <Check class="h-3.5 w-3.5" />
+              </button>
+              <button type="button" class="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700" @mousedown.prevent @click.stop="cancelEditing">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <p
+              v-else
+              class="min-w-0 truncate text-sm font-semibold text-slate-900 dark:text-white"
+              title="Двойной клик — переименовать группу локально"
+              @dblclick.stop="startEditing"
+            >
+              {{ group.customerName }}
+            </p>
+          </div>
+          <span class="shrink-0 rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+            {{ formatOrderCount(group.orders.length) }}
+          </span>
+        </div>
+        <div class="mt-2 flex flex-wrap gap-1.5 text-[11px] text-slate-500 dark:text-slate-400">
+          <span>Сумма: <strong class="text-slate-800 dark:text-slate-200">{{ formatMoney(group.totalAmount) }}</strong></span>
+          <span>Маржа: <strong class="text-teal-700 dark:text-teal-300">{{ formatMoney(group.margin) }}</strong></span>
+          <span v-if="group.needsAttention" class="font-semibold text-red-600 dark:text-red-300">Нужно внимание</span>
+        </div>
+      </div>
+      <span class="shrink-0 rounded-full p-1 text-slate-400 transition hover:bg-white hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-white">
+        <ChevronUp v-if="expanded" class="h-4 w-4" />
+        <ChevronDown v-else class="h-4 w-4" />
+      </span>
+    </div>
+
+    <Transition name="fade">
+      <div v-if="expanded" class="mt-3 space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700">
+        <component
+          :is="segment === 'b2b' ? OrderCardB2B : OrderCardB2C"
+          v-for="order in group.orders"
+          :key="order.id"
+          :order="order"
+          :expanded="expandedOrderId === order.id"
+          :draggable-disabled="movingOrderIds.includes(order.id)"
+          @open="(orderId) => emit('open', orderId)"
+          @generate="(payload) => emit('generate', payload)"
+          @drag-start="(payload) => emit('dragStart', payload)"
+          @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
+          @rename-order="(payload) => emit('renameOrder', payload)"
+        />
+      </div>
+    </Transition>
+  </article>
+</template>

--- a/manager_frontend/src/components/orders/OrderKanbanBoard.vue
+++ b/manager_frontend/src/components/orders/OrderKanbanBoard.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import type { ManagerOrderListItemResponse } from '../../client';
 import type { Segment } from '../../api';
+import type { OrderRenderItem } from './order-utils';
 import OrderColumn from './OrderColumn.vue';
 import { STATUS_LABELS, STATUS_ORDER } from './order-utils';
 
 defineProps<{
-  groupedOrders: Record<string, ManagerOrderListItemResponse[]>;
+  groupedItems: Record<string, OrderRenderItem[]>;
   segment: Segment;
   movingOrderIds: number[];
 }>();
@@ -15,10 +15,13 @@ const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
   move: [payload: { orderId: number; oldStatus: string; newStatus: string }];
+  renameCustomer: [payload: { customerId: number; alias: string | null }];
+  renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
 
 const dragContext = ref<{ orderId: number; oldStatus: string } | null>(null);
 const expandedOrderId = ref<number | null>(null);
+const expandedGroupIds = ref<string[]>([]);
 
 const onToggleExpanded = (orderId: number) => {
   expandedOrderId.value = expandedOrderId.value === orderId ? null : orderId;
@@ -41,6 +44,12 @@ const onDropTo = (newStatus: string) => {
 const onDragStart = (payload: { orderId: number; oldStatus: string }) => {
   dragContext.value = payload;
 };
+
+const onToggleGroup = (groupId: string) => {
+  expandedGroupIds.value = expandedGroupIds.value.includes(groupId)
+    ? expandedGroupIds.value.filter((id) => id !== groupId)
+    : [...expandedGroupIds.value, groupId];
+};
 </script>
 
 <template>
@@ -50,15 +59,19 @@ const onDragStart = (payload: { orderId: number; oldStatus: string }) => {
       :key="status"
       :status="status"
       :label="STATUS_LABELS[status] || status"
-      :orders="groupedOrders[status] || []"
+      :items="groupedItems[status] || []"
       :segment="segment"
       :moving-order-ids="movingOrderIds"
       :expanded-order-id="expandedOrderId"
+      :expanded-group-ids="expandedGroupIds"
       @open="(orderId) => emit('open', orderId)"
       @generate="(payload) => emit('generate', payload)"
       @drag-start="(payload) => onDragStart(payload)"
       @drop-to="(dropStatus) => onDropTo(dropStatus)"
       @toggle-expanded="onToggleExpanded"
+      @toggle-group="onToggleGroup"
+      @rename-customer="(payload) => emit('renameCustomer', payload)"
+      @rename-order="(payload) => emit('renameOrder', payload)"
     />
   </div>
 </template>

--- a/manager_frontend/src/components/orders/OrderListRow.vue
+++ b/manager_frontend/src/components/orders/OrderListRow.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import type { ManagerOrderListItemResponse } from '../../client';
+import type { Segment } from '../../api';
+import { STATUS_LABELS, formatDate, formatMoney, formatPhone, getOrderCustomerName, isOverdue } from './order-utils';
+import OrderTitleEditor from './OrderTitleEditor.vue';
+
+const props = defineProps<{
+  order: ManagerOrderListItemResponse;
+  segment: Segment;
+  nested?: boolean;
+}>();
+
+const emit = defineEmits<{
+  open: [orderId: number];
+  generate: [payload: { orderId: number; docType: string }];
+  renameOrder: [payload: { orderId: number; title: string | null }];
+}>();
+
+const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerName(order, props.segment);
+</script>
+
+<template>
+  <tr class="border-t border-gray-100" :class="[isOverdue(order) ? 'bg-red-50' : '', nested ? 'bg-slate-50/60' : '']">
+    <td class="px-3 py-3">
+      <div class="flex min-w-0 items-start gap-2">
+        <span v-if="nested" class="mt-1 h-2 w-2 shrink-0 rounded-full bg-slate-300" />
+        <div class="min-w-0">
+          <OrderTitleEditor
+            class="max-w-[260px]"
+            :order-id="order.id"
+            :title="order.title"
+            :fallback-title="customerName(order)"
+            text-class="text-sm"
+            @rename="(payload) => emit('renameOrder', payload)"
+          />
+          <p v-if="order.title?.trim()" class="max-w-[260px] truncate text-xs text-gray-500">#{{ order.id }} · {{ customerName(order) }}</p>
+          <div v-if="order.manager_labels?.length" class="mt-1 flex max-w-[260px] flex-wrap gap-1">
+            <span
+              v-for="label in order.manager_labels"
+              :key="label"
+              class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
+            >
+              {{ label }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </td>
+    <td class="px-3 py-3">
+      <template v-if="segment === 'b2b'">
+        <p>{{ customerName(order) }}</p>
+        <p class="text-xs text-gray-500">УНП: {{ order.customer?.inn || '—' }}</p>
+      </template>
+      <template v-else>
+        <p>{{ customerName(order) }}</p>
+        <p class="text-xs text-gray-500">{{ formatPhone(order.customer?.phone) }}</p>
+      </template>
+    </td>
+    <td class="px-3 py-3">
+      <div class="mb-1">{{ STATUS_LABELS[order.status] || order.status }}</div>
+      <div class="flex flex-col items-start gap-1">
+        <span v-if="order.needs_attention" class="rounded-full bg-red-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-red-700">Внимание</span>
+        <span v-if="order.awaiting_measurement" class="rounded-full bg-blue-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-blue-700">Замер</span>
+        <span v-if="order.client_thinking" class="rounded-full bg-amber-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-700">Думают</span>
+        <span v-if="order.ready_for_execution" class="rounded-full bg-green-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-green-700">Согласовано</span>
+      </div>
+    </td>
+    <td class="px-3 py-3">{{ formatDate(order.next_followup_date) }}</td>
+    <td class="px-3 py-3">{{ formatMoney(order.total_amount) }}</td>
+    <td class="px-3 py-3 font-semibold text-teal-700">{{ formatMoney(order.margin) }}</td>
+    <td class="px-3 py-3">
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-if="segment === 'b2b'"
+          class="btn-mini"
+          @click="emit('generate', { orderId: order.id, docType: 'invoice' })"
+        >
+          Счет
+        </button>
+        <button
+          v-if="segment === 'b2b'"
+          class="btn-mini"
+          @click="emit('generate', { orderId: order.id, docType: 'contract' })"
+        >
+          Договор
+        </button>
+        <button
+          v-if="segment === 'b2c'"
+          class="btn-mini"
+          @click="emit('generate', { orderId: order.id, docType: 'work_order' })"
+        >
+          Наряд
+        </button>
+        <button
+          v-if="segment === 'b2c'"
+          class="btn-mini"
+          @click="emit('generate', { orderId: order.id, docType: 'act' })"
+        >
+          Акт
+        </button>
+        <button class="btn-mini-outline" @click="emit('open', order.id)">Открыть</button>
+      </div>
+    </td>
+  </tr>
+</template>

--- a/manager_frontend/src/components/orders/OrderTitleEditor.vue
+++ b/manager_frontend/src/components/orders/OrderTitleEditor.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Check, X } from 'lucide-vue-next';
+
+const props = defineProps<{
+  orderId: number;
+  title?: string | null;
+  fallbackTitle: string;
+  textClass?: string;
+  inputClass?: string;
+}>();
+
+const emit = defineEmits<{
+  rename: [payload: { orderId: number; title: string | null }];
+}>();
+
+const editing = ref(false);
+const draft = ref('');
+
+const savedTitle = computed(() => props.title?.trim() || '');
+const displayTitle = computed(() => savedTitle.value || props.fallbackTitle);
+
+watch(
+  () => [props.title, props.fallbackTitle],
+  () => {
+    if (!editing.value) draft.value = savedTitle.value || props.fallbackTitle;
+  },
+);
+
+const startEditing = () => {
+  editing.value = true;
+  draft.value = savedTitle.value || props.fallbackTitle;
+};
+
+const saveTitle = () => {
+  const trimmed = draft.value.trim();
+  emit('rename', { orderId: props.orderId, title: trimmed || null });
+  editing.value = false;
+};
+
+const cancelEditing = () => {
+  editing.value = false;
+  draft.value = savedTitle.value || props.fallbackTitle;
+};
+</script>
+
+<template>
+  <div class="min-w-0" @click.stop @dblclick.stop>
+    <div v-if="editing" class="flex min-w-0 items-center gap-1">
+      <input
+        v-model="draft"
+        class="min-w-0 flex-1 rounded-lg border border-teal-200 bg-white px-2 py-1 text-sm font-semibold text-slate-900 outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+        :class="inputClass"
+        :placeholder="fallbackTitle"
+        autofocus
+        @blur="saveTitle"
+        @keydown.enter.prevent="saveTitle"
+        @keydown.esc.prevent="cancelEditing"
+      />
+      <button type="button" class="rounded-full p-1 text-teal-700 hover:bg-teal-50 dark:text-teal-300 dark:hover:bg-teal-500/10" @mousedown.prevent @click.stop="saveTitle">
+        <Check class="h-3.5 w-3.5" />
+      </button>
+      <button type="button" class="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-white" @mousedown.prevent @click.stop="cancelEditing">
+        <X class="h-3.5 w-3.5" />
+      </button>
+    </div>
+    <p
+      v-else
+      class="truncate font-semibold text-gray-900 dark:text-white"
+      :class="textClass"
+      title="Двойной клик — переименовать заказ"
+      @dblclick.stop="startEditing"
+    >
+      {{ displayTitle }}
+    </p>
+  </div>
+</template>

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
+import { SlidersHorizontal } from 'lucide-vue-next';
 import type { DashboardView, Segment } from '../../api';
 import { api } from '../../api';
 import type { ManagerOrderDetailResponse, ManagerOrderListItemResponse, ManagerOrderUpdatePayload } from '../../client';
@@ -8,11 +9,13 @@ import OrdersViewToggle from './OrdersViewToggle.vue';
 import OrderKanbanBoard from './OrderKanbanBoard.vue';
 import OrdersListTable from './OrdersListTable.vue';
 import OrderEditDrawer from './OrderEditDrawer.vue';
-import { STATUS_LABELS, STATUS_ORDER } from './order-utils';
+import { STATUS_LABELS, STATUS_ORDER, buildCustomerOrderRenderItems } from './order-utils';
 import { getApiErrorMessage, parseApiFieldErrors } from '../../utils/api-errors';
 
 const ORDERS_SEGMENT_STORAGE_KEY = 'manager_orders_segment';
 const ORDERS_VIEW_STORAGE_KEY = 'manager_orders_view';
+const ORDERS_GROUP_BY_CUSTOMER_STORAGE_KEY = 'manager_orders_group_by_customer_v2';
+const ORDERS_CUSTOMER_ALIASES_STORAGE_KEY = 'manager_orders_customer_aliases';
 
 const segment = ref<Segment>('b2c');
 const view = ref<DashboardView>('kanban');
@@ -41,18 +44,35 @@ const loginLoading = ref(false);
 const loginError = ref('');
 
 const hideOnHold = ref(true);
+const groupByCustomer = ref(true);
+const filtersOpen = ref(false);
+const customerAliases = ref<Record<number, string>>({});
+
+const visibleOrders = computed(() => (
+  hideOnHold.value ? orders.value.filter((order) => !order.is_on_hold) : orders.value
+));
 
 const groupedOrders = computed(() => {
   const groups: Record<string, ManagerOrderListItemResponse[]> = {};
   for (const statusKey of STATUS_ORDER) groups[statusKey] = [];
-  for (const order of orders.value) {
-    if (hideOnHold.value && order.is_on_hold) continue;
+  for (const order of visibleOrders.value) {
     const key = order.status;
     if (!groups[key]) groups[key] = [];
     groups[key].push(order);
   }
   return groups;
 });
+
+const groupedOrderItems = computed(() => {
+  const groups = groupedOrders.value;
+  const items: Record<string, ReturnType<typeof buildCustomerOrderRenderItems>> = {};
+  for (const statusKey of STATUS_ORDER) {
+    items[statusKey] = buildCustomerOrderRenderItems(groups[statusKey] || [], segment.value, groupByCustomer.value, customerAliases.value);
+  }
+  return items;
+});
+
+const listItems = computed(() => buildCustomerOrderRenderItems(visibleOrders.value, segment.value, groupByCustomer.value, customerAliases.value));
 
 const setToast = (message: string) => {
   toast.value = message;
@@ -76,9 +96,11 @@ const restoreSegmentAndView = () => {
   const params = new URLSearchParams(window.location.search);
   const segmentFromUrl = params.get('segment');
   const viewFromUrl = params.get('view');
+  const groupByFromUrl = params.get('groupBy');
 
   const segmentFromStorage = window.localStorage.getItem(ORDERS_SEGMENT_STORAGE_KEY);
   const viewFromStorage = window.localStorage.getItem(ORDERS_VIEW_STORAGE_KEY);
+  const groupByFromStorage = window.localStorage.getItem(ORDERS_GROUP_BY_CUSTOMER_STORAGE_KEY);
 
   const resolvedSegment = segmentFromUrl || segmentFromStorage;
   const resolvedView = viewFromUrl || viewFromStorage;
@@ -89,6 +111,11 @@ const restoreSegmentAndView = () => {
   if (resolvedView === 'kanban' || resolvedView === 'list') {
     view.value = resolvedView as DashboardView;
   }
+  if (groupByFromUrl === 'customer') {
+    groupByCustomer.value = true;
+  } else if (!groupByFromUrl && groupByFromStorage === 'false') {
+    groupByCustomer.value = false;
+  }
 };
 
 const persistSegmentAndView = () => {
@@ -96,6 +123,56 @@ const persistSegmentAndView = () => {
   window.localStorage.setItem(ORDERS_VIEW_STORAGE_KEY, view.value);
   setQueryParam('segment', segment.value);
   setQueryParam('view', view.value);
+};
+
+const persistGrouping = () => {
+  window.localStorage.setItem(ORDERS_GROUP_BY_CUSTOMER_STORAGE_KEY, groupByCustomer.value ? 'true' : 'false');
+  setQueryParam('groupBy', groupByCustomer.value ? 'customer' : '');
+};
+
+const restoreCustomerAliases = () => {
+  try {
+    const raw = window.localStorage.getItem(ORDERS_CUSTOMER_ALIASES_STORAGE_KEY);
+    customerAliases.value = raw ? JSON.parse(raw) : {};
+  } catch {
+    customerAliases.value = {};
+  }
+};
+
+const persistCustomerAliases = () => {
+  window.localStorage.setItem(ORDERS_CUSTOMER_ALIASES_STORAGE_KEY, JSON.stringify(customerAliases.value));
+};
+
+const renameCustomerGroup = (payload: { customerId: number; alias: string | null }) => {
+  const next = { ...customerAliases.value };
+  if (payload.alias) {
+    next[payload.customerId] = payload.alias;
+  } else {
+    delete next[payload.customerId];
+  }
+  customerAliases.value = next;
+  persistCustomerAliases();
+  setToast(payload.alias ? 'Название группы сохранено' : 'Название группы сброшено');
+};
+
+const renameOrderTitle = async (payload: { orderId: number; title: string | null }) => {
+  const nextTitle = payload.title?.trim() || null;
+  const snapshot = orders.value.map((item) => ({ ...item }));
+  const item = orders.value.find((order) => order.id === payload.orderId);
+  const previousSelectedTitle = selectedOrder.value?.id === payload.orderId ? selectedOrder.value.title : undefined;
+
+  if (item) item.title = nextTitle;
+  if (selectedOrder.value?.id === payload.orderId) selectedOrder.value.title = nextTitle;
+
+  try {
+    await api.patchManagerOrder(payload.orderId, { title: nextTitle });
+    setToast(nextTitle ? 'Название заказа сохранено' : 'Название заказа сброшено');
+  } catch (error) {
+    console.error(error);
+    orders.value = snapshot;
+    if (selectedOrder.value?.id === payload.orderId) selectedOrder.value.title = previousSelectedTitle ?? null;
+    setToast(`Не удалось сохранить название: ${getApiErrorMessage(error)}`);
+  }
 };
 
 const loadOrders = async () => {
@@ -145,6 +222,10 @@ watch(
 );
 watch(view, () => {
   persistSegmentAndView();
+});
+watch(groupByCustomer, () => {
+  if (!isHydrated.value) return;
+  persistGrouping();
 });
 watch(search, () => {
   if (!isHydrated.value) return;
@@ -280,6 +361,7 @@ const handleLogin = async () => {
 };
 
 onMounted(async () => {
+  restoreCustomerAliases();
   restoreSegmentAndView();
   const params = new URLSearchParams(window.location.search);
   const searchParam = params.get('search');
@@ -294,6 +376,7 @@ onMounted(async () => {
     }
   }
   persistSegmentAndView();
+  persistGrouping();
   try {
     await loadOrders();
   } finally {
@@ -315,38 +398,53 @@ watch(drawerOpen, (isOpen) => {
 <template>
   <div class="min-h-screen bg-gray-50 text-slate-900">
     <div class="mx-auto max-w-[1400px] px-4 py-6 md:px-8">
-      <header class="mb-5 rounded-[2rem] border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm p-4">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div class="flex flex-wrap items-center gap-3 md:gap-4">
-            <h1 class="text-xl md:text-2xl font-bold dark:text-white">Заказы</h1>
+      <header class="mb-4 rounded-2xl border border-gray-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+        <div class="flex items-center gap-1 pl-14 sm:gap-2 md:pl-0">
+          <div class="flex min-w-0 shrink items-center gap-1 sm:gap-2">
+            <h1 class="shrink-0 text-lg font-bold dark:text-white md:text-xl">Заказы</h1>
             <OrdersTabSwitcher v-model="segment" />
           </div>
-          <div class="flex items-center gap-3 ml-auto">
-            <label v-if="view === 'kanban'" class="hidden sm:inline-flex items-center gap-2 rounded-xl border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 text-gray-700 dark:text-slate-300 px-3 py-1.5 cursor-pointer text-sm font-medium">
-              <input v-model="hideOnHold" type="checkbox" class="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-              Скрывать отложенные
-            </label>
+          <div class="ml-auto flex shrink-0 items-center justify-end gap-1 sm:gap-2">
             <OrdersViewToggle v-model="view" />
+            <button
+              type="button"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-gray-200 bg-gray-50 text-gray-700 transition hover:bg-white dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:h-9 sm:w-9"
+              :class="filtersOpen ? 'bg-teal-50 text-teal-700 dark:bg-teal-500/10 dark:text-teal-300' : ''"
+              :aria-expanded="filtersOpen"
+              aria-label="Опции и фильтры"
+              title="Опции и фильтры"
+              @click="filtersOpen = !filtersOpen"
+            >
+              <SlidersHorizontal class="h-4 w-4" />
+            </button>
           </div>
         </div>
         
-        <div v-if="view === 'list'" class="mt-4 grid gap-3 md:grid-cols-3 lg:grid-cols-4 bg-slate-50 dark:bg-slate-800/50 p-3 rounded-[1rem] border border-gray-100 dark:border-slate-700">
-          <input v-model="search" class="field-input" placeholder="Поиск (клиент, УНП, ID)..." />
-          <select v-model="statusFilter" class="field-input">
-            <option value="">Все статусы</option>
-            <option v-for="statusKey in STATUS_ORDER" :key="statusKey" :value="statusKey">
-              {{ STATUS_LABELS[statusKey] || statusKey }}
-            </option>
-          </select>
-          <label class="inline-flex items-center gap-2 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 px-3 py-2 cursor-pointer transition hover:bg-gray-50 dark:hover:bg-slate-700">
-            <input v-model="overdueOnly" type="checkbox" class="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            <span class="font-medium text-sm">Только просроченные</span>
-          </label>
-          <label class="inline-flex items-center gap-2 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-300 px-3 py-2 cursor-pointer transition hover:bg-gray-50 dark:hover:bg-slate-700">
-            <input v-model="hideOnHold" type="checkbox" class="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            <span class="font-medium text-sm">Скрывать отложенные</span>
-          </label>
-        </div>
+        <Transition name="fade">
+          <div v-if="filtersOpen" class="mt-3 grid gap-3 rounded-2xl border border-gray-100 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800/50 md:grid-cols-3 lg:grid-cols-4">
+            <template v-if="view === 'list'">
+              <input v-model="search" class="field-input" placeholder="Поиск (клиент, УНП, ID)..." />
+              <select v-model="statusFilter" class="field-input">
+                <option value="">Все статусы</option>
+                <option v-for="statusKey in STATUS_ORDER" :key="statusKey" :value="statusKey">
+                  {{ STATUS_LABELS[statusKey] || statusKey }}
+                </option>
+              </select>
+              <label class="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700">
+                <input v-model="overdueOnly" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+                <span class="text-sm font-medium">Только просроченные</span>
+              </label>
+            </template>
+            <label class="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700">
+              <input v-model="groupByCustomer" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+              <span class="text-sm font-medium">Группировать</span>
+            </label>
+            <label class="inline-flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700">
+              <input v-model="hideOnHold" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+              <span class="text-sm font-medium">Скрывать отложенные</span>
+            </label>
+          </div>
+        </Transition>
       </header>
 
       <!-- Toast -->
@@ -359,22 +457,25 @@ watch(drawerOpen, (isOpen) => {
 
       <OrderKanbanBoard
         v-if="view === 'kanban'"
-        :grouped-orders="groupedOrders"
+        :grouped-items="groupedOrderItems"
         :segment="segment"
         :moving-order-ids="movingOrderIds"
         @open="openOrder"
         @generate="onGenerateDoc"
         @move="onMoveOrder"
+        @rename-customer="renameCustomerGroup"
+        @rename-order="renameOrderTitle"
       />
 
       <OrdersListTable
         v-else
-        :orders="orders"
+        :items="listItems"
         :segment="segment"
         :sort="sort"
         @update:sort="sort = $event"
         @open="openOrder"
         @generate="onGenerateDoc"
+        @rename-order="renameOrderTitle"
       />
     </div>
 

--- a/manager_frontend/src/components/orders/OrdersListTable.vue
+++ b/manager_frontend/src/components/orders/OrdersListTable.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import type { ManagerOrderListItemResponse } from '../../client';
+import { computed, ref } from 'vue';
 import type { Segment } from '../../api';
-import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
+import type { OrderRenderItem } from './order-utils';
+import { STATUS_LABELS, formatMoney, formatOrderCount } from './order-utils';
+import OrderListRow from './OrderListRow.vue';
 
 const props = defineProps<{
-  orders: ManagerOrderListItemResponse[];
+  items: OrderRenderItem[];
   segment: Segment;
   sort?: string;
 }>();
@@ -13,6 +15,7 @@ const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
   'update:sort': [value: string];
+  renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
 
 const toggleSort = (key: string) => {
@@ -20,13 +23,21 @@ const toggleSort = (key: string) => {
   else emit('update:sort', `${key}_desc`);
 };
 
-const customerName = (order: ManagerOrderListItemResponse) => (
-  props.segment === 'b2b'
-    ? (order.customer?.full_legal_name || order.customer?.name || '—')
-    : (order.customer?.name || '—')
+const expandedGroupIds = ref<string[]>([]);
+
+const toggleGroup = (groupId: string) => {
+  expandedGroupIds.value = expandedGroupIds.value.includes(groupId)
+    ? expandedGroupIds.value.filter((id) => id !== groupId)
+    : [...expandedGroupIds.value, groupId];
+};
+
+const groupStatusSummary = (item: OrderRenderItem) => (
+  item.type === 'group'
+    ? item.group.statusCounts.map((status) => `${status.count} ${STATUS_LABELS[status.status] || status.status}`).join(' · ')
+    : ''
 );
 
-const displayTitle = (order: ManagerOrderListItemResponse) => order.title?.trim() || `#${order.id}`;
+const totalOrderCount = computed(() => props.items.reduce((total, item) => total + (item.type === 'group' ? item.group.orders.length : 1), 0));
 </script>
 
 <template>
@@ -55,80 +66,58 @@ const displayTitle = (order: ManagerOrderListItemResponse) => order.title?.trim(
         </tr>
       </thead>
       <tbody>
-        <tr
-          v-for="order in orders"
-          :key="order.id"
-          class="border-t border-gray-100"
-          :class="isOverdue(order) ? 'bg-red-50' : ''"
-        >
-          <td class="px-3 py-3">
-            <p class="max-w-[260px] truncate font-semibold text-gray-900">{{ displayTitle(order) }}</p>
-            <p v-if="order.title?.trim()" class="max-w-[260px] truncate text-xs text-gray-500">#{{ order.id }} · {{ customerName(order) }}</p>
-            <div v-if="order.manager_labels?.length" class="mt-1 flex max-w-[260px] flex-wrap gap-1">
-              <span
-                v-for="label in order.manager_labels"
-                :key="label"
-                class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-[10px] font-semibold text-teal-800"
-              >
-                {{ label }}
-              </span>
-            </div>
-          </td>
-          <td class="px-3 py-3">
-            <template v-if="segment === 'b2b'">
-              <p>{{ customerName(order) }}</p>
-              <p class="text-xs text-gray-500">УНП: {{ order.customer?.inn || '—' }}</p>
-            </template>
-            <template v-else>
-              <p>{{ customerName(order) }}</p>
-              <p class="text-xs text-gray-500">{{ formatPhone(order.customer?.phone) }}</p>
-            </template>
-          </td>
-          <td class="px-3 py-3">
-            <div class="mb-1">{{ STATUS_LABELS[order.status] || order.status }}</div>
-            <div class="flex flex-col gap-1 items-start">
-              <span v-if="order.needs_attention" class="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider">🔴 Внимание</span>
-              <span v-if="order.awaiting_measurement" class="rounded-full bg-blue-100 text-blue-700 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider">🕒 Замер</span>
-              <span v-if="order.client_thinking" class="rounded-full bg-amber-100 text-amber-700 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider">⏳ Думают</span>
-              <span v-if="order.ready_for_execution" class="rounded-full bg-green-100 text-green-700 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider">✅ Согласовано</span>
-            </div>
-          </td>
-          <td class="px-3 py-3">{{ formatDate(order.next_followup_date) }}</td>
-          <td class="px-3 py-3">{{ formatMoney(order.total_amount) }}</td>
-          <td class="px-3 py-3 font-semibold text-teal-700">{{ formatMoney(order.margin) }}</td>
-          <td class="px-3 py-3">
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-if="segment === 'b2b'"
-                class="btn-mini"
-                @click="emit('generate', { orderId: order.id, docType: 'invoice' })"
-              >
-                Счет
-              </button>
-              <button
-                v-if="segment === 'b2b'"
-                class="btn-mini"
-                @click="emit('generate', { orderId: order.id, docType: 'contract' })"
-              >
-                Договор
-              </button>
-              <button
-                v-if="segment === 'b2c'"
-                class="btn-mini"
-                @click="emit('generate', { orderId: order.id, docType: 'work_order' })"
-              >
-                Наряд
-              </button>
-              <button
-                v-if="segment === 'b2c'"
-                class="btn-mini"
-                @click="emit('generate', { orderId: order.id, docType: 'act' })"
-              >
-                Акт
-              </button>
-              <button class="btn-mini-outline" @click="emit('open', order.id)">Открыть</button>
-            </div>
-          </td>
+        <template v-for="item in items" :key="item.type === 'group' ? item.group.id : item.order.id">
+          <template v-if="item.type === 'group'">
+            <tr class="border-t border-gray-100 bg-slate-50">
+              <td class="px-3 py-3">
+                <button type="button" class="flex w-full min-w-0 items-center gap-2 text-left" @click="toggleGroup(item.group.id)">
+                  <span class="material-icons-round text-[18px] text-slate-500">{{ expandedGroupIds.includes(item.group.id) ? 'expand_less' : 'expand_more' }}</span>
+                  <div class="min-w-0">
+                    <p class="max-w-[320px] truncate font-semibold text-gray-900">{{ item.group.customerName }}</p>
+                    <p class="text-xs text-gray-500">{{ formatOrderCount(item.group.orders.length) }} · {{ groupStatusSummary(item) }}</p>
+                  </div>
+                </button>
+              </td>
+              <td class="px-3 py-3">
+                <p class="max-w-[260px] truncate">{{ item.group.addresses.join(' · ') || '—' }}</p>
+                <p class="text-xs text-gray-500">Всего: {{ formatOrderCount(item.group.orders.length) }}</p>
+              </td>
+              <td class="px-3 py-3">
+                <span v-if="item.group.needsAttention" class="rounded-full bg-red-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-red-700">Внимание</span>
+                <span v-else-if="item.group.hasOverdue" class="rounded-full bg-amber-100 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wider text-amber-700">Есть просрочка</span>
+                <span v-else class="text-xs text-gray-500">Без срочных флагов</span>
+              </td>
+              <td class="px-3 py-3 text-xs text-gray-500">Группа клиента</td>
+              <td class="px-3 py-3">{{ formatMoney(item.group.totalAmount) }}</td>
+              <td class="px-3 py-3 font-semibold text-teal-700">{{ formatMoney(item.group.margin) }}</td>
+              <td class="px-3 py-3">
+                <button class="btn-mini-outline" type="button" @click="toggleGroup(item.group.id)">
+                  {{ expandedGroupIds.includes(item.group.id) ? 'Скрыть' : 'Показать' }}
+                </button>
+              </td>
+            </tr>
+            <OrderListRow
+              v-for="order in expandedGroupIds.includes(item.group.id) ? item.group.orders : []"
+              :key="`group-${item.group.id}-order-${order.id}`"
+              :order="order"
+              :segment="segment"
+              nested
+              @open="(orderId) => emit('open', orderId)"
+              @generate="(payload) => emit('generate', payload)"
+              @rename-order="(payload) => emit('renameOrder', payload)"
+            />
+          </template>
+          <OrderListRow
+            v-else
+            :order="item.order"
+            :segment="segment"
+            @open="(orderId) => emit('open', orderId)"
+            @generate="(payload) => emit('generate', payload)"
+            @rename-order="(payload) => emit('renameOrder', payload)"
+          />
+        </template>
+        <tr v-if="!totalOrderCount">
+          <td colspan="7" class="px-3 py-8 text-center text-sm text-gray-500">Заказы не найдены</td>
         </tr>
       </tbody>
     </table>

--- a/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
+++ b/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
@@ -6,20 +6,22 @@ const emit = defineEmits<{ 'update:modelValue': [value: Segment] }>();
 </script>
 
 <template>
-  <div class="inline-flex rounded-[12px] bg-gray-100 p-1 border border-gray-200 shrink-0">
+  <div class="inline-flex shrink-0 rounded-xl border border-gray-200 bg-gray-100 p-0.5">
     <button
-      class="rounded-[12px] px-3 py-1.5 md:px-4 md:py-2 text-sm font-semibold transition"
+      class="rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
       :class="modelValue === 'b2c' ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
+      title="Частные клиенты"
       @click="emit('update:modelValue', 'b2c')"
     >
-      Частные (B2C)
+      B2C
     </button>
     <button
-      class="rounded-[12px] px-3 py-1.5 md:px-4 md:py-2 text-sm font-semibold transition"
+      class="rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
       :class="modelValue === 'b2b' ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
+      title="Юридические лица"
       @click="emit('update:modelValue', 'b2b')"
     >
-      Юр. лица (B2B)
+      B2B
     </button>
   </div>
 </template>

--- a/manager_frontend/src/components/orders/OrdersViewToggle.vue
+++ b/manager_frontend/src/components/orders/OrdersViewToggle.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { LayoutGrid, List } from 'lucide-vue-next';
 import type { DashboardView } from '../../api';
 
 defineProps<{ modelValue: DashboardView }>();
@@ -6,20 +7,24 @@ const emit = defineEmits<{ 'update:modelValue': [value: DashboardView] }>();
 </script>
 
 <template>
-  <div class="inline-flex rounded-[12px] bg-gray-100 p-1 border border-gray-200">
+  <div class="inline-flex rounded-xl border border-gray-200 bg-gray-100 p-0.5">
     <button
-      class="rounded-[12px] px-3 py-2 text-sm font-medium transition"
+      class="rounded-[10px] p-1.5 transition sm:p-2"
       :class="modelValue === 'kanban' ? 'bg-[var(--mv-teal)] text-white' : 'text-gray-600 hover:text-gray-900'"
+      title="Канбан"
+      aria-label="Канбан"
       @click="emit('update:modelValue', 'kanban')"
     >
-      Канбан
+      <LayoutGrid class="h-4 w-4" />
     </button>
     <button
-      class="rounded-[12px] px-3 py-2 text-sm font-medium transition"
+      class="rounded-[10px] p-1.5 transition sm:p-2"
       :class="modelValue === 'list' ? 'bg-[var(--mv-teal)] text-white' : 'text-gray-600 hover:text-gray-900'"
+      title="Список"
+      aria-label="Список"
       @click="emit('update:modelValue', 'list')"
     >
-      Список
+      <List class="h-4 w-4" />
     </button>
   </div>
 </template>

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -1,4 +1,5 @@
 import type { ManagerOrderListItemResponse } from '../../client';
+import type { Segment } from '../../api';
 
 export const STATUS_ORDER = [
     'negotiation',
@@ -42,4 +43,125 @@ export function isOverdue(order: ManagerOrderListItemResponse): boolean {
     const date = new Date(order.next_followup_date);
     if (Number.isNaN(date.getTime())) return false;
     return date.getTime() < Date.now();
+}
+
+export type CustomerOrderGroup = {
+    id: string;
+    customerId: number;
+    customerName: string;
+    originalCustomerName: string;
+    orders: ManagerOrderListItemResponse[];
+    totalAmount: number;
+    margin: number;
+    statusCounts: Array<{ status: string; count: number }>;
+    addresses: string[];
+    hiddenAddressCount: number;
+    hasOverdue: boolean;
+    needsAttention: boolean;
+};
+
+export type OrderRenderItem =
+    | { type: 'order'; order: ManagerOrderListItemResponse }
+    | { type: 'group'; group: CustomerOrderGroup };
+
+export function getOrderCustomerName(order: ManagerOrderListItemResponse, segment: Segment): string {
+    const customer = order.customer;
+    if (!customer) return `Заказ #${order.id}`;
+
+    if (segment === 'b2b') {
+        return customer.full_legal_name
+            || customer.name
+            || customer.phone
+            || customer.email
+            || `Клиент #${customer.id}`;
+    }
+
+    return customer.name
+        || customer.phone
+        || customer.email
+        || `Клиент #${customer.id}`;
+}
+
+export function formatOrderCount(count: number): string {
+    const mod10 = count % 10;
+    const mod100 = count % 100;
+    if (mod10 === 1 && mod100 !== 11) return `${count} заказ`;
+    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${count} заказа`;
+    return `${count} заказов`;
+}
+
+export function buildCustomerOrderRenderItems(
+    orders: ManagerOrderListItemResponse[],
+    segment: Segment,
+    groupingEnabled: boolean,
+    customerAliases: Record<number, string> = {},
+): OrderRenderItem[] {
+    if (!groupingEnabled) {
+        return orders.map((order) => ({ type: 'order', order }));
+    }
+
+    const customerCounts = new Map<number, number>();
+    for (const order of orders) {
+        const customerId = order.customer?.id;
+        if (!customerId) continue;
+        customerCounts.set(customerId, (customerCounts.get(customerId) || 0) + 1);
+    }
+
+    const groupedByCustomer = new Map<number, ManagerOrderListItemResponse[]>();
+    const emittedCustomers = new Set<number>();
+    const items: OrderRenderItem[] = [];
+
+    for (const order of orders) {
+        const customerId = order.customer?.id;
+        if (!customerId || (customerCounts.get(customerId) || 0) < 2) {
+            items.push({ type: 'order', order });
+            continue;
+        }
+
+        if (!groupedByCustomer.has(customerId)) {
+            groupedByCustomer.set(customerId, orders.filter((item) => item.customer?.id === customerId));
+        }
+        if (emittedCustomers.has(customerId)) continue;
+
+        emittedCustomers.add(customerId);
+        const groupOrders = groupedByCustomer.get(customerId) || [order];
+        items.push({ type: 'group', group: createCustomerOrderGroup(customerId, groupOrders, segment, customerAliases[customerId]) });
+    }
+
+    return items;
+}
+
+function createCustomerOrderGroup(
+    customerId: number,
+    orders: ManagerOrderListItemResponse[],
+    segment: Segment,
+    alias?: string,
+): CustomerOrderGroup {
+    const firstOrder = orders[0];
+    const statusCounter = new Map<string, number>();
+    const addresses: string[] = [];
+
+    for (const order of orders) {
+        statusCounter.set(order.status, (statusCounter.get(order.status) || 0) + 1);
+        const address = order.delivery_address?.trim();
+        if (address && !addresses.includes(address)) addresses.push(address);
+    }
+
+    const originalCustomerName = firstOrder ? getOrderCustomerName(firstOrder, segment) : `Клиент #${customerId}`;
+    const customerName = alias?.trim() || originalCustomerName;
+
+    return {
+        id: `customer-${customerId}-${orders.map((order) => order.id).join('-')}`,
+        customerId,
+        customerName,
+        originalCustomerName,
+        orders,
+        totalAmount: orders.reduce((sum, order) => sum + order.total_amount, 0),
+        margin: orders.reduce((sum, order) => sum + order.margin, 0),
+        statusCounts: Array.from(statusCounter.entries()).map(([status, count]) => ({ status, count })),
+        addresses: addresses.slice(0, 3),
+        hiddenAddressCount: Math.max(addresses.length - 3, 0),
+        hasOverdue: orders.some(isOverdue),
+        needsAttention: orders.some((order) => order.needs_attention),
+    };
 }


### PR DESCRIPTION
## Summary
- add frontend-only grouping of manager orders by customer in kanban and list views
- keep grouping state in URL/localStorage and default it on for the manager orders page
- add compact customer group cards/rows with local double-click aliases
- add double-click inline title editing for individual orders in kanban and list
- compact the orders header and move grouping/hide-on-hold controls into the filters popover

Closes #291.

## Validation
- `cd manager_frontend && npm run build`
- `git diff --check`
- Browser smoke check on `/manager/orders?segment=b2b&view=kanban&groupBy=customer`: header order, filters popover, kanban/list presence, inline title edit path