### PR TITLE
Добавить debug-фильтр товаров без категории в менеджер

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -18,6 +18,7 @@ from models.supplier import ProductLocalStock, ProductSupplierMapping, SupplierO
 
 ALLOWED_FILTER_GROUP_SLUGS = {"brand", "series", "expert-badge", "type", "category"}
 ALLOWED_INDOOR_TYPE_FILTERS = {"duct", "cassette", "floor_ceiling", "column"}
+CATALOG_CATEGORY_SLUGS = {"cat-household", "cat-multi", "cat-industrial"}
 CATALOG_RANKING_WEIGHTS = {
     "availability": 100,
     "out_of_stock": -100,
@@ -231,6 +232,22 @@ class ProductDAO:
                 subq = select(ProductTagLink.product_id).where(ProductTagLink.tag_id.in_(tag_ids))
                 stmt = stmt.where(Product.id.in_(subq))
         return stmt
+
+    @staticmethod
+    def _apply_category_status_filter(stmt, category_status: Optional[str] = None):
+        normalized_status = (category_status or "").strip().lower()
+        if normalized_status != "missing":
+            return stmt
+
+        category_subq = (
+            select(ProductTagLink.product_id)
+            .join(Tag, ProductTagLink.tag_id == Tag.id)
+            .join(TagGroup, Tag.group_id == TagGroup.id)
+            .where(ProductTagLink.product_id == Product.id)
+            .where(TagGroup.slug == "category")
+            .where(Tag.slug.in_(CATALOG_CATEGORY_SLUGS))
+        )
+        return stmt.where(~exists(category_subq))
 
     @staticmethod
     def _apply_smart_search_filter(stmt, query: str):
@@ -555,8 +572,10 @@ class ProductDAO:
         has_fresh_air: Optional[bool] = None,
         brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
+        category_status: Optional[str] = None,
         sort: str = "recommended",
     ) -> tuple[List[Product], int]:
+        normalized_category_status = (category_status or "").strip().lower()
         stmt = select(Product).options(
             selectinload(Product.gallery_images),
             selectinload(Product.tags).selectinload(Tag.group),
@@ -571,7 +590,7 @@ class ProductDAO:
             "has_wifi": has_wifi,
             "has_fresh_air": has_fresh_air,
             "is_inverter": is_inverter,
-            "tag_slugs": [category_slug] if category_slug else None,
+            "tag_slugs": [category_slug] if category_slug and normalized_category_status != "missing" else None,
             "brand_slugs": brand_slugs,
             "is_published": is_published,
         }
@@ -580,11 +599,13 @@ class ProductDAO:
             stmt=stmt,
             **common_filter_kwargs,
         )
+        stmt = ProductDAO._apply_category_status_filter(stmt, normalized_category_status)
         count_stmt = ProductDAO._apply_common_filters(
             session=session,
             stmt=count_stmt,
             **common_filter_kwargs,
         )
+        count_stmt = ProductDAO._apply_category_status_filter(count_stmt, normalized_category_status)
 
         if search:
             stmt = stmt.where(Product.title.ilike(f"%{search}%"))
@@ -596,6 +617,8 @@ class ProductDAO:
             stmt = stmt.order_by(Product.price.desc())
         elif sort == "title":
             stmt = stmt.order_by(Product.title.asc())
+        elif sort == "newest":
+            stmt = stmt.order_by(Product.created_at.desc(), Product.id.desc())
         elif sort == "recommended":
             stmt = stmt.order_by(
                 ProductDAO._catalog_recommendation_score_expr(area_max=area_max).desc(),

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -111,6 +111,7 @@ export interface ManagerProductFilterOptions {
     brandSlugs?: string[];
     areaMin?: number;
     areaMax?: number;
+    categoryStatus?: 'assigned' | 'missing';
 }
 
 export const api = {
@@ -457,6 +458,7 @@ export const api = {
             filters.hasFreshAir ?? undefined,
             filters.brandSlugs ?? undefined,
             categorySlug ?? undefined,
+            filters.categoryStatus ?? undefined,
             sort,
         );
     },

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -77,6 +77,7 @@ export class ManagerService {
      * @param hasFreshAir
      * @param brandSlugs Brand slugs to include
      * @param categorySlug Category tag slug: cat-household/cat-multi/cat-industrial
+     * @param categoryStatus Catalog category status: assigned/missing
      * @param sort
      * @returns ManagerCatalogProductListResponse Successful Response
      * @throws ApiError
@@ -94,6 +95,7 @@ export class ManagerService {
         hasFreshAir?: (boolean | null),
         brandSlugs?: (Array<string> | null),
         categorySlug?: (string | null),
+        categoryStatus?: ('assigned' | 'missing' | null),
         sort: string = 'recommended',
     ): CancelablePromise<ManagerCatalogProductListResponse> {
         return __request(OpenAPI, {
@@ -112,6 +114,7 @@ export class ManagerService {
                 'has_fresh_air': hasFreshAir,
                 'brand_slugs': brandSlugs,
                 'category_slug': categorySlug,
+                'category_status': categoryStatus,
                 'sort': sort,
             },
             errors: {

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -146,12 +146,23 @@ const FAVORITE_TAG_TITLE = 'Избранное';
 const FAVORITE_TAG_GROUP_SLUG = 'manager-flags';
 const FAVORITE_TAG_GROUP_TITLE = 'Метки менеджера';
 const hasSearchQuery = computed(() => searchQuery.value.trim().length > 0);
-const categorySlug = ref<'cat-household' | 'cat-multi' | 'cat-industrial'>('cat-household');
-const CATEGORY_FILTER_TABS: Array<{ slug: 'cat-household' | 'cat-multi' | 'cat-industrial'; title: string }> = [
-    { slug: 'cat-household', title: 'Бытовые' },
-    { slug: 'cat-multi', title: 'Мульти-сплит' },
-    { slug: 'cat-industrial', title: 'Полупром' },
+type CatalogCategorySlug = 'cat-household' | 'cat-multi' | 'cat-industrial';
+type CategoryFilterValue = CatalogCategorySlug | 'missing';
+const categoryFilter = ref<CategoryFilterValue>('cat-household');
+const CATEGORY_FILTER_TABS: Array<{ value: CategoryFilterValue; title: string }> = [
+    { value: 'cat-household', title: 'Бытовые' },
+    { value: 'cat-multi', title: 'Мульти-сплит' },
+    { value: 'cat-industrial', title: 'Полупром' },
+    { value: 'missing', title: 'Без категории' },
 ];
+const isMissingCategoryFilter = computed(() => categoryFilter.value === 'missing');
+const categorySlug = computed<CatalogCategorySlug | undefined>(() => (
+    isMissingCategoryFilter.value ? undefined : categoryFilter.value as CatalogCategorySlug
+));
+const categoryStatus = computed<'missing' | undefined>(() => (
+    isMissingCategoryFilter.value ? 'missing' : undefined
+));
+const usesSmartSearch = computed(() => hasSearchQuery.value && !isMissingCategoryFilter.value);
 const favoriteTagId = ref<number | null>(null);
 const favoriteUpdatingIds = ref<Set<number>>(new Set());
 const availableBrands = computed(() => (
@@ -176,6 +187,9 @@ const applyFilters = () => {
 };
 
 const onCategoryChange = () => {
+    if (isMissingCategoryFilter.value && sortMode.value === 'recommended') {
+        sortMode.value = 'newest';
+    }
     selectedProductIds.value.clear();
     page.value = 1;
     loadProducts();
@@ -191,7 +205,7 @@ const resetFilters = () => {
     hasFreshAir.value = undefined;
     selectedBrandSlug.value = null;
     sortMode.value = 'recommended';
-    categorySlug.value = 'cat-household';
+    categoryFilter.value = 'cat-household';
     selectedProductIds.value.clear();
     page.value = 1;
     loadProducts();
@@ -204,6 +218,7 @@ const getManagerProductFilters = () => ({
     brandSlugs: selectedBrandSlug.value ? [selectedBrandSlug.value] : undefined,
     areaMin: areaMin.value,
     areaMax: areaMax.value,
+    categoryStatus: categoryStatus.value,
 });
 
 const toggleBrand = (slug: string | null) => {
@@ -453,7 +468,7 @@ const loadProducts = async () => {
   loading.value = true;
   page.value = 1;
   try {
-    if (hasSearchQuery.value) {
+    if (usesSmartSearch.value) {
       const smartResults = await api.smartSearchProducts(
           searchQuery.value.trim(),
           SMART_SEARCH_LIMIT,
@@ -468,7 +483,7 @@ const loadProducts = async () => {
       const data = await api.getManagerProducts(
           1,
           limit,
-          undefined,
+          isMissingCategoryFilter.value ? searchQuery.value.trim() || undefined : undefined,
           undefined, // isPublished (not exposed yet)
           areaMin.value,
           areaMax.value,
@@ -502,7 +517,7 @@ const loadProducts = async () => {
 };
 
 const loadMore = async () => {
-    if (loadingMore.value || !hasMore.value || hasSearchQuery.value) return;
+    if (loadingMore.value || !hasMore.value || usesSmartSearch.value) return;
     loadingMore.value = true;
     page.value++;
     try {
@@ -874,11 +889,11 @@ watchDebounced(
             </label>
             <select
               id="manager-product-category"
-              v-model="categorySlug"
+              v-model="categoryFilter"
               class="min-w-[150px] bg-transparent text-sm font-semibold text-gray-900 dark:text-slate-100 outline-none"
               @change="onCategoryChange"
             >
-              <option v-for="tab in CATEGORY_FILTER_TABS" :key="tab.slug" :value="tab.slug">
+              <option v-for="tab in CATEGORY_FILTER_TABS" :key="tab.value" :value="tab.value">
                 {{ tab.title }}
               </option>
             </select>

--- a/openapi.json
+++ b/openapi.json
@@ -2383,6 +2383,28 @@
             "description": "Category tag slug: cat-household/cat-multi/cat-industrial"
           },
           {
+            "name": "category_status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "assigned",
+                    "missing"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Catalog category status: assigned/missing",
+              "title": "Category Status"
+            },
+            "description": "Catalog category status: assigned/missing"
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,6 +74,7 @@ async def list_products_for_manager(
     has_fresh_air: Optional[bool] = Query(None),
     brand_slugs: Optional[List[str]] = Query(None, description="Brand slugs to include"),
     category_slug: Optional[str] = Query(None, description="Category tag slug: cat-household/cat-multi/cat-industrial"),
+    category_status: Optional[Literal["assigned", "missing"]] = Query(None, description="Catalog category status: assigned/missing"),
     sort: str = Query("recommended"),
     session: AsyncSession = Depends(get_session),
     _user: str = Depends(get_current_username),
@@ -96,6 +97,7 @@ async def list_products_for_manager(
         has_fresh_air=has_fresh_air,
         brand_slugs=brand_slugs,
         category_slug=category_slug,
+        category_status=category_status,
         sort=sort,
     )
 

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -30,6 +30,7 @@ class ManagerCatalogService:
         has_fresh_air: Optional[bool],
         brand_slugs: Optional[list[str]],
         category_slug: Optional[str],
+        category_status: Optional[str],
         sort: str,
     ) -> Dict[str, Any]:
         return await ProductService.get_manager_list(
@@ -46,6 +47,7 @@ class ManagerCatalogService:
             has_fresh_air=has_fresh_air,
             brand_slugs=brand_slugs,
             category_slug=category_slug,
+            category_status=category_status,
             sort=sort,
         )
 

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -165,6 +165,7 @@ class ProductManagerService:
         has_fresh_air: Optional[bool] = None,
         brand_slugs: Optional[List[str]] = None,
         category_slug: Optional[str] = None,
+        category_status: Optional[str] = None,
         sort: str = "recommended",
     ) -> Dict[str, Any]:
         items, total = await ProductDAO.get_for_manager(
@@ -181,6 +182,7 @@ class ProductManagerService:
             has_fresh_air=has_fresh_air,
             brand_slugs=brand_slugs,
             category_slug=category_slug,
+            category_status=category_status,
             sort=sort,
         )
         supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, list(items))

--- a/services/tag_logic.py
+++ b/services/tag_logic.py
@@ -253,6 +253,16 @@ def detect_category_slug(
     if "настенн" in combined_type:
         return "cat-household"
 
+    household_markers = (
+        "мобильн",
+        "portable",
+        "моноблок",
+        "моноблоч",
+        "monoblock",
+    )
+    if any(marker in combined_type for marker in household_markers):
+        return "cat-household"
+
     if any(marker in combined_type for marker in ("сплит", "split")):
         return "cat-household"
 

--- a/tests/integration/test_manager_products_category_filter_api.py
+++ b/tests/integration/test_manager_products_category_filter_api.py
@@ -85,6 +85,85 @@ async def test_manager_products_list_respects_category_slug(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_products_list_can_show_missing_category_products(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    household_tag = await _get_or_create_category_tag(db, "cat-household", "Бытовые")
+    multi_tag = await _get_or_create_category_tag(db, "cat-multi", "Мульти-сплит")
+    industrial_tag = await _get_or_create_category_tag(db, "cat-industrial", "Полупром")
+
+    marker = "UNITCATMISS111"
+    missing = Product(
+        title=f"{marker} Missing Category",
+        slug=f"{marker.lower()}-missing",
+        price=1000,
+        area=20,
+        is_published=True,
+    )
+    household = Product(
+        title=f"{marker} Household",
+        slug=f"{marker.lower()}-household",
+        price=1100,
+        area=20,
+        is_published=True,
+    )
+    multi = Product(
+        title=f"{marker} Multi",
+        slug=f"{marker.lower()}-multi",
+        price=1200,
+        area=20,
+        is_published=True,
+    )
+    industrial = Product(
+        title=f"{marker} Industrial",
+        slug=f"{marker.lower()}-industrial",
+        price=1300,
+        area=20,
+        is_published=True,
+    )
+    db.add_all([missing, household, multi, industrial])
+    await db.commit()
+    for product in [missing, household, multi, industrial]:
+        await db.refresh(product)
+
+    db.add_all(
+        [
+            ProductTagLink(product_id=household.id, tag_id=household_tag.id),
+            ProductTagLink(product_id=multi.id, tag_id=multi_tag.id),
+            ProductTagLink(product_id=industrial.id, tag_id=industrial_tag.id),
+        ]
+    )
+    await db.commit()
+
+    resp = await async_client.get(
+        "/api/manager/products/list",
+        headers=headers,
+        params={
+            "search": marker,
+            "category_status": "missing",
+            "category_slug": "cat-household",
+            "limit": 100,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    ids = {item["id"] for item in resp.json()["items"]}
+    assert missing.id in ids
+    assert household.id not in ids
+    assert multi.id not in ids
+    assert industrial.id not in ids
+
+    household_resp = await async_client.get(
+        "/api/manager/products/list",
+        headers=headers,
+        params={"search": marker, "category_slug": "cat-household", "limit": 100},
+    )
+    assert household_resp.status_code == 200, household_resp.text
+    household_ids = {item["id"] for item in household_resp.json()["items"]}
+    assert household.id in household_ids
+    assert missing.id not in household_ids
+
+
+@pytest.mark.asyncio
 async def test_manager_products_smart_search_respects_category_slug(async_client, db):
     headers = await _auth_headers(async_client)
 

--- a/tests/unit/test_tag_logic.py
+++ b/tests/unit/test_tag_logic.py
@@ -61,6 +61,24 @@ def test_detect_category_slug_for_multi_inner_block():
     assert slug == "cat-multi"
 
 
+def test_detect_category_slug_for_mobile_conditioner():
+    slug = detect_category_slug(
+        metrics={},
+        specs={"type": "мобильный", "indoor_type": "напольный"},
+        title="TCL TAC-09CPB/PSLW",
+    )
+    assert slug == "cat-household"
+
+
+def test_detect_category_slug_for_portable_monoblock_conditioner():
+    slug = detect_category_slug(
+        metrics={},
+        specs={"Тип кондиционера": "portable monoblock"},
+        title="MDV portable AC",
+    )
+    assert slug == "cat-household"
+
+
 def test_extract_brand_slug_falls_back_to_title_first_brand_word():
     slug = extract_brand_slug(
         specs={"Тип кондиционера": "сплит-система"},


### PR DESCRIPTION
## Summary
- Добавлен менеджерский фильтр `Без категории` для `/api/manager/products/list` через новый query param `category_status=missing`.
- Поиск `missing` исключает товары с витринными тегами `cat-household`, `cat-multi`, `cat-industrial` и не смешивается с `category_slug`.
- В `ProductsView` добавлена отдельная вкладка `Без категории`; при ее выборе сортировка переключается на `newest`.
- Улучшена автокатегоризация мобильных/portable/моноблочных кондиционеров в `cat-household` и добавлены unit-тесты.
- Для текущих данных выполнен безопасный `normalize_legacy`, чтобы обновить теги по новой логике.

## Testing
- `pytest tests/unit/test_tag_logic.py -q`
- `pytest tests/integration/test_manager_products_category_filter_api.py -q`
- `python3 scripts/legacy/extract_openapi.py`
- `cd manager_frontend && npm run gen:api`
- `cd manager_frontend && npm run build`