### PR TITLE
Fix backend deploy post-deploy ops defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,7 @@ jobs:
 
       - name: Optional Post-Deploy Backend Ops
         id: post_deploy_ops
+        continue-on-error: true
         env:
           RUN_POST_DEPLOY_OPS: ${{ secrets.RUN_POST_DEPLOY_OPS }}
           OPS_MODE: ${{ secrets.OPS_MODE }}
@@ -171,10 +172,10 @@ jobs:
           set -euo pipefail
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
           : "${RUN_POST_DEPLOY_OPS:=true}"
-          : "${OPS_MODE:=normalize_report}"
-          : "${RUN_NORMALIZE_LEGACY:=true}"
-          : "${RUN_BACKFILL_BRAND_SERIES:=true}"
-          : "${RUN_SAFE_BRAND_CLEANUP:=true}"
+          : "${OPS_MODE:=report_only}"
+          : "${RUN_NORMALIZE_LEGACY:=false}"
+          : "${RUN_BACKFILL_BRAND_SERIES:=false}"
+          : "${RUN_SAFE_BRAND_CLEANUP:=false}"
           : "${RUN_REPORT_LEGACY_LINKS:=true}"
           : "${RUN_CLEANUP_LEGACY_LINKS:=false}"
           : "${DRY_RUN:=true}"


### PR DESCRIPTION
## Summary
- make backend post-deploy ops use safe report-only defaults
- disable normalize/backfill defaults unless explicitly enabled by secrets
- allow optional ops failures to continue to the real post-deploy smoke check

## Root cause
The failed backend deploy run reached a running app container, then failed in the Optional Post-Deploy Backend Ops step. The workflow defaulted empty OPS_MODE to normalize_report and ran normalize_legacy.py, which exited with status 137 on the server. Because that optional step was blocking, the smoke check was skipped.

## Verification
- git diff --check
- inspected GitHub Actions run 25402516900 logs

## Notes
This does not remove manual data ops. Setting OPS_MODE=normalize_report/full or RUN_NORMALIZE_LEGACY=true still allows explicit runs; it just stops surprise normalization during a normal deploy.