### PR TITLE
Fix backend startup when static directory is absent

### DIFF
--- a/core/app_static.py
+++ b/core/app_static.py
@@ -30,9 +30,13 @@ class ManagerAssetsStaticFiles(StaticFiles):
 
 
 def mount_static_and_media(app: FastAPI, base_dir: Path) -> None:
+    static_dir = base_dir / settings.STATIC_DIR
+    if not static_dir.exists():
+        static_dir.mkdir(parents=True, exist_ok=True)
+
     app.mount(
         f"/{settings.STATIC_DIR}",
-        StaticFiles(directory=base_dir / settings.STATIC_DIR),
+        StaticFiles(directory=static_dir),
         name="static",
     )
 


### PR DESCRIPTION
## Summary
- create the configured static directory before mounting Starlette StaticFiles
- prevents backend startup crash after removing the last tracked files under static/

## Root cause
Production app logs show uvicorn restarts with:
`RuntimeError: Directory '/app/static' does not exist`

The SQLAdmin cleanup removed the old files under static/, so the Docker image no longer contains /app/static. Starlette raises during app import when mounting a missing StaticFiles directory.

## Verification
- python3 smoke snippet: mount_static_and_media creates both static and media dirs in a temp base
- python3 -m compileall -q core/app_static.py
- git diff --check

## Deploy note
After merge, rerun backend deploy. The app container should stop restart-looping and /health should no longer return 502.