### PR TITLE
Fix manager production errors and align product search contracts

### DIFF
--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -142,9 +142,10 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             q=(query or "").strip(),
             limit=max(limit, 1),
         )
+        smart_items = smart_results.get("items", []) if isinstance(smart_results, dict) else list(smart_results or [])
         if is_inverter is not None:
-            smart_results = [item for item in smart_results if bool(item.get("is_inverter")) is is_inverter]
-        return smart_results[:limit]
+            smart_items = [item for item in smart_items if bool(item.get("is_inverter")) is is_inverter]
+        return smart_items[:limit]
 
     @staticmethod
     async def get_curated(

--- a/services/tag_service.py
+++ b/services/tag_service.py
@@ -44,11 +44,10 @@ class TagService:
         )
         session.add(group)
         await session.commit()
-        await session.refresh(group)
-        
-        # Ensure 'tags' attr exists for response
-        group.tags = []
-        return group
+
+        stmt = select(TagGroup).where(TagGroup.id == group.id).options(selectinload(TagGroup.tags))
+        res = await session.execute(stmt)
+        return res.scalars().one()
 
     @staticmethod
     async def update_tag_group(session: AsyncSession, group_id: int, payload: ManagerTagGroupUpdatePayload) -> TagGroup:

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -54,6 +54,28 @@ async def test_product_not_found(async_client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_public_product_search_returns_items_from_smart_search(async_client: AsyncClient, db):
+    marker = "PUBLICSEARCHSMART123"
+    product = Product(
+        title=f"{marker} Smart Search Product",
+        slug=f"{marker.lower()}-smart-search-product",
+        price=1234,
+        area=25,
+        is_inverter=True,
+        is_published=True,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    response = await async_client.get("/api/products/search", params={"q": marker, "is_inverter": True})
+
+    assert response.status_code == 200, response.text
+    items = response.json()["items"]
+    assert any(item["id"] == product.id for item in items)
+
+
+@pytest.mark.asyncio
 async def test_catalog_default_sort_uses_recommendation_score(async_client: AsyncClient, db):
     now = datetime.now()
     apartment = Product(

--- a/tests/integration/test_manager_tags_api.py
+++ b/tests/integration/test_manager_tags_api.py
@@ -1,0 +1,35 @@
+import pytest
+
+from core.config import settings
+
+
+async def _auth_headers(async_client):
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_manager_create_tag_group_returns_empty_tags(async_client):
+    headers = await _auth_headers(async_client)
+
+    response = await async_client.post(
+        "/api/manager/tags/groups",
+        headers=headers,
+        json={
+            "title": "Sentry Regression Group",
+            "slug": "sentry-regression-group",
+            "is_public": True,
+            "color": "secondary",
+            "allow_multiple": False,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["slug"] == "sentry-regression-group"
+    assert data["tags"] == []


### PR DESCRIPTION
## Summary
- Fix `MissingGreenlet` when creating manager tag groups by reloading the created group with its tags eagerly loaded.
- Fix `/api/products/search` to handle the `smart_search()` response shape consistently instead of slicing a dict.
- Add regression coverage for public product search and manager tag group creation.
- Update generated manager client, OpenAPI, and related order/document artifacts to reflect the current backend contract.

## Testing
- `python3 -m py_compile services/tag_service.py services/product_read_service.py`
- Integration tests passed for the new regression cases covering product search and tag group creation.
- Existing manager smart-search integration coverage also passed.