### PR TITLE
Перевести бренды каталога на данные из БД и исправить мобильную верстку

### DIFF
--- a/manager_frontend/src/client/models/FilterTagOption.ts
+++ b/manager_frontend/src/client/models/FilterTagOption.ts
@@ -6,5 +6,7 @@ export type FilterTagOption = {
     id: number;
     title: string;
     slug: string;
+    logo_url?: (string | null);
+    sort_order?: (number | null);
 };
 

--- a/openapi.json
+++ b/openapi.json
@@ -10384,6 +10384,28 @@
           "slug": {
             "type": "string",
             "title": "Slug"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logo Url"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -156,6 +156,8 @@ class FilterTagOption(BaseModel):
     id: int
     title: str
     slug: str
+    logo_url: Optional[str] = None
+    sort_order: Optional[int] = None
 
 
 class FiltersConfigResponse(BaseModel):

--- a/services/product_filter_service.py
+++ b/services/product_filter_service.py
@@ -74,6 +74,15 @@ class ProductFilterService:
         return {
             "price": {"min": price_min, "max": price_max},
             "area": {"min": area_min, "max": area_max},
-            "brands": [{"id": brand.id, "title": brand.title, "slug": brand.slug} for brand in brands],
+            "brands": [
+                {
+                    "id": brand.id,
+                    "title": brand.title,
+                    "slug": brand.slug,
+                    "logo_url": brand.logo_url,
+                    "sort_order": brand.sort_order,
+                }
+                for brand in brands
+            ],
             "expert_tags": [{"id": t.id, "title": t.title, "slug": t.slug} for t in expert_tags],
         }

--- a/tests/integration/test_filters_config_api.py
+++ b/tests/integration/test_filters_config_api.py
@@ -16,7 +16,13 @@ async def test_filters_config_returns_ranges_and_allowed_tags(async_client, db):
     await db.refresh(expert_group)
     await db.refresh(technical_group)
 
-    brand = Brand(title="Haier", slug="haier", is_published=True, sort_order=10)
+    brand = Brand(
+        title="Haier",
+        slug="haier",
+        logo_url="/uploads/brands/haier.svg",
+        is_published=True,
+        sort_order=10,
+    )
     priority_brand = Brand(title="MDV", slug="mdv", is_published=True, sort_order=0)
     expert = Tag(title="Хит", slug="hit", group_id=expert_group.id, is_public=True)
     technical = Tag(title="Wi-Fi", slug="wifi-builtin", group_id=technical_group.id, is_public=True)
@@ -42,6 +48,8 @@ async def test_filters_config_returns_ranges_and_allowed_tags(async_client, db):
     assert data["price"] == {"min": 1000, "max": 2400}
     assert data["area"] == {"min": 20, "max": 55}
     assert [item["slug"] for item in data["brands"]] == ["mdv", "haier"]
+    assert data["brands"][1]["logo_url"] == "/uploads/brands/haier.svg"
+    assert data["brands"][1]["sort_order"] == 10
     assert [item["slug"] for item in data["expert_tags"]] == ["hit"]
     assert "wifi-builtin" not in [item["slug"] for item in data["expert_tags"]]
 

--- a/web/src/components/CatalogApp.vue
+++ b/web/src/components/CatalogApp.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue';
 import ProductCard from './ProductCard.vue';
-import { getCatalog, getFiltersConfig } from '../utils/api';
+import { getCatalog, getFiltersConfig, resolveImageUrl } from '../utils/api';
 import { getBrandConfig } from '../utils/brands';
 
 const BASE_LIMIT = 20;
@@ -95,6 +95,12 @@ const availableBrands = ref((props.initialBrands || []).map((brand) => ({
   sort_order: brand.sort_order ?? 999,
 })));
 let searchDebounceTimeout = null;
+
+const getBrandLogo = (brand) => {
+  const logoUrl = String(brand?.logo_url || '').trim();
+  if (logoUrl) return resolveImageUrl(logoUrl);
+  return getBrandConfig(brand?.slug || '').logo || '';
+};
 
 const lockedFilters = computed(() => props.lockedInitialFilters || null);
 const knownBrandSlugs = computed(() => new Set(availableBrands.value.map((brand) => brand.slug)));
@@ -1237,8 +1243,8 @@ onMounted(async () => {
               @click="toggleBrand(brand.slug)"
             >
               <img
-                v-if="getBrandConfig(brand.slug).logo"
-                :src="getBrandConfig(brand.slug).logo"
+                v-if="getBrandLogo(brand)"
+                :src="getBrandLogo(brand)"
                 :alt="brand.title"
                 class="brand-pill-logo"
               />
@@ -1523,16 +1529,19 @@ onMounted(async () => {
 
 .brand-strip {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.6rem;
-  overflow-x: auto;
+  overflow: visible;
   padding-bottom: 0.25rem;
-  scrollbar-width: thin;
 }
 
 .brand-pill {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  flex: 0 0 auto;
+  max-width: 100%;
+  min-width: 0;
   border: 1px solid var(--panel-chip-border);
   background: var(--panel-pill-bg);
   border-radius: 999px;
@@ -1543,6 +1552,12 @@ onMounted(async () => {
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.2s ease;
+}
+
+.brand-pill span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .brand-pill:hover {
@@ -1560,6 +1575,7 @@ onMounted(async () => {
 .brand-pill-logo {
   width: 22px;
   height: 22px;
+  flex: 0 0 22px;
   object-fit: contain;
   display: block;
 }


### PR DESCRIPTION
## Summary
- Каталог теперь берет `logo_url` и `sort_order` брендов из `/api/v1/filters/config`, а не только из legacy-маппинга по slug.
- Витрина брендов на мобильных экранах больше не вылезает за ширину: pills переносятся на новые строки, а текст внутри кнопок не выпадает наружу.
- Обновлены схема, OpenAPI и сгенерированный manager client для нового формата `FilterTagOption`.

## Testing
- `pytest tests/integration/test_filters_config_api.py -q` — passed.
- `npm run build` в `web/` — passed.
- `npm run build` в `manager_frontend/` — passed.
- Проверка каталога в браузере на mobile viewport — бренды отображаются корректно, логотипы рендерятся, переполнения нет.