### PR TITLE
[codex] Add manager document email sending

### DIFF
--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -4,6 +4,7 @@ import { ManagerOrdersService, ManagerDocsService, ManagerContractsService, Mana
 import type { BankReceiptResponse, DocumentTemplateItem, ManagerCustomerContractItemResponse, ManagerOrderDetailResponse, ManagerOrderDocumentItem } from '../../client';
 import { formatMoney } from './order-utils';
 import DateTimeField from '../ui/DateTimeField.vue';
+import DocumentSendModal from './DocumentSendModal.vue';
 import { getApiErrorMessage } from '../../utils/api-errors';
 
 const props = defineProps<{
@@ -206,6 +207,7 @@ const documents = ref<ManagerOrderDocumentItem[]>([]);
 const isGeneratingDoc = ref(false);
 const processingDocId = ref<number | null>(null);
 const docDropdownOpen = ref(false);
+const showDocumentSendModal = ref(false);
 const isUploadingDoc = ref(false);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 
@@ -356,6 +358,19 @@ const loadDocuments = async () => {
   }
 };
 
+const openDocumentSendModal = () => {
+  if (!documents.value.length) {
+    setToast('Сначала создайте или загрузите документ', 'error');
+    return;
+  }
+  showDocumentSendModal.value = true;
+};
+
+const handleDocumentsSent = () => {
+  setToast('Письмо отправлено');
+  emit('refresh');
+};
+
 const loadContractTemplates = async () => {
   try {
     const res = await ManagerDocsService.getDocTemplates('contract', props.order.id);
@@ -450,6 +465,13 @@ watch(() => props.order.id, () => {
 
 <template>
 <div class="space-y-6">
+  <DocumentSendModal
+    v-model="showDocumentSendModal"
+    :order="order"
+    :documents="documents"
+    @sent="handleDocumentsSent"
+  />
+
   <Transition name="fade">
     <div v-if="toast" class="fixed top-6 right-6 z-[100] text-white px-6 py-3 rounded-xl shadow-2xl font-medium" :class="toastType === 'success' ? 'bg-teal-600' : 'bg-red-500'">
       {{ toast }}
@@ -616,6 +638,16 @@ watch(() => props.order.id, () => {
           <div class="mb-2 flex items-center justify-between">
             <h4 class="text-md font-semibold text-slate-800">Documents (B2B / Contracts)</h4>
             <div class="relative flex items-center gap-2">
+              <button
+                class="flex items-center gap-1 rounded-xl bg-teal-600 px-3 py-1.5 text-sm font-medium text-white shadow hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
+                title="Отправить документы"
+                :disabled="!documents.length || isUploadingDoc || !!processingDocId || isGeneratingDoc"
+                @click="openDocumentSendModal"
+              >
+                <span class="material-icons-round text-[18px]">send</span>
+                Отправить
+              </button>
+
               <button
                 class="flex items-center gap-1 rounded-xl bg-[#007f80] px-3 py-1.5 text-sm font-medium text-white shadow hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
                 :disabled="isGeneratingDoc || !!processingDocId || isUploadingDoc"

--- a/manager_frontend/src/components/orders/DocumentSendModal.vue
+++ b/manager_frontend/src/components/orders/DocumentSendModal.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { ManagerMailService } from '../../client';
+import type { ManagerOrderDetailResponse, ManagerOrderDocumentItem } from '../../client';
+import { getApiErrorMessage } from '../../utils/api-errors';
+
+const props = defineProps<{
+  modelValue: boolean;
+  order: ManagerOrderDetailResponse;
+  documents: ManagerOrderDocumentItem[];
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+  sent: [];
+}>();
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  offer: 'КП',
+  contract: 'Договор',
+  invoice: 'Счет',
+  act: 'Акт',
+  tn2: 'ТН-2',
+  ttn1: 'ТТН-1',
+  uploaded_pdf: 'PDF',
+};
+
+const selectedDocumentIds = ref<number[]>([]);
+const toEmail = ref('');
+const subject = ref('');
+const bodyText = ref('');
+const error = ref('');
+const sending = ref(false);
+const subjectTouched = ref(false);
+const bodyTouched = ref(false);
+
+const selectedDocuments = computed(() => {
+  const selected = new Set(selectedDocumentIds.value);
+  return props.documents.filter((doc) => selected.has(doc.id));
+});
+
+const hasOfferSelected = computed(() => selectedDocuments.value.some((doc) => doc.doc_type === 'offer'));
+
+const documentLabel = (doc: ManagerOrderDocumentItem) => {
+  const typeLabel = DOC_TYPE_LABELS[doc.doc_type] || doc.doc_type || 'Документ';
+  return `${typeLabel} ${doc.number || `#${doc.id}`}`;
+};
+
+const latestDefaultDocumentIds = () => {
+  const ids: number[] = [];
+  for (const type of ['offer', 'contract', 'invoice']) {
+    const doc = props.documents.find((item) => item.doc_type === type);
+    if (doc && !ids.includes(doc.id)) ids.push(doc.id);
+  }
+  return ids.length ? ids : props.documents.slice(0, 1).map((doc) => doc.id);
+};
+
+const buildSubject = () => (
+  hasOfferSelected.value
+    ? `Коммерческое предложение по заказу #${props.order.id}`
+    : `Документы по заказу #${props.order.id}`
+);
+
+const buildBody = () => {
+  const customerName = props.order.customer?.name || 'клиент';
+  const lines = selectedDocuments.value.map((doc) => `- ${documentLabel(doc)}`);
+  return [
+    `Здравствуйте, ${customerName}!`,
+    '',
+    'Направляем документы по вашему заказу во вложении:',
+    ...(lines.length ? lines : ['- документы по заказу']),
+    '',
+    'С уважением,',
+    'Мастер Воздуха',
+  ].join('\n');
+};
+
+const refreshDefaults = () => {
+  selectedDocumentIds.value = latestDefaultDocumentIds();
+  toEmail.value = props.order.customer?.email || '';
+  subject.value = buildSubject();
+  bodyText.value = buildBody();
+  error.value = '';
+  subjectTouched.value = false;
+  bodyTouched.value = false;
+};
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) refreshDefaults();
+  },
+);
+
+watch(selectedDocumentIds, () => {
+  if (!subjectTouched.value) subject.value = buildSubject();
+  if (!bodyTouched.value) bodyText.value = buildBody();
+});
+
+const close = () => {
+  if (sending.value) return;
+  emit('update:modelValue', false);
+};
+
+const sendEmail = async () => {
+  error.value = '';
+  if (!selectedDocumentIds.value.length) {
+    error.value = 'Выберите хотя бы один документ';
+    return;
+  }
+  if (!toEmail.value.trim()) {
+    error.value = 'Укажите email получателя';
+    return;
+  }
+  if (!subject.value.trim()) {
+    error.value = 'Укажите тему письма';
+    return;
+  }
+  if (!bodyText.value.trim()) {
+    error.value = 'Укажите текст письма';
+    return;
+  }
+
+  sending.value = true;
+  try {
+    await ManagerMailService.sendManagerOrderEmail(props.order.id, {
+      to_email: toEmail.value.trim(),
+      subject: subject.value.trim(),
+      body_text: bodyText.value.trim(),
+      document_ids: selectedDocumentIds.value,
+    });
+    emit('sent');
+    emit('update:modelValue', false);
+  } catch (err) {
+    error.value = getApiErrorMessage(err);
+  } finally {
+    sending.value = false;
+  }
+};
+</script>
+
+<template>
+  <teleport to="body">
+    <div
+      v-if="modelValue"
+      class="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/50 px-4 py-6 backdrop-blur-sm"
+    >
+      <div class="flex max-h-[92vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white text-slate-900 shadow-2xl dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
+        <header class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-700">
+          <div>
+            <h3 class="text-lg font-semibold">Отправить документы</h3>
+            <p class="text-sm text-slate-500 dark:text-slate-400">Заказ #{{ order.id }}</p>
+          </div>
+          <button
+            type="button"
+            class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+            :disabled="sending"
+            title="Закрыть"
+            @click="close"
+          >
+            <span class="material-icons-round text-[20px]">close</span>
+          </button>
+        </header>
+
+        <div class="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          <div>
+            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Получатель</label>
+            <input
+              v-model="toEmail"
+              type="email"
+              class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              placeholder="client@example.com"
+            />
+          </div>
+
+          <div>
+            <label class="mb-2 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Документы</label>
+            <div v-if="documents.length" class="space-y-2">
+              <label
+                v-for="doc in documents"
+                :key="doc.id"
+                class="flex cursor-pointer items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm hover:border-teal-300 dark:border-slate-700 dark:bg-slate-800/70 dark:hover:border-teal-500/70"
+              >
+                <input
+                  v-model="selectedDocumentIds"
+                  type="checkbox"
+                  :value="doc.id"
+                  class="h-4 w-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+                />
+                <span class="min-w-0 flex-1">
+                  <span class="block font-medium text-slate-900 dark:text-white">{{ documentLabel(doc) }}</span>
+                  <span class="block text-xs text-slate-500 dark:text-slate-400">{{ new Date(doc.date).toLocaleDateString('ru-RU') }}</span>
+                </span>
+              </label>
+            </div>
+            <div v-else class="rounded-xl border border-dashed border-slate-300 py-5 text-center text-sm text-slate-500 dark:border-slate-700">
+              Нет сформированных документов
+            </div>
+          </div>
+
+          <div>
+            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Тема</label>
+            <input
+              v-model="subject"
+              type="text"
+              class="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              @input="subjectTouched = true"
+            />
+          </div>
+
+          <div>
+            <label class="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Текст</label>
+            <textarea
+              v-model="bodyText"
+              rows="8"
+              class="w-full resize-y rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm leading-6 outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+              @input="bodyTouched = true"
+            />
+          </div>
+
+          <p v-if="error" class="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-950/30 dark:text-red-200">
+            {{ error }}
+          </p>
+        </div>
+
+        <footer class="flex flex-col-reverse gap-2 border-t border-slate-200 px-5 py-4 sm:flex-row sm:justify-end dark:border-slate-700">
+          <button
+            type="button"
+            class="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            :disabled="sending"
+            @click="close"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-xl bg-teal-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-teal-700 disabled:opacity-50"
+            :disabled="sending || !documents.length"
+            @click="sendEmail"
+          >
+            <span v-if="sending" class="material-icons-round animate-spin text-[18px]">loop</span>
+            <span v-else class="material-icons-round text-[18px]">send</span>
+            {{ sending ? 'Отправляем...' : 'Отправить' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </teleport>
+</template>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -5,6 +5,7 @@ import { api } from '../../api';
 import DateTimeField from '../ui/DateTimeField.vue';
 import CustomerSummaryCard from '../customers/CustomerSummaryCard.vue';
 import DealExecutionTab from './DealExecutionTab.vue';
+import DocumentSendModal from './DocumentSendModal.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
 import type {
   ManagerOrderDetailResponse,
@@ -163,6 +164,7 @@ const estimateSearchQuery = ref('');
 const importingEstimate = ref(false);
 const showEstimateImport = ref(false);
 const documents = ref<ManagerOrderDocumentItem[]>([]);
+const showDocumentSendModal = ref(false);
 const payments = ref<PaymentResponse[]>([]);
 const bankReceipts = ref<BankReceiptResponse[]>([]);
 const bankReceiptsLoading = ref(false);
@@ -654,6 +656,21 @@ const loadDocuments = async (orderId: number) => {
   } catch (error) {
     console.error('Failed to load documents', error);
   }
+};
+
+const openDocumentSendModal = () => {
+  if (!props.order?.id) return;
+  if (!documents.value.length) {
+    setToast('Сначала создайте или загрузите документ', 'error');
+    return;
+  }
+  showDocumentSendModal.value = true;
+};
+
+const handleDocumentsSent = () => {
+  if (!props.order?.id) return;
+  setToast('Письмо отправлено', 'success');
+  emit('reload', props.order.id);
 };
 
 const loadCustomerContracts = async (customerId?: number, selectedId?: number | null) => {
@@ -2603,6 +2620,16 @@ watch(
         <div class="mb-2 flex items-center justify-between">
           <div class="relative ml-auto flex items-center gap-2">
             <button
+               class="flex items-center gap-1 rounded-xl bg-teal-600 px-3 py-1.5 text-sm font-medium text-white shadow hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
+               title="Отправить документы"
+               :disabled="!documents.length || isUploadingDoc || !!processingDocId || isGeneratingDoc"
+               @click="openDocumentSendModal"
+            >
+              <span class="material-icons-round text-[18px]">send</span>
+              Отправить
+            </button>
+
+            <button
                class="flex items-center gap-1 rounded-xl bg-[#007f80] px-3 py-1.5 text-sm font-medium text-white shadow hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
                :disabled="isGeneratingDoc || !!processingDocId || isUploadingDoc"
                @click="docDropdownOpen = !docDropdownOpen"
@@ -2889,6 +2916,14 @@ watch(
         </div>
       </footer>
     </aside>
+
+    <DocumentSendModal
+      v-if="order"
+      v-model="showDocumentSendModal"
+      :order="order"
+      :documents="documents"
+      @sent="handleDocumentsSent"
+    />
 
     <div
       v-if="showCustomerModal"

--- a/services/mail_smtp_service.py
+++ b/services/mail_smtp_service.py
@@ -157,17 +157,20 @@ class MailSmtpService:
             raise ValueError("Order not found")
 
         attachments: List[MailAttachment] = []
+        has_offer_document = False
         for doc_id in document_ids or []:
             doc = await session.get(OrderDocument, doc_id)
             if not doc or doc.order_id != order_id:
                 raise ValueError(f"Document {doc_id} not found on order")
+            if doc.doc_type == "offer":
+                has_offer_document = True
             stream, filename = await DocumentService.get_download_stream(session, doc_id)
             if not stream:
                 raise ValueError(f"Document {doc_id} cannot be downloaded")
             encoded = getattr(stream, "getvalue", lambda: bytes(stream))()
             attachments.append(MailAttachment(filename=filename or f"document-{doc_id}.pdf", content=encoded, mime_type="application/pdf"))
 
-        return await MailSmtpService.send_and_record(
+        email_row = await MailSmtpService.send_and_record(
             session,
             to_email=to_email,
             subject=subject,
@@ -178,3 +181,10 @@ class MailSmtpService:
             customer_id=order.customer_id,
             attachments=attachments,
         )
+        if has_offer_document:
+            order.proposal_status = "sent"
+            order.proposal_sent_at = datetime.now()
+            session.add(order)
+            await session.commit()
+            await session.refresh(email_row)
+        return email_row

--- a/tests/integration/test_manager_mail_api.py
+++ b/tests/integration/test_manager_mail_api.py
@@ -94,3 +94,46 @@ async def test_manager_mail_send_test_endpoint_uses_smtp_service(async_client, m
     assert payload["id"] == 99
     assert payload["status"] == "sent"
     assert payload["recipient_email"] == "client@example.com"
+
+
+@pytest.mark.asyncio
+async def test_manager_mail_send_order_email_passes_document_ids(async_client, monkeypatch):
+    async def fake_send(_session, **kwargs):
+        assert kwargs["order_id"] == 123
+        assert kwargs["to_email"] == "client@example.com"
+        assert kwargs["document_ids"] == [10, 11]
+        return OutgoingEmail(
+            id=100,
+            status="sent",
+            order_id=kwargs["order_id"],
+            recipient_email=kwargs["to_email"],
+            subject=kwargs["subject"],
+            body_text=kwargs["body_text"],
+            from_email="a@mvn.by",
+            from_name="Мастер Воздуха",
+            sent_at=datetime(2026, 5, 8, 15, 10),
+            attachments=[
+                {"filename": "КП-2026-001.pdf", "mime_type": "application/pdf", "size": 100},
+                {"filename": "СЧ-2026-001.pdf", "mime_type": "application/pdf", "size": 100},
+            ],
+        )
+
+    monkeypatch.setattr("routers.manager_mail.MailSmtpService.send_order_email", fake_send)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        "/api/manager/mail/orders/123/email",
+        headers=headers,
+        json={
+            "to_email": "client@example.com",
+            "subject": "Коммерческое предложение",
+            "body_text": "Здравствуйте, документы во вложении.",
+            "document_ids": [10, 11],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == 100
+    assert payload["order_id"] == 123
+    assert len(payload["attachments"]) == 2

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
 from core.config import settings
-from models import BankReceipt, Customer, Order, OrderServiceLink, Payment, PaymentCurrency
+from models import BankReceipt, Customer, Order, OrderDocument, OrderServiceLink, OutgoingEmail, Payment, PaymentCurrency
 from services.bank_email_parser_service import BankEmailParserService
 from services.bank_receipt_service import BankReceiptService
 from services.bot_service import BotService
@@ -252,3 +252,120 @@ def test_smtp_builds_utf8_message_and_sanitizes_errors(monkeypatch):
     assert "client@example.com" in rendered
     assert "application/pdf" in rendered
     assert "super-secret" not in MailSmtpService._sanitize_error(RuntimeError("failed with super-secret"))
+
+
+@pytest.mark.asyncio
+async def test_send_order_email_attaches_documents_and_marks_offer_sent(sqlite_session, monkeypatch):
+    monkeypatch.setattr(settings, "MAIL_SMTP_USERNAME", "a@mvn.by")
+    monkeypatch.setattr(settings, "MAIL_SMTP_PASSWORD", "super-secret")
+    monkeypatch.setattr(settings, "MAIL_FROM_EMAIL", "a@mvn.by")
+    monkeypatch.setattr(settings, "MAIL_FROM_NAME", "Мастер Воздуха")
+
+    customer = Customer(name="ООО Клиент", phone="+375291111111", type="company", email="client@example.com")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(customer_id=customer.id, status="negotiation", proposal_status="draft")
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    offer = OrderDocument(
+        order_id=order.id,
+        doc_type="offer",
+        number="КП-2026-001",
+        google_file_id="offer-file",
+        google_edit_url="https://docs.example/offer",
+    )
+    invoice = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="СЧ-2026-001",
+        google_file_id="invoice-file",
+        google_edit_url="https://docs.example/invoice",
+    )
+    sqlite_session.add(offer)
+    sqlite_session.add(invoice)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(offer)
+    await sqlite_session.refresh(invoice)
+
+    async def fake_download(_session, doc_id: int):
+        return b"%PDF-1.4", f"document-{doc_id}.pdf"
+
+    sent_messages = []
+
+    def fake_send(message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr("services.mail_smtp_service.DocumentService.get_download_stream", fake_download)
+    monkeypatch.setattr(MailSmtpService, "send_message", fake_send)
+
+    email_row = await MailSmtpService.send_order_email(
+        sqlite_session,
+        order_id=order.id,
+        to_email="client@example.com",
+        subject="Коммерческое предложение",
+        body_text="Здравствуйте, документы во вложении.",
+        document_ids=[offer.id, invoice.id],
+    )
+
+    assert email_row.status == "sent"
+    assert len(email_row.attachments or []) == 2
+    assert sent_messages
+
+    refreshed_order = await sqlite_session.get(Order, order.id)
+    assert refreshed_order.proposal_status == "sent"
+    assert refreshed_order.proposal_sent_at is not None
+
+    persisted_email = (await sqlite_session.execute(select(OutgoingEmail).where(OutgoingEmail.id == email_row.id))).scalar_one()
+    assert persisted_email.recipient_email == "client@example.com"
+    assert persisted_email.attachments[0]["mime_type"] == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_send_order_email_without_offer_keeps_proposal_status(sqlite_session, monkeypatch):
+    monkeypatch.setattr(settings, "MAIL_SMTP_USERNAME", "a@mvn.by")
+    monkeypatch.setattr(settings, "MAIL_SMTP_PASSWORD", "super-secret")
+    monkeypatch.setattr(settings, "MAIL_FROM_EMAIL", "a@mvn.by")
+
+    customer = Customer(name="ООО Клиент", phone="+375291111111", type="company", email="client@example.com")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(customer_id=customer.id, status="negotiation", proposal_status="draft")
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    invoice = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="СЧ-2026-002",
+        google_file_id="invoice-file",
+        google_edit_url="https://docs.example/invoice",
+    )
+    sqlite_session.add(invoice)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(invoice)
+
+    async def fake_download(_session, doc_id: int):
+        return b"%PDF-1.4", f"document-{doc_id}.pdf"
+
+    monkeypatch.setattr("services.mail_smtp_service.DocumentService.get_download_stream", fake_download)
+    monkeypatch.setattr(MailSmtpService, "send_message", lambda _message: None)
+
+    await MailSmtpService.send_order_email(
+        sqlite_session,
+        order_id=order.id,
+        to_email="client@example.com",
+        subject="Счет",
+        body_text="Здравствуйте, счет во вложении.",
+        document_ids=[invoice.id],
+    )
+
+    refreshed_order = await sqlite_session.get(Order, order.id)
+    assert refreshed_order.proposal_status == "draft"
+    assert refreshed_order.proposal_sent_at is None


### PR DESCRIPTION
## Summary

- add a manager modal for sending selected order documents by email
- wire the modal into both the regular order drawer and execution documents panel
- mark proposals as sent after a successful email containing an offer document
- cover document attachment sending, proposal-status behavior, and the manager mail endpoint with tests

## Impact

Managers can now prepare КП, договор, счет or uploaded PDFs, select the documents in Manager, confirm/edit the recipient email, subject and message body, and send everything through the existing SMTP integration. The modal no longer closes on backdrop click, so drafts are harder to lose accidentally.

## Validation

- `pytest tests/unit/test_mail_services.py -q`
- `cd manager_frontend && npm run build`
- `git diff --check`

Note: `pytest tests/integration/test_manager_mail_api.py -q` was attempted locally but the test Postgres host `db_test` is not resolvable in this environment.