### PR TITLE
Add document sending modal and preserve order mail history

### DIFF
--- a/web/src/components/ui/MobileMenu.vue
+++ b/web/src/components/ui/MobileMenu.vue
@@ -64,7 +64,7 @@
             </nav>
 
             <div class="menu-footer">
-              <a href="tel:+375333595959" class="btn btn-primary w-full">
+              <a :href="`tel:${phoneClean}`" class="btn btn-primary w-full">
                 <span class="material-icons-round">call</span>
                 Позвонить
               </a>
@@ -78,6 +78,13 @@
 
 <script setup>
 import { ref, watch } from 'vue';
+
+defineProps({
+  phoneClean: {
+    type: String,
+    required: true,
+  },
+});
 
 const isOpen = ref(false);
 

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -6,3 +6,13 @@ export const SITE_CONFIG = {
     address: "г. Витебск, пр-т Победы, 15",
 
 };
+
+export function normalizePhoneForTel(value?: string | null): string {
+    const raw = String(value || "").trim();
+    if (!raw) return "";
+
+    const digits = raw.replace(/\D/g, "");
+    if (!digits) return "";
+
+    return raw.startsWith("+") ? `+${digits}` : digits;
+}

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 import "../assets/index.css";
 import { getGlobalConfig } from "../utils/api";
-import { SITE_CONFIG } from "../config";
+import { normalizePhoneForTel, SITE_CONFIG } from "../config";
 import HeaderCart from "../components/cart/HeaderCart.vue";
 import MobileMenu from "../components/ui/MobileMenu.vue";
 import ToastContainer from "../components/ui/ToastContainer.vue";
@@ -38,7 +38,7 @@ const config = await getGlobalConfig();
 
 // Default fallbacks if config is missing
 const phone = config["phone"] || SITE_CONFIG.phone;
-const phoneClean = config["phone_clean"] || SITE_CONFIG.phoneClean;
+const phoneClean = normalizePhoneForTel(phone) || config["phone_clean"] || SITE_CONFIG.phoneClean;
 const email = config["email"] || SITE_CONFIG.email;
 const address = config["address"] || SITE_CONFIG.address;
 ---
@@ -174,7 +174,7 @@ const address = config["address"] || SITE_CONFIG.address;
 				</div>
 
 				<div class="nav-actions">
-					<MobileMenu client:media="(max-width: 980px)" />
+					<MobileMenu phoneClean={phoneClean} client:media="(max-width: 980px)" />
 					<button
 						id="theme-toggle"
 						class="icon-btn"


### PR DESCRIPTION
## Summary
- Add a manager UI modal for sending order documents by email with selectable attachments, subject/body editing, and success/error handling.
- Wire the new send action into order execution and order drawer flows, with a guarded entry point when no documents exist.
- Update mail and order services so sent offer documents mark proposal status, while deleted orders keep bank receipts and outgoing email history detached instead of orphaned.
- Add integration and unit coverage for document email sending, attachment handling, proposal-state updates, and hard-delete cleanup behavior.

## Testing
- Ran backend unit and integration tests covering mail services, manager mail API, and order cleanup scenarios.
- Ran the frontend build for the manager app to verify the new modal and order actions compile cleanly.