### PR TITLE
[codex] Add manager document conditions

### DIFF
--- a/alembic/versions/3b5c7d9e1f20_add_order_additional_conditions.py
+++ b/alembic/versions/3b5c7d9e1f20_add_order_additional_conditions.py
@@ -1,0 +1,33 @@
+"""add order additional conditions
+
+Revision ID: 3b5c7d9e1f20
+Revises: 0d4f7a9c3e21
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "3b5c7d9e1f20"
+down_revision: Union[str, Sequence[str], None] = "0d4f7a9c3e21"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table_name: str) -> set[str]:
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if "additional_conditions" not in _columns("order"):
+        with op.batch_alter_table("order", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("additional_conditions", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if "additional_conditions" in _columns("order"):
+        with op.batch_alter_table("order", schema=None) as batch_op:
+            batch_op.drop_column("additional_conditions")

--- a/docs/document-placeholders.md
+++ b/docs/document-placeholders.md
@@ -20,3 +20,18 @@ For acts and invoices only, the generator can replace these words and their comm
 - `contractor_customer`: продавец -> подрядчик, покупатель -> заказчик
 
 The role type can come from the contract template default, the open customer contract, or the order override.
+
+## Additional Conditions
+
+Use `{{additional_conditions}}` in contract templates for order-specific terms. The value comes from the manager order document block.
+Multiple filled lines are inserted with line breaks and without manual numbering. If the placeholder is placed in a numbered Google Docs paragraph, Google Docs continues the contract numbering for every line.
+
+To hide the whole numbered paragraph when the field is empty, put the conditional block on its own numbered paragraph:
+
+```text
+6.5 Во всем остальном стороны руководствуются законодательством Республики Беларусь.
+{{#if additional_conditions}}{{additional_conditions}}{{/if}}
+7. Юридические адреса и реквизиты сторон.
+```
+
+In the Google Docs template the second line should be one numbered-list item after `6.5`. When conditions are filled, they become `6.6`, `6.7`, and so on. When conditions are empty, the whole line is removed and no empty numbered item remains.

--- a/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
@@ -36,6 +36,7 @@ export type ManagerOrderDetailResponse = {
     customer_contract?: (OrderCustomerContractBrief | null);
     document_role_type?: (string | null);
     effective_document_role_type?: string;
+    additional_conditions?: (string | null);
     installer_id?: (number | null);
     installer?: (ManagerInstallerResponse | null);
     equipment_status?: string;

--- a/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
@@ -30,6 +30,7 @@ export type ManagerOrderListItemResponse = {
     customer_contract?: (OrderCustomerContractBrief | null);
     document_role_type?: (string | null);
     effective_document_role_type?: string;
+    additional_conditions?: (string | null);
     installer_id?: (number | null);
     installer?: (ManagerInstallerResponse | null);
     equipment_status?: string;

--- a/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
@@ -17,6 +17,7 @@ export type ManagerOrderUpdatePayload = {
     measurement_required?: (boolean | null);
     measurer_id?: (number | null);
     measurement_result?: (string | null);
+    additional_conditions?: (string | null);
     proposal_status?: (string | null);
     proposal_sent_at?: (string | null);
     is_paid?: (boolean | null);

--- a/manager_frontend/src/components/orders/AdditionalConditionsLibrary.vue
+++ b/manager_frontend/src/components/orders/AdditionalConditionsLibrary.vue
@@ -1,0 +1,336 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+type ConditionMode = 'contract' | 'invoice';
+type ConditionPreset = {
+  id: string;
+  title: string;
+  text: string;
+};
+type ConditionGroup = {
+  id: string;
+  title: string;
+  mode: ConditionMode;
+  presets: ConditionPreset[];
+};
+
+const props = withDefaults(defineProps<{
+  modelValue: string;
+  saving?: boolean;
+  saveDisabled?: boolean;
+  showSave?: boolean;
+}>(), {
+  modelValue: '',
+  saving: false,
+  saveDisabled: false,
+  showSave: false,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+  save: [];
+}>();
+
+const activeMode = ref<ConditionMode>('contract');
+const expandedGroupIds = ref<Set<string>>(new Set());
+
+const conditionGroups: ConditionGroup[] = [
+  {
+    id: 'universal',
+    title: 'Универсальные',
+    mode: 'contract',
+    presets: [
+      {
+        id: 'access',
+        title: 'Доступ к оборудованию',
+        text: 'Заказчик обязан обеспечить свободный и безопасный доступ к оборудованию и месту проведения работ.',
+      },
+      {
+        id: 'lifts',
+        title: 'Вышка / леса / альпинисты',
+        text: 'Прокат, сборка и разборка строительных лесов, услуги автовышки и промышленных альпинистов не входят в стоимость работ и оплачиваются отдельно либо предоставляются Заказчиком.',
+      },
+      {
+        id: 'extra-works',
+        title: 'Дополнительные работы',
+        text: 'Работы и материалы, не указанные в настоящем договоре, выполняются по дополнительному согласованию Сторон и оплачиваются отдельно.',
+      },
+      {
+        id: 'email-approval',
+        title: 'Согласование по переписке',
+        text: 'Согласование дополнительных работ, материалов и сроков допускается посредством электронной переписки.',
+      },
+    ],
+  },
+  {
+    id: 'installation',
+    title: 'Монтаж',
+    mode: 'contract',
+    presets: [
+      {
+        id: 'route-meters',
+        title: 'Дополнительные метры трассы',
+        text: 'Дополнительные метры межблочной трассы, декоративный короб, кронштейны, дренажные материалы, электрический кабель и иные материалы сверх согласованного объема оплачиваются отдельно.',
+      },
+      {
+        id: 'hidden-utilities',
+        title: 'Скрытые коммуникации',
+        text: 'Исполнитель не несет ответственности за скрытые коммуникации, кабели, трубы и иные элементы, не обозначенные Заказчиком до начала работ.',
+      },
+      {
+        id: 'customer-equipment',
+        title: 'Оборудование заказчика',
+        text: 'Оборудование и материалы, предоставленные Заказчиком, используются Исполнителем без гарантии на их качество, комплектность и работоспособность. Гарантия Исполнителя распространяется только на выполненные работы.',
+      },
+      {
+        id: 'winter-kit',
+        title: 'Низкотемпературный комплект',
+        text: 'Работа оборудования при отрицательных температурах наружного воздуха возможна только в пределах технических характеристик оборудования и установленного низкотемпературного комплекта.',
+      },
+    ],
+  },
+  {
+    id: 'repair',
+    title: 'Ремонт',
+    mode: 'contract',
+    presets: [
+      {
+        id: 'hidden-defects',
+        title: 'Скрытые дефекты',
+        text: 'В процессе диагностики или ремонта могут быть выявлены скрытые дефекты либо дополнительные неисправности, не определяемые при первоначальном осмотре оборудования.',
+      },
+      {
+        id: 'repair-impossible',
+        title: 'Невозможность ремонта',
+        text: 'Исполнитель не гарантирует возможность полного восстановления работоспособности оборудования при значительном износе, коррозии, множественных утечках, повреждении основных узлов либо отсутствии необходимых запасных частей.',
+      },
+      {
+        id: 'repair-not-worth',
+        title: 'Нерентабельный ремонт',
+        text: 'При выявлении экономической нецелесообразности ремонта Исполнитель вправе приостановить работы и уведомить Заказчика о возможных вариантах дальнейших действий.',
+      },
+      {
+        id: 'refrigerant-fact',
+        title: 'Хладагент по факту',
+        text: 'Стоимость хладагента, расходных материалов и комплектующих определяется по фактическому объему использованных материалов и может быть уточнена по результатам выполнения работ.',
+      },
+    ],
+  },
+  {
+    id: 'maintenance',
+    title: 'ТО',
+    mode: 'contract',
+    presets: [
+      {
+        id: 'maintenance-not-repair',
+        title: 'ТО не ремонт',
+        text: 'Техническое обслуживание не является ремонтом оборудования и не включает устранение неисправностей, замену комплектующих, дозаправку хладагента и выполнение ремонтных работ, если иное не согласовано Сторонами отдельно.',
+      },
+      {
+        id: 'maintenance-no-breakdown-guarantee',
+        title: 'Не гарантия отсутствия поломок',
+        text: 'Исполнитель не гарантирует отсутствие неисправностей оборудования, связанных с его техническим состоянием, износом либо скрытыми дефектами, выявление которых не входило в состав выполняемых работ по техническому обслуживанию.',
+      },
+      {
+        id: 'repair-separately',
+        title: 'Ремонт отдельно',
+        text: 'В случае выявления неисправностей либо необходимости проведения ремонтных работ Исполнитель уведомляет Заказчика отдельно. Ремонтные работы выполняются по дополнительному согласованию Сторон.',
+      },
+    ],
+  },
+  {
+    id: 'invoice',
+    title: 'Счет',
+    mode: 'invoice',
+    presets: [
+      {
+        id: 'invoice-lifts',
+        title: 'Вышка / леса / альпинисты',
+        text: 'Автовышка, леса и промышленный альпинизм в стоимость не входят.',
+      },
+      {
+        id: 'invoice-extra-works',
+        title: 'Дополнительные работы',
+        text: 'Дополнительные материалы и работы оплачиваются отдельно по факту согласования.',
+      },
+      {
+        id: 'invoice-repair-price',
+        title: 'Ремонт после диагностики',
+        text: 'Стоимость ремонта может быть уточнена после диагностики.',
+      },
+      {
+        id: 'invoice-maintenance',
+        title: 'ТО без ремонта',
+        text: 'Техническое обслуживание не включает ремонт и замену комплектующих.',
+      },
+      {
+        id: 'invoice-route',
+        title: 'Трасса сверх объема',
+        text: 'Длина трассы сверх согласованного объема оплачивается отдельно.',
+      },
+    ],
+  },
+];
+
+const normalizedLine = (value: string) => value.replace(/\s+/g, ' ').trim();
+const lines = computed(() => props.modelValue.split(/\r?\n/).map((line) => line.trim()).filter(Boolean));
+const selectedLineSet = computed(() => new Set(lines.value.map(normalizedLine)));
+const visibleGroups = computed(() => conditionGroups.filter((group) => group.mode === activeMode.value));
+const selectedCount = computed(() => (
+  conditionGroups.reduce((count, group) => (
+    count + group.presets.filter((preset) => selectedLineSet.value.has(normalizedLine(preset.text))).length
+  ), 0)
+));
+
+const selectedCountForGroup = (group: ConditionGroup) => (
+  group.presets.filter((preset) => selectedLineSet.value.has(normalizedLine(preset.text))).length
+);
+
+const updateLines = (nextLines: string[]) => {
+  emit('update:modelValue', nextLines.join('\n'));
+};
+
+const isSelected = (preset: ConditionPreset) => selectedLineSet.value.has(normalizedLine(preset.text));
+const isGroupExpanded = (groupId: string) => expandedGroupIds.value.has(groupId);
+
+const toggleGroup = (groupId: string) => {
+  const next = new Set(expandedGroupIds.value);
+  if (next.has(groupId)) {
+    next.delete(groupId);
+  } else {
+    next.add(groupId);
+  }
+  expandedGroupIds.value = next;
+};
+
+const togglePreset = (preset: ConditionPreset) => {
+  if (isSelected(preset)) {
+    const removeKey = normalizedLine(preset.text);
+    updateLines(lines.value.filter((line) => normalizedLine(line) !== removeKey));
+    return;
+  }
+  updateLines([...lines.value, preset.text]);
+};
+
+const clearSelected = () => {
+  const presetKeys = new Set(
+    conditionGroups.flatMap((group) => group.presets.map((preset) => normalizedLine(preset.text)))
+  );
+  updateLines(lines.value.filter((line) => !presetKeys.has(normalizedLine(line))));
+};
+</script>
+
+<template>
+  <div class="mb-3 rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700/50 dark:bg-slate-900/40 dark:shadow-none">
+    <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <label class="block text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Дополнительные условия</label>
+        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {{ saving ? 'Сохраняю перед генерацией...' : 'Выбранные строки сохранятся перед созданием документа.' }}
+        </p>
+      </div>
+      <button
+        v-if="showSave"
+        type="button"
+        class="rounded-lg bg-teal-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-teal-700 disabled:opacity-50"
+        :disabled="saveDisabled || saving"
+        @click="emit('save')"
+      >
+        {{ saving ? 'Сохраняю...' : 'Сохранить' }}
+      </button>
+    </div>
+
+    <div class="mb-3 inline-flex rounded-lg border border-slate-200 bg-slate-50 p-1 text-xs dark:border-slate-700 dark:bg-slate-800/70">
+      <button
+        type="button"
+        class="rounded-md px-3 py-1.5 font-semibold transition"
+        :class="activeMode === 'contract' ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-700 dark:text-white' : 'text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white'"
+        @click="activeMode = 'contract'"
+      >
+        Договор
+      </button>
+      <button
+        type="button"
+        class="rounded-md px-3 py-1.5 font-semibold transition"
+        :class="activeMode === 'invoice' ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-700 dark:text-white' : 'text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white'"
+        @click="activeMode = 'invoice'"
+      >
+        Счет
+      </button>
+    </div>
+
+    <div class="space-y-3">
+      <section v-for="group in visibleGroups" :key="group.id">
+        <button
+          type="button"
+          class="mb-2 flex w-full items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-left md:pointer-events-none md:border-0 md:bg-transparent md:px-0 md:py-0 dark:border-slate-700 dark:bg-slate-800 md:dark:bg-transparent"
+          :aria-expanded="isGroupExpanded(group.id)"
+          @click="toggleGroup(group.id)"
+        >
+          <span class="flex min-w-0 items-center gap-2">
+            <span class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{{ group.title }}</span>
+            <span
+              v-if="selectedCountForGroup(group)"
+              class="rounded-full bg-teal-100 px-2 py-0.5 text-[11px] font-semibold text-teal-700 dark:bg-teal-500/15 dark:text-teal-200"
+            >
+              {{ selectedCountForGroup(group) }}
+            </span>
+          </span>
+          <span class="material-icons-round text-[18px] text-slate-500 md:hidden">
+            {{ isGroupExpanded(group.id) ? 'expand_less' : 'expand_more' }}
+          </span>
+        </button>
+        <div
+          class="gap-2 md:grid md:grid-cols-2"
+          :class="isGroupExpanded(group.id) ? 'grid' : 'hidden'"
+        >
+          <button
+            v-for="preset in group.presets"
+            :key="preset.id"
+            type="button"
+            class="min-h-[86px] rounded-lg border px-3 py-2 text-left transition"
+            :class="isSelected(preset)
+              ? 'border-teal-400 bg-teal-50 text-teal-950 dark:border-teal-500/60 dark:bg-teal-500/10 dark:text-teal-100'
+              : 'border-slate-200 bg-white text-slate-700 hover:border-teal-200 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-teal-500/50'"
+            @click="togglePreset(preset)"
+          >
+            <span class="flex items-start gap-2">
+              <span
+                class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border text-[12px]"
+                :class="isSelected(preset) ? 'border-teal-500 bg-teal-500 text-white' : 'border-slate-300 bg-white dark:border-slate-600 dark:bg-slate-900'"
+              >
+                <span v-if="isSelected(preset)" class="material-icons-round text-[12px]">check</span>
+              </span>
+              <span class="min-w-0">
+                <span class="block text-sm font-semibold leading-snug">{{ preset.title }}</span>
+                <span class="mt-1 line-clamp-2 block text-xs leading-snug text-slate-500 dark:text-slate-400">{{ preset.text }}</span>
+              </span>
+            </span>
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <div class="mt-3 space-y-2">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <span class="text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Итоговый текст</span>
+        <button
+          v-if="selectedCount"
+          type="button"
+          class="text-xs font-semibold text-slate-500 hover:text-red-600 dark:text-slate-400 dark:hover:text-red-300"
+          @click="clearSelected"
+        >
+          Убрать выбранные
+        </button>
+      </div>
+      <textarea
+        :value="modelValue"
+        rows="5"
+        class="w-full resize-y rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500/50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+        placeholder="Редкое условие можно вписать вручную"
+        @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+      />
+      <p class="text-xs text-slate-500 dark:text-slate-400">В нумерованном пункте договора каждая строка станет отдельным пунктом.</p>
+    </div>
+  </div>
+</template>

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -4,6 +4,7 @@ import { ManagerOrdersService, ManagerDocsService, ManagerContractsService, Mana
 import type { BankReceiptResponse, DocumentTemplateItem, ManagerCustomerContractItemResponse, ManagerOrderDetailResponse, ManagerOrderDocumentItem } from '../../client';
 import { formatMoney } from './order-utils';
 import DateTimeField from '../ui/DateTimeField.vue';
+import AdditionalConditionsLibrary from './AdditionalConditionsLibrary.vue';
 import DocumentSendModal from './DocumentSendModal.vue';
 import { getApiErrorMessage } from '../../utils/api-errors';
 
@@ -232,6 +233,9 @@ const documentDate = ref(new Date().toISOString().slice(0, 10));
 const customerContracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const selectedCustomerContractId = ref<number | null>(props.order.customer_contract_id || null);
 const selectedDocumentRoleType = ref<string | null>(props.order.document_role_type || null);
+const additionalConditions = ref(props.order.additional_conditions || '');
+const additionalConditionsSaved = ref(props.order.additional_conditions || '');
+const isSavingAdditionalConditions = ref(false);
 const ONE_TIME_CONTRACT_VALUE = 'one-time-contract';
 
 const DOCUMENT_TYPES = [
@@ -289,6 +293,7 @@ const selectedDocumentRoleBinding = computed({
     void updateDocumentRoleBinding(value);
   },
 });
+const hasAdditionalConditionsChanges = computed(() => additionalConditions.value !== additionalConditionsSaved.value);
 
 const loadCustomerContracts = async () => {
   if (!props.order.customer?.id) {
@@ -341,6 +346,25 @@ const updateDocumentRoleBinding = async (value: string) => {
   }
 };
 
+const saveAdditionalConditions = async (showSuccessToast = true) => {
+  if (!hasAdditionalConditionsChanges.value) return true;
+  const valueToSave = additionalConditions.value;
+  isSavingAdditionalConditions.value = true;
+  try {
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      additional_conditions: valueToSave,
+    });
+    additionalConditionsSaved.value = valueToSave;
+    if (showSuccessToast) setToast('Условия сохранены', 'success');
+    return true;
+  } catch (error) {
+    setToast(`Ошибка сохранения условий: ${getApiErrorMessage(error)}`, 'error');
+    return false;
+  } finally {
+    isSavingAdditionalConditions.value = false;
+  }
+};
+
 const useOneTimeContractForClosingDocs = async () => {
   if (!selectedCustomerContractId.value) return;
   selectedCustomerContractId.value = null;
@@ -387,6 +411,7 @@ const handleDocGenerate = async (type: string) => {
   isGeneratingDoc.value = true;
   docDropdownOpen.value = false;
   try {
+    if (!(await saveAdditionalConditions(false))) return;
     const template = (type === 'contract' && selectedContractTemplateId.value)
       ? selectedContractTemplate.value
       : undefined;
@@ -460,6 +485,8 @@ watch(() => props.order.id, () => {
   loadCandidateBankReceipts();
   selectedCustomerContractId.value = props.order.customer_contract_id || null;
   selectedDocumentRoleType.value = props.order.document_role_type || null;
+  additionalConditionsSaved.value = props.order.additional_conditions || '';
+  additionalConditions.value = props.order.additional_conditions || '';
 }, { immediate: true });
 </script>
 
@@ -738,6 +765,11 @@ watch(() => props.order.id, () => {
             </div>
             <p v-else-if="!selectedCustomerContractId && !hasClosingBaseDocument" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов нужен договор или счет, для накладных нужен договор.</p>
           </div>
+
+          <AdditionalConditionsLibrary
+            v-model="additionalConditions"
+            :saving="isSavingAdditionalConditions"
+          />
 
           <div class="mb-3 rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700/50 dark:bg-slate-900/40 dark:shadow-none">
             <label class="mb-1 block text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Роли сторон в актах и счетах</label>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -4,6 +4,7 @@ import { useDebounceFn } from '@vueuse/core';
 import { api } from '../../api';
 import DateTimeField from '../ui/DateTimeField.vue';
 import CustomerSummaryCard from '../customers/CustomerSummaryCard.vue';
+import AdditionalConditionsLibrary from './AdditionalConditionsLibrary.vue';
 import DealExecutionTab from './DealExecutionTab.vue';
 import DocumentSendModal from './DocumentSendModal.vue';
 import OrderDrawerSection from './OrderDrawerSection.vue';
@@ -144,6 +145,9 @@ watch(targetCurrency, (newCurrency) => {
 const measurementRequired = ref(false);
 const measurerId = ref<number | null>(null);
 const measurementResult = ref('');
+const additionalConditions = ref('');
+const additionalConditionsSaved = ref('');
+const isSavingAdditionalConditions = ref(false);
 const proposalStatus = ref<'draft' | 'sent' | 'approved' | 'rejected'>('draft');
 const activeProposalId = ref<number | null>(null);
 const proposalActionLoading = ref(false);
@@ -673,6 +677,25 @@ const handleDocumentsSent = () => {
   emit('reload', props.order.id);
 };
 
+const saveAdditionalConditions = async (showSuccessToast = false) => {
+  if (!props.order?.id || additionalConditions.value === additionalConditionsSaved.value) return true;
+  const valueToSave = additionalConditions.value;
+  isSavingAdditionalConditions.value = true;
+  try {
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      additional_conditions: valueToSave,
+    });
+    additionalConditionsSaved.value = valueToSave;
+    if (showSuccessToast) setToast('Условия сохранены', 'success');
+    return true;
+  } catch (error) {
+    setToast(`Ошибка сохранения условий: ${getApiErrorMessage(error)}`, 'error');
+    return false;
+  } finally {
+    isSavingAdditionalConditions.value = false;
+  }
+};
+
 const loadCustomerContracts = async (customerId?: number, selectedId?: number | null) => {
   if (!customerId) {
     customerContracts.value = [];
@@ -738,6 +761,7 @@ const generateDocument = async (type: string, template?: DocumentTemplateItem | 
   if (!props.order?.id) return;
   isGeneratingDoc.value = true;
   try {
+    if (!(await saveAdditionalConditions(false))) return;
     if (type === 'contract' && isCompanyOrder.value) {
       await useOneTimeContractForClosingDocs();
     }
@@ -1126,6 +1150,8 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   measurementRequired.value = order.measurement_required ?? false;
   measurerId.value = order.measurer_id ?? null;
   measurementResult.value = order.measurement_result ?? '';
+  additionalConditionsSaved.value = order.additional_conditions ?? '';
+  additionalConditions.value = order.additional_conditions ?? '';
   proposalStatus.value = (order.proposal_status as any) || 'draft';
   targetCurrency.value = order.target_currency || null;
   targetCurrencyAmount.value = order.target_currency_amount || null;
@@ -1750,6 +1776,7 @@ const handleSave = () => {
     measurement_required: measurementRequired.value,
     measurer_id: measurerId.value,
     measurement_result: measurementResult.value,
+    additional_conditions: additionalConditions.value,
     proposal_status: status.value === 'execution' ? 'approved' : proposalStatus.value,
     target_currency: enableCurrency.value ? (targetCurrency.value || null) : null,
     target_currency_amount: enableCurrency.value && targetCurrencyAmount.value ? Number(String(targetCurrencyAmount.value).replace(',', '.')) : null,
@@ -2719,6 +2746,8 @@ watch(
           </div>
           <p v-else-if="!selectedCustomerContractId && !hasClosingBaseDocument" class="mt-2 text-xs text-amber-600 dark:text-amber-400">Для актов нужен договор или счет, для накладных нужен договор.</p>
         </div>
+
+        <AdditionalConditionsLibrary v-model="additionalConditions" :saving="isSavingAdditionalConditions" />
 
         <div class="mb-3 rounded-xl border border-slate-200 bg-white/80 p-3 shadow-sm dark:border-slate-700/50 dark:bg-slate-900/40 dark:shadow-none">
           <label class="mb-1 block text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Роли сторон в актах и счетах</label>

--- a/models/order.py
+++ b/models/order.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import BigInteger, Column, JSON, String
+from sqlalchemy import BigInteger, Column, JSON, String, Text
 from sqlmodel import Field, Relationship, SQLModel
 
 from .common import ClosingResult, DocumentRoleType, EquipmentStatus, LeadSource, OrderStageStatus, OrderStatus, PaymentCurrency, PaymentType
@@ -347,6 +347,7 @@ class Order(SQLModel, table=True):
     measurement_date: Optional[datetime] = None   # renamed from assessment_date
     measurer_id: Optional[int] = Field(default=None, index=True)
     measurement_result: Optional[str] = Field(default=None)
+    additional_conditions: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     proposal_status: str = Field(default="draft", sa_column=Column(String, default="draft", index=True))
     proposal_sent_at: Optional[datetime] = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -14930,6 +14930,17 @@
             "title": "Effective Document Role Type",
             "default": "seller_buyer"
           },
+          "additional_conditions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Additional Conditions"
+          },
           "installer_id": {
             "anyOf": [
               {
@@ -15452,6 +15463,17 @@
             "title": "Effective Document Role Type",
             "default": "seller_buyer"
           },
+          "additional_conditions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Additional Conditions"
+          },
           "installer_id": {
             "anyOf": [
               {
@@ -15915,6 +15937,17 @@
               }
             ],
             "title": "Measurement Result"
+          },
+          "additional_conditions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Additional Conditions"
           },
           "proposal_status": {
             "anyOf": [

--- a/schemas.py
+++ b/schemas.py
@@ -392,6 +392,7 @@ class ManagerOrderListItemResponse(BaseModel):
     customer_contract: Optional[OrderCustomerContractBrief] = None
     document_role_type: Optional[str] = None
     effective_document_role_type: str = "seller_buyer"
+    additional_conditions: Optional[str] = None
     installer_id: Optional[int] = None
     installer: Optional[ManagerInstallerResponse] = None
     # New fields
@@ -600,6 +601,7 @@ class ManagerOrderUpdatePayload(BaseModel):
     measurement_required: Optional[bool] = None
     measurer_id: Optional[int] = None
     measurement_result: Optional[str] = None
+    additional_conditions: Optional[str] = None
     proposal_status: Optional[str] = None
     proposal_sent_at: Optional[datetime] = None
 

--- a/services/documents/base.py
+++ b/services/documents/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
+import re
 from typing import Dict, Any, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -86,6 +87,21 @@ class BaseDocumentStrategy(ABC):
         except Exception:
             return str(amount)
 
+    @staticmethod
+    def _format_additional_conditions(value: Optional[str]) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        lines = []
+        for line in text.splitlines():
+            cleaned = line.strip()
+            if not cleaned:
+                continue
+            cleaned = re.sub(r"^(?:[-•]\s*|\d+[\.)]\s*)", "", cleaned).strip()
+            if cleaned:
+                lines.append(cleaned)
+        return "\n".join(lines)
+
     async def _prepare_base_variables(
         self,
         doc_number: Optional[str] = None,
@@ -128,6 +144,7 @@ class BaseDocumentStrategy(ABC):
             "{{act_number}}": "1",
             "{{act_sequence_number}}": "1",
             "{{document_role_type}}": DocumentRoleService.effective_role_type(order),
+            "{{additional_conditions}}": self._format_additional_conditions(order.additional_conditions),
         }
 
         # A one-time contract document must always use its own generated number/date,

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -422,7 +422,8 @@ class GoogleDocsService:
             new_file = drive_service.files().copy(fileId=template_id, body=copy_body).execute()
             new_doc_id = new_file.get('id')
 
-            # 2. Замены
+            # 2. Условные блоки и замены
+            self.render_conditional_blocks(docs_service, new_doc_id, replacements)
             requests = []
             for key, value in replacements.items():
                 requests.append({
@@ -512,6 +513,7 @@ class GoogleDocsService:
         
         try:
             docs_service = build('docs', 'v1', credentials=self.creds)
+            self.render_conditional_blocks(docs_service, file_id, replacements)
             
             # Формируем запросы на замену
             requests = []
@@ -530,6 +532,121 @@ class GoogleDocsService:
                 ).execute()
         except Exception as e:
             raise Exception(f"Google Docs API Error: {str(e)}")
+
+    @staticmethod
+    def _is_truthy_template_value(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (list, tuple, set, dict)):
+            return bool(value)
+        return bool(value)
+
+    @staticmethod
+    def _replacement_value_for_condition(replacements: Dict[str, Any], name: str) -> Any:
+        return replacements.get(f"{{{{{name}}}}}", replacements.get(name))
+
+    @staticmethod
+    def _iter_text_runs(elements: List[Dict[str, Any]]):
+        for element in elements or []:
+            if "paragraph" in element:
+                for paragraph_element in element["paragraph"].get("elements", []):
+                    text_run = paragraph_element.get("textRun")
+                    if text_run and "content" in text_run:
+                        yield {
+                            "text": text_run.get("content", ""),
+                            "start": paragraph_element.get("startIndex"),
+                            "end": paragraph_element.get("endIndex"),
+                        }
+            if "table" in element:
+                for row in element["table"].get("tableRows", []):
+                    for cell in row.get("tableCells", []):
+                        yield from GoogleDocsService._iter_text_runs(cell.get("content", []))
+            if "tableOfContents" in element:
+                yield from GoogleDocsService._iter_text_runs(element["tableOfContents"].get("content", []))
+
+    @staticmethod
+    def _expand_to_line_boundaries(text: str, start: int, end: int) -> tuple[int, int]:
+        line_start = text.rfind("\n", 0, start) + 1
+        line_end = text.find("\n", end)
+        before_marker = text[line_start:start]
+        after_marker = text[end:line_end] if line_end != -1 else text[end:]
+        if before_marker.strip() == "" and after_marker.strip() == "":
+            return line_start, line_end + 1 if line_end != -1 else end
+        return start, end
+
+    @staticmethod
+    def _build_conditional_block_requests(document: Dict[str, Any], replacements: Dict[str, Any]) -> List[Dict[str, Any]]:
+        runs = [
+            run for run in GoogleDocsService._iter_text_runs(document.get("body", {}).get("content", []))
+            if run.get("text") and run.get("start") is not None and run.get("end") is not None
+        ]
+        if not runs:
+            return []
+
+        full_text_parts: List[str] = []
+        spans: List[tuple[int, int, int]] = []
+        cursor = 0
+        for run in runs:
+            text = run["text"]
+            spans.append((cursor, int(run["start"]), len(text)))
+            full_text_parts.append(text)
+            cursor += len(text)
+        full_text = "".join(full_text_parts)
+
+        def doc_index(offset: int) -> int:
+            for text_offset, start_index, length in spans:
+                if text_offset <= offset <= text_offset + length:
+                    return start_index + (offset - text_offset)
+            last_offset, last_start, last_length = spans[-1]
+            return last_start + last_length + max(0, offset - (last_offset + last_length))
+
+        requests: List[Dict[str, Any]] = []
+        marker_re = re.compile(r"{{#if\s+([A-Za-z0-9_]+)\s*}}")
+        close_marker = "{{/if}}"
+        search_from = 0
+        while True:
+            opening = marker_re.search(full_text, search_from)
+            if not opening:
+                break
+            close_start = full_text.find(close_marker, opening.end())
+            if close_start == -1:
+                break
+            close_end = close_start + len(close_marker)
+            condition_name = opening.group(1)
+            condition_value = GoogleDocsService._replacement_value_for_condition(replacements, condition_name)
+            if GoogleDocsService._is_truthy_template_value(condition_value):
+                ranges = [
+                    GoogleDocsService._expand_to_line_boundaries(full_text, opening.start(), opening.end()),
+                    GoogleDocsService._expand_to_line_boundaries(full_text, close_start, close_end),
+                ]
+            else:
+                ranges = [GoogleDocsService._expand_to_line_boundaries(full_text, opening.start(), close_end)]
+
+            for start, end in ranges:
+                if end > start:
+                    requests.append({
+                        "deleteContentRange": {
+                            "range": {
+                                "startIndex": doc_index(start),
+                                "endIndex": doc_index(end),
+                            }
+                        }
+                    })
+            search_from = close_end
+
+        requests.sort(key=lambda item: item["deleteContentRange"]["range"]["startIndex"], reverse=True)
+        return requests
+
+    def render_conditional_blocks(self, docs_service: Any, file_id: str, replacements: Dict[str, Any]) -> None:
+        document = docs_service.documents().get(documentId=file_id).execute()
+        requests = self._build_conditional_block_requests(document, replacements)
+        if requests:
+            docs_service.documents().batchUpdate(
+                documentId=file_id,
+                body={"requests": requests},
+            ).execute()
     
     def export_file(self, file_id: str, mime_type: str = 'application/pdf') -> BytesIO:
         """

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1272,6 +1272,7 @@ class OrderService:
                 order.document_role_type.value if hasattr(order.document_role_type, "value") else order.document_role_type
             ),
             "effective_document_role_type": DocumentRoleService.effective_role_type(order),
+            "additional_conditions": order.additional_conditions,
             "closing_result": order.closing_result,
             "reject_reason": order.reject_reason,
             "is_on_hold": bool(order.is_on_hold),
@@ -1736,6 +1737,9 @@ class OrderService:
             order.measurer_id = payload.measurer_id
         if "measurement_result" in fields_set:
             order.measurement_result = payload.measurement_result
+        if "additional_conditions" in fields_set:
+            value = (payload.additional_conditions or "").strip()
+            order.additional_conditions = value or None
         if "proposal_status" in fields_set and payload.proposal_status is not None:
             order.proposal_status = payload.proposal_status
         if "proposal_sent_at" in fields_set:

--- a/tests/unit/test_document_conditionals.py
+++ b/tests/unit/test_document_conditionals.py
@@ -1,0 +1,97 @@
+from services.documents.base import BaseDocumentStrategy
+from services.google_service import GoogleDocsService
+
+
+def _doc(text: str) -> dict:
+    return {
+        "body": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "startIndex": 1,
+                                "endIndex": 1 + len(text),
+                                "textRun": {"content": text},
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+
+def _delete_ranges(requests: list[dict]) -> list[tuple[int, int]]:
+    return [
+        (
+            item["deleteContentRange"]["range"]["startIndex"],
+            item["deleteContentRange"]["range"]["endIndex"],
+        )
+        for item in requests
+    ]
+
+
+def _apply_delete_requests(text: str, requests: list[dict]) -> str:
+    for start, end in _delete_ranges(requests):
+        text = text[: start - 1] + text[end - 1 :]
+    return text
+
+
+def test_google_doc_condition_removes_falsey_block():
+    text = "A\n{{#if additional_conditions}}\nB {{additional_conditions}}\n{{/if}}\nC\n"
+
+    requests = GoogleDocsService._build_conditional_block_requests(
+        _doc(text),
+        {"{{additional_conditions}}": ""},
+    )
+
+    assert _delete_ranges(requests) == [(3, 69)]
+
+
+def test_google_doc_condition_keeps_truthy_body_and_removes_markers():
+    text = "A\n{{#if additional_conditions}}\nB {{additional_conditions}}\n{{/if}}\nC\n"
+
+    requests = GoogleDocsService._build_conditional_block_requests(
+        _doc(text),
+        {"{{additional_conditions}}": "Оплата после монтажа"},
+    )
+
+    assert _delete_ranges(requests) == [(61, 69), (3, 33)]
+
+
+def test_google_doc_condition_removes_empty_inline_conditional_paragraph():
+    text = "A\n{{#if additional_conditions}}{{additional_conditions}}{{/if}}\nC\n"
+
+    requests = GoogleDocsService._build_conditional_block_requests(
+        _doc(text),
+        {"{{additional_conditions}}": ""},
+    )
+
+    assert _apply_delete_requests(text, requests) == "A\nC\n"
+
+
+def test_google_doc_condition_keeps_placeholder_in_inline_conditional_paragraph():
+    text = "A\n{{#if additional_conditions}}{{additional_conditions}}{{/if}}\nC\n"
+
+    requests = GoogleDocsService._build_conditional_block_requests(
+        _doc(text),
+        {"{{additional_conditions}}": "Предоплата 200%"},
+    )
+
+    assert _apply_delete_requests(text, requests) == "A\n{{additional_conditions}}\nC\n"
+
+
+def test_template_truthiness_ignores_blank_strings_and_empty_collections():
+    assert GoogleDocsService._is_truthy_template_value("  ") is False
+    assert GoogleDocsService._is_truthy_template_value([]) is False
+    assert GoogleDocsService._is_truthy_template_value(["условие"]) is True
+
+
+def test_additional_conditions_formatter_keeps_contract_lines_without_manual_numbering():
+    assert BaseDocumentStrategy._format_additional_conditions(None) == ""
+    assert BaseDocumentStrategy._format_additional_conditions("  Оплата после монтажа  ") == "Оплата после монтажа"
+    assert (
+        BaseDocumentStrategy._format_additional_conditions("- Монтаж в будний день\n2. Доступ к объекту")
+        == "Монтаж в будний день\nДоступ к объекту"
+    )


### PR DESCRIPTION
## Summary
- add order `additional_conditions` storage/API support plus Alembic migration
- add Google Docs `{{#if placeholder}}...{{/if}}` conditional blocks and `{{additional_conditions}}` rendering
- add manager UI library of common contract/invoice conditions with mobile-collapsible groups
- save selected/manual conditions before document generation

## Validation
- `pytest tests/unit/test_document_conditionals.py -q`
- `cd manager_frontend && npm run build`
- `git diff --check`
- browser smoke: manager orders route loads with API 200 and no console errors
