### PR TITLE
[codex] Prefer official complaint wording in defect acts

### DIFF
--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -168,7 +168,13 @@ class DefectActStrategy(GoogleDocStrategy):
             if detailed_name:
                 equipment_name = detailed_name
         technical_condition = self._first_text(
-            self._meta_text("technical_condition", "defect_technical_condition", "customer_complaint", "complaint_text"),
+            self._meta_text(
+                "technical_condition",
+                "defect_technical_condition",
+                "complaint_official",
+                "customer_complaint",
+                "complaint_text",
+            ),
             getattr(self.order, "measurement_result", None) if self.order else None,
             default="_________________",
         )

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -936,6 +936,56 @@ async def test_manager_order_generate_defect_act_placeholders(async_client, db, 
 
 
 @pytest.mark.asyncio
+async def test_manager_order_defect_act_prefers_official_complaint_for_technical_condition(async_client, db, monkeypatch):
+    customer = Customer(name="ООО Мегахенд", phone="+375291111111", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEW_LEAD,
+        technical_meta={
+            "repair": {
+                "customer_complaint": "Вообще не холодит",
+                "complaint_official": "Отсутствие теплообмена в режиме охлаждения",
+            },
+        },
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            captured["template_id"] = template_id
+            captured["title"] = title
+            return {"file_id": "fake-defect-act", "edit_url": "https://docs.google.com/document/d/fake-defect-act/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            captured["file_id"] = file_id
+            captured["replacements"] = replacements
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/defect_act?contract_date=2026-05-14T00:00:00",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    replacements = captured["replacements"]
+    assert replacements["{{technical_condition}}"] == "Отсутствие теплообмена в режиме охлаждения"
+    assert replacements["{{customer_complaint}}"] == "Вообще не холодит"
+    assert replacements["{{complaint_official}}"] == "Отсутствие теплообмена в режиме охлаждения"
+
+
+@pytest.mark.asyncio
 async def test_manager_order_patch_customer_critical_requisites_requires_confirmation(async_client, db):
     customer = Customer(
         name="Critical Requisites",


### PR DESCRIPTION
## Summary
- prefer `complaint_official` when filling `{{technical_condition}}` in defect acts
- keep the raw customer phrase in `{{customer_complaint}}`
- add a regression test for the "Вообще не холодит" preset case

## Root Cause
Defect act generation fell back from an empty technical condition directly to the raw customer complaint. For preset-based repair complaints this put informal client wording into the technical condition field instead of the curated document wording.

## Validation
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 python3 -m pytest tests/integration/test_manager_orders_api.py -k "defect_act" -q`
