### PR TITLE
Show bank receipt details on order payments

### DIFF
--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -178,6 +178,7 @@ export type { OrderWorkStageResponse } from './models/OrderWorkStageResponse';
 export type { OrderWorkStageUpdatePayload } from './models/OrderWorkStageUpdatePayload';
 export type { OutgoingEmailResponse } from './models/OutgoingEmailResponse';
 export type { OutgoingEmailSendPayload } from './models/OutgoingEmailSendPayload';
+export type { PaymentBankReceiptResponse } from './models/PaymentBankReceiptResponse';
 export type { PaymentCreatePayload } from './models/PaymentCreatePayload';
 export type { PaymentCurrency } from './models/PaymentCurrency';
 export type { PaymentResponse } from './models/PaymentResponse';

--- a/manager_frontend/src/client/models/PaymentBankReceiptResponse.ts
+++ b/manager_frontend/src/client/models/PaymentBankReceiptResponse.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PaymentCurrency } from './PaymentCurrency';
+export type PaymentBankReceiptResponse = {
+    id: number;
+    status: string;
+    received_at?: (string | null);
+    amount: number;
+    currency: PaymentCurrency;
+    payer_name?: (string | null);
+    payer_unp?: (string | null);
+    payer_account?: (string | null);
+    payment_document_raw?: (string | null);
+    payment_document_number?: (string | null);
+    payment_purpose?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/PaymentResponse.ts
+++ b/manager_frontend/src/client/models/PaymentResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { PaymentBankReceiptResponse } from './PaymentBankReceiptResponse';
 import type { PaymentCurrency } from './PaymentCurrency';
 export type PaymentResponse = {
     id: number;
@@ -12,5 +13,6 @@ export type PaymentResponse = {
     comment?: (string | null);
     created_at: string;
     bank_receipt_id?: (number | null);
+    bank_receipt?: (PaymentBankReceiptResponse | null);
 };
 

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -183,6 +183,24 @@ const formatReceiptDate = (value?: string | null) => {
   return new Date(value).toLocaleString('ru-RU', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
 };
 
+const formatPaymentType = (value?: string | null) => (value === 'prepayment' ? 'Аванс' : 'Доплата');
+
+const formatBankPaymentDate = (value?: string | null) => {
+  if (!value) return 'дата не указана';
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const openBankReceiptJournal = () => {
+  window.history.pushState({}, '', `/manager/payments?orderId=${props.order.id}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
 const generateDocument = async (type: string, template?: DocumentTemplateItem | null, documentDate?: string) => {
   try {
     if (type === 'contract' && isCompanyOrder.value) {
@@ -652,11 +670,35 @@ watch(() => props.order.id, () => {
             </div>
           </div>
 
-          <div class="mt-4 space-y-2 max-h-32 overflow-y-auto pr-1">
-              <div v-for="p in payments" :key="p.id" class="flex justify-between items-center text-xs py-2 px-3 rounded-lg bg-white border border-slate-100 shadow-sm">
-                  <span class="text-slate-500">{{ new Date(p.date).toLocaleDateString() }}</span>
-                  <span class="font-bold text-slate-800">{{ formatMoney(p.amount) }}</span>
-                  <span class="text-slate-400 w-16 text-right">{{ p.type === 'prepayment' ? 'Аванс' : 'Доплата' }}</span>
+          <div class="mt-4 space-y-2 max-h-56 overflow-y-auto pr-1">
+              <div v-for="p in payments" :key="p.id" class="rounded-lg bg-white border border-slate-100 px-3 py-2 text-xs shadow-sm">
+                  <div class="flex flex-wrap items-center justify-between gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="text-slate-500">{{ new Date(p.date).toLocaleDateString() }}</span>
+                      <span
+                        v-if="p.bank_receipt"
+                        class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700"
+                      >
+                        <span class="material-icons-round text-[13px]">account_balance</span>
+                        Банк
+                      </span>
+                    </div>
+                    <span class="font-bold text-slate-800">{{ formatMoney(p.amount) }}</span>
+                    <span class="text-slate-400 w-16 text-right">{{ formatPaymentType(p.type) }}</span>
+                  </div>
+                  <div v-if="p.bank_receipt" class="mt-2 rounded-lg border border-emerald-100 bg-emerald-50/40 p-2 text-[11px] text-slate-600">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="font-semibold text-emerald-800">ПП № {{ p.bank_receipt.payment_document_number || p.bank_receipt.payment_document_raw || p.bank_receipt.id }}</span>
+                      <span>{{ formatBankPaymentDate(p.bank_receipt.received_at || p.date) }}</span>
+                      <span v-if="p.bank_receipt.payer_unp">УНП {{ p.bank_receipt.payer_unp }}</span>
+                    </div>
+                    <p v-if="p.bank_receipt.payer_name" class="mt-1 truncate font-medium text-slate-700">{{ p.bank_receipt.payer_name }}</p>
+                    <p v-if="p.bank_receipt.payment_purpose" class="mt-1 line-clamp-2 text-slate-500">{{ p.bank_receipt.payment_purpose }}</p>
+                    <button class="mt-1 inline-flex items-center gap-1 font-semibold text-emerald-700 hover:text-emerald-900" @click="openBankReceiptJournal">
+                      <span class="material-icons-round text-[13px]">receipt_long</span>
+                      Открыть в журнале
+                    </button>
+                  </div>
               </div>
           </div>
       </div>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1038,6 +1038,25 @@ const formatReceiptDate = (value?: string | null) => {
   return new Date(value).toLocaleString('ru-RU', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
 };
 
+const formatPaymentType = (value?: string | null) => (value === 'prepayment' ? 'Аванс' : 'Доплата');
+
+const formatBankPaymentDate = (value?: string | null) => {
+  if (!value) return 'дата не указана';
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const openBankReceiptJournal = (payment: PaymentResponse) => {
+  if (!props.order?.id || !payment.bank_receipt_id) return;
+  window.history.pushState({}, '', `/manager/payments?orderId=${props.order.id}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
 const deletingPaymentId = ref<number | null>(null);
 
 const confirmDeletePayment = (paymentId: number) => {
@@ -3264,21 +3283,46 @@ watch(
           </div>
         </div>
 
-        <div class="mt-4 space-y-2 max-h-32 overflow-y-auto pr-1">
-            <div v-for="p in payments" :key="p.id" class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-100 bg-white px-3 py-2 text-xs shadow-sm">
-                <span class="text-slate-500">{{ new Date(p.date).toLocaleDateString() }}</span>
-                <span class="font-bold text-slate-800" :class="p.currency !== 'BYN' ? 'text-blue-600' : ''">
-                    <template v-if="p.currency !== 'BYN'">{{ p.amount.toFixed(2) }} {{ p.currency }}</template>
-                    <template v-else>{{ formatMoney(p.amount) }}</template>
-                </span>
-                <span class="text-slate-400 w-16 text-right">{{ p.type === 'prepayment' ? 'Аванс' : 'Доплата' }}</span>
-                <div v-if="deletingPaymentId === p.id" class="flex gap-2 ml-2 items-center">
-                    <button class="text-slate-500 hover:text-slate-800 font-medium" @click="cancelDeletePayment()">Отмена</button>
-                    <button class="text-red-500 hover:text-red-700 font-bold" @click="deletePayment(p.id)">Да, удалить</button>
+        <div class="mt-4 space-y-2 max-h-56 overflow-y-auto pr-1">
+            <div v-for="p in payments" :key="p.id" class="rounded-lg border border-slate-100 bg-white px-3 py-2 text-xs shadow-sm">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="text-slate-500">{{ new Date(p.date).toLocaleDateString() }}</span>
+                        <span
+                          v-if="p.bank_receipt"
+                          class="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700"
+                        >
+                          <span class="material-icons-round text-[13px]">account_balance</span>
+                          Банк
+                        </span>
+                    </div>
+                    <span class="font-bold text-slate-800" :class="p.currency !== 'BYN' ? 'text-blue-600' : ''">
+                        <template v-if="p.currency !== 'BYN'">{{ p.amount.toFixed(2) }} {{ p.currency }}</template>
+                        <template v-else>{{ formatMoney(p.amount) }}</template>
+                    </span>
+                    <span class="text-slate-400 w-16 text-right">{{ formatPaymentType(p.type) }}</span>
+                    <div v-if="deletingPaymentId === p.id" class="flex gap-2 ml-2 items-center">
+                        <button class="text-slate-500 hover:text-slate-800 font-medium" @click="cancelDeletePayment()">Отмена</button>
+                        <button class="text-red-500 hover:text-red-700 font-bold" @click="deletePayment(p.id)">Да, удалить</button>
+                    </div>
+                    <button v-else class="flex h-6 w-6 ml-2 items-center justify-center rounded text-red-400 hover:bg-red-50 hover:text-red-600 transition-colors" @click="confirmDeletePayment(p.id)" title="Удалить платеж">
+                        <span class="material-icons-round text-[14px]">delete</span>
+                    </button>
                 </div>
-                <button v-else class="flex h-6 w-6 ml-2 items-center justify-center rounded text-red-400 hover:bg-red-50 hover:text-red-600 transition-colors" @click="confirmDeletePayment(p.id)" title="Удалить платеж">
-                    <span class="material-icons-round text-[14px]">delete</span>
-                </button>
+                <div v-if="p.bank_receipt" class="mt-2 rounded-lg border border-emerald-100 bg-emerald-50/40 p-2 text-[11px] text-slate-600">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="font-semibold text-emerald-800">ПП № {{ p.bank_receipt.payment_document_number || p.bank_receipt.payment_document_raw || p.bank_receipt.id }}</span>
+                        <span>{{ formatBankPaymentDate(p.bank_receipt.received_at || p.date) }}</span>
+                        <span v-if="p.bank_receipt.payer_unp">УНП {{ p.bank_receipt.payer_unp }}</span>
+                    </div>
+                    <p v-if="p.bank_receipt.payer_name" class="mt-1 truncate font-medium text-slate-700">{{ p.bank_receipt.payer_name }}</p>
+                    <p v-if="p.bank_receipt.payment_purpose" class="mt-1 line-clamp-2 text-slate-500">{{ p.bank_receipt.payment_purpose }}</p>
+                    <button class="mt-1 inline-flex items-center gap-1 font-semibold text-emerald-700 hover:text-emerald-900" @click="openBankReceiptJournal(p)">
+                        <span class="material-icons-round text-[13px]">receipt_long</span>
+                        Открыть в журнале
+                    </button>
+                </div>
+                <p v-else-if="p.comment" class="mt-1 text-[11px] text-slate-500">{{ p.comment }}</p>
             </div>
             <div v-if="!payments.length" class="text-sm text-gray-500 italic py-3 text-center rounded-xl border border-dashed border-gray-200">
                 Нет оплат

--- a/models/order.py
+++ b/models/order.py
@@ -603,6 +603,7 @@ class Payment(SQLModel, table=True):
     updated_at: Optional[datetime] = Field(default_factory=datetime.now, sa_column_kwargs={"onupdate": datetime.now})
 
     order: "Order" = Relationship(back_populates="payments")
+    bank_receipt: Optional[BankReceipt] = Relationship()
 
     def __str__(self):
         return f"Платеж {self.amount} BYN от {self.date.strftime('%d.%m.%Y')} ({self.type})"

--- a/openapi.json
+++ b/openapi.json
@@ -19660,6 +19660,111 @@
         ],
         "title": "OutgoingEmailSendPayload"
       },
+      "PaymentBankReceiptResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "received_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Received At"
+          },
+          "amount": {
+            "type": "number",
+            "title": "Amount"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/PaymentCurrency"
+          },
+          "payer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payer Name"
+          },
+          "payer_unp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payer Unp"
+          },
+          "payer_account": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payer Account"
+          },
+          "payment_document_raw": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Document Raw"
+          },
+          "payment_document_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Document Number"
+          },
+          "payment_purpose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Purpose"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "amount",
+          "currency"
+        ],
+        "title": "PaymentBankReceiptResponse"
+      },
       "PaymentCreatePayload": {
         "properties": {
           "amount": {
@@ -19750,6 +19855,16 @@
               }
             ],
             "title": "Bank Receipt Id"
+          },
+          "bank_receipt": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PaymentBankReceiptResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -479,6 +479,20 @@ class PaymentCreatePayload(BaseModel):
     comment: Optional[str] = None
 
 
+class PaymentBankReceiptResponse(BaseModel):
+    id: int
+    status: str
+    received_at: Optional[datetime] = None
+    amount: float
+    currency: PaymentCurrency
+    payer_name: Optional[str] = None
+    payer_unp: Optional[str] = None
+    payer_account: Optional[str] = None
+    payment_document_raw: Optional[str] = None
+    payment_document_number: Optional[str] = None
+    payment_purpose: Optional[str] = None
+
+
 class PaymentResponse(BaseModel):
     id: int
     amount: float
@@ -488,6 +502,7 @@ class PaymentResponse(BaseModel):
     comment: Optional[str] = None
     created_at: datetime
     bank_receipt_id: Optional[int] = None
+    bank_receipt: Optional[PaymentBankReceiptResponse] = None
 
 
 

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -4,12 +4,13 @@ from typing import Optional, List, Dict, Any
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
-from sqlalchemy import func, or_, and_, not_, cast, String, delete
+from sqlalchemy import func, or_, and_, not_, cast, String, delete, inspect
 from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import NO_VALUE
 
 from crud.order import OrderDAO
 from crud.product import ProductDAO
-from models import Order, OrderProductLink, OrderProposal, OrderServiceLink, Customer, CustomerBranch, CustomerContract, CustomerType, OrderStatus, PaymentCurrency, Product, LeadSource, Service, ServiceTariff, OrderInstaller, OrderWorkStage
+from models import Order, OrderProductLink, OrderProposal, OrderServiceLink, Customer, CustomerBranch, CustomerContract, CustomerType, OrderStatus, PaymentCurrency, Product, LeadSource, Service, ServiceTariff, OrderInstaller, OrderWorkStage, Payment
 from services.customer_contract_service import CustomerContractService
 from services.document_role_service import DocumentRoleService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
@@ -40,6 +41,37 @@ class OrderService:
         if title and title.startswith(OrderService.LEGACY_WEBSITE_TITLE_PREFIX):
             return None
         return title
+
+    @staticmethod
+    def _map_payment(payment: Payment) -> Dict[str, Any]:
+        receipt_value = inspect(payment).attrs.bank_receipt.loaded_value
+        receipt = receipt_value if receipt_value is not NO_VALUE else None
+        receipt_data = None
+        if receipt:
+            receipt_data = {
+                "id": receipt.id,
+                "status": receipt.status,
+                "received_at": receipt.received_at,
+                "amount": float(receipt.amount),
+                "currency": receipt.currency,
+                "payer_name": receipt.payer_name,
+                "payer_unp": receipt.payer_unp,
+                "payer_account": receipt.payer_account,
+                "payment_document_raw": receipt.payment_document_raw,
+                "payment_document_number": receipt.payment_document_number,
+                "payment_purpose": receipt.payment_purpose,
+            }
+        return {
+            "id": payment.id,
+            "amount": float(payment.amount),
+            "currency": payment.currency.value if hasattr(payment.currency, "value") else str(payment.currency),
+            "date": payment.date,
+            "type": payment.type.value if hasattr(payment.type, "value") else str(payment.type),
+            "comment": payment.comment,
+            "created_at": payment.created_at,
+            "bank_receipt_id": payment.bank_receipt_id,
+            "bank_receipt": receipt_data,
+        }
 
     @staticmethod
     def _build_default_order_title(
@@ -1526,7 +1558,7 @@ class OrderService:
                 selectinload(Order.service_links).selectinload(OrderServiceLink.service),
                 selectinload(Order.installers).selectinload(OrderInstaller.installer),
                 selectinload(Order.documents),
-                selectinload(Order.payments),
+                selectinload(Order.payments).selectinload(Payment.bank_receipt),
                 selectinload(Order.work_stages).selectinload(OrderWorkStage.installer),
             )
         )
@@ -1564,19 +1596,7 @@ class OrderService:
             }
             for doc in sorted(order.documents, key=lambda d: d.created_at, reverse=True)
         ]
-        data["payments"] = [
-            {
-                "id": p.id,
-                "amount": float(p.amount),
-                "currency": p.currency,
-                "date": p.date,
-                "type": p.type.value if hasattr(p.type, "value") else str(p.type),
-                "comment": p.comment,
-                "created_at": p.created_at,
-                "bank_receipt_id": p.bank_receipt_id,
-            }
-            for p in sorted(order.payments, key=lambda d: d.date, reverse=True)
-        ]
+        data["payments"] = [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
         data["work_stages"] = [
             {
                 "id": ws.id,
@@ -2164,20 +2184,8 @@ class OrderService:
         session.add(order)
         await session.commit()
         
-        # Return payments mapped exactly as in get_order_detail_for_manager
-        return [
-            {
-                "id": p.id,
-                "amount": float(p.amount),
-                "currency": p.currency.value if hasattr(p.currency, "value") else str(p.currency),
-                "date": p.date,
-                "type": p.type.value if hasattr(p.type, "value") else str(p.type),
-                "comment": p.comment,
-                "created_at": p.created_at,
-                "bank_receipt_id": p.bank_receipt_id,
-            }
-            for p in sorted(order.payments, key=lambda d: d.date, reverse=True)
-        ]
+        # Return payments mapped exactly as in get_order_detail_for_manager.
+        return [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
 
     @staticmethod
     async def delete_payment(session: AsyncSession, order_id: int, payment_id: int):
@@ -2199,19 +2207,7 @@ class OrderService:
         session.add(order)
         await session.commit()
         
-        return [
-            {
-                "id": p.id,
-                "amount": float(p.amount),
-                "currency": p.currency.value if hasattr(p.currency, "value") else str(p.currency),
-                "date": p.date,
-                "type": p.type.value if hasattr(p.type, "value") else str(p.type),
-                "comment": p.comment,
-                "created_at": p.created_at,
-                "bank_receipt_id": p.bank_receipt_id,
-            }
-            for p in sorted(order.payments, key=lambda d: d.date, reverse=True)
-        ]
+        return [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
 
     # -----------------------------------------------------------------
     # Leads Inbox (Order-based triage)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -4,6 +4,7 @@ from sqlmodel import select
 
 from core.config import settings
 from models import (
+    BankReceipt,
     Customer,
     CustomerBranch,
     CustomerContract,
@@ -17,6 +18,7 @@ from models import (
     OrderServiceLink,
     OrderStatus,
     Payment,
+    PaymentCurrency,
     Product,
     RepairComplaintPreset,
     Service,
@@ -1188,3 +1190,53 @@ async def test_manager_order_delete_cascades_related_entities(async_client, db, 
     docs = await db.execute(select(OrderDocument).where(OrderDocument.order_id == order.id))
     assert docs.scalars().first() is None
     assert "google-file-delete-1" in deleted_ids
+
+
+@pytest.mark.asyncio
+async def test_manager_order_detail_includes_bank_receipt_payment_details(async_client, db):
+    customer = Customer(name="Bank Customer", phone="+375290009999", type=CustomerType.individual, inn="192663084")
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.EXECUTION, total_amount=420, balance_due=420)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    receipt = BankReceipt(
+        status="matched",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="order-detail-bank-receipt",
+        received_at=datetime(2026, 5, 22, 14, 57),
+        amount=420,
+        currency=PaymentCurrency.BYN,
+        payer_name='ООО "МЕГАХЕНД"',
+        payer_unp="192663084",
+        payer_account="BY44PJCB30120493741000000933",
+        payment_document_raw="17",
+        payment_document_number="17",
+        payment_purpose="ОПЛАТА СОГЛАСНО СЧЕТА 61",
+        matched_order_id=order.id,
+        raw_body="statement row",
+    )
+    db.add(receipt)
+    await db.commit()
+    await db.refresh(receipt)
+
+    payment = Payment(order_id=order.id, bank_receipt_id=receipt.id, amount=420)
+    db.add(payment)
+    await db.commit()
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.get(f"/api/manager/orders/{order.id}", headers=headers)
+
+    assert response.status_code == 200
+    payments = response.json()["payments"]
+    assert len(payments) == 1
+    assert payments[0]["bank_receipt_id"] == receipt.id
+    assert payments[0]["bank_receipt"]["payment_document_number"] == "17"
+    assert payments[0]["bank_receipt"]["payer_unp"] == "192663084"
+    assert payments[0]["bank_receipt"]["payment_purpose"] == "ОПЛАТА СОГЛАСНО СЧЕТА 61"

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -1229,6 +1229,7 @@ async def test_manager_order_detail_includes_bank_receipt_payment_details(async_
     payment = Payment(order_id=order.id, bank_receipt_id=receipt.id, amount=420)
     db.add(payment)
     await db.commit()
+    db.expunge(order)
 
     headers = await _auth_headers(async_client)
     response = await async_client.get(f"/api/manager/orders/{order.id}", headers=headers)

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -14,6 +14,7 @@ from services.bank_statement_csv_service import BankStatementCsvService
 from services.bot_service import BotService
 from services.mail_smtp_service import MailAttachment, MailSmtpService
 from services.notification_service import NotificationService
+from services.order_service import OrderService
 
 
 SAMPLE_BANK_EMAIL = """
@@ -228,6 +229,51 @@ async def test_bank_receipt_can_be_marked_void_and_reverses_linked_payment(sqlit
     assert payments == []
     refreshed_order = await sqlite_session.get(Order, order.id)
     assert refreshed_order.balance_due == 420
+
+
+@pytest.mark.asyncio
+async def test_order_detail_payment_includes_bank_receipt(sqlite_session):
+    customer = Customer(name="Мегахенд", phone="+375291111114", type="company", inn="192663084")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(customer_id=customer.id, status="execution", total_amount=420, balance_due=420)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    receipt = BankReceipt(
+        status="matched",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="order-detail-receipt-fingerprint",
+        received_at=datetime(2026, 5, 22, 14, 57),
+        amount=420,
+        currency=PaymentCurrency.BYN,
+        payer_name='ООО "МЕГАХЕНД"',
+        payer_unp="192663084",
+        payer_account="BY44PJCB30120493741000000933",
+        payment_document_number="17",
+        payment_purpose="ОПЛАТА СОГЛАСНО СЧЕТА 61",
+        matched_order_id=order.id,
+        raw_body="statement row",
+    )
+    sqlite_session.add(receipt)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(receipt)
+
+    sqlite_session.add(Payment(order_id=order.id, bank_receipt_id=receipt.id, amount=420))
+    await sqlite_session.commit()
+    sqlite_session.expunge(order)
+
+    detail = await OrderService.get_order_detail_for_manager(sqlite_session, order.id)
+
+    assert detail is not None
+    assert detail["payments"][0]["bank_receipt_id"] == receipt.id
+    assert detail["payments"][0]["bank_receipt"]["payment_document_number"] == "17"
+    assert detail["payments"][0]["bank_receipt"]["payer_unp"] == "192663084"
 
 
 def test_bank_statement_csv_parser_reads_credit_rows():


### PR DESCRIPTION
## Summary
- Add a Payment -> BankReceipt ORM relation and expose compact bank receipt details on `PaymentResponse`.
- Show bank-linked payments in order payment blocks with bank badge, payment document number, receipt date, payer/UNP, purpose, and a link to the payment journal filtered by order.
- Keep manual payments unchanged; they still show as ordinary manual payments/comments.

## Testing
- `pytest tests/unit/test_mail_services.py -q` -> `12 passed`.
- `cd manager_frontend && npm run build`.
- `python3 -m compileall models/order.py services/order_service.py schemas.py tests/unit/test_mail_services.py tests/integration/test_manager_orders_api.py`.
- `git diff --check`.

Note: targeted integration test could not run locally because host `db_test` is not resolvable in this environment; the same contract is covered by a SQLite unit test and the integration test is included for CI.