### PR TITLE
Classify resolved bank receipts outside active orders

### DIFF
--- a/manager_frontend/src/views/BankReceiptsView.vue
+++ b/manager_frontend/src/views/BankReceiptsView.vue
@@ -27,6 +27,8 @@ const statusOptions = [
   { value: '', label: 'Все' },
   { value: 'requires_review', label: 'Требуют проверки' },
   { value: 'matched', label: 'Разнесены' },
+  { value: 'closed_orders', label: 'Закрытые заказы' },
+  { value: 'non_order_income', label: 'Не CRM' },
   { value: 'void', label: 'Ошибочные' },
   { value: 'parse_failed', label: 'Ошибки парсинга' },
 ];
@@ -37,6 +39,10 @@ const statusLabel = (value?: string | null) => {
       return 'Разнесен';
     case 'requires_review':
       return 'Проверить';
+    case 'closed_orders':
+      return 'Закрытые заказы';
+    case 'non_order_income':
+      return 'Не CRM';
     case 'void':
       return 'Ошибочный';
     case 'parse_failed':
@@ -52,6 +58,10 @@ const statusClass = (value?: string | null) => {
       return 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:border-emerald-500/20';
     case 'requires_review':
       return 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-500/10 dark:text-amber-300 dark:border-amber-500/20';
+    case 'closed_orders':
+      return 'bg-sky-100 text-sky-700 border-sky-200 dark:bg-sky-500/10 dark:text-sky-300 dark:border-sky-500/20';
+    case 'non_order_income':
+      return 'bg-violet-100 text-violet-700 border-violet-200 dark:bg-violet-500/10 dark:text-violet-300 dark:border-violet-500/20';
     case 'void':
       return 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700/50 dark:text-slate-300 dark:border-slate-600';
     case 'parse_failed':
@@ -158,6 +168,36 @@ const markVoid = async (receipt: BankReceiptResponse) => {
       reason: reason.trim() || 'Ошибочный банковский платеж',
     });
     notice.value = `Поступление #${receipt.id} помечено ошибочным.`;
+    await loadReceipts();
+  } catch (err) {
+    error.value = getApiErrorMessage(err);
+  } finally {
+    actionId.value = null;
+  }
+};
+
+const markClosedOrders = async (receipt: BankReceiptResponse) => {
+  const reason = window.prompt('Комментарий к оплате закрытых заказов', 'Оплата по актам/закрытым заказам');
+  if (reason === null) return;
+  await updateReceiptStatus(receipt, 'closed_orders', reason.trim() || 'Оплата закрытых заказов', `Поступление #${receipt.id} помечено оплатой закрытых заказов.`);
+};
+
+const markNonOrderIncome = async (receipt: BankReceiptResponse) => {
+  const reason = window.prompt('Почему поступление не относится к заказам', 'Не CRM-поступление');
+  if (reason === null) return;
+  await updateReceiptStatus(receipt, 'non_order_income', reason.trim() || 'Не относится к заказам', `Поступление #${receipt.id} помечено как не CRM.`);
+};
+
+const updateReceiptStatus = async (receipt: BankReceiptResponse, nextStatus: string, reason: string, successMessage: string) => {
+  actionId.value = receipt.id;
+  error.value = '';
+  notice.value = '';
+  try {
+    await ManagerMailService.patchManagerBankReceiptStatus(receipt.id, {
+      status: nextStatus,
+      reason,
+    });
+    notice.value = successMessage;
     await loadReceipts();
   } catch (err) {
     error.value = getApiErrorMessage(err);
@@ -307,6 +347,7 @@ onMounted(loadReceipts);
                     <span class="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold" :class="statusClass(receipt.status)">
                       <CheckCircle2 v-if="receipt.status === 'matched'" class="h-3.5 w-3.5" />
                       <AlertTriangle v-else-if="receipt.status === 'requires_review'" class="h-3.5 w-3.5" />
+                      <CheckCircle2 v-else-if="receipt.status === 'closed_orders' || receipt.status === 'non_order_income'" class="h-3.5 w-3.5" />
                       <XCircle v-else-if="receipt.status === 'void'" class="h-3.5 w-3.5" />
                       {{ statusLabel(receipt.status) }}
                     </span>
@@ -340,6 +381,22 @@ onMounted(loadReceipts);
                   </td>
                   <td class="px-4 py-3 text-right">
                     <div class="flex justify-end gap-2">
+                      <button
+                        class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-sky-200 text-sky-700 hover:bg-sky-50 disabled:opacity-40 dark:border-sky-500/30 dark:text-sky-300 dark:hover:bg-sky-500/10"
+                        title="Оплата закрытых заказов"
+                        :disabled="actionId === receipt.id || receipt.status === 'closed_orders'"
+                        @click="markClosedOrders(receipt)"
+                      >
+                        <CheckCircle2 class="h-4 w-4" />
+                      </button>
+                      <button
+                        class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-violet-200 text-violet-700 hover:bg-violet-50 disabled:opacity-40 dark:border-violet-500/30 dark:text-violet-300 dark:hover:bg-violet-500/10"
+                        title="Не относится к заказам"
+                        :disabled="actionId === receipt.id || receipt.status === 'non_order_income'"
+                        @click="markNonOrderIncome(receipt)"
+                      >
+                        <AlertTriangle class="h-4 w-4" />
+                      </button>
                       <button
                         class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
                         title="Ошибочный"

--- a/services/bank_receipt_service.py
+++ b/services/bank_receipt_service.py
@@ -24,6 +24,7 @@ class BankReceiptImportResult:
 
 class BankReceiptService:
     EXACT_AMOUNT_TOLERANCE = 0.01
+    RESOLVED_UNMATCHED_STATUSES = {"closed_orders", "non_order_income"}
 
     @staticmethod
     async def list_receipts(
@@ -165,6 +166,17 @@ class BankReceiptService:
         return len(markers) > 1
 
     @staticmethod
+    def _looks_like_non_order_income(purpose: Optional[str]) -> bool:
+        text = " ".join(str(purpose or "").casefold().split())
+        if not text:
+            return False
+        return (
+            "выплата процентов" in text
+            and "временно свободными средствами" in text
+            and "находящимися на счете" in text
+        )
+
+    @staticmethod
     def _document_reference_tokens(number: str) -> set[str]:
         raw = str(number or "").strip()
         if not raw:
@@ -204,6 +216,18 @@ class BankReceiptService:
         if receipt.id and receipt.matched_payment_id:
             return receipt
         base_meta = dict(receipt.match_meta or {})
+        if BankReceiptService._looks_like_non_order_income(receipt.payment_purpose):
+            receipt.status = "non_order_income"
+            receipt.match_meta = {
+                **base_meta,
+                "reason": "bank_interest_income",
+                "candidate_order_ids": [],
+                "exact_order_ids": [],
+                "document_candidates": [],
+            }
+            session.add(receipt)
+            await session.flush()
+            return receipt
         if not receipt.payer_unp or receipt.amount <= 0:
             receipt.status = "requires_review"
             receipt.match_meta = {**base_meta, "reason": "missing_unp_or_amount", "candidate_order_ids": []}
@@ -355,14 +379,14 @@ class BankReceiptService:
             raise ValueError("Bank receipt not found")
 
         normalized_status = str(status or "").strip().lower()
-        if normalized_status not in {"requires_review", "matched", "void", "parse_failed"}:
+        if normalized_status not in {"requires_review", "matched", "void", "parse_failed", "closed_orders", "non_order_income"}:
             raise ValueError("Unsupported bank receipt status")
         if normalized_status == "matched":
             raise ValueError("Use attach action to match a bank receipt")
 
         old_payment_id = receipt.matched_payment_id
         old_order_id = receipt.matched_order_id
-        if normalized_status == "void" and old_payment_id:
+        if normalized_status in {"void", *BankReceiptService.RESOLVED_UNMATCHED_STATUSES} and old_payment_id:
             payment = await session.get(Payment, old_payment_id)
             if payment and payment.bank_receipt_id == receipt.id:
                 await session.delete(payment)
@@ -385,7 +409,7 @@ class BankReceiptService:
             }
         )
         receipt.status = normalized_status
-        if normalized_status in {"void", "requires_review"}:
+        if normalized_status in {"void", "requires_review", *BankReceiptService.RESOLVED_UNMATCHED_STATUSES}:
             receipt.matched_order_id = None
             receipt.matched_payment_id = None
         receipt.match_meta = meta

--- a/services/bank_statement_csv_service.py
+++ b/services/bank_statement_csv_service.py
@@ -256,7 +256,7 @@ class BankStatementCsvService:
                 BankReceipt.amount > 0,
                 func.date(BankReceipt.received_at) >= start_date,
                 func.date(BankReceipt.received_at) <= end_date,
-                BankReceipt.status != "void",
+                BankReceipt.status.notin_(["void", "closed_orders", "non_order_income"]),
             )
             existing_result = await session.execute(existing_stmt)
             for receipt in existing_result.scalars().all():

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -106,6 +106,10 @@ class NotificationService:
                 )
             elif receipt.status == "requires_review":
                 status_text = "требует проверки"
+            elif receipt.status == "closed_orders":
+                status_text = "оплата закрытых заказов"
+            elif receipt.status == "non_order_income":
+                status_text = "не относится к заказам"
             else:
                 status_text = receipt.status or "новый"
             lines.extend(

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -232,6 +232,91 @@ async def test_bank_receipt_can_be_marked_void_and_reverses_linked_payment(sqlit
 
 
 @pytest.mark.asyncio
+async def test_bank_receipt_can_be_marked_closed_orders_and_reverses_linked_payment(sqlite_session):
+    customer = Customer(name="Мясная лавка", phone="+375291111115", type="company", inn="390185132")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(customer_id=customer.id, status="execution")
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+    sqlite_session.add(OrderServiceLink(order_id=order.id, title="Предоплата", quantity=1, price=6900, cost=0))
+    await sqlite_session.commit()
+
+    receipt = BankReceipt(
+        status="matched",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="closed-orders-receipt-fingerprint",
+        received_at=datetime(2026, 5, 8, 14, 57),
+        amount=6900,
+        currency=PaymentCurrency.BYN,
+        payer_name="Мясная лавка",
+        payer_unp="390185132",
+        payment_purpose="ОПЛАТА ЗА УСЛУГИ МАГАЗИН МЯСНАЯ ЛАВКА СОГЛАСНО АКТОВ ЗА 2026Г",
+        matched_order_id=order.id,
+        raw_body="statement row",
+    )
+    sqlite_session.add(receipt)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(receipt)
+
+    payment = Payment(order_id=order.id, bank_receipt_id=receipt.id, amount=6900)
+    sqlite_session.add(payment)
+    await sqlite_session.flush()
+    receipt.matched_payment_id = payment.id
+    sqlite_session.add(receipt)
+    await sqlite_session.commit()
+
+    resolved = await BankReceiptService.update_receipt_status(
+        sqlite_session,
+        receipt_id=receipt.id,
+        status="closed_orders",
+        reason="Оплата по актам закрытых заказов",
+    )
+
+    assert resolved.status == "closed_orders"
+    assert resolved.matched_order_id is None
+    assert resolved.matched_payment_id is None
+    assert resolved.match_meta["manual_reason"] == "Оплата по актам закрытых заказов"
+    payments = (await sqlite_session.execute(select(Payment))).scalars().all()
+    assert payments == []
+
+
+@pytest.mark.asyncio
+async def test_bank_interest_receipt_auto_marks_non_order_income(sqlite_session):
+    receipt = BankReceipt(
+        status="new",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="bank-interest-receipt-fingerprint",
+        received_at=datetime(2026, 5, 1),
+        amount=12.34,
+        currency=PaymentCurrency.BYN,
+        payer_name="Банк",
+        payer_unp="",
+        payment_purpose=(
+            "Выплата процентов за пользование временно свободными средствами, "
+            "находящимися на счете, согласно ведомости начисленных процентов"
+        ),
+        raw_body="statement row",
+    )
+    sqlite_session.add(receipt)
+    await sqlite_session.flush()
+
+    matched = await BankReceiptService.match_receipt(sqlite_session, receipt)
+
+    assert matched.status == "non_order_income"
+    assert matched.match_meta["reason"] == "bank_interest_income"
+    payments = (await sqlite_session.execute(select(Payment))).scalars().all()
+    assert payments == []
+
+
+@pytest.mark.asyncio
 async def test_order_detail_payment_includes_bank_receipt(sqlite_session):
     customer = Customer(name="Мегахенд", phone="+375291111114", type="company", inn="192663084")
     sqlite_session.add(customer)


### PR DESCRIPTION
## Summary
- Add resolved bank receipt statuses for payments from closed orders (`closed_orders`) and income unrelated to CRM orders (`non_order_income`).
- Auto-classify bank interest payouts as `non_order_income`, so they do not stay in `requires_review`.
- Add manager journal actions to mark a receipt as payment for closed orders or as non-CRM income, with a reason stored in metadata.
- Keep these resolved statuses out of statement-missing suspicion checks and Telegram status text readable.

## Testing
- `pytest tests/unit/test_mail_services.py -q` -> `14 passed`.
- `cd manager_frontend && npm run build`.
- `python3 -m compileall services/bank_receipt_service.py services/bank_statement_csv_service.py services/notification_service.py tests/unit/test_mail_services.py`.
- `git diff --check`.