### PR TITLE
[codex] Support multiple admin users in bot

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -10,7 +10,7 @@ router = Router()
 
 @router.callback_query(F.data.startswith("edit_price_"))
 async def edit_price_start(callback: CallbackQuery, state: FSMContext):
-    if callback.from_user.id != settings.ADMIN_ID: return
+    if not settings.is_admin_user(callback.from_user.id): return
     await state.update_data(product_id=callback.data.split("_")[-1])
     await state.set_state(ShopState.edit_price)
     await callback.message.answer("Новая цена (число):")
@@ -36,7 +36,7 @@ async def edit_price_finish(message: types.Message, state: FSMContext):
 
 @router.callback_query(F.data.startswith("del_confirm_"))
 async def delete_item(callback: CallbackQuery):
-    if callback.from_user.id != settings.ADMIN_ID: return
+    if not settings.is_admin_user(callback.from_user.id): return
     
     async with async_session_maker() as session:
         try:

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -63,7 +63,7 @@ async def _render_search_results(message: types.Message, query: str, products: l
         f"🔎 Нашел {len(selected_products)} вариантов по запросу «{html.escape(query)}».",
         parse_mode="HTML",
     )
-    is_admin = message.from_user.id == settings.ADMIN_ID if message.from_user else False
+    is_admin = settings.is_admin_user(message.from_user.id if message.from_user else None)
     for product in selected_products:
         await send_product_card(message, product, is_admin)
 
@@ -159,7 +159,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
             limit=5  # Максимум 5 результатов
         )
     
-    is_admin = callback.from_user.id == settings.ADMIN_ID
+    is_admin = settings.is_admin_user(callback.from_user.id)
     
     if not products:
         await callback.message.answer(
@@ -194,7 +194,7 @@ async def search_details(callback: CallbackQuery):
         await callback.answer("Товар не найден", show_alert=True)
         return
 
-    is_admin = callback.from_user.id == settings.ADMIN_ID
+    is_admin = settings.is_admin_user(callback.from_user.id)
     await send_product_card(callback, product, is_admin)
     await callback.answer()
 

--- a/bot_app/handlers/favorites.py
+++ b/bot_app/handlers/favorites.py
@@ -20,7 +20,7 @@ async def show_favorites(message: types.Message):
         return
         
     await message.answer(f"⭐ Ваши избранные товары ({len(favs)}):")
-    is_admin = user_id == settings.ADMIN_ID
+    is_admin = settings.is_admin_user(user_id)
     for product in favs:
         await send_product_card(message, product, is_admin)
 
@@ -35,7 +35,7 @@ async def process_fav_toggle(callback: CallbackQuery):
     status_msg = "Добавлено в избранное! ❤️" if is_added else "Удалено из избранного. 💔"
     
     # Update the keyboard on the existing message
-    is_admin = user_id == settings.ADMIN_ID
+    is_admin = settings.is_admin_user(user_id)
     new_kb = get_product_keyboard(product_id, is_admin, in_favorites=is_added)
     
     try:

--- a/core/config.py
+++ b/core/config.py
@@ -43,6 +43,9 @@ class Settings(BaseSettings):
         if self.ADMIN_ID and self.ADMIN_ID not in ids:
             ids.append(int(self.ADMIN_ID))
         return ids
+
+    def is_admin_user(self, user_id: int | None) -> bool:
+        return user_id is not None and int(user_id) in self.admin_list
     
     # Database Settings
     POSTGRES_USER: str = "postgres"

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -67,11 +67,12 @@ async def test_edit_price_finish_calls_service(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete_item_uses_callback_answer(monkeypatch):
     monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
-    monkeypatch.setattr(admin_handler.settings, "ADMIN_ID", 1, raising=False)
+    monkeypatch.setattr(admin_handler.settings, "ADMIN_ID", 0, raising=False)
+    monkeypatch.setattr(admin_handler.settings, "ADMIN_IDS", "1,2", raising=False)
     service_mock = AsyncMock(return_value=False)
     monkeypatch.setattr(admin_handler.ProductService, "delete", service_mock)
 
-    callback = _DummyCallback(data="del_confirm_10", user_id=1)
+    callback = _DummyCallback(data="del_confirm_10", user_id=2)
     await admin_handler.delete_item(callback)
 
     service_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

- add `settings.is_admin_user(...)` as the shared admin membership check
- switch Telegram bot admin affordances from single `ADMIN_ID` checks to `ADMIN_ID` + `ADMIN_IDS`
- cover the multi-admin path in the bot admin handler unit test

## Context

Notifications already iterate over `settings.admin_list`, but product admin actions and admin-only bot buttons still treated only `ADMIN_ID` as an admin. This makes the new companion ID receive notifications while missing some bot-side admin behavior.

This keeps the current env-based approach for now and leaves the fuller user/role migration to #339.

## Validation

- `python3 -m pytest tests/unit/test_bot_admin_handler.py tests/unit/test_notification_service.py tests/unit/test_website_lead_service.py -q`