### PR TITLE
[codex] Add Energolux import queue and normalization

### DIFF
--- a/alembic/versions/8b61a5d4c3e2_add_catalog_import_jobs.py
+++ b/alembic/versions/8b61a5d4c3e2_add_catalog_import_jobs.py
@@ -1,0 +1,56 @@
+"""add catalog import jobs
+
+Revision ID: 8b61a5d4c3e2
+Revises: 7d2a1c9b4e11
+Create Date: 2026-05-23 18:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8b61a5d4c3e2"
+down_revision: Union[str, Sequence[str], None] = "7d2a1c9b4e11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "catalog_import_job",
+        sa.Column("job_id", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="queued"),
+        sa.Column("stage", sa.String(), nullable=False, server_default="queued"),
+        sa.Column("error", sa.String(), nullable=True),
+        sa.Column("input_urls", sa.JSON(), nullable=False),
+        sa.Column("with_related", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("update_existing", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("input_total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("processed", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("pending", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("success_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("error_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("current_url", sa.String(), nullable=True),
+        sa.Column("current_title", sa.String(), nullable=True),
+        sa.Column("successes", sa.JSON(), nullable=False),
+        sa.Column("errors", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("job_id"),
+    )
+    op.create_index("ix_catalog_import_job_status", "catalog_import_job", ["status"], unique=False)
+    op.create_index("ix_catalog_import_job_stage", "catalog_import_job", ["stage"], unique=False)
+    op.create_index("ix_catalog_import_job_created_at", "catalog_import_job", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_catalog_import_job_created_at", table_name="catalog_import_job")
+    op.drop_index("ix_catalog_import_job_stage", table_name="catalog_import_job")
+    op.drop_index("ix_catalog_import_job_status", table_name="catalog_import_job")
+    op.drop_table("catalog_import_job")

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -15,6 +15,12 @@ async def _seed_installation_defaults() -> None:
         await InstallationService.seed_defaults(session)
 
 
+async def _resume_catalog_import_jobs() -> None:
+    from services.catalog_import_runtime_service import catalog_import_runtime_service
+
+    await catalog_import_runtime_service.resume_pending_jobs()
+
+
 def _start_scheduler_loop() -> None:
     from services.scheduler_service import scheduler_service
 
@@ -29,6 +35,7 @@ async def app_lifespan(app: FastAPI):
 
     await init_db()
     await _seed_installation_defaults()
+    await _resume_catalog_import_jobs()
     _start_scheduler_loop()
 
     yield

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -59,6 +59,8 @@ import {
     type ManagerBackupRunStatusResponse,
     type ManagerRestoreJobStartResponse,
     type ManagerRestoreJobStatusResponse,
+    type CatalogImportJobStartResponse,
+    type CatalogImportJobStatusResponse,
     type ManagerBrandResponse,
     type ManagerBrandCreatePayload,
     type ManagerBrandUpdatePayload,
@@ -80,6 +82,8 @@ export type {
     ManagerBackupRunStatusResponse,
     ManagerRestoreJobStartResponse,
     ManagerRestoreJobStatusResponse,
+    CatalogImportJobStartResponse,
+    CatalogImportJobStatusResponse,
 };
 export type {
     ManagerInstallEstimateCalculatePayload,
@@ -670,6 +674,26 @@ export const api = {
             with_related: withRelated,
             update_existing: updateExisting,
         });
+    },
+
+    async startImportProductsJob(
+        urls: string[],
+        withRelated: boolean,
+        updateExisting: boolean,
+    ): Promise<CatalogImportJobStartResponse> {
+        return await ManagerService.startCatalogImportJob({
+            urls,
+            with_related: withRelated,
+            update_existing: updateExisting,
+        });
+    },
+
+    async getImportProductsJobStatus(jobId: string): Promise<CatalogImportJobStatusResponse> {
+        return await ManagerService.getCatalogImportJobStatus(jobId);
+    },
+
+    async getCurrentImportProductsJobStatus(): Promise<CatalogImportJobStatusResponse> {
+        return await ManagerService.getCurrentCatalogImportJobStatus();
     },
 
     /** @deprecated Use importProducts() — kept for backward compatibility */

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -30,6 +30,8 @@ export type { BulkSpecUpdate } from './models/BulkSpecUpdate';
 export type { CalendarEventResponse } from './models/CalendarEventResponse';
 export type { CalendarEventType } from './models/CalendarEventType';
 export type { CartItemPayload } from './models/CartItemPayload';
+export type { CatalogImportJobStartResponse } from './models/CatalogImportJobStartResponse';
+export type { CatalogImportJobStatusResponse } from './models/CatalogImportJobStatusResponse';
 export type { CatalogImportPayload } from './models/CatalogImportPayload';
 export type { CatalogImportResultResponse } from './models/CatalogImportResultResponse';
 export type { CatalogResponse } from './models/CatalogResponse';

--- a/manager_frontend/src/client/models/CatalogImportJobStartResponse.ts
+++ b/manager_frontend/src/client/models/CatalogImportJobStartResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CatalogImportJobStartResponse = {
+    job_id: string;
+    status: string;
+    stage: string;
+};
+

--- a/manager_frontend/src/client/models/CatalogImportJobStatusResponse.ts
+++ b/manager_frontend/src/client/models/CatalogImportJobStatusResponse.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CatalogImportJobStatusResponse = {
+    job_id: string;
+    status: string;
+    stage: string;
+    error?: (string | null);
+    started_at?: (string | null);
+    finished_at?: (string | null);
+    input_total?: number;
+    total?: number;
+    processed?: number;
+    pending?: number;
+    success_count?: number;
+    error_count?: number;
+    current_url?: (string | null);
+    current_title?: (string | null);
+    successes?: Array<string>;
+    errors?: Array<string>;
+};
+

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -9,6 +9,8 @@ import type { BulkGalleryDeleteRequest } from '../models/BulkGalleryDeleteReques
 import type { BulkProductIdsRequest } from '../models/BulkProductIdsRequest';
 import type { BulkRoundRequest } from '../models/BulkRoundRequest';
 import type { BulkSpecUpdate } from '../models/BulkSpecUpdate';
+import type { CatalogImportJobStartResponse } from '../models/CatalogImportJobStartResponse';
+import type { CatalogImportJobStatusResponse } from '../models/CatalogImportJobStatusResponse';
 import type { CatalogImportPayload } from '../models/CatalogImportPayload';
 import type { CatalogImportResultResponse } from '../models/CatalogImportResultResponse';
 import type { CommonGalleryImageResponse } from '../models/CommonGalleryImageResponse';
@@ -547,6 +549,58 @@ export class ManagerService {
             url: '/api/manager/catalog/import',
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Start Catalog Import Job
+     * Start a universal catalog import in the background and return a job id
+     * that can be polled for progress.
+     * @param requestBody
+     * @returns CatalogImportJobStartResponse Successful Response
+     * @throws ApiError
+     */
+    public static startCatalogImportJob(
+        requestBody: CatalogImportPayload,
+    ): CancelablePromise<CatalogImportJobStartResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/catalog/import/jobs',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Current Catalog Import Job Status
+     * @returns CatalogImportJobStatusResponse Successful Response
+     * @throws ApiError
+     */
+    public static getCurrentCatalogImportJobStatus(): CancelablePromise<CatalogImportJobStatusResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/catalog/import/jobs/current',
+        });
+    }
+    /**
+     * Get Catalog Import Job Status
+     * @param jobId
+     * @returns CatalogImportJobStatusResponse Successful Response
+     * @throws ApiError
+     */
+    public static getCatalogImportJobStatus(
+        jobId: string,
+    ): CancelablePromise<CatalogImportJobStatusResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/catalog/import/jobs/{job_id}',
+            path: {
+                'job_id': jobId,
+            },
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/OnlinerImportModal.vue
+++ b/manager_frontend/src/components/OnlinerImportModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue';
-import { api } from '../api';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { api, type CatalogImportJobStatusResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 const emit = defineEmits<{
@@ -14,12 +14,94 @@ const updateExisting = ref(false);
 const loading = ref(false);
 const result = ref<{ success_count: number; error_count: number; errors: string[] } | null>(null);
 const importError = ref('');
+const importJobId = ref('');
+const importProgress = ref<CatalogImportJobStatusResponse | null>(null);
+let pollTimer: ReturnType<typeof window.setInterval> | null = null;
+
+const importPresets = [
+  {
+    id: 'energolux-severcon',
+    label: 'Energolux',
+    source: 'Severcon',
+    url: 'https://www.severcon.ru/bitrix/catalog_export/yandex_187449.php',
+    withRelated: false,
+    updateExisting: true,
+  },
+];
 
 const parsedUrls = () =>
   urlsText.value
     .split('\n')
     .map((u) => u.trim())
     .filter(Boolean);
+
+const progressPercent = computed(() => {
+  const progress = importProgress.value;
+  if (!progress?.total) return 0;
+  return Math.min(100, Math.round(((progress.processed ?? 0) / progress.total) * 100));
+});
+
+const stageLabel = computed(() => {
+  const stage = importProgress.value?.stage;
+  if (stage === 'expanding') return 'Ищем товары';
+  if (stage === 'expanded') return 'Список найден';
+  if (stage === 'importing') return 'Импортируем';
+  if (stage === 'completed') return 'Готово';
+  if (stage === 'failed') return 'Ошибка';
+  return 'В очереди';
+});
+
+const isImportFinished = (status?: string) => status === 'success' || status === 'failed';
+
+const stopPolling = () => {
+  if (pollTimer !== null) {
+    window.clearInterval(pollTimer);
+    pollTimer = null;
+  }
+};
+
+const applyImportStatus = (status: CatalogImportJobStatusResponse) => {
+  importProgress.value = status;
+  importJobId.value = status.job_id;
+  loading.value = !isImportFinished(status.status);
+
+  if (status.status === 'success') {
+    result.value = {
+      success_count: status.success_count ?? 0,
+      error_count: status.error_count ?? 0,
+      errors: status.errors ?? [],
+    };
+  } else if (status.status === 'failed') {
+    importError.value = status.error || 'Импорт завершился с ошибкой';
+  }
+};
+
+const startPolling = () => {
+  stopPolling();
+  pollTimer = window.setInterval(() => {
+    void refreshImportStatus();
+  }, 1500);
+};
+
+const refreshImportStatus = async () => {
+  if (!importJobId.value) return;
+
+  try {
+    const status = await api.getImportProductsJobStatus(importJobId.value);
+    applyImportStatus(status);
+
+    if (isImportFinished(status.status)) {
+      stopPolling();
+      if (status.status === 'success' && (status.success_count ?? 0) > 0) {
+        emit('imported', status.success_count ?? 0);
+      }
+    }
+  } catch (e) {
+    stopPolling();
+    loading.value = false;
+    importError.value = getApiErrorMessage(e);
+  }
+};
 
 const handleImport = async () => {
   const urls = parsedUrls();
@@ -28,23 +110,50 @@ const handleImport = async () => {
   loading.value = true;
   result.value = null;
   importError.value = '';
+  importJobId.value = '';
+  importProgress.value = null;
+  stopPolling();
 
   try {
-    const res = await api.importProducts(urls, withRelated.value, updateExisting.value);
-    result.value = res;
-    if (res.success_count > 0) {
-      emit('imported', res.success_count);
-    }
+    const job = await api.startImportProductsJob(urls, withRelated.value, updateExisting.value);
+    importJobId.value = job.job_id;
+    startPolling();
+    await refreshImportStatus();
   } catch (e) {
     importError.value = getApiErrorMessage(e);
-  } finally {
     loading.value = false;
   }
 };
 
-const handleClose = () => {
-  if (!loading.value) emit('close');
+const applyImportPreset = (preset: (typeof importPresets)[number]) => {
+  if (loading.value) return;
+  urlsText.value = preset.url;
+  withRelated.value = preset.withRelated;
+  updateExisting.value = preset.updateExisting;
+  result.value = null;
+  importError.value = '';
 };
+
+const handleClose = () => {
+  emit('close');
+};
+
+const restoreCurrentImportJob = async () => {
+  try {
+    const status = await api.getCurrentImportProductsJobStatus();
+    applyImportStatus(status);
+    if (!isImportFinished(status.status)) {
+      startPolling();
+    }
+  } catch {
+    // No import job has been started in this app process.
+  }
+};
+
+onMounted(() => {
+  void restoreCurrentImportJob();
+});
+onBeforeUnmount(stopPolling);
 </script>
 
 <template>
@@ -56,7 +165,7 @@ const handleClose = () => {
         @click.self="handleClose"
       >
         <div
-          class="w-full max-w-lg rounded-2xl bg-[#1e293b] border border-slate-700/60 shadow-2xl flex flex-col overflow-hidden"
+          class="w-full max-w-2xl rounded-2xl bg-[#1e293b] border border-slate-700/60 shadow-2xl flex flex-col overflow-hidden"
           style="max-height: 90vh"
         >
           <!-- Header -->
@@ -67,8 +176,7 @@ const handleClose = () => {
             </div>
             <button
               @click="handleClose"
-              :disabled="loading"
-              class="text-slate-400 hover:text-white transition-colors disabled:opacity-40"
+              class="text-slate-400 hover:text-white transition-colors"
             >
               <span class="material-icons-round text-xl">close</span>
             </button>
@@ -76,6 +184,26 @@ const handleClose = () => {
 
           <!-- Body -->
           <div class="px-6 py-5 space-y-5 overflow-y-auto">
+            <div>
+              <p class="block text-sm font-medium text-slate-300 mb-2">Готовые источники</p>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <button
+                  v-for="preset in importPresets"
+                  :key="preset.id"
+                  type="button"
+                  :disabled="loading"
+                  @click="applyImportPreset(preset)"
+                  class="flex items-center justify-between gap-3 rounded-xl border border-slate-700 bg-slate-800/60 px-4 py-3 text-left transition-colors hover:border-teal-500/60 hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span>
+                    <span class="block text-sm font-semibold text-slate-100">{{ preset.label }}</span>
+                    <span class="block text-xs text-slate-500 mt-0.5">{{ preset.source }}</span>
+                  </span>
+                  <span class="material-icons-round text-teal-400 text-xl">sync</span>
+                </button>
+              </div>
+            </div>
+
             <!-- URL textarea -->
             <div>
               <label class="block text-sm font-medium text-slate-300 mb-2">
@@ -86,7 +214,7 @@ const handleClose = () => {
                 v-model="urlsText"
                 :disabled="loading"
                 rows="7"
-                placeholder="https://catalog.onliner.by/split_systems/midea/msmb-09hrn8-wifib&#10;https://aircond.by/split-sistemy/mdv-integra-pro-inverter-...&#10;https://tvoy-klimat.by/catalog/bytovye-konditsionery/..."
+                placeholder="https://www.severcon.ru/bitrix/catalog_export/yandex_187449.php&#10;https://catalog.onliner.by/split_systems/midea/msmb-09hrn8-wifib&#10;https://aircond.by/split-sistemy/mdv-integra-pro-inverter-..."
                 class="w-full rounded-xl border border-slate-600 bg-slate-900 text-slate-100 placeholder-slate-600 text-sm px-4 py-3 resize-none outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all disabled:opacity-50"
               />
               <p class="text-xs text-slate-500 mt-1.5">
@@ -141,6 +269,60 @@ const handleClose = () => {
               </div>
             </label>
 
+            <!-- Progress -->
+            <div
+              v-if="loading || importProgress"
+              class="rounded-xl border border-slate-700 bg-slate-900/70 px-4 py-4 text-sm text-slate-200 space-y-3"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <p class="font-semibold text-slate-100">{{ stageLabel }}</p>
+                  <p v-if="loading" class="text-xs text-teal-300 mt-0.5">
+                    Идёт в фоне, окно можно закрыть и открыть позже
+                  </p>
+                  <p v-if="importProgress?.current_title" class="text-xs text-slate-400 mt-0.5">
+                    {{ importProgress.current_title }}
+                  </p>
+                  <p v-else-if="importProgress?.current_url" class="text-xs text-slate-400 mt-0.5 break-all">
+                    {{ importProgress.current_url }}
+                  </p>
+                </div>
+                <span class="tabular-nums text-lg font-bold text-teal-300">{{ progressPercent }}%</span>
+              </div>
+
+              <div class="h-2 overflow-hidden rounded-full bg-slate-800">
+                <div
+                  class="h-full rounded-full bg-teal-500 transition-all duration-500"
+                  :style="{ width: `${progressPercent}%` }"
+                />
+              </div>
+
+              <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <div class="rounded-lg bg-slate-800/70 px-3 py-2">
+                  <p class="text-[11px] uppercase tracking-wide text-slate-500">Найдено</p>
+                  <p class="mt-0.5 font-semibold text-slate-100 tabular-nums">{{ importProgress?.total || 0 }}</p>
+                </div>
+                <div class="rounded-lg bg-slate-800/70 px-3 py-2">
+                  <p class="text-[11px] uppercase tracking-wide text-slate-500">Готово</p>
+                  <p class="mt-0.5 font-semibold text-slate-100 tabular-nums">{{ importProgress?.processed || 0 }}</p>
+                </div>
+                <div class="rounded-lg bg-slate-800/70 px-3 py-2">
+                  <p class="text-[11px] uppercase tracking-wide text-slate-500">Успешно</p>
+                  <p class="mt-0.5 font-semibold text-emerald-300 tabular-nums">{{ importProgress?.success_count || 0 }}</p>
+                </div>
+                <div class="rounded-lg bg-slate-800/70 px-3 py-2">
+                  <p class="text-[11px] uppercase tracking-wide text-slate-500">Ошибки</p>
+                  <p class="mt-0.5 font-semibold text-amber-300 tabular-nums">{{ importProgress?.error_count || 0 }}</p>
+                </div>
+              </div>
+
+              <ul v-if="importProgress?.errors?.length" class="space-y-1 text-xs text-amber-300">
+                <li v-for="(err, i) in importProgress.errors?.slice(-3) || []" :key="i" class="break-words">
+                  {{ err }}
+                </li>
+              </ul>
+            </div>
+
             <!-- Result -->
             <div v-if="result" class="rounded-xl border px-4 py-3 text-sm space-y-1"
               :class="result.error_count === 0
@@ -166,10 +348,9 @@ const handleClose = () => {
           <div class="px-6 py-4 border-t border-slate-700/50 flex justify-end gap-3">
             <button
               @click="handleClose"
-              :disabled="loading"
-              class="px-4 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-700 transition-colors disabled:opacity-40"
+              class="px-4 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-700 transition-colors"
             >
-              Закрыть
+              {{ loading ? 'Скрыть' : 'Закрыть' }}
             </button>
             <button
               @click="handleImport"
@@ -203,10 +384,10 @@ const handleClose = () => {
 .modal-fade-leave-active .w-full {
   transition: transform 0.2s ease;
 }
-.modal-fade-enter-from .max-w-lg {
+.modal-fade-enter-from .max-w-2xl {
   transform: scale(0.96) translateY(8px);
 }
-.modal-fade-leave-to .max-w-lg {
+.modal-fade-leave-to .max-w-2xl {
   transform: scale(0.96) translateY(8px);
 }
 </style>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -15,6 +15,7 @@ from .common import (
 from .customer import Customer, CustomerBranch, CustomerContract, Lead
 from .brand import Brand, ProductSeries
 from .cart import Cart, CartItem
+from .catalog_import import CatalogImportJob
 from .content import Article, GlobalConfig
 from .order import (
     BankReceipt,
@@ -65,6 +66,7 @@ __all__ = [
     "Cart",
     "CartItem",
     "Brand",
+    "CatalogImportJob",
     "Customer",
     "CustomerBranch",
     "CustomerContract",

--- a/models/catalog_import.py
+++ b/models/catalog_import.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, JSON
+from sqlmodel import Field, SQLModel
+
+
+class CatalogImportJob(SQLModel, table=True):
+    __tablename__ = "catalog_import_job"
+
+    job_id: str = Field(primary_key=True)
+    status: str = Field(default="queued", index=True)
+    stage: str = Field(default="queued", index=True)
+    error: Optional[str] = None
+
+    input_urls: list[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    with_related: bool = Field(default=False)
+    update_existing: bool = Field(default=False)
+
+    input_total: int = Field(default=0)
+    total: int = Field(default=0)
+    processed: int = Field(default=0)
+    pending: int = Field(default=0)
+    success_count: int = Field(default=0)
+    error_count: int = Field(default=0)
+    current_url: Optional[str] = None
+    current_title: Optional[str] = None
+    successes: list[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    errors: list[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+
+    created_at: datetime = Field(default_factory=datetime.now, index=True)
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    updated_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_column_kwargs={"onupdate": datetime.now},
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -3044,6 +3044,126 @@
         ]
       }
     },
+    "/api/manager/catalog/import/jobs": {
+      "post": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Start Catalog Import Job",
+        "description": "Start a universal catalog import in the background and return a job id\nthat can be polled for progress.",
+        "operationId": "start_catalog_import_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CatalogImportPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogImportJobStartResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/manager/catalog/import/jobs/current": {
+      "get": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Get Current Catalog Import Job Status",
+        "operationId": "get_current_catalog_import_job_status",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogImportJobStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/manager/catalog/import/jobs/{job_id}": {
+      "get": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Get Catalog Import Job Status",
+        "operationId": "get_catalog_import_job_status",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogImportJobStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/search-images": {
       "post": {
         "tags": [
@@ -10802,6 +10922,153 @@
         },
         "type": "object",
         "title": "CartItemPayload"
+      },
+      "CatalogImportJobStartResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "stage": {
+            "type": "string",
+            "title": "Stage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "stage"
+        ],
+        "title": "CatalogImportJobStartResponse"
+      },
+      "CatalogImportJobStatusResponse": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "stage": {
+            "type": "string",
+            "title": "Stage"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "input_total": {
+            "type": "integer",
+            "title": "Input Total",
+            "default": 0
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "default": 0
+          },
+          "processed": {
+            "type": "integer",
+            "title": "Processed",
+            "default": 0
+          },
+          "pending": {
+            "type": "integer",
+            "title": "Pending",
+            "default": 0
+          },
+          "success_count": {
+            "type": "integer",
+            "title": "Success Count",
+            "default": 0
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count",
+            "default": 0
+          },
+          "current_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Url"
+          },
+          "current_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Title"
+          },
+          "successes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Successes"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "stage"
+        ],
+        "title": "CatalogImportJobStatusResponse"
       },
       "CatalogImportPayload": {
         "properties": {

--- a/parsers/severcon.py
+++ b/parsers/severcon.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+from xml.etree import ElementTree as ET
+
+import httpx
+import slugify
+
+from .base import BaseParser
+
+
+class SeverconEnergoluxParser(BaseParser):
+    """Parser for Energolux products from the Severcon YML/XML feed."""
+
+    FEED_URL = "https://www.severcon.ru/bitrix/catalog_export/yandex_187449.php"
+    SOURCE_NAME = "severcon"
+    _HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/122.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/xml,text/xml,*/*",
+    }
+    _EXCLUDED_MARKERS = (
+        "аксессуар",
+        "инфракрасн",
+        "конвектор",
+        "нагревател",
+        "обогревател",
+        "охладител",
+        "рекуператор",
+        "стойка",
+        "штатив",
+    )
+    _INCLUDED_MARKERS = (
+        "блок",
+        "кондиционер",
+        "система кондиционирования",
+        "сплит-система",
+        "тепловой насос",
+    )
+
+    def __init__(self) -> None:
+        self._feed_cache: dict[str, tuple[dict[str, str], dict[str, ET.Element]]] = {}
+
+    def supports(self, url: str) -> bool:
+        parts = urlsplit(url.strip())
+        return parts.netloc.endswith("severcon.ru") and parts.path.endswith(
+            "/bitrix/catalog_export/yandex_187449.php"
+        )
+
+    async def get_import_urls(self, url: str) -> List[str]:
+        """Expand the feed URL into stable per-offer pseudo-URLs."""
+        normalized_url = self._feed_url_without_offer(url)
+        if self._offer_id_from_url(url):
+            return [url]
+
+        categories, offers = await self._load_feed(normalized_url)
+        urls: List[str] = []
+        for offer_id, offer in offers.items():
+            if self._is_importable_offer(offer, categories):
+                urls.append(self._offer_url(normalized_url, offer_id))
+        return urls
+
+    async def parse(self, url: str) -> Dict[str, Any]:
+        feed_url = self._feed_url_without_offer(url)
+        offer_id = self._offer_id_from_url(url)
+        categories, offers = await self._load_feed(feed_url)
+
+        if not offer_id:
+            eligible = [
+                oid for oid, offer in offers.items() if self._is_importable_offer(offer, categories)
+            ]
+            if not eligible:
+                raise ValueError("Severcon feed does not contain importable Energolux offers.")
+            offer_id = eligible[0]
+
+        offer = offers.get(offer_id)
+        if offer is None:
+            raise ValueError(f"Severcon offer #{offer_id} was not found in the feed.")
+        if not self._is_importable_offer(offer, categories):
+            raise ValueError(f"Severcon offer #{offer_id} is not an importable Energolux HVAC item.")
+
+        name = self._text(offer, "name") or "Energolux"
+        offer_url = self._text(offer, "url")
+        category = categories.get(self._text(offer, "categoryId"), "")
+        params = self._params(offer)
+        specs = self._specs(offer=offer, params=params, category=category, offer_id=offer_id)
+        metrics = self._metrics(specs=specs, title=name, category=category)
+        pictures = self._pictures(offer=offer, params=params)
+        article = specs.get("Артикул") or offer_id
+        title = self._display_title(raw_title=name, specs=specs, category=category)
+
+        return {
+            "title": title,
+            "slug": self._slug(offer_url=offer_url, title=name, article=article),
+            "description": self._clean_text(self._text(offer, "description")),
+            "price": int(self._price(offer)),
+            "price_currency": (self._text(offer, "currencyId") or "RUB").upper(),
+            "area": metrics["area"],
+            "main_image": pictures[0] if pictures else "",
+            "images": pictures[1:] if len(pictures) > 1 else [],
+            "save_gallery": True,
+            "categories": [],
+            "specs": specs,
+            "metrics": metrics,
+            "related_urls": [],
+            "availability": "В наличии",
+            "in_stock": True,
+            "refresh_title_on_update": True,
+        }
+
+    async def _load_feed(self, feed_url: str) -> tuple[dict[str, str], dict[str, ET.Element]]:
+        if feed_url in self._feed_cache:
+            return self._feed_cache[feed_url]
+
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=30.0,
+            headers=self._HEADERS,
+        ) as client:
+            response = await client.get(feed_url)
+            if response.status_code != 200:
+                raise Exception(f"Ошибка загрузки XML Severcon: {response.status_code}")
+
+        try:
+            root = ET.fromstring(response.content)
+        except ET.ParseError as exc:
+            raise ValueError("Severcon XML feed could not be parsed.") from exc
+
+        shop = root.find("shop")
+        if shop is None:
+            raise ValueError("Severcon XML feed does not contain shop node.")
+
+        categories = {
+            str(category.attrib.get("id", "")).strip(): self._clean_text("".join(category.itertext()))
+            for category in shop.findall("./categories/category")
+        }
+        offers = {
+            str(offer.attrib.get("id", "")).strip(): offer
+            for offer in shop.findall("./offers/offer")
+            if str(offer.attrib.get("id", "")).strip()
+        }
+        self._feed_cache[feed_url] = (categories, offers)
+        return categories, offers
+
+    @classmethod
+    def _feed_url_without_offer(cls, url: str) -> str:
+        parts = urlsplit(url.strip())
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+    @classmethod
+    def _offer_id_from_url(cls, url: str) -> str:
+        parts = urlsplit(url.strip())
+        fragment_params = parse_qs(parts.fragment)
+        query_params = parse_qs(parts.query)
+        for params in (fragment_params, query_params):
+            for key in ("offer", "offer_id", "id"):
+                value = params.get(key)
+                if value and value[0]:
+                    return value[0].strip()
+        return ""
+
+    @classmethod
+    def _offer_url(cls, feed_url: str, offer_id: str) -> str:
+        parts = urlsplit(feed_url)
+        return urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, "", urlencode({"offer": offer_id}))
+        )
+
+    @staticmethod
+    def _text(parent: ET.Element, tag: str) -> str:
+        child = parent.find(tag)
+        if child is None:
+            return ""
+        return SeverconEnergoluxParser._clean_text("".join(child.itertext()))
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        return re.sub(r"\s+", " ", str(value or "").replace("\xa0", " ")).strip()
+
+    @classmethod
+    def _params(cls, offer: ET.Element) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for param in offer.findall("param"):
+            key = cls._clean_text(param.attrib.get("name", "")).rstrip(":")
+            value = cls._clean_text("".join(param.itertext()))
+            if not key or not value:
+                continue
+            if key not in result:
+                result[key] = value
+        return result
+
+    @classmethod
+    def _price(cls, offer: ET.Element) -> Decimal:
+        raw = cls._text(offer, "price").replace(" ", "").replace(",", ".")
+        try:
+            return Decimal(raw)
+        except (InvalidOperation, ValueError):
+            return Decimal("0")
+
+    @classmethod
+    def _is_importable_offer(cls, offer: ET.Element, categories: dict[str, str]) -> bool:
+        vendor = cls._text(offer, "vendor")
+        name = cls._text(offer, "name")
+        category = categories.get(cls._text(offer, "categoryId"), "")
+        combined = f"{vendor} {name} {category}".lower().replace("ё", "е")
+        if "energolux" not in combined:
+            return False
+        if cls._price(offer) <= Decimal("1"):
+            return False
+        if any(marker in combined for marker in cls._EXCLUDED_MARKERS):
+            return False
+        return any(marker in combined for marker in cls._INCLUDED_MARKERS)
+
+    @classmethod
+    def _specs(
+        cls,
+        *,
+        offer: ET.Element,
+        params: Dict[str, str],
+        category: str,
+        offer_id: str,
+    ) -> Dict[str, Any]:
+        specs: Dict[str, Any] = {
+            key: value
+            for key, value in params.items()
+            if key not in {"Доп. фото", "Цена по запросу"}
+        }
+        specs.setdefault("Бренд", cls._text(offer, "vendor") or "Energolux")
+        specs.setdefault("Артикул", params.get("Артикул") or offer_id)
+        cls._reconcile_models_from_article(specs)
+        specs["Категория поставщика"] = category
+        specs["ID предложения Severcon"] = offer_id
+        source_url = cls._text(offer, "url")
+        if source_url:
+            specs["URL поставщика"] = source_url
+        warranty = cls._text(offer, "manufacturer_warranty")
+        if warranty:
+            specs.setdefault("Гарантия", warranty)
+
+        inferred_type = cls._infer_type(title=cls._text(offer, "name"), category=category)
+        if inferred_type:
+            specs.setdefault("Тип", inferred_type)
+        indoor_type = cls._infer_indoor_type(title=cls._text(offer, "name"), category=category)
+        if indoor_type:
+            specs.setdefault("Тип внутреннего блока", indoor_type)
+        series = cls._series_from_category(category)
+        if series:
+            specs.setdefault("Серия", series)
+        inverter_type = cls._infer_inverter_type(
+            title=cls._text(offer, "name"),
+            category=category,
+            current=specs.get("Тип управления компрессором"),
+        )
+        if inverter_type:
+            specs.setdefault("Тип управления компрессором", inverter_type)
+        return specs
+
+    @classmethod
+    def _reconcile_models_from_article(cls, specs: Dict[str, Any]) -> None:
+        article = cls._clean_text(str(specs.get("Артикул") or ""))
+        if "/" not in article:
+            return
+        parts = [cls._clean_text(part) for part in article.split("/") if cls._clean_text(part)]
+        if len(parts) < 2:
+            return
+        specs["Модель внутреннего блока"] = parts[0]
+        specs["Модель наружного блока"] = parts[1]
+
+    @classmethod
+    def _pictures(cls, *, offer: ET.Element, params: Dict[str, str]) -> List[str]:
+        urls: List[str] = []
+        for picture in offer.findall("picture"):
+            value = cls._clean_text("".join(picture.itertext()))
+            if value and value not in urls:
+                urls.append(value)
+        for value in re.split(r"\s*,\s*", params.get("Доп. фото", "")):
+            if value and value not in urls:
+                urls.append(value)
+        return urls
+
+    @classmethod
+    def _slug(cls, *, offer_url: str, title: str, article: str) -> str:
+        if offer_url:
+            path = urlsplit(offer_url).path.rstrip("/")
+            last = path.rsplit("/", 1)[-1]
+            if last.endswith(".html"):
+                last = last[:-5]
+            if last:
+                return slugify.slugify(last)
+        return slugify.slugify(f"energolux-{article or title}")
+
+    @classmethod
+    def _metrics(cls, *, specs: Dict[str, Any], title: str, category: str = "") -> Dict[str, Any]:
+        cooling_kw = cls._parse_first_number(str(specs.get("Холодопроизводительность") or ""))
+        area = int(round(cooling_kw * 10)) if cooling_kw else 0
+        combined = " ".join(
+            [
+                str(specs.get("Тип управления компрессором") or ""),
+                title,
+                category,
+            ]
+        ).lower().replace("ё", "е")
+        combined = combined.replace("—", "-")
+        is_inverter = False
+        if cls._has_on_off_marker(combined):
+            is_inverter = False
+        elif "инвертор" in combined or "inverter" in combined:
+            is_inverter = True
+        return {
+            "area": area,
+            "is_inverter": is_inverter,
+            "power_cooling": cooling_kw,
+        }
+
+    @staticmethod
+    def _parse_first_number(value: str) -> float | None:
+        if not value:
+            return None
+        match = re.search(r"(-?\d[\d\s]*(?:[.,]\d+)?)", value.replace("\xa0", " "))
+        if not match:
+            return None
+        try:
+            return float(match.group(1).replace(" ", "").replace(",", "."))
+        except ValueError:
+            return None
+
+    @classmethod
+    def _infer_type(cls, *, title: str, category: str) -> str:
+        combined = f"{title} {category}".lower().replace("ё", "е")
+        if "наружн" in combined and "блок" in combined:
+            return "наружный блок"
+        if "внутренн" in combined and "блок" in combined:
+            return "внутренний блок"
+        if "блок" in combined and any(
+            marker in combined
+            for marker in ("настенн", "кассет", "каналь", "напольно", "потолоч", "колонн")
+        ):
+            return "внутренний блок"
+        if "мульти" in combined or "multi" in combined:
+            return "мульти-сплит-система"
+        if "сплит" in combined:
+            return "сплит-система"
+        if "тепловой насос" in combined or "система кондиционирования" in combined:
+            return "сплит-система"
+        return ""
+
+    @classmethod
+    def _infer_indoor_type(cls, *, title: str, category: str) -> str:
+        combined = f"{title} {category}".lower().replace("ё", "е")
+        if "кассет" in combined:
+            return "кассетный"
+        if "каналь" in combined:
+            return "канальный"
+        if "напольно" in combined or "потолоч" in combined:
+            return "напольно-потолочный"
+        if "колонн" in combined:
+            return "колонный"
+        if "настенн" in combined:
+            return "настенный"
+        return ""
+
+    @classmethod
+    def _infer_inverter_type(cls, *, title: str, category: str, current: Any = None) -> str:
+        combined = f"{current or ''} {title} {category}".lower().replace("ё", "е")
+        combined = combined.replace("—", "-")
+        if cls._has_on_off_marker(combined) or "классическ" in combined:
+            return "On/Off"
+        if "инвертор" in combined or "inverter" in combined:
+            return "Инверторный"
+        return ""
+
+    @staticmethod
+    def _has_on_off_marker(text: str) -> bool:
+        normalized = text.lower().replace("ё", "е").replace("—", "-")
+        return bool(
+            "неинвертор" in normalized
+            or "on/off" in normalized
+            or "on-off" in normalized
+            or "on off" in normalized
+            or "onoff" in normalized
+        )
+
+    @classmethod
+    def _series_from_category(cls, category: str) -> str:
+        text = cls._clean_text(category)
+        if not text:
+            return ""
+
+        series_match = re.search(r"\bсер(?:ия|ии)\s+(.+)$", text, flags=re.IGNORECASE)
+        if series_match:
+            return cls._clean_series(series_match.group(1))
+
+        brand_match = re.search(r"energolux\s+(.+)$", text, flags=re.IGNORECASE)
+        if not brand_match:
+            return ""
+
+        candidate = brand_match.group(1)
+        return cls._clean_series(candidate)
+
+    @classmethod
+    def _clean_series(cls, value: str) -> str:
+        text = cls._clean_text(value)
+        text = re.sub(r"\bсер(?:ия|ии)\b", "", text, flags=re.IGNORECASE)
+        text = cls._clean_text(text.strip(" -/"))
+        generic = {
+            "настенный блок",
+            "настенные блоки",
+            "наружный блок",
+            "наружные блоки",
+            "канальные блоки",
+            "кассетные блоки",
+            "сплит-системы",
+        }
+        if text.lower().replace("ё", "е") in generic:
+            return ""
+        return text
+
+    @classmethod
+    def _display_title(cls, *, raw_title: str, specs: Dict[str, Any], category: str) -> str:
+        brand = cls._clean_text(str(specs.get("Бренд") or "Energolux"))
+        series = cls._clean_text(str(specs.get("Серия") or ""))
+        product_type = str(specs.get("Тип") or "")
+        indoor_type = str(specs.get("Тип внутреннего блока") or "")
+        model = cls._model_label(specs=specs, raw_title=raw_title, brand=brand, series=series)
+
+        if product_type == "внутренний блок":
+            prefix = cls._inner_block_title(indoor_type)
+            return cls._join_title_parts([prefix, brand, series, model])
+
+        if product_type == "наружный блок":
+            fallback_series = "" if series else cls._series_from_title(raw_title)
+            return cls._join_title_parts(["Наружный блок", brand, series or fallback_series, model])
+
+        descriptor = cls._semi_industrial_descriptor(indoor_type=indoor_type, title=raw_title, category=category)
+        if descriptor:
+            return cls._join_title_parts([descriptor, "кондиционер", brand, series, model])
+
+        if product_type == "сплит-система":
+            return cls._join_title_parts([brand, series, model]) or cls._clean_source_title(raw_title)
+
+        if product_type == "мульти-сплит-система":
+            return cls._join_title_parts(["Мульти-сплит-система", brand, series, model])
+
+        cleaned = cls._clean_source_title(raw_title)
+        if cleaned.lower().startswith(brand.lower()):
+            return cleaned
+        brand_pos = cleaned.lower().find(brand.lower())
+        if brand_pos >= 0:
+            return cls._clean_text(cleaned[brand_pos:])
+        return cls._join_title_parts([brand, series, model]) or cleaned
+
+    @classmethod
+    def _model_label(
+        cls,
+        *,
+        specs: Dict[str, Any],
+        raw_title: str,
+        brand: str,
+        series: str,
+    ) -> str:
+        article = cls._clean_text(str(specs.get("Артикул") or ""))
+        if "/" in article and not article.isdigit():
+            return article.replace(" / ", "/").replace(" /", "/").replace("/ ", "/")
+
+        indoor = cls._clean_text(str(specs.get("Модель внутреннего блока") or ""))
+        outdoor = cls._clean_text(str(specs.get("Модель наружного блока") or ""))
+        if indoor and outdoor:
+            return f"{indoor}/{outdoor}"
+        if indoor:
+            return indoor
+        if outdoor:
+            return outdoor
+
+        for key in ("Модель", "Артикул"):
+            value = cls._clean_text(str(specs.get(key) or ""))
+            if value and not value.isdigit():
+                return value
+
+        cleaned = cls._clean_source_title(raw_title)
+        tail = cleaned
+        for marker in (brand, series):
+            if not marker:
+                continue
+            match = re.search(re.escape(marker), tail, flags=re.IGNORECASE)
+            if match:
+                tail = tail[match.end() :]
+        return cls._clean_text(tail.strip(" -/"))
+
+    @classmethod
+    def _clean_source_title(cls, title: str) -> str:
+        text = cls._clean_text(title)
+        text = re.sub(
+            r"^(?:инверторная|классическая)?\s*система\s+кондиционирования\s+",
+            "",
+            text,
+            flags=re.IGNORECASE,
+        )
+        return cls._clean_text(text)
+
+    @classmethod
+    def _series_from_title(cls, title: str) -> str:
+        cleaned = cls._clean_source_title(title)
+        match = re.search(r"Energolux\s+(.+?)\s+[A-ZА-Я]{2,}[\wА-Яа-я/-]*", cleaned)
+        if not match:
+            return ""
+        candidate = cls._clean_series(match.group(1))
+        if candidate.lower().replace("ё", "е") in {"smart multi", "big multi"}:
+            return candidate
+        return ""
+
+    @staticmethod
+    def _join_title_parts(parts: List[str]) -> str:
+        return SeverconEnergoluxParser._clean_text(" ".join(str(part or "").strip() for part in parts if part))
+
+    @classmethod
+    def _semi_industrial_descriptor(cls, *, indoor_type: str, title: str, category: str) -> str:
+        combined = f"{indoor_type} {title} {category}".lower().replace("ё", "е")
+        if "кассет" in combined:
+            return "Кассетный"
+        if "каналь" in combined:
+            return "Канальный"
+        if "напольно" in combined or "потолоч" in combined:
+            return "Напольно-потолочный"
+        if "колон" in combined:
+            return "Колонный"
+        return ""
+
+    @classmethod
+    def _inner_block_title(cls, indoor_type: str) -> str:
+        normalized = indoor_type.lower().replace("ё", "е")
+        if "кассет" in normalized:
+            return "Внутренний кассетный блок"
+        if "каналь" in normalized:
+            return "Внутренний канальный блок"
+        if "напольно" in normalized or "потолоч" in normalized:
+            return "Внутренний напольно-потолочный блок"
+        if "колон" in normalized:
+            return "Внутренний колонный блок"
+        return "Внутренний блок"

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -1,6 +1,6 @@
 from typing import List, Literal, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
@@ -12,6 +12,8 @@ from routers.manager_operation_ids import (
     BULK_SET_RRC_PRICE,
     BULK_DELETE_MANAGER_PRODUCTS,
     CATALOG_IMPORT,
+    GET_CATALOG_IMPORT_JOB_STATUS,
+    GET_CURRENT_CATALOG_IMPORT_JOB_STATUS,
     GET_ALL_TAGS,
     GET_MANAGER_CUSTOMERS,
     GET_MANAGER_CUSTOMER_DETAIL,
@@ -27,11 +29,14 @@ from routers.manager_operation_ids import (
     UPDATE_PRODUCT,
     DELETE_MANAGER_PRODUCT,
     IMPORT_ONLINER,
+    START_CATALOG_IMPORT_JOB,
 )
 from schemas import (
     BulkRoundRequest,
     BulkProductIdsRequest,
     CatalogImportPayload,
+    CatalogImportJobStartResponse,
+    CatalogImportJobStatusResponse,
     CatalogImportResultResponse,
     ManagerActionMessageResponse,
     ManagerCatalogCustomerItemResponse,
@@ -51,6 +56,7 @@ from schemas import (
     OnlinerImportResultResponse,
     ProductUpdate,
 )
+from services.catalog_import_runtime_service import catalog_import_runtime_service
 from services.manager_catalog_service import ManagerCatalogService
 from services.document_service import DocumentService
 from services.importer_service import ImporterService
@@ -576,3 +582,63 @@ async def catalog_import(
         successes=results["success"],
         errors=results["errors"],
     )
+
+
+@router.post(
+    "/catalog/import/jobs",
+    response_model=CatalogImportJobStartResponse,
+    operation_id=START_CATALOG_IMPORT_JOB,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def start_catalog_import_job(
+    payload: CatalogImportPayload,
+    _user: str = Depends(get_current_username),
+):
+    """
+    Start a universal catalog import in the background and return a job id
+    that can be polled for progress.
+    """
+    urls = [u.strip() for u in payload.urls if u.strip()]
+    if not urls:
+        raise HTTPException(status_code=400, detail="No URLs provided")
+
+    job = await catalog_import_runtime_service.start_import(
+        urls=urls,
+        with_related=payload.with_related,
+        update_existing=payload.update_existing,
+    )
+
+    return CatalogImportJobStartResponse(
+        job_id=job["job_id"],
+        status=job["status"],
+        stage=job["stage"],
+    )
+
+
+@router.get(
+    "/catalog/import/jobs/current",
+    response_model=CatalogImportJobStatusResponse,
+    operation_id=GET_CURRENT_CATALOG_IMPORT_JOB_STATUS,
+)
+async def get_current_catalog_import_job_status(
+    _user: str = Depends(get_current_username),
+):
+    job = await catalog_import_runtime_service.get_current_job()
+    if not job:
+        raise HTTPException(status_code=404, detail="Catalog import job not found")
+    return CatalogImportJobStatusResponse(**job)
+
+
+@router.get(
+    "/catalog/import/jobs/{job_id}",
+    response_model=CatalogImportJobStatusResponse,
+    operation_id=GET_CATALOG_IMPORT_JOB_STATUS,
+)
+async def get_catalog_import_job_status(
+    job_id: str,
+    _user: str = Depends(get_current_username),
+):
+    job = await catalog_import_runtime_service.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Catalog import job not found")
+    return CatalogImportJobStatusResponse(**job)

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -92,6 +92,9 @@ GET_MANAGER_CRM_HEALTH_REPORT = "get_manager_crm_health_report"
 GET_DASHBOARD_STATS = "get_dashboard_stats"
 IMPORT_ONLINER = "import_onliner"
 CATALOG_IMPORT = "catalog_import"
+START_CATALOG_IMPORT_JOB = "start_catalog_import_job"
+GET_CATALOG_IMPORT_JOB_STATUS = "get_catalog_import_job_status"
+GET_CURRENT_CATALOG_IMPORT_JOB_STATUS = "get_current_catalog_import_job_status"
 
 GET_MANAGER_INSTALLERS = "get_manager_installers"
 CREATE_MANAGER_INSTALLER = "create_manager_installer"
@@ -315,4 +318,7 @@ ALL_MANAGER_OPERATION_IDS = (
     BULK_CREATE_SUPPLIER_MAPPINGS,
     GET_DOC_TEMPLATES,
     CATALOG_IMPORT,
+    START_CATALOG_IMPORT_JOB,
+    GET_CATALOG_IMPORT_JOB_STATUS,
+    GET_CURRENT_CATALOG_IMPORT_JOB_STATUS,
 )

--- a/schemas.py
+++ b/schemas.py
@@ -1654,6 +1654,31 @@ class CatalogImportResultResponse(BaseModel):
     errors: List[str]
 
 
+class CatalogImportJobStartResponse(BaseModel):
+    job_id: str
+    status: str
+    stage: str
+
+
+class CatalogImportJobStatusResponse(BaseModel):
+    job_id: str
+    status: str
+    stage: str
+    error: Optional[str] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    input_total: int = 0
+    total: int = 0
+    processed: int = 0
+    pending: int = 0
+    success_count: int = 0
+    error_count: int = 0
+    current_url: Optional[str] = None
+    current_title: Optional[str] = None
+    successes: List[str] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
+
+
 # Backward-compatible aliases for the legacy import-onliner endpoint
 OnlinerImportPayload = CatalogImportPayload
 OnlinerImportResultResponse = CatalogImportResultResponse

--- a/services/catalog_import_runtime_service.py
+++ b/services/catalog_import_runtime_service.py
@@ -1,0 +1,242 @@
+import asyncio
+from datetime import datetime
+from threading import Lock
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from core.database import async_session_maker
+from core.logger import logger
+from models import CatalogImportJob
+from services.importer_service import ImporterService
+
+
+ACTIVE_STATUSES = {"queued", "running"}
+
+
+class CatalogImportRuntimeService:
+    def __init__(self):
+        self._running_task_ids: set[str] = set()
+        self._lock = Lock()
+
+    @staticmethod
+    def _snapshot(job: CatalogImportJob) -> Dict[str, Any]:
+        return {
+            "job_id": job.job_id,
+            "status": job.status,
+            "stage": job.stage,
+            "error": job.error,
+            "started_at": job.started_at,
+            "finished_at": job.finished_at,
+            "input_total": job.input_total,
+            "total": job.total,
+            "processed": job.processed,
+            "pending": job.pending,
+            "success_count": job.success_count,
+            "error_count": job.error_count,
+            "current_url": job.current_url,
+            "current_title": job.current_title,
+            "successes": list(job.successes or []),
+            "errors": list(job.errors or []),
+        }
+
+    async def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        async with async_session_maker() as session:
+            job = await session.get(CatalogImportJob, job_id)
+            return self._snapshot(job) if job else None
+
+    async def get_current_job(self) -> Optional[Dict[str, Any]]:
+        async with async_session_maker() as session:
+            running = (
+                await session.execute(
+                    select(CatalogImportJob)
+                    .where(CatalogImportJob.status == "running")
+                    .order_by(CatalogImportJob.updated_at.desc())
+                )
+            ).scalars().first()
+            if running:
+                return self._snapshot(running)
+
+            queued = (
+                await session.execute(
+                    select(CatalogImportJob)
+                    .where(CatalogImportJob.status == "queued")
+                    .order_by(CatalogImportJob.created_at.asc())
+                )
+            ).scalars().first()
+            if queued:
+                return self._snapshot(queued)
+
+            latest = (
+                await session.execute(
+                    select(CatalogImportJob).order_by(CatalogImportJob.created_at.desc())
+                )
+            ).scalars().first()
+            return self._snapshot(latest) if latest else None
+
+    async def _set_job_fields(self, job_id: str, **updates: Any) -> None:
+        async with async_session_maker() as session:
+            job = await session.get(CatalogImportJob, job_id)
+            if not job:
+                return
+
+            for key, value in updates.items():
+                if hasattr(job, key):
+                    setattr(job, key, value)
+            job.updated_at = datetime.now()
+            session.add(job)
+            await session.commit()
+
+    def _schedule_job(self, job_id: str) -> bool:
+        with self._lock:
+            if job_id in self._running_task_ids:
+                return False
+            self._running_task_ids.add(job_id)
+
+        asyncio.create_task(self._run_import_job(job_id))
+        return True
+
+    async def _start_next_queued_job(self) -> None:
+        async with async_session_maker() as session:
+            running = (
+                await session.execute(
+                    select(CatalogImportJob.job_id).where(CatalogImportJob.status == "running")
+                )
+            ).scalars().first()
+            if running:
+                return
+
+            next_job_id = (
+                await session.execute(
+                    select(CatalogImportJob.job_id)
+                    .where(CatalogImportJob.status == "queued")
+                    .order_by(CatalogImportJob.created_at.asc())
+                )
+            ).scalars().first()
+
+        if next_job_id:
+            self._schedule_job(next_job_id)
+
+    async def resume_pending_jobs(self) -> None:
+        async with async_session_maker() as session:
+            stale_running = (
+                await session.execute(
+                    select(CatalogImportJob).where(CatalogImportJob.status == "running")
+                )
+            ).scalars().all()
+            for job in stale_running:
+                job.status = "queued"
+                job.stage = "queued"
+                job.error = None
+                job.updated_at = datetime.now()
+                session.add(job)
+            await session.commit()
+
+        await self._start_next_queued_job()
+
+    async def start_import(
+        self,
+        *,
+        urls: list[str],
+        with_related: bool,
+        update_existing: bool,
+    ) -> Dict[str, Any]:
+        job_id = uuid4().hex
+        now = datetime.now()
+        job = CatalogImportJob(
+            job_id=job_id,
+            status="queued",
+            stage="queued",
+            input_urls=list(urls),
+            with_related=with_related,
+            update_existing=update_existing,
+            input_total=len(urls),
+            created_at=now,
+            updated_at=now,
+        )
+
+        async with async_session_maker() as session:
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            snapshot = self._snapshot(job)
+
+        await self._start_next_queued_job()
+        return snapshot
+
+    async def _run_import_job(self, job_id: str) -> None:
+        importer = ImporterService()
+
+        async with async_session_maker() as session:
+            job = await session.get(CatalogImportJob, job_id)
+            if not job:
+                with self._lock:
+                    self._running_task_ids.discard(job_id)
+                return
+
+            urls = list(job.input_urls or [])
+            with_related = job.with_related
+            update_existing = job.update_existing
+
+        async def progress(payload: Dict[str, object]) -> None:
+            await self._set_job_fields(
+                job_id,
+                status="running",
+                **payload,
+            )
+
+        try:
+            await self._set_job_fields(
+                job_id,
+                status="running",
+                stage="expanding",
+                error=None,
+                started_at=datetime.now(),
+                finished_at=None,
+                total=0,
+                processed=0,
+                pending=0,
+                success_count=0,
+                error_count=0,
+                current_url=None,
+                current_title=None,
+                successes=[],
+                errors=[],
+            )
+            results = await importer.import_products_bulk(
+                urls,
+                with_related=with_related,
+                update_existing=update_existing,
+                progress_callback=progress,
+            )
+            processed = len(results["success"]) + len(results["errors"])
+            await self._set_job_fields(
+                job_id,
+                status="success",
+                stage="completed",
+                finished_at=datetime.now(),
+                total=processed,
+                processed=processed,
+                pending=0,
+                success_count=len(results["success"]),
+                error_count=len(results["errors"]),
+                successes=results["success"],
+                errors=results["errors"],
+            )
+        except Exception as exc:
+            logger.exception("Catalog import job failed: job_id=%s", job_id)
+            await self._set_job_fields(
+                job_id,
+                status="failed",
+                stage="failed",
+                error=str(exc),
+                finished_at=datetime.now(),
+            )
+        finally:
+            with self._lock:
+                self._running_task_ids.discard(job_id)
+            await self._start_next_queued_job()
+
+
+catalog_import_runtime_service = CatalogImportRuntimeService()

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -1,6 +1,6 @@
 import logging
 from decimal import Decimal
-from typing import List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 import slugify
 from sqlalchemy import select
@@ -12,6 +12,7 @@ from parsers.haierproff import HaierProffParser
 from parsers.hobot import HobotParser
 from parsers.lg24 import Lg24Parser
 from parsers.onliner import OnlinerParser
+from parsers.severcon import SeverconEnergoluxParser
 from parsers.tvoy_klimat import TvoyKlimatParser
 from core.database import async_session_maker
 from models import Product, ProductImage, Tag, TagGroup
@@ -30,6 +31,7 @@ from services.brand_series_service import sync_product_brand_series
 
 logger = logging.getLogger(__name__)
 _CATEGORY_TAG_SLUGS = {"cat-household", "cat-multi", "cat-industrial"}
+ImportProgressCallback = Callable[[Dict[str, object]], Awaitable[None]]
 
 
 def _augment_auto_slugs_with_wifi_specs(auto_slugs: List[str], specs: dict) -> List[str]:
@@ -152,6 +154,7 @@ class ImporterService:
             HobotParser(),
             TvoyKlimatParser(),
             OnlinerParser(),
+            SeverconEnergoluxParser(),
         ]
 
     def get_parser(self, url: str) -> Optional[BaseParser]:
@@ -333,7 +336,9 @@ class ImporterService:
                 gallery_image_urls = data.get("images", [])
 
             if existing and update_existing:
-                # Re-import mode: refresh key business fields, keep photos/slug/title intact.
+                # Re-import mode: refresh key business fields, keep photos/slug intact.
+                if data.get("refresh_title_on_update") and data.get("title"):
+                    existing.title = data["title"]
                 existing.description = data.get('description', existing.description)
                 existing.price = data.get('price', existing.price)
                 existing.area = data.get('area', existing.area)
@@ -429,6 +434,7 @@ class ImporterService:
         urls: List[str],
         with_related: bool = False,
         update_existing: bool = False,
+        progress_callback: Optional[ImportProgressCallback] = None,
     ) -> dict:
         """
         Imports multiple products and returns a summary of success/errors.
@@ -436,11 +442,81 @@ class ImporterService:
         """
         results = {"success": [], "errors": []}
         processed_urls = set()
-        pending_urls = [u.strip().replace('\r', '').replace('\n', '') for u in urls if u.strip()]
+        pending_urls: List[str] = []
+
+        async def emit_progress(**payload: object) -> None:
+            if progress_callback:
+                await progress_callback(payload)
+
+        await emit_progress(
+            stage="expanding",
+            input_total=len([u for u in urls if u.strip()]),
+            total=0,
+            processed=0,
+            pending=0,
+            success_count=0,
+            error_count=0,
+        )
+
+        for raw_url in urls:
+            url = raw_url.strip().replace('\r', '').replace('\n', '')
+            if not url:
+                continue
+            parser = self.get_parser(url)
+            expand = getattr(parser, "get_import_urls", None) if parser else None
+            if expand:
+                try:
+                    expanded_urls = await expand(url)
+                    logger.info(
+                        "Expanded import URL %s into %s product URL(s)",
+                        url,
+                        len(expanded_urls or []),
+                    )
+                    pending_urls.extend(expanded_urls or [url])
+                except Exception as exc:
+                    results["errors"].append(f"URL '{url}': {str(exc)}")
+                    await emit_progress(
+                        stage="expanding",
+                        current_url=url,
+                        total=len(pending_urls),
+                        processed=0,
+                        pending=len(pending_urls),
+                        success_count=0,
+                        error_count=len(results["errors"]),
+                    )
+            else:
+                pending_urls.append(url)
+
+        unique_pending_urls: List[str] = []
+        seen_pending_urls = set()
+        for pending_url in pending_urls:
+            if pending_url not in seen_pending_urls:
+                unique_pending_urls.append(pending_url)
+                seen_pending_urls.add(pending_url)
+        pending_urls = unique_pending_urls
+
+        await emit_progress(
+            stage="expanded",
+            total=len(pending_urls),
+            processed=0,
+            pending=len(pending_urls),
+            success_count=0,
+            error_count=len(results["errors"]),
+        )
 
         while pending_urls:
             url = pending_urls.pop(0)
             if url in processed_urls: continue
+
+            await emit_progress(
+                stage="importing",
+                current_url=url,
+                total=len(processed_urls) + len(pending_urls) + 1,
+                processed=len(processed_urls),
+                pending=len(pending_urls) + 1,
+                success_count=len(results["success"]),
+                error_count=len(results["errors"]),
+            )
             
             try:
                 res = await self.import_product(
@@ -459,8 +535,44 @@ class ImporterService:
                     for rel_url in res["related_urls"]:
                         if rel_url not in processed_urls and rel_url not in pending_urls:
                             pending_urls.append(rel_url)
+                await emit_progress(
+                    stage="importing",
+                    current_url=url,
+                    current_title=product.title,
+                    total=len(processed_urls) + len(pending_urls),
+                    processed=len(processed_urls),
+                    pending=len(pending_urls),
+                    success_count=len(results["success"]),
+                    error_count=len(results["errors"]),
+                )
+
+                if len(processed_urls) % 25 == 0:
+                    logger.info(
+                        "Bulk import progress: processed=%s pending=%s success=%s errors=%s",
+                        len(processed_urls),
+                        len(pending_urls),
+                        len(results["success"]),
+                        len(results["errors"]),
+                    )
             except Exception as e:
                 results["errors"].append(f"URL '{url}': {str(e)}")
                 processed_urls.add(url)
+                await emit_progress(
+                    stage="importing",
+                    current_url=url,
+                    total=len(processed_urls) + len(pending_urls),
+                    processed=len(processed_urls),
+                    pending=len(pending_urls),
+                    success_count=len(results["success"]),
+                    error_count=len(results["errors"]),
+                )
 
+        await emit_progress(
+            stage="completed",
+            total=len(processed_urls),
+            processed=len(processed_urls),
+            pending=0,
+            success_count=len(results["success"]),
+            error_count=len(results["errors"]),
+        )
         return results

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -12,11 +12,15 @@ KEY_MAP = {
     "Тип внутреннего блока": "indoor_type",
     "Режим работы": "modes",
     "Режимы работы": "modes",
+    "Артикул": "sku",
+    "Артикул товара": "sku",
     "Обслуживаемая площадь": "area_m2",
     "Обслуживаемая площадь, кв.м": "area_m2",
     "Площадь охлаждения": "area_m2",
     "Площадь помещения": "area_m2",
     "Цвет": "color",
+    "Цвет корпуса": "color",
+    "Страна производства": "country",
     "Хладагент (фреон)": "freon_type",
     "Хладагент": "freon_type",
     "Тип хладагента": "freon_type",
@@ -25,6 +29,7 @@ KEY_MAP = {
     "Инверторное управление": "inverter",
     "Инверторное управление мощностью": "inverter",
     "Инверторный компрессор": "inverter",
+    "Тип управления компрессором": "inverter_type",
     "Бренд": "brand",
     "Марка": "brand",
     "Производитель": "brand",
@@ -38,11 +43,14 @@ KEY_MAP = {
     "Wi-Fi модуль": "wifi_ready",
     "Wi-Fi module": "wifi_ready",
     "Wi-Fi Ready": "wifi_ready",
+    "Вайфай": "wifi_ready",
     "Пульт дистанционного управления": "remote_control",
     "Пульт ДУ": "remote_control",
     "Пульт": "remote_control",
     "Пульт управления": "remote_control",
+    "Пульт управления в комплекте": "remote_control",
     "Внутренний блок: Пульт управления": "remote_control",
+    "Зимний комплект": "winter_kit",
     "Таймер включения/выключения": "timer",
     "Таймер": "timer",
     "Регулировка направления воздушного потока": "airflow_direction",
@@ -55,7 +63,7 @@ KEY_MAP = {
     "Режим «Сон»": "sleep_mode",
     "Ночной режим": "sleep_mode",
     "Осушение воздуха": "dehumidification",
-    "Осушение": "dehumidification",
+    "Осушение": "dehumidification_l_h",
     "Режим осушения воздуха": "dehumidification",
 
     # --- МОЩНОСТЬ ---
@@ -79,12 +87,14 @@ KEY_MAP = {
     "Нагрев максимум, кВт": "capacity_heating_max_kw",
     "Потребляемая мощность при охлаждении": "power_cons_cooling_kw",
     "Потребляемая мощность при охлаждении, кВт": "power_cons_cooling_kw",
+    "Потребляемая мощность, охлаждение": "power_cons_cooling_kw",
     "Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт": "power_cons_cooling_kw",
     "Номинальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_kw",
     "Минимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_min_kw",
     "Максимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_max_kw",
     "Потребляемая мощность при обогреве": "power_cons_heating_kw",
     "Потребляемая мощность при обогреве, кВт": "power_cons_heating_kw",
+    "Потребляемая мощность, обогрев": "power_cons_heating_kw",
     "Потребление электроэнергии в режиме нагрева (Мин / Ном / Макс), кВт": "power_cons_heating_kw",
     "Номинальная потребляемая мощность (нагрев), кВт": "power_cons_heating_kw",
     "Минимальная потребляемая мощность (нагрев), кВт": "power_cons_heating_min_kw",
@@ -118,6 +128,8 @@ KEY_MAP = {
     "Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
     "Наружный блок: Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
     "Внутренний блок: Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх": "noise_indoor",
+    "Уровень звукового давления внутреннего блока": "noise_indoor",
+    "Уровень звукового давления наружного блока": "noise_outdoor",
     
     # --- ГАБАРИТЫ ВНУТРЕННИЙ ---
     "Ширина внутреннего блока": "width_indoor",
@@ -128,6 +140,7 @@ KEY_MAP = {
     "Чистый вес / Вес в упаковке, кг": "weight_indoor",
     "Внутренний блок: Чистый вес / Вес в упаковке, кг": "weight_indoor",
     "Внутренний блок без упаковки, кг": "weight_indoor",
+    "Вес внутреннего блока без упаковки": "weight_indoor",
     
     # --- ГАБАРИТЫ НАРУЖНЫЙ ---
     "Ширина наружного блока": "width_outdoor",
@@ -141,18 +154,20 @@ KEY_MAP = {
     "Наружный блок: Чистый вес / вес в упаковке, кг": "weight_outdoor",
     "Наружный блок: Чистый вес / Вес в упаковке, кг": "weight_outdoor",
     "Наружный блок без упаковки, кг": "weight_outdoor",
+    "Вес наружного блока без упаковки": "weight_outdoor",
     
     # --- МОНТАЖ ---
     "Максимальная длина магистрали": "pipe_max_length",
     "Максимальная длина коммуникаций": "pipe_max_length",
     "Максимальная длина коммуникаций, м": "pipe_max_length",
+    "Максимальная длина фреонопровода": "pipe_max_length",
     "Макс. длина трассы": "pipe_max_length",
     "Макс. длина трубопроводов без дополнительной заправки, м": "pipe_max_length",
     "Перепад высот": "pipe_max_height",
     "Перепад высот, м": "pipe_max_height",
     "Максимальная длина/перепад высот, м": "pipe_max_length",
     "Максимальная длина/перепад высот, при использовании только в режиме охлаждения, м": "pipe_max_length",
-    "Максимальный перепад высот": "multi_max_height_diff",
+    "Максимальный перепад высот": "pipe_max_height",
     "Максимальное количество внутренних блоков": "multi_max_indoor_units",
     "Максимальная суммарная длина магистрали": "multi_max_total_pipe_length",
     "Диаметр жидкостной трубы": "pipe_liquid",
@@ -167,11 +182,13 @@ KEY_MAP = {
     "Рабочий диапазон температур при охлаждении": "temp_range_cool",
     "Рабочий диапазон температур при охлаждении,°C": "temp_range_cool",
     "Рабочий диапазон температур при охлаждении, °C": "temp_range_cool",
+    "Гарантированный диапазон рабочих t° наружного воздуха, охлаждение": "temp_range_cool",
     "Охлаждение, °С": "temp_range_cool",
     "Рабочая температура при обогреве": "temp_range_heat",
     "Рабочий диапазон температур при обогреве": "temp_range_heat",
     "Рабочий диапазон температур при обогреве,°C": "temp_range_heat",
     "Рабочий диапазон температур при обогреве, °C": "temp_range_heat",
+    "Гарантированный диапазон рабочих t° наружного воздуха, обогрев": "temp_range_heat",
     "Нагрев, °С": "temp_range_heat",
     "Минимальная температура наружного воздуха": "temp_range_heat",
     "Мин. температура (обогрев)": "temp_range_heat",
@@ -191,9 +208,14 @@ KEY_MAP = {
     "EER/COP": "eer",
     "Энергоэффективность SEER/EER": "eer",
     "Энергоэффективность SCOP/COP": "cop",
+    "SEER (коэффициент/класс)": "seer",
+    "EER (коэффициент / класс)": "eer",
+    "COP (коэффициент / класс)": "cop",
     
     "Максимальный расход воздуха внутреннего блока": "airflow_max",
     "Расход воздуха (высокая скорость), м 3 /ч": "airflow_max",
+    "Расход воздуха внутреннего блока": "airflow_max",
+    "Расход воздуха наружного блока": "airflow_outdoor",
 
     # --- ФИЛЬТРЫ И ДОП. ФУНКЦИИ ---
     "Приток свежего воздуха": "fresh_air",
@@ -217,16 +239,32 @@ KEY_MAP = {
     "Компрессор: Неинверторный компрессор": "inverter",
     "Номинальный уровень рабочего тока (охлаждение), А": "current_cooling_nominal_a",
     "Номинальный уровень рабочего тока (нагрев), А": "current_heating_nominal_a",
+    "Максимальный рабочий ток, охлаждение": "current_cooling_max_a",
+    "Максимальный рабочий ток, обогрев": "current_heating_max_a",
     "Дополнительная заправка (г/м)": "refrigerant_additional_g_m",
+    "Дополнительная заправка хладагента": "refrigerant_additional_g_m",
+    "Заводская заправка хладагента": "refrigerant_charge_g",
     "Вес заправляемого хладагента, г": "refrigerant_charge_g",
     "Артикулы товара": "sku_list",
     "Подача питания": "power_supply_location",
     "Подключение питания": "power_supply_location",
+    "Сторона подключения": "power_supply_location",
+    "Электропитание": "power_supply",
     "Электропитание, Ф/В/Гц": "power_supply",
     "Электропитание (Ø / В / Гц)": "power_supply",
+    "Параметры питающей сети": "power_supply_voltage",
+    "Диаметр дренажной трубы: мм (дюйм)": "drain_pipe_diameter",
     "Модель": "model",
+    "Модель внутреннего блока": "model_indoor",
+    "Модель наружного блока": "model_outdoor",
+    "Гарантия": "warranty_months",
+    "Установка": "installation_orientation",
     "Внутренний блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_indoor_package_mm",
     "Наружный блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
+    "Размеры внутреннего блока в упаковке (Ш х В х Г)": "dimensions_indoor_package_mm",
+    "Размеры наружного блока в упаковке (Ш х В х Г)": "dimensions_outdoor_package_mm",
+    "Вес внутреннего блока в упаковке": "weight_indoor_package",
+    "Вес наружного блока в упаковке": "weight_outdoor_package",
     "Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
 }
 
@@ -245,6 +283,17 @@ _DIMENSIONS_MAP = {
     "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
     "Внутренний блок без упаковки (Ш × В × Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
     "Наружный блок без упаковки (Ш × В × Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Размеры внутреннего блока без упаковки (Ш х В х Г)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Размеры наружного блока без упаковки (Ш х В х Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Размеры внутреннего блока без упаковки (Ш x В x Г)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Размеры наружного блока без упаковки (Ш x В x Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+}
+
+_UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS = {
+    "Размеры внутреннего блока без упаковки (Ш х В х Г)",
+    "Размеры наружного блока без упаковки (Ш х В х Г)",
+    "Размеры внутреннего блока без упаковки (Ш x В x Г)",
+    "Размеры наружного блока без упаковки (Ш x В x Г)",
 }
 
 _PREFERRED_NUMERIC_KEYS = {
@@ -259,6 +308,15 @@ _PREFERRED_NUMERIC_KEYS = {
     "area_m2",
     "weight_indoor",
     "weight_outdoor",
+    "weight_indoor_package",
+    "weight_outdoor_package",
+    "dehumidification_l_h",
+    "current_cooling_max_a",
+    "current_heating_max_a",
+    "current_cooling_nominal_a",
+    "current_heating_nominal_a",
+    "warranty_months",
+    "drain_pipe_diameter",
 }
 
 _DROPPED_SPEC_KEYS = {
@@ -266,6 +324,9 @@ _DROPPED_SPEC_KEYS = {
     "source_fx_rub_byn",
     "Цена источника",
     "Курс RUB/BYN (импорт)",
+    "Категория поставщика",
+    "ID предложения Severcon",
+    "URL поставщика",
 }
 
 
@@ -273,7 +334,7 @@ def _split_dimensions(specs: Dict[str, Any]) -> Dict[str, Any]:
     """Split composite dimension values like '940×1250×340' into
     individual width/height/depth keys.
 
-    Handles various separators: ×, x, X, *, х (cyrillic).
+    Handles various separators: ×, x, X, *, х (cyrillic), ?.
     """
     result = dict(specs)
     for raw_key, (w_key, h_key, d_key) in _DIMENSIONS_MAP.items():
@@ -282,7 +343,7 @@ def _split_dimensions(specs: Dict[str, Any]) -> Dict[str, Any]:
             continue
         text = str(val).strip()
         # Normalize separators
-        text = re.sub(r"[×xX*х]", "×", text)
+        text = re.sub(r"[×xX*х?？]", "×", text)
         parts = [p.strip() for p in text.split("×") if p.strip()]
         nums = []
         for p in parts:
@@ -290,6 +351,15 @@ def _split_dimensions(specs: Dict[str, Any]) -> Dict[str, Any]:
             if m:
                 nums.append(m.group(1).replace(",", "."))
         if len(nums) >= 3:
+            if raw_key in _UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS:
+                first = float(nums[0])
+                second = float(nums[1])
+                width = max(first, second)
+                height = min(first, second)
+                result.setdefault(w_key, str(width).rstrip("0").rstrip("."))
+                result.setdefault(h_key, str(height).rstrip("0").rstrip("."))
+                result.setdefault(d_key, nums[2])
+                continue
             result.setdefault(w_key, nums[0])
             result.setdefault(h_key, nums[1])
             result.setdefault(d_key, nums[2])
@@ -344,6 +414,12 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
                 return normalized
         return text
 
+    if key in {"dimensions_indoor_package_mm", "dimensions_outdoor_package_mm"}:
+        text = val.replace("?", "×").replace("？", "×")
+        text = re.sub(r"[xXх]", "×", text)
+        text = re.sub(r"\s*×\s*", " × ", text)
+        return re.sub(r"\s+", " ", text).strip()
+
     # 1. Логика для Булевых (Да/Нет)
     # Сюда попадают: inverter, wifi_ready, remote_control и все режимы
     boolean_keys = [
@@ -396,10 +472,10 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
 
     if key in boolean_keys:
         if key == "inverter":
-            if "инвертор" in val_lower or "inverter" in val_lower:
-                return True
             if "неинвертор" in val_lower or "on/off" in val_lower or "on off" in val_lower:
                 return False
+            if "инвертор" in val_lower or "inverter" in val_lower:
+                return True
         if val_lower in {"+", "✓", "✔"}:
             return True
         if "да" in val_lower or "есть" in val_lower or "поддерживается" in val_lower:
@@ -494,7 +570,13 @@ def _normalize_compressor_type(value: Any, inverter_value: Any) -> str | None:
     if text:
         if "full dc" in text or "full-dc" in text or "dc inverter" in text:
             return "full_dc"
-        if "on/off" in text or "on off" in text or "on-off" in text or "onoff" in text:
+        if (
+            "неинвертор" in text
+            or "on/off" in text
+            or "on off" in text
+            or "on-off" in text
+            or "onoff" in text
+        ):
             return "on_off"
         if "inverter" in text or "инвертор" in text:
             return "inverter"
@@ -818,6 +900,26 @@ def normalize_specs(
                     new_specs["scop"] = numbers[0].replace(",", ".")
                     if len(numbers) > 1:
                         new_specs["cop"] = numbers[1].replace(",", ".")
+                if rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+
+            if sys_key in {"eer", "cop", "seer", "scop"} and "класс" in rus_key_l and "/" in str(raw_val):
+                numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", str(raw_val))
+                if numbers:
+                    new_specs[sys_key] = numbers[0].replace(",", ".")
+                class_match = re.search(r"/\s*([A-Za-zА-Яа-я][+\-]*)", str(raw_val))
+                if class_match:
+                    energy_class = (
+                        class_match.group(1)
+                        .strip()
+                        .replace("А", "A")
+                        .replace("а", "A")
+                    )
+                    if sys_key in {"eer", "seer"}:
+                        new_specs["energy_class_cooling"] = energy_class
+                    else:
+                        new_specs["energy_class_heating"] = energy_class
                 if rus_key in new_specs:
                     del new_specs[rus_key]
                 continue

--- a/tests/unit/test_catalog_import_runtime_service.py
+++ b/tests/unit/test_catalog_import_runtime_service.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import CatalogImportJob
+from services import catalog_import_runtime_service as runtime_module
+from services.catalog_import_runtime_service import CatalogImportRuntimeService
+
+
+async def _sqlite_session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    return engine, session_factory
+
+
+@pytest.mark.asyncio
+async def test_catalog_import_job_is_persisted_and_progress_updates(monkeypatch):
+    engine, session_factory = await _sqlite_session_factory()
+    monkeypatch.setattr(runtime_module, "async_session_maker", session_factory)
+
+    class _FakeImporter:
+        async def import_products_bulk(
+            self,
+            urls,
+            with_related=False,  # noqa: ARG002
+            update_existing=False,  # noqa: ARG002
+            progress_callback=None,
+        ):
+            if progress_callback:
+                await progress_callback(
+                    {
+                        "stage": "importing",
+                        "total": len(urls),
+                        "processed": 1,
+                        "pending": 0,
+                        "success_count": 1,
+                        "error_count": 0,
+                        "current_url": urls[0],
+                        "current_title": "Persisted import product",
+                    }
+                )
+            return {"success": ["Persisted import product"], "errors": []}
+
+    monkeypatch.setattr(runtime_module, "ImporterService", _FakeImporter)
+
+    service = CatalogImportRuntimeService()
+    started = await service.start_import(
+        urls=["https://example.com/product"],
+        with_related=True,
+        update_existing=False,
+    )
+
+    for _ in range(20):
+        current = await service.get_job(started["job_id"])
+        if current and current["status"] == "success":
+            break
+        await asyncio.sleep(0.05)
+
+    current = await service.get_current_job()
+    assert current is not None
+    assert current["job_id"] == started["job_id"]
+    assert current["status"] == "success"
+    assert current["processed"] == 1
+    assert current["successes"] == ["Persisted import product"]
+
+    async with session_factory() as session:
+        row = (await session.execute(select(CatalogImportJob))).scalar_one()
+        assert row.job_id == started["job_id"]
+        assert row.input_urls == ["https://example.com/product"]
+        assert row.with_related is True
+        assert row.status == "success"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_catalog_import_runtime_resumes_running_job_from_database(monkeypatch):
+    engine, session_factory = await _sqlite_session_factory()
+    monkeypatch.setattr(runtime_module, "async_session_maker", session_factory)
+
+    async with session_factory() as session:
+        session.add(
+            CatalogImportJob(
+                job_id="resume-me",
+                status="running",
+                stage="importing",
+                input_urls=["https://example.com/resume"],
+                input_total=1,
+            )
+        )
+        await session.commit()
+
+    class _FakeImporter:
+        async def import_products_bulk(
+            self,
+            urls,
+            with_related=False,  # noqa: ARG002
+            update_existing=False,  # noqa: ARG002
+            progress_callback=None,
+        ):
+            if progress_callback:
+                await progress_callback(
+                    {
+                        "stage": "importing",
+                        "total": len(urls),
+                        "processed": 1,
+                        "pending": 0,
+                        "success_count": 1,
+                        "error_count": 0,
+                    }
+                )
+            return {"success": ["Resumed import product"], "errors": []}
+
+    monkeypatch.setattr(runtime_module, "ImporterService", _FakeImporter)
+
+    service = CatalogImportRuntimeService()
+    await service.resume_pending_jobs()
+
+    for _ in range(20):
+        current = await service.get_job("resume-me")
+        if current and current["status"] == "success":
+            break
+        await asyncio.sleep(0.05)
+
+    current = await service.get_job("resume-me")
+    assert current is not None
+    assert current["status"] == "success"
+    assert current["successes"] == ["Resumed import product"]
+
+    await engine.dispose()

--- a/tests/unit/test_severcon_parser.py
+++ b/tests/unit/test_severcon_parser.py
@@ -1,0 +1,225 @@
+import pytest
+
+from parsers.severcon import SeverconEnergoluxParser
+from services.importer_service import ImporterService
+
+
+_XML = b"""<?xml version="1.0" encoding="windows-1251"?>
+<yml_catalog>
+  <shop>
+    <categories>
+      <category id="1">Energolux BADEN</category>
+      <category id="2">\xdd\xeb\xe5\xea\xf2\xf0\xe8\xf7\xe5\xf1\xea\xe8\xe5 \xed\xe0\xe3\xf0\xe5\xe2\xe0\xf2\xe5\xeb\xe8 Energolux</category>
+      <category id="3">\xca\xe0\xed\xe0\xeb\xfc\xed\xfb\xe5 \xe1\xeb\xee\xea\xe8</category>
+    </categories>
+    <offers>
+      <offer id="101">
+        <url>https://www.severcon.ru/catalog/energolux-test-sas09.html</url>
+        <price>100000</price>
+        <currencyId>RUB</currencyId>
+        <categoryId>1</categoryId>
+        <picture>https://cdn.example.com/main.png</picture>
+        <vendor>Energolux</vendor>
+        <name>\xc8\xed\xe2\xe5\xf0\xf2\xee\xf0\xed\xe0\xff \xf1\xe8\xf1\xf2\xe5\xec\xe0 \xea\xee\xed\xe4\xe8\xf6\xe8\xee\xed\xe8\xf0\xee\xe2\xe0\xed\xe8\xff Energolux TEST SAS09/SAU09</name>
+        <description>\xd2\xe8\xf5\xe0\xff \xf0\xe0\xe1\xee\xf2\xe0&#10;\xcf\xf3\xeb\xfc\xf2 \xe2 \xea\xee\xec\xef\xeb\xe5\xea\xf2\xe5</description>
+        <manufacturer_warranty>3 \xe3\xee\xe4\xe0</manufacturer_warranty>
+        <param name="\xd5\xee\xeb\xee\xe4\xee\xef\xf0\xee\xe8\xe7\xe2\xee\xe4\xe8\xf2\xe5\xeb\xfc\xed\xee\xf1\xf2\xfc">2,64 (1,40~3,30)</param>
+        <param name="\xd2\xe8\xef \xf3\xef\xf0\xe0\xe2\xeb\xe5\xed\xe8\xff \xea\xee\xec\xef\xf0\xe5\xf1\xf1\xee\xf0\xee\xec">On/Off</param>
+        <param name="\xc2\xe0\xe9\xf4\xe0\xe9">\xce\xef\xf6\xe8\xee\xed\xe0\xeb\xfc\xed\xee</param>
+        <param name="\xc1\xf0\xe5\xed\xe4">Energolux</param>
+        <param name="\xc0\xf0\xf2\xe8\xea\xf3\xeb">SAS09/SAU09</param>
+        <param name="\xc4\xee\xef. \xf4\xee\xf2\xee">https://cdn.example.com/extra-a.png, https://cdn.example.com/extra-b.png</param>
+      </offer>
+      <offer id="102">
+        <price>5000</price>
+        <currencyId>RUB</currencyId>
+        <categoryId>2</categoryId>
+        <vendor>Energolux</vendor>
+        <name>\xdd\xeb\xe5\xea\xf2\xf0\xe8\xf7\xe5\xf1\xea\xe8\xe9 \xed\xe0\xe3\xf0\xe5\xe2\xe0\xf2\xe5\xeb\xfc Energolux SHRE</name>
+      </offer>
+      <offer id="103">
+        <price>0.01</price>
+        <currencyId>RUB</currencyId>
+        <categoryId>3</categoryId>
+        <vendor>Energolux</vendor>
+        <name>\xca\xe0\xed\xe0\xeb\xfc\xed\xfb\xe9 \xe2\xed\xf3\xf2\xf0\xe5\xed\xed\xe8\xe9 \xe1\xeb\xee\xea Energolux SAD</name>
+      </offer>
+    </offers>
+  </shop>
+</yml_catalog>
+"""
+
+
+class _FakeResponse:
+    status_code = 200
+    content = _XML
+
+
+class _FakeClient:
+    def __init__(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url):  # noqa: ARG002
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_severcon_expands_feed_to_importable_energolux_offers(monkeypatch):
+    monkeypatch.setattr("parsers.severcon.httpx.AsyncClient", _FakeClient)
+    parser = SeverconEnergoluxParser()
+
+    urls = await parser.get_import_urls(SeverconEnergoluxParser.FEED_URL)
+
+    assert urls == [f"{SeverconEnergoluxParser.FEED_URL}#offer=101"]
+
+
+@pytest.mark.asyncio
+async def test_severcon_parses_offer_payload(monkeypatch):
+    monkeypatch.setattr("parsers.severcon.httpx.AsyncClient", _FakeClient)
+    parser = SeverconEnergoluxParser()
+
+    data = await parser.parse(f"{SeverconEnergoluxParser.FEED_URL}#offer=101")
+
+    assert data["title"] == "Energolux BADEN SAS09/SAU09"
+    assert data["slug"] == "energolux-test-sas09"
+    assert data["price"] == 100000
+    assert data["price_currency"] == "RUB"
+    assert data["main_image"] == "https://cdn.example.com/main.png"
+    assert data["images"] == [
+        "https://cdn.example.com/extra-a.png",
+        "https://cdn.example.com/extra-b.png",
+    ]
+    assert data["save_gallery"] is True
+    assert data["specs"]["Бренд"] == "Energolux"
+    assert data["specs"]["Серия"] == "BADEN"
+    assert data["specs"]["Тип"] == "сплит-система"
+    assert data["metrics"]["area"] == 26
+    assert data["metrics"]["is_inverter"] is False
+    assert data["metrics"]["power_cooling"] == 2.64
+
+
+def test_severcon_extracts_series_from_supplier_categories():
+    assert SeverconEnergoluxParser._series_from_category("Energolux BADEN") == "BADEN"
+    assert (
+        SeverconEnergoluxParser._series_from_category(
+            "Настенный блок Energolux Smart Multi серия GENEVA"
+        )
+        == "GENEVA"
+    )
+    assert (
+        SeverconEnergoluxParser._series_from_category("ENERGOLUX FLOOR-CEILING-WS30 6 серия")
+        == "FLOOR-CEILING-WS30 6"
+    )
+    assert SeverconEnergoluxParser._series_from_category("Кассетные блоки") == ""
+
+
+def test_severcon_formats_catalog_titles_by_product_kind():
+    split_title = SeverconEnergoluxParser._display_title(
+        raw_title="Классическая система кондиционирования Energolux BADEN SAS07BD1-A/SAU07BD1-A",
+        category="Energolux BADEN",
+        specs={
+            "Бренд": "Energolux",
+            "Серия": "BADEN",
+            "Тип": "сплит-система",
+            "Артикул": "SAS07BD1-A/SAU07BD1-A",
+        },
+    )
+    assert split_title == "Energolux BADEN SAS07BD1-A/SAU07BD1-A"
+
+    multi_title = SeverconEnergoluxParser._display_title(
+        raw_title="Настенные блоки Smart Multi Energolux SAS09M3-AI",
+        category="Настенный блок Energolux Smart Multi серия GENEVA",
+        specs={
+            "Бренд": "Energolux",
+            "Серия": "GENEVA",
+            "Тип": "внутренний блок",
+            "Тип внутреннего блока": "настенный",
+            "Артикул": "SAS09M3-AI",
+        },
+    )
+    assert multi_title == "Внутренний блок Energolux GENEVA SAS09M3-AI"
+
+    semi_title = SeverconEnergoluxParser._display_title(
+        raw_title="Напольно-потолочная сплит-система Energolux SAСF18D6-A / SAU18U6-A",
+        category="ENERGOLUX FLOOR-CEILING 6 серия",
+        specs={
+            "Бренд": "Energolux",
+            "Серия": "FLOOR-CEILING 6",
+            "Тип": "сплит-система",
+            "Тип внутреннего блока": "напольно-потолочный",
+            "Модель внутреннего блока": "SAСF18D6-A",
+            "Модель наружного блока": "SAU18U6-A",
+        },
+    )
+    assert semi_title == "Напольно-потолочный кондиционер Energolux FLOOR-CEILING 6 SAСF18D6-A/SAU18U6-A"
+
+    article_title = SeverconEnergoluxParser._display_title(
+        raw_title="Кассетная сплит-система Energolux Cassete 6 SAС12С6-A / SAU12U6-A",
+        category="ENERGOLUX CASSETE 6 серия",
+        specs={
+            "Бренд": "Energolux",
+            "Серия": "CASSETE 6",
+            "Тип": "сплит-система",
+            "Тип внутреннего блока": "кассетный",
+            "Модель внутреннего блока": "SAС12С6-A",
+            "Модель наружного блока": "SAU12U5-A",
+            "Артикул": "SAС12С6-A/SAU12U6-A",
+        },
+    )
+    assert article_title == "Кассетный кондиционер Energolux CASSETE 6 SAС12С6-A/SAU12U6-A"
+
+
+def test_severcon_reconciles_model_pair_from_article_when_source_params_disagree():
+    specs = {
+        "Артикул": "SAС12С6-A/SAU12U6-A",
+        "Модель внутреннего блока": "SAС12С6-A",
+        "Модель наружного блока": "SAU12U5-A",
+    }
+
+    SeverconEnergoluxParser._reconcile_models_from_article(specs)
+
+    assert specs["Модель внутреннего блока"] == "SAС12С6-A"
+    assert specs["Модель наружного блока"] == "SAU12U6-A"
+
+
+@pytest.mark.asyncio
+async def test_importer_bulk_expands_supported_feed_urls(monkeypatch):
+    class _ExpandingParser:
+        def supports(self, url):
+            return url == "https://example.com/feed.xml"
+
+        async def get_import_urls(self, url):  # noqa: ARG002
+            return ["https://example.com/feed.xml#offer=1", "https://example.com/feed.xml#offer=2"]
+
+    service = ImporterService()
+    service.parsers = [_ExpandingParser()]
+    imported = []
+    progress_events = []
+
+    async def _fake_import_product(url, update_existing=False, collect_related=False):  # noqa: ARG001
+        imported.append(url)
+        return {"product": type("ProductStub", (), {"title": url, "id": len(imported)})(), "related_urls": []}
+
+    async def _capture_progress(payload):
+        progress_events.append(payload)
+
+    monkeypatch.setattr(service, "import_product", _fake_import_product)
+
+    result = await service.import_products_bulk(
+        ["https://example.com/feed.xml"],
+        progress_callback=_capture_progress,
+    )
+
+    assert imported == ["https://example.com/feed.xml#offer=1", "https://example.com/feed.xml#offer=2"]
+    assert result["errors"] == []
+    assert len(result["success"]) == 2
+    assert progress_events[0]["stage"] == "expanding"
+    assert any(event["stage"] == "expanded" and event["total"] == 2 for event in progress_events)
+    assert progress_events[-1]["stage"] == "completed"
+    assert progress_events[-1]["processed"] == 2

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -72,6 +72,147 @@ def test_wifi_option_value_maps_to_ready():
     assert specs["__filter_wifi_builtin"] is False
 
 
+def test_severcon_keys_are_normalized_for_catalog_filters():
+    specs = normalize_specs(
+        {
+            "Вайфай": "Опционально",
+            "Тип управления компрессором": "Инверторный",
+            "Серия": "BADEN",
+            "Категория поставщика": "Energolux BADEN",
+            "ID предложения Severcon": "123",
+            "URL поставщика": "https://www.severcon.ru/catalog/item.html",
+            "Модель внутреннего блока": "SAS09",
+            "Модель наружного блока": "SAU09",
+            "Гарантированный диапазон рабочих t° наружного воздуха, обогрев": "-15 ~ +24",
+            "Размеры внутреннего блока без упаковки (Ш х В х Г)": "292x788x198",
+        }
+    )
+
+    assert specs["wifi_ready"] == "ready"
+    assert specs["__filter_wifi"] is True
+    assert specs["series"] == "BADEN"
+    assert specs["compressor_type_norm"] == "inverter"
+    assert specs["model_indoor"] == "SAS09"
+    assert specs["model_outdoor"] == "SAU09"
+    assert specs["__filter_min_heat"] == -15
+    assert specs["width_indoor"] == "788"
+    assert specs["height_indoor"] == "292"
+    assert specs["depth_indoor"] == "198"
+    assert "Категория поставщика" not in specs
+    assert "ID предложения Severcon" not in specs
+    assert "URL поставщика" not in specs
+
+
+def test_non_inverter_values_do_not_match_inverter_substring():
+    by_value = normalize_specs({"Инверторный": "неинверторный"})
+    assert by_value["inverter"] is False
+    assert by_value["compressor_type_norm"] == "on_off"
+
+    by_type = normalize_specs({"Тип управления компрессором": "Неинверторный"})
+    assert by_type["compressor_type_norm"] == "on_off"
+
+
+def test_severcon_wall_split_specs_are_normalized_with_source_quirks():
+    specs = normalize_specs(
+        {
+            "Размеры внутреннего блока без упаковки (Ш х В х Г)": "283?690?199",
+            "Размеры наружного блока без упаковки (Ш х В х Г)": "455?650?233",
+            "Максимальный перепад высот": "5",
+            "Потребляемая мощность, охлаждение": "0,83",
+            "Потребляемая мощность, обогрев": "0,76",
+            "Расход воздуха внутреннего блока": "400",
+            "Расход воздуха наружного блока": "1430",
+            "Уровень звукового давления внутреннего блока": "23/26/31/35",
+            "Вес внутреннего блока без упаковки": "6,5",
+            "Вес наружного блока без упаковки": "20,0",
+            "Пульт управления в комплекте": "Да",
+            "Цвет корпуса": "Белый",
+            "Страна производства": "Китай",
+            "Электропитание": "1 фаза, 220 ~ 240 В, 50 Гц",
+            "Сторона подключения": "Внутренний блок",
+            "Гарантия": "48",
+            "Артикул": "SAS09B4-A/SAU09B4-A",
+            "Осушение": "1,3",
+            "EER (коэффициент / класс)": "3,23/А",
+            "COP (коэффициент / класс)": "3,63/A",
+        }
+    )
+
+    assert specs["width_indoor"] == "690"
+    assert specs["height_indoor"] == "283"
+    assert specs["depth_indoor"] == "199"
+    assert specs["width_outdoor"] == "650"
+    assert specs["height_outdoor"] == "455"
+    assert specs["depth_outdoor"] == "233"
+    assert specs["pipe_max_height"] == "5"
+    assert "multi_max_height_diff" not in specs
+    assert specs["power_cons_cooling_kw"] == "0.83"
+    assert specs["power_cons_heating_kw"] == "0.76"
+    assert specs["airflow_max"] == "400"
+    assert specs["airflow_outdoor"] == "1430"
+    assert specs["noise_indoor"] == "23/26/31/35"
+    assert specs["__filter_noise_min"] == 23
+    assert specs["weight_indoor"] == "6.5"
+    assert specs["weight_outdoor"] == "20.0"
+    assert specs["remote_control"] is True
+    assert specs["color"] == "Белый"
+    assert specs["country"] == "Китай"
+    assert specs["power_supply"] == "1 фаза, 220 ~ 240 В, 50 Гц"
+    assert specs["power_supply_location"] == "Внутренний блок"
+    assert specs["warranty_months"] == "48"
+    assert specs["sku"] == "SAS09B4-A/SAU09B4-A"
+    assert specs["dehumidification_l_h"] == "1.3"
+    assert "dehumidification" not in specs
+    assert specs["eer"] == "3.23"
+    assert specs["cop"] == "3.63"
+    assert specs["energy_class_cooling"] == "A"
+    assert specs["energy_class_heating"] == "A"
+
+
+def test_severcon_wall_dimensions_handle_reversed_first_two_numbers():
+    specs = normalize_specs(
+        {
+            "Размеры внутреннего блока без упаковки (Ш х В х Г)": "713?270?195",
+            "Размеры наружного блока без упаковки (Ш х В х Г)": "710?450?293",
+        }
+    )
+
+    assert specs["width_indoor"] == "713"
+    assert specs["height_indoor"] == "270"
+    assert specs["depth_indoor"] == "195"
+    assert specs["width_outdoor"] == "710"
+    assert specs["height_outdoor"] == "450"
+    assert specs["depth_outdoor"] == "293"
+
+
+def test_severcon_semi_industrial_extra_keys_are_normalized():
+    specs = normalize_specs(
+        {
+            "Максимальный рабочий ток, охлаждение": "4,8",
+            "Максимальный рабочий ток, обогрев": "5,6",
+            "Диаметр дренажной трубы: мм (дюйм)": "25",
+            "Размеры внутреннего блока в упаковке (Ш х В х Г)": "290х655x655",
+            "Размеры наружного блока в упаковке (Ш х В х Г)": "615x915x370",
+            "Вес внутреннего блока в упаковке": "17,8",
+            "Вес наружного блока в упаковке": "34,9",
+            "Зимний комплект": "Опционально",
+            "Параметры питающей сети": "220-240",
+            "Установка": "Горизонтальная",
+        }
+    )
+
+    assert specs["current_cooling_max_a"] == "4.8"
+    assert specs["current_heating_max_a"] == "5.6"
+    assert specs["drain_pipe_diameter"] == "25"
+    assert specs["dimensions_indoor_package_mm"] == "290 × 655 × 655"
+    assert specs["dimensions_outdoor_package_mm"] == "615 × 915 × 370"
+    assert specs["weight_indoor_package"] == "17.8"
+    assert specs["weight_outdoor_package"] == "34.9"
+    assert specs["winter_kit"] == "Опционально"
+    assert specs["power_supply_voltage"] == "220-240"
+    assert specs["installation_orientation"] == "Горизонтальная"
+
+
 def test_brand_normalization_and_auto_tag_slug_output():
     auto_slugs = []
     specs = normalize_specs(

--- a/web/src/utils/spec-dictionary.ts
+++ b/web/src/utils/spec-dictionary.ts
@@ -9,6 +9,7 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     // Basic
     brand: { label: "Бренд" },
     series: { label: "Серия" },
+    sku: { label: "Артикул" },
     release_year: { label: "Год выхода", unit: "г." },
     type: { label: "Тип кондиционера" },
     indoor_type: { label: "Тип внутреннего блока" },
@@ -17,6 +18,7 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     wifi_ready: { label: "Wi-Fi", type: "boolean" },
     inverter: { label: "Инвертор", type: "boolean" },
     country: { label: "Страна производства" },
+    warranty_months: { label: "Гарантия", unit: "мес." },
     indoor_units_count: { label: "Кол-во внутренних блоков" },
 
     // Controls & Modes
@@ -28,6 +30,8 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     turbo_mode: { label: "Турбо-режим", type: "boolean" },
     sleep_mode: { label: "Режим «Сон»", type: "boolean" },
     dehumidification: { label: "Осушение воздуха", type: "boolean" },
+    dehumidification_l_h: { label: "Осушение", unit: "л/ч" },
+    winter_kit: { label: "Зимний комплект" },
 
     // Performance
     capacity_cooling_kw: { label: "Мощность охлаждения", unit: "кВт" },
@@ -43,6 +47,7 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     eer: { label: "EER" },
     cop: { label: "COP" },
     airflow_max: { label: "Расход воздуха", unit: "м³/ч" },
+    airflow_outdoor: { label: "Расход воздуха наружного блока", unit: "м³/ч" },
 
     // Pipes & Installation
     temp_range_cool: { label: "Раб. темп. (охлаждение)", unit: "°C" },
@@ -59,6 +64,8 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     depth_outdoor: { label: "Глубина (наруж)", unit: "мм" },
     weight_indoor: { label: "Вес (внутр)", unit: "кг" },
     weight_outdoor: { label: "Вес (наруж)", unit: "кг" },
+    weight_indoor_package: { label: "Вес в упаковке (внутр)", unit: "кг" },
+    weight_outdoor_package: { label: "Вес в упаковке (наруж)", unit: "кг" },
 
     // MDV specific
     model_indoor: { label: "Модель вн. блока" },
@@ -70,6 +77,7 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
 
     pipe_liquid: { label: "Диаметр трубок (жидкость)", group: "installation" },
     pipe_gas: { label: "Диаметр трубок (газ)", group: "installation" },
+    drain_pipe_diameter: { label: "Дренажная труба", unit: "мм", group: "installation" },
     pipe_max_length: { label: "Макс. длина трассы", unit: "м", group: "installation" },
     pipe_max_height: { label: "Макс. перепад высот", unit: "м", group: "installation" },
 
@@ -78,6 +86,7 @@ export const SPEC_DICT: Record<string, SpecDefinition> = {
     compressor_type: { label: "Тип компрессора", group: "tech" },
     freon_type: { label: "Фреон", group: "tech" },
     power_supply: { label: "Электропитание", group: "installation" },
+    power_supply_voltage: { label: "Напряжение питания", group: "installation" },
 
     // --- ДЛЯ ПРОФИ (Диапазоны) ---
     // Можно вывести, если хочется, или использовать только для фильтров
@@ -115,7 +124,7 @@ const PUBLIC_SPEC_GROUPS: PublicSpecGroup[] = [
     {
         id: "general",
         title: "Общие характеристики",
-        keys: ["brand", "series", "type", "indoor_type", "color", "release_year"],
+        keys: ["brand", "series", "sku", "type", "indoor_type", "color", "country", "warranty_months", "release_year"],
     },
     {
         id: "purpose",
@@ -139,6 +148,8 @@ const PUBLIC_SPEC_GROUPS: PublicSpecGroup[] = [
             "cop",
             "inverter",
             "airflow_max",
+            "airflow_outdoor",
+            "dehumidification_l_h",
         ],
     },
     {
@@ -195,6 +206,9 @@ const PUBLIC_SPEC_GROUPS: PublicSpecGroup[] = [
             "compressor_brand",
             "power_supply_location",
             "power_supply",
+            "power_supply_voltage",
+            "drain_pipe_diameter",
+            "winter_kit",
         ],
     },
     {
@@ -205,10 +219,12 @@ const PUBLIC_SPEC_GROUPS: PublicSpecGroup[] = [
             "height_indoor",
             "depth_indoor",
             "weight_indoor",
+            "weight_indoor_package",
             "width_outdoor",
             "height_outdoor",
             "depth_outdoor",
             "weight_outdoor",
+            "weight_outdoor_package",
         ],
     },
 ];


### PR DESCRIPTION
## What changed

- Added a Severcon Energolux feed parser with fixed feed support, per-offer expansion, gallery import, cleaner titles, series extraction, and inverter detection.
- Added durable catalog import jobs backed by the database, manager endpoints, generated client models, and progress UI that can run imports in the background.
- Improved catalog spec normalization for Energolux wall splits, multi-system blocks, and semi-industrial products, including dimensions, power, airflow, noise, weights, EER/COP, warranty, SKU, and installation fields.
- Extended product spec display dictionary for the newly normalized fields.

## Why

Large Energolux imports from the dealer feed are slow and contain raw supplier naming/spec quirks. This makes imports backgroundable, resumable, and much closer to the catalog style used by the existing TCL products.

## Validation

- `pytest tests/unit/test_catalog_import_runtime_service.py tests/unit/test_severcon_parser.py tests/unit/test_importer_service_related.py tests/unit/test_spec_normalizer_filters.py tests/unit/test_importer_service_media_and_manuals.py tests/unit/test_import_media_service.py -q` -> 40 passed
- `npm run build` in `manager_frontend/` -> passed
- `npm run build` in `web/` -> passed
- `npm run audit:theme` in `web/` -> exit 0; reports pre-existing hardcodes in untouched style files

## Notes

OpenAPI and the manager client were regenerated by the pre-commit hook and committed.