### PR TITLE
[codex] Add repair AI polish mode

### DIFF
--- a/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
+++ b/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
@@ -6,6 +6,7 @@ export type ManagerRepairActAiDraftPayload = {
     defect_type: string;
     defect_label?: (string | null);
     allow_assumptions?: boolean;
+    polish_existing?: boolean;
     equipment_name?: (string | null);
     equipment_brand?: (string | null);
     equipment_model?: (string | null);

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -278,6 +278,7 @@ const repairComplaintsLoading = ref(false);
 const repairAiDefectType = ref(REPAIR_AI_DEFECT_TYPES[0]?.value || '');
 const repairAiExtraContext = ref('');
 const repairAiAllowAssumptions = ref(false);
+const repairAiPolishExisting = ref(true);
 const repairAiGenerating = ref(false);
 const payments = ref<PaymentResponse[]>([]);
 const bankReceipts = ref<BankReceiptResponse[]>([]);
@@ -1559,6 +1560,7 @@ const generateRepairAiDraft = async () => {
       defect_type: defect.value,
       defect_label: defect.label,
       allow_assumptions: repairAiAllowAssumptions.value,
+      polish_existing: repairAiPolishExisting.value,
       equipment_name: repairMeta.value.equipment_name || orderTitle.value || props.order?.title || '',
       equipment_brand: repairMeta.value.equipment_brand,
       equipment_model: repairMeta.value.equipment_model,
@@ -2360,10 +2362,16 @@ watch(
             </div>
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <p class="text-xs text-violet-700/80">{{ selectedRepairAiDefect?.hint }}</p>
-              <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
-                <input v-model="repairAiAllowAssumptions" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
-                Заполнить на усмотрение
-              </label>
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
+                  <input v-model="repairAiPolishExisting" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
+                  Причесать заполненное
+                </label>
+                <label class="inline-flex items-center gap-2 rounded-lg bg-white/70 px-2.5 py-1.5 text-xs font-semibold text-violet-800">
+                  <input v-model="repairAiAllowAssumptions" type="checkbox" class="h-4 w-4 rounded border-violet-300 text-violet-600 focus:ring-violet-500" />
+                  Заполнить на усмотрение
+                </label>
+              </div>
             </div>
           </div>
           <label class="field-label md:col-span-2">

--- a/openapi.json
+++ b/openapi.json
@@ -17583,6 +17583,11 @@
             "title": "Allow Assumptions",
             "default": false
           },
+          "polish_existing": {
+            "type": "boolean",
+            "title": "Polish Existing",
+            "default": true
+          },
           "equipment_name": {
             "anyOf": [
               {

--- a/schemas.py
+++ b/schemas.py
@@ -1957,6 +1957,7 @@ class ManagerRepairActAiDraftPayload(BaseModel):
     defect_type: str
     defect_label: Optional[str] = None
     allow_assumptions: bool = False
+    polish_existing: bool = True
     equipment_name: Optional[str] = None
     equipment_brand: Optional[str] = None
     equipment_model: Optional[str] = None

--- a/services/defect_act_ai_service.py
+++ b/services/defect_act_ai_service.py
@@ -58,6 +58,7 @@ class DefectActAIService:
             "defect_type": payload.defect_type,
             "defect_label": payload.defect_label,
             "allow_assumptions": payload.allow_assumptions,
+            "polish_existing": payload.polish_existing,
             "equipment_name": payload.equipment_name,
             "equipment_brand": payload.equipment_brand,
             "equipment_model": payload.equipment_model,
@@ -87,6 +88,15 @@ class DefectActAIService:
             "- Делай текст цельным и уверенным для дефектного акта, но без лишних технических чисел.\n"
         )
         mode_rules = assumptions_rules if payload.allow_assumptions else strict_rules
+        existing_rules = (
+            "- Если в current_meta уже есть осмысленное значение, можно улучшить его стиль: "
+            "исправить терминологию, сделать формулировку официальной, раскрыть мысль до уровня дефектного акта.\n"
+            "- При улучшении заполненных полей строго сохраняй фактический смысл. Не добавляй новые факты, работы, "
+            "числовые измерения, даты, серийные или инвентарные номера, которых нет во входных данных.\n"
+        ) if payload.polish_existing else (
+            "- Если в current_meta уже есть осмысленное значение, не переписывай это поле и не возвращай его в ответе.\n"
+            "- Заполняй только пустые или явно неполные поля, опираясь на входные данные.\n"
+        )
 
         return (
             "Ты инженер по ремонту систем кондиционирования и составляешь текстовые поля "
@@ -96,7 +106,7 @@ class DefectActAIService:
             "Правила:\n"
             "- Верни только JSON-объект без markdown.\n"
             f"{mode_rules}"
-            "- Если в current_meta уже есть осмысленное значение, сохрани его смысл и аккуратно улучши стиль.\n"
+            f"{existing_rules}"
             "- Итог должен быть пригоден для дефектного акта, но не должен обещать невозможное без диагностики.\n\n"
             "Разрешенные ключи JSON:\n"
             + ", ".join(sorted(DefectActAIService.ALLOWED_REPAIR_META_KEYS))
@@ -184,7 +194,16 @@ class DefectActAIService:
         prompt = DefectActAIService.build_prompt(payload)
         content = await DefectActAIService._request_completion(prompt)
         parsed = DefectActAIService._extract_json_object(content)
-        return DefectActAIService._clean_meta(parsed)
+        meta = DefectActAIService._clean_meta(parsed)
+        if payload.polish_existing:
+            return meta
+
+        existing_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        return {
+            key: value
+            for key, value in meta.items()
+            if not existing_meta.get(key)
+        }
 
     @staticmethod
     def _deepseek_error_message(response: httpx.Response) -> str:

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -799,48 +799,7 @@ class GoogleDocsService:
             last_row = table.get('tableRows')[last_row_index]
             cells = last_row.get('tableCells')
             
-            style_reqs = []
-            
-            # Ячейка 1 ("Всего:") - Жирный + По правому краю
-            cell_total_label = cells[0]
-            start = cell_total_label.get('startIndex')
-            end = cell_total_label.get('endIndex')
-            
-            style_reqs.append({
-                'updateTextStyle': {
-                    'range': {'startIndex': start, 'endIndex': end},
-                    'textStyle': {'bold': True},
-                    'fields': 'bold'
-                }
-            })
-            style_reqs.append({
-                'updateParagraphStyle': {
-                    'range': {'startIndex': start, 'endIndex': end},
-                    'paragraphStyle': {'alignment': 'END'}, # По правому краю
-                    'fields': 'alignment'
-                }
-            })
-            
-            # Ячейка 2 (Сумма) - Жирный
-            if len(cells) > 1:
-                cell_amount = cells[1]
-                start_amt = cell_amount.get('startIndex')
-                end_amt = cell_amount.get('endIndex')
-                
-                style_reqs.append({
-                    'updateTextStyle': {
-                        'range': {'startIndex': start_amt, 'endIndex': end_amt},
-                        'textStyle': {'bold': True},
-                        'fields': 'bold'
-                    }
-                })
-                style_reqs.append({
-                    'updateParagraphStyle': {
-                        'range': {'startIndex': start_amt, 'endIndex': end_amt},
-                        'paragraphStyle': {'alignment': 'END'},
-                        'fields': 'alignment'
-                    }
-                })
+            style_reqs = self._build_footer_table_style_requests(cells)
 
             if style_reqs:
                 docs_service.documents().batchUpdate(documentId=doc_id, body={'requests': style_reqs}).execute()
@@ -886,6 +845,39 @@ class GoogleDocsService:
                         'fields': 'alignment',
                     }
                 })
+
+        return requests
+
+    @staticmethod
+    def _build_footer_table_style_requests(cells: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if not cells:
+            return []
+
+        requests: List[Dict[str, Any]] = []
+        footer_cells = [cells[0]]
+        if len(cells) > 1:
+            footer_cells.append(cells[-1])
+
+        for cell in footer_cells:
+            start = cell.get('startIndex')
+            end = cell.get('endIndex')
+            if start is None or end is None or end <= start:
+                continue
+            cell_range = {'startIndex': start, 'endIndex': end}
+            requests.append({
+                'updateTextStyle': {
+                    'range': cell_range,
+                    'textStyle': {'bold': True},
+                    'fields': 'bold',
+                }
+            })
+            requests.append({
+                'updateParagraphStyle': {
+                    'range': cell_range,
+                    'paragraphStyle': {'alignment': 'END'},
+                    'fields': 'alignment',
+                }
+            })
 
         return requests
 

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -737,6 +737,23 @@ class GoogleDocsService:
         
         if fill_reqs: docs_service.documents().batchUpdate(documentId=doc_id, body={'requests': fill_reqs}).execute()
 
+        # 2.1. Выравнивание строк с позициями:
+        # № и ед. изм. — по центру, название — влево, количество/цена/сумма — вправо.
+        doc = docs_service.documents().get(documentId=doc_id).execute()
+        table = None
+        for element in doc.get('body').get('content'):
+            if 'table' in element and element.get('startIndex') == table_start_index:
+                table = element.get('table')
+                break
+
+        alignment_reqs = (
+            self._build_standard_table_alignment_requests(table, len(data), has_footer)
+            if table
+            else []
+        )
+        if alignment_reqs:
+            docs_service.documents().batchUpdate(documentId=doc_id, body={'requests': alignment_reqs}).execute()
+
         # 3. ФОРМАТИРОВАНИЕ ПОДВАЛА (Footer)
         if has_footer:
             # Нам нужно снова получить индексы, но для mergeTableCells нам нужен rowIndex
@@ -817,9 +834,60 @@ class GoogleDocsService:
                         'fields': 'bold'
                     }
                 })
+                style_reqs.append({
+                    'updateParagraphStyle': {
+                        'range': {'startIndex': start_amt, 'endIndex': end_amt},
+                        'paragraphStyle': {'alignment': 'END'},
+                        'fields': 'alignment'
+                    }
+                })
 
             if style_reqs:
                 docs_service.documents().batchUpdate(documentId=doc_id, body={'requests': style_reqs}).execute()
+
+    @staticmethod
+    def _build_standard_table_alignment_requests(
+        table: Dict[str, Any],
+        data_rows_count: int,
+        has_footer: bool,
+    ) -> List[Dict[str, Any]]:
+        if not table or data_rows_count <= 0:
+            return []
+
+        rows = table.get('tableRows') or []
+        body_rows_count = max(data_rows_count - 1, 0) if has_footer else data_rows_count
+        column_alignment = {
+            0: 'CENTER',
+            1: 'START',
+            2: 'CENTER',
+            3: 'END',
+            4: 'END',
+            5: 'END',
+        }
+        requests: List[Dict[str, Any]] = []
+
+        for data_idx in range(body_rows_count):
+            table_row_idx = data_idx + 1  # row 0 is the template header
+            if table_row_idx >= len(rows):
+                continue
+            cells = rows[table_row_idx].get('tableCells') or []
+            for column_idx, alignment in column_alignment.items():
+                if column_idx >= len(cells):
+                    continue
+                cell = cells[column_idx]
+                start = cell.get('startIndex')
+                end = cell.get('endIndex')
+                if start is None or end is None or end <= start:
+                    continue
+                requests.append({
+                    'updateParagraphStyle': {
+                        'range': {'startIndex': start, 'endIndex': end},
+                        'paragraphStyle': {'alignment': alignment},
+                        'fields': 'alignment',
+                    }
+                })
+
+        return requests
 
 
     def delete_file(self, file_id: str) -> None:

--- a/tests/unit/test_defect_act_ai_service.py
+++ b/tests/unit/test_defect_act_ai_service.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+
+from schemas import ManagerRepairActAiDraftPayload
+from services.defect_act_ai_service import DefectActAIService
+
+
+@pytest.mark.asyncio
+async def test_defect_act_ai_polishes_existing_fields_by_default(monkeypatch):
+    async def _fake_request_completion(prompt: str) -> str:
+        assert '"polish_existing": true' in prompt
+        return json.dumps(
+            {
+                "repair_meta": {
+                    "measurement_result": "Измерения показали пробой обмотки компрессора на корпус.",
+                    "technical_conclusion": "Компрессор неисправен, дальнейшая эксплуатация оборудования запрещена.",
+                }
+            },
+            ensure_ascii=False,
+        )
+
+    monkeypatch.setattr(DefectActAIService, "_request_completion", staticmethod(_fake_request_completion))
+
+    result = await DefectActAIService.generate_repair_meta(
+        ManagerRepairActAiDraftPayload(
+            defect_type="compressor_winding_breakdown",
+            polish_existing=True,
+            current_meta={
+                "measurement_result": "замерили токи, пробивает на корпус",
+                "technical_conclusion": "",
+            },
+        )
+    )
+
+    assert result["measurement_result"].startswith("Измерения показали")
+    assert result["technical_conclusion"].startswith("Компрессор неисправен")
+
+
+@pytest.mark.asyncio
+async def test_defect_act_ai_can_leave_existing_fields_untouched(monkeypatch):
+    async def _fake_request_completion(prompt: str) -> str:
+        assert '"polish_existing": false' in prompt
+        return json.dumps(
+            {
+                "repair_meta": {
+                    "measurement_result": "AI tried to rewrite existing value",
+                    "technical_conclusion": "Компрессор неисправен.",
+                }
+            },
+            ensure_ascii=False,
+        )
+
+    monkeypatch.setattr(DefectActAIService, "_request_completion", staticmethod(_fake_request_completion))
+
+    result = await DefectActAIService.generate_repair_meta(
+        ManagerRepairActAiDraftPayload(
+            defect_type="compressor_winding_breakdown",
+            polish_existing=False,
+            current_meta={
+                "measurement_result": "замерили токи, пробивает на корпус",
+                "technical_conclusion": "",
+            },
+        )
+    )
+
+    assert "measurement_result" not in result
+    assert result["technical_conclusion"] == "Компрессор неисправен."

--- a/tests/unit/test_google_service_table_formatting.py
+++ b/tests/unit/test_google_service_table_formatting.py
@@ -96,3 +96,39 @@ def test_standard_table_alignment_requests_skip_invalid_ranges():
     ]
 
     assert starts == [200, 230]
+
+
+def test_footer_table_style_requests_align_first_and_last_cells():
+    cells = [_cell(200 + column * 10, 208 + column * 10) for column in range(6)]
+
+    requests = GoogleDocsService._build_footer_table_style_requests(cells)
+
+    text_style_starts = [
+        request["updateTextStyle"]["range"]["startIndex"]
+        for request in requests
+        if "updateTextStyle" in request
+    ]
+    paragraph_styles = {
+        request["updateParagraphStyle"]["range"]["startIndex"]: (
+            request["updateParagraphStyle"]["paragraphStyle"]["alignment"]
+        )
+        for request in requests
+        if "updateParagraphStyle" in request
+    }
+
+    assert text_style_starts == [200, 250]
+    assert paragraph_styles == {200: "END", 250: "END"}
+
+
+def test_footer_table_style_requests_align_two_cell_footer():
+    cells = [_cell(200, 208), _cell(250, 258)]
+
+    requests = GoogleDocsService._build_footer_table_style_requests(cells)
+
+    starts = [
+        request["updateParagraphStyle"]["range"]["startIndex"]
+        for request in requests
+        if "updateParagraphStyle" in request
+    ]
+
+    assert starts == [200, 250]

--- a/tests/unit/test_google_service_table_formatting.py
+++ b/tests/unit/test_google_service_table_formatting.py
@@ -1,0 +1,98 @@
+from services.google_service import GoogleDocsService
+
+
+def _cell(start: int, end: int) -> dict:
+    return {"startIndex": start, "endIndex": end}
+
+
+def _row(row_start: int, columns: int = 6) -> dict:
+    return {
+        "tableCells": [
+            _cell(row_start + column * 10, row_start + column * 10 + 8)
+            for column in range(columns)
+        ]
+    }
+
+
+def test_standard_table_alignment_requests_format_document_rows():
+    table = {
+        "tableRows": [
+            _row(100),  # header
+            _row(200),
+            _row(300),
+            _row(400),  # footer, should be handled separately after merge
+        ]
+    }
+
+    requests = GoogleDocsService._build_standard_table_alignment_requests(
+        table,
+        data_rows_count=3,
+        has_footer=True,
+    )
+
+    by_start = {}
+    for request in requests:
+        paragraph_style = request["updateParagraphStyle"]
+        by_start[paragraph_style["range"]["startIndex"]] = paragraph_style["paragraphStyle"]["alignment"]
+
+    assert len(requests) == 12
+    assert by_start[200] == "CENTER"
+    assert by_start[210] == "START"
+    assert by_start[220] == "CENTER"
+    assert by_start[230] == "END"
+    assert by_start[240] == "END"
+    assert by_start[250] == "END"
+    assert by_start[310] == "START"
+    assert 410 not in by_start
+
+
+def test_standard_table_alignment_requests_include_last_row_when_no_footer():
+    table = {
+        "tableRows": [
+            _row(100),
+            _row(200),
+        ]
+    }
+
+    requests = GoogleDocsService._build_standard_table_alignment_requests(
+        table,
+        data_rows_count=1,
+        has_footer=False,
+    )
+
+    starts = {
+        request["updateParagraphStyle"]["range"]["startIndex"]
+        for request in requests
+    }
+
+    assert len(requests) == 6
+    assert {200, 210, 220, 230, 240, 250}.issubset(starts)
+
+
+def test_standard_table_alignment_requests_skip_invalid_ranges():
+    table = {
+        "tableRows": [
+            _row(100),
+            {
+                "tableCells": [
+                    _cell(200, 208),
+                    {"endIndex": 218},
+                    _cell(220, 220),
+                    _cell(230, 238),
+                ]
+            },
+        ]
+    }
+
+    requests = GoogleDocsService._build_standard_table_alignment_requests(
+        table,
+        data_rows_count=1,
+        has_footer=False,
+    )
+
+    starts = [
+        request["updateParagraphStyle"]["range"]["startIndex"]
+        for request in requests
+    ]
+
+    assert starts == [200, 230]


### PR DESCRIPTION
## What changed

- Added `polish_existing` to the defect-act AI draft payload, defaulting to enabled.
- Added a manager checkbox `Причесать заполненное`, enabled by default, next to the existing assumptions checkbox.
- Updated the DeepSeek prompt so filled fields can be rewritten into a more official defect-act style while preserving facts.
- Added backend protection for the disabled mode: when `polish_existing=false`, already-filled `current_meta` keys are filtered out from the AI response before returning to the frontend.
- Regenerated OpenAPI and the manager frontend client.

## Validation

- `python3 -m compileall services/defect_act_ai_service.py schemas.py routers/manager_repair_complaints.py`
- `pytest tests/unit/test_defect_act_ai_service.py tests/unit/test_manager_operation_ids_contract.py -q`
- `cd manager_frontend && npm run build`