### PR TITLE
Add logistics components for waybills

### DIFF
--- a/alembic/versions/8b61a5d4c3e2_add_catalog_import_jobs.py
+++ b/alembic/versions/8b61a5d4c3e2_add_catalog_import_jobs.py
@@ -18,35 +18,53 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _table_exists(inspector: sa.Inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _indexes(inspector: sa.Inspector, table_name: str) -> set[str]:
+    if not _table_exists(inspector, table_name):
+        return set()
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
 def upgrade() -> None:
-    op.create_table(
-        "catalog_import_job",
-        sa.Column("job_id", sa.String(), nullable=False),
-        sa.Column("status", sa.String(), nullable=False, server_default="queued"),
-        sa.Column("stage", sa.String(), nullable=False, server_default="queued"),
-        sa.Column("error", sa.String(), nullable=True),
-        sa.Column("input_urls", sa.JSON(), nullable=False),
-        sa.Column("with_related", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("update_existing", sa.Boolean(), nullable=False, server_default=sa.text("false")),
-        sa.Column("input_total", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("total", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("processed", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("pending", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("success_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("error_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
-        sa.Column("current_url", sa.String(), nullable=True),
-        sa.Column("current_title", sa.String(), nullable=True),
-        sa.Column("successes", sa.JSON(), nullable=False),
-        sa.Column("errors", sa.JSON(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False),
-        sa.Column("started_at", sa.DateTime(), nullable=True),
-        sa.Column("finished_at", sa.DateTime(), nullable=True),
-        sa.Column("updated_at", sa.DateTime(), nullable=False),
-        sa.PrimaryKeyConstraint("job_id"),
-    )
-    op.create_index("ix_catalog_import_job_status", "catalog_import_job", ["status"], unique=False)
-    op.create_index("ix_catalog_import_job_stage", "catalog_import_job", ["stage"], unique=False)
-    op.create_index("ix_catalog_import_job_created_at", "catalog_import_job", ["created_at"], unique=False)
+    inspector = sa.inspect(op.get_bind())
+    if not _table_exists(inspector, "catalog_import_job"):
+        op.create_table(
+            "catalog_import_job",
+            sa.Column("job_id", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False, server_default="queued"),
+            sa.Column("stage", sa.String(), nullable=False, server_default="queued"),
+            sa.Column("error", sa.String(), nullable=True),
+            sa.Column("input_urls", sa.JSON(), nullable=False),
+            sa.Column("with_related", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("update_existing", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("input_total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("total", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("processed", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("pending", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("success_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("error_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("current_url", sa.String(), nullable=True),
+            sa.Column("current_title", sa.String(), nullable=True),
+            sa.Column("successes", sa.JSON(), nullable=False),
+            sa.Column("errors", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("finished_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("job_id"),
+        )
+
+    inspector = sa.inspect(op.get_bind())
+    existing_indexes = _indexes(inspector, "catalog_import_job")
+    if "ix_catalog_import_job_status" not in existing_indexes:
+        op.create_index("ix_catalog_import_job_status", "catalog_import_job", ["status"], unique=False)
+    if "ix_catalog_import_job_stage" not in existing_indexes:
+        op.create_index("ix_catalog_import_job_stage", "catalog_import_job", ["stage"], unique=False)
+    if "ix_catalog_import_job_created_at" not in existing_indexes:
+        op.create_index("ix_catalog_import_job_created_at", "catalog_import_job", ["created_at"], unique=False)
 
 
 def downgrade() -> None:

--- a/alembic/versions/9a3f6b8c1d2e_add_order_product_logistics_components.py
+++ b/alembic/versions/9a3f6b8c1d2e_add_order_product_logistics_components.py
@@ -1,0 +1,28 @@
+"""add_order_product_logistics_components
+
+Revision ID: 9a3f6b8c1d2e
+Revises: 8b61a5d4c3e2
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9a3f6b8c1d2e"
+down_revision: Union[str, Sequence[str], None] = "8b61a5d4c3e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("order_product_link", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("logistics_components", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("order_product_link", schema=None) as batch_op:
+        batch_op.drop_column("logistics_components")

--- a/alembic/versions/9a3f6b8c1d2e_add_order_product_logistics_components.py
+++ b/alembic/versions/9a3f6b8c1d2e_add_order_product_logistics_components.py
@@ -18,7 +18,16 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
 def upgrade() -> None:
+    if "logistics_components" in _columns("order_product_link"):
+        return
     with op.batch_alter_table("order_product_link", schema=None) as batch_op:
         batch_op.add_column(sa.Column("logistics_components", sa.JSON(), nullable=True))
 

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -174,6 +174,7 @@ export type { OrderCustomerContractBrief } from './models/OrderCustomerContractB
 export type { OrderEmailSendPayload } from './models/OrderEmailSendPayload';
 export type { OrderPayload } from './models/OrderPayload';
 export type { OrderProductLineResponse } from './models/OrderProductLineResponse';
+export type { OrderProductLogisticsComponent } from './models/OrderProductLogisticsComponent';
 export type { OrderProposalCreatePayload } from './models/OrderProposalCreatePayload';
 export type { OrderProposalResponse } from './models/OrderProposalResponse';
 export type { OrderProposalUpdatePayload } from './models/OrderProposalUpdatePayload';
@@ -193,6 +194,7 @@ export type { ProductAvailabilityLeadResponse } from './models/ProductAvailabili
 export type { ProductImageResponse } from './models/ProductImageResponse';
 export type { ProductLocalStockPayload } from './models/ProductLocalStockPayload';
 export type { ProductLocalStockResponse } from './models/ProductLocalStockResponse';
+export type { ProductLogisticsComponentTemplate } from './models/ProductLogisticsComponentTemplate';
 export type { ProductManualPayload } from './models/ProductManualPayload';
 export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';

--- a/manager_frontend/src/client/models/ManagerOrderProductLinePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderProductLinePayload.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { OrderProductLogisticsComponent } from './OrderProductLogisticsComponent';
 export type ManagerOrderProductLinePayload = {
     link_id?: (number | null);
     proposal_id?: (number | null);
@@ -9,5 +10,6 @@ export type ManagerOrderProductLinePayload = {
     quantity: number;
     price: number;
     cost?: (number | null);
+    logistics_components?: (Array<OrderProductLogisticsComponent> | null);
 };
 

--- a/manager_frontend/src/client/models/OrderProductLineResponse.ts
+++ b/manager_frontend/src/client/models/OrderProductLineResponse.ts
@@ -2,6 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { OrderProductLogisticsComponent } from './OrderProductLogisticsComponent';
+import type { ProductLogisticsComponentTemplate } from './ProductLogisticsComponentTemplate';
 export type OrderProductLineResponse = {
     id: number;
     proposal_id?: (number | null);
@@ -13,5 +15,8 @@ export type OrderProductLineResponse = {
     is_installation_included: boolean;
     installation_price: number;
     line_total: number;
+    product_country?: (string | null);
+    product_logistics_components?: Array<ProductLogisticsComponentTemplate>;
+    logistics_components?: Array<OrderProductLogisticsComponent>;
 };
 

--- a/manager_frontend/src/client/models/OrderProductLogisticsComponent.ts
+++ b/manager_frontend/src/client/models/OrderProductLogisticsComponent.ts
@@ -10,3 +10,4 @@ export type OrderProductLogisticsComponent = {
     unit_price?: number;
     kind?: (string | null);
 };
+

--- a/manager_frontend/src/client/models/OrderProductLogisticsComponent.ts
+++ b/manager_frontend/src/client/models/OrderProductLogisticsComponent.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type OrderProductLogisticsComponent = {
+    title: string;
+    country?: (string | null);
+    unit?: string;
+    quantity_per_parent?: number;
+    unit_price?: number;
+    kind?: (string | null);
+};

--- a/manager_frontend/src/client/models/ProductLogisticsComponentTemplate.ts
+++ b/manager_frontend/src/client/models/ProductLogisticsComponentTemplate.ts
@@ -10,3 +10,4 @@ export type ProductLogisticsComponentTemplate = {
     price_weight?: number;
     kind?: (string | null);
 };
+

--- a/manager_frontend/src/client/models/ProductLogisticsComponentTemplate.ts
+++ b/manager_frontend/src/client/models/ProductLogisticsComponentTemplate.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductLogisticsComponentTemplate = {
+    title: string;
+    country?: (string | null);
+    unit?: string;
+    quantity_per_parent?: number;
+    price_weight?: number;
+    kind?: (string | null);
+};

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -1701,7 +1701,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                                         class="text-xs bg-white dark:bg-slate-800 border border-teal-200 dark:border-teal-800 px-2.5 py-1 rounded-lg hover:bg-teal-50 dark:hover:bg-teal-900/30 text-teal-700 dark:text-teal-300 font-bold flex items-center gap-1 transition-colors shadow-sm"
                                         @click="applyTwoBlockLogisticsTemplate"
                                     >
-                                        Внутренний + наружный 1/3
+                                        Внутренний + наружный
                                     </button>
                                     <button
                                         type="button"

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -33,6 +33,16 @@ interface MultiComboRule {
 }
 
 type MultiCompatMode = 'free_match' | 'strict';
+type LogisticsComponentKind = 'indoor' | 'outdoor' | 'accessory' | 'other';
+
+interface ProductLogisticsComponent {
+    title: string;
+    country: string;
+    unit: string;
+    quantity_per_parent: number;
+    price_weight: number;
+    kind: LogisticsComponentKind;
+}
 
 const props = defineProps<{
     modelValue: boolean;
@@ -74,12 +84,14 @@ const COMPATIBLE_OUTDOOR_KEY = 'compatible_outdoor_slugs';
 const MULTI_COMBO_RULES_KEY = 'multi_combo_rules';
 const MULTI_COMPAT_MODE_KEY = 'multi_compat_mode';
 const MULTI_CAPACITY_COMBOS_KEY = 'multi_capacity_combos';
+const LOGISTICS_COMPONENTS_KEY = 'logistics_components';
 const COMPATIBILITY_KEYS = new Set([
     COMPATIBLE_INDOOR_KEY,
     COMPATIBLE_OUTDOOR_KEY,
     MULTI_COMBO_RULES_KEY,
     MULTI_COMPAT_MODE_KEY,
     MULTI_CAPACITY_COMBOS_KEY,
+    LOGISTICS_COMPONENTS_KEY,
 ]);
 const compatibilityIndoorSlugs = ref<string[]>([]);
 const compatibilityOutdoorSlugs = ref<string[]>([]);
@@ -92,6 +104,7 @@ const compatibilityLoading = ref(false);
 const compatibilityInfo = ref('');
 const creatingBrand = ref(false);
 const newBrandTitle = ref('');
+const logisticsComponents = ref<ProductLogisticsComponent[]>([]);
 
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
@@ -133,6 +146,91 @@ const parseSlugList = (value: unknown): string[] => {
         );
     }
     return [];
+};
+
+const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
+    const raw = String(value || '').trim();
+    if (raw === 'indoor' || raw === 'outdoor' || raw === 'accessory') return raw;
+    return 'other';
+};
+
+const normalizePositiveInteger = (value: unknown, fallback = 1): number => {
+    const parsed = Math.trunc(Number(value));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const normalizePositiveNumber = (value: unknown, fallback = 1): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const parseLogisticsComponents = (value: unknown): ProductLogisticsComponent[] => {
+    if (!Array.isArray(value)) return [];
+    return value
+        .map((item) => {
+            const raw = (item || {}) as Record<string, unknown>;
+            const title = String(raw.title || '').trim();
+            if (!title) return null;
+            return {
+                title,
+                country: String(raw.country || '').trim() || 'Китай',
+                unit: String(raw.unit || '').trim() || 'шт.',
+                quantity_per_parent: normalizePositiveInteger(raw.quantity_per_parent, 1),
+                price_weight: normalizePositiveNumber(raw.price_weight, 1),
+                kind: normalizeLogisticsKind(raw.kind),
+            };
+        })
+        .filter((item): item is ProductLogisticsComponent => Boolean(item));
+};
+
+const serializeLogisticsComponents = (): ProductLogisticsComponent[] => (
+    logisticsComponents.value
+        .map((item) => ({
+            title: item.title.trim(),
+            country: item.country.trim() || 'Китай',
+            unit: item.unit.trim() || 'шт.',
+            quantity_per_parent: normalizePositiveInteger(item.quantity_per_parent, 1),
+            price_weight: normalizePositiveNumber(item.price_weight, 1),
+            kind: normalizeLogisticsKind(item.kind),
+        }))
+        .filter((item) => Boolean(item.title))
+);
+
+const addLogisticsComponent = () => {
+    logisticsComponents.value.push({
+        title: '',
+        country: 'Китай',
+        unit: 'шт.',
+        quantity_per_parent: 1,
+        price_weight: 1,
+        kind: 'other',
+    });
+};
+
+const removeLogisticsComponent = (index: number) => {
+    logisticsComponents.value.splice(index, 1);
+};
+
+const applyTwoBlockLogisticsTemplate = () => {
+    const title = String(form.value.title || props.product?.title || '').trim();
+    logisticsComponents.value = [
+        {
+            title: title ? `Внутренний блок ${title}` : 'Внутренний блок',
+            country: 'Китай',
+            unit: 'шт.',
+            quantity_per_parent: 1,
+            price_weight: 1,
+            kind: 'indoor',
+        },
+        {
+            title: title ? `Наружный блок ${title}` : 'Наружный блок',
+            country: 'Китай',
+            unit: 'шт.',
+            quantity_per_parent: 1,
+            price_weight: 2,
+            kind: 'outdoor',
+        },
+    ];
 };
 
 const normalizeCapacityToken = (value: unknown): string => {
@@ -825,6 +923,7 @@ watch(() => props.modelValue, async (val) => {
         const s = props.product.specs || {};
         compatibilityIndoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_INDOOR_KEY]);
         compatibilityOutdoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_OUTDOOR_KEY]);
+        logisticsComponents.value = parseLogisticsComponents((s as any)[LOGISTICS_COMPONENTS_KEY]);
         multiComboRules.value = parseMultiComboRules((s as any)[MULTI_COMBO_RULES_KEY]);
         multiCompatMode.value = String((s as any)[MULTI_COMPAT_MODE_KEY] || 'free_match') === 'strict'
             ? 'strict'
@@ -961,6 +1060,10 @@ const save = async () => {
     }
     if (compatibilityOutdoorSlugs.value.length > 0) {
         validSpecs[COMPATIBLE_OUTDOOR_KEY] = [...compatibilityOutdoorSlugs.value];
+    }
+    const serializedLogisticsComponents = serializeLogisticsComponents();
+    if (serializedLogisticsComponents.length > 0) {
+        validSpecs[LOGISTICS_COMPONENTS_KEY] = serializedLogisticsComponents;
     }
     validSpecs[MULTI_COMPAT_MODE_KEY] = multiCompatMode.value;
     if (multiCompatMode.value === 'free_match') {
@@ -1579,6 +1682,95 @@ const unlinkSupplierOffer = async (offer: any) => {
                                 <div v-if="manuals.length === 0" class="text-[11px] text-gray-400 dark:text-slate-500">
                                     Ссылки на инструкции не добавлены.
                                 </div>
+                            </div>
+                        </div>
+
+                        <div class="rounded-2xl border border-teal-100 dark:border-teal-900 bg-teal-50/40 dark:bg-teal-950/20 p-3 space-y-3">
+                            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <h3 class="text-xs font-bold text-teal-700 dark:text-teal-300 uppercase tracking-widest">
+                                        Состав для накладной
+                                    </h3>
+                                    <p class="mt-1 text-[11px] text-slate-500 dark:text-slate-400">
+                                        Шаблон строк для ТН-2/ТТН-1. Цены в заказе посчитаются по весам.
+                                    </p>
+                                </div>
+                                <div class="flex flex-wrap gap-2">
+                                    <button
+                                        type="button"
+                                        class="text-xs bg-white dark:bg-slate-800 border border-teal-200 dark:border-teal-800 px-2.5 py-1 rounded-lg hover:bg-teal-50 dark:hover:bg-teal-900/30 text-teal-700 dark:text-teal-300 font-bold flex items-center gap-1 transition-colors shadow-sm"
+                                        @click="applyTwoBlockLogisticsTemplate"
+                                    >
+                                        Внутренний + наружный 1/3
+                                    </button>
+                                    <button
+                                        type="button"
+                                        class="text-xs bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 px-2.5 py-1 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 text-teal-600 dark:text-teal-400 font-bold flex items-center gap-1 transition-colors shadow-sm"
+                                        @click="addLogisticsComponent"
+                                    >
+                                        <Plus class="w-3 h-3" /> Добавить
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div v-if="logisticsComponents.length" class="space-y-2">
+                                <div
+                                    v-for="(component, idx) in logisticsComponents"
+                                    :key="`logistics-component-${idx}`"
+                                    class="grid gap-2 rounded-xl border border-white/70 bg-white/80 p-2 dark:border-slate-700/50 dark:bg-slate-900/70 md:grid-cols-[1.4fr_100px_70px_80px_90px_32px]"
+                                >
+                                    <input
+                                        v-model="component.title"
+                                        type="text"
+                                        class="field-input h-9 text-xs"
+                                        placeholder="Название позиции"
+                                    />
+                                    <input
+                                        v-model="component.country"
+                                        type="text"
+                                        class="field-input h-9 text-xs"
+                                        placeholder="Страна"
+                                    />
+                                    <input
+                                        v-model="component.unit"
+                                        type="text"
+                                        class="field-input h-9 text-xs"
+                                        placeholder="Ед."
+                                    />
+                                    <input
+                                        v-model.number="component.quantity_per_parent"
+                                        type="number"
+                                        min="1"
+                                        class="field-input h-9 text-xs"
+                                        title="Количество на комплект"
+                                    />
+                                    <select v-model="component.kind" class="field-input h-9 text-xs">
+                                        <option value="indoor">внутр.</option>
+                                        <option value="outdoor">наруж.</option>
+                                        <option value="accessory">акс.</option>
+                                        <option value="other">прочее</option>
+                                    </select>
+                                    <button
+                                        type="button"
+                                        class="flex h-9 w-8 items-center justify-center rounded-lg text-gray-300 transition-all hover:bg-red-50 hover:text-red-500"
+                                        @click="removeLogisticsComponent(idx)"
+                                    >
+                                        <Trash2 class="w-3.5 h-3.5" />
+                                    </button>
+                                    <label class="md:col-span-6 flex items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
+                                        <span class="shrink-0">Вес цены</span>
+                                        <input
+                                            v-model.number="component.price_weight"
+                                            type="number"
+                                            min="0"
+                                            step="0.1"
+                                            class="h-8 w-24 rounded-lg border border-gray-200 bg-white px-2 text-xs dark:border-slate-700 dark:bg-slate-800"
+                                        />
+                                    </label>
+                                </div>
+                            </div>
+                            <div v-else class="rounded-xl border border-dashed border-teal-200 bg-white/70 px-3 py-4 text-center text-xs text-slate-500 dark:border-teal-900 dark:bg-slate-900/40">
+                                Состав не задан, накладная будет использовать товар одной строкой.
                             </div>
                         </div>
 

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -6,6 +6,8 @@ import type {
   ManagerCustomerContractItemResponse,
   ManagerOrderDetailResponse,
   ManagerOrderDocumentItem,
+  OrderProductLineResponse,
+  OrderProposalResponse,
 } from '../../client';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import AdditionalConditionsLibrary from './AdditionalConditionsLibrary.vue';
@@ -34,10 +36,13 @@ type OrderLogisticsComponent = {
 };
 
 type WaybillProductLine = {
+  id?: number | null;
+  proposal_id?: number | null;
   product_id?: number | null;
   product_query: string;
   quantity: number;
   price: number;
+  cost?: number | null;
   product_country?: string | null;
   product_logistics_components?: ProductLogisticsTemplateComponent[];
   logistics_components?: OrderLogisticsComponent[] | null;
@@ -113,11 +118,48 @@ const normalizeRoleType = (value: unknown): DocumentRoleType => {
 
 const isWaybillType = (type: string) => type === 'tn2' || type === 'ttn1';
 const isWaybillDocument = computed(() => isWaybillType(selectedDocumentType.value));
+const hasUsableWaybillProductLine = (line: WaybillProductLine) => (
+  String(line.product_query || '').trim().length > 0
+  && Number(line.quantity || 0) > 0
+);
+const selectedOrderProposal = computed(() => {
+  const proposals = props.order.proposals || [];
+  if (props.activeProposalId) {
+    const byId = proposals.find((proposal) => proposal.id === props.activeProposalId && !proposal.is_archived);
+    if (byId) return byId;
+  }
+  return proposals.find((proposal) => proposal.is_selected && !proposal.is_archived)
+    || proposals.find((proposal) => !proposal.is_archived)
+    || null;
+});
+const mapOrderProductLineToWaybillLine = (line: OrderProductLineResponse): WaybillProductLine => ({
+  id: line.id,
+  proposal_id: line.proposal_id,
+  product_id: line.product_id,
+  product_query: line.product_title || '',
+  quantity: Number(line.quantity || 0),
+  price: Number(line.price || 0),
+  cost: Number(line.cost || 0),
+  product_country: (line as any).product_country || null,
+  product_logistics_components: Array.isArray((line as any).product_logistics_components)
+    ? ((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])
+    : [],
+  logistics_components: Array.isArray((line as any).logistics_components) && (line as any).logistics_components.length
+    ? ((line as any).logistics_components as OrderLogisticsComponent[])
+    : null,
+});
+const orderFallbackProductLines = computed<WaybillProductLine[]>(() => {
+  const proposal = selectedOrderProposal.value as OrderProposalResponse | null;
+  if (proposal?.product_lines?.length) {
+    return proposal.product_lines.map(mapOrderProductLineToWaybillLine);
+  }
+  return (props.order.product_lines || []).map(mapOrderProductLineToWaybillLine);
+});
 const waybillProductLines = computed(() => (
-  (props.productLines || []).filter((line) => (
-    String(line.product_query || '').trim().length > 0
-    && Number(line.quantity || 0) > 0
-  ))
+  ((props.productLines || []).some(hasUsableWaybillProductLine)
+    ? (props.productLines || [])
+    : orderFallbackProductLines.value
+  ).filter(hasUsableWaybillProductLine)
 ));
 
 const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
@@ -548,6 +590,35 @@ const selectDocumentType = (type: string) => {
   if (isWaybillType(type)) ensureAllWaybillComponents();
 };
 
+const activeWaybillProposalId = computed(() => props.activeProposalId ?? selectedOrderProposal.value?.id ?? null);
+
+const saveWaybillProductLines = async () => {
+  const lines = waybillProductLines.value;
+  if (!lines.length) return true;
+  const missingProduct = lines.find((line) => !Number(line.product_id || 0));
+  if (missingProduct) {
+    notify('Для накладной выберите товар из каталога в товарной строке.', 'error');
+    return false;
+  }
+
+  try {
+    await ManagerOrdersService.patchManagerOrder(props.order.id, {
+      products: lines.map((line) => ({
+        product_id: Number(line.product_id),
+        quantity: Math.trunc(Number(line.quantity) || 0),
+        price: Math.round(Number(line.price) || 0),
+        cost: line.cost == null ? null : Math.round(Number(line.cost) || 0),
+        proposal_id: activeWaybillProposalId.value ?? undefined,
+        logistics_components: line.logistics_components?.length ? line.logistics_components : null,
+      })),
+    });
+    return true;
+  } catch (error) {
+    notify(`Ошибка сохранения состава накладной: ${getApiErrorMessage(error)}`, 'error');
+    return false;
+  }
+};
+
 const handleDocumentsSent = () => {
   notify('Письмо отправлено', 'success');
   emit('refresh');
@@ -559,6 +630,7 @@ const generateDocument = async (type: string) => {
     if (isWaybillType(type)) ensureAllWaybillComponents();
     const beforeResult = await props.beforeGenerate?.(type);
     if (beforeResult === false) return;
+    if (isWaybillType(type) && !(await saveWaybillProductLines())) return;
     if (!(await saveAdditionalConditions(false))) return;
     if (type === 'contract' && isCompanyOrder.value) {
       await useOneTimeContractForClosingDocs();
@@ -566,7 +638,7 @@ const generateDocument = async (type: string) => {
     const template = (type === 'contract' && selectedContractTemplateId.value)
       ? selectedContractTemplate.value
       : undefined;
-    const proposalId = (type === 'offer' || isWaybillType(type)) ? (props.activeProposalId ?? undefined) : undefined;
+    const proposalId = (type === 'offer' || isWaybillType(type)) ? (activeWaybillProposalId.value ?? undefined) : undefined;
     const res = await ManagerOrdersService.generateManagerOrderDocument(
       props.order.id,
       type,

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -13,10 +13,40 @@ import DocumentSendModal from './DocumentSendModal.vue';
 
 type ToastType = 'success' | 'error';
 type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
+type LogisticsComponentKind = 'indoor' | 'outdoor' | 'accessory' | 'other';
+
+type ProductLogisticsTemplateComponent = {
+  title: string;
+  country?: string | null;
+  unit?: string | null;
+  quantity_per_parent?: number | null;
+  price_weight?: number | null;
+  kind?: LogisticsComponentKind | null;
+};
+
+type OrderLogisticsComponent = {
+  title: string;
+  country?: string | null;
+  unit: string;
+  quantity_per_parent: number;
+  unit_price: number;
+  kind?: LogisticsComponentKind | null;
+};
+
+type WaybillProductLine = {
+  product_id: number;
+  product_query: string;
+  quantity: number;
+  price: number;
+  product_country?: string | null;
+  product_logistics_components?: ProductLogisticsTemplateComponent[];
+  logistics_components?: OrderLogisticsComponent[] | null;
+};
 
 const props = defineProps<{
   order: ManagerOrderDetailResponse;
   activeProposalId?: number | null;
+  productLines?: WaybillProductLine[];
   beforeGenerate?: (type: string) => boolean | void | Promise<boolean | void>;
 }>();
 
@@ -73,11 +103,177 @@ const notify = (message: string, type: ToastType = 'success') => {
   emit('toast', { message, type });
 };
 
+const formatMoney = (value: number | null | undefined) => `${Number(value || 0).toLocaleString('ru-RU')} BYN`;
+
 const normalizeRoleType = (value: unknown): DocumentRoleType => {
   const raw = String(value || '').trim();
   if (raw === 'executor_customer' || raw === 'contractor_customer') return raw;
   return 'seller_buyer';
 };
+
+const isWaybillType = (type: string) => type === 'tn2' || type === 'ttn1';
+const isWaybillDocument = computed(() => isWaybillType(selectedDocumentType.value));
+const waybillProductLines = computed(() => (
+  (props.productLines || []).filter((line) => line.product_id && Number(line.quantity || 0) > 0)
+));
+
+const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
+const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
+  const raw = String(value || '').trim();
+  return LOGISTICS_COMPONENT_KINDS.has(raw) ? (raw as LogisticsComponentKind) : 'other';
+};
+const normalizePositiveInteger = (value: unknown, fallback = 1) => {
+  const parsed = Math.trunc(Number(value));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+const normalizePositiveNumber = (value: unknown, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+const roundToNearest10 = (value: number) => Math.floor((Number(value || 0) + 5) / 10) * 10;
+const roundMoney = (value: number) => Number(Number(value || 0).toFixed(2));
+const allocateLogisticsPrices = (templates: ProductLogisticsTemplateComponent[], price: number): OrderLogisticsComponent[] => {
+  if (!templates.length) return [];
+  const weights = templates.map((item) => Math.max(0, Number(item.price_weight ?? 1)));
+  const totalWeight = weights.some((item) => item > 0)
+    ? weights.reduce((sum, item) => sum + item, 0)
+    : templates.length;
+  let remaining = Number(price || 0);
+  return templates.map((item, index) => {
+    const quantityPerParent = normalizePositiveInteger(item.quantity_per_parent, 1);
+    const componentTotal = index === templates.length - 1
+      ? remaining
+      : roundToNearest10(Number(price || 0) * ((weights[index] || 1) / totalWeight));
+    if (index !== templates.length - 1) remaining -= componentTotal;
+    return {
+      title: item.title,
+      country: item.country || 'Китай',
+      unit: item.unit || 'шт.',
+      quantity_per_parent: quantityPerParent,
+      unit_price: roundMoney(componentTotal / quantityPerParent),
+      kind: normalizeLogisticsKind(item.kind),
+    };
+  });
+};
+const createDefaultWaybillSplit = (line: WaybillProductLine): OrderLogisticsComponent[] => {
+  const title = String(line.product_query || '').trim();
+  const country = line.product_country || 'Китай';
+  return allocateLogisticsPrices(
+    [
+      {
+        title: title ? `Внутренний блок ${title}` : 'Внутренний блок',
+        country,
+        unit: 'шт.',
+        quantity_per_parent: 1,
+        price_weight: 1,
+        kind: 'indoor',
+      },
+      {
+        title: title ? `Наружный блок ${title}` : 'Наружный блок',
+        country,
+        unit: 'шт.',
+        quantity_per_parent: 1,
+        price_weight: 2,
+        kind: 'outdoor',
+      },
+    ],
+    Number(line.price || 0),
+  );
+};
+const ensureWaybillComponents = (line: WaybillProductLine) => {
+  if (line.logistics_components?.length) return;
+  line.logistics_components = line.product_logistics_components?.length
+    ? allocateLogisticsPrices(line.product_logistics_components, Number(line.price || 0))
+    : createDefaultWaybillSplit(line);
+};
+const ensureAllWaybillComponents = () => {
+  waybillProductLines.value.forEach(ensureWaybillComponents);
+};
+const componentPerParentTotal = (component: OrderLogisticsComponent) => (
+  normalizePositiveNumber(component.unit_price, 0) * normalizePositiveInteger(component.quantity_per_parent, 1)
+);
+const lineLogisticsPerParentTotal = (line: WaybillProductLine) => (
+  (line.logistics_components || []).reduce((sum, component) => sum + componentPerParentTotal(component), 0)
+);
+const chooseBalanceComponentIndex = (components: OrderLogisticsComponent[], changedIndex: number | null) => {
+  if (!components.length) return -1;
+  if (components.length === 1) return 0;
+  const changedKind = changedIndex === null ? null : normalizeLogisticsKind(components[changedIndex]?.kind);
+  const preferredKind = changedKind === 'outdoor' ? 'indoor' : 'outdoor';
+  const preferred = components.findIndex((component, index) => index !== changedIndex && normalizeLogisticsKind(component.kind) === preferredKind);
+  if (preferred >= 0) return preferred;
+  const outdoor = components.findIndex((component, index) => index !== changedIndex && normalizeLogisticsKind(component.kind) === 'outdoor');
+  if (outdoor >= 0) return outdoor;
+  return components.findIndex((_, index) => index !== changedIndex);
+};
+const setComponentTotal = (component: OrderLogisticsComponent, total: number) => {
+  const quantityPerParent = normalizePositiveInteger(component.quantity_per_parent, 1);
+  component.unit_price = roundMoney(Math.max(0, total) / quantityPerParent);
+};
+const rebalanceWaybillLine = (line: WaybillProductLine, changedIndex: number | null = null) => {
+  const components = line.logistics_components || [];
+  if (!components.length) return;
+  const targetIndex = chooseBalanceComponentIndex(components, changedIndex);
+  if (targetIndex < 0) return;
+  const target = components[targetIndex];
+  if (!target) return;
+  const linePrice = Number(line.price || 0);
+
+  if (changedIndex !== null && components[changedIndex]) {
+    const fixedWithoutTargetAndChanged = components.reduce((sum, component, index) => (
+      index === targetIndex || index === changedIndex ? sum : sum + componentPerParentTotal(component)
+    ), 0);
+    const maxChangedTotal = Math.max(0, linePrice - fixedWithoutTargetAndChanged);
+    const changed = components[changedIndex]!;
+    if (componentPerParentTotal(changed) > maxChangedTotal) {
+      setComponentTotal(changed, maxChangedTotal);
+    }
+  }
+
+  const fixedWithoutTarget = components.reduce((sum, component, index) => (
+    index === targetIndex ? sum : sum + componentPerParentTotal(component)
+  ), 0);
+  setComponentTotal(target, linePrice - fixedWithoutTarget);
+};
+const handleWaybillUnitPriceInput = (line: WaybillProductLine, componentIndex: number, event: Event) => {
+  const component = line.logistics_components?.[componentIndex];
+  if (!component) return;
+  component.unit_price = normalizePositiveNumber((event.target as HTMLInputElement).value, 0);
+  rebalanceWaybillLine(line, componentIndex);
+};
+const handleWaybillQuantityInput = (line: WaybillProductLine, componentIndex: number, event: Event) => {
+  const component = line.logistics_components?.[componentIndex];
+  if (!component) return;
+  component.quantity_per_parent = normalizePositiveInteger((event.target as HTMLInputElement).value, 1);
+  rebalanceWaybillLine(line, componentIndex);
+};
+const addWaybillComponent = (line: WaybillProductLine) => {
+  ensureWaybillComponents(line);
+  line.logistics_components = [
+    ...(line.logistics_components || []),
+    {
+      title: '',
+      country: line.product_country || 'Китай',
+      unit: 'шт.',
+      quantity_per_parent: 1,
+      unit_price: 0,
+      kind: 'other',
+    },
+  ];
+  rebalanceWaybillLine(line, null);
+};
+const removeWaybillComponent = (line: WaybillProductLine, componentIndex: number) => {
+  if (!line.logistics_components) return;
+  line.logistics_components.splice(componentIndex, 1);
+  if (!line.logistics_components.length) {
+    line.logistics_components = null;
+    return;
+  }
+  rebalanceWaybillLine(line, null);
+};
+const lineLogisticsHasMismatch = (line: WaybillProductLine) => (
+  Boolean(line.logistics_components?.length) && Math.abs(lineLogisticsPerParentTotal(line) - Number(line.price || 0)) >= 0.01
+);
 
 const getRoleLabel = (value?: string | null) => (
   DOCUMENT_ROLE_OPTIONS.find((option) => option.value === normalizeRoleType(value))?.label || 'Продавец / Покупатель'
@@ -341,6 +537,12 @@ const openCreatePanel = () => {
   selectedDocumentType.value = suggestedDocumentType.value;
   showAdvancedSettings.value = false;
   isCreatePanelOpen.value = true;
+  if (isWaybillDocument.value) ensureAllWaybillComponents();
+};
+
+const selectDocumentType = (type: string) => {
+  selectedDocumentType.value = type;
+  if (isWaybillType(type)) ensureAllWaybillComponents();
 };
 
 const handleDocumentsSent = () => {
@@ -351,6 +553,7 @@ const handleDocumentsSent = () => {
 const generateDocument = async (type: string) => {
   isGeneratingDoc.value = true;
   try {
+    if (isWaybillType(type)) ensureAllWaybillComponents();
     const beforeResult = await props.beforeGenerate?.(type);
     if (beforeResult === false) return;
     if (!(await saveAdditionalConditions(false))) return;
@@ -360,7 +563,7 @@ const generateDocument = async (type: string) => {
     const template = (type === 'contract' && selectedContractTemplateId.value)
       ? selectedContractTemplate.value
       : undefined;
-    const proposalId = type === 'offer' ? (props.activeProposalId ?? undefined) : undefined;
+    const proposalId = (type === 'offer' || isWaybillType(type)) ? (props.activeProposalId ?? undefined) : undefined;
     const res = await ManagerOrdersService.generateManagerOrderDocument(
       props.order.id,
       type,
@@ -647,7 +850,7 @@ const registerExternalContract = async () => {
                 :class="selectedDocumentType === dtype.type ? 'border-teal-500 bg-white text-teal-700 shadow-sm dark:bg-slate-900 dark:text-teal-300' : 'border-slate-200 bg-white/80 text-slate-600 hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300'"
                 :disabled="isDocumentTypeLocked(dtype.type)"
                 :title="isDocumentTypeLocked(dtype.type) ? lockedDocumentTitle(dtype.type) : ''"
-                @click="selectedDocumentType = dtype.type"
+                @click="selectDocumentType(dtype.type)"
               >
                 <span>{{ dtype.label }}</span>
                 <span v-if="isDocumentTypeLocked(dtype.type)" class="material-icons-round text-[16px] text-amber-500">lock</span>
@@ -794,6 +997,119 @@ const registerExternalContract = async () => {
         </p>
       </div>
 
+          <div
+            v-if="isWaybillDocument"
+            class="rounded-xl border border-teal-200 bg-white p-3 dark:border-teal-800/70 dark:bg-slate-900/70"
+          >
+            <div class="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p class="text-xs font-semibold text-slate-700 dark:text-slate-200">Шаг 3: состав накладной</p>
+                <p class="text-[11px] text-slate-500 dark:text-slate-400">
+                  {{ waybillProductLines.length }} товар. поз. в активном предложении
+                </p>
+              </div>
+            </div>
+
+            <div v-if="waybillProductLines.length" class="space-y-3">
+              <div
+                v-for="(line, lineIndex) in waybillProductLines"
+                :key="`waybill-line-${line.product_id}-${lineIndex}`"
+                class="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-700/60 dark:bg-slate-800/40"
+              >
+                <div class="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <div class="min-w-0">
+                    <p class="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">{{ line.product_query || 'Товар' }}</p>
+                    <p class="text-xs text-slate-500 dark:text-slate-400">
+                      {{ line.logistics_components?.length || 0 }} поз. · {{ formatMoney(line.price) }} за комплект · кол-во {{ line.quantity }}
+                    </p>
+                  </div>
+                  <span
+                    class="w-fit rounded-lg px-2 py-1 text-xs font-semibold"
+                    :class="lineLogisticsHasMismatch(line) ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' : 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300'"
+                  >
+                    {{ lineLogisticsHasMismatch(line) ? 'Проверьте сумму' : 'Сумма совпадает' }}
+                  </span>
+                </div>
+
+                <div class="space-y-2">
+                  <div
+                    v-for="(component, componentIndex) in line.logistics_components || []"
+                    :key="`waybill-component-${line.product_id}-${componentIndex}`"
+                    class="grid gap-2 rounded-lg border border-white bg-white p-2 dark:border-slate-700/60 dark:bg-slate-900/80 md:grid-cols-[1.4fr_100px_70px_80px_95px_32px]"
+                  >
+                    <textarea
+                      v-model="component.title"
+                      class="field-input min-h-[38px] resize-none text-xs"
+                      rows="1"
+                      placeholder="Название позиции"
+                    />
+                    <input v-model="component.country" class="field-input h-9 text-xs" placeholder="Страна" />
+                    <input v-model="component.unit" class="field-input h-9 text-xs" placeholder="Ед." />
+                    <input
+                      :value="component.quantity_per_parent"
+                      type="number"
+                      min="1"
+                      class="field-input h-9 text-xs"
+                      title="Количество на комплект"
+                      @input="handleWaybillQuantityInput(line, componentIndex, $event)"
+                    />
+                    <input
+                      :value="component.unit_price"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      class="field-input h-9 text-xs"
+                      title="Цена за единицу"
+                      @input="handleWaybillUnitPriceInput(line, componentIndex, $event)"
+                    />
+                    <button
+                      type="button"
+                      class="flex h-9 w-8 items-center justify-center rounded-lg text-red-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/30"
+                      @click="removeWaybillComponent(line, componentIndex)"
+                    >
+                      <span class="material-icons-round text-[18px]">delete</span>
+                    </button>
+                    <select
+                      v-model="component.kind"
+                      class="field-input h-9 text-xs md:col-span-2"
+                      @change="rebalanceWaybillLine(line, null)"
+                    >
+                      <option value="indoor">внутренний блок</option>
+                      <option value="outdoor">наружный блок</option>
+                      <option value="accessory">аксессуар</option>
+                      <option value="other">прочее</option>
+                    </select>
+                    <div class="flex items-center text-xs font-semibold text-slate-600 dark:text-slate-300 md:col-span-4">
+                      По строке: {{ formatMoney(component.unit_price * component.quantity_per_parent * line.quantity) }}
+                    </div>
+                  </div>
+
+                  <div class="flex flex-wrap items-center justify-between gap-2">
+                    <p
+                      v-if="lineLogisticsHasMismatch(line)"
+                      class="text-xs font-semibold text-amber-700 dark:text-amber-300"
+                    >
+                      Состав: {{ formatMoney(lineLogisticsPerParentTotal(line)) }}, товар: {{ formatMoney(line.price) }}.
+                    </p>
+                    <span v-else class="text-xs text-teal-700 dark:text-teal-300">
+                      Состав: {{ formatMoney(lineLogisticsPerParentTotal(line)) }}.
+                    </span>
+                    <button
+                      type="button"
+                      class="inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+                      @click="addWaybillComponent(line)"
+                    >
+                      + позиция
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div v-else class="rounded-lg border border-dashed border-amber-300 bg-amber-50 px-3 py-4 text-center text-xs font-semibold text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/20 dark:text-amber-300">
+              В активном предложении нет товаров для накладной.
+            </div>
+          </div>
+
           <div v-if="showsAdditionalConditions">
             <button
               type="button"
@@ -814,7 +1130,9 @@ const registerExternalContract = async () => {
           </div>
 
           <div class="rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-700/50 dark:bg-slate-900/60">
-            <p class="mb-2 text-xs font-semibold text-slate-700 dark:text-slate-200">Шаг 3: проверьте перед созданием</p>
+            <p class="mb-2 text-xs font-semibold text-slate-700 dark:text-slate-200">
+              {{ isWaybillDocument ? 'Шаг 4: проверьте перед созданием' : 'Шаг 3: проверьте перед созданием' }}
+            </p>
             <dl class="grid gap-2 text-xs sm:grid-cols-2">
               <div v-for="item in createChecklist" :key="item.label" class="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2 dark:bg-slate-800/70">
                 <dt class="text-slate-500 dark:text-slate-400">{{ item.label }}</dt>

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -155,12 +155,23 @@ const orderFallbackProductLines = computed<WaybillProductLine[]>(() => {
   }
   return (props.order.product_lines || []).map(mapOrderProductLineToWaybillLine);
 });
-const waybillProductLines = computed(() => (
+const resolvedWaybillProductLines = computed(() => (
   ((props.productLines || []).some(hasUsableWaybillProductLine)
     ? (props.productLines || [])
     : orderFallbackProductLines.value
   ).filter(hasUsableWaybillProductLine)
 ));
+const cloneWaybillProductLine = (line: WaybillProductLine): WaybillProductLine => ({
+  ...line,
+  product_logistics_components: (line.product_logistics_components || []).map((component) => ({ ...component })),
+  logistics_components: line.logistics_components?.length
+    ? line.logistics_components.map((component) => ({ ...component }))
+    : null,
+});
+const waybillProductLines = ref<WaybillProductLine[]>([]);
+const syncWaybillProductLines = () => {
+  waybillProductLines.value = resolvedWaybillProductLines.value.map(cloneWaybillProductLine);
+};
 
 const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
 const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
@@ -487,6 +498,7 @@ const resetFromOrder = () => {
 
 watch(() => props.order.id, () => {
   resetFromOrder();
+  waybillProductLines.value = [];
   selectedDocumentType.value = suggestedDocumentType.value;
   isCreatePanelOpen.value = false;
   showAdvancedSettings.value = false;
@@ -582,12 +594,18 @@ const openCreatePanel = () => {
   selectedDocumentType.value = suggestedDocumentType.value;
   showAdvancedSettings.value = false;
   isCreatePanelOpen.value = true;
-  if (isWaybillDocument.value) ensureAllWaybillComponents();
+  if (isWaybillDocument.value) {
+    syncWaybillProductLines();
+    ensureAllWaybillComponents();
+  }
 };
 
 const selectDocumentType = (type: string) => {
   selectedDocumentType.value = type;
-  if (isWaybillType(type)) ensureAllWaybillComponents();
+  if (isWaybillType(type)) {
+    syncWaybillProductLines();
+    ensureAllWaybillComponents();
+  }
 };
 
 const activeWaybillProposalId = computed(() => props.activeProposalId ?? selectedOrderProposal.value?.id ?? null);
@@ -627,7 +645,10 @@ const handleDocumentsSent = () => {
 const generateDocument = async (type: string) => {
   isGeneratingDoc.value = true;
   try {
-    if (isWaybillType(type)) ensureAllWaybillComponents();
+    if (isWaybillType(type)) {
+      if (!waybillProductLines.value.length) syncWaybillProductLines();
+      ensureAllWaybillComponents();
+    }
     const beforeResult = await props.beforeGenerate?.(type);
     if (beforeResult === false) return;
     if (isWaybillType(type) && !(await saveWaybillProductLines())) return;

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -34,7 +34,7 @@ type OrderLogisticsComponent = {
 };
 
 type WaybillProductLine = {
-  product_id: number;
+  product_id?: number | null;
   product_query: string;
   quantity: number;
   price: number;
@@ -114,7 +114,10 @@ const normalizeRoleType = (value: unknown): DocumentRoleType => {
 const isWaybillType = (type: string) => type === 'tn2' || type === 'ttn1';
 const isWaybillDocument = computed(() => isWaybillType(selectedDocumentType.value));
 const waybillProductLines = computed(() => (
-  (props.productLines || []).filter((line) => line.product_id && Number(line.quantity || 0) > 0)
+  (props.productLines || []).filter((line) => (
+    String(line.product_query || '').trim().length > 0
+    && Number(line.quantity || 0) > 0
+  ))
 ));
 
 const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -54,8 +54,35 @@ type ProductOption = {
   availability_status: string;
   vitebsk_qty: number;
   minsk_qty: number;
+  specs?: Record<string, any>;
 };
-type ProductLine = { product_id: number; product_query: string; quantity: number; price: number; cost: number };
+type LogisticsComponentKind = 'indoor' | 'outdoor' | 'accessory' | 'other';
+type ProductLogisticsTemplateComponent = {
+  title: string;
+  country?: string | null;
+  unit?: string | null;
+  quantity_per_parent?: number | null;
+  price_weight?: number | null;
+  kind?: LogisticsComponentKind | null;
+};
+type OrderLogisticsComponent = {
+  title: string;
+  country?: string | null;
+  unit: string;
+  quantity_per_parent: number;
+  unit_price: number;
+  kind?: LogisticsComponentKind | null;
+};
+type ProductLine = {
+  product_id: number;
+  product_query: string;
+  quantity: number;
+  price: number;
+  cost: number;
+  product_country?: string | null;
+  product_logistics_components?: ProductLogisticsTemplateComponent[];
+  logistics_components?: OrderLogisticsComponent[] | null;
+};
 type ServiceLine = { service_id?: number | null; title: string; quantity: number; price: number; cost: number };
 type OrderWorkflowType = 'sales_installation' | 'service_work' | 'maintenance' | 'repair';
 type RepairMeta = {
@@ -260,6 +287,7 @@ const proposalActionLoading = ref(false);
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
 const productLines = ref<ProductLine[]>([]);
+const expandedLogisticsProductLines = ref<number[]>([]);
 const serviceLines = ref<ServiceLine[]>([]);
 const activeServiceSuggestionIndex = ref<number | null>(null);
 const serviceTariffOptions = ref<ManagerQuickTariffResponse[]>([]);
@@ -690,7 +718,7 @@ const documentSectionHasError = computed(() => isCompanyOrder.value && !props.or
 
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
-  if (type === 'offer') {
+  if (type === 'offer' || type === 'tn2' || type === 'ttn1') {
     await saveCurrentProposalLines();
   }
   if (type === 'defect_act') {
@@ -914,6 +942,7 @@ const mapSmartSearchItemToOption = (item: any): ProductOption => ({
   availability_status: String(item.availability_status ?? 'out_of_stock'),
   vitebsk_qty: Number(item.vitebsk_qty ?? 0),
   minsk_qty: Number(item.minsk_qty ?? 0),
+  specs: ((item.specs || {}) as Record<string, any>),
 });
 
 const syncProductLookupFromLines = () => {
@@ -981,6 +1010,13 @@ const restoreDraft = () => {
         quantity: Number(line.quantity || 1),
         price: Number(line.price || 0),
         cost: Number(line.cost || 0),
+        product_country: (line as any).product_country || null,
+        product_logistics_components: Array.isArray((line as any).product_logistics_components)
+          ? [...((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])]
+          : [],
+        logistics_components: Array.isArray((line as any).logistics_components)
+          ? [...((line as any).logistics_components as OrderLogisticsComponent[])]
+          : null,
       }));
     }
   } catch (error) {
@@ -1003,6 +1039,13 @@ const mapProductLineFromResponse = (line: OrderProductLineResponse): ProductLine
   quantity: line.quantity,
   price: line.price,
   cost: line.cost,
+  product_country: (line as any).product_country || null,
+  product_logistics_components: Array.isArray((line as any).product_logistics_components)
+    ? ((line as any).product_logistics_components as ProductLogisticsTemplateComponent[])
+    : [],
+  logistics_components: Array.isArray((line as any).logistics_components) && (line as any).logistics_components.length
+    ? ((line as any).logistics_components as OrderLogisticsComponent[])
+    : null,
 });
 
 const mapServiceLineFromResponse = (line: OrderServiceLineResponse): ServiceLine => ({
@@ -1079,6 +1122,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     || (order.proposals || []).find((proposal) => !proposal.is_archived)
     || null;
   loadProposalLines(selectedProposal, order);
+  expandedLogisticsProductLines.value = [];
   showEstimateImport.value = false;
   await loadEstimateOptions();
 
@@ -1207,6 +1251,9 @@ const selectProductForLine = (index: number, option: ProductOption) => {
   row.product_id = option.id;
   row.product_query = option.title;
   row.price = option.price;
+  row.product_country = getProductCountryFromSpecs(option.specs);
+  row.product_logistics_components = normalizeProductLogisticsTemplate(option.specs?.logistics_components);
+  row.logistics_components = null;
   // Quick selection means the row now follows the selected catalog product.
   if (option.cost && option.cost > 0) {
     row.cost = option.cost;
@@ -1232,7 +1279,16 @@ const openSelectedProduct = (index: number) => {
 };
 
 const addProductLine = () => {
-  productLines.value.push({ product_id: 0, product_query: '', quantity: 1, price: 0, cost: 0 });
+  productLines.value.push({
+    product_id: 0,
+    product_query: '',
+    quantity: 1,
+    price: 0,
+    cost: 0,
+    product_country: null,
+    product_logistics_components: [],
+    logistics_components: null,
+  });
 };
 
 const addServiceLine = () => {
@@ -1262,6 +1318,7 @@ const buildProposalLinesPayload = () => ({
     quantity: Math.trunc(Number(line.quantity) || 0),
     price: Math.round(Number(line.price) || 0),
     cost: (!line.cost && line.cost !== 0) ? null : toIntegerMoney(line.cost),
+    logistics_components: normalizeOrderLogisticsComponents(line.logistics_components),
     link_id: null,
     proposal_id: activeProposalId.value,
   })),
@@ -1646,6 +1703,9 @@ const applyEstimateToServices = async () => {
 const removeProductLine = (index: number) => {
   if (!window.confirm('Удалить этот товар из заказа?')) return;
   productLines.value.splice(index, 1);
+  expandedLogisticsProductLines.value = expandedLogisticsProductLines.value
+    .filter((item) => item !== index)
+    .map((item) => (item > index ? item - 1 : item));
   if (activeSuggestionIndex.value === index) {
     activeSuggestionIndex.value = null;
     productOptions.value = [];
@@ -1670,6 +1730,164 @@ const lineTotal = (line: { quantity: number; price: number }) => Number(line.qua
 const toIntegerMoney = (value: number | null | undefined): number | null => {
   if (value == null || Number.isNaN(Number(value))) return null;
   return Math.round(Number(value));
+};
+const LOGISTICS_COMPONENT_KINDS = new Set(['indoor', 'outdoor', 'accessory', 'other']);
+const normalizeLogisticsKind = (value: unknown): LogisticsComponentKind => {
+  const raw = String(value || '').trim();
+  return LOGISTICS_COMPONENT_KINDS.has(raw) ? (raw as LogisticsComponentKind) : 'other';
+};
+const getProductCountryFromSpecs = (specs?: Record<string, any> | null) => {
+  if (!specs) return null;
+  return String(specs.country || specs.country_of_origin || specs['Страна производства'] || specs['Страна-производитель'] || '').trim() || null;
+};
+const normalizePositiveInteger = (value: unknown, fallback = 1) => {
+  const parsed = Math.trunc(Number(value));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+const normalizePositiveNumber = (value: unknown, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+const normalizeProductLogisticsTemplate = (raw: unknown): ProductLogisticsTemplateComponent[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item): ProductLogisticsTemplateComponent | null => {
+      const source = (item || {}) as Record<string, any>;
+      const title = String(source.title || '').trim();
+      if (!title) return null;
+      return {
+        title,
+        country: String(source.country || '').trim() || null,
+        unit: String(source.unit || '').trim() || 'шт.',
+        quantity_per_parent: normalizePositiveInteger(source.quantity_per_parent, 1),
+        price_weight: normalizePositiveNumber(source.price_weight, 1),
+        kind: normalizeLogisticsKind(source.kind),
+      };
+    })
+    .filter((item): item is ProductLogisticsTemplateComponent => Boolean(item));
+};
+const roundToNearest10 = (value: number) => Math.floor((Number(value || 0) + 5) / 10) * 10;
+const allocateLogisticsPrices = (templates: ProductLogisticsTemplateComponent[], price: number): OrderLogisticsComponent[] => {
+  if (!templates.length) return [];
+  const weights = templates.map((item) => Math.max(0, Number(item.price_weight ?? 1)));
+  const totalWeight = weights.some((item) => item > 0)
+    ? weights.reduce((sum, item) => sum + item, 0)
+    : templates.length;
+  let remaining = Number(price || 0);
+  return templates.map((item, index) => {
+    const quantityPerParent = normalizePositiveInteger(item.quantity_per_parent, 1);
+    const componentTotal = index === templates.length - 1
+      ? remaining
+      : roundToNearest10(Number(price || 0) * ((weights[index] || 1) / totalWeight));
+    if (index !== templates.length - 1) remaining -= componentTotal;
+    return {
+      title: item.title,
+      country: item.country || 'Китай',
+      unit: item.unit || 'шт.',
+      quantity_per_parent: quantityPerParent,
+      unit_price: Number((componentTotal / quantityPerParent).toFixed(2)),
+      kind: normalizeLogisticsKind(item.kind),
+    };
+  });
+};
+const createDefaultLogisticsSplit = (line: ProductLine): OrderLogisticsComponent[] => {
+  const title = line.product_query.trim();
+  return allocateLogisticsPrices(
+    [
+      {
+        title: title ? `Внутренний блок ${title}` : 'Внутренний блок',
+        country: line.product_country || 'Китай',
+        unit: 'шт.',
+        quantity_per_parent: 1,
+        price_weight: 1,
+        kind: 'indoor',
+      },
+      {
+        title: title ? `Наружный блок ${title}` : 'Наружный блок',
+        country: line.product_country || 'Китай',
+        unit: 'шт.',
+        quantity_per_parent: 1,
+        price_weight: 2,
+        kind: 'outdoor',
+      },
+    ],
+    Number(line.price || 0),
+  );
+};
+const getLineProductTemplateComponents = (line: ProductLine): ProductLogisticsTemplateComponent[] => {
+  if (line.product_logistics_components?.length) return line.product_logistics_components;
+  const option = productLookupById.value[line.product_id];
+  return normalizeProductLogisticsTemplate(option?.specs?.logistics_components);
+};
+const ensureLineLogisticsComponents = (index: number) => {
+  const line = productLines.value[index];
+  if (!line) return;
+  if (!line.logistics_components?.length) {
+    const template = getLineProductTemplateComponents(line);
+    line.logistics_components = template.length
+      ? allocateLogisticsPrices(template, Number(line.price || 0))
+      : createDefaultLogisticsSplit(line);
+  }
+};
+const toggleLineLogisticsEditor = (index: number) => {
+  if (expandedLogisticsProductLines.value.includes(index)) {
+    expandedLogisticsProductLines.value = expandedLogisticsProductLines.value.filter((item) => item !== index);
+    return;
+  }
+  ensureLineLogisticsComponents(index);
+  expandedLogisticsProductLines.value = [...expandedLogisticsProductLines.value, index];
+};
+const addLineLogisticsComponent = (index: number) => {
+  ensureLineLogisticsComponents(index);
+  const line = productLines.value[index];
+  if (!line) return;
+  line.logistics_components = [
+    ...(line.logistics_components || []),
+    {
+      title: '',
+      country: line.product_country || 'Китай',
+      unit: 'шт.',
+      quantity_per_parent: 1,
+      unit_price: 0,
+      kind: 'other',
+    },
+  ];
+};
+const removeLineLogisticsComponent = (lineIndex: number, componentIndex: number) => {
+  const line = productLines.value[lineIndex];
+  if (!line?.logistics_components) return;
+  line.logistics_components.splice(componentIndex, 1);
+  if (!line.logistics_components.length) line.logistics_components = null;
+};
+const resetLineLogisticsComponents = (index: number) => {
+  const line = productLines.value[index];
+  if (!line) return;
+  line.logistics_components = createDefaultLogisticsSplit(line);
+};
+const lineLogisticsPerParentTotal = (line: ProductLine) => (
+  (line.logistics_components || []).reduce(
+    (sum, component) => sum + normalizePositiveNumber(component.unit_price, 0) * normalizePositiveInteger(component.quantity_per_parent, 1),
+    0,
+  )
+);
+const lineLogisticsHasMismatch = (line: ProductLine) => (
+  Boolean(line.logistics_components?.length) && Math.abs(lineLogisticsPerParentTotal(line) - Number(line.price || 0)) >= 0.01
+);
+const normalizeOrderLogisticsComponents = (
+  components?: OrderLogisticsComponent[] | null,
+): OrderLogisticsComponent[] | null => {
+  if (!components?.length) return null;
+  const normalized = components
+    .map((component) => ({
+      title: String(component.title || '').trim(),
+      country: String(component.country || '').trim() || 'Китай',
+      unit: String(component.unit || '').trim() || 'шт.',
+      quantity_per_parent: normalizePositiveInteger(component.quantity_per_parent, 1),
+      unit_price: normalizePositiveNumber(component.unit_price, 0),
+      kind: normalizeLogisticsKind(component.kind),
+    }))
+    .filter((component) => Boolean(component.title));
+  return normalized.length ? normalized : null;
 };
 
 const handleSave = () => {
@@ -2659,6 +2877,102 @@ watch(
               >
                 Цена строки отличается от каталожной ({{ formatMoney(currentCatalogPrice(line.product_id) || 0) }}).
               </p>
+              <div class="col-span-6 md:col-span-12">
+                <div class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                  <div class="min-w-0 text-xs text-slate-600">
+                    <span class="font-semibold text-slate-800">Накладная</span>
+                    <span v-if="line.logistics_components?.length">
+                      · {{ line.logistics_components.length }} поз. · {{ formatMoney(lineLogisticsPerParentTotal(line)) }} за комплект
+                    </span>
+                    <span v-else-if="getLineProductTemplateComponents(line).length">
+                      · шаблон товара: {{ getLineProductTemplateComponents(line).length }} поз.
+                    </span>
+                    <span v-else>· одной строкой</span>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      class="btn-mini-outline text-xs"
+                      @click="toggleLineLogisticsEditor(index)"
+                    >
+                      {{ expandedLogisticsProductLines.includes(index) ? 'Скрыть' : 'Накладная' }}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn-mini-outline text-xs"
+                      @click="resetLineLogisticsComponents(index)"
+                    >
+                      Разложить 1/3
+                    </button>
+                  </div>
+                </div>
+
+                <div
+                  v-if="expandedLogisticsProductLines.includes(index)"
+                  class="mt-2 space-y-2 rounded-xl border border-teal-200 bg-teal-50/40 p-3"
+                >
+                  <div
+                    v-for="(component, componentIndex) in line.logistics_components || []"
+                    :key="`line-logistics-${index}-${componentIndex}`"
+                    class="grid gap-2 rounded-lg border border-white bg-white p-2 md:grid-cols-[1.4fr_100px_70px_80px_90px_32px]"
+                  >
+                    <textarea
+                      v-model="component.title"
+                      class="field-input min-h-[38px] resize-none text-xs"
+                      rows="1"
+                      placeholder="Название позиции в накладной"
+                    />
+                    <input v-model="component.country" class="field-input h-9 text-xs" placeholder="Страна" />
+                    <input v-model="component.unit" class="field-input h-9 text-xs" placeholder="Ед." />
+                    <input
+                      v-model.number="component.quantity_per_parent"
+                      type="number"
+                      min="1"
+                      class="field-input h-9 text-xs"
+                      title="Количество на комплект"
+                    />
+                    <input
+                      v-model.number="component.unit_price"
+                      type="number"
+                      min="0"
+                      class="field-input h-9 text-xs"
+                      title="Цена за единицу"
+                    />
+                    <button
+                      type="button"
+                      class="flex h-9 w-8 items-center justify-center rounded-lg text-red-400 hover:bg-red-50 hover:text-red-600"
+                      @click="removeLineLogisticsComponent(index, componentIndex)"
+                    >
+                      <span class="material-icons-round text-[18px]">delete</span>
+                    </button>
+                    <select v-model="component.kind" class="field-input h-9 text-xs md:col-span-2">
+                      <option value="indoor">внутренний блок</option>
+                      <option value="outdoor">наружный блок</option>
+                      <option value="accessory">аксессуар</option>
+                      <option value="other">прочее</option>
+                    </select>
+                    <div class="flex items-center text-xs font-semibold text-slate-600 md:col-span-4">
+                      Итого по позиции: {{ formatMoney(component.unit_price * component.quantity_per_parent * line.quantity) }}
+                    </div>
+                  </div>
+                  <div class="flex flex-wrap items-center justify-between gap-2">
+                    <p
+                      v-if="lineLogisticsHasMismatch(line)"
+                      class="text-xs font-semibold text-amber-700"
+                    >
+                      Сумма состава за комплект {{ formatMoney(lineLogisticsPerParentTotal(line)) }}, цена товара {{ formatMoney(line.price) }}.
+                    </p>
+                    <span v-else class="text-xs text-teal-700">Сумма состава совпадает с ценой товара.</span>
+                    <button
+                      type="button"
+                      class="btn-mini-outline text-xs"
+                      @click="addLineLogisticsComponent(index)"
+                    >
+                      + позиция
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -287,7 +287,6 @@ const proposalActionLoading = ref(false);
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
 const productLines = ref<ProductLine[]>([]);
-const expandedLogisticsProductLines = ref<number[]>([]);
 const serviceLines = ref<ServiceLine[]>([]);
 const activeServiceSuggestionIndex = ref<number | null>(null);
 const serviceTariffOptions = ref<ManagerQuickTariffResponse[]>([]);
@@ -1122,7 +1121,6 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     || (order.proposals || []).find((proposal) => !proposal.is_archived)
     || null;
   loadProposalLines(selectedProposal, order);
-  expandedLogisticsProductLines.value = [];
   showEstimateImport.value = false;
   await loadEstimateOptions();
 
@@ -1703,9 +1701,6 @@ const applyEstimateToServices = async () => {
 const removeProductLine = (index: number) => {
   if (!window.confirm('Удалить этот товар из заказа?')) return;
   productLines.value.splice(index, 1);
-  expandedLogisticsProductLines.value = expandedLogisticsProductLines.value
-    .filter((item) => item !== index)
-    .map((item) => (item > index ? item - 1 : item));
   if (activeSuggestionIndex.value === index) {
     activeSuggestionIndex.value = null;
     productOptions.value = [];
@@ -1766,113 +1761,6 @@ const normalizeProductLogisticsTemplate = (raw: unknown): ProductLogisticsTempla
     })
     .filter((item): item is ProductLogisticsTemplateComponent => Boolean(item));
 };
-const roundToNearest10 = (value: number) => Math.floor((Number(value || 0) + 5) / 10) * 10;
-const allocateLogisticsPrices = (templates: ProductLogisticsTemplateComponent[], price: number): OrderLogisticsComponent[] => {
-  if (!templates.length) return [];
-  const weights = templates.map((item) => Math.max(0, Number(item.price_weight ?? 1)));
-  const totalWeight = weights.some((item) => item > 0)
-    ? weights.reduce((sum, item) => sum + item, 0)
-    : templates.length;
-  let remaining = Number(price || 0);
-  return templates.map((item, index) => {
-    const quantityPerParent = normalizePositiveInteger(item.quantity_per_parent, 1);
-    const componentTotal = index === templates.length - 1
-      ? remaining
-      : roundToNearest10(Number(price || 0) * ((weights[index] || 1) / totalWeight));
-    if (index !== templates.length - 1) remaining -= componentTotal;
-    return {
-      title: item.title,
-      country: item.country || 'Китай',
-      unit: item.unit || 'шт.',
-      quantity_per_parent: quantityPerParent,
-      unit_price: Number((componentTotal / quantityPerParent).toFixed(2)),
-      kind: normalizeLogisticsKind(item.kind),
-    };
-  });
-};
-const createDefaultLogisticsSplit = (line: ProductLine): OrderLogisticsComponent[] => {
-  const title = line.product_query.trim();
-  return allocateLogisticsPrices(
-    [
-      {
-        title: title ? `Внутренний блок ${title}` : 'Внутренний блок',
-        country: line.product_country || 'Китай',
-        unit: 'шт.',
-        quantity_per_parent: 1,
-        price_weight: 1,
-        kind: 'indoor',
-      },
-      {
-        title: title ? `Наружный блок ${title}` : 'Наружный блок',
-        country: line.product_country || 'Китай',
-        unit: 'шт.',
-        quantity_per_parent: 1,
-        price_weight: 2,
-        kind: 'outdoor',
-      },
-    ],
-    Number(line.price || 0),
-  );
-};
-const getLineProductTemplateComponents = (line: ProductLine): ProductLogisticsTemplateComponent[] => {
-  if (line.product_logistics_components?.length) return line.product_logistics_components;
-  const option = productLookupById.value[line.product_id];
-  return normalizeProductLogisticsTemplate(option?.specs?.logistics_components);
-};
-const ensureLineLogisticsComponents = (index: number) => {
-  const line = productLines.value[index];
-  if (!line) return;
-  if (!line.logistics_components?.length) {
-    const template = getLineProductTemplateComponents(line);
-    line.logistics_components = template.length
-      ? allocateLogisticsPrices(template, Number(line.price || 0))
-      : createDefaultLogisticsSplit(line);
-  }
-};
-const toggleLineLogisticsEditor = (index: number) => {
-  if (expandedLogisticsProductLines.value.includes(index)) {
-    expandedLogisticsProductLines.value = expandedLogisticsProductLines.value.filter((item) => item !== index);
-    return;
-  }
-  ensureLineLogisticsComponents(index);
-  expandedLogisticsProductLines.value = [...expandedLogisticsProductLines.value, index];
-};
-const addLineLogisticsComponent = (index: number) => {
-  ensureLineLogisticsComponents(index);
-  const line = productLines.value[index];
-  if (!line) return;
-  line.logistics_components = [
-    ...(line.logistics_components || []),
-    {
-      title: '',
-      country: line.product_country || 'Китай',
-      unit: 'шт.',
-      quantity_per_parent: 1,
-      unit_price: 0,
-      kind: 'other',
-    },
-  ];
-};
-const removeLineLogisticsComponent = (lineIndex: number, componentIndex: number) => {
-  const line = productLines.value[lineIndex];
-  if (!line?.logistics_components) return;
-  line.logistics_components.splice(componentIndex, 1);
-  if (!line.logistics_components.length) line.logistics_components = null;
-};
-const resetLineLogisticsComponents = (index: number) => {
-  const line = productLines.value[index];
-  if (!line) return;
-  line.logistics_components = createDefaultLogisticsSplit(line);
-};
-const lineLogisticsPerParentTotal = (line: ProductLine) => (
-  (line.logistics_components || []).reduce(
-    (sum, component) => sum + normalizePositiveNumber(component.unit_price, 0) * normalizePositiveInteger(component.quantity_per_parent, 1),
-    0,
-  )
-);
-const lineLogisticsHasMismatch = (line: ProductLine) => (
-  Boolean(line.logistics_components?.length) && Math.abs(lineLogisticsPerParentTotal(line) - Number(line.price || 0)) >= 0.01
-);
 const normalizeOrderLogisticsComponents = (
   components?: OrderLogisticsComponent[] | null,
 ): OrderLogisticsComponent[] | null => {
@@ -2877,102 +2765,6 @@ watch(
               >
                 Цена строки отличается от каталожной ({{ formatMoney(currentCatalogPrice(line.product_id) || 0) }}).
               </p>
-              <div class="col-span-6 md:col-span-12">
-                <div class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-                  <div class="min-w-0 text-xs text-slate-600">
-                    <span class="font-semibold text-slate-800">Накладная</span>
-                    <span v-if="line.logistics_components?.length">
-                      · {{ line.logistics_components.length }} поз. · {{ formatMoney(lineLogisticsPerParentTotal(line)) }} за комплект
-                    </span>
-                    <span v-else-if="getLineProductTemplateComponents(line).length">
-                      · шаблон товара: {{ getLineProductTemplateComponents(line).length }} поз.
-                    </span>
-                    <span v-else>· одной строкой</span>
-                  </div>
-                  <div class="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      class="btn-mini-outline text-xs"
-                      @click="toggleLineLogisticsEditor(index)"
-                    >
-                      {{ expandedLogisticsProductLines.includes(index) ? 'Скрыть' : 'Накладная' }}
-                    </button>
-                    <button
-                      type="button"
-                      class="btn-mini-outline text-xs"
-                      @click="resetLineLogisticsComponents(index)"
-                    >
-                      Разложить 1/3
-                    </button>
-                  </div>
-                </div>
-
-                <div
-                  v-if="expandedLogisticsProductLines.includes(index)"
-                  class="mt-2 space-y-2 rounded-xl border border-teal-200 bg-teal-50/40 p-3"
-                >
-                  <div
-                    v-for="(component, componentIndex) in line.logistics_components || []"
-                    :key="`line-logistics-${index}-${componentIndex}`"
-                    class="grid gap-2 rounded-lg border border-white bg-white p-2 md:grid-cols-[1.4fr_100px_70px_80px_90px_32px]"
-                  >
-                    <textarea
-                      v-model="component.title"
-                      class="field-input min-h-[38px] resize-none text-xs"
-                      rows="1"
-                      placeholder="Название позиции в накладной"
-                    />
-                    <input v-model="component.country" class="field-input h-9 text-xs" placeholder="Страна" />
-                    <input v-model="component.unit" class="field-input h-9 text-xs" placeholder="Ед." />
-                    <input
-                      v-model.number="component.quantity_per_parent"
-                      type="number"
-                      min="1"
-                      class="field-input h-9 text-xs"
-                      title="Количество на комплект"
-                    />
-                    <input
-                      v-model.number="component.unit_price"
-                      type="number"
-                      min="0"
-                      class="field-input h-9 text-xs"
-                      title="Цена за единицу"
-                    />
-                    <button
-                      type="button"
-                      class="flex h-9 w-8 items-center justify-center rounded-lg text-red-400 hover:bg-red-50 hover:text-red-600"
-                      @click="removeLineLogisticsComponent(index, componentIndex)"
-                    >
-                      <span class="material-icons-round text-[18px]">delete</span>
-                    </button>
-                    <select v-model="component.kind" class="field-input h-9 text-xs md:col-span-2">
-                      <option value="indoor">внутренний блок</option>
-                      <option value="outdoor">наружный блок</option>
-                      <option value="accessory">аксессуар</option>
-                      <option value="other">прочее</option>
-                    </select>
-                    <div class="flex items-center text-xs font-semibold text-slate-600 md:col-span-4">
-                      Итого по позиции: {{ formatMoney(component.unit_price * component.quantity_per_parent * line.quantity) }}
-                    </div>
-                  </div>
-                  <div class="flex flex-wrap items-center justify-between gap-2">
-                    <p
-                      v-if="lineLogisticsHasMismatch(line)"
-                      class="text-xs font-semibold text-amber-700"
-                    >
-                      Сумма состава за комплект {{ formatMoney(lineLogisticsPerParentTotal(line)) }}, цена товара {{ formatMoney(line.price) }}.
-                    </p>
-                    <span v-else class="text-xs text-teal-700">Сумма состава совпадает с ценой товара.</span>
-                    <button
-                      type="button"
-                      class="btn-mini-outline text-xs"
-                      @click="addLineLogisticsComponent(index)"
-                    >
-                      + позиция
-                    </button>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -3159,6 +2951,7 @@ watch(
           v-if="order"
           :order="order"
           :active-proposal-id="activeProposalId"
+          :product-lines="productLines"
           :before-generate="beforeDocumentGenerate"
           @refresh="refreshOrderFromDocumentsPanel"
           @toast="handleDocumentPanelToast"

--- a/models/order.py
+++ b/models/order.py
@@ -218,6 +218,7 @@ class OrderProductLink(SQLModel, table=True):
     is_installation_included: bool = Field(default=False)
     installation_price: int = Field(default=0)
     installation_details: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    logistics_components: Optional[List[Dict[str, Any]]] = Field(default=None, sa_column=Column(JSON))
 
     order: "Order" = Relationship(back_populates="product_links")
     proposal: Optional[OrderProposal] = Relationship(back_populates="product_links")

--- a/openapi.json
+++ b/openapi.json
@@ -16879,6 +16879,20 @@
               }
             ],
             "title": "Cost"
+          },
+          "logistics_components": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/OrderProductLogisticsComponent"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logistics Components"
           }
         },
         "type": "object",
@@ -19644,6 +19658,31 @@
           "line_total": {
             "type": "integer",
             "title": "Line Total"
+          },
+          "product_country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Product Country"
+          },
+          "product_logistics_components": {
+            "items": {
+              "$ref": "#/components/schemas/ProductLogisticsComponentTemplate"
+            },
+            "type": "array",
+            "title": "Product Logistics Components"
+          },
+          "logistics_components": {
+            "items": {
+              "$ref": "#/components/schemas/OrderProductLogisticsComponent"
+            },
+            "type": "array",
+            "title": "Logistics Components"
           }
         },
         "type": "object",
@@ -19658,6 +19697,56 @@
           "line_total"
         ],
         "title": "OrderProductLineResponse"
+      },
+      "OrderProductLogisticsComponent": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country"
+          },
+          "unit": {
+            "type": "string",
+            "title": "Unit",
+            "default": "\u0448\u0442."
+          },
+          "quantity_per_parent": {
+            "type": "integer",
+            "title": "Quantity Per Parent",
+            "default": 1
+          },
+          "unit_price": {
+            "type": "number",
+            "title": "Unit Price",
+            "default": 0.0
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "OrderProductLogisticsComponent"
       },
       "OrderProposalCreatePayload": {
         "properties": {
@@ -20721,6 +20810,56 @@
           "updated_at"
         ],
         "title": "ProductLocalStockResponse"
+      },
+      "ProductLogisticsComponentTemplate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country"
+          },
+          "unit": {
+            "type": "string",
+            "title": "Unit",
+            "default": "\u0448\u0442."
+          },
+          "quantity_per_parent": {
+            "type": "integer",
+            "title": "Quantity Per Parent",
+            "default": 1
+          },
+          "price_weight": {
+            "type": "number",
+            "title": "Price Weight",
+            "default": 1.0
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ProductLogisticsComponentTemplate"
       },
       "ProductManualPayload": {
         "properties": {

--- a/schemas.py
+++ b/schemas.py
@@ -345,6 +345,70 @@ class OrderCustomerContractBrief(BaseModel):
     edit_url: Optional[str] = None
 
 
+LOGISTICS_COMPONENT_KINDS = {"indoor", "outdoor", "accessory", "other"}
+
+
+class OrderProductLogisticsComponent(BaseModel):
+    title: str
+    country: Optional[str] = None
+    unit: str = "шт."
+    quantity_per_parent: int = 1
+    unit_price: float = 0.0
+    kind: Optional[str] = None
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, value: str) -> str:
+        cleaned = " ".join(str(value or "").split())
+        if not cleaned:
+            raise ValueError("component title is required")
+        return cleaned
+
+    @field_validator("country", mode="before")
+    @classmethod
+    def normalize_country(cls, value: Optional[str]) -> Optional[str]:
+        cleaned = " ".join(str(value or "").split())
+        return cleaned or None
+
+    @field_validator("unit")
+    @classmethod
+    def normalize_unit(cls, value: str) -> str:
+        return " ".join(str(value or "").split()) or "шт."
+
+    @field_validator("quantity_per_parent")
+    @classmethod
+    def validate_quantity_per_parent(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("quantity_per_parent must be greater than zero")
+        return value
+
+    @field_validator("unit_price")
+    @classmethod
+    def validate_unit_price(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("unit_price must be >= 0")
+        return value
+
+    @field_validator("kind")
+    @classmethod
+    def validate_kind(cls, value: Optional[str]) -> Optional[str]:
+        cleaned = " ".join(str(value or "").split())
+        if not cleaned:
+            return None
+        if cleaned not in LOGISTICS_COMPONENT_KINDS:
+            raise ValueError("invalid logistics component kind")
+        return cleaned
+
+
+class ProductLogisticsComponentTemplate(BaseModel):
+    title: str
+    country: Optional[str] = None
+    unit: str = "шт."
+    quantity_per_parent: int = 1
+    price_weight: float = 1.0
+    kind: Optional[str] = None
+
+
 class OrderProductLineResponse(BaseModel):
     id: int
     proposal_id: Optional[int] = None
@@ -356,6 +420,9 @@ class OrderProductLineResponse(BaseModel):
     is_installation_included: bool
     installation_price: int
     line_total: int
+    product_country: Optional[str] = None
+    product_logistics_components: List[ProductLogisticsComponentTemplate] = Field(default_factory=list)
+    logistics_components: List[OrderProductLogisticsComponent] = Field(default_factory=list)
 
 
 class OrderServiceLineResponse(BaseModel):
@@ -594,6 +661,7 @@ class ManagerOrderProductLinePayload(BaseModel):
     quantity: int
     price: int
     cost: Optional[int] = None
+    logistics_components: Optional[List[OrderProductLogisticsComponent]] = None
 
 
 class ManagerOrderServiceLinePayload(BaseModel):

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -19,6 +19,7 @@ class DocumentService:
     """Сервис для работы с документами заказов через Google Drive"""
 
     ALLOWED_DOC_TYPES = {"contract", "invoice", "work_order", "act", "defect_act", "offer", "tn2", "ttn1"}
+    PROPOSAL_SCOPED_DOC_TYPES = {"offer", "tn2", "ttn1"}
     ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".doc", ".docx"}
     DEFAULT_UPLOAD_MIME_TYPES = {
         ".pdf": "application/pdf",
@@ -137,7 +138,7 @@ class DocumentService:
         Returns:
             OrderDocument объект с данными о документе
         """
-        if doc_type == "offer":
+        if doc_type in DocumentService.PROPOSAL_SCOPED_DOC_TYPES:
             return await DocumentService._create_new_document(
                 session,
                 order_id,
@@ -529,7 +530,11 @@ class DocumentService:
         # 4. Получаем стратегию для подготовки данных
         strategy = DocumentFactory.get_strategy(doc_type, session, order_id)
         await strategy.fetch_order()
-        effective_proposal_id = DocumentService._apply_offer_proposal(strategy.order, proposal_id) if doc_type == "offer" else None
+        effective_proposal_id = (
+            DocumentService._apply_proposal_lines(strategy.order, proposal_id)
+            if doc_type in DocumentService.PROPOSAL_SCOPED_DOC_TYPES
+            else None
+        )
         if doc_type == "contract" and strategy.order:
             if not strategy.order.document_role_type:
                 strategy.order.document_role_type = await DocumentService._get_contract_template_role_type(session, template_id)
@@ -634,7 +639,7 @@ class DocumentService:
         return new_doc
 
     @staticmethod
-    def _apply_offer_proposal(order: Optional[Order], proposal_id: Optional[int]) -> Optional[int]:
+    def _apply_proposal_lines(order: Optional[Order], proposal_id: Optional[int]) -> Optional[int]:
         if not order:
             return None
 

--- a/services/documents/logistics.py
+++ b/services/documents/logistics.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+import math
+from typing import Any, Dict, List, Optional, Tuple
 from num2words import num2words
 
 from services.google_service import get_google_service
@@ -7,6 +8,9 @@ from services.documents.base import BaseDocumentStrategy, TEMPLATES, DOC_NAMES
 
 class LogisticsSheetStrategy(BaseDocumentStrategy):
     """Strategy for TN-2 and TTN-1 using Google Sheets API."""
+
+    DEFAULT_COUNTRY = "Китай"
+    LOGISTICS_COMPONENT_KINDS = {"indoor", "outdoor", "accessory", "other"}
 
     async def generate(
         self,
@@ -108,57 +112,49 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
         
         # Rows
         for link in self.order.product_links:
-            p = link.product
-            title = p.title if p else "Товар"
-            qty = link.quantity
-            price = link.price
-            cost = price * qty
+            for component_line in self._expand_product_link_for_logistics(link):
+                p = component_line.get("product")
+                title = component_line["title"]
+                unit = component_line["unit"]
+                qty = component_line["quantity"]
+                price = component_line["unit_price"]
+                cost = component_line["line_total"]
             
-            # VAT Logic: Hardcoded "без НДС" for now based on original code
-            # Wait, original TTN1 specific logic:
-            # vat_amount = sum_val * 20 / 120 ?
-            # Lines 362 in original: `vat_amount = sum_val * 20 / 120` BUT `vat_rate` is "без НДС".
-            # The original code at line 362 calculates `vat_amount` but effectively uses "без НДС" text in column.
-            # And `price_without_vat` is calculated but `cost` (which is `sum_val`) is used in col 4 (N).
-            # Wait, line 367 uses `sum_val` (gross) in column 4?
-            # Original code:
-            # TN2:  Col 4(O) = cost (price*qty). Col 7(W) = cost_with_vat (=cost).
-            # TTN1: Col 4(N) = sum_val (price*qty). Col 7(U) = sum_val.
-            # So effectively Price = Gross Price, VAT = 0.
-            
-            cost_with_vat = cost 
-            vat_rate = "без НДС"
+                # VAT Logic: Hardcoded "без НДС" for now based on original code.
+                cost_with_vat = cost
+                vat_rate = "без НДС"
 
-            row_logical = [
-                title,                  # 0
-                "шт.",                  # 1
-                str(qty),               # 2
-                f"{price:.2f}",         # 3
-                f"{cost:.2f}",          # 4
-                vat_rate,               # 5
-                "-",                    # 6
-                f"{cost_with_vat:.2f}", # 7
-            ]
-            
-            if is_ttn1:
-                row_logical.extend([str(qty), "0.00", "X"]) # 8, 9, 10 (Seats, Mass, Note)
-            else:
-                row_logical.append("X") # 8 (Note)
+                row_logical = [
+                    title,                  # 0
+                    unit,                   # 1
+                    str(qty),               # 2
+                    f"{price:.2f}",         # 3
+                    f"{cost:.2f}",          # 4
+                    vat_rate,               # 5
+                    "-",                    # 6
+                    f"{cost_with_vat:.2f}", # 7
+                ]
 
-            sparse_row = self._build_sparse_row(row_logical, col_map, start_col)
-            table_rows.append(sparse_row)
+                if is_ttn1:
+                    row_logical.extend([str(qty), "0.00", "X"]) # 8, 9, 10 (Seats, Mass, Note)
+                else:
+                    row_logical.append("X") # 8 (Note)
 
-            total_qty += qty
-            total_cost_net += cost
-            total_cost_gross += cost_with_vat
-            
-            # Weight calc
-            if p and p.specs:
-                 spec_w = p.specs.get("weight") or p.specs.get("weight_net") or p.specs.get("вес")
-                 if spec_w:
-                     try:
-                        total_weight += (float(spec_w) * qty)
-                     except Exception: pass  # Ignore weight parsing errors
+                sparse_row = self._build_sparse_row(row_logical, col_map, start_col)
+                table_rows.append(sparse_row)
+
+                total_qty += qty
+                total_cost_net += cost
+                total_cost_gross += cost_with_vat
+
+                # Weight calc
+                if p and p.specs:
+                    spec_w = p.specs.get("weight") or p.specs.get("weight_net") or p.specs.get("вес")
+                    if spec_w:
+                        try:
+                            total_weight += (float(spec_w) * qty)
+                        except Exception:
+                            pass  # Ignore weight parsing errors
 
         # Total Row
         if table_rows:
@@ -197,6 +193,209 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
         totals_map["{{sum_word}}"] = totals_map["{{total_services_word}}"] # Fallback
 
         return table_rows, totals_map
+
+    @classmethod
+    def _expand_product_link_for_logistics(cls, link: Any) -> List[Dict[str, Any]]:
+        product = getattr(link, "product", None)
+        product_title = getattr(product, "title", None) or "Товар"
+        parent_qty = max(1, int(getattr(link, "quantity", 1) or 1))
+        parent_unit_price = float(getattr(link, "price", 0) or 0)
+        product_country = cls._product_country(product)
+
+        order_components = cls._normalize_order_components(getattr(link, "logistics_components", None))
+        if order_components:
+            components = cls._ensure_component_prices(order_components, parent_unit_price)
+        else:
+            template_components = cls._normalize_product_template_components(product)
+            if template_components:
+                components = cls._allocate_template_component_prices(template_components, parent_unit_price)
+            else:
+                components = [
+                    {
+                        "title": product_title,
+                        "country": product_country or cls.DEFAULT_COUNTRY,
+                        "unit": "шт.",
+                        "quantity_per_parent": 1,
+                        "unit_price": parent_unit_price,
+                        "kind": None,
+                    }
+                ]
+
+        rows: List[Dict[str, Any]] = []
+        for component in components:
+            quantity_per_parent = max(1, int(component.get("quantity_per_parent") or 1))
+            qty = parent_qty * quantity_per_parent
+            unit_price = float(component.get("unit_price") or 0)
+            country = cls._clean_text(component.get("country")) or product_country or cls.DEFAULT_COUNTRY
+            title = cls._format_title_with_country(component.get("title") or product_title, country)
+            rows.append(
+                {
+                    "title": title,
+                    "unit": cls._clean_text(component.get("unit")) or "шт.",
+                    "quantity": qty,
+                    "unit_price": unit_price,
+                    "line_total": unit_price * qty,
+                    "product": product,
+                }
+            )
+        return rows
+
+    @classmethod
+    def _normalize_order_components(cls, raw_components: Any) -> List[Dict[str, Any]]:
+        if not isinstance(raw_components, list):
+            return []
+        out: List[Dict[str, Any]] = []
+        for item in raw_components:
+            if not isinstance(item, dict):
+                continue
+            title = cls._clean_text(item.get("title"))
+            if not title:
+                continue
+            out.append(
+                {
+                    "title": title,
+                    "country": cls._clean_text(item.get("country")),
+                    "unit": cls._clean_text(item.get("unit")) or "шт.",
+                    "quantity_per_parent": cls._positive_int(item.get("quantity_per_parent"), 1),
+                    "unit_price": cls._positive_float(item.get("unit_price"), 0.0),
+                    "kind": cls._component_kind(item.get("kind")),
+                }
+            )
+        return out
+
+    @classmethod
+    def _normalize_product_template_components(cls, product: Any) -> List[Dict[str, Any]]:
+        specs = getattr(product, "specs", None)
+        raw_components = specs.get("logistics_components") if isinstance(specs, dict) else None
+        if not isinstance(raw_components, list):
+            return []
+        out: List[Dict[str, Any]] = []
+        for item in raw_components:
+            if not isinstance(item, dict):
+                continue
+            title = cls._clean_text(item.get("title"))
+            if not title:
+                continue
+            out.append(
+                {
+                    "title": title,
+                    "country": cls._clean_text(item.get("country")),
+                    "unit": cls._clean_text(item.get("unit")) or "шт.",
+                    "quantity_per_parent": cls._positive_int(item.get("quantity_per_parent"), 1),
+                    "price_weight": cls._positive_float(item.get("price_weight"), 1.0),
+                    "kind": cls._component_kind(item.get("kind")),
+                }
+            )
+        return out
+
+    @classmethod
+    def _allocate_template_component_prices(
+        cls,
+        components: List[Dict[str, Any]],
+        parent_unit_price: float,
+    ) -> List[Dict[str, Any]]:
+        weighted = [max(0.0, float(item.get("price_weight") or 0)) for item in components]
+        if not any(weighted):
+            weighted = [1.0 for _ in components]
+        return cls._allocate_component_prices(components, weighted, parent_unit_price)
+
+    @classmethod
+    def _ensure_component_prices(
+        cls,
+        components: List[Dict[str, Any]],
+        parent_unit_price: float,
+    ) -> List[Dict[str, Any]]:
+        per_parent_sum = sum(
+            float(item.get("unit_price") or 0) * cls._positive_int(item.get("quantity_per_parent"), 1)
+            for item in components
+        )
+        if per_parent_sum <= 0:
+            weights = [1.0 for _ in components]
+            return cls._allocate_component_prices(components, weights, parent_unit_price)
+
+        resolved = [dict(item) for item in components]
+        diff = parent_unit_price - per_parent_sum
+        if abs(diff) >= 0.005 and resolved:
+            last = resolved[-1]
+            last_qpp = cls._positive_int(last.get("quantity_per_parent"), 1)
+            last["unit_price"] = float(last.get("unit_price") or 0) + (diff / last_qpp)
+        return resolved
+
+    @classmethod
+    def _allocate_component_prices(
+        cls,
+        components: List[Dict[str, Any]],
+        weights: List[float],
+        parent_unit_price: float,
+    ) -> List[Dict[str, Any]]:
+        if not components:
+            return []
+        total_weight = sum(weights) or float(len(components))
+        remaining = parent_unit_price
+        resolved: List[Dict[str, Any]] = []
+        for idx, item in enumerate(components):
+            next_item = dict(item)
+            qpp = cls._positive_int(next_item.get("quantity_per_parent"), 1)
+            if idx == len(components) - 1:
+                component_total = remaining
+            else:
+                raw_component_total = parent_unit_price * (weights[idx] / total_weight)
+                component_total = cls._round_to_nearest_10(raw_component_total)
+                remaining -= component_total
+            next_item["unit_price"] = component_total / qpp
+            resolved.append(next_item)
+        return resolved
+
+    @staticmethod
+    def _round_to_nearest_10(value: float) -> float:
+        return float(math.floor((float(value) + 5) / 10) * 10)
+
+    @classmethod
+    def _product_country(cls, product: Any) -> Optional[str]:
+        specs = getattr(product, "specs", None)
+        if not isinstance(specs, dict):
+            return None
+        for key in ("country", "country_of_origin", "Страна производства", "Страна-производитель"):
+            country = cls._clean_text(specs.get(key))
+            if country:
+                return country
+        return None
+
+    @staticmethod
+    def _clean_text(value: Any) -> str:
+        return " ".join(str(value or "").split())
+
+    @staticmethod
+    def _positive_int(value: Any, default: int) -> int:
+        try:
+            parsed = int(float(value))
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    @staticmethod
+    def _positive_float(value: Any, default: float) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed >= 0 else default
+
+    @classmethod
+    def _component_kind(cls, value: Any) -> Optional[str]:
+        kind = cls._clean_text(value)
+        return kind if kind in cls.LOGISTICS_COMPONENT_KINDS else None
+
+    @classmethod
+    def _format_title_with_country(cls, title: Any, country: str) -> str:
+        cleaned_title = cls._clean_text(title) or "Товар"
+        normalized_title = cleaned_title.lower().replace("ё", "е")
+        if "страна происх" in normalized_title:
+            return cleaned_title
+        cleaned_country = cls._clean_text(country)
+        if not cleaned_country:
+            return cleaned_title
+        return f"{cleaned_title},\nстрана происх. {cleaned_country}"
 
     @staticmethod
     def _letter_to_index(letter: str) -> int:

--- a/services/documents/logistics.py
+++ b/services/documents/logistics.py
@@ -59,7 +59,8 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
             start_cell_addr=config['start_addr'], 
             target_sheet_name=config['sheet_name'],
             merge_cols=config['merge_list'],
-            draw_borders=True
+            draw_borders=True,
+            sheet_format_ranges=config.get('format_ranges'),
         )
 
     def _get_sheet_config(self, doc_type: str) -> dict:
@@ -81,7 +82,17 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
                     (22, 24),    # W-X (Seats)
                     (24, 26),    # Y-Z (Mass)
                     (26, 30)     # AA-AD (Note)
-                ]
+                ],
+                "format_ranges": [
+                    {"cols": (1, 9), "alignment": "LEFT", "rows": "body", "wrap_strategy": "WRAP"},
+                    {"cols": (1, 9), "alignment": "CENTER", "rows": "footer"},
+                    {"cols": (9, 10), "alignment": "CENTER"},
+                    {"cols": (10, 11), "alignment": "RIGHT"},
+                    {"cols": (11, 17), "alignment": "RIGHT"},
+                    {"cols": (17, 18), "alignment": "CENTER"},
+                    {"cols": (18, 26), "alignment": "RIGHT"},
+                    {"cols": (26, 30), "alignment": "CENTER"},
+                ],
             }
         else:
              # TN-2
@@ -96,7 +107,17 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
                 "merge_list": [
                     (1, 9), (11, 14), (14, 18), 
                     (19, 22), (22, 26), (26, 30)
-                ]
+                ],
+                "format_ranges": [
+                    {"cols": (1, 9), "alignment": "LEFT", "rows": "body", "wrap_strategy": "WRAP"},
+                    {"cols": (1, 9), "alignment": "CENTER", "rows": "footer"},
+                    {"cols": (9, 10), "alignment": "CENTER"},
+                    {"cols": (10, 11), "alignment": "RIGHT"},
+                    {"cols": (11, 18), "alignment": "RIGHT"},
+                    {"cols": (18, 19), "alignment": "CENTER"},
+                    {"cols": (19, 26), "alignment": "RIGHT"},
+                    {"cols": (26, 30), "alignment": "CENTER"},
+                ],
             }
 
     def _prepare_sheet_data(self, doc_type: str) -> Tuple[List[List[str]], Dict[str, str]]:

--- a/services/documents/logistics.py
+++ b/services/documents/logistics.py
@@ -20,7 +20,8 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
         doc_number: Optional[str] = None,
         document_date: Optional[datetime] = None,
     ) -> str:
-        await self.fetch_order()
+        if not self.order:
+            await self.fetch_order()
         if not self.order: return "Order not found"
 
         template_id = template_id or TEMPLATES.get(doc_type)

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -106,7 +106,8 @@ class GoogleDocsService:
                        start_cell_addr: str = None,
                        target_sheet_name: str = None,
                        merge_cols: List[tuple] = None, 
-                       draw_borders: bool = False) -> str:
+                       draw_borders: bool = False,
+                       sheet_format_ranges: Optional[List[Dict[str, Any]]] = None) -> str:
         """
         Генерация документа на основе Google Sheets.
         start_cell_addr: Адрес ячейки (напр. "A12").
@@ -145,7 +146,7 @@ class GoogleDocsService:
             if table_data and len(table_data) > 0:
                 self._fill_sheet_table(sheets_service, new_sheet_id, table_data, 
                                        start_cell_addr, target_sheet_name,
-                                       merge_cols, draw_borders)
+                                       merge_cols, draw_borders, sheet_format_ranges)
 
             return f"https://docs.google.com/spreadsheets/d/{new_sheet_id}/edit"
             
@@ -229,7 +230,8 @@ class GoogleDocsService:
 
     def _fill_sheet_table(self, sheets_service, sheet_id, data: List[List[str]], 
                           start_cell_addr=None, target_sheet_name=None,
-                          merge_cols: List[tuple] = None, draw_borders: bool = False):
+                          merge_cols: List[tuple] = None, draw_borders: bool = False,
+                          sheet_format_ranges: Optional[List[Dict[str, Any]]] = None):
         """
         merge_cols: список кортежей (start_col_idx, end_col_idx) для объединения ВНУТРИ каждой строки данных.
                     Индексы 0-based. start включительно, end исключительно.
@@ -359,6 +361,54 @@ class GoogleDocsService:
                     'innerVertical': {'style': 'SOLID', 'width': 1, 'color': {'red': 0, 'green': 0, 'blue': 0}},
                 }
             })
+
+        # 2.3.1. Выравнивание данных в таблицах Google Sheets.
+        # Диапазоны задаются абсолютными 0-based колонками Google Sheets.
+        for fmt in sheet_format_ranges or []:
+            cols = fmt.get('cols')
+            alignment = fmt.get('alignment')
+            if not cols or len(cols) != 2 or alignment not in {'LEFT', 'CENTER', 'RIGHT'}:
+                continue
+
+            row_mode = fmt.get('rows', 'all')
+            row_start = start_row
+            row_end = start_row + len(data)
+            if row_mode == 'body':
+                row_end = max(row_start, row_end - 1)
+            elif row_mode == 'footer':
+                row_start = max(row_start, row_end - 1)
+
+            if row_end <= row_start:
+                continue
+
+            user_format = {
+                'horizontalAlignment': alignment,
+                'verticalAlignment': 'MIDDLE',
+            }
+            fields = [
+                'userEnteredFormat.horizontalAlignment',
+                'userEnteredFormat.verticalAlignment',
+            ]
+            wrap_strategy = fmt.get('wrap_strategy')
+            if wrap_strategy in {'WRAP', 'OVERFLOW_CELL', 'CLIP'}:
+                user_format['wrapStrategy'] = wrap_strategy
+                fields.append('userEnteredFormat.wrapStrategy')
+
+            reqs.append({
+                'repeatCell': {
+                    'range': {
+                        'sheetId': sht_id,
+                        'startRowIndex': row_start,
+                        'endRowIndex': row_end,
+                        'startColumnIndex': cols[0],
+                        'endColumnIndex': cols[1],
+                    },
+                    'cell': {
+                        'userEnteredFormat': user_format
+                    },
+                    'fields': ','.join(fields),
+                }
+            })
         
         # 2.4 Удаление старой строки-шаблона (которая оказалась ниже вставленных)
         # Она теперь индексируется как start_row + rows_to_insert
@@ -373,6 +423,18 @@ class GoogleDocsService:
                 }
             }
         })
+
+        if sheet_format_ranges:
+            reqs.append({
+                'autoResizeDimensions': {
+                    'dimensions': {
+                        'sheetId': sht_id,
+                        'dimension': 'ROWS',
+                        'startIndex': start_row,
+                        'endIndex': start_row + len(data),
+                    }
+                }
+            })
 
         try:
             sheets_service.spreadsheets().batchUpdate(spreadsheetId=sheet_id, body={'requests': reqs}).execute()

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -29,6 +29,104 @@ class OrderService:
         "repair": "Ремонт",
         "dismantling": "Демонтаж",
     }
+    LOGISTICS_COMPONENT_KINDS = {"indoor", "outdoor", "accessory", "other"}
+    DEFAULT_LOGISTICS_COUNTRY = "Китай"
+
+    @staticmethod
+    def _clean_optional_text(value: Any) -> Optional[str]:
+        cleaned = " ".join(str(value or "").split())
+        return cleaned or None
+
+    @staticmethod
+    def _extract_product_country(product: Optional[Product]) -> Optional[str]:
+        specs = getattr(product, "specs", None)
+        if not isinstance(specs, dict):
+            return None
+        for key in ("country", "country_of_origin", "Страна производства", "Страна-производитель"):
+            country = OrderService._clean_optional_text(specs.get(key))
+            if country:
+                return country
+        return None
+
+    @staticmethod
+    def _serialize_product_logistics_components(product: Optional[Product]) -> List[Dict[str, Any]]:
+        specs = getattr(product, "specs", None)
+        if not isinstance(specs, dict):
+            return []
+        raw_components = specs.get("logistics_components")
+        if not isinstance(raw_components, list):
+            return []
+
+        out: List[Dict[str, Any]] = []
+        for item in raw_components:
+            if not isinstance(item, dict):
+                continue
+            title = OrderService._clean_optional_text(item.get("title"))
+            if not title:
+                continue
+            country = OrderService._clean_optional_text(item.get("country"))
+            unit = OrderService._clean_optional_text(item.get("unit")) or "шт."
+            try:
+                quantity_per_parent = max(1, int(float(item.get("quantity_per_parent") or 1)))
+            except (TypeError, ValueError):
+                quantity_per_parent = 1
+            try:
+                price_weight = max(0.0, float(item.get("price_weight") or 1))
+            except (TypeError, ValueError):
+                price_weight = 1.0
+            kind = OrderService._clean_optional_text(item.get("kind"))
+            if kind not in OrderService.LOGISTICS_COMPONENT_KINDS:
+                kind = None
+            out.append(
+                {
+                    "title": title,
+                    "country": country,
+                    "unit": unit,
+                    "quantity_per_parent": quantity_per_parent,
+                    "price_weight": price_weight,
+                    "kind": kind,
+                }
+            )
+        return out
+
+    @staticmethod
+    def _serialize_order_logistics_components(raw_components: Any) -> Optional[List[Dict[str, Any]]]:
+        if not raw_components:
+            return None
+
+        out: List[Dict[str, Any]] = []
+        for item in raw_components:
+            if hasattr(item, "model_dump"):
+                item = item.model_dump()
+            if not isinstance(item, dict):
+                continue
+            title = OrderService._clean_optional_text(item.get("title"))
+            if not title:
+                continue
+            country = OrderService._clean_optional_text(item.get("country"))
+            unit = OrderService._clean_optional_text(item.get("unit")) or "шт."
+            try:
+                quantity_per_parent = max(1, int(float(item.get("quantity_per_parent") or 1)))
+            except (TypeError, ValueError):
+                quantity_per_parent = 1
+            try:
+                unit_price = max(0.0, float(item.get("unit_price") or 0))
+            except (TypeError, ValueError):
+                unit_price = 0.0
+            kind = OrderService._clean_optional_text(item.get("kind"))
+            if kind not in OrderService.LOGISTICS_COMPONENT_KINDS:
+                kind = None
+            out.append(
+                {
+                    "title": title,
+                    "country": country,
+                    "unit": unit,
+                    "quantity_per_parent": quantity_per_parent,
+                    "unit_price": unit_price,
+                    "kind": kind,
+                }
+            )
+        return out or None
 
     @staticmethod
     def _clean_order_title(raw: Any) -> Optional[str]:
@@ -993,7 +1091,10 @@ class OrderService:
                 proposal_id=proposal.id,
                 product_id=p["product_id"],
                 quantity=p["quantity"],
-                price=p["price"] # Цена должна приходить актуальная
+                price=p["price"], # Цена должна приходить актуальная
+                logistics_components=OrderService._serialize_order_logistics_components(
+                    p.get("logistics_components")
+                ),
             )
             session.add(link)
         
@@ -1127,7 +1228,10 @@ class OrderService:
                 proposal_id=proposal.id,
                 product_id=int(prod["product_id"]),
                 quantity=int(prod["quantity"]),
-                price=int(prod["price"])
+                price=int(prod["price"]),
+                logistics_components=OrderService._serialize_order_logistics_components(
+                    prod.get("logistics_components")
+                ),
             )
             session.add(link)
         
@@ -1397,6 +1501,9 @@ class OrderService:
             "is_installation_included": bool(link.is_installation_included),
             "installation_price": int(link.installation_price or 0),
             "line_total": line_total,
+            "product_country": OrderService._extract_product_country(link.product),
+            "product_logistics_components": OrderService._serialize_product_logistics_components(link.product),
+            "logistics_components": OrderService._serialize_order_logistics_components(link.logistics_components) or [],
         }
 
     @staticmethod
@@ -1675,6 +1782,9 @@ class OrderService:
                         is_installation_included=link.is_installation_included,
                         installation_price=link.installation_price,
                         installation_details=link.installation_details,
+                        logistics_components=OrderService._serialize_order_logistics_components(
+                            link.logistics_components
+                        ),
                     )
                 )
             for link in [item for item in order.service_links if item.proposal_id == source.id]:
@@ -2082,6 +2192,9 @@ class OrderService:
                         quantity=product_line.quantity,
                         price=product_line.price,
                         cost=product_line.cost if product_line.cost is not None else defaults["cost"],
+                        logistics_components=OrderService._serialize_order_logistics_components(
+                            product_line.logistics_components
+                        ),
                     )
                     session.add(new_product_link)
 

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -701,6 +701,7 @@ async def test_manager_order_patch_lines_persists_logistics_components(async_cli
                     {
                         "title": "Внутренний блок TEST-IN",
                         "country": "Китай",
+                        "unit": "шт.",
                         "quantity_per_parent": 1,
                         "unit_price": 600,
                         "kind": "indoor",
@@ -708,6 +709,7 @@ async def test_manager_order_patch_lines_persists_logistics_components(async_cli
                     {
                         "title": "Наружный блок TEST-OUT",
                         "country": "Китай",
+                        "unit": "шт.",
                         "quantity_per_parent": 1,
                         "unit_price": 1203,
                         "kind": "outdoor",

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -897,6 +897,131 @@ async def test_manager_order_offer_generation_uses_requested_proposal_and_create
 
 
 @pytest.mark.asyncio
+async def test_manager_order_tn2_generation_uses_requested_proposal_logistics_components(async_client, db, monkeypatch):
+    customer = Customer(name="Waybill Proposal", phone="+375296666669", type=CustomerType.individual)
+    p1 = Product(title="Waybill P1", slug="waybill-p1", price=1000, area=25)
+    p2 = Product(title="Waybill P2", slug="waybill-p2", price=1803, area=35)
+    db.add(customer)
+    db.add(p1)
+    db.add(p2)
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(p1)
+    await db.refresh(p2)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEGOTIATION)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    first_resp = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"products": [{"product_id": p1.id, "quantity": 1, "price": 1000, "cost": 700}], "services": []},
+        headers=headers,
+    )
+    assert first_resp.status_code == 200
+    default_proposal = first_resp.json()["proposals"][0]
+
+    duplicate_resp = await async_client.post(
+        f"/api/manager/orders/{order.id}/proposals/{default_proposal['id']}/duplicate",
+        json={"name": "Накладная"},
+        headers=headers,
+    )
+    assert duplicate_resp.status_code == 200
+    second_proposal = next(item for item in duplicate_resp.json()["proposals"] if item["name"] == "Накладная")
+
+    edit_second_resp = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={
+            "products": [
+                {
+                    "product_id": p2.id,
+                    "quantity": 1,
+                    "price": 1803,
+                    "cost": 1300,
+                    "proposal_id": second_proposal["id"],
+                    "logistics_components": [
+                        {
+                            "title": "Внутренний блок WAY-IN",
+                            "country": "Китай",
+                            "unit": "шт.",
+                            "quantity_per_parent": 1,
+                            "unit_price": 600,
+                            "kind": "indoor",
+                        },
+                        {
+                            "title": "Наружный блок WAY-OUT",
+                            "country": "Китай",
+                            "unit": "шт.",
+                            "quantity_per_parent": 1,
+                            "unit_price": 1203,
+                            "kind": "outdoor",
+                        },
+                    ],
+                },
+            ],
+            "services": [],
+        },
+        headers=headers,
+    )
+    assert edit_second_resp.status_code == 200
+
+    contract = OrderDocument(
+        order_id=order.id,
+        doc_type="contract",
+        number="Д-TEST",
+        date=datetime.now(),
+        google_file_id="contract-file",
+        google_edit_url="https://docs.google.com/document/d/contract-file/edit",
+    )
+    db.add(contract)
+    await db.commit()
+
+    sheet_captures = []
+
+    class _FakeGoogleSheetService:
+        def generate_sheet(
+            self,
+            template_id,
+            doc_title,
+            replacements,
+            table_rows,
+            start_cell_addr,
+            target_sheet_name,
+            merge_cols,
+            draw_borders,
+        ):
+            _ = (template_id, doc_title, replacements, start_cell_addr, target_sheet_name, merge_cols, draw_borders)
+            sheet_captures.append(table_rows)
+            return f"https://docs.google.com/spreadsheets/d/waybill-{len(sheet_captures)}/edit"
+
+    from services.documents import logistics
+
+    monkeypatch.setattr(logistics, "get_google_service", lambda: _FakeGoogleSheetService())
+
+    first_tn2_resp = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/tn2",
+        params={"proposal_id": second_proposal["id"]},
+        headers=headers,
+    )
+    assert first_tn2_resp.status_code == 200, first_tn2_resp.text
+    first_tn2 = first_tn2_resp.json()
+    assert first_tn2["proposal_id"] == second_proposal["id"]
+    assert sheet_captures[-1][0][0].startswith("Внутренний блок WAY-IN")
+    assert sheet_captures[-1][1][0].startswith("Наружный блок WAY-OUT")
+    assert "Waybill P1" not in "\n".join(str(cell) for row in sheet_captures[-1] for cell in row)
+
+    second_tn2_resp = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/tn2",
+        params={"proposal_id": second_proposal["id"]},
+        headers=headers,
+    )
+    assert second_tn2_resp.status_code == 200, second_tn2_resp.text
+    assert second_tn2_resp.json()["doc_id"] != first_tn2["doc_id"]
+
+
+@pytest.mark.asyncio
 async def test_manager_order_patch_validation_errors(async_client, db):
     customer = Customer(name="Validation", phone="+375299999999", type=CustomerType.individual)
     db.add(customer)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -675,6 +675,56 @@ async def test_manager_order_patch_lines_preserves_installers(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_order_patch_lines_persists_logistics_components(async_client, db):
+    customer = Customer(name="Logistics", phone="+375296666668", type=CustomerType.individual)
+    product = Product(title="Split Logistics", slug="split-logistics", price=1803, area=30)
+    db.add(customer)
+    db.add(product)
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(product)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    payload = {
+        "products": [
+            {
+                "product_id": product.id,
+                "quantity": 1,
+                "price": 1803,
+                "cost": 1200,
+                "logistics_components": [
+                    {
+                        "title": "Внутренний блок TEST-IN",
+                        "country": "Китай",
+                        "quantity_per_parent": 1,
+                        "unit_price": 600,
+                        "kind": "indoor",
+                    },
+                    {
+                        "title": "Наружный блок TEST-OUT",
+                        "country": "Китай",
+                        "quantity_per_parent": 1,
+                        "unit_price": 1203,
+                        "kind": "outdoor",
+                    },
+                ],
+            }
+        ],
+        "services": [],
+    }
+    response = await async_client.patch(f"/api/manager/orders/{order.id}", json=payload, headers=headers)
+    assert response.status_code == 200
+
+    product_lines = response.json()["product_lines"]
+    assert product_lines[0]["logistics_components"] == payload["products"][0]["logistics_components"]
+
+
+@pytest.mark.asyncio
 async def test_manager_order_proposals_can_duplicate_edit_and_select(async_client, db):
     customer = Customer(name="Proposal Customer", phone="+375296666667", type=CustomerType.individual)
     p1 = Product(title="Proposal P1", slug="proposal-p1", price=1000, area=25)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -991,8 +991,18 @@ async def test_manager_order_tn2_generation_uses_requested_proposal_logistics_co
             target_sheet_name,
             merge_cols,
             draw_borders,
+            sheet_format_ranges=None,
         ):
-            _ = (template_id, doc_title, replacements, start_cell_addr, target_sheet_name, merge_cols, draw_borders)
+            _ = (
+                template_id,
+                doc_title,
+                replacements,
+                start_cell_addr,
+                target_sheet_name,
+                merge_cols,
+                draw_borders,
+                sheet_format_ranges,
+            )
             sheet_captures.append(table_rows)
             return f"https://docs.google.com/spreadsheets/d/waybill-{len(sheet_captures)}/edit"
 

--- a/tests/unit/test_logistics_components.py
+++ b/tests/unit/test_logistics_components.py
@@ -1,0 +1,99 @@
+from models import OrderProductLink, Product
+from services.documents.logistics import LogisticsSheetStrategy
+
+
+def _link(
+    *,
+    price: int = 1803,
+    quantity: int = 1,
+    specs: dict | None = None,
+    logistics_components: list[dict] | None = None,
+) -> OrderProductLink:
+    product = Product(
+        title="Кондиционер Test-24",
+        slug="conditioner-test-24",
+        price=price,
+        area=70,
+        specs=specs or {},
+    )
+    link = OrderProductLink(
+        product_id=1,
+        quantity=quantity,
+        price=price,
+        logistics_components=logistics_components,
+    )
+    link.product = product
+    return link
+
+
+def test_logistics_default_two_block_split_rounds_inner_to_nearest_10():
+    components = [
+        {"title": "Внутренний блок MDSAF-24HRN8", "price_weight": 1, "kind": "indoor"},
+        {"title": "Наружный блок MDOAF-24HN8", "price_weight": 2, "kind": "outdoor"},
+    ]
+    rows = LogisticsSheetStrategy._expand_product_link_for_logistics(
+        _link(specs={"logistics_components": components})
+    )
+
+    assert [row["unit_price"] for row in rows] == [600, 1203]
+    assert sum(row["line_total"] for row in rows) == 1803
+    assert rows[0]["title"] == "Внутренний блок MDSAF-24HRN8,\nстрана происх. Китай"
+    assert rows[1]["title"] == "Наружный блок MDOAF-24HN8,\nстрана происх. Китай"
+
+
+def test_order_level_logistics_components_override_product_template():
+    rows = LogisticsSheetStrategy._expand_product_link_for_logistics(
+        _link(
+            specs={
+                "logistics_components": [
+                    {"title": "Внутренний блок из товара", "price_weight": 1},
+                    {"title": "Наружный блок из товара", "price_weight": 2},
+                ]
+            },
+            logistics_components=[
+                {"title": "Позиция заказа 1", "country": "Китай", "unit_price": 700},
+                {"title": "Позиция заказа 2", "country": "Китай", "unit_price": 1103},
+            ],
+        )
+    )
+
+    assert [row["title"] for row in rows] == [
+        "Позиция заказа 1,\nстрана происх. Китай",
+        "Позиция заказа 2,\nстрана происх. Китай",
+    ]
+    assert [row["unit_price"] for row in rows] == [700, 1103]
+    assert sum(row["line_total"] for row in rows) == 1803
+
+
+def test_product_specs_template_expands_multiple_components_and_keeps_total():
+    rows = LogisticsSheetStrategy._expand_product_link_for_logistics(
+        _link(
+            price=2500,
+            specs={
+                "country": "Китай",
+                "logistics_components": [
+                    {"title": "Внутренний кассетный блок", "price_weight": 1},
+                    {"title": "Наружный блок", "price_weight": 2},
+                    {"title": "Декоративная панель", "price_weight": 0.5, "kind": "accessory"},
+                ],
+            },
+        )
+    )
+
+    assert len(rows) == 3
+    assert rows[0]["unit_price"] == 710
+    assert rows[1]["unit_price"] == 1430
+    assert rows[2]["unit_price"] == 360
+    assert sum(row["line_total"] for row in rows) == 2500
+
+
+def test_logistics_fallback_keeps_single_product_row():
+    rows = LogisticsSheetStrategy._expand_product_link_for_logistics(
+        _link(quantity=2, specs={})
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Кондиционер Test-24,\nстрана происх. Китай"
+    assert rows[0]["quantity"] == 2
+    assert rows[0]["unit_price"] == 1803
+    assert rows[0]["line_total"] == 3606


### PR DESCRIPTION
Summary:
- add order-level logistics_components with migration and typed schemas
- expand only ТН-2/ТТН-1 rows from order overrides or product specs templates, with 1/3 allocation and country fallback
- add product template editor and per-order waybill component editor, saving lines before waybill generation
- regenerate OpenAPI and manager client

Tests:
- python3 -m compileall models/order.py schemas.py services/order_service.py services/documents/logistics.py
- pytest tests/unit/test_logistics_components.py tests/unit/test_manager_operation_ids_contract.py -q
- python3 scripts/legacy/extract_openapi.py
- cd manager_frontend && npm run gen:api
- cd manager_frontend && npm run build
- pytest tests/integration/test_manager_orders_api.py::test_manager_order_patch_lines_persists_logistics_components -q (blocked locally: db_test host is not resolvable)

Browser smoke:
- localhost manager app opens, but reload lands on login screen, so authenticated order UI was not visually inspected locally