### PR TITLE
[codex] Fix web deploy API precheck

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -274,14 +274,29 @@ jobs:
       - name: Build Astro Site
         working-directory: ./web
         env:
-           # SSR Build: Use production API for static generation
-           INTERNAL_API_URL: https://api.mvn.by/api/v1
+           # SSR Build: bypass public CDN/WAF checks via SSH tunnel to the API host.
+           INTERNAL_API_URL: http://127.0.0.1:18000/api/v1
            # Client-side: Use production API  
            # CRITICAL: API Router prefix is /api, full path: https://api.mvn.by/api/v1
            PUBLIC_API_URL: https://api.mvn.by/api/v1
            # Google Tag Manager ID
            PUBLIC_GTM_ID: GTM-5CR6WBBC
-        run: npm run build
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
+          ssh -f -N \
+            -L 18000:127.0.0.1:8000 \
+            -i ~/.ssh/deploy_key \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ExitOnForwardFailure=yes \
+            -o ConnectTimeout=20 \
+            ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}
+          curl -fsS --retry 10 --retry-delay 3 http://127.0.0.1:18000/api/v1/config >/dev/null
+          npm run build
 
       - name: Setup SSH Key for Web Server
         run: |

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -28,13 +28,28 @@ jobs:
       - name: Build Astro Site
         working-directory: ./web
         env:
-           # SSR Build: Use production API for static generation
-           INTERNAL_API_URL: https://api.mvn.by/api/v1
+           # SSR Build: bypass public CDN/WAF checks via SSH tunnel to the API host.
+           INTERNAL_API_URL: http://127.0.0.1:18000/api/v1
            # Client-side: Use production API  
            PUBLIC_API_URL: https://api.mvn.by/api/v1
            # Google Tag Manager ID
            PUBLIC_GTM_ID: GTM-5CR6WBBC
-        run: npm run build
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
+          ssh -f -N \
+            -L 18000:127.0.0.1:8000 \
+            -i ~/.ssh/deploy_key \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ExitOnForwardFailure=yes \
+            -o ConnectTimeout=20 \
+            ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}
+          curl -fsS --retry 10 --retry-delay 3 http://127.0.0.1:18000/api/v1/config >/dev/null
+          npm run build
 
       - name: Setup SSH Key
         run: |


### PR DESCRIPTION
## What changed
- Updated production web deploy and turbo web rebuild workflows to use an SSH tunnel for build-time API access.
- `INTERNAL_API_URL` now points to `http://127.0.0.1:18000/api/v1` during the Astro build.
- `PUBLIC_API_URL` remains `https://api.mvn.by/api/v1` for browser/client-side requests.

## Why
The production frontend deploy is failing during `npm run check-api` because GitHub-hosted runners receive `403 Forbidden` from the public API endpoint. The backend deploy and server-local smoke checks pass, and the same public endpoint returns `200` locally, which points to public CDN/WAF behavior rather than an API route regression.

Using an SSH tunnel keeps the SSG build tied to the freshly deployed API server while avoiding public edge filtering for GitHub runner traffic.

## Validation
- Parsed both edited workflow YAML files locally.
- Ran `git diff --check` successfully.
- Ran `npm run check-api` locally against `https://api.mvn.by/api/v1`; it passed and found 653 products.

`actionlint` was not installed locally, so that check was not run.