### PR TITLE
[codex] Add document basis links for closing docs

### DIFF
--- a/alembic/versions/4f6a7b8c9d10_add_order_document_base_document.py
+++ b/alembic/versions/4f6a7b8c9d10_add_order_document_base_document.py
@@ -1,0 +1,81 @@
+"""Add order document base links
+
+Revision ID: 4f6a7b8c9d10
+Revises: a4e5f6b7c8d9
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4f6a7b8c9d10"
+down_revision: Union[str, Sequence[str], None] = "a4e5f6b7c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _indexes(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _foreign_keys(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {fk["name"] for fk in inspector.get_foreign_keys(table_name) if fk.get("name")}
+
+
+def upgrade() -> None:
+    columns = _columns("order_document")
+    if "base_document_id" not in columns:
+        with op.batch_alter_table("order_document", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("base_document_id", sa.Integer(), nullable=True))
+    if "base_customer_contract_id" not in columns:
+        with op.batch_alter_table("order_document", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("base_customer_contract_id", sa.Integer(), nullable=True))
+
+    if "ix_order_document_base_document_id" not in _indexes("order_document"):
+        op.create_index("ix_order_document_base_document_id", "order_document", ["base_document_id"])
+    if "ix_order_document_base_customer_contract_id" not in _indexes("order_document"):
+        op.create_index(
+            "ix_order_document_base_customer_contract_id",
+            "order_document",
+            ["base_customer_contract_id"],
+        )
+
+    if "fk_order_document_base_document_id_order_document" not in _foreign_keys("order_document"):
+        with op.batch_alter_table("order_document", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                "fk_order_document_base_document_id_order_document",
+                "order_document",
+                ["base_document_id"],
+                ["id"],
+            )
+    if "fk_order_document_base_customer_contract_id_customer_contract" not in _foreign_keys("order_document"):
+        with op.batch_alter_table("order_document", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                "fk_order_document_base_customer_contract_id_customer_contract",
+                "customer_contract",
+                ["base_customer_contract_id"],
+                ["id"],
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("order_document", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("fk_order_document_base_customer_contract_id_customer_contract"), type_="foreignkey")
+        batch_op.drop_constraint(batch_op.f("fk_order_document_base_document_id_order_document"), type_="foreignkey")
+        batch_op.drop_index(batch_op.f("ix_order_document_base_customer_contract_id"))
+        batch_op.drop_index(batch_op.f("ix_order_document_base_document_id"))
+        batch_op.drop_column("base_customer_contract_id")
+        batch_op.drop_column("base_document_id")

--- a/docs/document-placeholders.md
+++ b/docs/document-placeholders.md
@@ -21,6 +21,16 @@ For acts and invoices only, the generator can replace these words and their comm
 
 The role type can come from the contract template default, the open customer contract, or the order override.
 
+## Base Document
+
+Closing document templates for acts, ТН-2 and ТТН-1 can use a neutral base document reference:
+
+- `{{base_document_type}}`
+- `{{base_document_number}}`
+- `{{base_document_date}}`
+
+When the selected base document is an invoice, `{{invoice_number}}` and `{{invoice_date}}` are also populated. When it is a one-time order contract, `{{contract_number}}` and `{{contract_date}}` use that document.
+
 ## Additional Conditions
 
 Use `{{additional_conditions}}` in contract templates for order-specific terms. The value comes from the manager order document block.

--- a/manager_frontend/src/client/models/ManagerCustomerDocumentItem.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerDocumentItem.ts
@@ -6,6 +6,11 @@ export type ManagerCustomerDocumentItem = {
     id: number;
     order_id: number;
     proposal_id?: (number | null);
+    base_document_id?: (number | null);
+    base_customer_contract_id?: (number | null);
+    base_document_type?: (string | null);
+    base_document_number?: (string | null);
+    base_document_date?: (string | null);
     doc_type: string;
     number: string;
     date: string;

--- a/manager_frontend/src/client/models/ManagerOrderDocumentItem.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDocumentItem.ts
@@ -5,6 +5,11 @@
 export type ManagerOrderDocumentItem = {
     id: number;
     proposal_id?: (number | null);
+    base_document_id?: (number | null);
+    base_customer_contract_id?: (number | null);
+    base_document_type?: (string | null);
+    base_document_number?: (string | null);
+    base_document_date?: (string | null);
     doc_type: string;
     number: string;
     date: string;

--- a/manager_frontend/src/client/models/ManagerOrderDocumentResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDocumentResponse.ts
@@ -5,6 +5,8 @@
 export type ManagerOrderDocumentResponse = {
     doc_id: number;
     proposal_id?: (number | null);
+    base_document_id?: (number | null);
+    base_customer_contract_id?: (number | null);
     doc_type: string;
     edit_url: string;
 };

--- a/manager_frontend/src/client/services/ManagerOrdersService.ts
+++ b/manager_frontend/src/client/services/ManagerOrdersService.ts
@@ -270,6 +270,7 @@ export class ManagerOrdersService {
      * @param templateId Google Drive template file ID
      * @param contractDate Document/contract date as ISO datetime
      * @param proposalId Order proposal ID for generated commercial offer
+     * @param baseDocumentId Order document ID used as basis for closing documents; 0 means selected open customer contract
      * @returns ManagerOrderDocumentResponse Successful Response
      * @throws ApiError
      */
@@ -280,6 +281,7 @@ export class ManagerOrdersService {
         templateId?: (string | null),
         contractDate?: (string | null),
         proposalId?: (number | null),
+        baseDocumentId?: (number | null),
     ): CancelablePromise<ManagerOrderDocumentResponse> {
         return __request(OpenAPI, {
             method: 'POST',
@@ -293,6 +295,7 @@ export class ManagerOrdersService {
                 'template_id': templateId,
                 'contract_date': contractDate,
                 'proposal_id': proposalId,
+                'base_document_id': baseDocumentId,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -61,7 +61,10 @@ const emit = defineEmits<{
 }>();
 
 const DOCUMENT_FILE_ACCEPT = '.pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-const ONE_TIME_CONTRACT_VALUE = 'one-time-contract';
+const OPEN_CONTRACT_PREFIX = 'open:';
+const ORDER_DOCUMENT_PREFIX = 'doc:';
+const BASE_DOCUMENT_TYPES = new Set(['offer', 'contract', 'invoice']);
+const CLOSING_DOCUMENT_TYPES = new Set(['act', 'tn2', 'ttn1']);
 
 const DOCUMENT_TYPES = [
   { type: 'contract', label: 'Договор' },
@@ -85,6 +88,7 @@ const contractTemplates = ref<DocumentTemplateItem[]>([]);
 const selectedCustomerContractId = ref<number | null>(props.order.customer_contract_id || null);
 const selectedDocumentRoleType = ref<string | null>(props.order.document_role_type || null);
 const selectedContractTemplateId = ref<string>('');
+const selectedBaseDocumentValue = ref<string>('');
 const additionalConditions = ref(props.order.additional_conditions || '');
 const additionalConditionsSaved = ref(props.order.additional_conditions || '');
 const isSavingAdditionalConditions = ref(false);
@@ -117,7 +121,9 @@ const normalizeRoleType = (value: unknown): DocumentRoleType => {
 };
 
 const isWaybillType = (type: string) => type === 'tn2' || type === 'ttn1';
+const isClosingDocumentType = (type: string) => CLOSING_DOCUMENT_TYPES.has(type);
 const isWaybillDocument = computed(() => isWaybillType(selectedDocumentType.value));
+const documentTypeLabel = (type?: string | null) => DOCUMENT_TYPES.find((item) => item.type === type)?.label || type || 'Документ';
 const hasUsableWaybillProductLine = (line: WaybillProductLine) => (
   String(line.product_query || '').trim().length > 0
   && Number(line.quantity || 0) > 0
@@ -344,7 +350,28 @@ const oneTimeContractDocument = computed(() => (
 const hasOrderContract = computed(() => !!oneTimeContractDocument.value);
 const hasContract = computed(() => (isCompanyOrder.value ? !!selectedCustomerContractId.value : false) || hasOrderContract.value);
 const hasOrderInvoice = computed(() => documents.value.some((doc) => doc.doc_type === 'invoice'));
-const hasClosingBaseDocument = computed(() => hasContract.value || hasOrderInvoice.value);
+const baseOrderDocuments = computed(() => (
+  [...documents.value]
+    .filter((doc) => BASE_DOCUMENT_TYPES.has(doc.doc_type))
+    .sort((a, b) => b.id - a.id)
+));
+const baseDocumentOptions = computed(() => {
+  const options: Array<{ value: string; label: string }> = [];
+  for (const contract of customerContracts.value) {
+    options.push({
+      value: `${OPEN_CONTRACT_PREFIX}${contract.id}`,
+      label: `Открытый договор · ${contract.number}`,
+    });
+  }
+  for (const doc of baseOrderDocuments.value) {
+    options.push({
+      value: `${ORDER_DOCUMENT_PREFIX}${doc.id}`,
+      label: `${documentTypeLabel(doc.doc_type)} · ${doc.number}`,
+    });
+  }
+  return options;
+});
+const hasClosingBaseDocument = computed(() => baseDocumentOptions.value.length > 0);
 const selectedContractTemplate = computed(() => contractTemplates.value.find((template) => template.id === selectedContractTemplateId.value) || null);
 const selectedDocumentTypeItem = computed(() => DOCUMENT_TYPES.find((item) => item.type === selectedDocumentType.value) || DOCUMENT_TYPES[0]!);
 const selectedOpenContract = computed(() => (
@@ -357,7 +384,7 @@ const inheritedDocumentRoleType = computed(() => normalizeRoleType(
     || props.order.effective_document_role_type
 ));
 const documentSummary = computed(() => {
-  const base = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : 'без договора');
+  const base = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : (hasClosingBaseDocument.value ? 'есть основание' : 'без основания'));
   return `${documents.value.length} док. · ${base}`;
 });
 const hasDocumentSetupWarning = computed(() => isCompanyOrder.value && !selectedCustomerContractId.value && !hasClosingBaseDocument.value);
@@ -368,11 +395,7 @@ const suggestedDocumentType = computed(() => {
   return 'act';
 });
 const needsContractBinding = computed(() => (
-  isCompanyOrder.value && (
-    selectedDocumentType.value === 'tn2'
-    || selectedDocumentType.value === 'ttn1'
-    || (selectedDocumentType.value === 'act' && !hasOrderInvoice.value)
-  )
+  isClosingDocumentType(selectedDocumentType.value)
 ));
 const selectedTemplateLabel = computed(() => (
   selectedDocumentType.value === 'contract'
@@ -388,12 +411,8 @@ const showsAdditionalConditions = computed(() => (
 const additionalConditionsMode = computed(() => (selectedDocumentType.value === 'contract' ? 'contract' : 'invoice'));
 const contractBindingLabel = computed(() => {
   if (selectedDocumentType.value === 'contract') return 'будет создан разовый договор заказа';
-  if (!isCompanyOrder.value) return 'не требуется';
-  if (selectedDocumentType.value === 'act' && hasOrderInvoice.value) return 'Счет как основание для акта';
   if (!needsContractBinding.value) return 'не требуется';
-  if (selectedCustomerContractId.value) return selectedOpenContract.value ? `Открытый договор · ${selectedOpenContract.value.number}` : 'Открытый договор';
-  if (oneTimeContractDocument.value) return `Разовый договор заказа · ${oneTimeContractDocument.value.number}`;
-  return 'не выбран';
+  return baseDocumentOptions.value.find((option) => option.value === selectedBaseDocumentValue.value)?.label || 'не выбран';
 });
 const roleChecklistLabel = computed(() => (
   selectedDocumentRoleType.value ? getRoleLabel(selectedDocumentRoleType.value) : 'Оставить по шаблону'
@@ -420,10 +439,10 @@ const getDocumentDateForType = (type: string) => (
 );
 
 const isDocumentTypeLocked = (type: string) => (
-  type === 'act' ? !hasClosingBaseDocument.value : (type === 'ttn1' || type === 'tn2') && !hasContract.value
+  isClosingDocumentType(type) && !hasClosingBaseDocument.value
 );
 const lockedDocumentTitle = (type: string) => (
-  type === 'act' ? 'Сначала создайте договор или счет' : 'Сначала создайте договор'
+  isClosingDocumentType(type) ? 'Сначала создайте договор, счет или оферту' : ''
 );
 
 const documentProposalName = (doc: ManagerOrderDocumentItem) => {
@@ -432,14 +451,29 @@ const documentProposalName = (doc: ManagerOrderDocumentItem) => {
   return proposal?.name || `вариант #${doc.proposal_id}`;
 };
 
-const selectedContractBinding = computed({
-  get: () => {
-    if (selectedCustomerContractId.value) return `open:${selectedCustomerContractId.value}`;
-    if (oneTimeContractDocument.value) return ONE_TIME_CONTRACT_VALUE;
-    return '';
-  },
+const syncBaseDocumentSelection = () => {
+  if (!isClosingDocumentType(selectedDocumentType.value)) {
+    selectedBaseDocumentValue.value = '';
+    return;
+  }
+  const options = baseDocumentOptions.value;
+  if (selectedBaseDocumentValue.value && options.some((option) => option.value === selectedBaseDocumentValue.value)) {
+    return;
+  }
+  if (selectedCustomerContractId.value) {
+    const openValue = `${OPEN_CONTRACT_PREFIX}${selectedCustomerContractId.value}`;
+    if (options.some((option) => option.value === openValue)) {
+      selectedBaseDocumentValue.value = openValue;
+      return;
+    }
+  }
+  selectedBaseDocumentValue.value = options.length === 1 ? options[0]!.value : '';
+};
+
+const selectedBaseDocumentBinding = computed({
+  get: () => selectedBaseDocumentValue.value,
   set: (value: string) => {
-    void updateContractBinding(value);
+    void updateBaseDocumentBinding(value);
   },
 });
 
@@ -457,6 +491,7 @@ const loadDocuments = async () => {
     const res = await ManagerDocsService.getManagerOrderDocuments(props.order.id);
     documents.value = res.items;
     if (!isCreatePanelOpen.value) selectedDocumentType.value = suggestedDocumentType.value;
+    syncBaseDocumentSelection();
   } catch (error) {
     console.error('Failed to load documents', error);
   }
@@ -478,12 +513,14 @@ const loadCustomerContracts = async () => {
   if (!props.order.customer?.id) {
     customerContracts.value = [];
     selectedCustomerContractId.value = null;
+    syncBaseDocumentSelection();
     return;
   }
   try {
     const res = await ManagerContractsService.getManagerCustomerContracts(props.order.customer.id);
     customerContracts.value = res.items.filter((contract) => contract.status === 'active');
     selectedCustomerContractId.value = props.order.customer_contract_id || null;
+    syncBaseDocumentSelection();
   } catch (error) {
     console.error('Failed to load customer contracts', error);
   }
@@ -500,6 +537,7 @@ watch(() => props.order.id, () => {
   resetFromOrder();
   waybillProductLines.value = [];
   selectedDocumentType.value = suggestedDocumentType.value;
+  selectedBaseDocumentValue.value = '';
   isCreatePanelOpen.value = false;
   showAdvancedSettings.value = false;
   void loadDocuments();
@@ -509,6 +547,7 @@ watch(() => props.order.id, () => {
 
 watch(selectedDocumentType, () => {
   if (!showsAdditionalConditions.value) showAdvancedSettings.value = false;
+  syncBaseDocumentSelection();
 });
 
 watch(() => [
@@ -544,19 +583,23 @@ const useOneTimeContractForClosingDocs = async () => {
   await ManagerOrdersService.patchManagerOrder(props.order.id, {
     customer_contract_id: null,
   });
+  syncBaseDocumentSelection();
 };
 
-const updateContractBinding = async (value: string) => {
-  const nextCustomerContractId = value.startsWith('open:') ? Number(value.slice(5)) : null;
+const updateBaseDocumentBinding = async (value: string) => {
+  const nextCustomerContractId = value.startsWith(OPEN_CONTRACT_PREFIX) ? Number(value.slice(OPEN_CONTRACT_PREFIX.length)) : null;
   if (nextCustomerContractId !== null && Number.isNaN(nextCustomerContractId)) return;
   try {
+    selectedBaseDocumentValue.value = value;
     selectedCustomerContractId.value = nextCustomerContractId;
-    await ManagerOrdersService.patchManagerOrder(props.order.id, {
-      customer_contract_id: nextCustomerContractId,
-    });
-    emit('refresh');
+    if (value.startsWith(OPEN_CONTRACT_PREFIX) || props.order.customer_contract_id) {
+      await ManagerOrdersService.patchManagerOrder(props.order.id, {
+        customer_contract_id: nextCustomerContractId,
+      });
+      emit('refresh');
+    }
   } catch (error) {
-    notify(`Ошибка выбора договора: ${getApiErrorMessage(error)}`, 'error');
+    notify(`Ошибка выбора основания: ${getApiErrorMessage(error)}`, 'error');
   }
 };
 
@@ -594,6 +637,7 @@ const openCreatePanel = () => {
   selectedDocumentType.value = suggestedDocumentType.value;
   showAdvancedSettings.value = false;
   isCreatePanelOpen.value = true;
+  syncBaseDocumentSelection();
   if (isWaybillDocument.value) {
     syncWaybillProductLines();
     ensureAllWaybillComponents();
@@ -602,6 +646,7 @@ const openCreatePanel = () => {
 
 const selectDocumentType = (type: string) => {
   selectedDocumentType.value = type;
+  syncBaseDocumentSelection();
   if (isWaybillType(type)) {
     syncWaybillProductLines();
     ensureAllWaybillComponents();
@@ -609,6 +654,17 @@ const selectDocumentType = (type: string) => {
 };
 
 const activeWaybillProposalId = computed(() => props.activeProposalId ?? selectedOrderProposal.value?.id ?? null);
+
+const getSelectedBaseDocumentId = (type: string) => {
+  if (!isClosingDocumentType(type)) return undefined;
+  const value = selectedBaseDocumentValue.value;
+  if (value.startsWith(ORDER_DOCUMENT_PREFIX)) {
+    const docId = Number(value.slice(ORDER_DOCUMENT_PREFIX.length));
+    return Number.isFinite(docId) ? docId : undefined;
+  }
+  if (value.startsWith(OPEN_CONTRACT_PREFIX)) return 0;
+  return undefined;
+};
 
 const saveWaybillProductLines = async () => {
   const lines = waybillProductLines.value;
@@ -645,6 +701,11 @@ const handleDocumentsSent = () => {
 const generateDocument = async (type: string) => {
   isGeneratingDoc.value = true;
   try {
+    syncBaseDocumentSelection();
+    if (isClosingDocumentType(type) && !selectedBaseDocumentValue.value) {
+      notify('Выберите документ-основание', 'error');
+      return;
+    }
     if (isWaybillType(type)) {
       if (!waybillProductLines.value.length) syncWaybillProductLines();
       ensureAllWaybillComponents();
@@ -660,6 +721,7 @@ const generateDocument = async (type: string) => {
       ? selectedContractTemplate.value
       : undefined;
     const proposalId = (type === 'offer' || isWaybillType(type)) ? (activeWaybillProposalId.value ?? undefined) : undefined;
+    const baseDocumentId = getSelectedBaseDocumentId(type);
     const res = await ManagerOrdersService.generateManagerOrderDocument(
       props.order.id,
       type,
@@ -667,6 +729,7 @@ const generateDocument = async (type: string) => {
       template && !template.document_template_id ? template.id : undefined,
       getDocumentDateForType(type),
       proposalId,
+      baseDocumentId,
     );
     window.open(res.edit_url, '_blank');
     await loadDocuments();
@@ -874,6 +937,9 @@ const registerExternalContract = async () => {
                   {{ new Date(doc.date).toLocaleDateString('ru-RU') }} · <span class="uppercase">{{ doc.doc_type }}</span>
                   <span v-if="documentProposalName(doc)"> · {{ documentProposalName(doc) }}</span>
                 </p>
+                <p v-if="doc.base_document_number" class="truncate text-[11px] text-slate-400 dark:text-slate-500">
+                  Основание: {{ documentTypeLabel(doc.base_document_type) }} · {{ doc.base_document_number }}
+                </p>
               </div>
             </div>
             <div class="flex shrink-0 items-center gap-1 sm:gap-2">
@@ -990,7 +1056,7 @@ const registerExternalContract = async () => {
 
       <div v-if="needsContractBinding" class="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-slate-700/50 dark:bg-slate-800/40">
         <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <label class="block text-xs font-semibold text-slate-700 dark:text-slate-200">Шаг 2: договор для актов и накладных</label>
+          <label class="block text-xs font-semibold text-slate-700 dark:text-slate-200">Шаг 2: документ-основание</label>
           <button
             type="button"
             class="inline-flex w-fit items-center gap-1 rounded-lg border border-slate-300 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
@@ -1002,20 +1068,17 @@ const registerExternalContract = async () => {
         </div>
 
         <select
-          v-model="selectedContractBinding"
+          v-model="selectedBaseDocumentBinding"
           class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-teal-500/50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
         >
-          <option value="">Выберите договор</option>
-          <option v-if="oneTimeContractDocument" :value="ONE_TIME_CONTRACT_VALUE">
-            Использовать разовый договор заказа · {{ oneTimeContractDocument.number }}
-          </option>
-          <option v-for="contract in customerContracts" :key="contract.id" :value="`open:${contract.id}`">
-            Открытый договор · {{ contract.number }} · до {{ new Date(contract.valid_until).toLocaleDateString('ru-RU') }}
+          <option value="">Выберите основание</option>
+          <option v-for="option in baseDocumentOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
           </option>
         </select>
 
-        <p v-if="oneTimeContractDocument && customerContracts.length" class="mt-2 text-xs text-slate-500 dark:text-slate-400">
-          Выберите, куда ссылать закрывающие документы: на разовый договор заказа или на открытый договор клиента.
+        <p v-if="baseDocumentOptions.length > 1" class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Если в заказе несколько счетов, договоров или оферт, закрывающий документ будет привязан к выбранному основанию.
         </p>
 
         <form
@@ -1088,8 +1151,8 @@ const registerExternalContract = async () => {
             Создать открытый договор
           </button>
         </div>
-        <p v-else-if="!selectedCustomerContractId && !hasClosingBaseDocument" class="mt-2 text-xs text-amber-600 dark:text-amber-400">
-          Для актов нужен договор или счет, для накладных нужен договор.
+        <p v-else-if="!hasClosingBaseDocument" class="mt-2 text-xs text-amber-600 dark:text-amber-400">
+          Для актов и накладных нужен договор, счет или оферта.
         </p>
       </div>
 

--- a/models/order.py
+++ b/models/order.py
@@ -504,6 +504,8 @@ class OrderDocument(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     order_id: int = Field(foreign_key="order.id", index=True)
     proposal_id: Optional[int] = Field(default=None, foreign_key="order_proposal.id", index=True)
+    base_document_id: Optional[int] = Field(default=None, foreign_key="order_document.id", index=True)
+    base_customer_contract_id: Optional[int] = Field(default=None, foreign_key="customer_contract.id", index=True)
     document_template_id: Optional[int] = Field(default=None, foreign_key="document_template.id", index=True)
     template_id: Optional[str] = Field(default=None, index=True)
     doc_type: str = Field(index=True)
@@ -517,6 +519,10 @@ class OrderDocument(SQLModel, table=True):
 
     order: "Order" = Relationship(back_populates="documents")
     proposal: Optional[OrderProposal] = Relationship()
+    base_document: Optional["OrderDocument"] = Relationship(
+        sa_relationship_kwargs={"remote_side": "OrderDocument.id"}
+    )
+    base_customer_contract: Optional["CustomerContract"] = Relationship()
     document_template: Optional["DocumentTemplate"] = Relationship()
 
     def __str__(self):

--- a/openapi.json
+++ b/openapi.json
@@ -5381,6 +5381,24 @@
               "title": "Proposal Id"
             },
             "description": "Order proposal ID for generated commercial offer"
+          },
+          {
+            "name": "base_document_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Order document ID used as basis for closing documents; 0 means selected open customer contract",
+              "title": "Base Document Id"
+            },
+            "description": "Order document ID used as basis for closing documents; 0 means selected open customer contract"
           }
         ],
         "responses": {
@@ -14997,6 +15015,62 @@
             ],
             "title": "Proposal Id"
           },
+          "base_document_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Id"
+          },
+          "base_customer_contract_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Customer Contract Id"
+          },
+          "base_document_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type"
+          },
+          "base_document_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Number"
+          },
+          "base_document_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Date"
+          },
           "doc_type": {
             "type": "string",
             "title": "Doc Type"
@@ -16625,6 +16699,62 @@
             ],
             "title": "Proposal Id"
           },
+          "base_document_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Id"
+          },
+          "base_customer_contract_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Customer Contract Id"
+          },
+          "base_document_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type"
+          },
+          "base_document_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Number"
+          },
+          "base_document_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Date"
+          },
           "doc_type": {
             "type": "string",
             "title": "Doc Type"
@@ -16696,6 +16826,28 @@
               }
             ],
             "title": "Proposal Id"
+          },
+          "base_document_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Id"
+          },
+          "base_customer_contract_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Customer Contract Id"
           },
           "doc_type": {
             "type": "string",

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -172,12 +172,14 @@ async def get_customer_docs_for_manager(
     _user: str = Depends(get_current_username),
 ):
     docs = await DocumentService.get_customer_documents(session, customer_id)
+    basis_lookup = await DocumentService.build_document_basis_lookup(session, list(docs))
     return {
         "items": [
             {
                 "id": doc.id,
                 "order_id": doc.order_id,
                 "proposal_id": doc.proposal_id,
+                **basis_lookup.get(doc.id, {}),
                 "doc_type": doc.doc_type,
                 "number": doc.number,
                 "date": doc.date,

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -55,11 +55,13 @@ async def get_manager_order_documents(
     session: AsyncSession = Depends(get_session),
 ):
     docs = await DocumentService.list_order_documents(session, order_id)
+    basis_lookup = await DocumentService.build_document_basis_lookup(session, list(docs))
     return {
         "items": [
             ManagerOrderDocumentItem(
                 id=d.id,
                 proposal_id=d.proposal_id,
+                **basis_lookup.get(d.id, {}),
                 doc_type=d.doc_type,
                 number=d.number,
                 date=d.date,
@@ -86,6 +88,8 @@ async def upload_manager_order_document(
     return ManagerOrderDocumentItem(
         id=doc.id,
         proposal_id=doc.proposal_id,
+        base_document_id=doc.base_document_id,
+        base_customer_contract_id=doc.base_customer_contract_id,
         doc_type=doc.doc_type,
         number=doc.number,
         date=doc.date,
@@ -127,6 +131,8 @@ async def register_manager_external_contract(
     return ManagerOrderDocumentItem(
         id=doc.id,
         proposal_id=doc.proposal_id,
+        base_document_id=doc.base_document_id,
+        base_customer_contract_id=doc.base_customer_contract_id,
         doc_type=doc.doc_type,
         number=doc.number,
         date=doc.date,
@@ -164,6 +170,8 @@ async def attach_manager_doc_file(
     return ManagerOrderDocumentItem(
         id=doc.id,
         proposal_id=doc.proposal_id,
+        base_document_id=doc.base_document_id,
+        base_customer_contract_id=doc.base_customer_contract_id,
         doc_type=doc.doc_type,
         number=doc.number,
         date=doc.date,

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -193,6 +193,7 @@ async def generate_manager_order_document(
     template_id: Optional[str] = Query(None, description="Google Drive template file ID"),
     contract_date: Optional[str] = Query(None, description="Document/contract date as ISO datetime"),
     proposal_id: Optional[int] = Query(None, description="Order proposal ID for generated commercial offer"),
+    base_document_id: Optional[int] = Query(None, description="Order document ID used as basis for closing documents; 0 means selected open customer contract"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
 ):
@@ -209,6 +210,7 @@ async def generate_manager_order_document(
             template_id=template_id,
             contract_date=parsed_contract_date,
             proposal_id=proposal_id,
+            base_document_id=base_document_id,
         )
     except ValueError as exc:
         raise manager_http_error(

--- a/schemas.py
+++ b/schemas.py
@@ -515,6 +515,11 @@ class ManagerOrderListItemResponse(BaseModel):
 class ManagerOrderDocumentItem(BaseModel):
     id: int
     proposal_id: Optional[int] = None
+    base_document_id: Optional[int] = None
+    base_customer_contract_id: Optional[int] = None
+    base_document_type: Optional[str] = None
+    base_document_number: Optional[str] = None
+    base_document_date: Optional[datetime] = None
     doc_type: str
     number: str
     date: datetime
@@ -530,6 +535,11 @@ class ManagerCustomerDocumentItem(BaseModel):
     id: int
     order_id: int
     proposal_id: Optional[int] = None
+    base_document_id: Optional[int] = None
+    base_customer_contract_id: Optional[int] = None
+    base_document_type: Optional[str] = None
+    base_document_number: Optional[str] = None
+    base_document_date: Optional[datetime] = None
     doc_type: str
     number: str
     date: datetime
@@ -756,6 +766,8 @@ class ManagerOrderCreatePayload(BaseModel):
 class ManagerOrderDocumentResponse(BaseModel):
     doc_id: int
     proposal_id: Optional[int] = None
+    base_document_id: Optional[int] = None
+    base_customer_contract_id: Optional[int] = None
     doc_type: str
     edit_url: str
 

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
-from models import CustomerType, OrderDocument, Order, GlobalConfig
+from models import CustomerContract, CustomerType, OrderDocument, Order, GlobalConfig
 from services.google_service import get_google_service
 from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
@@ -20,6 +20,18 @@ class DocumentService:
 
     ALLOWED_DOC_TYPES = {"contract", "invoice", "work_order", "act", "defect_act", "offer", "tn2", "ttn1"}
     PROPOSAL_SCOPED_DOC_TYPES = {"offer", "tn2", "ttn1"}
+    CLOSING_DOC_TYPES = {"act", "tn2", "ttn1"}
+    BASE_DOC_TYPES = {"offer", "contract", "invoice"}
+    DOC_NUMBER_PREFIXES = {
+        "contract": "Д",
+        "offer": "КП",
+        "invoice": "С",
+        "act": "А",
+        "defect_act": "ДА",
+        "work_order": "НЗ",
+        "tn2": "ТН2",
+        "ttn1": "ТТН1",
+    }
     ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".doc", ".docx"}
     DEFAULT_UPLOAD_MIME_TYPES = {
         ".pdf": "application/pdf",
@@ -125,6 +137,7 @@ class DocumentService:
         template_id: Optional[str] = None,
         contract_date: Optional[datetime] = None,
         proposal_id: Optional[int] = None,
+        base_document_id: Optional[int] = None,
     ) -> OrderDocument:
         """
         Создает документ или возвращает существующий.
@@ -138,7 +151,7 @@ class DocumentService:
         Returns:
             OrderDocument объект с данными о документе
         """
-        if doc_type in DocumentService.PROPOSAL_SCOPED_DOC_TYPES:
+        if doc_type in DocumentService.PROPOSAL_SCOPED_DOC_TYPES or doc_type in DocumentService.CLOSING_DOC_TYPES:
             return await DocumentService._create_new_document(
                 session,
                 order_id,
@@ -147,6 +160,7 @@ class DocumentService:
                 template_id=template_id,
                 contract_date=contract_date,
                 proposal_id=proposal_id,
+                base_document_id=base_document_id,
             )
 
         # 1. Проверяем, есть ли уже такой документ
@@ -170,6 +184,7 @@ class DocumentService:
             template_id=template_id,
             contract_date=contract_date,
             proposal_id=proposal_id,
+            base_document_id=base_document_id,
         )
 
     @staticmethod
@@ -181,6 +196,7 @@ class DocumentService:
         template_id: Optional[str] = None,
         contract_date: Optional[datetime] = None,
         proposal_id: Optional[int] = None,
+        base_document_id: Optional[int] = None,
     ) -> dict:
         if doc_type not in DocumentService.ALLOWED_DOC_TYPES:
             raise ValueError(f"Unsupported document type: {doc_type}")
@@ -193,10 +209,13 @@ class DocumentService:
             template_id=template_id,
             contract_date=contract_date,
             proposal_id=proposal_id,
+            base_document_id=base_document_id,
         )
         return {
             "doc_id": doc.id,
             "proposal_id": getattr(doc, "proposal_id", None),
+            "base_document_id": getattr(doc, "base_document_id", None),
+            "base_customer_contract_id": getattr(doc, "base_customer_contract_id", None),
             "doc_type": doc.doc_type,
             "edit_url": doc.google_edit_url,
         }
@@ -471,6 +490,107 @@ class DocumentService:
         result = await session.execute(query)
         return result.scalars().all()
 
+    @staticmethod
+    async def _resolve_base_document(
+        session: AsyncSession,
+        *,
+        order_id: int,
+        doc_type: str,
+        base_document_id: Optional[int],
+    ) -> tuple[Optional[OrderDocument], Optional[CustomerContract]]:
+        if doc_type not in DocumentService.CLOSING_DOC_TYPES:
+            return None, None
+
+        order = await session.get(Order, order_id)
+        if not order:
+            raise ValueError("Order not found")
+
+        if base_document_id == 0:
+            if not order.customer_contract_id:
+                raise ValueError("Открытый договор-основание не выбран")
+            base_customer_contract = await session.get(CustomerContract, order.customer_contract_id)
+            if not base_customer_contract:
+                raise ValueError("Открытый договор-основание не найден")
+            return None, base_customer_contract
+
+        if base_document_id is not None:
+            base_document = await session.get(OrderDocument, base_document_id)
+            if not base_document or base_document.order_id != order_id:
+                raise ValueError("Документ-основание не найден в этом заказе")
+            if base_document.doc_type not in DocumentService.BASE_DOC_TYPES:
+                raise ValueError("Документ-основание должен быть договором, счетом или офертой")
+            return base_document, None
+
+        query = (
+            select(OrderDocument)
+            .where(
+                OrderDocument.order_id == order_id,
+                OrderDocument.doc_type.in_(DocumentService.BASE_DOC_TYPES),
+            )
+            .order_by(OrderDocument.created_at.desc())
+        )
+        result = await session.execute(query)
+        candidates = list(result.scalars().all())
+        base_customer_contract = None
+        if order.customer_contract_id:
+            base_customer_contract = await session.get(CustomerContract, order.customer_contract_id)
+
+        if len(candidates) + (1 if base_customer_contract else 0) == 0:
+            return None, None
+        if len(candidates) + (1 if base_customer_contract else 0) > 1:
+            raise ValueError("Выберите документ-основание для акта или накладной")
+        if candidates:
+            return candidates[0], None
+        return None, base_customer_contract
+
+    @staticmethod
+    async def build_document_basis_lookup(
+        session: AsyncSession,
+        documents: list[OrderDocument],
+    ) -> dict[int, dict]:
+        docs_by_id = {doc.id: doc for doc in documents if doc.id is not None}
+        contract_ids = {
+            doc.base_customer_contract_id
+            for doc in documents
+            if getattr(doc, "base_customer_contract_id", None) is not None
+        }
+        contracts_by_id: dict[int, CustomerContract] = {}
+        if contract_ids:
+            result = await session.execute(select(CustomerContract).where(CustomerContract.id.in_(contract_ids)))
+            contracts_by_id = {contract.id: contract for contract in result.scalars().all() if contract.id is not None}
+
+        lookup: dict[int, dict] = {}
+        for doc in documents:
+            if doc.id is None:
+                continue
+            base_doc = docs_by_id.get(doc.base_document_id)
+            base_contract = contracts_by_id.get(doc.base_customer_contract_id)
+            if base_doc:
+                lookup[doc.id] = {
+                    "base_document_id": base_doc.id,
+                    "base_customer_contract_id": None,
+                    "base_document_type": base_doc.doc_type,
+                    "base_document_number": base_doc.number,
+                    "base_document_date": base_doc.date,
+                }
+            elif base_contract:
+                lookup[doc.id] = {
+                    "base_document_id": None,
+                    "base_customer_contract_id": base_contract.id,
+                    "base_document_type": "contract",
+                    "base_document_number": base_contract.number,
+                    "base_document_date": base_contract.valid_from,
+                }
+            else:
+                lookup[doc.id] = {
+                    "base_document_id": None,
+                    "base_customer_contract_id": None,
+                    "base_document_type": None,
+                    "base_document_number": None,
+                    "base_document_date": None,
+                }
+        return lookup
+
     
     @staticmethod
     async def _create_new_document(
@@ -481,10 +601,18 @@ class DocumentService:
         template_id: Optional[str] = None,
         contract_date: Optional[datetime] = None,
         proposal_id: Optional[int] = None,
+        base_document_id: Optional[int] = None,
     ) -> OrderDocument:
         """Создает новый документ в Google Drive и сохраняет в БД"""
-        
-        if doc_type in ["act", "tn2", "ttn1"]:
+
+        base_document, base_customer_contract = await DocumentService._resolve_base_document(
+            session,
+            order_id=order_id,
+            doc_type=doc_type,
+            base_document_id=base_document_id,
+        )
+
+        if doc_type in DocumentService.CLOSING_DOC_TYPES:
             order_result = await session.execute(
                 select(Order)
                 .where(Order.id == order_id)
@@ -493,17 +621,11 @@ class DocumentService:
             order = order_result.scalars().first()
             if not order:
                 raise ValueError("Order not found")
-            base_doc_types = ["contract", "invoice"] if doc_type == "act" else ["contract"]
-            contract_query = select(OrderDocument).where(
-                OrderDocument.order_id == order_id,
-                OrderDocument.doc_type.in_(base_doc_types)
-            )
-            result = await session.execute(contract_query)
-            has_one_time_base_doc = result.scalars().first() is not None
+            has_stable_base = base_document is not None or base_customer_contract is not None
             if order.customer and order.customer.type == CustomerType.company:
-                if not order.customer_contract_id and not has_one_time_base_doc:
+                if not has_stable_base:
                     raise ValueError("Невозможно создать акт/накладную: выберите открытый договор клиента или создайте договор/счет заказа")
-            elif not has_one_time_base_doc:
+            elif not has_stable_base:
                 raise ValueError("Невозможно создать акт/накладную: отсутствует договор или счет")
 
         # 1. Получаем template_id (managed template, legacy query param or default)
@@ -513,6 +635,7 @@ class DocumentService:
             doc_type=doc_type,
             document_template_id=document_template_id,
             template_id=template_id,
+            base_document_id=base_document.id if base_document else None,
         )
         if not template_id:
             raise ValueError(f"Unknown document type: {doc_type}")
@@ -544,6 +667,8 @@ class DocumentService:
             doc_number=doc_number,
             doc_type=doc_type,
             document_date=effective_doc_date,
+            base_document=base_document,
+            base_customer_contract=base_customer_contract,
         )
         if doc_type == "act":
             act_number = await DocumentService._get_act_number_for_order_contract(session, strategy.order)
@@ -571,6 +696,8 @@ class DocumentService:
                     template_id=template_id,
                     doc_number=doc_number,
                     document_date=effective_doc_date,
+                    base_document=base_document,
+                    base_customer_contract=base_customer_contract,
                 )
                 
                 # Извлекаем file_id из URL
@@ -614,6 +741,8 @@ class DocumentService:
         new_doc = OrderDocument(
             order_id=order_id,
             proposal_id=effective_proposal_id,
+            base_document_id=base_document.id if base_document else None,
+            base_customer_contract_id=base_customer_contract.id if base_customer_contract else None,
             document_template_id=document_template_id,
             template_id=template_id,
             doc_type=doc_type,
@@ -680,42 +809,25 @@ class DocumentService:
         Формат: Д-2024-001 (для договоров), КП-2024-001 (для КП), и т.д.
         """
         current_year = (base_date or datetime.now()).year
-        
-        # Получаем последний документ этого типа за текущий год
-        query = select(OrderDocument).where(
-            OrderDocument.doc_type == doc_type
-        ).order_by(OrderDocument.id.desc())
-        
+
+        prefix = DocumentService.DOC_NUMBER_PREFIXES.get(doc_type, doc_type.upper()[:2])
+        number_prefix = f"{prefix}-{current_year}-"
+
+        query = (
+            select(OrderDocument)
+            .where(OrderDocument.number.like(f"{number_prefix}%"))
+            .order_by(OrderDocument.id.desc())
+        )
         result = await session.execute(query)
-        last_doc = result.scalars().first()
-        
-        # Определяем префикс
-        prefix_map = {
-            "contract": "Д",
-            "offer": "КП",
-            "invoice": "С",
-            "act": "А",
-            "defect_act": "ДА",
-            "work_order": "НЗ",
-            "tn2": "ТН2",
-            "ttn1": "ТТН1"
-        }
-        prefix = prefix_map.get(doc_type, doc_type.upper()[:2])
-        
-        # Вычисляем следующий номер
-        if last_doc and str(current_year) in last_doc.number:
-            # Извлекаем номер из формата "Д-2024-001"
+        docs = list(result.scalars().all())
+
+        next_num = 1
+        for doc in docs:
             try:
-                parts = last_doc.number.split('-')
-                if len(parts) >= 3:
-                    last_num = int(parts[-1])
-                    next_num = last_num + 1
-                else:
-                    next_num = 1
+                next_num = int(str(doc.number).split("-")[-1]) + 1
+                break
             except (ValueError, IndexError):
-                next_num = 1
-        else:
-            next_num = 1
+                continue
         
         return f"{prefix}-{current_year}-{next_num:03d}"
 

--- a/services/document_template_service.py
+++ b/services/document_template_service.py
@@ -13,6 +13,7 @@ from models import (
     DocumentTemplateCustomerLink,
     GlobalConfig,
     Order,
+    OrderDocument,
 )
 from services.document_role_service import DocumentRoleService
 from services.documents.base import DOC_NAMES, TEMPLATES
@@ -371,6 +372,7 @@ class DocumentTemplateService:
         doc_type: str,
         document_template_id: Optional[int] = None,
         template_id: Optional[str] = None,
+        base_document_id: Optional[int] = None,
     ) -> tuple[Optional[int], str]:
         normalized_doc_type = str(doc_type or "").strip()
         if normalized_doc_type not in DocumentTemplateService.MANAGED_TYPES:
@@ -388,7 +390,11 @@ class DocumentTemplateService:
             return None, template_id
 
         if normalized_doc_type == "act":
-            base_doc = await DocumentTemplateService._latest_order_document(session, order_id, {"contract", "invoice"})
+            base_doc = await session.get(OrderDocument, base_document_id) if base_document_id else None
+            if base_doc and base_doc.order_id != order_id:
+                base_doc = None
+            if not base_doc:
+                base_doc = await DocumentTemplateService._latest_order_document(session, order_id, {"contract", "invoice"})
             contract_template_id = base_doc.document_template_id if base_doc else None
             order = await session.get(Order, order_id)
             relevant = await DocumentTemplateService.get_relevant_templates(

--- a/services/documents/base.py
+++ b/services/documents/base.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from num2words import num2words
 
-from models import Order, OrderProductLink, OrderServiceLink, CustomerType
+from models import CustomerContract, Order, OrderDocument, OrderProductLink, OrderServiceLink, CustomerType
 from services.document_role_service import DocumentRoleService
 
 # Template IDs
@@ -109,6 +109,8 @@ class BaseDocumentStrategy(ABC):
         doc_number: Optional[str] = None,
         doc_type: Optional[str] = None,
         document_date: Optional[datetime] = None,
+        base_document: Optional[OrderDocument] = None,
+        base_customer_contract: Optional[CustomerContract] = None,
     ) -> Dict[str, str]:
         if not self.order:
             raise ValueError("Order not fetched")
@@ -143,6 +145,11 @@ class BaseDocumentStrategy(ABC):
             "{{contract_date}}": order.contract_date.strftime("%d.%m.%Y") if order.contract_date else "-",
             "{{contract_valid_from}}": order.contract_date.strftime("%d.%m.%Y") if order.contract_date else "-",
             "{{contract_valid_until}}": "-",
+            "{{invoice_number}}": "-",
+            "{{invoice_date}}": "-",
+            "{{base_document_type}}": "-",
+            "{{base_document_number}}": "-",
+            "{{base_document_date}}": "-",
             "{{act_number}}": "1",
             "{{act_sequence_number}}": "1",
             "{{document_role_type}}": DocumentRoleService.effective_role_type(order),
@@ -151,13 +158,15 @@ class BaseDocumentStrategy(ABC):
 
         # A one-time contract document must always use its own generated number/date,
         # even when the order currently points at a reusable customer contract.
+        effective_customer_contract = base_customer_contract or getattr(order, "customer_contract", None)
+
         if doc_type == "contract" and doc_number:
             replacements["{{contract_name}}"] = doc_number
             replacements["{{contract_number}}"] = doc_number
             replacements["{{contract_date}}"] = effective_date.strftime("%d.%m.%Y")
             replacements["{{contract_valid_from}}"] = effective_date.strftime("%d.%m.%Y")
-        elif getattr(order, "customer_contract", None):
-            contract = order.customer_contract
+        elif effective_customer_contract:
+            contract = effective_customer_contract
             replacements["{{contract_name}}"] = contract.number
             replacements["{{contract_number}}"] = contract.number
             replacements["{{contract_date}}"] = contract.valid_from.strftime("%d.%m.%Y") if contract.valid_from else "-"
@@ -165,7 +174,6 @@ class BaseDocumentStrategy(ABC):
             replacements["{{contract_valid_until}}"] = contract.valid_until.strftime("%d.%m.%Y") if contract.valid_until else "-"
         else:
             # Fetch contract document if exists to get contract number
-            from models import OrderDocument
             contract_query = select(OrderDocument).where(
                 OrderDocument.order_id == order.id,
                 OrderDocument.doc_type == "contract"
@@ -181,6 +189,56 @@ class BaseDocumentStrategy(ABC):
                 if not order.contract_date:
                     replacements["{{contract_date}}"] = contract_doc.date.strftime("%d.%m.%Y")
                     replacements["{{contract_valid_from}}"] = contract_doc.date.strftime("%d.%m.%Y")
+
+        if base_customer_contract:
+            replacements["{{base_document_type}}"] = DOC_NAMES.get("contract", "Договор")
+            replacements["{{base_document_number}}"] = base_customer_contract.number
+            replacements["{{base_document_date}}"] = (
+                base_customer_contract.valid_from.strftime("%d.%m.%Y")
+                if base_customer_contract.valid_from
+                else "-"
+            )
+            replacements["{{contract_name}}"] = base_customer_contract.number
+            replacements["{{contract_number}}"] = base_customer_contract.number
+            replacements["{{contract_date}}"] = replacements["{{base_document_date}}"]
+            replacements["{{contract_valid_from}}"] = replacements["{{base_document_date}}"]
+            replacements["{{contract_valid_until}}"] = (
+                base_customer_contract.valid_until.strftime("%d.%m.%Y")
+                if base_customer_contract.valid_until
+                else "-"
+            )
+
+        invoice_doc = None
+        if base_document and base_document.doc_type == "invoice":
+            invoice_doc = base_document
+        else:
+            invoice_query = (
+                select(OrderDocument)
+                .where(OrderDocument.order_id == order.id, OrderDocument.doc_type == "invoice")
+                .order_by(OrderDocument.created_at.desc())
+            )
+            invoice_result = await self.session.execute(invoice_query)
+            invoice_doc = invoice_result.scalars().first()
+
+        if invoice_doc:
+            replacements["{{invoice_number}}"] = invoice_doc.number
+            replacements["{{invoice_date}}"] = invoice_doc.date.strftime("%d.%m.%Y") if invoice_doc.date else "-"
+
+        if base_document:
+            replacements["{{base_document_type}}"] = DOC_NAMES.get(base_document.doc_type, base_document.doc_type)
+            replacements["{{base_document_number}}"] = base_document.number
+            replacements["{{base_document_date}}"] = base_document.date.strftime("%d.%m.%Y") if base_document.date else "-"
+            if base_document.doc_type == "contract":
+                replacements["{{contract_name}}"] = base_document.number
+                replacements["{{contract_number}}"] = base_document.number
+                replacements["{{contract_date}}"] = base_document.date.strftime("%d.%m.%Y") if base_document.date else "-"
+                replacements["{{contract_valid_from}}"] = replacements["{{contract_date}}"]
+            elif base_document.doc_type == "invoice":
+                replacements["{{invoice_number}}"] = base_document.number
+                replacements["{{invoice_date}}"] = base_document.date.strftime("%d.%m.%Y") if base_document.date else "-"
+            elif base_document.doc_type == "offer":
+                replacements["{{offer_number}}"] = base_document.number
+                replacements["{{offer_date}}"] = base_document.date.strftime("%d.%m.%Y") if base_document.date else "-"
 
         # Technical Meta
         if order.technical_meta and isinstance(order.technical_meta, dict):

--- a/services/documents/logistics.py
+++ b/services/documents/logistics.py
@@ -5,6 +5,7 @@ from num2words import num2words
 
 from services.google_service import get_google_service
 from services.documents.base import BaseDocumentStrategy, TEMPLATES, DOC_NAMES
+from models import CustomerContract, OrderDocument
 
 class LogisticsSheetStrategy(BaseDocumentStrategy):
     """Strategy for TN-2 and TTN-1 using Google Sheets API."""
@@ -19,6 +20,8 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
         template_id: Optional[str] = None,
         doc_number: Optional[str] = None,
         document_date: Optional[datetime] = None,
+        base_document: Optional[OrderDocument] = None,
+        base_customer_contract: Optional[CustomerContract] = None,
     ) -> str:
         if not self.order:
             await self.fetch_order()
@@ -29,6 +32,8 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
             doc_number=doc_number,
             doc_type=doc_type,
             document_date=document_date,
+            base_document=base_document,
+            base_customer_contract=base_customer_contract,
         )
         
         # Add TTN specific empty placeholders if TTN-1

--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, List, Optional
 from services.google_service import get_google_service
 from services.documents.base import BaseDocumentStrategy, TEMPLATES, DOC_NAMES
+from models import CustomerContract, OrderDocument
 
 class GoogleDocStrategy(BaseDocumentStrategy):
     """Base for documents using Google Docs API."""
@@ -13,6 +14,8 @@ class GoogleDocStrategy(BaseDocumentStrategy):
         template_id: Optional[str] = None,
         doc_number: Optional[str] = None,
         document_date: Optional[datetime] = None,
+        base_document: Optional[OrderDocument] = None,
+        base_customer_contract: Optional[CustomerContract] = None,
     ) -> str:
         await self.fetch_order()
         if not self.order:
@@ -26,6 +29,8 @@ class GoogleDocStrategy(BaseDocumentStrategy):
             doc_number=doc_number,
             doc_type=doc_type,
             document_date=document_date,
+            base_document=base_document,
+            base_customer_contract=base_customer_contract,
         )
         table_rows = self._prepare_table_data()
         

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1692,18 +1692,23 @@ class OrderService:
             OrderService._map_order_proposal(order, proposal)
             for proposal in sorted(order.proposals, key=lambda proposal: (proposal.is_archived, proposal.sort_order, proposal.id or 0))
         ]
-        data["documents"] = [
-            {
-                "id": doc.id,
-                "proposal_id": doc.proposal_id,
-                "doc_type": doc.doc_type,
-                "number": doc.number,
-                "date": doc.date,
-                "edit_url": doc.google_edit_url,
-                "is_downloadable": bool(doc.google_file_id),
-            }
-            for doc in sorted(order.documents, key=lambda d: d.created_at, reverse=True)
-        ]
+        from services.document_service import DocumentService
+
+        basis_lookup = await DocumentService.build_document_basis_lookup(session, list(order.documents))
+        data["documents"] = []
+        for doc in sorted(order.documents, key=lambda d: d.created_at, reverse=True):
+            data["documents"].append(
+                {
+                    "id": doc.id,
+                    "proposal_id": doc.proposal_id,
+                    **basis_lookup.get(doc.id, {}),
+                    "doc_type": doc.doc_type,
+                    "number": doc.number,
+                    "date": doc.date,
+                    "edit_url": doc.google_edit_url,
+                    "is_downloadable": bool(doc.google_file_id),
+                }
+            )
         data["payments"] = [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
         data["work_stages"] = [
             {

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -1081,8 +1081,9 @@ async def test_manager_order_generate_document(async_client, db, monkeypatch):
         template_id=None,
         contract_date=None,
         proposal_id=None,
+        base_document_id=None,
     ):
-        _ = (session, order_id, doc_type, document_template_id, template_id, proposal_id)
+        _ = (session, order_id, doc_type, document_template_id, template_id, proposal_id, base_document_id)
         captured["contract_date"] = contract_date
         return _FakeDoc()
 
@@ -1100,6 +1101,331 @@ async def test_manager_order_generate_document(async_client, db, monkeypatch):
     assert data["doc_type"] == "contract"
     assert data["edit_url"].startswith("https://docs.google.com")
     assert captured["contract_date"] == datetime(2026, 4, 20)
+
+
+@pytest.mark.asyncio
+async def test_document_numbering_uses_shared_prefix_sequence_per_year(db):
+    from services.document_service import DocumentService
+
+    customer = Customer(name="Numbering", phone="+375297777777", type=CustomerType.individual)
+    order = Order(customer=customer, status=OrderStatus.NEGOTIATION)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    db.add_all(
+        [
+            OrderDocument(
+                order_id=order.id,
+                doc_type="contract",
+                number="Д-2026-001",
+                date=datetime(2026, 1, 10),
+                google_file_id="contract-a",
+                google_edit_url="https://example.com/contract-a",
+            ),
+            OrderDocument(
+                order_id=order.id,
+                doc_type="contract",
+                number="Д-2025-999",
+                date=datetime(2025, 12, 31),
+                google_file_id="contract-old",
+                google_edit_url="https://example.com/contract-old",
+            ),
+        ]
+    )
+    await db.commit()
+
+    assert await DocumentService._get_next_number(db, "contract", datetime(2026, 5, 1)) == "Д-2026-002"
+    assert await DocumentService._get_next_number(db, "contract", datetime(2027, 1, 1)) == "Д-2027-001"
+
+
+@pytest.mark.asyncio
+async def test_manager_order_act_can_use_invoice_as_base_document(async_client, db, monkeypatch):
+    customer = Customer(name="Invoice Base", phone="+375297777777", type=CustomerType.individual)
+    order = Order(customer=customer, status=OrderStatus.NEGOTIATION, total_amount=200)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    invoice = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-005",
+        date=datetime(2026, 5, 10),
+        google_file_id="invoice-file",
+        google_edit_url="https://example.com/invoice",
+    )
+    db.add(invoice)
+    await db.commit()
+    await db.refresh(invoice)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            captured["template_id"] = template_id
+            captured["title"] = title
+            return {"file_id": "fake-act", "edit_url": "https://docs.google.com/document/d/fake-act/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            captured["file_id"] = file_id
+            captured["replacements"] = replacements
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        params={"contract_date": "2026-05-20T00:00:00", "base_document_id": invoice.id},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["base_document_id"] == invoice.id
+    replacements = captured["replacements"]
+    assert replacements["{{base_document_type}}"] == "Счет"
+    assert replacements["{{base_document_number}}"] == "С-2026-005"
+    assert replacements["{{base_document_date}}"] == "10.05.2026"
+    assert replacements["{{invoice_number}}"] == "С-2026-005"
+
+    result = await db.execute(select(OrderDocument).where(OrderDocument.doc_type == "act"))
+    act = result.scalars().first()
+    assert act.base_document_id == invoice.id
+
+
+@pytest.mark.asyncio
+async def test_manager_order_waybills_can_use_invoice_as_base_document(async_client, db, monkeypatch):
+    customer = Customer(name="Waybill Base", phone="+375297777777", type=CustomerType.individual)
+    product = Product(title="Кондиционер", slug="base-waybill-product", price=1000)
+    order = Order(customer=customer, status=OrderStatus.NEGOTIATION, total_amount=1000)
+    db.add_all([customer, product, order])
+    await db.commit()
+    await db.refresh(order)
+    await db.refresh(product)
+
+    db.add(OrderProductLink(order_id=order.id, product_id=product.id, quantity=1, price=1000, cost=700))
+    invoice = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-006",
+        date=datetime(2026, 5, 11),
+        google_file_id="invoice-file",
+        google_edit_url="https://example.com/invoice",
+    )
+    db.add(invoice)
+    await db.commit()
+    await db.refresh(invoice)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def generate_sheet(
+            self,
+            template_id,
+            doc_title,
+            replacements,
+            table_rows,
+            start_cell_addr,
+            target_sheet_name,
+            merge_cols,
+            draw_borders=True,
+            sheet_format_ranges=None,
+        ):
+            captured.setdefault("calls", []).append(
+                {
+                    "template_id": template_id,
+                    "title": doc_title,
+                    "replacements": replacements,
+                    "table_rows": table_rows,
+                    "sheet": target_sheet_name,
+                }
+            )
+            return f"https://docs.google.com/spreadsheets/d/fake-{target_sheet_name}/edit"
+
+    from services.documents import logistics
+
+    monkeypatch.setattr(logistics, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    for doc_type in ("tn2", "ttn1"):
+        response = await async_client.post(
+            f"/api/manager/orders/{order.id}/documents/{doc_type}",
+            params={"contract_date": "2026-05-21T00:00:00", "base_document_id": invoice.id},
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["base_document_id"] == invoice.id
+
+    assert [call["replacements"]["{{base_document_number}}"] for call in captured["calls"]] == [
+        "С-2026-006",
+        "С-2026-006",
+    ]
+    result = await db.execute(select(OrderDocument).where(OrderDocument.doc_type.in_(["tn2", "ttn1"])))
+    docs = result.scalars().all()
+    assert {doc.base_document_id for doc in docs} == {invoice.id}
+
+
+@pytest.mark.asyncio
+async def test_manager_order_requires_selected_base_document_when_multiple_exist(async_client, db, monkeypatch):
+    customer = Customer(name="Multi Base", phone="+375297777777", type=CustomerType.individual)
+    order = Order(customer=customer, status=OrderStatus.NEGOTIATION)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    invoice_a = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-007",
+        date=datetime(2026, 5, 12),
+        google_file_id="invoice-a",
+        google_edit_url="https://example.com/invoice-a",
+    )
+    invoice_b = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-008",
+        date=datetime(2026, 5, 13),
+        google_file_id="invoice-b",
+        google_edit_url="https://example.com/invoice-b",
+    )
+    db.add_all([invoice_a, invoice_b])
+    await db.commit()
+    await db.refresh(invoice_b)
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            return {"file_id": "fake-act-selected", "edit_url": "https://docs.google.com/document/d/fake-act-selected/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            pass
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    missing_response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        params={"contract_date": "2026-05-22T00:00:00"},
+        headers=headers,
+    )
+    assert missing_response.status_code == 400
+    assert "основание" in missing_response.json()["detail"]["message"]
+
+    selected_response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        params={"contract_date": "2026-05-22T00:00:00", "base_document_id": invoice_b.id},
+        headers=headers,
+    )
+    assert selected_response.status_code == 200, selected_response.text
+    assert selected_response.json()["base_document_id"] == invoice_b.id
+
+
+@pytest.mark.asyncio
+async def test_manager_order_closing_doc_keeps_open_contract_base_after_order_contract_changes(async_client, db, monkeypatch):
+    customer = Customer(name='ООО "Стабильность"', phone="+375297777777", type=CustomerType.company)
+    contract_a = CustomerContract(
+        customer=customer,
+        number="ОД-2026-А",
+        valid_from=datetime(2026, 1, 15),
+        valid_until=datetime(2027, 1, 15),
+        status="active",
+    )
+    contract_b = CustomerContract(
+        customer=customer,
+        number="ОД-2026-Б",
+        valid_from=datetime(2026, 2, 20),
+        valid_until=datetime(2027, 2, 20),
+        status="active",
+    )
+    order = Order(customer=customer, customer_contract=contract_a, status=OrderStatus.NEGOTIATION)
+    db.add_all([customer, contract_a, contract_b, order])
+    await db.commit()
+    await db.refresh(order)
+    await db.refresh(contract_a)
+    await db.refresh(contract_b)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            return {"file_id": "fake-act-open-contract", "edit_url": "https://docs.google.com/document/d/fake-act-open-contract/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            captured["replacements"] = replacements
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        params={"contract_date": "2026-05-23T00:00:00", "base_document_id": 0},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["base_customer_contract_id"] == contract_a.id
+    assert captured["replacements"]["{{base_document_number}}"] == "ОД-2026-А"
+    assert captured["replacements"]["{{base_document_date}}"] == "15.01.2026"
+
+    result = await db.execute(select(OrderDocument).where(OrderDocument.doc_type == "act"))
+    act_doc = result.scalars().first()
+    assert act_doc.base_customer_contract_id == contract_a.id
+    order_id = order.id
+    customer_id = customer.id
+    contract_a_id = contract_a.id
+    contract_b_id = contract_b.id
+    act_doc_id = act_doc.id
+    act_doc_number = act_doc.number
+    act_doc_date = act_doc.date
+    act_base_customer_contract_id = act_doc.base_customer_contract_id
+
+    order.customer_contract_id = contract_b_id
+    db.add(order)
+    await db.commit()
+    db.expire_all()
+
+    docs_response = await async_client.get(f"/api/manager/orders/{order_id}/documents", headers=headers)
+    assert docs_response.status_code == 200
+    act_item = next(item for item in docs_response.json()["items"] if item["id"] == act_doc_id)
+    assert act_item["base_customer_contract_id"] == contract_a_id
+    assert act_item["base_document_type"] == "contract"
+    assert act_item["base_document_number"] == "ОД-2026-А"
+    assert act_item["base_document_date"].startswith("2026-01-15")
+
+    detail_response = await async_client.get(f"/api/manager/orders/{order_id}", headers=headers)
+    assert detail_response.status_code == 200
+    detail_act_item = next(item for item in detail_response.json()["documents"] if item["id"] == act_doc_id)
+    assert detail_act_item["base_customer_contract_id"] == contract_a_id
+    assert detail_act_item["base_document_type"] == "contract"
+    assert detail_act_item["base_document_number"] == "ОД-2026-А"
+    assert detail_act_item["base_document_date"].startswith("2026-01-15")
+
+    customer_docs_response = await async_client.get(f"/api/manager/customers/{customer_id}/docs", headers=headers)
+    assert customer_docs_response.status_code == 200
+    customer_act_item = next(item for item in customer_docs_response.json()["items"] if item["id"] == act_doc_id)
+    assert customer_act_item["base_customer_contract_id"] == contract_a_id
+    assert customer_act_item["base_document_type"] == "contract"
+    assert customer_act_item["base_document_number"] == "ОД-2026-А"
+    assert customer_act_item["base_document_date"].startswith("2026-01-15")
+
+    from services.documents.standard import ActStrategy
+
+    strategy = ActStrategy(db, order_id)
+    await strategy.fetch_order()
+    base_contract = await db.get(CustomerContract, act_base_customer_contract_id)
+    replacements_after_switch = await strategy._prepare_base_variables(
+        doc_number=act_doc_number,
+        doc_type="act",
+        document_date=act_doc_date,
+        base_customer_contract=base_contract,
+    )
+    assert replacements_after_switch["{{base_document_number}}"] == "ОД-2026-А"
+    assert replacements_after_switch["{{contract_number}}"] == "ОД-2026-А"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -470,6 +470,7 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
         params={"contract_date": "2026-04-26T00:00:00"},
     )
     assert one_time_contract_with_open_selected.status_code == 200
+    one_time_contract_id = one_time_contract_with_open_selected.json()["doc_id"]
     assert captured_replacements[-1]["{{contract_number}}"].startswith("Д-2026-")
     assert captured_replacements[-1]["{{contract_number}}"] != "ОД-2026-777"
     assert captured_replacements[-1]["{{contract_date}}"] == "26.04.2026"
@@ -494,10 +495,24 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
     assert captured_replacements[-1]["{{act_number}}"] == "1"
 
     first_act = await async_client.post(f"/api/manager/orders/{order.id}/documents/act", headers=headers)
+    assert first_act.status_code == 400
+    assert "основан" in first_act.json()["detail"]["message"].lower()
+
+    first_act = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        headers=headers,
+        params={"base_document_id": 0},
+    )
     assert first_act.status_code == 200
+    assert first_act.json()["base_document_id"] is None
+    assert first_act.json()["base_customer_contract_id"] == contract.id
     assert captured_replacements[-1]["{{act_number}}"] == "1"
     assert captured_replacements[-1]["{{act_sequence_number}}"] == "1"
     assert captured_replacements[-1]["{{object_address}}"] == "Минск, объект 1"
+    first_act_doc = await db.get(OrderDocument, first_act.json()["doc_id"])
+    assert first_act_doc is not None
+    assert first_act_doc.base_document_id is None
+    assert first_act_doc.base_customer_contract_id == contract.id
 
     second_order = Order(customer_id=customer.id, customer_contract_id=contract.id, status=OrderStatus.NEW_LEAD)
     db.add(second_order)
@@ -508,6 +523,19 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
     assert second_act.status_code == 200
     assert captured_replacements[-1]["{{act_number}}"] == "2"
     assert captured_replacements[-1]["{{act_sequence_number}}"] == "2"
+
+    one_time_contract_act = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        headers=headers,
+        params={"base_document_id": one_time_contract_id},
+    )
+    assert one_time_contract_act.status_code == 200
+    assert one_time_contract_act.json()["base_document_id"] == one_time_contract_id
+    assert one_time_contract_act.json()["base_customer_contract_id"] is None
+    one_time_contract_act_doc = await db.get(OrderDocument, one_time_contract_act.json()["doc_id"])
+    assert one_time_contract_act_doc is not None
+    assert one_time_contract_act_doc.base_document_id == one_time_contract_id
+    assert one_time_contract_act_doc.base_customer_contract_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_document_service_base_documents.py
+++ b/tests/unit/test_document_service_base_documents.py
@@ -1,0 +1,181 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import Customer, CustomerContract, Order, OrderDocument
+from services.document_service import DocumentService
+from services.documents.standard import ActStrategy
+
+
+@pytest.fixture()
+async def sqlite_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'doc_base.db'}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_document_numbering_uses_prefix_and_year(sqlite_session):
+    customer = Customer(name="Numbering", phone="+375291111111")
+    order = Order(customer=customer)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    sqlite_session.add_all(
+        [
+            OrderDocument(
+                order_id=order.id,
+                doc_type="contract",
+                number="Д-2026-001",
+                date=datetime(2026, 1, 10),
+                google_file_id="contract-a",
+                google_edit_url="https://example.com/contract-a",
+            ),
+            OrderDocument(
+                order_id=order.id,
+                doc_type="contract",
+                number="Д-2025-999",
+                date=datetime(2025, 12, 31),
+                google_file_id="contract-old",
+                google_edit_url="https://example.com/contract-old",
+            ),
+        ]
+    )
+    await sqlite_session.commit()
+
+    assert await DocumentService._get_next_number(sqlite_session, "contract", datetime(2026, 5, 1)) == "Д-2026-002"
+    assert await DocumentService._get_next_number(sqlite_session, "contract", datetime(2027, 1, 1)) == "Д-2027-001"
+
+
+@pytest.mark.asyncio
+async def test_resolve_base_document_requires_choice_when_multiple_exist(sqlite_session):
+    customer = Customer(name="Base", phone="+375291111111")
+    order = Order(customer=customer)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    invoice_a = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-001",
+        date=datetime(2026, 5, 1),
+        google_file_id="invoice-a",
+        google_edit_url="https://example.com/a",
+    )
+    invoice_b = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-002",
+        date=datetime(2026, 5, 2),
+        google_file_id="invoice-b",
+        google_edit_url="https://example.com/b",
+    )
+    sqlite_session.add_all([invoice_a, invoice_b])
+    await sqlite_session.commit()
+    await sqlite_session.refresh(invoice_b)
+
+    with pytest.raises(ValueError, match="основание"):
+        await DocumentService._resolve_base_document(
+            sqlite_session,
+            order_id=order.id,
+            doc_type="act",
+            base_document_id=None,
+        )
+
+    resolved_document, resolved_customer_contract = await DocumentService._resolve_base_document(
+        sqlite_session,
+        order_id=order.id,
+        doc_type="act",
+        base_document_id=invoice_b.id,
+    )
+    assert resolved_document.id == invoice_b.id
+    assert resolved_customer_contract is None
+
+
+@pytest.mark.asyncio
+async def test_base_document_placeholders_support_invoice(sqlite_session):
+    customer = Customer(name="Invoice Customer", phone="+375291111111")
+    order = Order(customer=customer, total_amount=120)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    invoice = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="С-2026-003",
+        date=datetime(2026, 5, 3),
+        google_file_id="invoice-c",
+        google_edit_url="https://example.com/c",
+    )
+    sqlite_session.add(invoice)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(invoice)
+
+    strategy = ActStrategy(sqlite_session, order.id)
+    await strategy.fetch_order()
+    replacements = await strategy._prepare_base_variables(
+        doc_number="А-2026-001",
+        doc_type="act",
+        document_date=datetime(2026, 5, 4),
+        base_document=invoice,
+    )
+
+    assert replacements["{{base_document_type}}"] == "Счет"
+    assert replacements["{{base_document_number}}"] == "С-2026-003"
+    assert replacements["{{base_document_date}}"] == "03.05.2026"
+    assert replacements["{{invoice_number}}"] == "С-2026-003"
+    assert replacements["{{invoice_date}}"] == "03.05.2026"
+
+
+@pytest.mark.asyncio
+async def test_open_customer_contract_can_be_stable_base(sqlite_session):
+    customer = Customer(name="Contract Customer", phone="+375291111111", type="company")
+    contract = CustomerContract(
+        customer=customer,
+        number="ОД-2026-010",
+        valid_from=datetime(2026, 1, 15),
+        valid_until=datetime(2027, 1, 15),
+        status="active",
+    )
+    order = Order(customer=customer, customer_contract=contract)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+    await sqlite_session.refresh(contract)
+
+    base_document, base_customer_contract = await DocumentService._resolve_base_document(
+        sqlite_session,
+        order_id=order.id,
+        doc_type="act",
+        base_document_id=0,
+    )
+
+    assert base_document is None
+    assert base_customer_contract.id == contract.id
+
+    strategy = ActStrategy(sqlite_session, order.id)
+    await strategy.fetch_order()
+    replacements = await strategy._prepare_base_variables(
+        doc_number="А-2026-002",
+        doc_type="act",
+        document_date=datetime(2026, 5, 5),
+        base_customer_contract=base_customer_contract,
+    )
+
+    assert replacements["{{base_document_type}}"] == "Договор"
+    assert replacements["{{base_document_number}}"] == "ОД-2026-010"
+    assert replacements["{{base_document_date}}"] == "15.01.2026"
+    assert replacements["{{contract_number}}"] == "ОД-2026-010"


### PR DESCRIPTION
## Summary

- Add document-basis links for closing order documents, including `OrderDocument.base_document_id` and `base_customer_contract_id` with an Alembic migration.
- Allow `act`, `tn2`, and `ttn1` documents to use offers, contracts, invoices, or open customer contracts as their basis.
- Surface basis display fields through manager APIs, OpenAPI, generated client types, and the manager document UI.
- Add neutral basis placeholders: `{{base_document_type}}`, `{{base_document_number}}`, and `{{base_document_date}}`.

## Verification

Already verified by the audit thread:

```bash
pytest tests/unit/test_document_service_base_documents.py -q
TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -k "base_document or document_numbering or closing_doc" -q
python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api && npm run build
python3 -m compileall models services routers schemas.py
git diff --check
```

Before publishing, this thread also checked:

```bash
git status --short
git branch --show-current
git diff --stat
git diff --check
gh pr list --repo mvnby/air-api --limit 20 --json number,title,headRefName,state,isDraft,updatedAt,url
```

## Process Note

Audit update was already left in issue #349: https://github.com/mvnby/air-api/issues/349#issuecomment-4592991209

Issue #349 is intentionally not closed automatically.