### PR TITLE
[codex] Add document basis display labels

### DIFF
--- a/alembic/versions/5a6b7c8d9e10_add_document_template_base_type_label.py
+++ b/alembic/versions/5a6b7c8d9e10_add_document_template_base_type_label.py
@@ -1,0 +1,37 @@
+"""Add document template base type label
+
+Revision ID: 5a6b7c8d9e10
+Revises: 4f6a7b8c9d10
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5a6b7c8d9e10"
+down_revision: Union[str, Sequence[str], None] = "4f6a7b8c9d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if "base_document_type_label" not in _columns("document_template"):
+        with op.batch_alter_table("document_template", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("base_document_type_label", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    if "base_document_type_label" in _columns("document_template"):
+        with op.batch_alter_table("document_template", schema=None) as batch_op:
+            batch_op.drop_column("base_document_type_label")

--- a/manager_frontend/src/client/models/DocumentTemplateItem.ts
+++ b/manager_frontend/src/client/models/DocumentTemplateItem.ts
@@ -10,6 +10,7 @@ export type DocumentTemplateItem = {
     is_open_contract?: boolean;
     doc_type?: string;
     description?: (string | null);
+    base_document_type_label?: (string | null);
     is_default?: boolean;
     is_active?: boolean;
     client_restricted?: boolean;

--- a/manager_frontend/src/client/models/DocumentTemplatePayload.ts
+++ b/manager_frontend/src/client/models/DocumentTemplatePayload.ts
@@ -8,6 +8,7 @@ export type DocumentTemplatePayload = {
     google_template_id: string;
     document_role_type?: (string | null);
     description?: (string | null);
+    base_document_type_label?: (string | null);
     is_default?: boolean;
     is_active?: boolean;
     is_open_contract?: boolean;

--- a/manager_frontend/src/client/models/DocumentTemplateUpdatePayload.ts
+++ b/manager_frontend/src/client/models/DocumentTemplateUpdatePayload.ts
@@ -8,6 +8,7 @@ export type DocumentTemplateUpdatePayload = {
     google_template_id?: (string | null);
     document_role_type?: (string | null);
     description?: (string | null);
+    base_document_type_label?: (string | null);
     is_default?: (boolean | null);
     is_active?: (boolean | null);
     is_open_contract?: (boolean | null);

--- a/manager_frontend/src/client/models/ManagerCustomerDocumentItem.ts
+++ b/manager_frontend/src/client/models/ManagerCustomerDocumentItem.ts
@@ -9,6 +9,7 @@ export type ManagerCustomerDocumentItem = {
     base_document_id?: (number | null);
     base_customer_contract_id?: (number | null);
     base_document_type?: (string | null);
+    base_document_type_label?: (string | null);
     base_document_number?: (string | null);
     base_document_date?: (string | null);
     doc_type: string;

--- a/manager_frontend/src/client/models/ManagerOrderDocumentItem.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDocumentItem.ts
@@ -8,6 +8,7 @@ export type ManagerOrderDocumentItem = {
     base_document_id?: (number | null);
     base_customer_contract_id?: (number | null);
     base_document_type?: (string | null);
+    base_document_type_label?: (string | null);
     base_document_number?: (string | null);
     base_document_date?: (string | null);
     doc_type: string;

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -938,7 +938,7 @@ const registerExternalContract = async () => {
                   <span v-if="documentProposalName(doc)"> · {{ documentProposalName(doc) }}</span>
                 </p>
                 <p v-if="doc.base_document_number" class="truncate text-[11px] text-slate-400 dark:text-slate-500">
-                  Основание: {{ documentTypeLabel(doc.base_document_type) }} · {{ doc.base_document_number }}
+                  Основание: {{ doc.base_document_type_label || documentTypeLabel(doc.base_document_type) }} · {{ doc.base_document_number }}
                 </p>
               </div>
             </div>

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -45,6 +45,7 @@ type DocumentTemplateForm = {
     google_template_id: string;
     document_role_type: DocumentRoleType;
     description: string;
+    base_document_type_label: string;
     is_default: boolean;
     is_active: boolean;
     is_open_contract: boolean;
@@ -199,6 +200,7 @@ const emptyDocumentTemplate = (docType: ManagedDocumentType = 'contract'): Docum
     google_template_id: '',
     document_role_type: 'seller_buyer',
     description: '',
+    base_document_type_label: '',
     is_default: false,
     is_active: true,
     is_open_contract: false,
@@ -216,6 +218,7 @@ const mapTemplateItemToForm = (item: DocumentTemplateItem): DocumentTemplateForm
     google_template_id: item.id || '',
     document_role_type: normalizeRoleType(item.document_role_type),
     description: item.description || '',
+    base_document_type_label: item.base_document_type_label || '',
     is_default: item.is_default === true,
     is_active: item.is_active !== false,
     is_open_contract: item.is_open_contract === true,
@@ -267,6 +270,7 @@ const documentTemplatePayload = (template: DocumentTemplateForm): DocumentTempla
     google_template_id: template.google_template_id.trim(),
     document_role_type: normalizeRoleType(template.document_role_type),
     description: template.description.trim() || undefined,
+    base_document_type_label: template.base_document_type_label.trim() || undefined,
     is_default: template.is_default,
     is_active: template.is_active,
     is_open_contract: template.doc_type === 'contract' ? template.is_open_contract : false,
@@ -965,12 +969,21 @@ onMounted(() => {
                     </div>
 
                     <div class="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
-                        <textarea
-                            v-model="template.description"
-                            rows="3"
-                            class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
-                            placeholder="Комментарий для менеджера"
-                        />
+                        <div class="space-y-2">
+                            <textarea
+                                v-model="template.description"
+                                rows="3"
+                                class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                                placeholder="Комментарий для менеджера"
+                            />
+                            <input
+                                v-if="template.doc_type === 'contract' || template.doc_type === 'invoice'"
+                                v-model="template.base_document_type_label"
+                                type="text"
+                                class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+                                placeholder="Тип основания: Счет-договор"
+                            />
+                        </div>
                         <div>
                             <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-slate-400">Доступность</label>
                             <div class="rounded-lg border border-gray-300 bg-white p-3 shadow-sm dark:border-slate-600 dark:bg-slate-900">

--- a/models/order.py
+++ b/models/order.py
@@ -266,6 +266,7 @@ class DocumentTemplate(SQLModel, table=True):
     google_template_id: str = Field(index=True)
     document_role_type: Optional[DocumentRoleType] = Field(default=None, sa_column=Column(String, nullable=True))
     description: Optional[str] = None
+    base_document_type_label: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
 
     is_default: bool = Field(default=False, index=True)
     is_active: bool = Field(default=True, index=True)

--- a/openapi.json
+++ b/openapi.json
@@ -11939,6 +11939,17 @@
             ],
             "title": "Description"
           },
+          "base_document_type_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type Label"
+          },
           "is_default": {
             "type": "boolean",
             "title": "Is Default",
@@ -12039,6 +12050,17 @@
               }
             ],
             "title": "Description"
+          },
+          "base_document_type_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type Label"
           },
           "is_default": {
             "type": "boolean",
@@ -12151,6 +12173,17 @@
               }
             ],
             "title": "Description"
+          },
+          "base_document_type_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type Label"
           },
           "is_default": {
             "anyOf": [
@@ -15048,6 +15081,17 @@
             ],
             "title": "Base Document Type"
           },
+          "base_document_type_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type Label"
+          },
           "base_document_number": {
             "anyOf": [
               {
@@ -16731,6 +16775,17 @@
               }
             ],
             "title": "Base Document Type"
+          },
+          "base_document_type_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Document Type Label"
           },
           "base_document_number": {
             "anyOf": [

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -351,6 +351,7 @@ async def get_doc_templates(
                 is_open_contract=bool(t.get("is_open_contract")),
                 doc_type=t.get("doc_type", doc_type),
                 description=t.get("description"),
+                base_document_type_label=t.get("base_document_type_label"),
                 is_default=bool(t.get("is_default")),
                 is_active=bool(t.get("is_active", True)),
                 client_restricted=bool(t.get("client_restricted")),

--- a/schemas.py
+++ b/schemas.py
@@ -518,6 +518,7 @@ class ManagerOrderDocumentItem(BaseModel):
     base_document_id: Optional[int] = None
     base_customer_contract_id: Optional[int] = None
     base_document_type: Optional[str] = None
+    base_document_type_label: Optional[str] = None
     base_document_number: Optional[str] = None
     base_document_date: Optional[datetime] = None
     doc_type: str
@@ -538,6 +539,7 @@ class ManagerCustomerDocumentItem(BaseModel):
     base_document_id: Optional[int] = None
     base_customer_contract_id: Optional[int] = None
     base_document_type: Optional[str] = None
+    base_document_type_label: Optional[str] = None
     base_document_number: Optional[str] = None
     base_document_date: Optional[datetime] = None
     doc_type: str
@@ -780,6 +782,7 @@ class DocumentTemplateItem(BaseModel):
     is_open_contract: bool = False
     doc_type: str = "contract"
     description: Optional[str] = None
+    base_document_type_label: Optional[str] = None
     is_default: bool = False
     is_active: bool = True
     client_restricted: bool = False
@@ -810,6 +813,7 @@ class DocumentTemplatePayload(BaseModel):
     google_template_id: str
     document_role_type: Optional[str] = None
     description: Optional[str] = None
+    base_document_type_label: Optional[str] = None
     is_default: bool = False
     is_active: bool = True
     is_open_contract: bool = False
@@ -826,6 +830,7 @@ class DocumentTemplateUpdatePayload(BaseModel):
     google_template_id: Optional[str] = None
     document_role_type: Optional[str] = None
     description: Optional[str] = None
+    base_document_type_label: Optional[str] = None
     is_default: Optional[bool] = None
     is_active: Optional[bool] = None
     is_open_contract: Optional[bool] = None

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
-from models import CustomerContract, CustomerType, OrderDocument, Order, GlobalConfig
+from models import CustomerContract, CustomerType, DocumentTemplate, OrderDocument, Order, GlobalConfig
 from services.google_service import get_google_service
 from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
@@ -558,6 +558,15 @@ class DocumentService:
         if contract_ids:
             result = await session.execute(select(CustomerContract).where(CustomerContract.id.in_(contract_ids)))
             contracts_by_id = {contract.id: contract for contract in result.scalars().all() if contract.id is not None}
+        template_ids = {
+            doc.document_template_id
+            for doc in docs_by_id.values()
+            if getattr(doc, "document_template_id", None) is not None
+        }
+        templates_by_id: dict[int, DocumentTemplate] = {}
+        if template_ids:
+            result = await session.execute(select(DocumentTemplate).where(DocumentTemplate.id.in_(template_ids)))
+            templates_by_id = {template.id: template for template in result.scalars().all() if template.id is not None}
 
         lookup: dict[int, dict] = {}
         for doc in documents:
@@ -566,10 +575,13 @@ class DocumentService:
             base_doc = docs_by_id.get(doc.base_document_id)
             base_contract = contracts_by_id.get(doc.base_customer_contract_id)
             if base_doc:
+                template = templates_by_id.get(base_doc.document_template_id)
+                custom_type = str(getattr(template, "base_document_type_label", "") or "").strip()
                 lookup[doc.id] = {
                     "base_document_id": base_doc.id,
                     "base_customer_contract_id": None,
                     "base_document_type": base_doc.doc_type,
+                    "base_document_type_label": custom_type or DOC_NAMES.get(base_doc.doc_type, base_doc.doc_type),
                     "base_document_number": base_doc.number,
                     "base_document_date": base_doc.date,
                 }
@@ -578,6 +590,7 @@ class DocumentService:
                     "base_document_id": None,
                     "base_customer_contract_id": base_contract.id,
                     "base_document_type": "contract",
+                    "base_document_type_label": DOC_NAMES.get("contract", "Договор"),
                     "base_document_number": base_contract.number,
                     "base_document_date": base_contract.valid_from,
                 }
@@ -586,6 +599,7 @@ class DocumentService:
                     "base_document_id": None,
                     "base_customer_contract_id": None,
                     "base_document_type": None,
+                    "base_document_type_label": None,
                     "base_document_number": None,
                     "base_document_date": None,
                 }
@@ -678,10 +692,12 @@ class DocumentService:
         # Добавляем номер документа в замены
         replacements["{{doc_number}}"] = doc_number
         replacements["{{number}}"] = doc_number
+        strategy._append_placeholder_aliases(replacements)
         
         # Добавляем специфичные для типа документа замены
         if hasattr(strategy, '_add_specific_replacements'):
             strategy._add_specific_replacements(replacements)
+            strategy._append_placeholder_aliases(replacements)
         
         # 5. Определяем тип документа (Docs или Sheets)
         is_sheet = doc_type in ["tn2", "ttn1"]

--- a/services/document_template_service.py
+++ b/services/document_template_service.py
@@ -46,6 +46,7 @@ class DocumentTemplateService:
             "doc_type": template.doc_type,
             "document_role_type": DocumentRoleService.normalize_role_type(template.document_role_type),
             "description": template.description,
+            "base_document_type_label": template.base_document_type_label,
             "is_default": bool(template.is_default),
             "is_active": bool(template.is_active),
             "is_open_contract": bool(template.is_open_contract),
@@ -73,6 +74,7 @@ class DocumentTemplateService:
             "doc_type": "contract",
             "document_role_type": DocumentRoleService.normalize_role_type(item.get("document_role_type")),
             "description": None,
+            "base_document_type_label": None,
             "is_default": index == 0,
             "is_active": True,
             "is_open_contract": DocumentTemplateService._normalize_bool(item.get("is_open_contract")),
@@ -210,6 +212,8 @@ class DocumentTemplateService:
             template.document_role_type = DocumentRoleService.normalize_role_type(payload.document_role_type)
         if should_set("description"):
             template.description = str(payload.description or "").strip() or None
+        if should_set("base_document_type_label"):
+            template.base_document_type_label = str(payload.base_document_type_label or "").strip() or None
         if should_set("is_default"):
             template.is_default = bool(payload.is_default)
         if should_set("is_active"):
@@ -352,6 +356,7 @@ class DocumentTemplateService:
                         "doc_type": normalized_doc_type,
                         "document_role_type": DocumentRoleService.normalize_role_type(None),
                         "description": None,
+                        "base_document_type_label": None,
                         "is_default": True,
                         "is_active": True,
                         "is_open_contract": False,

--- a/services/documents/base.py
+++ b/services/documents/base.py
@@ -8,7 +8,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from num2words import num2words
 
-from models import CustomerContract, Order, OrderDocument, OrderProductLink, OrderServiceLink, CustomerType
+from models import CustomerContract, DocumentTemplate, Order, OrderDocument, OrderProductLink, OrderServiceLink, CustomerType
 from services.document_role_service import DocumentRoleService
 
 # Template IDs
@@ -160,6 +160,16 @@ class BaseDocumentStrategy(ABC):
         # even when the order currently points at a reusable customer contract.
         effective_customer_contract = base_customer_contract or getattr(order, "customer_contract", None)
 
+        if doc_number:
+            replacements["{{doc_number}}"] = doc_number
+            replacements["{{number}}"] = doc_number
+        if doc_type == "invoice" and doc_number:
+            replacements["{{invoice_number}}"] = doc_number
+            replacements["{{invoice_date}}"] = effective_date.strftime("%d.%m.%Y")
+        if doc_type == "offer" and doc_number:
+            replacements["{{offer_number}}"] = doc_number
+            replacements["{{offer_date}}"] = effective_date.strftime("%d.%m.%Y")
+
         if doc_type == "contract" and doc_number:
             replacements["{{contract_name}}"] = doc_number
             replacements["{{contract_number}}"] = doc_number
@@ -225,7 +235,7 @@ class BaseDocumentStrategy(ABC):
             replacements["{{invoice_date}}"] = invoice_doc.date.strftime("%d.%m.%Y") if invoice_doc.date else "-"
 
         if base_document:
-            replacements["{{base_document_type}}"] = DOC_NAMES.get(base_document.doc_type, base_document.doc_type)
+            replacements["{{base_document_type}}"] = await self._base_document_type_label(base_document)
             replacements["{{base_document_number}}"] = base_document.number
             replacements["{{base_document_date}}"] = base_document.date.strftime("%d.%m.%Y") if base_document.date else "-"
             if base_document.doc_type == "contract":
@@ -245,7 +255,28 @@ class BaseDocumentStrategy(ABC):
             for key, value in order.technical_meta.items():
                 replacements[f"{{{{meta_{key}}}}}"] = str(value)
 
-        return self._append_customer_variables(replacements, c)
+        return self._append_placeholder_aliases(self._append_customer_variables(replacements, c))
+
+    async def _base_document_type_label(self, base_document: OrderDocument) -> str:
+        default_label = DOC_NAMES.get(base_document.doc_type, base_document.doc_type)
+        if not base_document.document_template_id:
+            return default_label
+        template = base_document.__dict__.get("document_template")
+        if not template:
+            template = await self.session.get(DocumentTemplate, base_document.document_template_id)
+        custom_label = str(getattr(template, "base_document_type_label", "") or "").strip()
+        return custom_label or default_label
+
+    @staticmethod
+    def _append_placeholder_aliases(replacements: Dict[str, str]) -> Dict[str, str]:
+        for key, value in list(replacements.items()):
+            if not (key.startswith("{{") and key.endswith("}}")):
+                continue
+            name = key[2:-2]
+            if not name or name.upper() == name:
+                continue
+            replacements[f"{{{{{name.upper()}}}}}"] = value
+        return replacements
 
     def _append_customer_variables(self, replacements: Dict[str, str], c: Any) -> Dict[str, str]:
         # Customer Real Data

--- a/services/documents/logistics.py
+++ b/services/documents/logistics.py
@@ -50,6 +50,7 @@ class LogisticsSheetStrategy(BaseDocumentStrategy):
         
         # Enriched Replacements with Totals
         replacements.update(totals)
+        self._append_placeholder_aliases(replacements)
         
         doc_title = f"{DOC_NAMES.get(doc_type, 'Док')} {doc_number or f'#{self.order.id}'} {replacements.get('{{client_name}}', '')}"
         

--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -36,6 +36,7 @@ class GoogleDocStrategy(BaseDocumentStrategy):
         
         # Additional Replacements specific to doc logic
         self._add_specific_replacements(replacements)
+        self._append_placeholder_aliases(replacements)
 
         doc_title = f"{DOC_NAMES.get(doc_type, 'Док')} #{self.order.id} {replacements.get('{{client_name}}', '')}"
         

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -10,6 +10,7 @@ from models import (
     CustomerBranch,
     CustomerContract,
     CustomerType,
+    DocumentTemplate,
     GlobalConfig,
     Installer,
     Order,
@@ -1183,6 +1184,16 @@ async def test_manager_order_act_can_use_invoice_as_base_document(async_client, 
         google_file_id="invoice-file",
         google_edit_url="https://example.com/invoice",
     )
+    invoice_template = DocumentTemplate(
+        name="Счет-договор",
+        doc_type="invoice",
+        google_template_id="invoice-template",
+        base_document_type_label="Счет-договор",
+    )
+    db.add(invoice_template)
+    await db.commit()
+    await db.refresh(invoice_template)
+    invoice.document_template_id = invoice_template.id
     db.add(invoice)
     await db.commit()
     await db.refresh(invoice)
@@ -1213,7 +1224,7 @@ async def test_manager_order_act_can_use_invoice_as_base_document(async_client, 
     assert response.status_code == 200, response.text
     assert response.json()["base_document_id"] == invoice.id
     replacements = captured["replacements"]
-    assert replacements["{{base_document_type}}"] == "Счет"
+    assert replacements["{{base_document_type}}"] == "Счет-договор"
     assert replacements["{{base_document_number}}"] == "С-2026-005"
     assert replacements["{{base_document_date}}"] == "10.05.2026"
     assert replacements["{{invoice_number}}"] == "С-2026-005"
@@ -1221,6 +1232,29 @@ async def test_manager_order_act_can_use_invoice_as_base_document(async_client, 
     result = await db.execute(select(OrderDocument).where(OrderDocument.doc_type == "act"))
     act = result.scalars().first()
     assert act.base_document_id == invoice.id
+    order_id = order.id
+    customer_id = customer.id
+    act_id = act.id
+
+    docs_response = await async_client.get(f"/api/manager/orders/{order_id}/documents", headers=headers)
+    assert docs_response.status_code == 200
+    act_item = next(item for item in docs_response.json()["items"] if item["id"] == act_id)
+    assert act_item["base_document_type"] == "invoice"
+    assert act_item["base_document_type_label"] == "Счет-договор"
+
+    db.expire_all()
+
+    detail_response = await async_client.get(f"/api/manager/orders/{order_id}", headers=headers)
+    assert detail_response.status_code == 200
+    detail_act_item = next(item for item in detail_response.json()["documents"] if item["id"] == act_id)
+    assert detail_act_item["base_document_type"] == "invoice"
+    assert detail_act_item["base_document_type_label"] == "Счет-договор"
+
+    customer_docs_response = await async_client.get(f"/api/manager/customers/{customer_id}/docs", headers=headers)
+    assert customer_docs_response.status_code == 200
+    customer_act_item = next(item for item in customer_docs_response.json()["items"] if item["id"] == act_id)
+    assert customer_act_item["base_document_type"] == "invoice"
+    assert customer_act_item["base_document_type_label"] == "Счет-договор"
 
 
 @pytest.mark.asyncio
@@ -1422,6 +1456,7 @@ async def test_manager_order_closing_doc_keeps_open_contract_base_after_order_co
     act_item = next(item for item in docs_response.json()["items"] if item["id"] == act_doc_id)
     assert act_item["base_customer_contract_id"] == contract_a_id
     assert act_item["base_document_type"] == "contract"
+    assert act_item["base_document_type_label"] == "Договор"
     assert act_item["base_document_number"] == "ОД-2026-А"
     assert act_item["base_document_date"].startswith("2026-01-15")
 
@@ -1430,6 +1465,7 @@ async def test_manager_order_closing_doc_keeps_open_contract_base_after_order_co
     detail_act_item = next(item for item in detail_response.json()["documents"] if item["id"] == act_doc_id)
     assert detail_act_item["base_customer_contract_id"] == contract_a_id
     assert detail_act_item["base_document_type"] == "contract"
+    assert detail_act_item["base_document_type_label"] == "Договор"
     assert detail_act_item["base_document_number"] == "ОД-2026-А"
     assert detail_act_item["base_document_date"].startswith("2026-01-15")
 
@@ -1438,6 +1474,7 @@ async def test_manager_order_closing_doc_keeps_open_contract_base_after_order_co
     customer_act_item = next(item for item in customer_docs_response.json()["items"] if item["id"] == act_doc_id)
     assert customer_act_item["base_customer_contract_id"] == contract_a_id
     assert customer_act_item["base_document_type"] == "contract"
+    assert customer_act_item["base_document_type_label"] == "Договор"
     assert customer_act_item["base_document_number"] == "ОД-2026-А"
     assert customer_act_item["base_document_date"].startswith("2026-01-15")
 

--- a/tests/unit/test_document_service_base_documents.py
+++ b/tests/unit/test_document_service_base_documents.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
-from models import Customer, CustomerContract, Order, OrderDocument
+from models import Customer, CustomerContract, DocumentTemplate, Order, OrderDocument
 from services.document_service import DocumentService
 from services.documents.standard import ActStrategy
 
@@ -138,6 +138,73 @@ async def test_base_document_placeholders_support_invoice(sqlite_session):
     assert replacements["{{base_document_date}}"] == "03.05.2026"
     assert replacements["{{invoice_number}}"] == "С-2026-003"
     assert replacements["{{invoice_date}}"] == "03.05.2026"
+    assert replacements["{{INVOICE_NUMBER}}"] == "С-2026-003"
+    assert replacements["{{INVOICE_DATE}}"] == "03.05.2026"
+
+
+@pytest.mark.asyncio
+async def test_current_invoice_placeholders_use_generated_number_and_uppercase_aliases(sqlite_session):
+    customer = Customer(name="Invoice Self", phone="+375291111111")
+    order = Order(customer=customer, total_amount=120)
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+
+    strategy = ActStrategy(sqlite_session, order.id)
+    await strategy.fetch_order()
+    replacements = await strategy._prepare_base_variables(
+        doc_number="С-2026-004",
+        doc_type="invoice",
+        document_date=datetime(2026, 6, 1),
+    )
+
+    assert replacements["{{invoice_number}}"] == "С-2026-004"
+    assert replacements["{{invoice_date}}"] == "01.06.2026"
+    assert replacements["{{INVOICE_NUMBER}}"] == "С-2026-004"
+    assert replacements["{{INVOICE_DATE}}"] == "01.06.2026"
+    assert replacements["{{DOC_NUMBER}}"] == "С-2026-004"
+
+
+@pytest.mark.asyncio
+async def test_base_document_type_uses_invoice_template_label(sqlite_session):
+    customer = Customer(name="Invoice Label", phone="+375291111111")
+    order = Order(customer=customer, total_amount=120)
+    template = DocumentTemplate(
+        name="Счет-договор",
+        doc_type="invoice",
+        google_template_id="invoice-template",
+        base_document_type_label="Счет-договор",
+    )
+    sqlite_session.add_all([order, template])
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+    await sqlite_session.refresh(template)
+
+    invoice = OrderDocument(
+        order_id=order.id,
+        document_template_id=template.id,
+        doc_type="invoice",
+        number="С-2026-005",
+        date=datetime(2026, 6, 1),
+        google_file_id="invoice-d",
+        google_edit_url="https://example.com/d",
+    )
+    sqlite_session.add(invoice)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(invoice)
+
+    strategy = ActStrategy(sqlite_session, order.id)
+    await strategy.fetch_order()
+    replacements = await strategy._prepare_base_variables(
+        doc_number="А-2026-003",
+        doc_type="act",
+        document_date=datetime(2026, 6, 2),
+        base_document=invoice,
+    )
+
+    assert replacements["{{base_document_type}}"] == "Счет-договор"
+    assert replacements["{{BASE_DOCUMENT_TYPE}}"] == "Счет-договор"
+    assert replacements["{{base_document_number}}"] == "С-2026-005"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add document template display labels for document-basis text
- keep API basis type machine-readable while exposing base_document_type_label for UI display
- support uppercase document placeholders for invoices and basis fields

## Contract note
- base_document_type stays machine-readable: invoice, contract, offer
- base_document_type_label carries display text such as Счет-договор or Договор
- Google document placeholders can still render human text through {{base_document_type}}

## Verification
- pytest tests/unit/test_document_service_base_documents.py -q
- TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -k "base_document or document_numbering or closing_doc or contract_selection" -q
- python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api && npm run build
- git diff --check

Issue #349 is intentionally not closed automatically.