### PR TITLE
[codex] Improve email lead intake filtering

### DIFF
--- a/manager_frontend/src/client/services/ManagerMailService.ts
+++ b/manager_frontend/src/client/services/ManagerMailService.ts
@@ -40,17 +40,20 @@ export class ManagerMailService {
     /**
      * Import Manager Email Leads
      * @param dryRun
+     * @param lookbackDays
      * @returns EmailLeadImportResponse Successful Response
      * @throws ApiError
      */
     public static importManagerEmailLeads(
         dryRun: boolean = false,
+        lookbackDays?: (number | null),
     ): CancelablePromise<EmailLeadImportResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/manager/mail/leads/import',
             query: {
                 'dry_run': dryRun,
+                'lookback_days': lookbackDays,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/components/leads/LeadsDashboard.vue
+++ b/manager_frontend/src/components/leads/LeadsDashboard.vue
@@ -31,6 +31,7 @@ import { CUSTOMER_UPDATED_EVENT, type CustomerUpdatedEventPayload } from '../../
 type LeadTab = '' | 'new' | 'contacted' | 'qualified' | 'lost' | 'spam';
 type RequisiteFieldKey = 'inn' | 'full_legal_name' | 'legal_address' | 'iban' | 'bic' | 'bank_name';
 const CRITICAL_REQUISITE_KEYS: ReadonlySet<RequisiteFieldKey> = new Set(['inn', 'iban', 'bic', 'bank_name']);
+const EMAIL_LEAD_MANUAL_LOOKBACK_DAYS = 14;
 
 const leads = ref<LeadResponse[]>([]);
 const loading = ref(false);
@@ -309,7 +310,7 @@ const importEmailLeads = async (dryRun: boolean) => {
   emailLeadImporting.value = true;
   emailLeadImportResult.value = null;
   try {
-    const result = await ManagerMailService.importManagerEmailLeads(dryRun);
+    const result = await ManagerMailService.importManagerEmailLeads(dryRun, EMAIL_LEAD_MANUAL_LOOKBACK_DAYS);
     emailLeadImportResult.value = result;
     const createdText = dryRun
       ? `можно создать ${result.would_create || 0}`
@@ -1392,13 +1393,13 @@ const onQualifyIbanBlur = async () => {
             class="grid gap-2 border-b border-gray-100 px-3 py-2 text-sm last:border-b-0 dark:border-slate-700 md:grid-cols-[120px_minmax(0,1fr)_minmax(0,2fr)]"
           >
             <span class="font-semibold text-slate-700 dark:text-slate-200">
-              {{ decision.status === 'rejected' ? 'Отклонено' : decision.status === 'would_create' ? 'Кандидат' : decision.status === 'created' ? 'Создан' : decision.status === 'duplicate' ? 'Дубль' : 'Ошибка' }}
+              {{ decision.status === 'rejected' ? 'Отклонено' : decision.status === 'would_create' ? 'Кандидат' : decision.status === 'created' ? 'Создан' : decision.status === 'duplicate' ? 'Дубль' : decision.status === 'filtered' ? 'Не кандидат' : 'Ошибка' }}
             </span>
             <span class="min-w-0 truncate text-slate-600 dark:text-slate-300">
               {{ decision.subject || 'Без темы' }}
             </span>
             <span class="min-w-0 text-slate-500 dark:text-slate-400">
-              {{ decision.reason || decision.sender_email }}
+              {{ decision.reason === 'keyword_filter' ? 'Не прошло быстрый фильтр' : decision.reason || decision.sender_email }}
             </span>
           </div>
         </div>

--- a/manager_frontend/src/views/LeadInbox.vue
+++ b/manager_frontend/src/views/LeadInbox.vue
@@ -9,6 +9,7 @@ import { useBelarusPhoneMask } from '../composables/useBelarusPhoneMask';
 import { useB2BLookup } from '../composables/useB2BLookup';
 
 type Scope = 'active' | 'archive';
+const EMAIL_LEAD_MANUAL_LOOKBACK_DAYS = 14;
 
 const scope = ref<Scope>('active');
 const items = ref<LeadsInboxItemResponse[]>([]);
@@ -115,7 +116,7 @@ const importEmailLeads = async () => {
   emailLeadImporting.value = true;
   emailLeadImportResult.value = null;
   try {
-    const result = await ManagerMailService.importManagerEmailLeads(false);
+    const result = await ManagerMailService.importManagerEmailLeads(false, EMAIL_LEAD_MANUAL_LOOKBACK_DAYS);
     emailLeadImportResult.value = result;
     setToast(`Почта: обработано ${result.processed || 0}, кандидатов ${result.candidates || 0}, создано ${result.created || 0}.`);
     if ((result.created || 0) > 0) {
@@ -356,7 +357,7 @@ const scopeOptions: { value: Scope; label: string }[] = [
         <div>
           <p class="text-sm font-bold uppercase tracking-wide text-teal-700 dark:text-teal-300">Email-лиды</p>
           <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
-            Проверка новых писем с последнего прохода; при первом запуске берутся последние 5 дней.
+            Ручная проверка берёт последние 14 дней; автоимпорт идёт с последнего прохода.
           </p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
@@ -395,14 +396,14 @@ const scopeOptions: { value: Scope; label: string }[] = [
           class="grid gap-2 border-b border-slate-100 px-3 py-2 text-sm last:border-b-0 dark:border-slate-700 md:grid-cols-[120px_minmax(0,1fr)_minmax(0,2fr)]"
         >
           <span class="font-semibold text-slate-700 dark:text-slate-200">
-            {{ decision.status === 'rejected' ? 'Отклонено' : decision.status === 'would_create' ? 'Кандидат' : decision.status === 'created' ? 'Создан' : decision.status === 'duplicate' ? 'Дубль' : 'Ошибка' }}
+            {{ decision.status === 'rejected' ? 'Отклонено' : decision.status === 'would_create' ? 'Кандидат' : decision.status === 'created' ? 'Создан' : decision.status === 'duplicate' ? 'Дубль' : decision.status === 'filtered' ? 'Не кандидат' : 'Ошибка' }}
             <span v-if="decision.order_id" class="text-slate-400">#{{ decision.order_id }}</span>
           </span>
           <span class="min-w-0 truncate text-slate-600 dark:text-slate-300">
             {{ decision.subject || 'Без темы' }}
           </span>
           <span class="min-w-0 text-slate-500 dark:text-slate-400">
-            {{ decision.reason || decision.sender_email }}
+            {{ decision.reason === 'keyword_filter' ? 'Не прошло быстрый фильтр' : decision.reason || decision.sender_email }}
           </span>
         </div>
       </div>

--- a/openapi.json
+++ b/openapi.json
@@ -6537,6 +6537,24 @@
               "default": false,
               "title": "Dry Run"
             }
+          },
+          {
+            "name": "lookback_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 30,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lookback Days"
+            }
           }
         ],
         "responses": {

--- a/routers/manager_mail.py
+++ b/routers/manager_mail.py
@@ -69,10 +69,15 @@ async def import_manager_bank_receipts(
 )
 async def import_manager_email_leads(
     dry_run: bool = Query(False),
+    lookback_days: int | None = Query(None, ge=1, le=30),
     session: AsyncSession = Depends(get_session),
 ):
     try:
-        result = await MailImapService.import_email_leads(session, dry_run=dry_run)
+        result = await MailImapService.import_email_leads(
+            session,
+            dry_run=dry_run,
+            lookback_days=lookback_days,
+        )
         return EmailLeadImportResponse(**result.__dict__)
     except Exception as exc:
         raise manager_http_error(

--- a/services/email_lead_intake_service.py
+++ b/services/email_lead_intake_service.py
@@ -87,6 +87,41 @@ class EmailLeadIntakeService:
         "счет",
         "счёт",
     )
+    HVAC_CONTEXT_STEMS = (
+        "кондиц",
+        "сплит",
+        "вентиляц",
+        "чиллер",
+        "теплов",
+        "климат",
+        "кассетн",
+        "канальн",
+        "фанкойл",
+        "внутренн",
+        "наружн",
+        "блок",
+    )
+    LEAD_INTENT_STEMS = (
+        "цен",
+        "стоим",
+        "предложен",
+        "коммерческ",
+        "кп",
+        "счет",
+        "счёт",
+        "заявк",
+        "заказ",
+        "просим",
+        "подготов",
+        "обслуживан",
+        "ремонт",
+        "монтаж",
+        "установ",
+        "демонтаж",
+        "диагност",
+        "заправ",
+        "сервис",
+    )
 
     @staticmethod
     def _configured_keywords() -> tuple[str, ...]:
@@ -105,6 +140,10 @@ class EmailLeadIntakeService:
         return text[:max_length].strip()
 
     @staticmethod
+    def _has_any_stem(haystack: str, stems: tuple[str, ...]) -> bool:
+        return any(stem in haystack for stem in stems)
+
+    @staticmethod
     def looks_like_lead_candidate(*, sender_email: str, subject: str, raw_body: str) -> bool:
         sender = str(sender_email or "").strip().lower()
         clean_subject = EmailLeadIntakeService.normalize_text(subject, max_length=500).casefold()
@@ -116,7 +155,18 @@ class EmailLeadIntakeService:
             return False
 
         haystack = f"{clean_subject} {clean_body}"
-        return any(keyword in haystack for keyword in EmailLeadIntakeService._configured_keywords())
+        if any(keyword in haystack for keyword in EmailLeadIntakeService._configured_keywords()):
+            return True
+
+        has_hvac_context = EmailLeadIntakeService._has_any_stem(
+            haystack,
+            EmailLeadIntakeService.HVAC_CONTEXT_STEMS,
+        )
+        has_lead_intent = EmailLeadIntakeService._has_any_stem(
+            haystack,
+            EmailLeadIntakeService.LEAD_INTENT_STEMS,
+        )
+        return has_hvac_context and has_lead_intent
 
     @staticmethod
     def build_fingerprint(

--- a/services/mail_imap_service.py
+++ b/services/mail_imap_service.py
@@ -294,10 +294,18 @@ class MailImapService:
             client.logout()
 
     @staticmethod
-    async def import_email_leads(session: AsyncSession, *, dry_run: bool = False) -> EmailLeadImportResult:
+    async def import_email_leads(
+        session: AsyncSession,
+        *,
+        dry_run: bool = False,
+        lookback_days: Optional[int] = None,
+    ) -> EmailLeadImportResult:
         result = EmailLeadImportResult()
         scan_started_at = datetime.now()
-        scan_since = await MailImapService._email_lead_scan_since(session)
+        if lookback_days is not None:
+            scan_since = scan_started_at - timedelta(days=max(1, min(30, int(lookback_days))))
+        else:
+            scan_since = await MailImapService._email_lead_scan_since(session)
         result.scanned_since = scan_since.isoformat(timespec="seconds")
         client = MailImapService._connect()
         try:
@@ -357,6 +365,7 @@ class MailImapService:
 
                 if outcome.is_candidate:
                     result.candidates += 1
+                if outcome.is_candidate or (dry_run and outcome.status == "filtered"):
                     result.decisions.append(
                         EmailLeadDecision(
                             status=outcome.status,

--- a/tests/integration/test_manager_mail_api.py
+++ b/tests/integration/test_manager_mail_api.py
@@ -68,8 +68,9 @@ async def test_manager_mail_import_endpoint_uses_imap_service(async_client, monk
 
 @pytest.mark.asyncio
 async def test_manager_mail_lead_import_endpoint_uses_imap_service(async_client, monkeypatch):
-    async def fake_import(_session, *, dry_run=False):
+    async def fake_import(_session, *, dry_run=False, lookback_days=None):
         assert dry_run is True
+        assert lookback_days == 7
         return EmailLeadImportResult(
             processed=3,
             scanned_since="2026-05-23T09:00:00",
@@ -90,7 +91,7 @@ async def test_manager_mail_lead_import_endpoint_uses_imap_service(async_client,
     monkeypatch.setattr("routers.manager_mail.MailImapService.import_email_leads", fake_import)
 
     headers = await _auth_headers(async_client)
-    response = await async_client.post("/api/manager/mail/leads/import?dry_run=true", headers=headers)
+    response = await async_client.post("/api/manager/mail/leads/import?dry_run=true&lookback_days=7", headers=headers)
 
     assert response.status_code == 200
     assert response.json() == {

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -93,6 +93,14 @@ def test_email_lead_keyword_filter_finds_hvac_request_and_skips_bank_email():
     )
 
 
+def test_email_lead_keyword_filter_finds_inflected_service_offer_for_blocks():
+    assert EmailLeadIntakeService.looks_like_lead_candidate(
+        sender_email="client@example.com",
+        subject="Ценовое предложение",
+        raw_body="Добрый день. Просим предоставить ценовое предложение на обслуживание нескольких блоков.",
+    )
+
+
 def test_email_lead_attachment_text_participates_in_keyword_filter():
     body = "Добрый день, во вложении заявка."
     msg = EmailMessage()
@@ -202,6 +210,46 @@ async def test_email_lead_intake_dry_run_does_not_create_order(sqlite_session, m
     assert result.status == "would_create"
     orders = (await sqlite_session.execute(select(Order))).scalars().all()
     assert orders == []
+
+
+@pytest.mark.asyncio
+async def test_email_lead_import_dry_run_reports_keyword_filtered_message(sqlite_session, monkeypatch):
+    class FakeImapClient:
+        def select(self, *_args, **_kwargs):
+            return "OK", []
+
+        def search(self, *_args):
+            return "OK", [b"1"]
+
+        def fetch(self, *_args):
+            msg = EmailMessage()
+            msg["Subject"] = "Документы"
+            msg["From"] = "client@example.com"
+            msg["Date"] = "Mon, 01 Jun 2026 12:00:00 +0300"
+            msg["Message-ID"] = "<filtered-lead@example.test>"
+            msg.set_content("Добрый день. Во вложении документы.")
+            return "OK", [(b"RFC822", msg.as_bytes())]
+
+        def close(self):
+            pass
+
+        def logout(self):
+            pass
+
+    async def fake_scan_since(_session):
+        return datetime(2026, 5, 31, 0, 0, 0)
+
+    monkeypatch.setattr(MailImapService, "_connect", lambda: FakeImapClient())
+    monkeypatch.setattr(MailImapService, "_email_lead_scan_since", fake_scan_since)
+
+    result = await MailImapService.import_email_leads(sqlite_session, dry_run=True)
+
+    assert result.processed == 1
+    assert result.candidates == 0
+    assert result.ai_checked == 0
+    assert len(result.decisions) == 1
+    assert result.decisions[0].status == "filtered"
+    assert result.decisions[0].reason == "keyword_filter"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- broaden email lead keyword prefilter with HVAC/context and intent stems so inflected requests like “ценовое предложение на обслуживание нескольких блоков” reach AI classification
- add optional `lookback_days` to manual email lead import and use a 14-day manual lookback in manager UI
- show dry-run keyword-filtered messages as “Не кандидат” instead of making them invisible or labeling them as errors
- regenerate OpenAPI and manager client

## Validation
- `pytest tests/unit/test_mail_services.py -q` — 20 passed
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_mail_api.py::test_manager_mail_lead_import_endpoint_uses_imap_service -q` — 1 passed
- `cd manager_frontend && npm run build` — passed

## Notes
This fixes the email-lead intake changes that were previously local only and therefore were not deployed to `api.mvn.by`. Legacy `.doc` attachment extraction remains tracked separately in #358.