### PR TITLE
[codex] Support legacy Word attachments in email leads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     libpq-dev \
+    antiword \
     postgresql-client \
     poppler-utils \
     tesseract-ocr \

--- a/services/mail_imap_service.py
+++ b/services/mail_imap_service.py
@@ -1,7 +1,11 @@
 import email
 import imaplib
 import re
+import shutil
+import subprocess
+import tempfile
 import zipfile
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from email.header import decode_header
 from email.message import Message
@@ -19,8 +23,16 @@ from services.bank_receipt_service import BankReceiptImportResult, BankReceiptSe
 from services.email_lead_intake_service import EmailLeadDecision, EmailLeadImportResult, EmailLeadIntakeService
 
 
+@dataclass(frozen=True)
+class AttachmentTextExtraction:
+    text: str = ""
+    diagnostic: Optional[str] = None
+
+
 class MailImapService:
     EMAIL_LEAD_LAST_IMPORT_KEY = "mail_lead_last_import_at"
+    LEGACY_DOC_MAX_BYTES = 5 * 1024 * 1024
+    LEGACY_DOC_TIMEOUT_SECONDS = 8
 
     @staticmethod
     def _decode_header_value(raw: Optional[str]) -> str:
@@ -119,7 +131,59 @@ class MailImapService:
         return re.sub(r"[ \t]+", " ", text).strip()
 
     @staticmethod
-    def _extract_attachment_text(filename: str, content_type: str, content: bytes, *, max_chars: int = 4000) -> str:
+    def _decode_extracted_bytes(content: bytes) -> str:
+        for encoding in ("utf-8", "cp1251", "cp866"):
+            try:
+                return content.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+        return content.decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _extract_legacy_doc_text(content: bytes, *, max_chars: int = 4000) -> AttachmentTextExtraction:
+        if len(content) > MailImapService.LEGACY_DOC_MAX_BYTES:
+            size_mb = MailImapService.LEGACY_DOC_MAX_BYTES // (1024 * 1024)
+            return AttachmentTextExtraction(diagnostic=f"legacy .doc не распознан: размер вложения больше {size_mb} МБ")
+
+        antiword_path = shutil.which("antiword")
+        if not antiword_path:
+            return AttachmentTextExtraction(diagnostic="legacy .doc не распознан: antiword не установлен в runtime")
+
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".doc") as tmp:
+                tmp.write(content)
+                tmp.flush()
+                completed = subprocess.run(
+                    [antiword_path, tmp.name],
+                    capture_output=True,
+                    timeout=MailImapService.LEGACY_DOC_TIMEOUT_SECONDS,
+                    check=False,
+                )
+        except subprocess.TimeoutExpired:
+            return AttachmentTextExtraction(diagnostic="legacy .doc не распознан: истекло время обработки antiword")
+        except OSError as exc:
+            detail = str(exc).strip()
+            return AttachmentTextExtraction(diagnostic=f"legacy .doc не распознан: ошибка запуска antiword ({detail})")
+
+        if completed.returncode != 0:
+            detail = MailImapService._decode_extracted_bytes(completed.stderr or b"").strip()
+            suffix = f": {detail[:180]}" if detail else ""
+            return AttachmentTextExtraction(diagnostic=f"legacy .doc не распознан: antiword вернул код {completed.returncode}{suffix}")
+
+        text = MailImapService._decode_extracted_bytes(completed.stdout or b"")
+        text = re.sub(r"\s+", " ", text).strip()[:max_chars].strip()
+        if not text:
+            return AttachmentTextExtraction(diagnostic="legacy .doc не распознан: antiword не извлек текст")
+        return AttachmentTextExtraction(text=text)
+
+    @staticmethod
+    def _extract_attachment_text_result(
+        filename: str,
+        content_type: str,
+        content: bytes,
+        *,
+        max_chars: int = 4000,
+    ) -> AttachmentTextExtraction:
         lower_name = filename.lower()
         content_type = str(content_type or "").lower()
         text = ""
@@ -134,12 +198,23 @@ class MailImapService:
             or lower_name.endswith(".docx")
         ):
             text = MailImapService._extract_docx_text(content)
+        elif content_type in {"application/msword", "application/vnd.ms-word"} or lower_name.endswith(".doc"):
+            return MailImapService._extract_legacy_doc_text(content, max_chars=max_chars)
         elif lower_name.endswith(".rtf"):
             text = content.decode("utf-8", errors="replace")
             text = re.sub(r"\\'[0-9a-fA-F]{2}", " ", text)
             text = re.sub(r"[{}\\][a-zA-Z0-9*'-]+ ?", " ", text)
         text = re.sub(r"\s+", " ", text).strip()
-        return text[:max_chars].strip()
+        return AttachmentTextExtraction(text=text[:max_chars].strip())
+
+    @staticmethod
+    def _extract_attachment_text(filename: str, content_type: str, content: bytes, *, max_chars: int = 4000) -> str:
+        return MailImapService._extract_attachment_text_result(
+            filename=filename,
+            content_type=content_type,
+            content=content,
+            max_chars=max_chars,
+        ).text
 
     @staticmethod
     def _extract_attachment_texts(msg: Message) -> list[str]:
@@ -154,13 +229,15 @@ class MailImapService:
             payload = part.get_payload(decode=True)
             if not payload:
                 continue
-            attachment_text = MailImapService._extract_attachment_text(
+            extraction = MailImapService._extract_attachment_text_result(
                 filename=filename or "attachment",
                 content_type=part.get_content_type(),
                 content=payload,
             )
-            if attachment_text:
-                texts.append(f"Вложение {filename or 'attachment'}:\n{attachment_text}")
+            if extraction.text:
+                texts.append(f"Вложение {filename or 'attachment'}:\n{extraction.text}")
+            elif extraction.diagnostic:
+                texts.append(f"Вложение {filename or 'attachment'}: {extraction.diagnostic}")
             elif filename:
                 texts.append(f"Вложение {filename}: текст не извлечен")
         return texts
@@ -331,6 +408,7 @@ class MailImapService:
                 attachment_texts = MailImapService._extract_attachment_texts(msg)
                 if attachment_texts:
                     raw_body = f"{raw_body}\n\nТекст вложений:\n" + "\n\n".join(attachment_texts)
+                attachment_diagnostics = [item for item in attachment_texts if "legacy .doc не распознан" in item]
 
                 try:
                     outcome = await EmailLeadIntakeService.process_email(
@@ -365,6 +443,15 @@ class MailImapService:
                             reason=outcome.reason,
                             lead_id=outcome.lead_id,
                             order_id=outcome.order_id,
+                        )
+                    )
+                elif dry_run and attachment_diagnostics:
+                    result.decisions.append(
+                        EmailLeadDecision(
+                            status=outcome.status,
+                            sender_email=sender_email,
+                            subject=subject,
+                            reason="; ".join(attachment_diagnostics)[:300],
                         )
                     )
                 if outcome.used_ai:

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from datetime import datetime
 from email.message import EmailMessage
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -13,7 +14,7 @@ from services.bank_email_parser_service import BankEmailParserService
 from services.bank_receipt_service import BankReceiptService
 from services.bank_statement_csv_service import BankStatementCsvService
 from services.bot_service import BotService
-from services.email_lead_intake_service import EmailLeadIntakeService
+from services.email_lead_intake_service import EmailLeadIntakeService, EmailLeadProcessResult
 from services.mail_smtp_service import MailAttachment, MailSmtpService
 from services.mail_imap_service import MailImapService
 from services.notification_service import NotificationService
@@ -113,6 +114,131 @@ def test_email_lead_attachment_text_participates_in_keyword_filter():
         subject=msg["Subject"],
         raw_body=f"{body}\n{attachment_text}",
     )
+
+
+def test_email_lead_legacy_doc_attachment_text_participates_in_keyword_filter(monkeypatch):
+    body = "Добрый день, во вложении заявка."
+    msg = EmailMessage()
+    msg["Subject"] = "Документы"
+    msg.set_content(body)
+    msg.add_attachment(
+        b"legacy-doc-bytes",
+        maintype="application",
+        subtype="msword",
+        filename="request.doc",
+    )
+
+    def fake_run(command, **kwargs):
+        assert command[0] == "/usr/bin/antiword"
+        assert command[1].endswith(".doc")
+        assert kwargs["timeout"] == MailImapService.LEGACY_DOC_TIMEOUT_SECONDS
+        assert kwargs["capture_output"] is True
+        return SimpleNamespace(
+            returncode=0,
+            stdout="Просим предоставить ценовое предложение на обслуживание кондиционеров.".encode("utf-8"),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(
+        "services.mail_imap_service.shutil.which",
+        lambda name: "/usr/bin/antiword" if name == "antiword" else None,
+    )
+    monkeypatch.setattr("services.mail_imap_service.subprocess.run", fake_run)
+
+    attachment_text = "\n".join(MailImapService._extract_attachment_texts(msg))
+
+    assert "обслуживание кондиционеров" in attachment_text
+    assert EmailLeadIntakeService.looks_like_lead_candidate(
+        sender_email="client@example.com",
+        subject=msg["Subject"],
+        raw_body=f"{body}\n{attachment_text}",
+    )
+
+
+def test_legacy_doc_attachment_reports_missing_runtime_dependency(monkeypatch):
+    monkeypatch.setattr("services.mail_imap_service.shutil.which", lambda _name: None)
+
+    extraction = MailImapService._extract_attachment_text_result(
+        filename="request.doc",
+        content_type="application/msword",
+        content=b"legacy-doc-bytes",
+    )
+
+    assert extraction.text == ""
+    assert extraction.diagnostic == "legacy .doc не распознан: antiword не установлен в runtime"
+
+
+def test_legacy_doc_attachment_size_limit_skips_converter(monkeypatch):
+    called = False
+
+    def fake_run(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("antiword should not be called for an oversized attachment")
+
+    monkeypatch.setattr(MailImapService, "LEGACY_DOC_MAX_BYTES", 4)
+    monkeypatch.setattr(
+        "services.mail_imap_service.shutil.which",
+        lambda name: "/usr/bin/antiword" if name == "antiword" else None,
+    )
+    monkeypatch.setattr("services.mail_imap_service.subprocess.run", fake_run)
+
+    extraction = MailImapService._extract_attachment_text_result(
+        filename="request.doc",
+        content_type="application/msword",
+        content=b"12345",
+    )
+
+    assert called is False
+    assert extraction.text == ""
+    assert "размер вложения больше" in (extraction.diagnostic or "")
+
+
+@pytest.mark.asyncio
+async def test_email_lead_dry_run_reports_unrecognized_legacy_doc(sqlite_session, monkeypatch):
+    msg = EmailMessage()
+    msg["Subject"] = "Документы"
+    msg["From"] = "client@example.com"
+    msg.set_content("Добрый день, во вложении заявка.")
+    msg.add_attachment(
+        b"legacy-doc-bytes",
+        maintype="application",
+        subtype="msword",
+        filename="request.doc",
+    )
+
+    class FakeImapClient:
+        def select(self, *_args, **_kwargs):
+            return "OK", []
+
+        def search(self, *_args):
+            return "OK", [b"1"]
+
+        def fetch(self, *_args):
+            return "OK", [(b"RFC822", msg.as_bytes())]
+
+        def close(self):
+            pass
+
+        def logout(self):
+            pass
+
+    async def fake_process_email(_session, **kwargs):
+        assert "legacy .doc не распознан" in kwargs["raw_body"]
+        return EmailLeadProcessResult(status="filtered", is_candidate=False, reason="keyword_filter")
+
+    monkeypatch.setattr("services.mail_imap_service.shutil.which", lambda _name: None)
+    monkeypatch.setattr(MailImapService, "_connect", lambda: FakeImapClient())
+    monkeypatch.setattr(EmailLeadIntakeService, "process_email", fake_process_email)
+
+    result = await MailImapService.import_email_leads(sqlite_session, dry_run=True)
+
+    assert result.processed == 1
+    assert result.candidates == 0
+    assert len(result.decisions) == 1
+    assert result.decisions[0].status == "filtered"
+    assert result.decisions[0].reason
+    assert "antiword не установлен" in result.decisions[0].reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add legacy `.doc` attachment extraction for email lead intake via the lightweight `antiword` runtime tool
- cap legacy `.doc` processing at 5 MB and 8 seconds to avoid blocking mail import
- include diagnostic attachment text when `.doc` extraction fails so manual dry-run can show why context was missing
- add focused tests for successful extraction, missing runtime dependency, size-limit skip, and dry-run diagnostics

## Validation
- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_mail_services.py -q` — 22 passed
- `PYTHONPYCACHEPREFIX=/tmp/pycache-doc358 python3 -m py_compile services/mail_imap_service.py` — passed
- `git diff --check` — passed
- Agent smoke-tested `antiword` availability/install on `python:3.11-slim`; full app Docker build was not run because this Dockerfile expects `manager_frontend/dist` to already exist.

## Runtime dependency
- Adds Debian package `antiword` to the app image.
- Production needs a new backend image rebuild before `.doc` extraction is active.

## Merge note
PR #359 contains the related keyword-filter/lookback fix that was previously local-only. Prefer merging #359 first, then rebasing this branch if GitHub reports conflicts in `services/mail_imap_service.py` or `tests/unit/test_mail_services.py`.