### PR TITLE
[codex] Prefer .doc diagnostics in email lead dry run

### DIFF
--- a/services/mail_imap_service.py
+++ b/services/mail_imap_service.py
@@ -444,23 +444,17 @@ class MailImapService:
                 if outcome.is_candidate:
                     result.candidates += 1
                 if outcome.is_candidate or (dry_run and outcome.status == "filtered"):
+                    decision_reason = outcome.reason
+                    if dry_run and outcome.status == "filtered" and attachment_diagnostics:
+                        decision_reason = "; ".join(attachment_diagnostics)[:300]
                     result.decisions.append(
                         EmailLeadDecision(
                             status=outcome.status,
                             sender_email=sender_email,
                             subject=subject,
-                            reason=outcome.reason,
+                            reason=decision_reason,
                             lead_id=outcome.lead_id,
                             order_id=outcome.order_id,
-                        )
-                    )
-                elif dry_run and attachment_diagnostics:
-                    result.decisions.append(
-                        EmailLeadDecision(
-                            status=outcome.status,
-                            sender_email=sender_email,
-                            subject=subject,
-                            reason="; ".join(attachment_diagnostics)[:300],
                         )
                     )
                 if outcome.used_ai:


### PR DESCRIPTION
## Summary
- fix the interaction between #359 and #360 where dry-run filtered decisions used keyword_filter instead of the legacy .doc extraction diagnostic
- prefer .doc attachment diagnostics when present, while keeping normal filtered decisions unchanged
- remove the now-unreachable separate diagnostic append branch

## Validation
- BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_mail_services.py -q — 24 passed
- PYTHONPYCACHEPREFIX=/tmp/pycache-doc-diagnostic-reason python3 -m py_compile services/mail_imap_service.py — passed
- git diff --check — passed