### PR TITLE
[codex] Add StaffUser foundation for installers

### DIFF
--- a/alembic/versions/6c7d8e9f0a12_add_staff_users_foundation.py
+++ b/alembic/versions/6c7d8e9f0a12_add_staff_users_foundation.py
@@ -1,0 +1,96 @@
+"""Add staff users foundation
+
+Revision ID: 6c7d8e9f0a12
+Revises: 5a6b7c8d9e10
+Create Date: 2026-06-03 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6c7d8e9f0a12"
+down_revision: Union[str, Sequence[str], None] = "5a6b7c8d9e10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _tables() -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return set(inspector.get_table_names())
+
+
+def upgrade() -> None:
+    if "staff_users" not in _tables():
+        op.create_table(
+            "staff_users",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("display_name", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("roles", sa.JSON(), nullable=False),
+            sa.Column("phone", sa.String(), nullable=True),
+            sa.Column("email", sa.String(), nullable=True),
+            sa.Column("telegram_id", sa.BigInteger(), nullable=True),
+            sa.Column("legacy_installer_id", sa.Integer(), nullable=True),
+            sa.Column("default_rate", sa.Float(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["legacy_installer_id"], ["installers.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("telegram_id", name="uq_staff_users_telegram_id"),
+            sa.UniqueConstraint("legacy_installer_id", name="uq_staff_users_legacy_installer_id"),
+        )
+        op.create_index("ix_staff_users_display_name", "staff_users", ["display_name"], unique=False)
+        op.create_index("ix_staff_users_status", "staff_users", ["status"], unique=False)
+        op.create_index("ix_staff_users_phone", "staff_users", ["phone"], unique=False)
+        op.create_index("ix_staff_users_email", "staff_users", ["email"], unique=False)
+        op.create_index("ix_staff_users_legacy_installer_id", "staff_users", ["legacy_installer_id"], unique=False)
+
+    conn = op.get_bind()
+    roles_expr = """'["installer"]'::json""" if conn.dialect.name == "postgresql" else """'["installer"]'"""
+    conn.execute(
+        sa.text(
+            f"""
+            INSERT INTO staff_users (
+                display_name,
+                status,
+                roles,
+                telegram_id,
+                legacy_installer_id,
+                default_rate,
+                created_at,
+                updated_at
+            )
+            SELECT
+                i.name,
+                CASE WHEN i.is_active THEN 'active' ELSE 'inactive' END,
+                {roles_expr},
+                i.telegram_id,
+                i.id,
+                i.default_rate,
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            FROM installers i
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM staff_users su
+                WHERE su.legacy_installer_id = i.id
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    if "staff_users" in _tables():
+        op.drop_index("ix_staff_users_legacy_installer_id", table_name="staff_users")
+        op.drop_index("ix_staff_users_email", table_name="staff_users")
+        op.drop_index("ix_staff_users_phone", table_name="staff_users")
+        op.drop_index("ix_staff_users_status", table_name="staff_users")
+        op.drop_index("ix_staff_users_display_name", table_name="staff_users")
+        op.drop_table("staff_users")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -17,6 +17,7 @@ from .brand import Brand, ProductSeries
 from .cart import Cart, CartItem
 from .catalog_import import CatalogImportJob
 from .content import Article, GlobalConfig
+from .staff import StaffUser
 from .order import (
     BankReceipt,
     Installer,
@@ -109,6 +110,7 @@ __all__ = [
     "ProductSeries",
     "ProductTagLink",
     "Service",
+    "StaffUser",
     "Tag",
     "TagGroup",
     "Payment",

--- a/models/staff.py
+++ b/models/staff.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import BigInteger, Column, JSON, String
+from sqlmodel import Field, SQLModel
+
+
+class StaffUser(SQLModel, table=True):
+    __tablename__ = "staff_users"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    display_name: str = Field(index=True)
+    status: str = Field(default="active", sa_column=Column(String, index=True, nullable=False))
+    roles: List[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+
+    phone: Optional[str] = Field(default=None, index=True)
+    email: Optional[str] = Field(default=None, index=True)
+    telegram_id: Optional[int] = Field(default=None, sa_column=Column(BigInteger, unique=True, nullable=True))
+
+    legacy_installer_id: Optional[int] = Field(default=None, foreign_key="installers.id", unique=True, index=True)
+    default_rate: Optional[float] = Field(default=None)
+
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: Optional[datetime] = Field(
+        default_factory=datetime.now,
+        sa_column_kwargs={"onupdate": datetime.now},
+    )

--- a/services/installer_service.py
+++ b/services/installer_service.py
@@ -1,8 +1,8 @@
-from typing import Optional, Any
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select, or_, func
 
-from models.order import Installer
+from models import Installer, StaffUser
 from schemas import (
     ManagerInstallerCreatePayload,
     ManagerInstallerUpdatePayload,
@@ -10,8 +10,39 @@ from schemas import (
     ManagerInstallerListResponse,
     Meta,
 )
+from services.staff_user_service import StaffUserService
 
 class ManagerInstallerService:
+    @staticmethod
+    def _response_from_installer(inst: Installer, staff_user: StaffUser | None = None) -> ManagerInstallerResponse:
+        status_active = (
+            StaffUserService.is_active(staff_user)
+            if staff_user is not None
+            else bool(inst.is_active)
+        )
+        return ManagerInstallerResponse(
+            id=inst.id,
+            name=staff_user.display_name if staff_user is not None else inst.name,
+            is_active=status_active,
+            default_rate=staff_user.default_rate if staff_user is not None else inst.default_rate,
+            telegram_id=staff_user.telegram_id if staff_user is not None else inst.telegram_id,
+        )
+
+    @staticmethod
+    def _response_from_staff_user(staff_user: StaffUser) -> ManagerInstallerResponse:
+        return ManagerInstallerResponse(
+            id=int(staff_user.legacy_installer_id or 0),
+            name=staff_user.display_name,
+            is_active=StaffUserService.is_active(staff_user),
+            default_rate=staff_user.default_rate,
+            telegram_id=staff_user.telegram_id,
+        )
+
+    @classmethod
+    async def _staff_by_legacy_installer_id(cls, session: AsyncSession) -> dict[int, StaffUser]:
+        result = await session.execute(select(StaffUser).where(StaffUser.legacy_installer_id.is_not(None)))
+        users = list(result.scalars().all())
+        return {int(user.legacy_installer_id): user for user in users if user.legacy_installer_id is not None}
 
     @classmethod
     async def get_all(
@@ -22,11 +53,15 @@ class ManagerInstallerService:
         search: Optional[str] = None,
     ) -> ManagerInstallerListResponse:
         stmt = select(Installer)
-        
+
         if search:
             search_query = f"%{search.lower()}%"
-            stmt = stmt.where(func.lower(Installer.name).like(search_query))
-            
+            staff_match = select(StaffUser.legacy_installer_id).where(
+                StaffUser.legacy_installer_id.is_not(None),
+                func.lower(StaffUser.display_name).like(search_query),
+            )
+            stmt = stmt.where(or_(func.lower(Installer.name).like(search_query), Installer.id.in_(staff_match)))
+
         # Count total
         count_stmt = select(func.count()).select_from(stmt.subquery())
         total_res = await session.execute(count_stmt)
@@ -36,17 +71,12 @@ class ManagerInstallerService:
         stmt = stmt.order_by(Installer.name.asc()).offset((page - 1) * limit).limit(limit)
         res = await session.execute(stmt)
         installers = res.scalars().all()
-        
+
+        staff_by_installer_id = await cls._staff_by_legacy_installer_id(session)
         items = []
         for inst in installers:
-            items.append(ManagerInstallerResponse(
-                id=inst.id,
-                name=inst.name,
-                is_active=inst.is_active,
-                default_rate=inst.default_rate,
-                telegram_id=inst.telegram_id,
-            ))
-            
+            items.append(cls._response_from_installer(inst, staff_by_installer_id.get(int(inst.id))))
+
         pages = (total + limit - 1) // limit if total > 0 else 1
         return ManagerInstallerListResponse(
             items=items,
@@ -66,15 +96,12 @@ class ManagerInstallerService:
             telegram_id=payload.telegram_id,
         )
         session.add(inst)
+        await session.flush()
+        await StaffUserService.ensure_for_installer(session, inst)
         await session.commit()
         await session.refresh(inst)
-        return ManagerInstallerResponse(
-            id=inst.id,
-            name=inst.name,
-            is_active=inst.is_active,
-            default_rate=inst.default_rate,
-            telegram_id=inst.telegram_id,
-        )
+        staff_user = await StaffUserService.get_by_legacy_installer_id(session, int(inst.id))
+        return cls._response_from_installer(inst, staff_user)
 
     @classmethod
     async def update(
@@ -96,18 +123,18 @@ class ManagerInstallerService:
             inst.default_rate = payload.default_rate
         if payload.telegram_id is not None:
             inst.telegram_id = payload.telegram_id
-            
+
         session.add(inst)
+        await session.flush()
+        staff_user = await StaffUserService.ensure_for_installer(session, inst)
+        if payload.is_active is not None:
+            staff_user.status = StaffUserService.STATUS_ACTIVE if payload.is_active else StaffUserService.STATUS_INACTIVE
+            session.add(staff_user)
         await session.commit()
         await session.refresh(inst)
-        
-        return ManagerInstallerResponse(
-            id=inst.id,
-            name=inst.name,
-            is_active=inst.is_active,
-            default_rate=inst.default_rate,
-            telegram_id=inst.telegram_id,
-        )
+
+        staff_user = await StaffUserService.get_by_legacy_installer_id(session, int(inst.id))
+        return cls._response_from_installer(inst, staff_user)
 
     @classmethod
     async def search(
@@ -116,26 +143,47 @@ class ManagerInstallerService:
         q: str,
         limit: int = 50,
     ) -> ManagerInstallerListResponse:
-        stmt = select(Installer).where(Installer.is_active == True)
-        
-        if q:
-            search_query = f"%{q.lower()}%"
-            stmt = stmt.where(func.lower(Installer.name).like(search_query))
-            
-        stmt = stmt.order_by(Installer.name.asc()).limit(limit)
-        res = await session.execute(stmt)
-        installers = res.scalars().all()
-        
-        items = []
-        for inst in installers:
-            items.append(ManagerInstallerResponse(
-                id=inst.id,
-                name=inst.name,
-                is_active=inst.is_active,
-                default_rate=inst.default_rate,
-                telegram_id=inst.telegram_id,
-            ))
-            
+        staff_users = await StaffUserService.find_active_executors_by_role(
+            session,
+            StaffUserService.ROLE_INSTALLER,
+            search=q,
+            limit=limit,
+        )
+        items = [
+            cls._response_from_staff_user(user)
+            for user in staff_users
+            if user.legacy_installer_id is not None
+        ]
+
+        staff_by_installer_id = await cls._staff_by_legacy_installer_id(session)
+        if len(items) < limit:
+            stmt = select(Installer).where(Installer.is_active == True)
+
+            if q:
+                search_query = f"%{q.lower()}%"
+                stmt = stmt.where(func.lower(Installer.name).like(search_query))
+
+            stmt = stmt.order_by(Installer.name.asc()).limit(limit)
+            res = await session.execute(stmt)
+            installers = res.scalars().all()
+
+            existing_response_ids = {item.id for item in items}
+            for inst in installers:
+                if inst.id in existing_response_ids:
+                    continue
+                if inst.id in staff_by_installer_id:
+                    staff_user = staff_by_installer_id[inst.id]
+                    if StaffUserService.can_be_executor(staff_user, StaffUserService.ROLE_INSTALLER):
+                        items.append(cls._response_from_installer(inst, staff_user))
+                        if len(items) >= limit:
+                            break
+                    continue
+                items.append(cls._response_from_installer(inst))
+                if len(items) >= limit:
+                    break
+
+        items.sort(key=lambda item: item.name.casefold())
+
         return ManagerInstallerListResponse(
             items=items,
             meta=Meta(total=len(items), page=1, limit=limit, pages=1),

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -5,14 +5,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from core.config import settings
 from models.order import BankReceipt, Order, OrderProductLink
 from services.bot_service import BotService
+from services.staff_user_service import StaffUserService
 
 logger = logging.getLogger(__name__)
 
 
 class NotificationService:
+    @staticmethod
+    async def _admin_recipient_ids(session: AsyncSession) -> list[int]:
+        return await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+
     @staticmethod
     async def notify_admins_new_order(
         session: AsyncSession,
@@ -21,7 +25,8 @@ class NotificationService:
         customer_username: str | None,
         customer_phone: str | None,
     ) -> None:
-        if not settings.admin_list:
+        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not admin_ids:
             return
 
         stmt = (
@@ -55,7 +60,7 @@ class NotificationService:
         message_lines.append(f"💰 <b>Итого: {order.total_amount} руб.</b>")
         admin_text = "\n".join(message_lines)
 
-        for admin_id in settings.admin_list:
+        for admin_id in admin_ids:
             try:
                 await BotService.send_message(admin_id, admin_text)
             except Exception:
@@ -66,7 +71,8 @@ class NotificationService:
         session: AsyncSession,
         receipt_ids: list[int],
     ) -> int:
-        if not settings.admin_list or not receipt_ids:
+        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not admin_ids or not receipt_ids:
             return 0
 
         stmt = (
@@ -131,7 +137,7 @@ class NotificationService:
 
         text = "\n".join(lines).strip()
         sent = 0
-        for admin_id in settings.admin_list:
+        for admin_id in admin_ids:
             try:
                 await BotService.send_message(admin_id, text)
                 sent += 1
@@ -146,7 +152,8 @@ class NotificationService:
         session: AsyncSession,
         order_ids: list[int],
     ) -> int:
-        if not settings.admin_list or not order_ids:
+        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not admin_ids or not order_ids:
             return 0
 
         stmt = (
@@ -189,7 +196,7 @@ class NotificationService:
 
         text = "\n".join(lines).strip()
         sent = 0
-        for admin_id in settings.admin_list:
+        for admin_id in admin_ids:
             try:
                 await BotService.send_message(admin_id, text)
                 sent += 1

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1121,7 +1121,7 @@ class OrderService:
         await session.commit()
 
     @staticmethod
-    async def _ensure_assignable_installer(
+    async def _ensure_assignable_legacy_executor(
         session: AsyncSession,
         installer_id: int,
     ) -> None:
@@ -1130,7 +1130,7 @@ class OrderService:
 
         staff_user = await StaffUserService.get_by_legacy_installer_id(session, installer_id)
         if staff_user is not None:
-            if not StaffUserService.can_be_executor(staff_user, StaffUserService.ROLE_INSTALLER):
+            if not StaffUserService.can_be_any_executor(staff_user):
                 raise ValueError("Selected installer is inactive or blocked")
             return
 
@@ -1166,7 +1166,7 @@ class OrderService:
         for i_data in installers_data:
             i_id = int(i_data['installer_id'])
             if i_id not in existing_map:
-                await OrderService._ensure_assignable_installer(session, i_id)
+                await OrderService._ensure_assignable_legacy_executor(session, i_id)
                 # Это новый!
                 item = OrderInstaller(
                     order_id=order_id,
@@ -1272,7 +1272,7 @@ class OrderService:
         
         # 4. Add installers
         for inst in items_data.get("installers", []):
-            await OrderService._ensure_assignable_installer(session, int(inst["installer_id"]))
+            await OrderService._ensure_assignable_legacy_executor(session, int(inst["installer_id"]))
             new_inst = OrderInstaller(
                 order_id=order_id,
                 installer_id=int(inst["installer_id"]),
@@ -1989,6 +1989,8 @@ class OrderService:
         if "measurement_required" in fields_set and payload.measurement_required is not None:
             order.measurement_required = payload.measurement_required
         if "measurer_id" in fields_set:
+            if payload.measurer_id is not None and payload.measurer_id != order.measurer_id:
+                await OrderService._ensure_assignable_legacy_executor(session, int(payload.measurer_id))
             order.measurer_id = payload.measurer_id
         if "measurement_result" in fields_set:
             order.measurement_result = payload.measurement_result
@@ -2048,7 +2050,7 @@ class OrderService:
             )
             existing_installer_ids = set(existing_installer_ids_res.scalars().all())
             if getattr(payload, "installer_id", None) is not None and payload.installer_id not in existing_installer_ids:
-                await OrderService._ensure_assignable_installer(session, int(payload.installer_id))
+                await OrderService._ensure_assignable_legacy_executor(session, int(payload.installer_id))
             await session.execute(delete(OrderInstaller).where(OrderInstaller.order_id == order_id))
             if getattr(payload, "installer_id", None) is not None:
                 new_installer_link = OrderInstaller(

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1121,6 +1121,24 @@ class OrderService:
         await session.commit()
 
     @staticmethod
+    async def _ensure_assignable_installer(
+        session: AsyncSession,
+        installer_id: int,
+    ) -> None:
+        from models import Installer
+        from services.staff_user_service import StaffUserService
+
+        staff_user = await StaffUserService.get_by_legacy_installer_id(session, installer_id)
+        if staff_user is not None:
+            if not StaffUserService.can_be_executor(staff_user, StaffUserService.ROLE_INSTALLER):
+                raise ValueError("Selected installer is inactive or blocked")
+            return
+
+        installer = await session.get(Installer, installer_id)
+        if not installer or not installer.is_active:
+            raise ValueError("Selected installer is inactive or blocked")
+
+    @staticmethod
     async def update_order_installers(session: AsyncSession, order_id: int, installers_data: List[Dict[str, Any]]) -> None:
         """
         Updates installers for an order and triggers notifications for NEW assignments.
@@ -1148,6 +1166,7 @@ class OrderService:
         for i_data in installers_data:
             i_id = int(i_data['installer_id'])
             if i_id not in existing_map:
+                await OrderService._ensure_assignable_installer(session, i_id)
                 # Это новый!
                 item = OrderInstaller(
                     order_id=order_id,
@@ -1253,6 +1272,7 @@ class OrderService:
         
         # 4. Add installers
         for inst in items_data.get("installers", []):
+            await OrderService._ensure_assignable_installer(session, int(inst["installer_id"]))
             new_inst = OrderInstaller(
                 order_id=order_id,
                 installer_id=int(inst["installer_id"]),
@@ -2023,6 +2043,12 @@ class OrderService:
 
         if "installer_id" in fields_set:
             from models import OrderInstaller
+            existing_installer_ids_res = await session.execute(
+                select(OrderInstaller.installer_id).where(OrderInstaller.order_id == order_id)
+            )
+            existing_installer_ids = set(existing_installer_ids_res.scalars().all())
+            if getattr(payload, "installer_id", None) is not None and payload.installer_id not in existing_installer_ids:
+                await OrderService._ensure_assignable_installer(session, int(payload.installer_id))
             await session.execute(delete(OrderInstaller).where(OrderInstaller.order_id == order_id))
             if getattr(payload, "installer_id", None) is not None:
                 new_installer_link = OrderInstaller(

--- a/services/staff_user_service.py
+++ b/services/staff_user_service.py
@@ -14,15 +14,30 @@ logger = logging.getLogger(__name__)
 class StaffUserService:
     ROLE_OWNER = "owner"
     ROLE_ADMIN = "admin"
+    ROLE_MANAGER = "manager"
     ROLE_INSTALLER = "installer"
+    ROLE_MAINTENANCE = "maintenance"
+    ROLE_REPAIR = "repair"
+    # Extra legacy-compatible executor role for the current manager measurer_id flow;
+    # this does not replace the issue-defined maintenance/repair roles.
     ROLE_MEASURER = "measurer"
 
     STATUS_ACTIVE = "active"
     STATUS_INACTIVE = "inactive"
     STATUS_BLOCKED = "blocked"
 
+    ROLES = {
+        ROLE_OWNER,
+        ROLE_ADMIN,
+        ROLE_MANAGER,
+        ROLE_INSTALLER,
+        ROLE_MAINTENANCE,
+        ROLE_REPAIR,
+        ROLE_MEASURER,
+    }
     OWNER_ADMIN_ROLES = {ROLE_OWNER, ROLE_ADMIN}
-    EXECUTOR_ROLES = {ROLE_INSTALLER, ROLE_MEASURER}
+    MANAGEMENT_ROLES = {ROLE_OWNER, ROLE_ADMIN, ROLE_MANAGER}
+    EXECUTOR_ROLES = {ROLE_INSTALLER, ROLE_MAINTENANCE, ROLE_REPAIR, ROLE_MEASURER}
     STATUSES = {STATUS_ACTIVE, STATUS_INACTIVE, STATUS_BLOCKED}
 
     @classmethod
@@ -77,6 +92,10 @@ class StaffUserService:
     @classmethod
     def can_be_executor(cls, staff_user: StaffUser, role: str) -> bool:
         return cls.is_active(staff_user) and cls.has_role(staff_user, role)
+
+    @classmethod
+    def can_be_any_executor(cls, staff_user: StaffUser) -> bool:
+        return cls.is_active(staff_user) and cls.has_any_role(staff_user, cls.EXECUTOR_ROLES)
 
     @classmethod
     async def find_active_executors_by_role(

--- a/services/staff_user_service.py
+++ b/services/staff_user_service.py
@@ -1,0 +1,190 @@
+import logging
+import json
+from typing import Iterable, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from core.config import settings
+from models import Installer, StaffUser
+
+logger = logging.getLogger(__name__)
+
+
+class StaffUserService:
+    ROLE_OWNER = "owner"
+    ROLE_ADMIN = "admin"
+    ROLE_INSTALLER = "installer"
+    ROLE_MEASURER = "measurer"
+
+    STATUS_ACTIVE = "active"
+    STATUS_INACTIVE = "inactive"
+    STATUS_BLOCKED = "blocked"
+
+    OWNER_ADMIN_ROLES = {ROLE_OWNER, ROLE_ADMIN}
+    EXECUTOR_ROLES = {ROLE_INSTALLER, ROLE_MEASURER}
+    STATUSES = {STATUS_ACTIVE, STATUS_INACTIVE, STATUS_BLOCKED}
+
+    @classmethod
+    def normalize_role(cls, role: str) -> str:
+        return str(role or "").strip().lower()
+
+    @classmethod
+    def normalize_roles(cls, roles: Iterable[str] | None) -> list[str]:
+        if isinstance(roles, str):
+            try:
+                parsed = json.loads(roles)
+            except json.JSONDecodeError:
+                parsed = [roles]
+            roles = parsed if isinstance(parsed, list) else [roles]
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for role in roles or []:
+            value = cls.normalize_role(role)
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            normalized.append(value)
+        return normalized
+
+    @classmethod
+    def normalize_status(cls, status: str | None) -> str:
+        value = str(status or "").strip().lower()
+        return value if value in cls.STATUSES else cls.STATUS_ACTIVE
+
+    @classmethod
+    def has_role(cls, staff_user: StaffUser, role: str) -> bool:
+        return cls.normalize_role(role) in cls.normalize_roles(getattr(staff_user, "roles", []))
+
+    @classmethod
+    def has_any_role(cls, staff_user: StaffUser, roles: Iterable[str]) -> bool:
+        staff_roles = set(cls.normalize_roles(getattr(staff_user, "roles", [])))
+        return any(cls.normalize_role(role) in staff_roles for role in roles)
+
+    @classmethod
+    def is_active(cls, staff_user: StaffUser) -> bool:
+        return cls.normalize_status(getattr(staff_user, "status", None)) == cls.STATUS_ACTIVE
+
+    @classmethod
+    def can_receive_admin_notifications(cls, staff_user: StaffUser) -> bool:
+        return (
+            cls.is_active(staff_user)
+            and bool(getattr(staff_user, "telegram_id", None))
+            and cls.has_any_role(staff_user, cls.OWNER_ADMIN_ROLES)
+        )
+
+    @classmethod
+    def can_be_executor(cls, staff_user: StaffUser, role: str) -> bool:
+        return cls.is_active(staff_user) and cls.has_role(staff_user, role)
+
+    @classmethod
+    async def find_active_executors_by_role(
+        cls,
+        session: AsyncSession,
+        role: str,
+        *,
+        search: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[StaffUser]:
+        stmt = select(StaffUser).where(StaffUser.status == cls.STATUS_ACTIVE).order_by(StaffUser.display_name.asc())
+        result = await session.execute(stmt)
+        users = list(result.scalars().all())
+
+        search_value = str(search or "").strip().casefold()
+        filtered: list[StaffUser] = []
+        for user in users:
+            if not cls.can_be_executor(user, role):
+                continue
+            if search_value and search_value not in str(user.display_name or "").casefold():
+                continue
+            filtered.append(user)
+            if len(filtered) >= limit:
+                break
+        return filtered
+
+    @classmethod
+    async def get_active_owner_admin_telegram_recipient_ids(cls, session: AsyncSession) -> list[int]:
+        try:
+            stmt = (
+                select(StaffUser)
+                .where(StaffUser.status == cls.STATUS_ACTIVE)
+                .where(StaffUser.telegram_id.is_not(None))
+                .order_by(StaffUser.id.asc())
+            )
+            result = await session.execute(stmt)
+            users = list(result.scalars().all())
+        except Exception:
+            logger.debug("STAFF_RECIPIENTS_DB_LOOKUP_FAILED using legacy ADMIN_IDS fallback", exc_info=True)
+            return settings.admin_list
+
+        recipient_ids: list[int] = []
+        seen: set[int] = set()
+        for user in users:
+            if not cls.can_receive_admin_notifications(user):
+                continue
+            telegram_id = int(user.telegram_id)
+            if telegram_id in seen:
+                continue
+            seen.add(telegram_id)
+            recipient_ids.append(telegram_id)
+
+        return recipient_ids or settings.admin_list
+
+    @classmethod
+    async def get_by_legacy_installer_id(
+        cls,
+        session: AsyncSession,
+        installer_id: int,
+    ) -> StaffUser | None:
+        result = await session.execute(
+            select(StaffUser).where(StaffUser.legacy_installer_id == installer_id)
+        )
+        return result.scalar_one_or_none()
+
+    @classmethod
+    async def ensure_for_installer(
+        cls,
+        session: AsyncSession,
+        installer: Installer,
+    ) -> StaffUser:
+        if installer.id is None:
+            await session.flush()
+
+        staff_user = await cls.get_by_legacy_installer_id(session, int(installer.id))
+        if not staff_user:
+            staff_user = StaffUser(
+                display_name=installer.name,
+                status=cls.STATUS_ACTIVE if installer.is_active else cls.STATUS_INACTIVE,
+                roles=[cls.ROLE_INSTALLER],
+                telegram_id=installer.telegram_id,
+                legacy_installer_id=installer.id,
+                default_rate=installer.default_rate,
+            )
+            session.add(staff_user)
+            await session.flush()
+            return staff_user
+
+        staff_user.display_name = installer.name
+        staff_user.default_rate = installer.default_rate
+        staff_user.telegram_id = installer.telegram_id
+        roles = cls.normalize_roles(staff_user.roles)
+        if cls.ROLE_INSTALLER not in roles:
+            roles.append(cls.ROLE_INSTALLER)
+        staff_user.roles = roles
+        session.add(staff_user)
+        await session.flush()
+        return staff_user
+
+    @classmethod
+    async def set_installer_active_status(
+        cls,
+        session: AsyncSession,
+        installer: Installer,
+        is_active: bool,
+    ) -> StaffUser:
+        staff_user = await cls.ensure_for_installer(session, installer)
+        staff_user.status = cls.STATUS_ACTIVE if is_active else cls.STATUS_INACTIVE
+        session.add(staff_user)
+        await session.flush()
+        return staff_user

--- a/services/website_lead_service.py
+++ b/services/website_lead_service.py
@@ -8,13 +8,13 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
-from core.config import settings
 from crud.product import ProductDAO
 from models import LeadSource, Order, OrderStatus, Product
 from schemas import ProductAvailabilityLeadPayload, ProductAvailabilityLeadResponse
 from services.bot_service import BotService
 from services.lead_service import LeadService
 from services.order_service import OrderService
+from services.staff_user_service import StaffUserService
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +200,8 @@ class WebsiteLeadService:
         now: datetime,
         is_repeat: bool,
     ) -> None:
-        if not settings.admin_list:
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        if not admin_ids:
             return
 
         message_lines = [
@@ -214,7 +215,7 @@ class WebsiteLeadService:
             message_lines.insert(4, f"👤 {payload.name.strip()}")
 
         admin_text = "\n".join(message_lines)
-        for admin_id in settings.admin_list:
+        for admin_id in admin_ids:
             try:
                 await BotService.send_message(admin_id, admin_text)
             except Exception as exc:

--- a/services/website_order_service.py
+++ b/services/website_order_service.py
@@ -4,11 +4,11 @@ import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from core.config import settings
 from models import LeadSource, Order, OrderStatus
 from schemas import OrderPayload, OrderResponse
 from services.bot_service import BotService
 from services.order_service import OrderService
+from services.staff_user_service import StaffUserService
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,8 @@ class WebsiteOrderService:
 
     @staticmethod
     async def _notify_admins(session: AsyncSession, order: Order, payload: OrderPayload) -> None:
-        if not settings.admin_list:
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        if not admin_ids:
             return
 
         await session.refresh(order, ["product_links", "service_links", "customer"])
@@ -115,7 +116,7 @@ class WebsiteOrderService:
         message_lines.append(f"💰 <b>Итого: {order.total_amount} руб.</b>")
         admin_text = "\n".join(message_lines)
 
-        for admin_id in settings.admin_list:
+        for admin_id in admin_ids:
             try:
                 await BotService.send_message(admin_id, admin_text)
             except Exception as exc:

--- a/tests/integration/test_manager_installers_api.py
+++ b/tests/integration/test_manager_installers_api.py
@@ -1,0 +1,99 @@
+import pytest
+
+from core.config import settings
+from models import Installer, StaffUser
+
+
+async def _auth_headers(async_client):
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_manager_installers_search_uses_active_staff_users(async_client, db):
+    active = Installer(name="Legacy Active", is_active=True)
+    blocked = Installer(name="Legacy Blocked", is_active=True)
+    inactive = Installer(name="Legacy Inactive", is_active=True)
+    db.add_all([active, blocked, inactive])
+    await db.flush()
+
+    db.add(
+        StaffUser(
+            display_name="Active Staff Installer",
+            status="active",
+            roles=["installer"],
+            legacy_installer_id=active.id,
+        )
+    )
+    db.add(
+        StaffUser(
+            display_name="Blocked Staff Installer",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=blocked.id,
+        )
+    )
+    db.add(
+        StaffUser(
+            display_name="Inactive Staff Installer",
+            status="inactive",
+            roles=["installer"],
+            legacy_installer_id=inactive.id,
+        )
+    )
+    await db.commit()
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.get(
+        "/api/manager/installers/search",
+        params={"q": "Staff", "limit": 10},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["name"] for item in items] == ["Active Staff Installer"]
+    assert items[0]["id"] == active.id
+
+    legacy_name_response = await async_client.get(
+        "/api/manager/installers/search",
+        params={"q": "Legacy Active", "limit": 10},
+        headers=headers,
+    )
+
+    assert legacy_name_response.status_code == 200
+    assert [item["name"] for item in legacy_name_response.json()["items"]] == ["Active Staff Installer"]
+
+
+@pytest.mark.asyncio
+async def test_manager_installers_list_keeps_blocked_historical_staff_visible(async_client, db):
+    installer = Installer(name="Legacy Historical", is_active=True)
+    db.add(installer)
+    await db.flush()
+    db.add(
+        StaffUser(
+            display_name="Blocked Historical Staff",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    await db.commit()
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.get(
+        "/api/manager/installers",
+        params={"search": "Historical"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["name"] == "Blocked Historical Staff"
+    assert items[0]["is_active"] is False

--- a/tests/unit/test_installer_compatibility_service.py
+++ b/tests/unit/test_installer_compatibility_service.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import Installer, Order, OrderInstaller, StaffUser
+from services.installer_service import ManagerInstallerService
+from services.order_service import OrderService
+
+
+@pytest.fixture
+async def sqlite_installer_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'installers.db'}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_installer_search_uses_staff_user_status_and_keeps_orphan_legacy_fallback(sqlite_installer_session):
+    active = Installer(name="Active Legacy", is_active=True)
+    blocked = Installer(name="Blocked Legacy", is_active=True)
+    inactive = Installer(name="Inactive Legacy", is_active=True)
+    orphan = Installer(name="Orphan Legacy", is_active=True)
+    sqlite_installer_session.add_all([active, blocked, inactive, orphan])
+    await sqlite_installer_session.flush()
+
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Active Staff",
+            status="active",
+            roles=["installer"],
+            legacy_installer_id=active.id,
+        )
+    )
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Blocked Staff",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=blocked.id,
+        )
+    )
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Inactive Staff",
+            status="inactive",
+            roles=["installer"],
+            legacy_installer_id=inactive.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    result = await ManagerInstallerService.search(sqlite_installer_session, q="Staff", limit=10)
+
+    assert [item.name for item in result.items] == ["Active Staff"]
+
+    fallback_result = await ManagerInstallerService.search(sqlite_installer_session, q="Orphan", limit=10)
+
+    assert [item.name for item in fallback_result.items] == ["Orphan Legacy"]
+
+    legacy_name_result = await ManagerInstallerService.search(sqlite_installer_session, q="Active Legacy", limit=10)
+
+    assert [item.name for item in legacy_name_result.items] == ["Active Staff"]
+
+
+@pytest.mark.asyncio
+async def test_installer_list_keeps_historical_blocked_staff_visible(sqlite_installer_session):
+    installer = Installer(name="Legacy Name", is_active=True)
+    sqlite_installer_session.add(installer)
+    await sqlite_installer_session.flush()
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Blocked Historical",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    result = await ManagerInstallerService.get_all(sqlite_installer_session)
+
+    assert len(result.items) == 1
+    assert result.items[0].name == "Blocked Historical"
+    assert result.items[0].is_active is False
+
+
+@pytest.mark.asyncio
+async def test_new_order_assignment_rejects_blocked_staff_user(sqlite_installer_session):
+    installer = Installer(name="Blocked Installer", is_active=True)
+    order = Order()
+    sqlite_installer_session.add(installer)
+    sqlite_installer_session.add(order)
+    await sqlite_installer_session.flush()
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Blocked Installer",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    with pytest.raises(ValueError, match="inactive or blocked"):
+        await OrderService.update_order_installers(
+            sqlite_installer_session,
+            order.id,
+            [{"installer_id": installer.id, "agreed_pay": 100}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_existing_historical_blocked_assignment_can_still_update(sqlite_installer_session):
+    installer = Installer(name="Historical Installer", is_active=True)
+    order = Order()
+    sqlite_installer_session.add(installer)
+    sqlite_installer_session.add(order)
+    await sqlite_installer_session.flush()
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Historical Installer",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    sqlite_installer_session.add(
+        OrderInstaller(
+            order_id=order.id,
+            installer_id=installer.id,
+            agreed_pay=50,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    await OrderService.update_order_installers(
+        sqlite_installer_session,
+        order.id,
+        [{"installer_id": installer.id, "agreed_pay": 125}],
+    )
+
+    link = await sqlite_installer_session.get(OrderInstaller, (order.id, installer.id))
+    assert link is not None
+    assert link.agreed_pay == 125

--- a/tests/unit/test_installer_compatibility_service.py
+++ b/tests/unit/test_installer_compatibility_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from models import Installer, Order, OrderInstaller, StaffUser
+from schemas import ManagerOrderUpdatePayload
 from services.installer_service import ManagerInstallerService
 from services.order_service import OrderService
 
@@ -151,3 +152,57 @@ async def test_existing_historical_blocked_assignment_can_still_update(sqlite_in
     link = await sqlite_installer_session.get(OrderInstaller, (order.id, installer.id))
     assert link is not None
     assert link.agreed_pay == 125
+
+
+@pytest.mark.asyncio
+async def test_new_manager_measurer_assignment_rejects_blocked_staff_user(sqlite_installer_session):
+    installer = Installer(name="Blocked Measurer", is_active=True)
+    order = Order(comment="before")
+    sqlite_installer_session.add(installer)
+    sqlite_installer_session.add(order)
+    await sqlite_installer_session.flush()
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Blocked Measurer",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    with pytest.raises(ValueError, match="inactive or blocked"):
+        await OrderService.update_order_for_manager(
+            sqlite_installer_session,
+            order.id,
+            ManagerOrderUpdatePayload(measurer_id=installer.id),
+        )
+
+
+@pytest.mark.asyncio
+async def test_unchanged_historical_blocked_measurer_can_still_save(sqlite_installer_session):
+    installer = Installer(name="Historical Measurer", is_active=True)
+    order = Order(measurer_id=None, comment="before")
+    sqlite_installer_session.add(installer)
+    sqlite_installer_session.add(order)
+    await sqlite_installer_session.flush()
+    order.measurer_id = installer.id
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Historical Measurer",
+            status="blocked",
+            roles=["installer"],
+            legacy_installer_id=installer.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    data = await OrderService.update_order_for_manager(
+        sqlite_installer_session,
+        order.id,
+        ManagerOrderUpdatePayload(measurer_id=installer.id, comment="after"),
+    )
+
+    assert data is not None
+    assert data["measurer_id"] == installer.id
+    assert data["comment"] == "after"

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -41,7 +41,6 @@ async def test_notify_admins_new_order_skips_when_no_admins(monkeypatch):
         customer_phone="+123",
     )
 
-    session.execute.assert_not_called()
     send_mock.assert_not_called()
 
 

--- a/tests/unit/test_staff_user_migration.py
+++ b/tests/unit/test_staff_user_migration.py
@@ -1,0 +1,49 @@
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Boolean, Column, Float, Integer, MetaData, String, Table, create_engine, text
+
+
+def test_staff_users_migration_backfills_existing_installers(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    installers = Table(
+        "installers",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String, nullable=False),
+        Column("is_active", Boolean, nullable=False),
+        Column("default_rate", Float),
+        Column("telegram_id", Integer),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(
+            installers.insert(),
+            [
+                {"id": 1, "name": "Active", "is_active": True, "default_rate": 100, "telegram_id": 101},
+                {"id": 2, "name": "Inactive", "is_active": False, "default_rate": None, "telegram_id": None},
+            ],
+        )
+
+        migration_path = Path("alembic/versions/6c7d8e9f0a12_add_staff_users_foundation.py")
+        spec = importlib.util.spec_from_file_location("staff_users_migration", migration_path)
+        assert spec and spec.loader
+        migration = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(migration)
+        context = MigrationContext.configure(conn)
+        monkeypatch.setattr(migration, "op", Operations(context))
+
+        migration.upgrade()
+
+        rows = conn.execute(text("SELECT * FROM staff_users ORDER BY id")).fetchall()
+
+    assert len(rows) == 2
+    by_name = {row._mapping["display_name"]: row._mapping for row in rows}
+    assert by_name["Active"]["status"] == "active"
+    assert by_name["Active"]["roles"] == '["installer"]'
+    assert by_name["Active"]["legacy_installer_id"] == 1
+    assert by_name["Inactive"]["status"] == "inactive"

--- a/tests/unit/test_staff_user_service.py
+++ b/tests/unit/test_staff_user_service.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from core.config import settings
+from models import Installer, StaffUser
+from services.staff_user_service import StaffUserService
+
+
+@pytest.fixture
+async def sqlite_staff_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'staff.db'}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def test_staff_role_and_status_helpers():
+    active_admin = StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101)
+    blocked_admin = StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=102)
+    inactive_installer = StaffUser(display_name="Inactive", status="inactive", roles=["installer"])
+    json_roles_admin = StaffUser(display_name="JSON Admin", status="active", roles='["admin"]', telegram_id=103)
+
+    assert StaffUserService.has_role(active_admin, "owner")
+    assert StaffUserService.can_receive_admin_notifications(active_admin)
+    assert not StaffUserService.can_receive_admin_notifications(blocked_admin)
+    assert not StaffUserService.can_be_executor(inactive_installer, "installer")
+    assert StaffUserService.has_role(json_roles_admin, "admin")
+
+
+@pytest.mark.asyncio
+async def test_find_active_executors_by_role_excludes_inactive_and_blocked(sqlite_staff_session):
+    sqlite_staff_session.add(
+        StaffUser(display_name="Active Installer", status="active", roles=["installer"], legacy_installer_id=None)
+    )
+    sqlite_staff_session.add(StaffUser(display_name="Inactive Installer", status="inactive", roles=["installer"]))
+    sqlite_staff_session.add(StaffUser(display_name="Blocked Installer", status="blocked", roles=["installer"]))
+    sqlite_staff_session.add(StaffUser(display_name="Active Admin", status="active", roles=["admin"]))
+    await sqlite_staff_session.commit()
+
+    users = await StaffUserService.find_active_executors_by_role(
+        sqlite_staff_session,
+        StaffUserService.ROLE_INSTALLER,
+    )
+
+    assert [user.display_name for user in users] == ["Active Installer"]
+
+
+@pytest.mark.asyncio
+async def test_admin_recipients_use_active_db_owner_admin_before_legacy_fallback(sqlite_staff_session, monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "999", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+
+    sqlite_staff_session.add(StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101))
+    sqlite_staff_session.add(StaffUser(display_name="Admin", status="active", roles=["admin"], telegram_id=202))
+    sqlite_staff_session.add(StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=303))
+    sqlite_staff_session.add(StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404))
+    await sqlite_staff_session.commit()
+
+    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session)
+
+    assert recipients == [101, 202]
+
+
+@pytest.mark.asyncio
+async def test_admin_recipients_fall_back_to_legacy_admin_ids_when_db_has_none(sqlite_staff_session, monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "901,902", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 903, raising=False)
+
+    sqlite_staff_session.add(StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404))
+    await sqlite_staff_session.commit()
+
+    recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session)
+
+    assert recipients == [901, 902, 903]
+
+
+@pytest.mark.asyncio
+async def test_ensure_for_installer_creates_compatibility_staff_user(sqlite_staff_session):
+    installer = Installer(name="Legacy Installer", is_active=True, default_rate=120, telegram_id=777)
+    sqlite_staff_session.add(installer)
+    await sqlite_staff_session.flush()
+
+    staff_user = await StaffUserService.ensure_for_installer(sqlite_staff_session, installer)
+
+    assert staff_user.legacy_installer_id == installer.id
+    assert staff_user.display_name == "Legacy Installer"
+    assert staff_user.status == "active"
+    assert staff_user.roles == ["installer"]
+    assert staff_user.telegram_id == 777

--- a/tests/unit/test_staff_user_service.py
+++ b/tests/unit/test_staff_user_service.py
@@ -27,12 +27,28 @@ def test_staff_role_and_status_helpers():
     active_admin = StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101)
     blocked_admin = StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=102)
     inactive_installer = StaffUser(display_name="Inactive", status="inactive", roles=["installer"])
+    maintenance_executor = StaffUser(display_name="Maintenance", status="active", roles=["maintenance"])
+    repair_executor = StaffUser(display_name="Repair", status="active", roles=["repair"])
+    manager = StaffUser(display_name="Manager", status="active", roles=["manager"])
     json_roles_admin = StaffUser(display_name="JSON Admin", status="active", roles='["admin"]', telegram_id=103)
 
+    assert StaffUserService.ROLES == {
+        "owner",
+        "admin",
+        "manager",
+        "installer",
+        "maintenance",
+        "repair",
+        "measurer",
+    }
+    assert StaffUserService.EXECUTOR_ROLES == {"installer", "maintenance", "repair", "measurer"}
     assert StaffUserService.has_role(active_admin, "owner")
     assert StaffUserService.can_receive_admin_notifications(active_admin)
     assert not StaffUserService.can_receive_admin_notifications(blocked_admin)
     assert not StaffUserService.can_be_executor(inactive_installer, "installer")
+    assert StaffUserService.can_be_any_executor(maintenance_executor)
+    assert StaffUserService.can_be_any_executor(repair_executor)
+    assert not StaffUserService.can_be_any_executor(manager)
     assert StaffUserService.has_role(json_roles_admin, "admin")
 
 


### PR DESCRIPTION
## Summary

Adds backend StaffUser foundation for issue #366 / epic #339 while keeping the current Installer, OrderInstaller, and `/api/manager/installers` compatibility surface intact.

## What changed

- Added `StaffUser` model with roles, status, contacts, nullable unique `telegram_id`, executor rate, and `legacy_installer_id` bridge to `installers`.
- Added Alembic migration `6c7d8e9f0a12` to create `staff_users` and backfill all existing installers as StaffUsers with role `installer` and status derived from `Installer.is_active`.
- Added `StaffUserService` for role/status normalization, active executor lookup, owner/admin recipient resolution, and legacy installer synchronization.
- Added explicit StaffUser role constants/sets for the issue-defined roles: `owner`, `admin`, `manager`, `installer`, `maintenance`, `repair`.
- Kept `measurer` as an additional legacy-compatible executor role for the existing manager `measurer_id` flow; it does not replace `maintenance` / `repair`.
- Reworked `/api/manager/installers` service behavior to preserve list/create/update response contracts while sourcing active search from StaffUser status/roles and falling back only for legacy installers without a StaffUser bridge.
- Added assignment guards so new installer and measurer assignments reject inactive/blocked StaffUsers while existing historical assignments can remain visible and be updated.
- Switched admin notifications to active DB owner/admin Telegram recipients first, with legacy `ADMIN_ID` / `ADMIN_IDS` fallback when DB has no active owner/admin recipients or StaffUser lookup is unavailable.
- Added unit and integration coverage for migration backfill, helper logic, notifications fallback, installer compatibility, blocked/inactive assignment/search behavior, and the `measurer_id` review case.

## Review follow-up addressed

- Completed the StaffUser role surface with `manager`, `maintenance`, and `repair` constants/sets/tests.
- Added `OrderService` guard for new `ManagerOrderUpdatePayload(measurer_id=...)` assignments.
- Preserved historical behavior: unchanged blocked/inactive `measurer_id` can still be saved so old orders do not break.
- Kept compatibility with the current manager drawer list by allowing active legacy executors through StaffUser executor roles or legacy active Installer fallback.

## Compatibility notes

- No manager UI rename or roles editor included.
- No Telegram bot handler migration included.
- No mass rename of `installer_id` fields.
- Existing `/api/manager/installers` route and response schema are unchanged; `openapi.json` was regenerated and remained unchanged, so manager client regen was not needed.

## Checks

- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_staff_user_service.py tests/unit/test_staff_user_migration.py tests/unit/test_installer_compatibility_service.py tests/unit/test_notification_service.py tests/unit/test_website_lead_service.py tests/unit/test_website_order_service.py tests/unit/test_mail_services.py -q` -> 46 passed
- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_installers_api.py tests/integration/test_manager_orders_api.py -k "manager_installers or installer or installers" -q` -> 3 passed, JWT test-key warnings only
- `python3 -m compileall models services routers schemas.py` -> passed
- `git diff --check` -> passed
- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin python3 scripts/legacy/extract_openapi.py` -> passed; `openapi.json` unchanged

## Risks / audit focus

- Migration should be reviewed for production data edge cases around unique `telegram_id` and one-to-one `legacy_installer_id` bridge assumptions.
- Staff roles are JSON with Python-side filtering for now; acceptable for small staff tables, but future arbitrary RBAC may need indexed/relational role storage.
- `/api/manager/installers/search` now excludes StaffUsers with `inactive` or `blocked` status; audit current manager workflows that may rely on assigning inactive installers directly.
- Notification recipient routing is DB-first but falls back to env only when there are no active owner/admin Telegram recipients; audit bootstrap rollout order so at least one owner/admin StaffUser is created intentionally.

Closes #366 for the first backend foundation PR scope.
