### PR TITLE
[codex] Fix Alembic revision order after merged PRs

### DIFF
--- a/alembic/versions/7c8d9e0f1a23_add_staff_users_foundation.py
+++ b/alembic/versions/7c8d9e0f1a23_add_staff_users_foundation.py
@@ -1,7 +1,7 @@
 """Add staff users foundation
 
-Revision ID: 6c7d8e9f0a12
-Revises: 5a6b7c8d9e10
+Revision ID: 7c8d9e0f1a23
+Revises: 6c7d8e9f0a12
 Create Date: 2026-06-03 00:00:00.000000
 
 """
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "6c7d8e9f0a12"
-down_revision: Union[str, Sequence[str], None] = "5a6b7c8d9e10"
+revision: str = "7c8d9e0f1a23"
+down_revision: Union[str, Sequence[str], None] = "6c7d8e9f0a12"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/tests/unit/test_staff_user_migration.py
+++ b/tests/unit/test_staff_user_migration.py
@@ -29,7 +29,7 @@ def test_staff_users_migration_backfills_existing_installers(monkeypatch):
             ],
         )
 
-        migration_path = Path("alembic/versions/6c7d8e9f0a12_add_staff_users_foundation.py")
+        migration_path = Path("alembic/versions/7c8d9e0f1a23_add_staff_users_foundation.py")
         spec = importlib.util.spec_from_file_location("staff_users_migration", migration_path)
         assert spec and spec.loader
         migration = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary

Fixes the Alembic migration graph after PR #377 and PR #376 were both merged with the same revision id `6c7d8e9f0a12`.

## What changed

- Keep product image variants migration as revision `6c7d8e9f0a12` because it landed first in `main`.
- Rename StaffUser migration to `7c8d9e0f1a23_add_staff_users_foundation.py`.
- Set StaffUser `down_revision` to `6c7d8e9f0a12`, making the graph linear:
  - `5a6b7c8d9e10` -> image variants `6c7d8e9f0a12` -> StaffUser `7c8d9e0f1a23`.
- Update the StaffUser migration unit test import path.

## Checks

- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin alembic heads` -> one head: `7c8d9e0f1a23`.
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_staff_user_migration.py tests/unit/test_product_image_variants.py -q` -> 8 passed.
- `python3 -m compileall alembic tests/unit/test_staff_user_migration.py` passed.
- `git diff --check` passed.

## Deployment note

Production deploy was stopped before migrations ran, so this follow-up should be safe to merge before the next deploy attempt.