### PR TITLE
[codex] Update manager staff UI

### DIFF
--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, onMounted, onBeforeUnmount, ref } from 'vue';
-import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Wrench, Settings, Wallet, ChevronLeft, ChevronRight, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText } from 'lucide-vue-next';
+import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText } from 'lucide-vue-next';
 import { api } from './api';
 import { getApiErrorMessage } from './utils/api-errors';
 
@@ -46,7 +46,7 @@ const navItems = [
   { path: '/manager/calendar', label: 'Календарь', icon: Calendar },
   { path: '/manager/products', label: 'Кондиционеры', icon: Package },
   { path: '/manager/customers', label: 'Клиенты', icon: Users },
-  { path: '/manager/installers', label: 'Монтажники', icon: Wrench },
+  { path: '/manager/installers', label: 'Сотрудники', icon: Users },
   { path: '/manager/tariffs', label: 'Тарифы услуг', icon: Wallet },
   { path: '/manager/service-estimates', label: 'Сметы услуг', icon: Calculator },
   { path: '/manager/payments', label: 'Платежи', icon: ReceiptText },

--- a/manager_frontend/src/components/InstallerEditModal.vue
+++ b/manager_frontend/src/components/InstallerEditModal.vue
@@ -82,7 +82,7 @@ const submit = async () => {
                 <div class="modal-content bg-white dark:bg-[#1e293b] rounded-xl shadow-xl w-full max-w-md overflow-hidden border border-gray-200 dark:border-slate-700/60 flex flex-col">
                     <div class="px-6 py-4 border-b border-gray-200 dark:border-slate-700/50 flex justify-between items-center bg-gray-50 dark:bg-slate-800/50">
                         <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-                            {{ installer ? 'Редактировать Монтажника' : 'Новый Монтажник' }}
+                            {{ installer ? 'Редактировать сотрудника' : 'Новый сотрудник' }}
                         </h3>
                         <button @click="close" class="text-gray-400 hover:text-gray-600 dark:text-slate-400 dark:hover:text-white transition-colors" :disabled="loading">
                             <span class="material-icons-round text-xl">close</span>
@@ -95,7 +95,7 @@ const submit = async () => {
                         </div>
 
                         <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Имя бригады / монтажника *</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Имя сотрудника или бригады *</label>
                             <input
                                 v-model="formData.name"
                                 type="text"
@@ -136,7 +136,7 @@ const submit = async () => {
                                      :class="{'translate-x-4': formData.is_active}"></div>
                             </div>
                             <span class="text-sm font-medium text-gray-700 dark:text-slate-300 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">
-                                Активен (может получать заказы)
+                                Активен (доступен для новых назначений)
                             </span>
                         </label>
                     </div>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -385,6 +385,13 @@ const repairAiGenerating = ref(false);
 const payments = ref<PaymentResponse[]>([]);
 const bankReceipts = ref<BankReceiptResponse[]>([]);
 const bankReceiptsLoading = ref(false);
+
+const executorOptions = computed(() => {
+  const selectedIds = new Set<number>();
+  if (installerId.value !== null) selectedIds.add(installerId.value);
+  if (measurerId.value !== null) selectedIds.add(measurerId.value);
+  return installersList.value.filter((inst) => inst.is_active || selectedIds.has(inst.id));
+});
 const attachingReceiptId = ref<number | null>(null);
 const localServerErrors = ref<Record<string, string>>({});
 
@@ -1193,7 +1200,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
 
   if (installersList.value.length === 0) {
     api.getManagerInstallers(1, 100).then(res => {
-      installersList.value = res.items.filter(i => i.is_active || i.id === installerId.value);
+      installersList.value = res.items;
     }).catch(e => console.error("Failed to load installers", e));
   }
 
@@ -2439,7 +2446,7 @@ watch(
                 {{ isRepairWorkflow ? 'Специалист' : 'Замерщик' }}
                 <select v-model="measurerId" class="field-input">
                   <option :value="null">Не назначен</option>
-                  <option v-for="inst in installersList" :key="inst.id" :value="inst.id">
+                  <option v-for="inst in executorOptions" :key="inst.id" :value="inst.id">
                     {{ inst.name }} {{ !inst.is_active ? '(в архиве)' : '' }}
                   </option>
                 </select>
@@ -2458,7 +2465,7 @@ watch(
               {{ isRepairWorkflow ? 'Исполнитель ремонта' : 'Монтажник' }}
               <select v-model="installerId" class="field-input">
                 <option :value="null">Не назначен</option>
-                <option v-for="inst in installersList" :key="inst.id" :value="inst.id">
+                <option v-for="inst in executorOptions" :key="inst.id" :value="inst.id">
                   {{ inst.name }} {{ !inst.is_active ? '(в архиве)' : '' }}
                 </option>
               </select>

--- a/manager_frontend/src/views/InstallersView.vue
+++ b/manager_frontend/src/views/InstallersView.vue
@@ -13,6 +13,16 @@ const toast = ref('');
 const showModal = ref(false);
 const editingInstaller = ref<ManagerInstallerResponse | null>(null);
 
+const getEmployeeStatusLabel = (inst: ManagerInstallerResponse) => (
+    inst.is_active ? 'Активен' : 'В архиве'
+);
+
+const getEmployeeStatusClasses = (inst: ManagerInstallerResponse) => (
+    inst.is_active
+        ? 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:border-emerald-500/30'
+        : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700/60 dark:text-slate-300 dark:border-slate-600'
+);
+
 const setToast = (msg: string) => {
     toast.value = msg;
     window.setTimeout(() => { toast.value = ''; }, 3000);
@@ -42,7 +52,7 @@ const openEditModal = (inst: ManagerInstallerResponse) => {
 };
 
 const handleSuccess = () => {
-    setToast('Монтажник сохранен');
+    setToast('Сотрудник сохранен');
     loadInstallers();
 };
 
@@ -75,10 +85,10 @@ onMounted(() => {
             <div>
                 <h1 class="text-2xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3">
                     <span class="material-icons-round text-teal-600 dark:text-teal-400">engineering</span>
-                    Бригады монтажников
+                    Сотрудники
                 </h1>
                 <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">
-                    Управление монтажниками, их ставками и доступностью для заказов
+                    Управление сотрудниками-исполнителями, ставками и доступностью для заказов
                 </p>
             </div>
             
@@ -113,7 +123,7 @@ onMounted(() => {
                             Базовая ставка
                         </th>
                         <th class="px-6 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">
-                            Активен
+                            Статус
                         </th>
                         <th class="px-6 py-4 text-right text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">
                             Действия
@@ -132,6 +142,11 @@ onMounted(() => {
                                     <div class="text-xs text-gray-500 dark:text-slate-500 sm:hidden mt-0.5">
                                         {{ inst.default_rate ? inst.default_rate + ' BYN' : 'Ставка не задана' }}
                                     </div>
+                                    <div class="mt-1 sm:hidden">
+                                        <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium" :class="getEmployeeStatusClasses(inst)">
+                                            {{ getEmployeeStatusLabel(inst) }}
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </td>
@@ -148,10 +163,15 @@ onMounted(() => {
                             </div>
                         </td>
                         <td class="px-6 py-4">
-                            <label class="relative inline-flex items-center cursor-pointer" @click.prevent="toggleActive(inst)">
-                                <input type="checkbox" :checked="inst.is_active" class="sr-only peer" />
-                                <div class="w-9 h-5 bg-gray-200 dark:bg-slate-600 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-500 transition-colors"></div>
-                            </label>
+                            <div class="flex items-center gap-3">
+                                <span class="hidden sm:inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium" :class="getEmployeeStatusClasses(inst)">
+                                    {{ getEmployeeStatusLabel(inst) }}
+                                </span>
+                                <label class="relative inline-flex items-center cursor-pointer" @click.prevent="toggleActive(inst)" :title="inst.is_active ? 'Перевести в архив' : 'Вернуть в активные'">
+                                    <input type="checkbox" :checked="inst.is_active" class="sr-only peer" />
+                                    <div class="w-9 h-5 bg-gray-200 dark:bg-slate-600 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-500 transition-colors"></div>
+                                </label>
+                            </div>
                         </td>
                         <td class="px-6 py-4 text-right">
                             <button
@@ -166,7 +186,7 @@ onMounted(() => {
                     
                     <tr v-if="installers.length === 0 && !loading">
                         <td colspan="5" class="px-6 py-12 text-center text-gray-500 dark:text-slate-400">
-                            Монтажники не найдены. Создайте первую бригаду!
+                            Сотрудники не найдены. Добавьте первого сотрудника.
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
## Summary
- Renames the manager admin surface from "Монтажники" to "Сотрудники" while keeping the compatibility route `/manager/installers` and existing generated `ManagerInstaller*` API client usage.
- Updates the employee create/edit modal labels and list status display around the current `is_active` contract.
- Keeps order assignment labels domain-specific, but filters executor selects to active employees plus already selected historical inactive values for both installer and measurer assignments.

## Notes / Follow-up
- The current `/api/manager/installers` response exposes only `is_active`, not StaffUser `status` or `roles`; this PR intentionally does not invent roles or a separate blocked editor in the UI.
- A follow-up backend/API contract can expose staff roles and `active | inactive | blocked` if the manager UI should display/edit the full StaffUser model.

## Checks
- `cd manager_frontend && npm run build`
- Text search for stale admin-section labels: no remaining `Монтажники`, `Работники`, old modal titles, or old save toast in `manager_frontend/src`.
- Browser smoke on `http://127.0.0.1:5173/manager/installers`: SPA loaded to login gate with no console errors; authenticated employees screen was not visually exercised because local manager credentials/API session were not available in this worktree.

Closes #367