### PR TITLE
[codex] Improve web deploy SSH diagnostics

### DIFF
--- a/.github/workflows/check-web-ssh.yml
+++ b/.github/workflows/check-web-ssh.yml
@@ -1,0 +1,91 @@
+name: Web SSH Connectivity Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      attempts:
+        description: "Probe attempts, 1-10"
+        type: string
+        required: false
+        default: "5"
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Setup SSH Key for Web Server
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_WEB }} >> ~/.ssh/known_hosts || true
+
+      - name: Probe Web SSH Connectivity
+        run: |
+          set -euo pipefail
+
+          WEB_HOST="${{ secrets.SSH_HOST_WEB }}"
+          WEB_USER="${{ secrets.SSH_USER_WEB }}"
+          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
+          MAX_ATTEMPTS="${{ inputs.attempts }}"
+          PORT_FAILURES=0
+          LOGIN_FAILURES=0
+
+          if ! [[ "${MAX_ATTEMPTS}" =~ ^[0-9]+$ ]] || [ "${MAX_ATTEMPTS}" -lt 1 ] || [ "${MAX_ATTEMPTS}" -gt 10 ]; then
+            echo "::error::attempts must be an integer from 1 to 10"
+            exit 1
+          fi
+
+          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "Web SSH probe attempt ${attempt}/${MAX_ATTEMPTS}"
+
+            if nc -z -w 10 "${WEB_HOST}" 22; then
+              echo "Web SSH port is reachable"
+            else
+              PORT_FAILURES=$((PORT_FAILURES + 1))
+              echo "::warning::Web SSH port 22 is not reachable on probe attempt ${attempt}"
+            fi
+
+            if ssh ${SSH_OPTS} "${WEB_USER}@${WEB_HOST}" "true"; then
+              {
+                echo "## Web SSH Connectivity Check"
+                echo "- target: ${WEB_USER}@${WEB_HOST}:22"
+                echo "- attempts_used: ${attempt}"
+                echo "- status: success"
+                echo "- failure_kind: n/a"
+                echo "- ssh_port_failures: ${PORT_FAILURES}"
+                echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+                echo "- deploy_performed: false"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
+            LOGIN_FAILURES=$((LOGIN_FAILURES + 1))
+            echo "::warning::SSH login preflight failed on probe attempt ${attempt}"
+
+            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+              sleep_seconds=$((attempt * 20))
+              echo "Waiting ${sleep_seconds}s before retry..."
+              sleep "${sleep_seconds}"
+            fi
+          done
+
+          {
+            echo "## Web SSH Connectivity Check"
+            echo "- target: ${WEB_USER}@${WEB_HOST}:22"
+            echo "- attempts_used: ${MAX_ATTEMPTS}"
+            echo "- status: failed"
+            echo "- failure_kind: web_ssh_connectivity"
+            echo "- ssh_port_failures: ${PORT_FAILURES}"
+            echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+            echo "- deploy_performed: false"
+            echo "- next_step: inspect web host SSH/firewall/rate-limits or choose a pull-based/static-hosting deploy architecture"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::Web SSH connectivity failed after ${MAX_ATTEMPTS} probe attempts."
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -316,6 +316,9 @@ jobs:
           WEB_TARGET="/var/www/${{ secrets.SSH_USER_WEB }}/data/www/mvn.by/"
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
           MAX_ATTEMPTS=5
+          PORT_FAILURES=0
+          LOGIN_FAILURES=0
+          RSYNC_FAILURES=0
 
           for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
             echo "🚀 Frontend deploy attempt ${attempt}/${MAX_ATTEMPTS}"
@@ -323,6 +326,7 @@ jobs:
             if nc -z -w 10 "${WEB_HOST}" 22; then
               echo "✅ Web SSH port is reachable"
             else
+              PORT_FAILURES=$((PORT_FAILURES + 1))
               echo "::warning::Web SSH port 22 is not reachable before rsync attempt ${attempt}"
             fi
 
@@ -334,15 +338,24 @@ jobs:
                 echo "✅ Frontend deployment completed on attempt ${attempt}!"
                 {
                   echo "## Frontend Deploy Summary"
+                  echo "- job: deploy-frontend"
                   echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
                   echo "- attempts_used: ${attempt}"
                   echo "- status: success"
+                  echo "- backend_dependency: deploy-backend completed before frontend deploy"
+                  echo "- build_status: success"
+                  echo "- failure_kind: n/a"
+                  echo "- ssh_port_failures: ${PORT_FAILURES}"
+                  echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+                  echo "- rsync_failures: ${RSYNC_FAILURES}"
                 } >> "$GITHUB_STEP_SUMMARY"
                 exit 0
               fi
 
+              RSYNC_FAILURES=$((RSYNC_FAILURES + 1))
               echo "::warning::rsync failed on attempt ${attempt}"
             else
+              LOGIN_FAILURES=$((LOGIN_FAILURES + 1))
               echo "::warning::SSH login preflight failed on attempt ${attempt}"
             fi
 
@@ -353,12 +366,28 @@ jobs:
             fi
           done
 
+          if [ "${PORT_FAILURES}" -gt 0 ] || [ "${LOGIN_FAILURES}" -gt 0 ]; then
+            FAILURE_KIND="web_ssh_connectivity"
+          elif [ "${RSYNC_FAILURES}" -gt 0 ]; then
+            FAILURE_KIND="rsync_transfer"
+          else
+            FAILURE_KIND="unknown"
+          fi
+
           {
             echo "## Frontend Deploy Summary"
+            echo "- job: deploy-frontend"
             echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
             echo "- attempts_used: ${MAX_ATTEMPTS}"
             echo "- status: failed"
+            echo "- backend_dependency: deploy-backend completed before frontend deploy"
+            echo "- build_status: success"
+            echo "- failure_kind: ${FAILURE_KIND}"
+            echo "- ssh_port_failures: ${PORT_FAILURES}"
+            echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+            echo "- rsync_failures: ${RSYNC_FAILURES}"
+            echo "- next_step: run the manual Web SSH Connectivity Check workflow or choose a more reliable web deploy architecture"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "::error::Frontend deployment failed after ${MAX_ATTEMPTS} attempts. Web SSH connectivity is likely unstable from GitHub Actions."
+          echo "::error::Frontend deployment failed after ${MAX_ATTEMPTS} attempts (${FAILURE_KIND}). Backend deploy/smoke already completed; this failure is scoped to the web deploy path."
           exit 1

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,19 +52,93 @@ jobs:
           curl -fsS --retry 10 --retry-delay 3 http://127.0.0.1:18000/api/v1/config >/dev/null
           npm run build
 
-      - name: Setup SSH Key
+      - name: Setup SSH Key for Web Server
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ env.SSH_HOST_WEB }} >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H ${{ env.SSH_HOST_WEB }} >> ~/.ssh/known_hosts || true
 
       - name: Deploy to Web Server
         run: |
-          # Upload files using rsync over SSH
-          rsync -avz --delete \
-            -e "ssh -i ~/.ssh/deploy_key" \
-            web/dist/ \
-            ${{ env.SSH_USER_WEB }}@${{ env.SSH_HOST_WEB }}:/var/www/user2154318/data/www/mvn.by/
-          
-          echo "✅ Turbo Rebuild completed!"
+          set -euo pipefail
+
+          WEB_HOST="${SSH_HOST_WEB}"
+          WEB_USER="${SSH_USER_WEB}"
+          WEB_TARGET="/var/www/${SSH_USER_WEB}/data/www/mvn.by/"
+          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
+          MAX_ATTEMPTS=5
+          PORT_FAILURES=0
+          LOGIN_FAILURES=0
+          RSYNC_FAILURES=0
+
+          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "Frontend rebuild deploy attempt ${attempt}/${MAX_ATTEMPTS}"
+
+            if nc -z -w 10 "${WEB_HOST}" 22; then
+              echo "Web SSH port is reachable"
+            else
+              PORT_FAILURES=$((PORT_FAILURES + 1))
+              echo "::warning::Web SSH port 22 is not reachable before rsync attempt ${attempt}"
+            fi
+
+            if ssh ${SSH_OPTS} "${WEB_USER}@${WEB_HOST}" "true"; then
+              if rsync -avz --delete \
+                -e "ssh ${SSH_OPTS}" \
+                web/dist/ \
+                "${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"; then
+                echo "Manual web rebuild completed on attempt ${attempt}."
+                {
+                  echo "## Manual Web Rebuild Summary"
+                  echo "- job: rebuild-web"
+                  echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
+                  echo "- attempts_used: ${attempt}"
+                  echo "- status: success"
+                  echo "- build_status: success"
+                  echo "- failure_kind: n/a"
+                  echo "- ssh_port_failures: ${PORT_FAILURES}"
+                  echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+                  echo "- rsync_failures: ${RSYNC_FAILURES}"
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+
+              RSYNC_FAILURES=$((RSYNC_FAILURES + 1))
+              echo "::warning::rsync failed on attempt ${attempt}"
+            else
+              LOGIN_FAILURES=$((LOGIN_FAILURES + 1))
+              echo "::warning::SSH login preflight failed on attempt ${attempt}"
+            fi
+
+            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
+              sleep_seconds=$((attempt * 20))
+              echo "Waiting ${sleep_seconds}s before retry..."
+              sleep "${sleep_seconds}"
+            fi
+          done
+
+          if [ "${PORT_FAILURES}" -gt 0 ] || [ "${LOGIN_FAILURES}" -gt 0 ]; then
+            FAILURE_KIND="web_ssh_connectivity"
+          elif [ "${RSYNC_FAILURES}" -gt 0 ]; then
+            FAILURE_KIND="rsync_transfer"
+          else
+            FAILURE_KIND="unknown"
+          fi
+
+          {
+            echo "## Manual Web Rebuild Summary"
+            echo "- job: rebuild-web"
+            echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
+            echo "- attempts_used: ${MAX_ATTEMPTS}"
+            echo "- status: failed"
+            echo "- build_status: success"
+            echo "- failure_kind: ${FAILURE_KIND}"
+            echo "- ssh_port_failures: ${PORT_FAILURES}"
+            echo "- ssh_login_failures: ${LOGIN_FAILURES}"
+            echo "- rsync_failures: ${RSYNC_FAILURES}"
+            echo "- next_step: run the manual Web SSH Connectivity Check workflow or choose a more reliable web deploy architecture"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::Manual web rebuild failed after ${MAX_ATTEMPTS} attempts (${FAILURE_KIND})."
+          exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,7 +70,19 @@ The workflow requires these env vars in the build step:
 ### Deployment Steps
 
 1. **deploy-backend:** Builds and pushes Docker image, deploys to API server
-2. **deploy-frontend:** Builds Astro site, uploads to web server via SCP
+2. **deploy-frontend:** Builds Astro site, uploads to web server via rsync over SSH
+
+### Web SSH Reliability
+
+`deploy-frontend` and the manual `rebuild-web.yml` workflow use bounded SSH port/login preflight checks before rsync. They retry 5 times with backoff and write a summary with separate `ssh_port_failures`, `ssh_login_failures`, `rsync_failures`, and `failure_kind` fields.
+
+If `deploy-backend` and backend smoke-check are green but `deploy-frontend` fails with `failure_kind: web_ssh_connectivity`, treat it as web-host SSH/network instability from GitHub-hosted runners, not an Astro/backend build failure.
+
+Use the manual **Web SSH Connectivity Check** workflow to probe `SSH_HOST_WEB` from GitHub Actions without building or deploying files. If the probe is flaky too, the next decision should be architectural rather than adding more retries:
+
+- move the static site to a managed static hosting/CDN deploy path;
+- move web hosting to infrastructure with stable SSH from GitHub Actions;
+- switch to a pull-based deploy where the web host fetches a release artifact instead of GitHub Actions opening inbound SSH to the host.
 
 ## Manager Frontend Env Model
 
@@ -161,11 +173,13 @@ After apply, smoke-check:
 - **Mac:** `Cmd + Shift + R`
 - **Windows:** `Ctrl + Shift + R`
 
-### Issue: rsync connection timeout
+### Issue: web SSH or rsync timeout
 
-**Symptoms:** `rsync: error: unexpected end of file`
+**Symptoms:** `ssh: connect to host ... port 22: Connection timed out`, `rsync error: unexplained error (code 255)`, or deploy summary `failure_kind: web_ssh_connectivity`.
 
-**Fix:** Use GitHub Actions deployment instead of local rsync for large updates
+**Checks:** Confirm whether backend deploy and smoke-check were green, then run the manual **Web SSH Connectivity Check** workflow. A flaky probe means the web SSH path is unstable before file transfer starts.
+
+**Fix direction:** Do not keep increasing retries. Pick a more reliable deploy architecture: managed static hosting/CDN, web hosting with stable SSH from GitHub Actions, or pull-based artifact deployment from the web host.
 
 ## Verification
 


### PR DESCRIPTION
## What changed

Refs #364.

- Added a manual `Web SSH Connectivity Check` workflow that probes `SSH_HOST_WEB:22` from GitHub Actions without building or deploying files.
- Added explicit frontend deploy summary fields in `.github/workflows/deploy.yml`: `failure_kind`, SSH port/login failure counters, rsync failure counter, and a clearer error that backend deploy/smoke already completed before the frontend failure.
- Brought `.github/workflows/rebuild-web.yml` up to the same bounded retry/preflight/summary behavior as the main production frontend deploy, including use of the `SSH_USER_WEB` secret for the target path instead of a hardcoded user id.
- Updated `docs/deployment.md` with the web SSH reliability runbook and architecture options.

## Why this is no-regret

The reopened #364 evidence shows the current deploy code path can succeed after a manual rerun on the same SHA, while the first attempt failed all 5 web SSH port/login checks. Adding more deploy retries would mostly mask the web-host connectivity problem. This PR instead removes a weaker manual rebuild path, improves failure classification, and adds a no-deploy probe so owners can verify the SSH path independently of Astro/backend builds.

Evidence used:

- Run 26893530656 attempt 1: `deploy-backend` green, backend smoke green, `deploy-frontend` failed after 5/5 web SSH connectivity attempts.
- The same run attempt 2 succeeded after manual rerun, with `deploy-frontend` succeeding on attempt 1.

## Checks

- `git status --short --branch --untracked-files=all` in `/Users/maksimkorotov/dev/mvn` confirmed only intended files were changed and the new `.github/workflows/check-web-ssh.yml` workflow was included.
- `git diff --check -- .github/workflows/deploy.yml .github/workflows/rebuild-web.yml .github/workflows/check-web-ssh.yml docs/deployment.md`
- `git diff --cached --check`
- Python/PyYAML syntax parse for all changed workflow files.
- Ruby YAML syntax parse for all changed workflow files.

Production deploy was not run.

## How to verify

1. Review the workflow summaries in future `deploy-frontend` failures for `failure_kind`, `ssh_port_failures`, `ssh_login_failures`, and `rsync_failures`.
2. Run the manual `Web SSH Connectivity Check` workflow with the default 5 attempts to test web SSH from GitHub Actions without deploy side effects.
3. Use `rebuild-web.yml` only when an actual rebuild/deploy is intended; it now has the same retry/preflight summary behavior as production deploy.

## Strategic decisions still needed

If the probe or future deploys continue to show `failure_kind: web_ssh_connectivity`, the next fix should be architectural rather than more retries. The viable options are:

- move the static site to managed static hosting/CDN;
- move web hosting to infrastructure with stable SSH from GitHub Actions;
- switch to pull-based artifact deployment where the web host fetches a release artifact instead of requiring inbound SSH from GitHub Actions.

This PR intentionally does not change production secrets, hostnames, deployment targets beyond deriving the existing web user from `SSH_USER_WEB`, backend deploy behavior, or required deploy gates.