### PR TITLE
[codex] Add product image variant worker

### DIFF
--- a/scripts/process_product_image_variants.py
+++ b/scripts/process_product_image_variants.py
@@ -1,0 +1,213 @@
+"""Safely process ProductImageVariant records from the command line.
+
+Default mode is dry-run. Use --execute for bounded writes only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+sys.path.append(".")
+
+from services.product_image_processing_contract import (  # noqa: E402
+    ProductImageProcessingProvider,
+    ProductImageVariantType,
+)
+from services.product_image_variant_service import ProductImageVariantService  # noqa: E402
+
+
+PROCESSABLE_VARIANTS = (
+    ProductImageVariantType.PROCESSED.value,
+    ProductImageVariantType.CARD.value,
+    ProductImageVariantType.FULL.value,
+)
+CLI_PROVIDERS = (
+    ProductImageProcessingProvider.NOOP.value,
+    ProductImageProcessingProvider.REMBG.value,
+)
+
+
+async def process_product_image_variants(
+    *,
+    session: AsyncSession,
+    execute: bool,
+    limit: int,
+    product_id: int | None,
+    variant_type: str,
+    provider: str,
+    include_installation: bool,
+    only_missing: bool,
+    retry_failed: bool,
+) -> dict[str, Any]:
+    return await ProductImageVariantService.process_missing_variants(
+        session=session,
+        variant_type=variant_type,
+        limit=limit,
+        include_installation=include_installation,
+        dry_run=not execute,
+        provider=provider,
+        product_id=product_id,
+        only_missing=only_missing,
+        retry_failed=retry_failed,
+    )
+
+
+async def run(
+    *,
+    execute: bool,
+    limit: int,
+    product_id: int | None,
+    variant_type: str,
+    provider: str,
+    include_installation: bool,
+    only_missing: bool,
+    retry_failed: bool,
+) -> dict[str, Any]:
+    from core.database import async_session_maker
+
+    async with async_session_maker() as session:
+        return await process_product_image_variants(
+            session=session,
+            execute=execute,
+            limit=limit,
+            product_id=product_id,
+            variant_type=variant_type,
+            provider=provider,
+            include_installation=include_installation,
+            only_missing=only_missing,
+            retry_failed=retry_failed,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare missing or failed product image variants. "
+            "Dry-run is the default; pass --execute to persist a bounded batch."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist processing results. Without this flag the command only prints candidates.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Force dry-run mode. This is already the default.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum images to inspect/process in this run (1-100, default: 20).",
+    )
+    parser.add_argument(
+        "--product-id",
+        type=int,
+        default=None,
+        help="Limit candidates to one product id.",
+    )
+    parser.add_argument(
+        "--variant-type",
+        choices=PROCESSABLE_VARIANTS,
+        default=ProductImageVariantType.CARD.value,
+        help="Variant to prepare.",
+    )
+    parser.add_argument(
+        "--only-missing",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Include images with no variant row. This is the default safe selection; "
+            "use --no-only-missing with --retry-failed to target failed rows only."
+        ),
+    )
+    parser.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Also include existing failed variants for the selected type.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=CLI_PROVIDERS,
+        default=ProductImageProcessingProvider.NOOP.value,
+        help="Processing provider. noop means local Pillow normalization without background removal.",
+    )
+    parser.add_argument(
+        "--include-installation",
+        action="store_true",
+        help="Include installation photos. Catalog variants skip them by default.",
+    )
+    return parser
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if args.execute and args.dry_run:
+        parser.error("--execute and --dry-run cannot be used together")
+    if args.limit < 1 or args.limit > 100:
+        parser.error("--limit must be between 1 and 100")
+    if args.product_id is not None and args.product_id < 1:
+        parser.error("--product-id must be a positive integer")
+
+
+def _print_result(result: dict[str, Any], *, execute: bool, provider: str) -> None:
+    mode = "EXECUTE" if execute else "DRY-RUN"
+    print("Product Image Variant Worker")
+    print(f"  mode={mode}")
+    print(f"  variant_type={result['variant_type']}")
+    print(f"  provider={provider}")
+    print(f"  total_candidates={result.get('total_candidates', 0)}")
+    print(f"  returned={result.get('returned', 0)}")
+
+    candidates = result.get("candidates") or []
+    for item in candidates:
+        print(
+            "  - "
+            f"image#{item['product_image_id']} product#{item['product_id']} "
+            f"reason={item['reason']} url={item['url']}"
+        )
+
+    if not execute:
+        print("\nDry run only. Use --execute to persist this bounded batch.")
+        return
+
+    print(f"\nprocessed={result.get('processed', 0)}")
+    errors = result.get("errors") or []
+    print(f"errors={len(errors)}")
+    for item in errors:
+        print(
+            "  - "
+            f"image#{item.get('product_image_id')} "
+            f"status={item.get('status', 'failed')} error={item.get('error')}"
+        )
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    _validate_args(args, parser)
+
+    execute = bool(args.execute and not args.dry_run)
+    result = asyncio.run(
+        run(
+            execute=execute,
+            limit=args.limit,
+            product_id=args.product_id,
+            variant_type=args.variant_type,
+            provider=args.provider,
+            include_installation=args.include_installation,
+            only_missing=args.only_missing,
+            retry_failed=args.retry_failed,
+        )
+    )
+    _print_result(result, execute=execute, provider=args.provider)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/product_image_processing_provider.py
+++ b/services/product_image_processing_provider.py
@@ -6,9 +6,22 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import Protocol
 
-from PIL import Image
+from PIL import Image, ImageOps, UnidentifiedImageError, features
 
-from services.product_image_processing_contract import ProductImageProcessingProvider
+from services.product_image_processing_contract import (
+    ProductImageProcessingProvider,
+    ProductImageVariantType,
+)
+
+
+# Storefront-facing sizes are intentionally conservative: product cards render
+# around 640px wide today, while detail-gallery images benefit from extra DPR
+# headroom without creating production-sized source mutations.
+CARD_CANVAS_SIZE = (960, 960)
+CARD_PADDING_RATIO = 0.08
+PROCESSED_MAX_EDGE = 1600
+FULL_MAX_EDGE = 1800
+MAX_SOURCE_PIXELS = 40_000_000
 
 
 @dataclass(frozen=True)
@@ -39,7 +52,7 @@ class ProductImageProcessor(Protocol):
 
 
 class NoopProductImageProcessor:
-    """Safe provider that stores the current bytes as the requested variant."""
+    """Safe provider with no background removal, only classical normalization."""
 
     provider_name = ProductImageProcessingProvider.NOOP.value
 
@@ -49,7 +62,7 @@ class NoopProductImageProcessor:
         source_content: bytes,
         context: ProductImageProcessingContext,
     ) -> ProductImageProcessingResult:
-        return ProductImageProcessingResult(content=source_content, extension="webp")
+        return _process_image_bytes(source_content, context=context)
 
 
 class ManualProductImageProcessor(NoopProductImageProcessor):
@@ -59,7 +72,7 @@ class ManualProductImageProcessor(NoopProductImageProcessor):
 
 
 class RembgProductImageProcessor:
-    """Optional future provider; imports rembg lazily when explicitly selected."""
+    """Optional provider; imports rembg lazily when explicitly selected."""
 
     provider_name = ProductImageProcessingProvider.REMBG.value
 
@@ -75,10 +88,7 @@ class RembgProductImageProcessor:
             raise RuntimeError("rembg provider is not installed") from exc
 
         output = remove(source_content)
-        image = Image.open(BytesIO(output))
-        buffer = BytesIO()
-        image.save(buffer, format="WEBP", quality=90)
-        return ProductImageProcessingResult(content=buffer.getvalue(), extension="webp")
+        return _process_image_bytes(output, context=context)
 
 
 def get_product_image_processor(provider: str) -> ProductImageProcessor:
@@ -89,3 +99,119 @@ def get_product_image_processor(provider: str) -> ProductImageProcessor:
     if provider == ProductImageProcessingProvider.REMBG.value:
         return RembgProductImageProcessor()
     raise ValueError(f"Unsupported image processing provider={provider!r}")
+
+
+def _process_image_bytes(
+    source_content: bytes,
+    *,
+    context: ProductImageProcessingContext | None,
+) -> ProductImageProcessingResult:
+    variant_type = (
+        context.variant_type
+        if context is not None
+        else ProductImageVariantType.PROCESSED.value
+    )
+    image = _open_source_image(source_content)
+    image = _trim_transparent_borders(image)
+
+    if variant_type == ProductImageVariantType.CARD.value:
+        image = _normalize_card_canvas(image)
+    elif variant_type == ProductImageVariantType.FULL.value:
+        image = _resize_to_max_edge(image, FULL_MAX_EDGE)
+    else:
+        image = _resize_to_max_edge(image, PROCESSED_MAX_EDGE)
+
+    content, extension = _export_image(image)
+    return ProductImageProcessingResult(
+        content=content,
+        extension=extension,
+        width=image.width,
+        height=image.height,
+    )
+
+
+def _open_source_image(source_content: bytes) -> Image.Image:
+    if not source_content:
+        raise ValueError("Source image is empty")
+
+    try:
+        with Image.open(BytesIO(source_content)) as image:
+            if image.width * image.height > MAX_SOURCE_PIXELS:
+                raise ValueError("Source image is too large for safe processing")
+            transposed = ImageOps.exif_transpose(image)
+            converted = transposed.convert("RGBA" if _has_alpha(transposed) else "RGB")
+            converted.load()
+            return converted.copy()
+    except UnidentifiedImageError as exc:
+        raise ValueError("Source image cannot be opened by Pillow") from exc
+
+
+def _has_alpha(image: Image.Image) -> bool:
+    return image.mode in {"RGBA", "LA"} or (
+        image.mode == "P" and "transparency" in image.info
+    )
+
+
+def _ensure_rgba(image: Image.Image) -> Image.Image:
+    if image.mode == "RGBA":
+        return image
+    return image.convert("RGBA")
+
+
+def _trim_transparent_borders(image: Image.Image) -> Image.Image:
+    if image.mode != "RGBA":
+        return image
+
+    bbox = image.getchannel("A").getbbox()
+    if not bbox:
+        return image
+    return image.crop(bbox)
+
+
+def _normalize_card_canvas(image: Image.Image) -> Image.Image:
+    image = _ensure_rgba(_trim_transparent_borders(image))
+    canvas_width, canvas_height = CARD_CANVAS_SIZE
+    padding = int(round(min(canvas_width, canvas_height) * CARD_PADDING_RATIO))
+    max_width = max(1, canvas_width - padding * 2)
+    max_height = max(1, canvas_height - padding * 2)
+
+    fitted = _resize_to_box(image, max_width=max_width, max_height=max_height)
+    canvas = Image.new("RGBA", CARD_CANVAS_SIZE, (255, 255, 255, 0))
+    offset = (
+        (canvas_width - fitted.width) // 2,
+        (canvas_height - fitted.height) // 2,
+    )
+    canvas.alpha_composite(fitted, dest=offset)
+    return canvas
+
+
+def _resize_to_max_edge(image: Image.Image, max_edge: int) -> Image.Image:
+    if max(image.width, image.height) <= max_edge:
+        return image.copy()
+    scale = max_edge / max(image.width, image.height)
+    size = (
+        max(1, int(round(image.width * scale))),
+        max(1, int(round(image.height * scale))),
+    )
+    return image.resize(size, Image.Resampling.LANCZOS)
+
+
+def _resize_to_box(image: Image.Image, *, max_width: int, max_height: int) -> Image.Image:
+    scale = min(max_width / image.width, max_height / image.height)
+    if scale == 1:
+        return image.copy()
+    size = (
+        max(1, int(round(image.width * scale))),
+        max(1, int(round(image.height * scale))),
+    )
+    return image.resize(size, Image.Resampling.LANCZOS)
+
+
+def _export_image(image: Image.Image) -> tuple[bytes, str]:
+    buffer = BytesIO()
+    if features.check("webp"):
+        image.save(buffer, format="WEBP", quality=88, method=6, exact=True)
+        return buffer.getvalue(), "webp"
+
+    image.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue(), "png"

--- a/services/product_image_variant_service.py
+++ b/services/product_image_variant_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from PIL import Image
-from sqlalchemy import exists, func
+from sqlalchemy import exists, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -67,35 +67,56 @@ class ProductImageVariantService:
         variant_type: str = ProductImageVariantType.CARD.value,
         limit: int = 100,
         include_installation: bool = False,
+        product_id: int | None = None,
+        only_missing: bool = True,
+        retry_failed: bool = False,
     ) -> dict[str, Any]:
-        """Return dry-run candidates whose requested variant is absent or retryable."""
+        """Return dry-run candidates whose requested variant is absent or failed."""
         normalized_type = normalize_variant_type(variant_type).value
         safe_limit = max(1, min(int(limit), 100))
 
-        retryable_statuses = {
-            ProductImageProcessingStatus.FAILED.value,
-            ProductImageProcessingStatus.SKIPPED.value,
-        }
-        retryable_variant_ids = select(ProductImageVariant.product_image_id).where(
-            ProductImageVariant.variant_type == normalized_type,
-            ProductImageVariant.processing_status.in_(retryable_statuses),
-        )
-        ready_or_inflight_exists = exists(
+        any_variant_exists = exists(
             select(ProductImageVariant.id).where(
                 ProductImageVariant.product_image_id == ProductImage.id,
                 ProductImageVariant.variant_type == normalized_type,
-                ProductImageVariant.processing_status.notin_(retryable_statuses),
+            )
+        )
+        failed_variant_exists = exists(
+            select(ProductImageVariant.id).where(
+                ProductImageVariant.product_image_id == ProductImage.id,
+                ProductImageVariant.variant_type == normalized_type,
+                ProductImageVariant.processing_status == ProductImageProcessingStatus.FAILED.value,
             )
         )
 
-        count_stmt = select(func.count()).select_from(ProductImage).where(~ready_or_inflight_exists)
-        stmt = select(ProductImage).where(~ready_or_inflight_exists)
+        candidate_conditions = []
+        if only_missing or not retry_failed:
+            candidate_conditions.append(~any_variant_exists)
+        if retry_failed:
+            candidate_conditions.append(failed_variant_exists)
+
+        candidate_filter = or_(*candidate_conditions)
+        count_stmt = select(func.count()).select_from(ProductImage).where(candidate_filter)
+        stmt = select(ProductImage).where(candidate_filter)
+
+        if product_id is not None:
+            count_stmt = count_stmt.where(ProductImage.product_id == product_id)
+            stmt = stmt.where(ProductImage.product_id == product_id)
 
         if not include_installation:
             count_stmt = count_stmt.where(ProductImage.is_installation_photo == False)  # noqa: E712
             stmt = stmt.where(ProductImage.is_installation_photo == False)  # noqa: E712
 
-        retryable_ids = set((await session.execute(retryable_variant_ids)).scalars().all())
+        failed_variant_ids_stmt = select(ProductImageVariant.product_image_id).where(
+            ProductImageVariant.variant_type == normalized_type,
+            ProductImageVariant.processing_status == ProductImageProcessingStatus.FAILED.value,
+        )
+        if product_id is not None:
+            failed_variant_ids_stmt = failed_variant_ids_stmt.join(ProductImage).where(
+                ProductImage.product_id == product_id
+            )
+
+        failed_variant_ids = set((await session.execute(failed_variant_ids_stmt)).scalars().all())
         total = int((await session.execute(count_stmt)).scalar_one() or 0)
         rows = (await session.execute(stmt.order_by(ProductImage.id).limit(safe_limit))).scalars().all()
 
@@ -105,7 +126,7 @@ class ProductImageVariantService:
                 "product_id": image.product_id,
                 "url": image.url,
                 "is_installation_photo": image.is_installation_photo,
-                "reason": "retryable_status" if image.id in retryable_ids else "missing_variant",
+                "reason": "failed_variant" if image.id in failed_variant_ids else "missing_variant",
             }
             for image in rows
         ]
@@ -128,18 +149,25 @@ class ProductImageVariantService:
         provider: str = ProductImageProcessingProvider.NOOP.value,
         storage: ProductMediaStorage | None = None,
         processor: ProductImageProcessor | None = None,
+        product_id: int | None = None,
+        only_missing: bool = True,
+        retry_failed: bool = False,
     ) -> dict[str, Any]:
         candidates = await ProductImageVariantService.get_missing_variant_candidates(
             session,
             variant_type=variant_type,
             limit=limit,
             include_installation=include_installation,
+            product_id=product_id,
+            only_missing=only_missing,
+            retry_failed=retry_failed,
         )
         if dry_run:
             return candidates
 
         processed: list[dict[str, Any]] = []
         errors: list[dict[str, Any]] = []
+        variants: list[dict[str, Any]] = []
         for item in candidates["candidates"]:
             image_id = item["product_image_id"]
             try:
@@ -152,7 +180,17 @@ class ProductImageVariantService:
                     processor=processor,
                     commit=False,
                 )
-                processed.append(result)
+                variants.append(result)
+                if result.get("processing_status") == ProductImageProcessingStatus.READY.value:
+                    processed.append(result)
+                elif result.get("processing_status") == ProductImageProcessingStatus.FAILED.value:
+                    errors.append(
+                        {
+                            "product_image_id": image_id,
+                            "status": result.get("processing_status"),
+                            "error": result.get("processing_error"),
+                        }
+                    )
             except Exception as exc:
                 await ProductImageVariantService._record_processing_error(
                     session,
@@ -169,9 +207,12 @@ class ProductImageVariantService:
         return {
             "dry_run": False,
             "variant_type": normalize_variant_type(variant_type).value,
+            "total_candidates": candidates["total_candidates"],
+            "returned": candidates["returned"],
+            "candidates": candidates["candidates"],
             "processed": len(processed),
             "errors": errors,
-            "variants": processed,
+            "variants": variants,
         }
 
     @staticmethod

--- a/tests/unit/test_product_image_variants.py
+++ b/tests/unit/test_product_image_variants.py
@@ -14,12 +14,25 @@ from services.product_image_processing_contract import (
     ProductImageProcessingStatus,
     ProductImageVariantType,
 )
-from services.product_image_processing_provider import NoopProductImageProcessor
+from services.product_image_processing_provider import (
+    CARD_CANVAS_SIZE,
+    NoopProductImageProcessor,
+    ProductImageProcessingContext,
+)
 from services.product_image_variant_service import ProductImageVariantService
+from scripts.process_product_image_variants import process_product_image_variants
 
 
 def _image_bytes(color: tuple[int, int, int] = (40, 90, 180), *, fmt: str = "PNG") -> bytes:
     image = Image.new("RGB", (12, 10), color)
+    output = BytesIO()
+    image.save(output, format=fmt)
+    return output.getvalue()
+
+
+def _transparent_product_bytes(*, fmt: str = "PNG") -> bytes:
+    image = Image.new("RGBA", (80, 60), (255, 255, 255, 0))
+    image.paste((210, 30, 30, 255), box=(18, 12, 62, 48))
     output = BytesIO()
     image.save(output, format=fmt)
     return output.getvalue()
@@ -56,6 +69,14 @@ async def _make_product(session: AsyncSession, idx: int = 1) -> Product:
     await session.commit()
     await session.refresh(product)
     return product
+
+
+def _write_source_image(tmp_path: Path, name: str, content: bytes | None = None) -> str:
+    source_dir = tmp_path / "media/products/shared"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    source_path = source_dir / name
+    source_path.write_bytes(content or _image_bytes(fmt="WEBP"))
+    return f"/media/products/shared/{name}"
 
 
 @pytest.mark.asyncio
@@ -217,6 +238,7 @@ async def test_reprocess_local_image_creates_card_variant_without_mutating_curre
     source_path.write_bytes(_image_bytes(fmt="WEBP"))
     source_url = "/media/products/shared/source.webp"
     product.main_image = source_url
+    product.images = [source_url]
     image = ProductImage(product_id=product.id, url=source_url)
     sqlite_session.add(image)
     await sqlite_session.commit()
@@ -235,6 +257,7 @@ async def test_reprocess_local_image_creates_card_variant_without_mutating_curre
     assert result["url"] != image.url
     assert Path(result["url"].lstrip("/")).exists()
     assert product.main_image == source_url
+    assert product.images == [source_url]
     assert image.url == source_url
 
 
@@ -261,3 +284,235 @@ async def test_reprocess_failed_source_records_error_without_mutating_originals(
     assert result["processing_error"] == "Source image is not available in local media storage"
     assert product.main_image == "https://example.com/current.jpg"
     assert image.url == "https://example.com/source.jpg"
+
+
+@pytest.mark.asyncio
+async def test_cli_dry_run_scopes_product_and_default_missing_only(sqlite_session):
+    first = await _make_product(sqlite_session, 41)
+    second = await _make_product(sqlite_session, 42)
+    first_image = ProductImage(product_id=first.id, url="/media/products/shared/first.webp")
+    second_image = ProductImage(product_id=second.id, url="/media/products/shared/second.webp")
+    failed_image = ProductImage(product_id=first.id, url="/media/products/shared/failed.webp")
+    sqlite_session.add_all([first_image, second_image, failed_image])
+    await sqlite_session.flush()
+    sqlite_session.add(
+        ProductImageVariant(
+            product_image_id=failed_image.id,
+            variant_type=ProductImageVariantType.CARD.value,
+            processing_status=ProductImageProcessingStatus.FAILED.value,
+            processing_stage="variant_generation",
+            processing_error="previous failure",
+        )
+    )
+    await sqlite_session.commit()
+
+    report = await process_product_image_variants(
+        session=sqlite_session,
+        execute=False,
+        limit=10,
+        product_id=first.id,
+        variant_type=ProductImageVariantType.CARD.value,
+        provider="noop",
+        include_installation=False,
+        only_missing=True,
+        retry_failed=False,
+    )
+
+    assert report["dry_run"] is True
+    assert report["total_candidates"] == 1
+    assert report["candidates"][0]["product_image_id"] == first_image.id
+    assert report["candidates"][0]["reason"] == "missing_variant"
+
+
+@pytest.mark.asyncio
+async def test_process_missing_variants_respects_bounded_batch(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product = await _make_product(sqlite_session, 51)
+    images = []
+    for idx in range(3):
+        url = _write_source_image(tmp_path, f"bounded-{idx}.webp")
+        images.append(ProductImage(product_id=product.id, url=url))
+    sqlite_session.add_all(images)
+    await sqlite_session.commit()
+
+    result = await ProductImageVariantService.process_missing_variants(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=2,
+        dry_run=False,
+        provider="noop",
+    )
+
+    variant_rows = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.variant_type == ProductImageVariantType.CARD.value
+            )
+        )
+    ).scalars().all()
+    assert result["processed"] == 2
+    assert len(result["variants"]) == 2
+    assert len(variant_rows) == 2
+    assert {row.processing_status for row in variant_rows} == {
+        ProductImageProcessingStatus.READY.value
+    }
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_includes_failed_variant_only_when_requested(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product = await _make_product(sqlite_session, 61)
+    source_url = _write_source_image(tmp_path, "retry.webp")
+    image = ProductImage(product_id=product.id, url=source_url)
+    sqlite_session.add(image)
+    await sqlite_session.flush()
+    sqlite_session.add(
+        ProductImageVariant(
+            product_image_id=image.id,
+            variant_type=ProductImageVariantType.CARD.value,
+            processing_status=ProductImageProcessingStatus.FAILED.value,
+            processing_stage="variant_generation",
+            processing_error="previous failure",
+        )
+    )
+    await sqlite_session.commit()
+
+    default_report = await ProductImageVariantService.get_missing_variant_candidates(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+    )
+    retry_report = await ProductImageVariantService.get_missing_variant_candidates(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+        retry_failed=True,
+    )
+    result = await ProductImageVariantService.process_missing_variants(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+        dry_run=False,
+        provider="noop",
+        retry_failed=True,
+    )
+
+    assert default_report["total_candidates"] == 0
+    assert retry_report["total_candidates"] == 1
+    assert retry_report["candidates"][0]["reason"] == "failed_variant"
+    assert result["processed"] == 1
+    assert result["errors"] == []
+    assert result["variants"][0]["processing_status"] == ProductImageProcessingStatus.READY.value
+
+
+@pytest.mark.asyncio
+async def test_idempotent_rerun_does_not_duplicate_ready_variant(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product = await _make_product(sqlite_session, 71)
+    source_url = _write_source_image(tmp_path, "idempotent.webp")
+    image = ProductImage(product_id=product.id, url=source_url)
+    sqlite_session.add(image)
+    await sqlite_session.commit()
+
+    first = await ProductImageVariantService.process_missing_variants(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+        dry_run=False,
+        provider="noop",
+    )
+    second = await ProductImageVariantService.process_missing_variants(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+        dry_run=False,
+        provider="noop",
+    )
+    variants = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.product_image_id == image.id,
+                ProductImageVariant.variant_type == ProductImageVariantType.CARD.value,
+            )
+        )
+    ).scalars().all()
+
+    assert first["processed"] == 1
+    assert second["processed"] == 0
+    assert second["total_candidates"] == 0
+    assert len(variants) == 1
+    assert variants[0].processing_status == ProductImageProcessingStatus.READY.value
+
+
+@pytest.mark.asyncio
+async def test_batch_error_isolation_records_failed_variant_and_continues(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product = await _make_product(sqlite_session, 81)
+    good_url = _write_source_image(tmp_path, "good.webp")
+    good = ProductImage(product_id=product.id, url=good_url)
+    missing = ProductImage(product_id=product.id, url="/media/products/shared/missing.webp")
+    sqlite_session.add_all([good, missing])
+    await sqlite_session.commit()
+
+    result = await ProductImageVariantService.process_missing_variants(
+        sqlite_session,
+        variant_type=ProductImageVariantType.CARD.value,
+        limit=10,
+        dry_run=False,
+        provider="noop",
+    )
+    variants = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.variant_type == ProductImageVariantType.CARD.value
+            )
+        )
+    ).scalars().all()
+
+    statuses_by_image = {variant.product_image_id: variant.processing_status for variant in variants}
+    assert result["processed"] == 1
+    assert len(result["errors"]) == 1
+    assert statuses_by_image[good.id] == ProductImageProcessingStatus.READY.value
+    assert statuses_by_image[missing.id] == ProductImageProcessingStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_card_canvas_normalization_preserves_alpha_and_expected_dimensions():
+    processor = NoopProductImageProcessor()
+
+    result = await processor.process(
+        source_content=_transparent_product_bytes(),
+        context=ProductImageProcessingContext(
+            product_image_id=1,
+            source_url="/media/products/shared/source.png",
+            variant_type=ProductImageVariantType.CARD.value,
+        ),
+    )
+
+    with Image.open(BytesIO(result.content)) as output:
+        image = output.convert("RGBA")
+        bbox = image.getchannel("A").getbbox()
+
+    assert result.width == CARD_CANVAS_SIZE[0]
+    assert result.height == CARD_CANVAS_SIZE[1]
+    assert image.size == CARD_CANVAS_SIZE
+    assert image.getpixel((0, 0))[3] == 0
+    assert bbox is not None
+    assert bbox[0] >= int(CARD_CANVAS_SIZE[0] * 0.07)
+    assert bbox[2] <= int(CARD_CANVAS_SIZE[0] * 0.93) + 1


### PR DESCRIPTION
## Summary

Implements stage 2 for product image variants on top of the already merged #370 contract.

- Adds `scripts/process_product_image_variants.py`, a dry-run-first bounded CLI/worker for missing and failed `ProductImageVariant` rows.
- Extends `ProductImageVariantService` candidate selection with `product_id`, `only_missing`, and `retry_failed` controls while keeping ready variants idempotent.
- Replaces raw-copy provider behavior with a conservative Pillow pipeline: safe image open, EXIF transpose, alpha preservation, transparent trim, `card` square canvas normalization, `processed`/`full` max-edge resizing, and WebP export where Pillow supports it.
- Keeps `rembg` lazy/optional; selecting `--provider rembg` records a failed variant if the package is unavailable.

Closes #371.

## CLI usage examples

```bash
python3 scripts/process_product_image_variants.py --dry-run --limit 20 --variant-type card
python3 scripts/process_product_image_variants.py --dry-run --product-id 123 --variant-type full
python3 scripts/process_product_image_variants.py --execute --limit 10 --variant-type card --provider noop
python3 scripts/process_product_image_variants.py --execute --limit 10 --variant-type card --retry-failed
python3 scripts/process_product_image_variants.py --execute --limit 5 --variant-type processed --provider rembg
```

## Safety defaults

- CLI defaults to dry-run; writes require explicit `--execute`.
- `--limit` is capped to 1-100.
- Default selection is only missing variants; failed rows are included only with `--retry-failed`.
- Originals remain intact: no writes to `Product.main_image`, legacy `Product.images`, or `ProductImage.url`.
- Variant files are saved by content hash through the existing media storage service.
- Batch processing isolates per-image failures and records failed variant state instead of crashing the whole batch.
- No AI/generative enhancement is enabled.

## Tests run

- `pytest tests/unit/test_product_image_variants.py -q` (`13 passed`)
- CLI dry-run smoke against a temporary SQLite DB
- `python3 -m compileall services scripts models routers schemas.py`
- `git diff --check`

## Residual risks

- `rembg` remains optional and was not exercised as an installed dependency in this PR.
- Canvas targets are conservative code-level defaults (`card` 960x960, `processed` max edge 1600, `full` max edge 1800); storefront adoption remains out of scope for #373.
- This PR does not run production processing or add manager UI controls/status panels.
