### PR TITLE
[codex] Add repair workflow meta contract

### DIFF
--- a/services/order_service.py
+++ b/services/order_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 from sqlalchemy import func, or_, and_, not_, cast, String, delete, inspect
 from sqlalchemy.orm import selectinload
-from sqlalchemy.orm.attributes import NO_VALUE
+from sqlalchemy.orm.attributes import NO_VALUE, flag_modified
 
 from crud.order import OrderDAO
 from crud.product import ProductDAO
@@ -21,6 +21,26 @@ class OrderService:
     MANAGER_LABELS_META_KEY = "manager_labels"
     LEGACY_WEBSITE_TITLE_PREFIX = "Заказ с сайта от "
     ORDER_WORKFLOW_TYPES = {"sales_installation", "service_work", "maintenance", "repair"}
+    REPAIR_META_KEY = "repair"
+    REPAIR_STATUS_KEY = "repair_status"
+    REPAIR_DEFAULT_STATUS = "new"
+    REPAIR_WORKFLOW_STATUSES = (
+        "new",
+        "scheduled",
+        "diagnostic_in_progress",
+        "awaiting_diagnostic_result",
+        "awaiting_customer_approval",
+        "approved_for_repair",
+        "repair_in_progress",
+        "awaiting_parts",
+        "completed",
+        "not_repairable",
+        "cancelled",
+    )
+    REPAIR_WORKFLOW_STATUS_SET = set(REPAIR_WORKFLOW_STATUSES)
+    REPAIR_BOOLEAN_META_KEYS = {"repair_possible", "repair_not_viable"}
+    REPAIR_TRUE_VALUES = {"1", "true", "yes", "y", "да", "д", "истина"}
+    REPAIR_FALSE_VALUES = {"0", "false", "no", "n", "нет", "н", "ложь"}
     SERVICE_TYPE_TITLE_MAP = {
         "turnkey": "Продажа + монтаж",
         "install_only": "Монтаж",
@@ -265,27 +285,191 @@ class OrderService:
         return fallback
 
     @staticmethod
-    def _get_repair_meta(order: Order) -> Dict[str, Any]:
-        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
-        repair_meta = meta.get("repair")
-        return dict(repair_meta) if isinstance(repair_meta, dict) else {}
+    def normalize_repair_status(raw: Any, fallback: Optional[str] = None) -> str:
+        value = str(raw or "").strip()
+        if not value:
+            if fallback is not None:
+                return OrderService.normalize_repair_status(fallback)
+            raise ValueError(f"{OrderService.REPAIR_STATUS_KEY} is required")
+
+        normalized = "_".join(value.casefold().replace("-", "_").split())
+        if normalized not in OrderService.REPAIR_WORKFLOW_STATUS_SET:
+            allowed = ", ".join(OrderService.REPAIR_WORKFLOW_STATUSES)
+            raise ValueError(f"Invalid {OrderService.REPAIR_STATUS_KEY}: {raw}. Allowed: {allowed}")
+        return normalized
 
     @staticmethod
-    def _set_repair_meta(order: Order, raw_meta: Any) -> None:
-        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
-        if isinstance(raw_meta, dict):
-            cleaned = {
-                str(key): value
-                for key, value in raw_meta.items()
-                if value is not None and not (isinstance(value, str) and not value.strip())
-            }
+    def _normalize_repair_boolish(raw: Any) -> Any:
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            value = raw.strip()
+            lowered = value.casefold()
+            if lowered in OrderService.REPAIR_TRUE_VALUES:
+                return True
+            if lowered in OrderService.REPAIR_FALSE_VALUES:
+                return False
+            return value
+        return raw
+
+    @staticmethod
+    def normalize_repair_meta(raw_meta: Any, default_status: Optional[str] = None) -> Dict[str, Any]:
+        if not isinstance(raw_meta, dict):
+            cleaned: Dict[str, Any] = {}
         else:
             cleaned = {}
+            for raw_key, raw_value in raw_meta.items():
+                key = str(raw_key or "").strip()
+                if not key or raw_value is None:
+                    continue
+                if isinstance(raw_value, str):
+                    value: Any = raw_value.strip()
+                    if not value:
+                        continue
+                else:
+                    value = raw_value
+
+                if key == OrderService.REPAIR_STATUS_KEY:
+                    cleaned[key] = OrderService.normalize_repair_status(value, fallback=default_status)
+                elif key in OrderService.REPAIR_BOOLEAN_META_KEYS:
+                    cleaned[key] = OrderService._normalize_repair_boolish(value)
+                else:
+                    cleaned[key] = value
+
+        if OrderService.REPAIR_STATUS_KEY not in cleaned and default_status is not None:
+            cleaned[OrderService.REPAIR_STATUS_KEY] = OrderService.normalize_repair_status(default_status)
+        return cleaned
+
+    @staticmethod
+    def _get_repair_meta(order: Order) -> Dict[str, Any]:
+        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+        repair_meta = meta.get(OrderService.REPAIR_META_KEY)
+        raw = dict(repair_meta) if isinstance(repair_meta, dict) else {}
+        if OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)) != "repair":
+            return raw
+        try:
+            return OrderService.normalize_repair_meta(raw, default_status=OrderService.REPAIR_DEFAULT_STATUS)
+        except ValueError:
+            logger.warning("Order %s has invalid repair meta status", getattr(order, "id", None))
+            return raw
+
+    @staticmethod
+    def _set_repair_meta(
+        order: Order,
+        raw_meta: Any,
+        default_status: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        cleaned = OrderService.normalize_repair_meta(raw_meta, default_status=default_status)
         if cleaned:
-            meta["repair"] = cleaned
+            meta[OrderService.REPAIR_META_KEY] = cleaned
         else:
-            meta.pop("repair", None)
+            meta.pop(OrderService.REPAIR_META_KEY, None)
         order.technical_meta = meta
+        return cleaned
+
+    @staticmethod
+    def _ensure_repair_meta_defaults(order: Order) -> Dict[str, Any]:
+        if OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)) != "repair":
+            return OrderService._get_repair_meta(order)
+        return OrderService._set_repair_meta(
+            order,
+            OrderService._get_repair_meta(order),
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+
+    @staticmethod
+    def _ensure_repair_workflow(order: Order) -> None:
+        if OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)) != "repair":
+            raise ValueError("Repair workflow transitions can only be applied to repair orders")
+
+    @staticmethod
+    def set_repair_workflow_status(
+        order: Order,
+        status: Any,
+        extra_meta: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        OrderService._ensure_repair_workflow(order)
+        repair_meta = OrderService._get_repair_meta(order)
+        if extra_meta:
+            repair_meta.update(extra_meta)
+        repair_meta[OrderService.REPAIR_STATUS_KEY] = status
+        return OrderService._set_repair_meta(
+            order,
+            repair_meta,
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+
+    @staticmethod
+    def mark_repair_diagnostic_in_progress(order: Order) -> Dict[str, Any]:
+        return OrderService.set_repair_workflow_status(order, "diagnostic_in_progress")
+
+    @staticmethod
+    def mark_repair_awaiting_diagnostic_result(order: Order) -> Dict[str, Any]:
+        return OrderService.set_repair_workflow_status(order, "awaiting_diagnostic_result")
+
+    @staticmethod
+    def record_repair_diagnostic_result(
+        order: Order,
+        diagnostic_result: Any,
+        *,
+        repair_recommendation: Any = None,
+        repair_possible: Any = None,
+        next_status: str = "awaiting_customer_approval",
+    ) -> Dict[str, Any]:
+        updates = {"diagnostic_result": diagnostic_result}
+        if repair_recommendation is not None:
+            updates["repair_recommendation"] = repair_recommendation
+        if repair_possible is not None:
+            updates["repair_possible"] = repair_possible
+        return OrderService.set_repair_workflow_status(order, next_status, updates)
+
+    @staticmethod
+    def mark_repair_awaiting_customer_approval(order: Order, note: Any = None) -> Dict[str, Any]:
+        updates = {"customer_approval_status": "pending"}
+        if note is not None:
+            updates["customer_approval_note"] = note
+        return OrderService.set_repair_workflow_status(order, "awaiting_customer_approval", updates)
+
+    @staticmethod
+    def mark_repair_approved_for_repair(order: Order, note: Any = None) -> Dict[str, Any]:
+        updates = {"customer_approval_status": "approved"}
+        if note is not None:
+            updates["customer_approval_note"] = note
+        return OrderService.set_repair_workflow_status(order, "approved_for_repair", updates)
+
+    @staticmethod
+    def mark_repair_in_progress(order: Order) -> Dict[str, Any]:
+        return OrderService.set_repair_workflow_status(order, "repair_in_progress")
+
+    @staticmethod
+    def mark_repair_awaiting_parts(order: Order, note: Any = None) -> Dict[str, Any]:
+        updates = {"parts_status": "awaiting"}
+        if note is not None:
+            updates["parts_note"] = note
+        return OrderService.set_repair_workflow_status(order, "awaiting_parts", updates)
+
+    @staticmethod
+    def mark_repair_completed(order: Order, note: Any = None) -> Dict[str, Any]:
+        updates = {"repair_completion_note": note} if note is not None else None
+        return OrderService.set_repair_workflow_status(order, "completed", updates)
+
+    @staticmethod
+    def mark_repair_not_repairable(
+        order: Order,
+        reason: Any = None,
+        *,
+        diagnostic_result: Any = None,
+    ) -> Dict[str, Any]:
+        updates: Dict[str, Any] = {
+            "repair_possible": False,
+            "repair_not_viable": True,
+        }
+        if reason is not None:
+            updates["repair_not_viable_reason"] = reason
+        if diagnostic_result is not None:
+            updates["diagnostic_result"] = diagnostic_result
+        return OrderService.set_repair_workflow_status(order, "not_repairable", updates)
 
     @staticmethod
     def _set_manager_labels(order: Order, raw_labels: Any) -> None:
@@ -568,12 +752,16 @@ class OrderService:
             changed = True
 
         if payload.service_type:
-            from sqlalchemy.orm.attributes import flag_modified
-
             order.technical_meta = dict(order.technical_meta or {})
             order.technical_meta["service_type"] = payload.service_type
             order.workflow_type = OrderService._workflow_type_from_service_type(payload.service_type, order.workflow_type)
             flag_modified(order, "technical_meta")
+            changed = True
+
+        if order.workflow_type == "repair":
+            OrderService._ensure_repair_meta_defaults(order)
+            flag_modified(order, "technical_meta")
+            await OrderService._maybe_add_default_repair_diagnostic(session, order)
             changed = True
 
         if changed:
@@ -1945,6 +2133,8 @@ class OrderService:
         if fields_set is None:
             fields_set = getattr(payload, "__fields_set__", set())
 
+        previous_workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+
         if "status" in fields_set and payload.status is not None:
             try:
                 order.status = OrderStatus(payload.status)
@@ -1952,14 +2142,16 @@ class OrderService:
                 raise ValueError(f"Invalid status: {payload.status}") from exc
         if "title" in fields_set:
             order.title = OrderService._clean_order_title(payload.title)
-        workflow_type_changed = False
         if "workflow_type" in fields_set and payload.workflow_type is not None:
             next_workflow_type = OrderService._normalize_workflow_type(payload.workflow_type, order.workflow_type)
-            workflow_type_changed = next_workflow_type != order.workflow_type
             order.workflow_type = next_workflow_type
         if "repair_meta" in fields_set:
-            OrderService._set_repair_meta(order, payload.repair_meta)
-            from sqlalchemy.orm.attributes import flag_modified
+            default_status = (
+                OrderService.REPAIR_DEFAULT_STATUS
+                if OrderService._normalize_workflow_type(order.workflow_type) == "repair"
+                else None
+            )
+            OrderService._set_repair_meta(order, payload.repair_meta, default_status=default_status)
             flag_modified(order, "technical_meta")
         if "manager_labels" in fields_set:
             OrderService._set_manager_labels(order, payload.manager_labels)
@@ -2182,7 +2374,11 @@ class OrderService:
                     if field == "service_type" and "workflow_type" not in fields_set:
                         order.workflow_type = OrderService._workflow_type_from_service_type(val, order.workflow_type)
             order.technical_meta = new_meta
-            from sqlalchemy.orm.attributes import flag_modified
+            flag_modified(order, "technical_meta")
+
+        current_workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+        if current_workflow_type == "repair":
+            OrderService._ensure_repair_meta_defaults(order)
             flag_modified(order, "technical_meta")
 
         if "products" in fields_set or "services" in fields_set:
@@ -2266,7 +2462,8 @@ class OrderService:
             await session.flush()
             await OrderService._refresh_order_financials(session, order)
 
-        if workflow_type_changed and order.workflow_type == "repair" and "services" not in fields_set:
+        transitioned_to_repair = previous_workflow_type != "repair" and current_workflow_type == "repair"
+        if transitioned_to_repair and "services" not in fields_set:
             await OrderService._maybe_add_default_repair_diagnostic(session, order)
 
         session.add(order)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -206,9 +206,95 @@ async def test_manager_order_patch_repair_workflow_adds_diagnostic_and_meta(asyn
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["workflow_type"] == "repair"
+    assert data["repair_meta"]["repair_status"] == "new"
     assert data["repair_meta"]["customer_complaint"] == "Не охлаждает"
     assert data["repair_meta"]["equipment_serial_number"] == "SN-REPAIR-1"
-    assert any("Диагностика кондиционера" in line["service_title"] for line in data["service_lines"])
+    diagnostic_lines = [
+        line for line in data["service_lines"]
+        if "Диагностика кондиционера" in line["service_title"]
+    ]
+    assert len(diagnostic_lines) == 1
+
+    second_response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"workflow_type": "repair", "repair_meta": {"repair_status": "scheduled"}},
+        headers=headers,
+    )
+    assert second_response.status_code == 200, second_response.text
+    second_data = second_response.json()
+    assert second_data["repair_meta"]["repair_status"] == "scheduled"
+    diagnostic_lines = [
+        line for line in second_data["service_lines"]
+        if "Диагностика кондиционера" in line["service_title"]
+    ]
+    assert len(diagnostic_lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_order_patch_rejects_invalid_repair_status(async_client, db):
+    customer = Customer(name="Repair Invalid Status", phone="+375295555559", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={
+            "workflow_type": "repair",
+            "repair_meta": {"repair_status": "waiting_for_magic"},
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "Invalid repair_status" in response.text
+
+
+@pytest.mark.asyncio
+async def test_manager_order_create_repair_sets_default_status_and_diagnostic(async_client, db):
+    tariff = ServiceTariff(
+        service_kind="repair",
+        selector_label="Диагностика кондиционера на объекте",
+        estimate_template="Диагностика кондиционера на объекте",
+        category="diagnostic",
+        power_range="",
+        base_price=80,
+        is_active=True,
+        sort_order=1,
+    )
+    db.add(tariff)
+    await db.commit()
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        "/api/manager/orders",
+        json={
+            "source": "manager",
+            "request_text": "Клиент просит ремонт кондиционера, не охлаждает.",
+            "service_type": "repair",
+            "customer_type": "individual",
+            "name": "Repair Create",
+            "phone": "+375295555560",
+            "address": "Минск",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["workflow_type"] == "repair"
+    assert data["repair_meta"]["repair_status"] == "new"
+    diagnostic_lines = [
+        line for line in data["service_lines"]
+        if "Диагностика кондиционера" in line["service_title"]
+    ]
+    assert len(diagnostic_lines) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -6,7 +6,19 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 from sqlmodel import select
 
-from models import BankReceipt, Customer, CustomerType, Order, OrderProposal, OrderStatus, OutgoingEmail, PaymentCurrency, Product, Service
+from models import (
+    BankReceipt,
+    Customer,
+    CustomerType,
+    Order,
+    OrderProposal,
+    OrderStatus,
+    OutgoingEmail,
+    PaymentCurrency,
+    Product,
+    Service,
+    ServiceTariff,
+)
 from schemas import ManagerOrderUpdatePayload
 from services.order_service import OrderService
 
@@ -46,6 +58,109 @@ def test_service_json_text_search_variants_include_escaped_cyrillic():
         "\\u0430\\u0434\\u0440\\u0435\\u0441",
         "\\\\u0430\\\\u0434\\\\u0440\\\\u0435\\\\u0441",
     ]
+
+
+def test_service_repair_meta_normalizes_status_and_booleanish_values():
+    meta = OrderService.normalize_repair_meta(
+        {
+            "repair_status": "Awaiting Customer Approval",
+            "customer_complaint": "  Не охлаждает  ",
+            "diagnostic_result": "Недостаток хладагента.",
+            "repair_recommendation": "Проверить контур на утечку.",
+            "repair_possible": "Да",
+            "repair_not_viable": " нет ",
+            "empty": "   ",
+        },
+        default_status=OrderService.REPAIR_DEFAULT_STATUS,
+    )
+
+    assert meta["repair_status"] == "awaiting_customer_approval"
+    assert meta["customer_complaint"] == "Не охлаждает"
+    assert meta["diagnostic_result"] == "Недостаток хладагента."
+    assert meta["repair_recommendation"] == "Проверить контур на утечку."
+    assert meta["repair_possible"] is True
+    assert meta["repair_not_viable"] is False
+    assert "empty" not in meta
+
+    with pytest.raises(ValueError, match="Invalid repair_status"):
+        OrderService.normalize_repair_meta({"repair_status": "waiting_for_magic"})
+
+
+def test_service_repair_meta_preserves_canonical_and_refrigerant_fields():
+    meta = OrderService.normalize_repair_meta(
+        {
+            "customer_complaint": "Не запускается",
+            "complaint_official": "Отсутствие запуска оборудования",
+            "additional_conditions": "Работы после согласования.",
+            "customer_approval_status": "pending",
+            "customer_approval_note": "Ждет звонка.",
+            "parts_status": "ordered",
+            "refrigerant_type": " R32 ",
+            "refrigerant_amount": " 0,35 кг ",
+            "refrigerant_pricing_mode": " по фактической массе ",
+        },
+        default_status=OrderService.REPAIR_DEFAULT_STATUS,
+    )
+
+    assert meta["repair_status"] == "new"
+    assert meta["complaint_official"] == "Отсутствие запуска оборудования"
+    assert meta["additional_conditions"] == "Работы после согласования."
+    assert meta["customer_approval_status"] == "pending"
+    assert meta["customer_approval_note"] == "Ждет звонка."
+    assert meta["parts_status"] == "ordered"
+    assert meta["refrigerant_type"] == "R32"
+    assert meta["refrigerant_amount"] == "0,35 кг"
+    assert meta["refrigerant_pricing_mode"] == "по фактической массе"
+
+
+def test_service_repair_transition_helpers_complete_without_global_status_change():
+    order = Order(status=OrderStatus.NEW_LEAD, workflow_type="repair")
+
+    OrderService.set_repair_workflow_status(order, "new", {"customer_complaint": "Не охлаждает"})
+    OrderService.mark_repair_diagnostic_in_progress(order)
+    OrderService.record_repair_diagnostic_result(
+        order,
+        "Выявлена утечка хладагента.",
+        repair_recommendation="Устранить утечку и дозаправить контур.",
+        repair_possible="да",
+    )
+    OrderService.mark_repair_approved_for_repair(order, note="Клиент согласовал ремонт.")
+    OrderService.mark_repair_in_progress(order)
+    final_meta = OrderService.mark_repair_completed(order, note="Работы выполнены.")
+
+    assert order.status == OrderStatus.NEW_LEAD
+    assert final_meta["repair_status"] == "completed"
+    assert final_meta["customer_complaint"] == "Не охлаждает"
+    assert final_meta["diagnostic_result"] == "Выявлена утечка хладагента."
+    assert final_meta["repair_recommendation"] == "Устранить утечку и дозаправить контур."
+    assert final_meta["repair_possible"] is True
+    assert final_meta["customer_approval_status"] == "approved"
+    assert final_meta["repair_completion_note"] == "Работы выполнены."
+
+
+def test_service_repair_transition_helpers_support_not_repairable_path():
+    order = Order(status=OrderStatus.NEGOTIATION, workflow_type="repair")
+
+    OrderService.set_repair_workflow_status(order, "new", {"customer_complaint": "Не запускается"})
+    meta = OrderService.mark_repair_not_repairable(
+        order,
+        "Компрессор разрушен, ремонт экономически нецелесообразен.",
+        diagnostic_result="Диагностика подтвердила критический отказ компрессора.",
+    )
+
+    assert order.status == OrderStatus.NEGOTIATION
+    assert meta["repair_status"] == "not_repairable"
+    assert meta["repair_possible"] is False
+    assert meta["repair_not_viable"] is True
+    assert meta["repair_not_viable_reason"] == "Компрессор разрушен, ремонт экономически нецелесообразен."
+    assert meta["diagnostic_result"] == "Диагностика подтвердила критический отказ компрессора."
+
+
+def test_service_repair_transition_helpers_reject_non_repair_orders():
+    order = Order(status=OrderStatus.NEW_LEAD, workflow_type="sales_installation")
+
+    with pytest.raises(ValueError, match="repair orders"):
+        OrderService.mark_repair_in_progress(order)
 
 
 @pytest.mark.asyncio
@@ -186,6 +301,39 @@ async def test_service_update_order_for_manager_title_and_labels(db):
     assert cleared is not None
     assert cleared["title"] is None
     assert cleared["manager_labels"] == []
+
+
+@pytest.mark.asyncio
+async def test_service_non_repair_update_has_no_repair_side_effects(db):
+    customer = Customer(name="No Repair", phone="+375294444446", type=CustomerType.individual)
+    tariff = ServiceTariff(
+        service_kind="repair",
+        selector_label="Диагностика кондиционера",
+        estimate_template="Диагностика кондиционера",
+        category="diagnostic",
+        base_price=80,
+        is_active=True,
+    )
+    db.add(customer)
+    db.add(tariff)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD, workflow_type="sales_installation")
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    data = await OrderService.update_order_for_manager(
+        db,
+        order.id,
+        ManagerOrderUpdatePayload(comment="Обычная заявка без ремонта"),
+    )
+
+    assert data is not None
+    assert data["workflow_type"] == "sales_installation"
+    assert data["repair_meta"] == {}
+    assert data["service_lines"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #369. Stage 1 repair workflow now stays on the existing `Order + workflow_type=repair + technical_meta["repair"]` foundation instead of introducing a second repair model.

## Architecture

- Added an explicit service-layer repair workflow status contract in `OrderService` with enum-like allowed values and normalization for `repair_status`.
- Added repair meta normalization that trims/drops empty values, preserves canonical repair/AI draft fields, validates status values, and normalizes boolean-ish `repair_possible` / `repair_not_viable` inputs.
- Added backend-scoped transition helpers for diagnostic progress/result, awaiting approval, approved repair, repair in progress, awaiting parts, completed, and not repairable paths.
- Manager create/update now stores a default `repair_status=new` whenever the order workflow is repair, including when repair workflow is inferred from `service_type=repair`.
- Switching an existing order to repair still adds the default diagnostic service line through the existing tariff path, and the line is not duplicated on repeated repair updates.

## Repair meta vs global CRM status

Repair-specific state is stored only in `technical_meta["repair"]["repair_status"]`. It does not overwrite or replace global `Order.status` / Kanban status. The new transition helpers mutate repair meta only and leave global CRM status untouched.

## Tests

- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/unit/test_order_service_manager.py -q` -> 17 passed
- `BOT_TOKEN=test SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -k "repair or defect_act" -q` -> 7 passed, 28 deselected
- `BOT_TOKEN=test SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_defect_act_ai_service.py -q` -> 3 passed
- `python3 -m compileall services models routers schemas.py` -> passed
- `git diff --check` -> passed

## Generated artifacts

No generated API artifacts changed. I did not run OpenAPI/client regeneration because this PR does not change schemas, routes, operation IDs, or API response models.

## Residual risks

- The status contract is intentionally service-layer only in this PR; no manager UI timeline/forms are included.
- Existing stored repair meta with an invalid legacy `repair_status` is not migrated here; new saves reject invalid status values.