### PR TITLE
[codex] Route Telegram access through staff roles

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -1,16 +1,23 @@
 from aiogram import Router, types, F
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
-from core.config import settings
 from core.database import async_session_maker
 from services.product_service import ProductService
+from services.staff_user_service import StaffUserService
 from ..states import ShopState
 
 router = Router()
 
+
+async def _is_admin_user(user_id: int | None) -> bool:
+    async with async_session_maker() as session:
+        return await StaffUserService.is_active_owner_admin_telegram_user(session, user_id)
+
+
 @router.callback_query(F.data.startswith("edit_price_"))
 async def edit_price_start(callback: CallbackQuery, state: FSMContext):
-    if not settings.is_admin_user(callback.from_user.id): return
+    if not await _is_admin_user(callback.from_user.id):
+        return
     await state.update_data(product_id=callback.data.split("_")[-1])
     await state.set_state(ShopState.edit_price)
     await callback.message.answer("Новая цена (число):")
@@ -18,6 +25,10 @@ async def edit_price_start(callback: CallbackQuery, state: FSMContext):
 
 @router.message(ShopState.edit_price)
 async def edit_price_finish(message: types.Message, state: FSMContext):
+    if not await _is_admin_user(message.from_user.id if message.from_user else None):
+        await state.clear()
+        return
+
     if not message.text.isdigit():
         await message.answer("Цена должна быть числом.")
         return
@@ -36,7 +47,8 @@ async def edit_price_finish(message: types.Message, state: FSMContext):
 
 @router.callback_query(F.data.startswith("del_confirm_"))
 async def delete_item(callback: CallbackQuery):
-    if not settings.is_admin_user(callback.from_user.id): return
+    if not await _is_admin_user(callback.from_user.id):
+        return
     
     async with async_session_maker() as session:
         try:

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -6,9 +6,9 @@ from aiogram import Router, types, F
 from aiogram.filters import Command, StateFilter
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
-from core.config import settings
 from core.database import async_session_maker
 from services.product_service import ProductService
+from services.staff_user_service import StaffUserService
 from ..keyboards import area_selection_kb, type_selection_kb, winter_selection_kb, wifi_selection_kb
 from ..utils import send_product_card
 from ..states import ShopState
@@ -63,7 +63,11 @@ async def _render_search_results(message: types.Message, query: str, products: l
         f"🔎 Нашел {len(selected_products)} вариантов по запросу «{html.escape(query)}».",
         parse_mode="HTML",
     )
-    is_admin = settings.is_admin_user(message.from_user.id if message.from_user else None)
+    async with async_session_maker() as session:
+        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(
+            session,
+            message.from_user.id if message.from_user else None,
+        )
     for product in selected_products:
         await send_product_card(message, product, is_admin)
 
@@ -158,8 +162,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
             tag_slugs=tag_slugs if tag_slugs else None,
             limit=5  # Максимум 5 результатов
         )
-    
-    is_admin = settings.is_admin_user(callback.from_user.id)
+        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, callback.from_user.id)
     
     if not products:
         await callback.message.answer(
@@ -189,12 +192,12 @@ async def search_details(callback: CallbackQuery):
     product_id = int(callback.data.split("_")[-1])
     async with async_session_maker() as session:
         product = await ProductService.get_by_id(session, product_id)
+        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, callback.from_user.id)
 
     if not product:
         await callback.answer("Товар не найден", show_alert=True)
         return
 
-    is_admin = settings.is_admin_user(callback.from_user.id)
     await send_product_card(callback, product, is_admin)
     await callback.answer()
 

--- a/bot_app/handlers/favorites.py
+++ b/bot_app/handlers/favorites.py
@@ -1,8 +1,8 @@
 from aiogram import Router, types, F
 from aiogram.types import CallbackQuery
-from core.config import settings
 from core.database import async_session_maker
 from services.favorite_service import FavoriteService
+from services.staff_user_service import StaffUserService
 from ..utils import send_product_card, format_caption
 from ..keyboards import get_product_keyboard
 
@@ -14,13 +14,13 @@ async def show_favorites(message: types.Message):
     
     async with async_session_maker() as session:
         favs = await FavoriteService.get_favorites(session, user_id)
+        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, user_id)
     
     if not favs:
         await message.answer("У вас пока нет избранных товаров.")
         return
         
     await message.answer(f"⭐ Ваши избранные товары ({len(favs)}):")
-    is_admin = settings.is_admin_user(user_id)
     for product in favs:
         await send_product_card(message, product, is_admin)
 
@@ -31,11 +31,11 @@ async def process_fav_toggle(callback: CallbackQuery):
     
     async with async_session_maker() as session:
         is_added = await FavoriteService.toggle(session, user_id, product_id)
+        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, user_id)
     
     status_msg = "Добавлено в избранное! ❤️" if is_added else "Удалено из избранного. 💔"
     
     # Update the keyboard on the existing message
-    is_admin = settings.is_admin_user(user_id)
     new_kb = get_product_keyboard(product_id, is_admin, in_favorites=is_added)
     
     try:

--- a/core/config.py
+++ b/core/config.py
@@ -38,9 +38,18 @@ class Settings(BaseSettings):
     @property
     def admin_list(self) -> list[int]:
         ids = []
+        seen = set()
         if self.ADMIN_IDS:
-            ids.extend([int(x.strip()) for x in self.ADMIN_IDS.split(",") if x.strip()])
-        if self.ADMIN_ID and self.ADMIN_ID not in ids:
+            for raw_id in self.ADMIN_IDS.split(","):
+                value = raw_id.strip()
+                if not value:
+                    continue
+                admin_id = int(value)
+                if admin_id in seen:
+                    continue
+                seen.add(admin_id)
+                ids.append(admin_id)
+        if self.ADMIN_ID and int(self.ADMIN_ID) not in seen:
             ids.append(int(self.ADMIN_ID))
         return ids
 

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1333,6 +1333,7 @@ class OrderService:
         """
         from models import OrderInstaller, Installer
         from services.bot_service import BotService
+        from services.staff_user_service import StaffUserService
         
         # 1. Забираем текущие назначения чтобы понять, кто новый
         existing = await session.execute(select(OrderInstaller).where(OrderInstaller.order_id == order_id))
@@ -1382,9 +1383,13 @@ class OrderService:
             installers_to_notify = res.scalars().all()
             
             for inst in installers_to_notify:
-                if inst.telegram_id:
+                telegram_id = await StaffUserService.get_active_executor_telegram_id_for_legacy_installer(
+                    session,
+                    inst,
+                )
+                if telegram_id:
                     await BotService.notify_installer_new_order(
-                        installer_tg_id=inst.telegram_id,
+                        installer_tg_id=telegram_id,
                         order_id=order_id,
                         address=order.delivery_address or "Адрес не указан",
                         date_str=order.installation_date.strftime("%d.%m.%Y") if order.installation_date else "Не назначена",

--- a/services/staff_user_service.py
+++ b/services/staff_user_service.py
@@ -90,6 +90,10 @@ class StaffUserService:
         )
 
     @classmethod
+    def can_use_bot_admin(cls, staff_user: StaffUser) -> bool:
+        return cls.can_receive_admin_notifications(staff_user)
+
+    @classmethod
     def can_be_executor(cls, staff_user: StaffUser, role: str) -> bool:
         return cls.is_active(staff_user) and cls.has_role(staff_user, role)
 
@@ -149,6 +153,53 @@ class StaffUserService:
             recipient_ids.append(telegram_id)
 
         return recipient_ids or settings.admin_list
+
+    @classmethod
+    async def is_active_owner_admin_telegram_user(
+        cls,
+        session: AsyncSession,
+        telegram_id: int | str | None,
+    ) -> bool:
+        if telegram_id is None:
+            return False
+
+        try:
+            normalized_telegram_id = int(telegram_id)
+        except (TypeError, ValueError):
+            return False
+
+        try:
+            result = await session.execute(
+                select(StaffUser)
+                .where(StaffUser.telegram_id == normalized_telegram_id)
+                .order_by(StaffUser.id.asc())
+            )
+            users = list(result.scalars().all())
+        except Exception:
+            logger.debug("STAFF_ADMIN_CHECK_DB_LOOKUP_FAILED using legacy ADMIN_IDS fallback", exc_info=True)
+            return settings.is_admin_user(normalized_telegram_id)
+
+        if not users:
+            return settings.is_admin_user(normalized_telegram_id)
+
+        return any(cls.can_use_bot_admin(user) for user in users)
+
+    @classmethod
+    async def get_active_executor_telegram_id_for_legacy_installer(
+        cls,
+        session: AsyncSession,
+        installer: Installer,
+    ) -> int | None:
+        if installer.id is not None:
+            staff_user = await cls.get_by_legacy_installer_id(session, int(installer.id))
+            if staff_user is not None:
+                if not cls.can_be_any_executor(staff_user) or not staff_user.telegram_id:
+                    return None
+                return int(staff_user.telegram_id)
+
+        if not installer.is_active or not installer.telegram_id:
+            return None
+        return int(installer.telegram_id)
 
     @classmethod
     async def get_by_legacy_installer_id(

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -8,8 +8,9 @@ from bot_app.handlers import admin as admin_handler
 
 
 class _DummyMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str, user_id: int = 1):
         self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
         self.answer = AsyncMock()
         self.delete = AsyncMock()
 
@@ -52,6 +53,7 @@ def test_admin_handler_has_no_direct_dao_import():
 @pytest.mark.asyncio
 async def test_edit_price_finish_calls_service(monkeypatch):
     monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     service_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(admin_handler.ProductService, "update_price", service_mock)
 
@@ -67,8 +69,8 @@ async def test_edit_price_finish_calls_service(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete_item_uses_callback_answer(monkeypatch):
     monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
-    monkeypatch.setattr(admin_handler.settings, "ADMIN_ID", 0, raising=False)
-    monkeypatch.setattr(admin_handler.settings, "ADMIN_IDS", "1,2", raising=False)
+    admin_check = AsyncMock(return_value=True)
+    monkeypatch.setattr(admin_handler, "_is_admin_user", admin_check)
     service_mock = AsyncMock(return_value=False)
     monkeypatch.setattr(admin_handler.ProductService, "delete", service_mock)
 
@@ -76,4 +78,40 @@ async def test_delete_item_uses_callback_answer(monkeypatch):
     await admin_handler.delete_item(callback)
 
     service_mock.assert_awaited_once()
+    admin_check.assert_awaited_once_with(2)
     callback.answer.assert_awaited_with("Товар не найден", show_alert=True)
+
+
+@pytest.mark.asyncio
+async def test_delete_item_skips_service_for_non_admin(monkeypatch):
+    admin_check = AsyncMock(return_value=False)
+    monkeypatch.setattr(admin_handler, "_is_admin_user", admin_check)
+    service_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(admin_handler.ProductService, "delete", service_mock)
+
+    callback = _DummyCallback(data="del_confirm_10", user_id=3)
+    await admin_handler.delete_item(callback)
+
+    admin_check.assert_awaited_once_with(3)
+    service_mock.assert_not_called()
+    callback.answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_is_admin_user_uses_staff_service(monkeypatch):
+    session = object()
+
+    class _StaticSessionContext:
+        async def __aenter__(self):
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    admin_check = AsyncMock(return_value=True)
+    monkeypatch.setattr(admin_handler.StaffUserService, "is_active_owner_admin_telegram_user", admin_check)
+    monkeypatch.setattr(admin_handler, "async_session_maker", lambda: _StaticSessionContext())
+
+    assert await admin_handler._is_admin_user(7)
+    admin_check.assert_awaited_once()
+    assert admin_check.await_args.args == (session, 7)

--- a/tests/unit/test_installer_compatibility_service.py
+++ b/tests/unit/test_installer_compatibility_service.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -117,6 +118,40 @@ async def test_new_order_assignment_rejects_blocked_staff_user(sqlite_installer_
             order.id,
             [{"installer_id": installer.id, "agreed_pay": 100}],
         )
+
+
+@pytest.mark.asyncio
+async def test_new_order_assignment_notification_uses_active_staff_telegram_id(
+    sqlite_installer_session,
+    monkeypatch,
+):
+    installer = Installer(name="Active Installer", is_active=True, telegram_id=1001)
+    order = Order(delivery_address="Vitebsk")
+    sqlite_installer_session.add(installer)
+    sqlite_installer_session.add(order)
+    await sqlite_installer_session.flush()
+    sqlite_installer_session.add(
+        StaffUser(
+            display_name="Active Staff",
+            status="active",
+            roles=["installer"],
+            telegram_id=2001,
+            legacy_installer_id=installer.id,
+        )
+    )
+    await sqlite_installer_session.commit()
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr("services.bot_service.BotService.notify_installer_new_order", notify_mock)
+
+    await OrderService.update_order_installers(
+        sqlite_installer_session,
+        order.id,
+        [{"installer_id": installer.id, "agreed_pay": 100}],
+    )
+
+    notify_mock.assert_awaited_once()
+    assert notify_mock.await_args.kwargs["installer_tg_id"] == 2001
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_staff_user_service.py
+++ b/tests/unit/test_staff_user_service.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -87,6 +89,55 @@ async def test_admin_recipients_use_active_db_owner_admin_before_legacy_fallback
 
 
 @pytest.mark.asyncio
+async def test_telegram_admin_check_uses_active_owner_admin_and_blocks_non_admin_staff(
+    sqlite_staff_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "404,505", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+
+    sqlite_staff_session.add(StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101))
+    sqlite_staff_session.add(StaffUser(display_name="Admin", status="active", roles=["admin"], telegram_id=202))
+    sqlite_staff_session.add(StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=303))
+    sqlite_staff_session.add(StaffUser(display_name="Manager", status="active", roles=["manager"], telegram_id=404))
+    sqlite_staff_session.add(StaffUser(display_name="Inactive", status="inactive", roles=["owner"], telegram_id=505))
+    await sqlite_staff_session.commit()
+
+    assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 101)
+    assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 202)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 303)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 404)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 505)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 606)
+
+
+@pytest.mark.asyncio
+async def test_telegram_admin_check_keeps_legacy_fallback_when_no_staff_match(
+    sqlite_staff_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "707", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 808, raising=False)
+
+    sqlite_staff_session.add(StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101))
+    await sqlite_staff_session.commit()
+
+    assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 707)
+    assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 808)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 909)
+
+
+@pytest.mark.asyncio
+async def test_telegram_admin_check_falls_back_to_legacy_when_db_lookup_fails(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "909", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    session = SimpleNamespace(execute=AsyncMock(side_effect=RuntimeError("db down")))
+
+    assert await StaffUserService.is_active_owner_admin_telegram_user(session, 909)
+    assert not await StaffUserService.is_active_owner_admin_telegram_user(session, 101)
+
+
+@pytest.mark.asyncio
 async def test_admin_recipients_fall_back_to_legacy_admin_ids_when_db_has_none(sqlite_staff_session, monkeypatch):
     monkeypatch.setattr(settings, "ADMIN_IDS", "901,902", raising=False)
     monkeypatch.setattr(settings, "ADMIN_ID", 903, raising=False)
@@ -112,3 +163,52 @@ async def test_ensure_for_installer_creates_compatibility_staff_user(sqlite_staf
     assert staff_user.status == "active"
     assert staff_user.roles == ["installer"]
     assert staff_user.telegram_id == 777
+
+
+@pytest.mark.asyncio
+async def test_executor_notification_telegram_prefers_active_staff_and_skips_blocked(
+    sqlite_staff_session,
+):
+    active = Installer(name="Active Legacy", is_active=True, telegram_id=1001)
+    blocked = Installer(name="Blocked Legacy", is_active=True, telegram_id=1002)
+    orphan = Installer(name="Orphan Legacy", is_active=True, telegram_id=1003)
+    inactive_orphan = Installer(name="Inactive Orphan", is_active=False, telegram_id=1004)
+    sqlite_staff_session.add_all([active, blocked, orphan, inactive_orphan])
+    await sqlite_staff_session.flush()
+
+    sqlite_staff_session.add(
+        StaffUser(
+            display_name="Active Staff",
+            status="active",
+            roles=["installer"],
+            telegram_id=2001,
+            legacy_installer_id=active.id,
+        )
+    )
+    sqlite_staff_session.add(
+        StaffUser(
+            display_name="Blocked Staff",
+            status="blocked",
+            roles=["installer"],
+            telegram_id=2002,
+            legacy_installer_id=blocked.id,
+        )
+    )
+    await sqlite_staff_session.commit()
+
+    assert await StaffUserService.get_active_executor_telegram_id_for_legacy_installer(
+        sqlite_staff_session,
+        active,
+    ) == 2001
+    assert await StaffUserService.get_active_executor_telegram_id_for_legacy_installer(
+        sqlite_staff_session,
+        blocked,
+    ) is None
+    assert await StaffUserService.get_active_executor_telegram_id_for_legacy_installer(
+        sqlite_staff_session,
+        orphan,
+    ) == 1003
+    assert await StaffUserService.get_active_executor_telegram_id_for_legacy_installer(
+        sqlite_staff_session,
+        inactive_orphan,
+    ) is None


### PR DESCRIPTION
## Summary
- Add StaffUser role/status-aware Telegram admin access checks for active `owner`/`admin` staff.
- Replace legacy direct bot checks in `bot_app/handlers/admin.py`, `bot_app/handlers/catalog.py`, and `bot_app/handlers/favorites.py` with the StaffUser-backed path.
- Prefer active StaffUser executor Telegram IDs for new installer assignment notifications and skip inactive/blocked staff when StaffUser state exists.
- Deduplicate legacy `ADMIN_ID`/`ADMIN_IDS` fallback IDs while keeping the env fallback for bootstrap/emergency use.

## Legacy fallback
- `ADMIN_ID` / `ADMIN_IDS` remain the fallback inside `StaffUserService.is_active_owner_admin_telegram_user(...)` when DB lookup fails or no StaffUser record matches the Telegram ID.
- Admin notification recipient fallback remains in `StaffUserService.get_active_owner_admin_telegram_recipient_ids(...)` when no active owner/admin StaffUser Telegram recipients are configured.
- If a matching StaffUser exists, bot admin access now requires active `owner`/`admin`; inactive/blocked or manager-only staff do not pass through the legacy fallback accidentally.

## Replaced direct checks
- `bot_app/handlers/admin.py`: edit price start, edit price finish, delete confirm.
- `bot_app/handlers/catalog.py`: search result card rendering, smart selection results, product details card rendering.
- `bot_app/handlers/favorites.py`: favorites list card rendering and favorite toggle keyboard refresh.

## Validation
- `env BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=pass pytest tests/unit/test_staff_user_service.py -q`
- `env BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=pass pytest tests/unit/test_notification_service.py -q`
- `env BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=pass pytest tests/unit/test_bot_admin_handler.py -q`
- `env BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=pass pytest tests/unit/test_installer_compatibility_service.py -q`
- `python3 -m compileall services bot_app core routers schemas.py`
- `git diff --check`

Initial pytest runs without those four required local env vars failed during Settings collection; rerunning with test values passed.

## Residual risk
- Bot handlers now perform DB-backed access checks in more user-facing card-rendering paths, so runtime session availability should be watched after deploy. The helper keeps legacy env fallback on DB lookup failure.
- No API route/schema changes were made; manager OpenAPI/client regeneration should not be needed.

Refs #368
Refs #339