### PR TITLE
[codex] Use approved storefront image variants

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Brand, Product, Tag, TagGroup, ProductTagLink
+from models import Brand, Product, ProductImage, Tag, TagGroup, ProductTagLink
 from models.product_constants import BTU_MAPPING
 from models.supplier import ProductLocalStock, ProductSupplierMapping, SupplierOffer
 
@@ -34,41 +34,67 @@ CATALOG_RANKING_WEIGHTS = {
 
 class ProductDAO:
     @staticmethod
-    async def get_by_id(session: AsyncSession, product_id: int) -> Optional[Product]:
+    def _gallery_images_option(*, load_image_variants: bool = False):
+        option = selectinload(Product.gallery_images)
+        if load_image_variants:
+            return option.selectinload(ProductImage.variants)
+        return option
+
+    @staticmethod
+    async def get_by_id(
+        session: AsyncSession,
+        product_id: int,
+        *,
+        load_image_variants: bool = False,
+    ) -> Optional[Product]:
         stmt = select(Product).where(Product.id == product_id).options(
             selectinload(Product.tags).selectinload(Tag.group),
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def get_by_slug(session: AsyncSession, slug: str) -> Optional[Product]:
+    async def get_by_slug(
+        session: AsyncSession,
+        slug: str,
+        *,
+        load_image_variants: bool = False,
+    ) -> Optional[Product]:
         stmt = select(Product).where(Product.slug == slug).options(
             selectinload(Product.tags).selectinload(Tag.group),
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def get_all_published(session: AsyncSession) -> List[Product]:
+    async def get_all_published(
+        session: AsyncSession,
+        *,
+        load_image_variants: bool = False,
+    ) -> List[Product]:
         stmt = select(Product).where(Product.is_published == True).options(
             selectinload(Product.tags).selectinload(Tag.group),
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
 
     @staticmethod
-    async def get_by_ids(session: AsyncSession, product_ids: List[int]) -> List[Product]:
+    async def get_by_ids(
+        session: AsyncSession,
+        product_ids: List[int],
+        *,
+        load_image_variants: bool = False,
+    ) -> List[Product]:
         if not product_ids:
             return []
         stmt = select(Product).where(Product.id.in_(product_ids)).options(
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
         result = await session.execute(stmt)
@@ -418,10 +444,11 @@ class ProductDAO:
         limit: int = 20,
         faceted_tag_ids: Optional[dict[int, list[int]]] = None,
         search_query: Optional[str] = None,
+        load_image_variants: bool = False,
     ) -> List[Product]:
         stmt = select(Product).options(
             selectinload(Product.tags).selectinload(Tag.group),
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
 
@@ -577,7 +604,7 @@ class ProductDAO:
     ) -> tuple[List[Product], int]:
         normalized_category_status = (category_status or "").strip().lower()
         stmt = select(Product).options(
-            selectinload(Product.gallery_images),
+            ProductDAO._gallery_images_option(),
             selectinload(Product.tags).selectinload(Tag.group),
             selectinload(Product.attachments),
         )

--- a/manager_frontend/src/client/models/ProductImageResponse.ts
+++ b/manager_frontend/src/client/models/ProductImageResponse.ts
@@ -6,5 +6,7 @@ export type ProductImageResponse = {
     id: number;
     url: string;
     is_installation_photo: boolean;
+    card_variant_url?: (string | null);
+    full_variant_url?: (string | null);
 };
 

--- a/manager_frontend/src/client/models/ProductResponse.ts
+++ b/manager_frontend/src/client/models/ProductResponse.ts
@@ -16,6 +16,8 @@ export type ProductResponse = {
     is_inverter: boolean;
     power_cooling: (number | null);
     main_image: (string | null);
+    card_image?: (string | null);
+    full_image?: (string | null);
     is_published: boolean;
     created_at: string;
     vitebsk_qty?: number;

--- a/openapi.json
+++ b/openapi.json
@@ -23004,6 +23004,28 @@
           "is_installation_photo": {
             "type": "boolean",
             "title": "Is Installation Photo"
+          },
+          "card_variant_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Card Variant Url"
+          },
+          "full_variant_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Variant Url"
           }
         },
         "type": "object",
@@ -23512,6 +23534,28 @@
               }
             ],
             "title": "Main Image"
+          },
+          "card_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Card Image"
+          },
+          "full_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Image"
           },
           "is_published": {
             "type": "boolean",

--- a/schemas.py
+++ b/schemas.py
@@ -47,6 +47,8 @@ class ProductBase(BaseModel):
     is_inverter: bool
     power_cooling: Optional[float]
     main_image: Optional[str]
+    card_image: Optional[str] = None
+    full_image: Optional[str] = None
     is_published: bool
     created_at: datetime
 
@@ -68,6 +70,8 @@ class ProductImageResponse(BaseModel):
     id: int
     url: str
     is_installation_photo: bool
+    card_variant_url: Optional[str] = None
+    full_variant_url: Optional[str] = None
 
 
 class ProductManualResponse(BaseModel):

--- a/services/catalog.py
+++ b/services/catalog.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Product, Tag
+from models import Product, ProductImage, Tag
 from models.supplier import ProductLocalStock
 
 
@@ -32,7 +32,7 @@ class CatalogService:
             .join(ProductLocalStock, Product.id == ProductLocalStock.product_id)
             .options(
                 selectinload(Product.tags).selectinload(Tag.group),
-                selectinload(Product.gallery_images),
+                selectinload(Product.gallery_images).selectinload(ProductImage.variants),
                 selectinload(Product.attachments),
             )
             .where(

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -98,6 +98,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
             limit=limit,
             is_published=True,
             search_query=search,
+            load_image_variants=True,
         )
         total = await ProductDAO.count_filtered(
             session,
@@ -205,10 +206,18 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
     @staticmethod
     async def get_product_by_identifier(session: AsyncSession, identifier: str) -> Optional[Product]:
         if identifier.isdigit():
-            product = await ProductDAO.get_by_id(session, int(identifier))
+            product = await ProductDAO.get_by_id(
+                session,
+                int(identifier),
+                load_image_variants=True,
+            )
             if product:
                 return product
-        return await ProductDAO.get_by_slug(session, identifier)
+        return await ProductDAO.get_by_slug(
+            session,
+            identifier,
+            load_image_variants=True,
+        )
 
     @staticmethod
     async def get_all(session: AsyncSession) -> List[Dict[str, Any]]:

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -11,7 +11,51 @@ from schemas import (
     TagGroupResponse,
     TagResponse,
 )
+from services.product_image_processing_contract import (
+    ProductImageManualQualityStatus,
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
 from services.product_serialization import parse_legacy_images, sanitize_specs
+
+
+def _is_same_image_url(left: Optional[str], right: Optional[str]) -> bool:
+    if not left or not right:
+        return False
+    return left == right or left.strip("/") == right.strip("/")
+
+
+def _approved_ready_variant_url(image: Any, variant_type: ProductImageVariantType) -> Optional[str]:
+    for variant in getattr(image, "variants", None) or []:
+        if (
+            variant.variant_type == variant_type.value
+            and variant.processing_status == ProductImageProcessingStatus.READY.value
+            and variant.manual_quality_status == ProductImageManualQualityStatus.APPROVED.value
+            and variant.url
+        ):
+            return variant.url
+    return None
+
+
+def _main_image_variant_or_fallback(
+    product: Product,
+    variant_type: ProductImageVariantType,
+) -> Optional[str]:
+    if not product.main_image:
+        return None
+
+    source_image = next(
+        (
+            image
+            for image in (product.gallery_images or [])
+            if _is_same_image_url(image.url, product.main_image)
+        ),
+        None,
+    )
+    if not source_image:
+        return product.main_image
+
+    return _approved_ready_variant_url(source_image, variant_type) or product.main_image
 
 
 def map_product_to_response(
@@ -52,6 +96,14 @@ def map_product_to_response(
                     id=img.id,
                     url=img.url,
                     is_installation_photo=img.is_installation_photo,
+                    card_variant_url=_approved_ready_variant_url(
+                        img,
+                        ProductImageVariantType.CARD,
+                    ),
+                    full_variant_url=_approved_ready_variant_url(
+                        img,
+                        ProductImageVariantType.FULL,
+                    ),
                 )
             )
 
@@ -91,6 +143,8 @@ def map_product_to_response(
         is_inverter=product.is_inverter,
         power_cooling=product.power_cooling,
         main_image=product.main_image,
+        card_image=_main_image_variant_or_fallback(product, ProductImageVariantType.CARD),
+        full_image=_main_image_variant_or_fallback(product, ProductImageVariantType.FULL),
         is_published=product.is_published,
         created_at=product.created_at,
         vitebsk_qty=int((supply_metrics or {}).get("vitebsk_qty", 0) or 0),

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -1,8 +1,13 @@
 import pytest
 from httpx import AsyncClient
 from datetime import datetime, timedelta
-from models import Brand, Product
+from models import Brand, Product, ProductImage, ProductImageVariant
 from crud.supplier import ProductLocalStockDAO
+from services.product_image_processing_contract import (
+    ProductImageManualQualityStatus,
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
 from services.spec_normalizer import normalize_specs
 
 @pytest.fixture
@@ -44,6 +49,71 @@ async def test_product_detail(async_client: AsyncClient, seed_product):
     assert data["id"] == seed_product.id
     assert data["title"] == seed_product.title
     assert data["slug"] == seed_product.slug
+
+
+@pytest.mark.asyncio
+async def test_public_product_payload_exposes_approved_ready_image_variants(async_client: AsyncClient, db):
+    product = Product(
+        title="Approved Variant Product",
+        slug="approved-variant-product",
+        price=1500,
+        area=25,
+        is_published=True,
+        main_image="/media/products/source.webp",
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    image = ProductImage(
+        product_id=product.id,
+        url="/media/products/source.webp",
+        is_installation_photo=False,
+    )
+    db.add(image)
+    await db.commit()
+    await db.refresh(image)
+
+    db.add_all(
+        [
+            ProductImageVariant(
+                product_image_id=image.id,
+                variant_type=ProductImageVariantType.CARD.value,
+                url="/media/products/variants/card/source.webp",
+                processing_status=ProductImageProcessingStatus.READY.value,
+                manual_quality_status=ProductImageManualQualityStatus.APPROVED.value,
+            ),
+            ProductImageVariant(
+                product_image_id=image.id,
+                variant_type=ProductImageVariantType.FULL.value,
+                url="/media/products/variants/full/source.webp",
+                processing_status=ProductImageProcessingStatus.READY.value,
+                manual_quality_status=ProductImageManualQualityStatus.APPROVED.value,
+            ),
+        ]
+    )
+    await db.commit()
+
+    catalog_response = await async_client.get("/api/v1/products", params={"limit": 20})
+    assert catalog_response.status_code == 200, catalog_response.text
+    catalog_item = next(
+        item
+        for item in catalog_response.json()["items"]
+        if item["slug"] == product.slug
+    )
+    assert catalog_item["main_image"] == "/media/products/source.webp"
+    assert catalog_item["card_image"] == "/media/products/variants/card/source.webp"
+    assert catalog_item["full_image"] == "/media/products/variants/full/source.webp"
+
+    detail_response = await async_client.get(f"/api/v1/products/{product.slug}")
+    assert detail_response.status_code == 200, detail_response.text
+    detail = detail_response.json()
+    assert detail["main_image"] == "/media/products/source.webp"
+    assert detail["card_image"] == "/media/products/variants/card/source.webp"
+    assert detail["full_image"] == "/media/products/variants/full/source.webp"
+    assert detail["gallery_images"][0]["url"] == "/media/products/source.webp"
+    assert detail["gallery_images"][0]["card_variant_url"] == "/media/products/variants/card/source.webp"
+    assert detail["gallery_images"][0]["full_variant_url"] == "/media/products/variants/full/source.webp"
 
 @pytest.mark.asyncio
 async def test_product_not_found(async_client: AsyncClient):

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -1,0 +1,129 @@
+import pytest
+
+from models import Product, ProductImage, ProductImageVariant
+from services.product_image_processing_contract import (
+    ProductImageManualQualityStatus,
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
+from services.product_response_mapper import map_product_to_response
+
+
+def _product_with_variant(
+    *,
+    variant_type: ProductImageVariantType = ProductImageVariantType.CARD,
+    processing_status: str = ProductImageProcessingStatus.READY.value,
+    manual_quality_status: str = ProductImageManualQualityStatus.APPROVED.value,
+    variant_url: str | None = "/media/products/variants/card/source.webp",
+) -> Product:
+    product = Product(
+        id=1,
+        title="Variant Product",
+        slug="variant-product",
+        description="",
+        price=1200,
+        area=25,
+        main_image="/media/products/source.webp",
+        is_published=True,
+    )
+    source_image = ProductImage(
+        id=10,
+        product_id=product.id,
+        url="/media/products/source.webp",
+        is_installation_photo=False,
+    )
+    source_image.variants = [
+        ProductImageVariant(
+            id=100,
+            product_image_id=source_image.id,
+            variant_type=variant_type.value,
+            url=variant_url,
+            processing_status=processing_status,
+            manual_quality_status=manual_quality_status,
+        )
+    ]
+    product.gallery_images = [source_image]
+    return product
+
+
+def test_map_product_to_response_selects_only_approved_ready_card_and_full_variants():
+    product = _product_with_variant()
+    product.gallery_images[0].variants.append(
+        ProductImageVariant(
+            id=101,
+            product_image_id=product.gallery_images[0].id,
+            variant_type=ProductImageVariantType.FULL.value,
+            url="/media/products/variants/full/source.webp",
+            processing_status=ProductImageProcessingStatus.READY.value,
+            manual_quality_status=ProductImageManualQualityStatus.APPROVED.value,
+        )
+    )
+
+    payload = map_product_to_response(product)
+
+    assert payload.main_image == "/media/products/source.webp"
+    assert payload.card_image == "/media/products/variants/card/source.webp"
+    assert payload.full_image == "/media/products/variants/full/source.webp"
+    assert payload.gallery_images[0].url == "/media/products/source.webp"
+    assert payload.gallery_images[0].card_variant_url == "/media/products/variants/card/source.webp"
+    assert payload.gallery_images[0].full_variant_url == "/media/products/variants/full/source.webp"
+
+
+@pytest.mark.parametrize(
+    ("processing_status", "manual_quality_status", "variant_url"),
+    [
+        (ProductImageProcessingStatus.PROCESSING.value, ProductImageManualQualityStatus.APPROVED.value, "/card.webp"),
+        (ProductImageProcessingStatus.FAILED.value, ProductImageManualQualityStatus.APPROVED.value, "/card.webp"),
+        (ProductImageProcessingStatus.SKIPPED.value, ProductImageManualQualityStatus.APPROVED.value, "/card.webp"),
+        (ProductImageProcessingStatus.READY.value, ProductImageManualQualityStatus.UNREVIEWED.value, "/card.webp"),
+        (ProductImageProcessingStatus.READY.value, ProductImageManualQualityStatus.REJECTED.value, "/card.webp"),
+        (ProductImageProcessingStatus.READY.value, ProductImageManualQualityStatus.APPROVED.value, None),
+    ],
+)
+def test_map_product_to_response_falls_back_when_variant_is_not_public(
+    processing_status,
+    manual_quality_status,
+    variant_url,
+):
+    product = _product_with_variant(
+        processing_status=processing_status,
+        manual_quality_status=manual_quality_status,
+        variant_url=variant_url,
+    )
+
+    payload = map_product_to_response(product)
+
+    assert payload.card_image == "/media/products/source.webp"
+    assert payload.full_image == "/media/products/source.webp"
+    assert payload.gallery_images[0].card_variant_url is None
+    assert payload.gallery_images[0].full_variant_url is None
+
+
+def test_map_product_to_response_keeps_legacy_product_without_variants_unchanged():
+    product = Product(
+        id=1,
+        title="Legacy Product",
+        slug="legacy-product",
+        description="",
+        price=1200,
+        area=25,
+        main_image="/media/products/legacy.webp",
+        is_published=True,
+    )
+    product.gallery_images = [
+        ProductImage(
+            id=10,
+            product_id=product.id,
+            url="/media/products/legacy.webp",
+            is_installation_photo=False,
+        )
+    ]
+
+    payload = map_product_to_response(product)
+
+    assert payload.main_image == "/media/products/legacy.webp"
+    assert payload.card_image == "/media/products/legacy.webp"
+    assert payload.full_image == "/media/products/legacy.webp"
+    assert payload.gallery_images[0].url == "/media/products/legacy.webp"
+    assert payload.gallery_images[0].card_variant_url is None
+    assert payload.gallery_images[0].full_variant_url is None

--- a/web/src/components/ProductCard.astro
+++ b/web/src/components/ProductCard.astro
@@ -8,6 +8,7 @@ interface Props {
     price: number;
     slug: string;
     main_image?: string;
+    card_image?: string | null;
     description?: string; // For hero card
     id?: number;
     vitebsk_qty?: number;
@@ -56,6 +57,7 @@ const pricingProps = {
 };
 
 const formatPrice = (price: number) => price.toLocaleString();
+const productCardImage = product.card_image || product.main_image;
 
 // --- Logic for Tags & Badges ---
 
@@ -133,7 +135,7 @@ const showAreaBadge = !!product.area;
     <div class="product-item card group">
       <a href={`/product/${product.slug}`} class="p-img-box">
         <img
-          src={resolveImageUrl(product.main_image)}
+          src={resolveImageUrl(productCardImage)}
           alt={product.title}
           width="640"
           height="480"
@@ -199,7 +201,7 @@ const showAreaBadge = !!product.area;
             id={product.slug}
             productId={product.id}
             title={product.title}
-            image={resolveImageUrl(product.main_image)}
+            image={resolveImageUrl(productCardImage)}
             vitebskQty={product.vitebsk_qty}
             minskQty={product.minsk_qty}
             availabilityStatus={product.availability_status}
@@ -216,7 +218,7 @@ const showAreaBadge = !!product.area;
   variant === "hero" && (
     <div class="featured-card">
       <img
-        src={resolveImageUrl(product.main_image)}
+        src={resolveImageUrl(productCardImage)}
         alt={product.title}
         class="featured-img"
         width="960"
@@ -263,7 +265,7 @@ const showAreaBadge = !!product.area;
             id={product.slug}
             productId={product.id}
             title={product.title}
-            image={resolveImageUrl(product.main_image)}
+            image={resolveImageUrl(productCardImage)}
             vitebskQty={product.vitebsk_qty}
             minskQty={product.minsk_qty}
             availabilityStatus={product.availability_status}
@@ -281,7 +283,7 @@ const showAreaBadge = !!product.area;
     <a href={`/product/${product.slug}`} class="minimal-card card">
       <div class="m-img-box">
         <img
-          src={resolveImageUrl(product.main_image)}
+          src={resolveImageUrl(productCardImage)}
           alt={product.title}
           width="128"
           height="128"
@@ -340,6 +342,7 @@ const showAreaBadge = !!product.area;
     max-height: 100%;
     object-fit: contain;
     transition: transform 0.4s;
+    filter: drop-shadow(0 12px 14px rgb(15 23 42 / 0.1));
   }
   .product-item:hover .p-img-box img {
     transform: scale(1.1);
@@ -511,6 +514,7 @@ const showAreaBadge = !!product.area;
     object-fit: contain;
     padding: 2.5rem; /* More generous padding */
     background: var(--bg);
+    filter: drop-shadow(0 14px 18px rgb(15 23 42 / 0.1));
   }
   .featured-info {
     padding: 2rem;

--- a/web/src/components/ProductCard.vue
+++ b/web/src/components/ProductCard.vue
@@ -108,13 +108,14 @@ const displayFeatureTags = computed(() => {
 
 // Fallback for legacy props if no tags present
 const showAreaBadge = computed(() => Boolean(props.product.area));
+const productCardImage = computed(() => props.product.card_image || props.product.main_image);
 </script>
 
 <template>
   <div v-if="variant === 'default'" class="product-item card group">
     <a :href="`/product/${product.slug}`" class="product-link">
       <div class="p-img-box">
-        <img :src="resolveImageUrl(product.main_image)" :alt="product.title" />
+        <img :src="resolveImageUrl(productCardImage)" :alt="product.title" />
 
         <!-- Top Left: Functionality Badges + Inverter -->
         <div class="p-badge-list">
@@ -157,7 +158,7 @@ const showAreaBadge = computed(() => Boolean(props.product.area));
           :id="product.slug"
           :productId="product.id"
           :title="product.title"
-          :image="resolveImageUrl(product.main_image)"
+          :image="resolveImageUrl(productCardImage)"
           :vitebskQty="product.vitebsk_qty"
           :minskQty="product.minsk_qty"
           :availabilityStatus="product.availability_status"
@@ -201,6 +202,7 @@ const showAreaBadge = computed(() => Boolean(props.product.area));
     max-height: 100%;
     object-fit: contain;
     transition: transform 0.4s;
+    filter: drop-shadow(0 12px 14px rgb(15 23 42 / 0.1));
   }
   .product-item:hover .p-img-box img {
     transform: scale(1.1);

--- a/web/src/components/product/Gallery.vue
+++ b/web/src/components/product/Gallery.vue
@@ -7,6 +7,7 @@
         alt="Product Image"
         class="main-img"
         @click="zoomImage"
+        @error="handleImageError(activeImage)"
       />
       <div v-else class="image-placeholder">
           <span class="material-icons-round placeholder-icon">image_not_supported</span>
@@ -91,18 +92,18 @@ const zoomImage = () => {
   position: relative;
   width: 100%;
   aspect-ratio: 4/3.5; /* Keeping it slightly rectangular */
-  background: var(--surface, #fff);
+  background: var(--surface);
   border-radius: 2rem;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.03);
+  box-shadow: var(--panel-glass-shadow);
   border: 1px solid var(--border);
 }
 
 :global(.dark) .main-image-wrapper {
-    background: rgba(255,255,255,0.02);
+    background: var(--panel-chip-bg);
 }
 
 .main-img {
@@ -112,6 +113,7 @@ const zoomImage = () => {
   transition: transform 0.3s ease;
   cursor: zoom-in;
   padding: 1.5rem;
+  filter: drop-shadow(0 16px 18px rgb(15 23 42 / 0.12));
 }
 
 .main-img:hover {
@@ -151,7 +153,7 @@ const zoomImage = () => {
   overflow: hidden;
   border: 2px solid transparent;
   cursor: pointer;
-  background: var(--surface, white);
+  background: var(--surface);
   transition: all 0.2s ease;
   border: 1px solid var(--border);
   user-select: none;
@@ -165,7 +167,7 @@ const zoomImage = () => {
 }
 
 .thumb-item.active {
-  border-color: #007f80; /* Teal Brand Color */
+  border-color: var(--primary);
   transform: translateY(-2px);
   box-shadow: 0 4px 10px rgba(0, 127, 128, 0.2);
 }

--- a/web/src/pages/catalog.astro
+++ b/web/src/pages/catalog.astro
@@ -95,6 +95,7 @@ interface Product {
     price: number;
     slug: string;
     main_image?: string;
+    card_image?: string | null;
     description?: string;
     vitebsk_qty?: number;
     minsk_qty?: number;

--- a/web/src/pages/catalog/[virtual].astro
+++ b/web/src/pages/catalog/[virtual].astro
@@ -21,6 +21,7 @@ interface Product {
     price: number;
     slug: string;
     main_image?: string;
+    card_image?: string | null;
     description?: string;
     vitebsk_qty?: number;
     minsk_qty?: number;

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -48,12 +48,12 @@ const manuals = (product.manuals || [])
     }))
     .filter((item: any) => Boolean(item.url));
 const galleryUrls = product.gallery_images?.length
-    ? product.gallery_images.map((img: any) => img.url)
+    ? product.gallery_images.map((img: any) => img.full_variant_url || img.url)
     : [];
 
 // 3. Собираем всё вместе: Главное фото + Галерея
 // Исключаем legacy product.images так как они низкого качества
-const images = [product.main_image, ...galleryUrls]
+const images = [product.full_image || product.main_image, ...galleryUrls]
     .filter(Boolean) // Убираем null/undefined
     .map(resolveImageUrl); // Превращаем в полные ссылки
 
@@ -875,11 +875,11 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
 
     /* 🌙 ТЕМНАЯ ТЕМА (Dark Mode) - если используешь класс .dark на <html> или <body> */
     .dark {
-        --dim-stroke: rgba(255, 255, 255, 0.65);
-        --dim-stroke-light: rgba(255, 255, 255, 0.35);
-        --dim-fill-body: rgba(255, 255, 255, 0.08);
-        --dim-fill-accent: rgba(255, 255, 255, 0.12);
-        --dim-text: rgba(255, 255, 255, 0.92);
+        --dim-stroke: var(--text-muted);
+        --dim-stroke-light: var(--border);
+        --dim-fill-body: var(--panel-pill-bg);
+        --dim-fill-accent: var(--panel-input-bg);
+        --dim-text: var(--text);
     }
 
     /* ✨ Добавим плавность при переключении темы */
@@ -991,9 +991,9 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
     }
 
     .dark .badge {
-        background: rgba(255, 255, 255, 0.05);
-        color: rgba(255, 255, 255, 0.7);
-        border-color: rgba(255, 255, 255, 0.1);
+        background: var(--panel-pill-bg);
+        color: var(--text-muted);
+        border-color: var(--panel-chip-border);
     }
     .dark .badge.primary {
         background: rgba(45, 212, 191, 0.12);

--- a/web/src/store/cart.ts
+++ b/web/src/store/cart.ts
@@ -169,7 +169,7 @@ export async function refreshPrices() {
                     price: fresh.price,
                     productId: fresh.id, // Update numeric ID just in case
                     name: fresh.title, // Sync name if changed
-                    image: fresh.main_image // Sync image
+                    image: fresh.card_image || fresh.main_image // Sync image
                 };
             }
             return item;

--- a/web/src/utils/catalog-seo.ts
+++ b/web/src/utils/catalog-seo.ts
@@ -4,6 +4,7 @@ type CatalogSeoProduct = {
     slug?: string | null;
     price?: number | null;
     main_image?: string | null;
+    card_image?: string | null;
     availability_status?: string | null;
     vitebsk_qty?: number | null;
     minsk_qty?: number | null;
@@ -38,7 +39,7 @@ export function buildCatalogItemListSchema(products: CatalogSeoProduct[], origin
                 "@type": "Product",
                 name: product.title,
                 url: absoluteUrl(product.slug ? `/product/${product.slug}` : undefined, origin),
-                image: absoluteUrl(product.main_image, origin),
+                image: absoluteUrl(product.card_image || product.main_image, origin),
                 sku: product.id ? String(product.id) : undefined,
                 offers: {
                     "@type": "Offer",


### PR DESCRIPTION
## Summary
- Adds public image selection fields so the storefront can prefer manager-approved processed variants without mutating legacy image fields.
- Updates catalog cards to use `card_image` and product gallery/detail flows to use approved `full` variants with legacy fallbacks.
- Keeps legacy products and non-approved/failed/processing variants on the existing `main_image` / `ProductImage.url` path.

## Public API / DTO Choice
- `ProductResponse` / `ProductBase` now expose `card_image` and `full_image`.
  - These are resolved display URLs: approved ready variant URL when eligible, otherwise the current `main_image` fallback.
  - `main_image` remains unchanged for backward compatibility.
- `ProductImageResponse` now exposes `card_variant_url` and `full_variant_url`.
  - These fields contain only eligible variant URLs, or `null`.
  - Storefront gallery uses `full_variant_url || url`, so `gallery_images[].url` remains the stable fallback.
- `openapi.json` and generated manager client model types were updated by the pre-commit API sync hook.

## Variant Eligibility Rule
A variant is public only when all of these are true:
- `variant_type` matches the requested type (`card` for catalog/cards, `full` for product page/gallery)
- `processing_status == "ready"`
- `manual_quality_status == "approved"`
- `url` is present

Unreviewed, rejected, failed, skipped, processing, missing-url, and absent variants are ignored by the storefront.

## Storefront Files Changed
- `web/src/components/ProductCard.astro`
- `web/src/components/ProductCard.vue`
- `web/src/components/product/Gallery.vue`
- `web/src/pages/catalog.astro`
- `web/src/pages/catalog/[virtual].astro`
- `web/src/pages/product/[slug].astro`
- `web/src/store/cart.ts`
- `web/src/utils/catalog-seo.ts`

## Tests / Checks
- `pytest tests/unit/test_product_response_mapper_variants.py -q` ✅
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_catalog_api.py::test_public_product_payload_exposes_approved_ready_image_variants -q` ✅
- `python3 -m compileall services routers schemas.py` ✅
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin python3 scripts/legacy/extract_openapi.py` ✅
- `bash scripts/audit_theme_hardcodes.sh` ✅ (remaining output is pre-existing untouched files)
- `INTERNAL_API_URL=http://localhost:8000/api/v1 PUBLIC_API_URL=http://localhost:8000 npm run build` from `web/` ✅
- Browser smoke on `http://localhost:4321/catalog/` and `/product/mdsops09hrfn8` ✅
  - catalog cards rendered on desktop/mobile
  - product gallery rendered
  - thumbnail click changed the active gallery image
  - no current-origin console errors during smoke

## Residual Risk
- The local catalog database had no products with approved variants, so browser QA exercised the legacy fallback visual path. Mapper and API tests cover approved variant selection with synthetic data.
- Products without approved variants continue to render current legacy images until manager approval is completed.

Closes #373