### PR TITLE
[codex] Add manager equipment history UI

### DIFF
--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -22,8 +22,12 @@ import type {
   BankReceiptResponse,
   FxRateResponse,
   ManagerRepairComplaintPresetResponse,
+  EquipmentServiceEventType,
+  ManagerEquipmentDetailResponse,
+  ManagerEquipmentItemResponse,
+  ManagerEquipmentHistoryFromRepairOrderPayload,
 } from '../../client';
-import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService } from '../../client';
+import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
 import { formatMoney } from './order-utils';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 
@@ -207,6 +211,16 @@ const REFRIGERANT_PRICING_MODE_OPTIONS = [
   'включен в стоимость ремонта',
   'отдельной строкой сметы',
   'не требуется',
+];
+const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
+  { value: 'diagnostic', label: 'Диагностика' },
+  { value: 'repair', label: 'Ремонт' },
+  { value: 'maintenance', label: 'Обслуживание' },
+  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
+  { value: 'leak', label: 'Утечка' },
+  { value: 'recommendation', label: 'Рекомендация' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'other', label: 'Другое' },
 ];
 
 const textValue = (value: unknown) => String(value ?? '').trim();
@@ -446,6 +460,16 @@ const repairAiExtraContext = ref('');
 const repairAiAllowAssumptions = ref(false);
 const repairAiPolishExisting = ref(true);
 const repairAiGenerating = ref(false);
+const repairEquipment = ref<ManagerEquipmentItemResponse[]>([]);
+const repairEquipmentLoading = ref(false);
+const repairEquipmentError = ref('');
+const selectedRepairEquipmentId = ref<number | null>(null);
+const selectedRepairEquipmentDetail = ref<ManagerEquipmentDetailResponse | null>(null);
+const repairEquipmentHistoryLoading = ref(false);
+const creatingRepairEquipment = ref(false);
+const recordingRepairHistory = ref(false);
+const repairHistoryEventType = ref<EquipmentServiceEventType | ''>('');
+const repairHistoryNotes = ref('');
 const payments = ref<PaymentResponse[]>([]);
 const bankReceipts = ref<BankReceiptResponse[]>([]);
 const bankReceiptsLoading = ref(false);
@@ -592,6 +616,132 @@ const createCustomerBranch = async () => {
   }
 };
 
+const resetRepairEquipment = () => {
+  repairEquipment.value = [];
+  selectedRepairEquipmentId.value = null;
+  selectedRepairEquipmentDetail.value = null;
+  repairEquipmentError.value = '';
+  repairHistoryEventType.value = '';
+  repairHistoryNotes.value = '';
+};
+
+const loadRepairEquipmentDetail = async (equipmentId: number) => {
+  repairEquipmentHistoryLoading.value = true;
+  repairEquipmentError.value = '';
+  try {
+    selectedRepairEquipmentDetail.value = await ManagerEquipmentService.getManagerEquipment(equipmentId, 10);
+  } catch (error) {
+    selectedRepairEquipmentDetail.value = null;
+    repairEquipmentError.value = `Не удалось загрузить историю оборудования: ${getApiErrorMessage(error)}`;
+  } finally {
+    repairEquipmentHistoryLoading.value = false;
+  }
+};
+
+const selectRepairEquipment = async (equipmentId: number) => {
+  selectedRepairEquipmentId.value = equipmentId;
+  await loadRepairEquipmentDetail(equipmentId);
+};
+
+const loadRepairEquipment = async () => {
+  const customerId = customer.value?.id;
+  if (!customerId || !isRepairWorkflow.value) {
+    resetRepairEquipment();
+    return;
+  }
+  repairEquipmentLoading.value = true;
+  repairEquipmentError.value = '';
+  try {
+    const branchId = customerBranchId.value || null;
+    const response = await ManagerEquipmentService.listManagerEquipment(customerId, branchId, 1, 50, false);
+    repairEquipment.value = response.items || [];
+    if (selectedRepairEquipmentId.value && !repairEquipment.value.some((item) => item.id === selectedRepairEquipmentId.value)) {
+      selectedRepairEquipmentId.value = null;
+      selectedRepairEquipmentDetail.value = null;
+    }
+    if (!selectedRepairEquipmentId.value && repairEquipment.value.length) {
+      await selectRepairEquipment(repairEquipment.value[0]!.id);
+    } else if (selectedRepairEquipmentId.value) {
+      await loadRepairEquipmentDetail(selectedRepairEquipmentId.value);
+    }
+  } catch (error) {
+    repairEquipment.value = [];
+    selectedRepairEquipmentDetail.value = null;
+    repairEquipmentError.value = `Не удалось загрузить оборудование клиента: ${getApiErrorMessage(error)}`;
+  } finally {
+    repairEquipmentLoading.value = false;
+  }
+};
+
+const createRepairEquipmentFromMeta = async () => {
+  const customerId = customer.value?.id;
+  if (!customerId || creatingRepairEquipment.value) return;
+  const meta = repairMeta.value;
+  const displayName = trimOrNull(meta.equipment_name) || trimOrNull(orderTitle.value) || trimOrNull(props.order?.title || '');
+  const hasPassportData = Boolean(
+    displayName
+    || trimOrNull(meta.equipment_brand)
+    || trimOrNull(meta.equipment_model)
+    || trimOrNull(meta.equipment_serial_number)
+    || trimOrNull(meta.equipment_inventory_number),
+  );
+  if (!hasPassportData) {
+    repairEquipmentError.value = 'Заполните название, бренд, модель, серийный или инвентарный номер';
+    return;
+  }
+  creatingRepairEquipment.value = true;
+  repairEquipmentError.value = '';
+  try {
+    const notes = [
+      meta.equipment_power ? `Мощность: ${meta.equipment_power}` : '',
+      meta.equipment_commissioning_date ? `Ввод в эксплуатацию: ${meta.equipment_commissioning_date}` : '',
+    ].filter(Boolean).join('\n') || null;
+    const created = await ManagerEquipmentService.createManagerEquipment({
+      customer_id: customerId,
+      customer_branch_id: customerBranchId.value || null,
+      equipment_type: 'hvac',
+      display_name: displayName,
+      brand: trimOrNull(meta.equipment_brand),
+      model: trimOrNull(meta.equipment_model),
+      serial: trimOrNull(meta.equipment_serial_number),
+      inventory_number: trimOrNull(meta.equipment_inventory_number),
+      location_hint: trimOrNull(compactObjectAddress.value),
+      refrigerant_type: trimOrNull(meta.refrigerant_type),
+      notes,
+    });
+    selectedRepairEquipmentId.value = created.id;
+    await loadRepairEquipment();
+    await loadRepairEquipmentDetail(created.id);
+    setToast('Оборудование создано из полей ремонта', 'success');
+  } catch (error) {
+    repairEquipmentError.value = `Не удалось создать оборудование: ${getApiErrorMessage(error)}`;
+  } finally {
+    creatingRepairEquipment.value = false;
+  }
+};
+
+const recordRepairHistoryFromOrder = async () => {
+  if (!props.order?.id || !selectedRepairEquipmentId.value || recordingRepairHistory.value) return;
+  recordingRepairHistory.value = true;
+  repairEquipmentError.value = '';
+  try {
+    const payload: ManagerEquipmentHistoryFromRepairOrderPayload = {
+      order_id: props.order.id,
+      event_type: repairHistoryEventType.value || null,
+      notes: trimOrNull(repairHistoryNotes.value),
+    };
+    await ManagerEquipmentService.createManagerEquipmentHistoryFromRepairOrder(selectedRepairEquipmentId.value, payload);
+    repairHistoryEventType.value = '';
+    repairHistoryNotes.value = '';
+    await loadRepairEquipmentDetail(selectedRepairEquipmentId.value);
+    setToast('Событие записано в историю оборудования', 'success');
+  } catch (error) {
+    repairEquipmentError.value = `Не удалось записать историю: ${getApiErrorMessage(error)}`;
+  } finally {
+    recordingRepairHistory.value = false;
+  }
+};
+
 const customer = computed(() => props.order?.customer ?? null);
 const isWebsiteOrder = computed(() => props.order?.lead_source === 'site');
 const isB2cCustomer = computed(() => {
@@ -613,6 +763,9 @@ const selectedCustomerBranch = computed(() => (
   customerBranches.value.find((branch) => branch.id === customerBranchId.value)
   || props.order?.customer_branch
   || null
+));
+const selectedRepairEquipment = computed(() => (
+  repairEquipment.value.find((item) => item.id === selectedRepairEquipmentId.value) || null
 ));
 const compactObjectAddress = computed(() => (
   customerDeliveryAddress.value.trim()
@@ -721,6 +874,49 @@ const formatDateTime = (value?: string | null) => {
     hour: '2-digit',
     minute: '2-digit',
   });
+};
+
+const trimOrNull = (value: string) => {
+  const normalized = value.trim();
+  return normalized || null;
+};
+
+const equipmentEventLabel = (value?: EquipmentServiceEventType | null) => (
+  EQUIPMENT_EVENT_OPTIONS.find((option) => option.value === value)?.label || 'Другое'
+);
+
+const equipmentTitle = (item?: Pick<ManagerEquipmentItemResponse, 'display_name' | 'brand' | 'model' | 'serial' | 'inventory_number'> | null) => {
+  if (!item) return 'Оборудование';
+  const name = item.display_name?.trim();
+  if (name) return name;
+  const parts = [item.brand, item.model, item.serial || item.inventory_number].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' ') || 'Оборудование';
+};
+
+const equipmentSubtitle = (item: ManagerEquipmentItemResponse | ManagerEquipmentDetailResponse) => {
+  const parts = [
+    item.brand,
+    item.model,
+    item.serial ? `SN ${item.serial}` : '',
+    item.inventory_number ? `Инв. ${item.inventory_number}` : '',
+    item.location_hint,
+    item.refrigerant_type,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Паспортные данные не заполнены';
+};
+
+const repairHistoryLine = (item: NonNullable<ManagerEquipmentDetailResponse['recent_history']>[number]) => {
+  const parts = [
+    item.complaint_snapshot,
+    item.diagnostic_result,
+    item.repair_recommendation,
+    item.refrigerant_type ? `Хладагент ${item.refrigerant_type}` : '',
+    item.refrigerant_amount,
+    item.not_repairable ? 'Не ремонтируется' : '',
+    item.not_repairable_reason,
+    item.notes,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Без подробностей';
 };
 
 const copyText = async (value: string | null | undefined, label: string) => {
@@ -1293,6 +1489,11 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   } else {
     resetCustomerBranches();
   }
+  if (workflowType.value === 'repair') {
+    await loadRepairEquipment();
+  } else {
+    resetRepairEquipment();
+  }
 
   productLookupById.value = {};
 
@@ -1358,6 +1559,12 @@ watch(
     if (props.modelValue) await initForm(value);
   },
 );
+
+watch(customerBranchId, () => {
+  if (props.modelValue && isRepairWorkflow.value && customer.value?.id) {
+    void loadRepairEquipment();
+  }
+});
 
 const onProductChanged = (index: number, applyCatalogPrice = false) => {
   const row = productLines.value[index];
@@ -1743,7 +1950,10 @@ const setWorkflowType = async (next: OrderWorkflowType) => {
   if (next === 'repair') {
     repairMeta.value = normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: true });
     void loadRepairComplaintPresets();
+    void loadRepairEquipment();
     await addDefaultRepairDiagnostic();
+  } else {
+    resetRepairEquipment();
   }
 };
 
@@ -2810,6 +3020,119 @@ watch(
             Дата ввода в эксплуатацию
             <input v-model="repairMeta.equipment_commissioning_date" class="field-input" placeholder="Например: 2021 г. или 12.05.2021" />
           </label>
+
+          <div class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div class="min-w-0">
+                <p class="text-sm font-semibold text-slate-900">Карточка оборудования и история</p>
+                <p class="mt-1 text-xs text-slate-600">
+                  История оборудования записывается отдельным действием и не меняет CRM/Kanban статус заказа.
+                </p>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  class="btn-mini-outline justify-center whitespace-nowrap text-xs"
+                  :disabled="repairEquipmentLoading"
+                  @click="loadRepairEquipment"
+                >
+                  Обновить
+                </button>
+                <button
+                  type="button"
+                  class="btn-mini justify-center whitespace-nowrap text-xs"
+                  :disabled="creatingRepairEquipment || !customer?.id"
+                  @click="createRepairEquipmentFromMeta"
+                >
+                  {{ creatingRepairEquipment ? 'Создаем...' : 'Создать из полей' }}
+                </button>
+              </div>
+            </div>
+
+            <p v-if="repairEquipmentError" class="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+              {{ repairEquipmentError }}
+            </p>
+
+            <div v-if="!customer?.id" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
+              Выберите клиента, чтобы вести оборудование.
+            </div>
+            <div v-else-if="repairEquipmentLoading" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-xs text-slate-500">
+              Загружаем оборудование клиента...
+            </div>
+            <div v-else class="grid gap-3 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+              <div class="space-y-2">
+                <button
+                  v-for="item in repairEquipment"
+                  :key="item.id"
+                  type="button"
+                  class="w-full rounded-lg border px-3 py-2 text-left text-xs transition"
+                  :class="selectedRepairEquipmentId === item.id
+                    ? 'border-teal-400 bg-white text-teal-900 shadow-sm'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-teal-200'"
+                  @click="selectRepairEquipment(item.id)"
+                >
+                  <span class="block break-words font-semibold">{{ equipmentTitle(item) }}</span>
+                  <span class="mt-1 block break-words text-slate-500">{{ equipmentSubtitle(item) }}</span>
+                </button>
+                <div v-if="!repairEquipment.length" class="rounded-lg border border-dashed border-slate-200 bg-white px-3 py-4 text-center text-xs text-slate-500">
+                  {{ customerBranchId ? 'Для выбранного филиала оборудование не найдено.' : 'Оборудование клиента пока не заведено.' }}
+                </div>
+              </div>
+
+              <div class="rounded-lg border border-slate-200 bg-white p-3">
+                <div v-if="repairEquipmentHistoryLoading" class="text-xs text-slate-500">Загружаем историю...</div>
+                <template v-else-if="selectedRepairEquipment">
+                  <div class="mb-3">
+                    <p class="break-words text-sm font-semibold text-slate-900">{{ equipmentTitle(selectedRepairEquipment) }}</p>
+                    <p class="mt-1 break-words text-xs text-slate-500">{{ equipmentSubtitle(selectedRepairEquipment) }}</p>
+                  </div>
+                  <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                    <label class="field-label !mb-0">
+                      Тип записи из заказа
+                      <select v-model="repairHistoryEventType" class="field-input bg-white">
+                        <option value="">Определить автоматически</option>
+                        <option v-for="option in EQUIPMENT_EVENT_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+                      </select>
+                    </label>
+                    <label class="field-label !mb-0">
+                      Заметка
+                      <input v-model="repairHistoryNotes" class="field-input bg-white" placeholder="Например: закрыто после согласования" />
+                    </label>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn-mini mt-2 w-full justify-center text-xs"
+                    :disabled="recordingRepairHistory || !selectedRepairEquipmentId || !order?.id"
+                    @click="recordRepairHistoryFromOrder"
+                  >
+                    {{ recordingRepairHistory ? 'Записываем...' : 'Записать историю из этого ремонта' }}
+                  </button>
+                  <p class="mt-2 text-[11px] text-slate-500">
+                    Действие создаст запись истории оборудования из repair meta текущего заказа. Статус заказа и этап ремонта останутся отдельными.
+                  </p>
+
+                  <div class="mt-3 max-h-56 space-y-2 overflow-y-auto pr-1">
+                    <div
+                      v-for="entry in selectedRepairEquipmentDetail?.recent_history || []"
+                      :key="entry.id"
+                      class="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-xs"
+                    >
+                      <div class="flex flex-wrap items-center gap-2">
+                        <span class="rounded-full bg-teal-50 px-2 py-0.5 font-semibold text-teal-700">{{ equipmentEventLabel(entry.event_type) }}</span>
+                        <span class="text-slate-500">{{ formatDateTime(entry.event_date) || 'Без даты' }}</span>
+                        <span v-if="entry.order_id" class="text-slate-500">Заказ #{{ entry.order_id }}</span>
+                      </div>
+                      <p class="mt-1 break-words text-slate-600">{{ repairHistoryLine(entry) }}</p>
+                    </div>
+                    <div v-if="!(selectedRepairEquipmentDetail?.recent_history || []).length" class="rounded-lg border border-dashed border-slate-200 px-3 py-3 text-center text-xs text-slate-500">
+                      История пока пустая
+                    </div>
+                  </div>
+                </template>
+                <div v-else class="text-xs text-slate-500">Выберите оборудование слева или создайте карточку из полей ремонта.</div>
+              </div>
+            </div>
+          </div>
 
           <label class="field-label">
             Техническое состояние

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -3,7 +3,23 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { ArrowLeft, Building2, Mail, Phone, Plus, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
 import CreateOrderModal from '../components/CreateOrderModal.vue';
 import { api } from '../api';
-import { ManagerContractsService, ManagerDocsService, ManagerService, type DocumentTemplateItem, type ManagerCatalogCustomerItemResponse, type ManagerCustomerContractItemResponse, type ManagerCustomerDocumentItem } from '../client';
+import {
+  ManagerContractsService,
+  ManagerDocsService,
+  ManagerEquipmentService,
+  ManagerService,
+  type DocumentTemplateItem,
+  type EquipmentServiceEventType,
+  type ManagerCatalogCustomerItemResponse,
+  type ManagerCustomerContractItemResponse,
+  type ManagerCustomerDocumentItem,
+  type ManagerEquipmentCreatePayload,
+  type ManagerEquipmentDetailResponse,
+  type ManagerEquipmentItemResponse,
+  type ManagerEquipmentServiceHistoryCreatePayload,
+  type ManagerEquipmentServiceHistoryItemResponse,
+  type ManagerEquipmentUpdatePayload,
+} from '../client';
 import { useBelarusPhoneMask } from '../composables/useBelarusPhoneMask';
 import { useB2BLookup } from '../composables/useB2BLookup';
 import { dispatchCustomerUpdated } from '../utils/customer-events';
@@ -36,6 +52,32 @@ type CustomerForm = {
   acting_basis: string;
 };
 
+type EquipmentForm = {
+  customer_branch_id: number | null;
+  equipment_type: string;
+  display_name: string;
+  brand: string;
+  model: string;
+  serial: string;
+  inventory_number: string;
+  location_hint: string;
+  refrigerant_type: string;
+  notes: string;
+};
+
+type EquipmentHistoryForm = {
+  event_type: EquipmentServiceEventType;
+  event_date: string;
+  complaint_snapshot: string;
+  diagnostic_result: string;
+  repair_recommendation: string;
+  refrigerant_type: string;
+  refrigerant_amount: string;
+  not_repairable: boolean;
+  not_repairable_reason: string;
+  notes: string;
+};
+
 const customer = ref<ManagerCatalogCustomerItemResponse | null>(null);
 const loading = ref(false);
 const saving = ref(false);
@@ -63,6 +105,16 @@ const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> =
 ];
 const contractTemplates = ref<DocumentTemplateItem[]>([]);
 const openContractTemplates = computed(() => contractTemplates.value.filter((template) => template.is_open_contract));
+const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
+  { value: 'diagnostic', label: 'Диагностика' },
+  { value: 'repair', label: 'Ремонт' },
+  { value: 'maintenance', label: 'Обслуживание' },
+  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
+  { value: 'leak', label: 'Утечка' },
+  { value: 'recommendation', label: 'Рекомендация' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'other', label: 'Другое' },
+];
 
 const normalizeRoleType = (value: unknown): DocumentRoleType => {
   const raw = String(value || '').trim();
@@ -159,11 +211,129 @@ const contractUploadForm = ref({
   file: null as File | null,
 });
 
+const emptyEquipmentForm = (): EquipmentForm => ({
+  customer_branch_id: null,
+  equipment_type: 'hvac',
+  display_name: '',
+  brand: '',
+  model: '',
+  serial: '',
+  inventory_number: '',
+  location_hint: '',
+  refrigerant_type: '',
+  notes: '',
+});
+
+const emptyHistoryForm = (): EquipmentHistoryForm => ({
+  event_type: 'diagnostic',
+  event_date: toInputDate(new Date()),
+  complaint_snapshot: '',
+  diagnostic_result: '',
+  repair_recommendation: '',
+  refrigerant_type: '',
+  refrigerant_amount: '',
+  not_repairable: false,
+  not_repairable_reason: '',
+  notes: '',
+});
+
+const equipment = ref<ManagerEquipmentItemResponse[]>([]);
+const equipmentLoading = ref(false);
+const equipmentSaving = ref(false);
+const equipmentActionId = ref<number | null>(null);
+const equipmentError = ref('');
+const includeArchivedEquipment = ref(true);
+const showEquipmentForm = ref(false);
+const editingEquipmentId = ref<number | null>(null);
+const equipmentForm = ref<EquipmentForm>(emptyEquipmentForm());
+const selectedEquipmentId = ref<number | null>(null);
+const selectedEquipmentDetail = ref<ManagerEquipmentDetailResponse | null>(null);
+const equipmentHistoryLoading = ref(false);
+const historySaving = ref(false);
+const showHistoryForm = ref(false);
+const historyForm = ref<EquipmentHistoryForm>(emptyHistoryForm());
+
 const setToast = (message: string) => {
   toast.value = message;
   window.setTimeout(() => {
     if (toast.value === message) toast.value = '';
   }, 3500);
+};
+
+const trimOrNull = (value: string) => {
+  const normalized = value.trim();
+  return normalized || null;
+};
+
+const equipmentBranchLabel = (branchId?: number | null) => {
+  if (!branchId) return 'Без филиала';
+  const branch = customer.value?.branches?.find((item) => item.id === branchId);
+  return branch?.name || branch?.delivery_address || `Филиал #${branchId}`;
+};
+
+const equipmentEventLabel = (value?: EquipmentServiceEventType | null) => (
+  EQUIPMENT_EVENT_OPTIONS.find((option) => option.value === value)?.label || 'Другое'
+);
+
+const equipmentTitle = (item?: Pick<ManagerEquipmentItemResponse, 'display_name' | 'brand' | 'model' | 'serial' | 'inventory_number'> | null) => {
+  if (!item) return 'Оборудование';
+  const name = item.display_name?.trim();
+  if (name) return name;
+  const parts = [item.brand, item.model, item.serial || item.inventory_number].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' ') || 'Оборудование';
+};
+
+const equipmentSubtitle = (item: ManagerEquipmentItemResponse | ManagerEquipmentDetailResponse) => {
+  const parts = [
+    item.equipment_type || 'hvac',
+    item.brand,
+    item.model,
+    item.serial ? `SN ${item.serial}` : '',
+    item.inventory_number ? `Инв. ${item.inventory_number}` : '',
+    item.location_hint,
+    item.refrigerant_type,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Паспортные данные не заполнены';
+};
+
+const equipmentFormPayload = (): ManagerEquipmentCreatePayload | ManagerEquipmentUpdatePayload => ({
+  customer_branch_id: equipmentForm.value.customer_branch_id,
+  equipment_type: trimOrNull(equipmentForm.value.equipment_type) || 'hvac',
+  display_name: trimOrNull(equipmentForm.value.display_name),
+  brand: trimOrNull(equipmentForm.value.brand),
+  model: trimOrNull(equipmentForm.value.model),
+  serial: trimOrNull(equipmentForm.value.serial),
+  inventory_number: trimOrNull(equipmentForm.value.inventory_number),
+  location_hint: trimOrNull(equipmentForm.value.location_hint),
+  refrigerant_type: trimOrNull(equipmentForm.value.refrigerant_type),
+  notes: trimOrNull(equipmentForm.value.notes),
+});
+
+const historyPayload = (): ManagerEquipmentServiceHistoryCreatePayload => ({
+  event_type: historyForm.value.event_type,
+  event_date: historyForm.value.event_date ? `${historyForm.value.event_date}T00:00:00` : null,
+  complaint_snapshot: trimOrNull(historyForm.value.complaint_snapshot),
+  diagnostic_result: trimOrNull(historyForm.value.diagnostic_result),
+  repair_recommendation: trimOrNull(historyForm.value.repair_recommendation),
+  refrigerant_type: trimOrNull(historyForm.value.refrigerant_type),
+  refrigerant_amount: trimOrNull(historyForm.value.refrigerant_amount),
+  not_repairable: historyForm.value.not_repairable,
+  not_repairable_reason: trimOrNull(historyForm.value.not_repairable_reason),
+  notes: trimOrNull(historyForm.value.notes),
+});
+
+const historyLine = (item: ManagerEquipmentServiceHistoryItemResponse) => {
+  const parts = [
+    item.complaint_snapshot,
+    item.diagnostic_result,
+    item.repair_recommendation,
+    item.refrigerant_type ? `Хладагент ${item.refrigerant_type}` : '',
+    item.refrigerant_amount,
+    item.not_repairable ? 'Не ремонтируется' : '',
+    item.not_repairable_reason,
+    item.notes,
+  ].map((value) => value?.trim()).filter(Boolean);
+  return parts.join(' · ') || 'Без подробностей';
 };
 
 const toForm = (item: ManagerCatalogCustomerItemResponse): CustomerForm => ({
@@ -274,6 +444,152 @@ const loadCustomerContracts = async () => {
     console.error('Failed to load customer contracts', e);
   } finally {
     contractsLoading.value = false;
+  }
+};
+
+const loadEquipmentDetail = async (equipmentId: number) => {
+  equipmentHistoryLoading.value = true;
+  equipmentError.value = '';
+  try {
+    selectedEquipmentDetail.value = await ManagerEquipmentService.getManagerEquipment(equipmentId, 10);
+  } catch (e) {
+    console.error('Failed to load equipment detail', e);
+    equipmentError.value = `Не удалось загрузить историю: ${getApiErrorMessage(e)}`;
+    selectedEquipmentDetail.value = null;
+  } finally {
+    equipmentHistoryLoading.value = false;
+  }
+};
+
+const selectEquipment = async (equipmentId: number) => {
+  selectedEquipmentId.value = equipmentId;
+  showHistoryForm.value = false;
+  historyForm.value = emptyHistoryForm();
+  await loadEquipmentDetail(equipmentId);
+};
+
+const loadCustomerEquipment = async () => {
+  if (!customerId.value) return;
+  equipmentLoading.value = true;
+  equipmentError.value = '';
+  try {
+    const res = await ManagerEquipmentService.listManagerEquipment(
+      customerId.value,
+      null,
+      1,
+      100,
+      includeArchivedEquipment.value,
+    );
+    equipment.value = res.items || [];
+    if (selectedEquipmentId.value && !equipment.value.some((item) => item.id === selectedEquipmentId.value)) {
+      selectedEquipmentId.value = null;
+      selectedEquipmentDetail.value = null;
+    }
+    if (!selectedEquipmentId.value && equipment.value.length) {
+      await selectEquipment(equipment.value[0]!.id);
+    } else if (selectedEquipmentId.value) {
+      await loadEquipmentDetail(selectedEquipmentId.value);
+    }
+  } catch (e) {
+    console.error('Failed to load customer equipment', e);
+    equipmentError.value = `Не удалось загрузить оборудование: ${getApiErrorMessage(e)}`;
+  } finally {
+    equipmentLoading.value = false;
+  }
+};
+
+const openEquipmentCreateForm = () => {
+  equipmentForm.value = emptyEquipmentForm();
+  editingEquipmentId.value = null;
+  showEquipmentForm.value = true;
+};
+
+const openEquipmentEditForm = (item: ManagerEquipmentItemResponse) => {
+  equipmentForm.value = {
+    customer_branch_id: item.customer_branch_id ?? null,
+    equipment_type: item.equipment_type || 'hvac',
+    display_name: item.display_name || '',
+    brand: item.brand || '',
+    model: item.model || '',
+    serial: item.serial || '',
+    inventory_number: item.inventory_number || '',
+    location_hint: item.location_hint || '',
+    refrigerant_type: item.refrigerant_type || '',
+    notes: item.notes || '',
+  };
+  editingEquipmentId.value = item.id;
+  showEquipmentForm.value = true;
+};
+
+const saveEquipment = async () => {
+  if (!customerId.value || equipmentSaving.value) return;
+  const payload = equipmentFormPayload();
+  if (!payload.display_name && !payload.brand && !payload.model && !payload.serial && !payload.inventory_number) {
+    equipmentError.value = 'Укажите название, бренд, модель, серийный или инвентарный номер';
+    return;
+  }
+  equipmentSaving.value = true;
+  equipmentError.value = '';
+  try {
+    if (editingEquipmentId.value) {
+      const updated = await ManagerEquipmentService.patchManagerEquipment(editingEquipmentId.value, payload);
+      selectedEquipmentId.value = updated.id;
+      setToast('Оборудование обновлено');
+    } else {
+      const created = await ManagerEquipmentService.createManagerEquipment({
+        ...(payload as ManagerEquipmentCreatePayload),
+        customer_id: customerId.value,
+      });
+      selectedEquipmentId.value = created.id;
+      setToast('Оборудование создано');
+    }
+    showEquipmentForm.value = false;
+    editingEquipmentId.value = null;
+    await loadCustomerEquipment();
+  } catch (e) {
+    equipmentError.value = `Не удалось сохранить оборудование: ${getApiErrorMessage(e)}`;
+  } finally {
+    equipmentSaving.value = false;
+  }
+};
+
+const toggleEquipmentArchive = async (item: ManagerEquipmentItemResponse) => {
+  if (equipmentActionId.value) return;
+  equipmentActionId.value = item.id;
+  equipmentError.value = '';
+  try {
+    await ManagerEquipmentService.patchManagerEquipment(item.id, { is_archived: !item.is_archived });
+    setToast(item.is_archived ? 'Оборудование возвращено из архива' : 'Оборудование архивировано');
+    await loadCustomerEquipment();
+  } catch (e) {
+    equipmentError.value = `Не удалось изменить архив: ${getApiErrorMessage(e)}`;
+  } finally {
+    equipmentActionId.value = null;
+  }
+};
+
+const openHistoryCreateForm = () => {
+  historyForm.value = {
+    ...emptyHistoryForm(),
+    refrigerant_type: selectedEquipmentDetail.value?.refrigerant_type || '',
+  };
+  showHistoryForm.value = true;
+};
+
+const createEquipmentHistory = async () => {
+  if (!selectedEquipmentId.value || historySaving.value) return;
+  historySaving.value = true;
+  equipmentError.value = '';
+  try {
+    await ManagerEquipmentService.createManagerEquipmentHistory(selectedEquipmentId.value, historyPayload());
+    setToast('Событие истории добавлено');
+    showHistoryForm.value = false;
+    historyForm.value = emptyHistoryForm();
+    await loadEquipmentDetail(selectedEquipmentId.value);
+  } catch (e) {
+    equipmentError.value = `Не удалось добавить событие: ${getApiErrorMessage(e)}`;
+  } finally {
+    historySaving.value = false;
   }
 };
 
@@ -600,13 +916,19 @@ watch(customerId, () => {
   void loadCustomer();
   void loadCustomerDocs();
   void loadCustomerContracts();
+  void loadCustomerEquipment();
   void loadContractTemplates();
+});
+
+watch(includeArchivedEquipment, () => {
+  void loadCustomerEquipment();
 });
 
 onMounted(() => {
   void loadCustomer();
   void loadCustomerDocs();
   void loadCustomerContracts();
+  void loadCustomerEquipment();
   void loadContractTemplates();
 });
 </script>
@@ -850,6 +1172,209 @@ onMounted(() => {
           </div>
           <div v-else class="text-sm text-[var(--mv-text-muted)] italic py-5 text-center rounded-2xl border border-dashed border-[var(--mv-border)]">
             Открытые договоры пока не созданы
+          </div>
+        </section>
+
+        <section v-if="!editMode" class="mt-8 mb-6">
+          <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <h2 class="flex items-center gap-2 text-lg font-bold">
+              <span class="material-icons-round text-teal-500">precision_manufacturing</span>
+              Оборудование клиента
+              <span v-if="equipment.length" class="flex h-6 min-w-6 items-center justify-center rounded-full bg-teal-500/20 px-2 text-xs text-teal-400">{{ equipment.length }}</span>
+            </h2>
+            <div class="flex flex-wrap items-center gap-2">
+              <label class="inline-flex items-center gap-2 rounded-xl border border-[var(--mv-border)] px-3 py-2 text-xs text-[var(--mv-text-muted)]">
+                <input v-model="includeArchivedEquipment" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500" />
+                Архив
+              </label>
+              <button class="btn-mini-outline" type="button" :disabled="equipmentLoading" @click="loadCustomerEquipment">
+                Обновить
+              </button>
+              <button class="btn-mini" type="button" @click="openEquipmentCreateForm">
+                Создать оборудование
+              </button>
+            </div>
+          </div>
+
+          <p v-if="equipmentError" class="mb-3 rounded-xl border border-red-500/40 bg-red-900/20 px-4 py-3 text-sm text-red-200">
+            {{ equipmentError }}
+          </p>
+
+          <form v-if="showEquipmentForm" class="mb-4 rounded-2xl border border-[var(--mv-border)] bg-[var(--mv-panel)] p-4" @submit.prevent="saveEquipment">
+            <div class="grid gap-3 md:grid-cols-3">
+              <label class="field-label">
+                Филиал
+                <select v-model="equipmentForm.customer_branch_id" class="field-input">
+                  <option :value="null">Без филиала</option>
+                  <option v-for="branch in customer.branches || []" :key="branch.id" :value="branch.id">
+                    {{ branch.name || branch.delivery_address || `Филиал #${branch.id}` }}
+                  </option>
+                </select>
+              </label>
+              <label class="field-label">
+                Тип
+                <input v-model="equipmentForm.equipment_type" class="field-input" placeholder="hvac, chiller..." />
+              </label>
+              <label class="field-label">
+                Название
+                <input v-model="equipmentForm.display_name" class="field-input" placeholder="Кондиционер серверной" />
+              </label>
+              <label class="field-label">
+                Бренд
+                <input v-model="equipmentForm.brand" class="field-input" placeholder="Gree, LG..." />
+              </label>
+              <label class="field-label">
+                Модель
+                <input v-model="equipmentForm.model" class="field-input" placeholder="Модель блока" />
+              </label>
+              <label class="field-label">
+                Серийный номер
+                <input v-model="equipmentForm.serial" class="field-input" placeholder="SN..." />
+              </label>
+              <label class="field-label">
+                Инвентарный номер
+                <input v-model="equipmentForm.inventory_number" class="field-input" placeholder="Инв. номер клиента" />
+              </label>
+              <label class="field-label">
+                Локация
+                <input v-model="equipmentForm.location_hint" class="field-input" placeholder="Серверная, 2 этаж" />
+              </label>
+              <label class="field-label">
+                Хладагент
+                <input v-model="equipmentForm.refrigerant_type" class="field-input" placeholder="R32, R410A" />
+              </label>
+              <label class="field-label md:col-span-3">
+                Заметки
+                <textarea v-model="equipmentForm.notes" class="field-input min-h-[72px]" placeholder="Особенности доступа, состояние, монтаж..." />
+              </label>
+            </div>
+            <div class="mt-3 flex flex-wrap justify-end gap-2">
+              <button class="btn-mini-outline" type="button" :disabled="equipmentSaving" @click="showEquipmentForm = false">Отмена</button>
+              <button class="btn-mini" type="submit" :disabled="equipmentSaving">
+                {{ equipmentSaving ? 'Сохраняем...' : (editingEquipmentId ? 'Сохранить' : 'Создать') }}
+              </button>
+            </div>
+          </form>
+
+          <div v-if="equipmentLoading" class="rounded-2xl border border-dashed border-[var(--mv-border)] p-5 text-sm text-[var(--mv-text-muted)]">
+            Загрузка оборудования...
+          </div>
+          <div v-else-if="equipment.length" class="grid gap-4 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+            <div class="space-y-3">
+              <button
+                v-for="item in equipment"
+                :key="item.id"
+                type="button"
+                class="w-full rounded-xl border p-4 text-left shadow-sm transition"
+                :class="selectedEquipmentId === item.id ? 'border-teal-400 bg-teal-500/10' : 'border-[var(--mv-border)] bg-[var(--mv-surface)] hover:border-teal-400/60'"
+                @click="selectEquipment(item.id)"
+              >
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div class="min-w-0">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <p class="break-words text-sm font-semibold text-[var(--mv-text)]">{{ equipmentTitle(item) }}</p>
+                      <span v-if="item.is_archived" class="rounded-full bg-slate-500/20 px-2 py-0.5 text-[11px] font-semibold text-slate-400">Архив</span>
+                    </div>
+                    <p class="mt-1 break-words text-xs text-[var(--mv-text-muted)]">{{ equipmentSubtitle(item) }}</p>
+                    <p class="mt-1 text-xs text-[var(--mv-text-muted)]">{{ equipmentBranchLabel(item.customer_branch_id) }}</p>
+                  </div>
+                  <div class="flex shrink-0 flex-wrap gap-2">
+                    <button class="btn-mini-outline text-xs" type="button" @click.stop="openEquipmentEditForm(item)">Править</button>
+                    <button class="btn-mini-outline text-xs" type="button" :disabled="equipmentActionId === item.id" @click.stop="toggleEquipmentArchive(item)">
+                      {{ equipmentActionId === item.id ? '...' : (item.is_archived ? 'Вернуть' : 'Архив') }}
+                    </button>
+                  </div>
+                </div>
+              </button>
+            </div>
+
+            <div class="rounded-2xl border border-[var(--mv-border)] bg-[var(--mv-surface)] p-4">
+              <div v-if="equipmentHistoryLoading" class="text-sm text-[var(--mv-text-muted)]">Загрузка истории...</div>
+              <template v-else-if="selectedEquipmentDetail">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div class="min-w-0">
+                    <p class="break-words text-base font-semibold">{{ equipmentTitle(selectedEquipmentDetail) }}</p>
+                    <p class="mt-1 break-words text-xs text-[var(--mv-text-muted)]">{{ equipmentSubtitle(selectedEquipmentDetail) }}</p>
+                  </div>
+                  <button class="btn-mini whitespace-nowrap text-xs" type="button" @click="openHistoryCreateForm">Добавить событие</button>
+                </div>
+
+                <form v-if="showHistoryForm" class="mt-4 rounded-xl border border-[var(--mv-border)] bg-[var(--mv-panel)] p-3" @submit.prevent="createEquipmentHistory">
+                  <div class="grid gap-3 md:grid-cols-2">
+                    <label class="field-label">
+                      Тип события
+                      <select v-model="historyForm.event_type" class="field-input">
+                        <option v-for="option in EQUIPMENT_EVENT_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+                      </select>
+                    </label>
+                    <label class="field-label">
+                      Дата
+                      <input v-model="historyForm.event_date" class="field-input" type="date" />
+                    </label>
+                    <label class="field-label md:col-span-2">
+                      Жалоба / причина
+                      <textarea v-model="historyForm.complaint_snapshot" class="field-input min-h-[58px]" />
+                    </label>
+                    <label class="field-label">
+                      Диагностика
+                      <textarea v-model="historyForm.diagnostic_result" class="field-input min-h-[70px]" />
+                    </label>
+                    <label class="field-label">
+                      Рекомендация
+                      <textarea v-model="historyForm.repair_recommendation" class="field-input min-h-[70px]" />
+                    </label>
+                    <label class="field-label">
+                      Хладагент
+                      <input v-model="historyForm.refrigerant_type" class="field-input" />
+                    </label>
+                    <label class="field-label">
+                      Количество
+                      <input v-model="historyForm.refrigerant_amount" class="field-input" />
+                    </label>
+                    <label class="inline-flex items-center gap-2 text-xs text-[var(--mv-text-muted)] md:col-span-2">
+                      <input v-model="historyForm.not_repairable" type="checkbox" class="h-4 w-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500" />
+                      Оборудование не ремонтируется
+                    </label>
+                    <label class="field-label md:col-span-2">
+                      Причина / заметки
+                      <textarea v-model="historyForm.not_repairable_reason" class="field-input min-h-[58px]" placeholder="Причина неремонтопригодности" />
+                    </label>
+                    <label class="field-label md:col-span-2">
+                      Внутренние заметки
+                      <textarea v-model="historyForm.notes" class="field-input min-h-[58px]" />
+                    </label>
+                  </div>
+                  <div class="mt-3 flex flex-wrap justify-end gap-2">
+                    <button class="btn-mini-outline" type="button" :disabled="historySaving" @click="showHistoryForm = false">Отмена</button>
+                    <button class="btn-mini" type="submit" :disabled="historySaving">
+                      {{ historySaving ? 'Добавляем...' : 'Добавить' }}
+                    </button>
+                  </div>
+                </form>
+
+                <div class="mt-4 space-y-2">
+                  <div
+                    v-for="entry in selectedEquipmentDetail.recent_history || []"
+                    :key="entry.id"
+                    class="rounded-xl border border-[var(--mv-border)] bg-[var(--mv-panel)] p-3 text-sm"
+                  >
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span class="rounded-full bg-teal-500/10 px-2 py-0.5 text-xs font-semibold text-teal-400">{{ equipmentEventLabel(entry.event_type) }}</span>
+                      <span class="text-xs text-[var(--mv-text-muted)]">{{ formatDate(entry.event_date) }}</span>
+                      <span v-if="entry.order_id" class="text-xs text-[var(--mv-text-muted)]">Заказ #{{ entry.order_id }}</span>
+                    </div>
+                    <p class="mt-2 break-words text-[var(--mv-text-muted)]">{{ historyLine(entry) }}</p>
+                  </div>
+                  <div v-if="!(selectedEquipmentDetail.recent_history || []).length" class="rounded-xl border border-dashed border-[var(--mv-border)] px-3 py-4 text-center text-sm text-[var(--mv-text-muted)]">
+                    История обслуживания пока пустая
+                  </div>
+                </div>
+              </template>
+              <div v-else class="text-sm text-[var(--mv-text-muted)]">Выберите оборудование слева.</div>
+            </div>
+          </div>
+          <div v-else class="rounded-2xl border border-dashed border-[var(--mv-border)] py-5 text-center text-sm italic text-[var(--mv-text-muted)]">
+            Оборудование пока не заведено
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Adds a customer-profile equipment section for listing, creating, editing, archiving/unarchiving, viewing recent history, and adding manual service-history events.
- Adds a compact repair-order drawer equipment panel for repair workflows, including branch-filtered equipment lookup, create-from-repair-meta, recent history display, and an explicit history-from-current-repair action.

## UI locations changed
- `manager_frontend/src/views/CustomerProfileView.vue`
  - New "Оборудование клиента" section under customer artifacts.
  - Supports customer equipment create/edit/archive, recent service history, and manual history event creation.
- `manager_frontend/src/components/orders/OrderEditDrawer.vue`
  - New repair-only "Карточка оборудования и история" panel inside the existing repair/diagnostics section.
  - Uses the order customer and current branch filter when present.
  - Creates equipment from repair meta fields (`equipment_name`, `equipment_brand`, `equipment_model`, serial, inventory, refrigerant, location/address, notes from power/commissioning date).
  - Records service history from the current repair order only through an explicit button.

## Generated client methods used
- `ManagerEquipmentService.listManagerEquipment(customerId, customerBranchId, page, limit, includeArchived)`
- `ManagerEquipmentService.createManagerEquipment(payload)`
- `ManagerEquipmentService.getManagerEquipment(equipmentId, historyLimit)`
- `ManagerEquipmentService.patchManagerEquipment(equipmentId, payload)`
- `ManagerEquipmentService.createManagerEquipmentHistory(equipmentId, payload)`
- `ManagerEquipmentService.createManagerEquipmentHistoryFromRepairOrder(equipmentId, { order_id, event_type, notes })`

## Contract and scope notes
- No backend/API schema changes were made.
- No generated client files were changed.
- No public `web/` storefront files were touched.
- Persistent `order.equipment_id` linking is not implemented in this PR by design. This UI selects equipment locally for history actions; durable order-equipment linking remains a residual backend/product proposal if the team wants it later.
- No automatic equipment history is created on save, status change, or repair milestone change.

## Checks
- `cd manager_frontend && npm install` to install missing local worktree deps (`vue-tsc` was initially missing). npm reported existing audit findings: 2 moderate, 3 high, 1 critical.
- `cd manager_frontend && npm run build` ✅
- `git diff --check` ✅

## Browser smoke notes
- Started manager dev server at `http://127.0.0.1:5173/manager/` and opened `http://127.0.0.1:5173/manager/customers/profile?customerId=1` in the in-app browser.
- Page identity was correct (`CRM Мастер Воздуха`) and console logs were clean, but the app stopped at the manager login modal. Common local credentials did not authenticate.
- The currently running backend on port 8000 did not expose `/api/manager/equipment` in OpenAPI, so live create/edit/history API smoke could not be completed in this local browser session.

## Residual risks
- Old repair orders without equipment records will show an empty equipment list until a manager creates/selects equipment; no backfill is included here.
- Because persistent order-equipment linking is intentionally absent, reopening an order does not remember a selected equipment record unless history has already been written and reviewed through the customer equipment history.
- Reviewer should test against the deployed #386 backend contract with valid manager auth: customer profile equipment create/edit/archive/manual history, and repair drawer create-from-meta/history-from-order in both branch and no-branch orders.

Closes #394
Refs #329, #386
