### PR TITLE
[codex] Add repair equipment history backfill workflow

### DIFF
--- a/scripts/backfill_repair_equipment_history.py
+++ b/scripts/backfill_repair_equipment_history.py
@@ -1,0 +1,127 @@
+import argparse
+import asyncio
+import sys
+from typing import List, Optional, Set
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from scripts.repair_equipment_history_backfill_common import (
+    BackfillApplyResult,
+    apply_backfill_contexts,
+    fetch_repair_order_backfill_contexts,
+    summarize_results,
+)
+
+
+def _parse_customer_ids(raw_values: Optional[List[int]]) -> Optional[Set[int]]:
+    if not raw_values:
+        return None
+    return {int(value) for value in raw_values if int(value) > 0}
+
+
+def _async_database_url() -> str:
+    db_url = settings.DATABASE_URL
+    if db_url.startswith("postgresql+psycopg://"):
+        return db_url.replace("postgresql+psycopg://", "postgresql+asyncpg://", 1)
+    if db_url.startswith("postgresql://"):
+        return db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return db_url
+
+
+def _print_result(result: BackfillApplyResult) -> None:
+    target = f" equipment_id={result.equipment_id}" if result.equipment_id is not None else ""
+    history = f" history_id={result.history_id}" if result.history_id is not None else ""
+    mode = "applied" if result.executed else "planned"
+    print(f"  - order_id={result.order_id} {mode} action={result.action}{target}{history} reason={result.reason}")
+
+
+async def run(
+    *,
+    execute: bool,
+    customer_ids: Optional[Set[int]],
+    max_orders: Optional[int],
+) -> None:
+    engine = create_async_engine(_async_database_url())
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        contexts = await fetch_repair_order_backfill_contexts(
+            session,
+            customer_ids=customer_ids,
+            max_orders=max_orders,
+        )
+        results = await apply_backfill_contexts(session, contexts, execute=execute)
+        counts = summarize_results(results)
+
+        print("Repair Equipment History Backfill")
+        print(f"  mode={'execute' if execute else 'dry-run'}")
+        print(f"  repair_orders_with_meta={len(contexts)}")
+        if customer_ids:
+            print(f"  customer_scope={sorted(customer_ids)}")
+        if max_orders is not None:
+            print(f"  max_orders={max(0, int(max_orders))}")
+        for action, count in sorted(counts.items()):
+            print(f"  {action}={count}")
+
+        if not results:
+            print("Nothing to backfill.")
+        else:
+            print("\nPlan:")
+            for result in results:
+                _print_result(result)
+
+        if not execute:
+            print("\nDry run only. Use --execute to persist safe history records.")
+        else:
+            created_history = sum(1 for result in results if result.executed and result.history_id is not None)
+            created_equipment = sum(
+                1 for result in results if result.executed and result.action == "create-equipment-and-history"
+            )
+            print(f"\nApplied. Created {created_history} history records and {created_equipment} equipment records.")
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill customer equipment service history from old repair orders. "
+            "Default mode is dry-run."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist safe changes. Without this flag script only prints planned actions.",
+    )
+    parser.add_argument(
+        "--customer-id",
+        action="append",
+        type=int,
+        default=None,
+        help="Limit backfill to a specific customer id. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--limit",
+        "--max-orders",
+        dest="max_orders",
+        type=int,
+        default=None,
+        help="Limit number of repair orders with repair meta considered.",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run(
+            execute=args.execute,
+            customer_ids=_parse_customer_ids(args.customer_id),
+            max_orders=args.max_orders,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair_equipment_history_backfill_common.py
+++ b/scripts/repair_equipment_history_backfill_common.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, Literal, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Customer, CustomerBranch, CustomerEquipment, EquipmentServiceHistory, Order
+from services.equipment_service import EquipmentService
+
+
+_SPACE_RE = re.compile(r"\s+")
+
+EQUIPMENT_NAME_KEYS = ("equipment_name", "defect_equipment_name", "display_name")
+BRAND_KEYS = ("equipment_brand", "defect_equipment_brand", "brand")
+MODEL_KEYS = ("equipment_model", "defect_equipment_model", "model")
+SERIAL_KEYS = ("equipment_serial_number", "defect_serial_number", "serial_number", "serial")
+INVENTORY_KEYS = ("equipment_inventory_number", "defect_inventory_number", "inventory_number")
+EQUIPMENT_TYPE_KEYS = ("equipment_type", "equipment_kind")
+REFRIGERANT_KEYS = ("refrigerant_type",)
+
+BackfillAction = Literal[
+    "skip-existing-history",
+    "create-history",
+    "create-equipment-and-history",
+    "manual-needed",
+]
+
+
+@dataclass(frozen=True)
+class EquipmentFingerprint:
+    equipment_name: str | None = None
+    brand: str | None = None
+    model: str | None = None
+    serial: str | None = None
+    inventory_number: str | None = None
+    equipment_type: str | None = None
+    refrigerant_type: str | None = None
+
+    @property
+    def has_strong_identifier(self) -> bool:
+        return bool(self.serial or self.inventory_number)
+
+    @property
+    def has_any_identity_data(self) -> bool:
+        return any(
+            (
+                self.equipment_name,
+                self.brand,
+                self.model,
+                self.serial,
+                self.inventory_number,
+                self.equipment_type,
+                self.refrigerant_type,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class EquipmentCandidateMatch:
+    equipment: CustomerEquipment
+    confidence: Literal["exact-identifier", "weak-passport", "conflicting-identifier"]
+    reasons: tuple[str, ...]
+    branch_scope: Literal["same-branch", "equipment-unassigned", "order-unassigned"]
+    conflicts: tuple[str, ...] = ()
+
+    @property
+    def is_safe_for_backfill(self) -> bool:
+        return self.confidence == "exact-identifier" and not self.conflicts and not bool(self.equipment.is_archived)
+
+
+@dataclass(frozen=True)
+class RepairOrderBackfillContext:
+    order: Order
+    customer: Customer
+    branch: CustomerBranch | None
+    fingerprint: EquipmentFingerprint
+    existing_history: tuple[EquipmentServiceHistory, ...]
+    candidate_matches: tuple[EquipmentCandidateMatch, ...]
+
+
+@dataclass(frozen=True)
+class BackfillDecision:
+    action: BackfillAction
+    reason: str
+    equipment: CustomerEquipment | None = None
+    equipment_payload: dict[str, Any] | None = None
+    safe_match_count: int = 0
+
+
+@dataclass(frozen=True)
+class BackfillApplyResult:
+    order_id: int
+    action: BackfillAction
+    reason: str
+    executed: bool
+    equipment_id: int | None = None
+    history_id: int | None = None
+
+
+def clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    cleaned = _SPACE_RE.sub(" ", str(value)).strip()
+    return cleaned or None
+
+
+def fingerprint_key(value: Any) -> str | None:
+    cleaned = clean_text(value)
+    return cleaned.casefold() if cleaned else None
+
+
+def _meta_sources(order: Order) -> tuple[dict[str, Any], dict[str, Any]]:
+    meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+    repair_meta = meta.get("repair")
+    return meta, repair_meta if isinstance(repair_meta, dict) else {}
+
+
+def _first_meta_text(sources: Sequence[dict[str, Any]], keys: Iterable[str]) -> str | None:
+    for source in sources:
+        for key in keys:
+            cleaned = clean_text(source.get(key))
+            if cleaned:
+                return cleaned
+    return None
+
+
+def _has_meaningful_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(clean_text(value))
+    if isinstance(value, dict | list | tuple | set):
+        return bool(value)
+    return True
+
+
+def order_has_repair_meta(order: Order) -> bool:
+    _, repair_meta = _meta_sources(order)
+    return any(_has_meaningful_value(value) for value in repair_meta.values())
+
+
+def build_order_equipment_fingerprint(order: Order) -> EquipmentFingerprint:
+    meta, repair_meta = _meta_sources(order)
+    sources = (meta, repair_meta)
+    return EquipmentFingerprint(
+        equipment_name=_first_meta_text(sources, EQUIPMENT_NAME_KEYS),
+        brand=_first_meta_text(sources, BRAND_KEYS),
+        model=_first_meta_text(sources, MODEL_KEYS),
+        serial=_first_meta_text(sources, SERIAL_KEYS),
+        inventory_number=_first_meta_text(sources, INVENTORY_KEYS),
+        equipment_type=_first_meta_text(sources, EQUIPMENT_TYPE_KEYS),
+        refrigerant_type=_first_meta_text(sources, REFRIGERANT_KEYS),
+    )
+
+
+def build_equipment_fingerprint(equipment: CustomerEquipment) -> EquipmentFingerprint:
+    return EquipmentFingerprint(
+        equipment_name=clean_text(equipment.display_name),
+        brand=clean_text(equipment.brand),
+        model=clean_text(equipment.model),
+        serial=clean_text(equipment.serial),
+        inventory_number=clean_text(equipment.inventory_number),
+        equipment_type=clean_text(equipment.equipment_type),
+        refrigerant_type=clean_text(equipment.refrigerant_type),
+    )
+
+
+def _branch_scope(
+    *,
+    order_branch_id: int | None,
+    equipment_branch_id: int | None,
+) -> Literal["same-branch", "equipment-unassigned", "order-unassigned"] | None:
+    if order_branch_id is None:
+        return "order-unassigned"
+    if equipment_branch_id is None:
+        return "equipment-unassigned"
+    if int(order_branch_id) == int(equipment_branch_id):
+        return "same-branch"
+    return None
+
+
+def _matching_fields(order_fp: EquipmentFingerprint, equipment_fp: EquipmentFingerprint) -> tuple[list[str], list[str]]:
+    reasons: list[str] = []
+    conflicts: list[str] = []
+
+    for field_name in ("serial", "inventory_number"):
+        order_value = fingerprint_key(getattr(order_fp, field_name))
+        equipment_value = fingerprint_key(getattr(equipment_fp, field_name))
+        if order_value and equipment_value:
+            if order_value == equipment_value:
+                reasons.append(field_name)
+            else:
+                conflicts.append(f"{field_name}_mismatch")
+
+    for field_name in ("brand", "model", "refrigerant_type"):
+        order_value = fingerprint_key(getattr(order_fp, field_name))
+        equipment_value = fingerprint_key(getattr(equipment_fp, field_name))
+        if order_value and equipment_value:
+            if order_value == equipment_value:
+                reasons.append(field_name)
+            else:
+                conflicts.append(f"{field_name}_mismatch")
+
+    order_name = fingerprint_key(order_fp.equipment_name)
+    equipment_name = fingerprint_key(equipment_fp.equipment_name)
+    if order_name and equipment_name and order_name == equipment_name:
+        reasons.append("display_name")
+
+    return reasons, conflicts
+
+
+def match_equipment_candidates(
+    *,
+    fingerprint: EquipmentFingerprint,
+    equipment_items: Iterable[CustomerEquipment],
+    order_branch_id: int | None,
+) -> list[EquipmentCandidateMatch]:
+    matches: list[EquipmentCandidateMatch] = []
+    for equipment in equipment_items:
+        branch_scope = _branch_scope(
+            order_branch_id=order_branch_id,
+            equipment_branch_id=equipment.customer_branch_id,
+        )
+        if branch_scope is None:
+            continue
+
+        equipment_fp = build_equipment_fingerprint(equipment)
+        reasons, conflicts = _matching_fields(fingerprint, equipment_fp)
+        if not reasons:
+            continue
+
+        strong_reasons = {"serial", "inventory_number"}.intersection(reasons)
+        if strong_reasons and conflicts:
+            confidence: Literal["exact-identifier", "weak-passport", "conflicting-identifier"] = "conflicting-identifier"
+        elif strong_reasons:
+            confidence = "exact-identifier"
+        else:
+            confidence = "weak-passport"
+
+        matches.append(
+            EquipmentCandidateMatch(
+                equipment=equipment,
+                confidence=confidence,
+                reasons=tuple(reasons),
+                branch_scope=branch_scope,
+                conflicts=tuple(conflicts),
+            )
+        )
+
+    return sorted(
+        matches,
+        key=lambda item: (
+            0 if item.is_safe_for_backfill else 1,
+            item.equipment.customer_branch_id is None,
+            item.equipment.id or 0,
+        ),
+    )
+
+
+def build_auto_create_equipment_payload(context: RepairOrderBackfillContext) -> dict[str, Any] | None:
+    fingerprint = context.fingerprint
+    if not fingerprint.has_strong_identifier:
+        return None
+    if context.order.customer_branch_id is None or context.branch is None:
+        return None
+
+    payload = {
+        "customer_id": int(context.order.customer_id),
+        "customer_branch_id": int(context.order.customer_branch_id),
+        "equipment_type": clean_text(fingerprint.equipment_type) or "hvac",
+        "display_name": clean_text(fingerprint.equipment_name),
+        "brand": clean_text(fingerprint.brand),
+        "model": clean_text(fingerprint.model),
+        "serial": clean_text(fingerprint.serial),
+        "inventory_number": clean_text(fingerprint.inventory_number),
+        "refrigerant_type": clean_text(fingerprint.refrigerant_type),
+        "notes": f"Auto-created by repair equipment history backfill from order #{context.order.id}.",
+    }
+    payload["display_name"] = EquipmentService._default_display_name(payload)
+    return payload
+
+
+def build_backfill_decision(context: RepairOrderBackfillContext) -> BackfillDecision:
+    if context.existing_history:
+        return BackfillDecision(
+            action="skip-existing-history",
+            reason=f"history already exists for order_id={context.order.id}",
+        )
+
+    safe_matches = [match for match in context.candidate_matches if match.is_safe_for_backfill]
+    if len(safe_matches) == 1:
+        return BackfillDecision(
+            action="create-history",
+            reason=f"unique exact equipment match by {', '.join(safe_matches[0].reasons)}",
+            equipment=safe_matches[0].equipment,
+            safe_match_count=1,
+        )
+    if len(safe_matches) > 1:
+        return BackfillDecision(
+            action="manual-needed",
+            reason=f"multiple exact equipment matches ({len(safe_matches)})",
+            safe_match_count=len(safe_matches),
+        )
+    if context.candidate_matches:
+        return BackfillDecision(
+            action="manual-needed",
+            reason="only weak or conflicting equipment candidates found",
+        )
+
+    payload = build_auto_create_equipment_payload(context)
+    if payload is not None:
+        return BackfillDecision(
+            action="create-equipment-and-history",
+            reason="no existing candidate; strong passport identifier and branch scope allow auto-create",
+            equipment_payload=payload,
+        )
+
+    if not context.fingerprint.has_any_identity_data:
+        reason = "missing equipment passport data"
+    elif not context.fingerprint.has_strong_identifier:
+        reason = "missing strong identifier (serial or inventory_number)"
+    else:
+        reason = "missing branch scope for safe equipment auto-create"
+    return BackfillDecision(action="manual-needed", reason=reason)
+
+
+async def fetch_repair_order_backfill_contexts(
+    session: AsyncSession,
+    *,
+    customer_ids: set[int] | None = None,
+    max_orders: int | None = None,
+) -> list[RepairOrderBackfillContext]:
+    stmt = (
+        select(Order, Customer, CustomerBranch)
+        .join(Customer, Customer.id == Order.customer_id)
+        .outerjoin(CustomerBranch, CustomerBranch.id == Order.customer_branch_id)
+        .where(
+            Order.workflow_type == "repair",
+            Order.customer_id.is_not(None),
+        )
+        .order_by(Order.updated_at.desc(), Order.created_at.desc(), Order.id.desc())
+    )
+    if customer_ids:
+        stmt = stmt.where(Order.customer_id.in_(sorted(customer_ids)))
+
+    rows = (await session.execute(stmt)).all()
+    order_rows: list[tuple[Order, Customer, CustomerBranch | None]] = []
+    for order, customer, branch in rows:
+        if not order_has_repair_meta(order):
+            continue
+        order_rows.append((order, customer, branch))
+        if max_orders is not None and len(order_rows) >= max(0, int(max_orders)):
+            break
+
+    if not order_rows:
+        return []
+
+    scoped_customer_ids = {int(order.customer_id) for order, _, _ in order_rows if order.customer_id is not None}
+    order_ids = {int(order.id) for order, _, _ in order_rows if order.id is not None}
+
+    equipment_by_customer: dict[int, list[CustomerEquipment]] = defaultdict(list)
+    if scoped_customer_ids:
+        equipment_result = await session.execute(
+            select(CustomerEquipment)
+            .where(CustomerEquipment.customer_id.in_(sorted(scoped_customer_ids)))
+            .order_by(
+                CustomerEquipment.customer_id.asc(),
+                CustomerEquipment.customer_branch_id.asc(),
+                CustomerEquipment.is_archived.asc(),
+                CustomerEquipment.id.asc(),
+            )
+        )
+        for equipment in equipment_result.scalars().all():
+            equipment_by_customer[int(equipment.customer_id)].append(equipment)
+
+    history_by_order: dict[int, list[EquipmentServiceHistory]] = defaultdict(list)
+    if order_ids:
+        history_result = await session.execute(
+            select(EquipmentServiceHistory)
+            .where(EquipmentServiceHistory.order_id.in_(sorted(order_ids)))
+            .order_by(EquipmentServiceHistory.order_id.asc(), EquipmentServiceHistory.id.asc())
+        )
+        for history in history_result.scalars().all():
+            if history.order_id is not None:
+                history_by_order[int(history.order_id)].append(history)
+
+    contexts: list[RepairOrderBackfillContext] = []
+    for order, customer, branch in order_rows:
+        fingerprint = build_order_equipment_fingerprint(order)
+        equipment_items = equipment_by_customer.get(int(order.customer_id), [])
+        candidate_matches = match_equipment_candidates(
+            fingerprint=fingerprint,
+            equipment_items=equipment_items,
+            order_branch_id=order.customer_branch_id,
+        )
+        contexts.append(
+            RepairOrderBackfillContext(
+                order=order,
+                customer=customer,
+                branch=branch,
+                fingerprint=fingerprint,
+                existing_history=tuple(history_by_order.get(int(order.id or 0), [])),
+                candidate_matches=tuple(candidate_matches),
+            )
+        )
+    return contexts
+
+
+async def _fetch_existing_history_for_order(
+    session: AsyncSession,
+    *,
+    order_id: int,
+) -> list[EquipmentServiceHistory]:
+    result = await session.execute(
+        select(EquipmentServiceHistory)
+        .where(EquipmentServiceHistory.order_id == order_id)
+        .order_by(EquipmentServiceHistory.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def apply_backfill_context(
+    session: AsyncSession,
+    context: RepairOrderBackfillContext,
+    *,
+    execute: bool,
+) -> BackfillApplyResult:
+    decision = build_backfill_decision(context)
+    order_id = int(context.order.id)
+    equipment_id = int(decision.equipment.id) if decision.equipment and decision.equipment.id is not None else None
+
+    if not execute or decision.action not in {"create-history", "create-equipment-and-history"}:
+        return BackfillApplyResult(
+            order_id=order_id,
+            action=decision.action,
+            reason=decision.reason,
+            executed=False,
+            equipment_id=equipment_id,
+        )
+
+    existing_history = await _fetch_existing_history_for_order(session, order_id=order_id)
+    if existing_history:
+        return BackfillApplyResult(
+            order_id=order_id,
+            action="skip-existing-history",
+            reason=f"history already exists for order_id={order_id}",
+            executed=False,
+            equipment_id=existing_history[0].equipment_id,
+            history_id=existing_history[0].id,
+        )
+
+    if decision.action == "create-equipment-and-history":
+        assert decision.equipment_payload is not None
+        equipment = CustomerEquipment(**decision.equipment_payload)
+        session.add(equipment)
+        await session.flush()
+        await session.refresh(equipment)
+    else:
+        assert decision.equipment is not None
+        equipment = await session.get(CustomerEquipment, int(decision.equipment.id))
+        if equipment is None:
+            raise RuntimeError(f"Equipment #{decision.equipment.id} disappeared before backfill")
+
+    order = await session.get(Order, order_id)
+    if order is None:
+        raise RuntimeError(f"Order #{order_id} disappeared before backfill")
+
+    await EquipmentService._validate_order_link(session, equipment=equipment, order_id=order_id)
+    history_payload = EquipmentService.build_history_payload_from_repair_order(order)
+    history = EquipmentServiceHistory(
+        equipment_id=int(equipment.id),
+        order_id=history_payload["order_id"],
+        event_type=history_payload["event_type"],
+        event_date=history_payload["event_date"] or datetime.now(),
+        complaint_snapshot=history_payload["complaint_snapshot"],
+        diagnostic_result=history_payload["diagnostic_result"],
+        repair_recommendation=history_payload["repair_recommendation"],
+        refrigerant_type=history_payload["refrigerant_type"],
+        refrigerant_amount=history_payload["refrigerant_amount"],
+        not_repairable=history_payload["not_repairable"],
+        not_repairable_reason=history_payload["not_repairable_reason"],
+        notes=history_payload["notes"],
+    )
+    session.add(history)
+    await session.commit()
+    await session.refresh(history)
+
+    return BackfillApplyResult(
+        order_id=order_id,
+        action=decision.action,
+        reason=decision.reason,
+        executed=True,
+        equipment_id=int(equipment.id),
+        history_id=int(history.id),
+    )
+
+
+async def apply_backfill_contexts(
+    session: AsyncSession,
+    contexts: Iterable[RepairOrderBackfillContext],
+    *,
+    execute: bool,
+) -> list[BackfillApplyResult]:
+    results: list[BackfillApplyResult] = []
+    for context in contexts:
+        results.append(await apply_backfill_context(session, context, execute=execute))
+    return results
+
+
+def summarize_results(results: Iterable[BackfillApplyResult]) -> Counter[str]:
+    return Counter(result.action for result in results)

--- a/scripts/report_repair_equipment_history_candidates.py
+++ b/scripts/report_repair_equipment_history_candidates.py
@@ -1,0 +1,205 @@
+import argparse
+import asyncio
+import sys
+from collections import Counter
+from datetime import datetime
+from typing import Iterable, List, Optional, Set
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from scripts.repair_equipment_history_backfill_common import (
+    EquipmentCandidateMatch,
+    EquipmentFingerprint,
+    RepairOrderBackfillContext,
+    build_backfill_decision,
+    fetch_repair_order_backfill_contexts,
+)
+
+
+def _parse_customer_ids(raw_values: Optional[List[int]]) -> Optional[Set[int]]:
+    if not raw_values:
+        return None
+    return {int(value) for value in raw_values if int(value) > 0}
+
+
+def _async_database_url() -> str:
+    db_url = settings.DATABASE_URL
+    if db_url.startswith("postgresql+psycopg://"):
+        return db_url.replace("postgresql+psycopg://", "postgresql+asyncpg://", 1)
+    if db_url.startswith("postgresql://"):
+        return db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return db_url
+
+
+def _fmt_dt(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.strftime("%Y-%m-%d")
+
+
+def _fmt_fingerprint(fingerprint: EquipmentFingerprint) -> str:
+    parts = [
+        ("name", fingerprint.equipment_name),
+        ("brand", fingerprint.brand),
+        ("model", fingerprint.model),
+        ("serial", fingerprint.serial),
+        ("inventory", fingerprint.inventory_number),
+        ("type", fingerprint.equipment_type),
+        ("refrigerant", fingerprint.refrigerant_type),
+    ]
+    rendered = [f"{label}={value}" for label, value in parts if value]
+    return ", ".join(rendered) if rendered else "none"
+
+
+def _fmt_branch(context: RepairOrderBackfillContext) -> str:
+    if context.branch is None:
+        if context.order.customer_branch_id is None:
+            return "unassigned"
+        return f"missing branch #{context.order.customer_branch_id}"
+    label = context.branch.name or context.branch.delivery_address
+    return f"#{context.branch.id} {label}"
+
+
+def _enum_value(value) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+def _fmt_candidate(match: EquipmentCandidateMatch) -> str:
+    equipment = match.equipment
+    conflicts = f" conflicts={','.join(match.conflicts)}" if match.conflicts else ""
+    archived = " archived" if equipment.is_archived else ""
+    title = equipment.display_name or "unnamed"
+    return (
+        f"equipment_id={equipment.id} branch={equipment.customer_branch_id or '-'} "
+        f"{title!r} confidence={match.confidence} scope={match.branch_scope} "
+        f"reasons={','.join(match.reasons)}{conflicts}{archived}"
+    )
+
+
+def _should_print(context: RepairOrderBackfillContext, only_candidates: bool) -> bool:
+    if not only_candidates:
+        return True
+    decision = build_backfill_decision(context)
+    return bool(context.candidate_matches) or decision.action in {"create-history", "create-equipment-and-history"}
+
+
+def _print_context(context: RepairOrderBackfillContext) -> None:
+    decision = build_backfill_decision(context)
+    order = context.order
+    print(f"\n[{context.customer.id}] {context.customer.name}")
+    print(f"  branch: {_fmt_branch(context)}")
+    print(
+        "  order: "
+        f"#{order.id} status={_enum_value(order.status)} updated={_fmt_dt(order.updated_at)} "
+        f"delivery={order.delivery_address or '-'}"
+    )
+    print(f"  fingerprint: {_fmt_fingerprint(context.fingerprint)}")
+    if context.existing_history:
+        history_ids = ", ".join(str(item.id) for item in context.existing_history)
+        equipment_ids = ", ".join(str(item.equipment_id) for item in context.existing_history)
+        print(f"  existing_history: count={len(context.existing_history)} ids={history_ids} equipment_ids={equipment_ids}")
+    else:
+        print("  existing_history: none")
+
+    if context.candidate_matches:
+        print(f"  candidates: {len(context.candidate_matches)}")
+        for match in context.candidate_matches:
+            print(f"    - {_fmt_candidate(match)}")
+    else:
+        print("  candidates: none")
+
+    print(f"  decision: {decision.action} ({decision.reason})")
+    if decision.equipment_payload:
+        payload = decision.equipment_payload
+        print(
+            "    auto_create: "
+            f"display={payload.get('display_name')!r} "
+            f"serial={payload.get('serial') or '-'} "
+            f"inventory={payload.get('inventory_number') or '-'} "
+            f"branch={payload.get('customer_branch_id')}"
+        )
+
+
+def _decision_counts(contexts: Iterable[RepairOrderBackfillContext]) -> Counter[str]:
+    return Counter(build_backfill_decision(context).action for context in contexts)
+
+
+async def run(
+    *,
+    customer_ids: Optional[Set[int]],
+    max_orders: Optional[int],
+    only_candidates: bool,
+) -> None:
+    engine = create_async_engine(_async_database_url())
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        contexts = await fetch_repair_order_backfill_contexts(
+            session,
+            customer_ids=customer_ids,
+            max_orders=max_orders,
+        )
+        printable = [context for context in contexts if _should_print(context, only_candidates)]
+        counts = _decision_counts(contexts)
+
+        print("Repair Equipment History Candidate Report")
+        print(f"  repair_orders_with_meta={len(contexts)}")
+        print(f"  printed_orders={len(printable)}")
+        print(f"  only_candidates={only_candidates}")
+        if customer_ids:
+            print(f"  customer_scope={sorted(customer_ids)}")
+        if max_orders is not None:
+            print(f"  max_orders={max(0, int(max_orders))}")
+        for action, count in sorted(counts.items()):
+            print(f"  {action}={count}")
+
+        for context in printable:
+            _print_context(context)
+
+        print("\nTips:")
+        print("  - Use --only-candidates to hide already-linked and non-actionable orders.")
+        print("  - Use scripts/backfill_repair_equipment_history.py for dry-run/apply.")
+
+    await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report old repair orders that can be linked to customer equipment history."
+    )
+    parser.add_argument(
+        "--customer-id",
+        action="append",
+        type=int,
+        default=None,
+        help="Limit report to a specific customer id. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--limit",
+        "--max-orders",
+        dest="max_orders",
+        type=int,
+        default=None,
+        help="Limit number of repair orders with repair meta considered.",
+    )
+    parser.add_argument(
+        "--only-candidates",
+        action="store_true",
+        help="Show only orders with equipment candidates or planned auto-create/history actions.",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run(
+            customer_ids=_parse_customer_ids(args.customer_id),
+            max_orders=args.max_orders,
+            only_candidates=args.only_candidates,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_repair_equipment_history_backfill_common.py
+++ b/tests/unit/test_repair_equipment_history_backfill_common.py
@@ -1,0 +1,280 @@
+from datetime import datetime
+
+import pytest
+from sqlmodel import select
+
+from models import (
+    Customer,
+    CustomerBranch,
+    CustomerEquipment,
+    CustomerType,
+    EquipmentServiceHistory,
+    Order,
+    OrderStatus,
+)
+from scripts.repair_equipment_history_backfill_common import (
+    RepairOrderBackfillContext,
+    apply_backfill_contexts,
+    build_backfill_decision,
+    build_order_equipment_fingerprint,
+    fetch_repair_order_backfill_contexts,
+    match_equipment_candidates,
+    order_has_repair_meta,
+)
+
+
+def _repair_order(**kwargs):
+    defaults = {
+        "id": 100,
+        "customer_id": 1,
+        "customer_branch_id": 10,
+        "status": OrderStatus.NEGOTIATION,
+        "workflow_type": "repair",
+        "updated_at": datetime(2026, 6, 1, 12, 0, 0),
+        "technical_meta": {
+            "equipment_name": " Кондиционер Daikin ",
+            "equipment_serial_number": " SN-001 ",
+            "equipment_inventory_number": " INV-001 ",
+            "repair": {
+                "repair_status": "completed",
+                "equipment_model": " FTXB25C ",
+                "refrigerant_type": " R32 ",
+                "customer_complaint": "Не охлаждает",
+            },
+        },
+    }
+    defaults.update(kwargs)
+    return Order(**defaults)
+
+
+def test_order_equipment_fingerprint_reads_top_level_and_repair_meta_aliases():
+    order = _repair_order(technical_meta={
+        "equipment_name": " Кондиционер Daikin ",
+        "equipment_brand": " Daikin ",
+        "equipment_serial_number": " SN-001 ",
+        "repair": {
+            "repair_status": "completed",
+            "equipment_model": " FTXB25C ",
+            "equipment_inventory_number": " INV-001 ",
+            "refrigerant_type": " R32 ",
+        },
+    })
+
+    fingerprint = build_order_equipment_fingerprint(order)
+
+    assert order_has_repair_meta(order) is True
+    assert fingerprint.equipment_name == "Кондиционер Daikin"
+    assert fingerprint.brand == "Daikin"
+    assert fingerprint.model == "FTXB25C"
+    assert fingerprint.serial == "SN-001"
+    assert fingerprint.inventory_number == "INV-001"
+    assert fingerprint.refrigerant_type == "R32"
+
+
+def test_match_equipment_candidates_requires_branch_scope_and_marks_safe_exact_identifier():
+    fingerprint = build_order_equipment_fingerprint(_repair_order())
+    exact = CustomerEquipment(
+        id=1,
+        customer_id=1,
+        customer_branch_id=10,
+        display_name="Daikin FTXB25C",
+        brand="Daikin",
+        model="FTXB25C",
+        serial="sn-001",
+    )
+    weak = CustomerEquipment(
+        id=2,
+        customer_id=1,
+        customer_branch_id=10,
+        display_name="Кондиционер Daikin",
+        brand="Daikin",
+        model="FTXB25C",
+    )
+    wrong_branch = CustomerEquipment(
+        id=3,
+        customer_id=1,
+        customer_branch_id=11,
+        display_name="Daikin wrong branch",
+        serial="SN-001",
+    )
+
+    matches = match_equipment_candidates(
+        fingerprint=fingerprint,
+        equipment_items=[weak, wrong_branch, exact],
+        order_branch_id=10,
+    )
+
+    assert [match.equipment.id for match in matches] == [1, 2]
+    assert matches[0].confidence == "exact-identifier"
+    assert matches[0].is_safe_for_backfill is True
+    assert matches[1].confidence == "weak-passport"
+    assert matches[1].is_safe_for_backfill is False
+
+
+def test_backfill_decision_skips_existing_history_by_order_id():
+    order = _repair_order(id=101)
+    context = RepairOrderBackfillContext(
+        order=order,
+        customer=Customer(id=1, name="Owner", phone="+375291111111", type=CustomerType.company),
+        branch=CustomerBranch(id=10, customer_id=1, name="Office", delivery_address="Minsk"),
+        fingerprint=build_order_equipment_fingerprint(order),
+        existing_history=(EquipmentServiceHistory(id=55, equipment_id=9, order_id=101),),
+        candidate_matches=(),
+    )
+
+    decision = build_backfill_decision(context)
+
+    assert decision.action == "skip-existing-history"
+    assert "order_id=101" in decision.reason
+
+
+def test_backfill_decision_sends_ambiguous_exact_matches_to_manual_review():
+    order = _repair_order(id=102)
+    fingerprint = build_order_equipment_fingerprint(order)
+    equipment_a = CustomerEquipment(id=1, customer_id=1, customer_branch_id=10, serial="SN-001")
+    equipment_b = CustomerEquipment(id=2, customer_id=1, customer_branch_id=10, serial="SN-001")
+    matches = match_equipment_candidates(
+        fingerprint=fingerprint,
+        equipment_items=[equipment_a, equipment_b],
+        order_branch_id=10,
+    )
+    context = RepairOrderBackfillContext(
+        order=order,
+        customer=Customer(id=1, name="Owner", phone="+375291111111", type=CustomerType.company),
+        branch=CustomerBranch(id=10, customer_id=1, name="Office", delivery_address="Minsk"),
+        fingerprint=fingerprint,
+        existing_history=(),
+        candidate_matches=tuple(matches),
+    )
+
+    decision = build_backfill_decision(context)
+
+    assert decision.action == "manual-needed"
+    assert "multiple exact" in decision.reason
+
+
+def test_backfill_decision_auto_creates_only_with_strong_identifier_and_branch_scope():
+    order = _repair_order(id=103)
+    context = RepairOrderBackfillContext(
+        order=order,
+        customer=Customer(id=1, name="Owner", phone="+375291111111", type=CustomerType.company),
+        branch=CustomerBranch(id=10, customer_id=1, name="Office", delivery_address="Minsk"),
+        fingerprint=build_order_equipment_fingerprint(order),
+        existing_history=(),
+        candidate_matches=(),
+    )
+
+    decision = build_backfill_decision(context)
+
+    assert decision.action == "create-equipment-and-history"
+    assert decision.equipment_payload["customer_branch_id"] == 10
+    assert decision.equipment_payload["serial"] == "SN-001"
+
+    no_branch_order = _repair_order(id=104, customer_branch_id=None)
+    no_branch_context = RepairOrderBackfillContext(
+        order=no_branch_order,
+        customer=Customer(id=1, name="Owner", phone="+375291111111", type=CustomerType.company),
+        branch=None,
+        fingerprint=build_order_equipment_fingerprint(no_branch_order),
+        existing_history=(),
+        candidate_matches=(),
+    )
+
+    no_branch_decision = build_backfill_decision(no_branch_context)
+
+    assert no_branch_decision.action == "manual-needed"
+    assert "branch scope" in no_branch_decision.reason
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_does_not_create_history(db):
+    customer = Customer(name="Dry Run Owner", phone="+375291110201", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+    branch = CustomerBranch(customer_id=customer.id, name="Office", delivery_address="Minsk, Test 1")
+    db.add(branch)
+    await db.commit()
+    await db.refresh(branch)
+    equipment = CustomerEquipment(
+        customer_id=customer.id,
+        customer_branch_id=branch.id,
+        display_name="Daikin FTXB25C",
+        serial="SN-DRY-1",
+    )
+    db.add(equipment)
+    await db.commit()
+    await db.refresh(equipment)
+    order = _repair_order(
+        id=None,
+        customer_id=customer.id,
+        customer_branch_id=branch.id,
+        technical_meta={
+            "equipment_serial_number": "SN-DRY-1",
+            "repair": {"repair_status": "completed", "customer_complaint": "Не охлаждает"},
+        },
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    contexts = await fetch_repair_order_backfill_contexts(db, customer_ids={customer.id})
+    results = await apply_backfill_contexts(db, contexts, execute=False)
+
+    assert [result.action for result in results] == ["create-history"]
+    history_result = await db.execute(
+        select(EquipmentServiceHistory).where(EquipmentServiceHistory.order_id == order.id)
+    )
+    assert history_result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_execute_is_idempotent_by_order_id(db):
+    customer = Customer(name="Repeat Owner", phone="+375291110202", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+    branch = CustomerBranch(customer_id=customer.id, name="Shop", delivery_address="Minsk, Test 2")
+    db.add(branch)
+    await db.commit()
+    await db.refresh(branch)
+    equipment = CustomerEquipment(
+        customer_id=customer.id,
+        customer_branch_id=branch.id,
+        display_name="Mitsubishi MSZ",
+        serial="SN-REPEAT-1",
+    )
+    db.add(equipment)
+    await db.commit()
+    await db.refresh(equipment)
+    order = _repair_order(
+        id=None,
+        customer_id=customer.id,
+        customer_branch_id=branch.id,
+        technical_meta={
+            "equipment_serial_number": "SN-REPEAT-1",
+            "repair": {
+                "repair_status": "completed",
+                "customer_complaint": "Плохо холодит",
+                "diagnostic_result": "Недостаток хладагента.",
+            },
+        },
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    first_contexts = await fetch_repair_order_backfill_contexts(db, customer_ids={customer.id})
+    first_results = await apply_backfill_contexts(db, first_contexts, execute=True)
+    second_contexts = await fetch_repair_order_backfill_contexts(db, customer_ids={customer.id})
+    second_results = await apply_backfill_contexts(db, second_contexts, execute=True)
+
+    assert [result.action for result in first_results] == ["create-history"]
+    assert first_results[0].executed is True
+    assert [result.action for result in second_results] == ["skip-existing-history"]
+    history_result = await db.execute(
+        select(EquipmentServiceHistory).where(EquipmentServiceHistory.order_id == order.id)
+    )
+    histories = history_result.scalars().all()
+    assert len(histories) == 1
+    assert histories[0].equipment_id == equipment.id


### PR DESCRIPTION
## Summary

- Add a shared repair equipment history backfill helper for repair-order fingerprinting, exact candidate matching, idempotency checks, and safe apply decisions.
- Add report and dry-run/apply scripts for old `Order.workflow_type = repair` orders with repair meta.
- Add tests for fingerprint/candidate logic, dry-run no-write behavior, and repeated backfill idempotency by `EquipmentServiceHistory.order_id`.

## Safety notes

- Backfill defaults to dry-run; writes require `--execute`.
- Existing `EquipmentServiceHistory.order_id = order.id` always skips creation.
- No fuzzy matching is used: automatic history creation requires one unique exact serial/inventory match; otherwise the order is `manual-needed`.
- Equipment auto-create only happens with a strong serial/inventory identifier and a clear customer branch scope.
- Archived, weak, conflicting, and ambiguous equipment matches stay manual.

## Dry-run commands

Local report:

```bash
python3 scripts/report_repair_equipment_history_candidates.py --customer-id 123 --limit 20 --only-candidates
```

Local backfill dry-run:

```bash
python3 scripts/backfill_repair_equipment_history.py --customer-id 123 --limit 20
```

Prod report:

```bash
docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/report_repair_equipment_history_candidates.py --customer-id 123 --limit 20 --only-candidates
```

Prod backfill dry-run:

```bash
docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_repair_equipment_history.py --customer-id 123 --limit 20
```

Do not run prod apply without an explicit manual approval and `--execute`.

## Checks

```bash
TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass pytest tests/unit/test_repair_equipment_history_backfill_common.py -q
TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass pytest tests/unit/test_equipment_service.py -q
TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass BOT_TOKEN=test-token SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_manager_equipment_api.py -q
git diff --check
```

Closes #396