### PR TITLE
[codex] Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ on:
   pull_request:
     branches: [ main, master ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Dummy Env
         run: |
@@ -31,7 +34,7 @@ jobs:
           echo "WEBSITE_URL=http://localhost:4321" >> .env
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ on:
         default: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # Secrets needed:
@@ -36,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -115,17 +116,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -144,7 +145,7 @@ jobs:
       - name: Build and push Backend (App + Bot) [Attempt 1]
         id: backend_push_1
         continue-on-error: true
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -156,7 +157,7 @@ jobs:
         id: backend_push_2
         if: steps.backend_push_1.outcome == 'failure'
         continue-on-error: true
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -167,7 +168,7 @@ jobs:
       - name: Build and push Backend (App + Bot) [Attempt 3]
         id: backend_push_3
         if: steps.backend_push_1.outcome == 'failure' && steps.backend_push_2.outcome == 'failure'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -292,7 +293,7 @@ jobs:
 
       - name: Upload Backend Ops Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: backend-ops-logs-${{ github.run_id }}
           path: |
@@ -342,10 +343,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   SSH_HOST_WEB: ${{ secrets.SSH_HOST_WEB }}
   SSH_USER_WEB: ${{ secrets.SSH_USER_WEB }}
 
@@ -13,10 +14,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Update JavaScript GitHub Actions in CI/deploy workflows to Node 24-compatible major versions:
  - `actions/checkout@v6`
  - `actions/setup-node@v6`
  - `actions/upload-artifact@v7`
  - `docker/login-action@v4`
  - `docker/build-push-action@v7`
- Add workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` in workflows that use JavaScript actions.
- Leave `node-version: '20'` unchanged for manager/storefront builds. That setting controls the project build Node.js version installed by `setup-node`; it is not the runtime used by the GitHub Actions themselves.

## Notes

- Audited `.github/workflows/*.yml`; `check-web-ssh.yml` has no JavaScript `uses:` actions, so it was left unchanged.
- Upstream action metadata for the selected major versions declares `runs.using: node24`; no remaining action in these workflows needed a documented exception.
- The #397 frontend deploy gating is preserved. `deploy-frontend` still runs only when `detect-frontend-changes.outputs.web_changed == 'true'`, and that detector still treats `web/`, `.github/workflows/deploy.yml`, `.github/workflows/rebuild-web.yml`, and `.github/workflows/check-web-ssh.yml` as storefront-relevant.
- Because this PR changes `deploy.yml` and `rebuild-web.yml`, a PR/merge workflow-only run may still exercise frontend deploy under the existing storefront-relevant logic.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`
- Verified no old Node20-runtime action refs remain for the audited actions: `actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`, `docker/login-action@v3`, `docker/build-push-action@v5`.
- Local backend/frontend tests were not run because this is workflow-only infra configuration.

Closes #400