### PR TITLE
[codex] Make repair equipment history sync idempotent

### DIFF
--- a/services/equipment_service.py
+++ b/services/equipment_service.py
@@ -19,6 +19,7 @@ from models import (
 class EquipmentService:
     TRUE_VALUES = {"1", "true", "yes", "y", "да", "д", "истина"}
     FALSE_VALUES = {"0", "false", "no", "n", "нет", "н", "ложь"}
+    REPAIR_HISTORY_AUTO_SYNC_STATUSES = frozenset({"completed", "not_repairable"})
 
     @staticmethod
     def _clean_optional_text(value: Any) -> Optional[str]:
@@ -70,6 +71,25 @@ class EquipmentService:
             if cleaned:
                 return cleaned
         return None
+
+    @staticmethod
+    def is_repair_order_history_sync_eligible(order: Order) -> bool:
+        """Policy for future automation: only terminal repair milestones may sync automatically."""
+        from services.order_service import OrderService
+
+        workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+        if workflow_type != "repair":
+            return False
+
+        repair_meta = OrderService._get_repair_meta(order)
+        try:
+            status = OrderService.normalize_repair_status(
+                repair_meta.get(OrderService.REPAIR_STATUS_KEY),
+                fallback=OrderService.REPAIR_DEFAULT_STATUS,
+            )
+        except ValueError:
+            return False
+        return status in EquipmentService.REPAIR_HISTORY_AUTO_SYNC_STATUSES
 
     @staticmethod
     def _default_display_name(data: Dict[str, Any]) -> Optional[str]:
@@ -126,6 +146,91 @@ class EquipmentService:
             "created_at": entry.created_at,
             "updated_at": entry.updated_at,
         }
+
+    @staticmethod
+    def _history_values_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+        order_id = payload.get("order_id")
+        return {
+            "order_id": int(order_id) if order_id is not None else None,
+            "event_type": EquipmentService._normalize_event_type(payload.get("event_type")),
+            "event_date": EquipmentService._normalize_naive_datetime(payload.get("event_date")) or datetime.now(),
+            "complaint_snapshot": EquipmentService._clean_optional_text(payload.get("complaint_snapshot")),
+            "diagnostic_result": EquipmentService._clean_optional_text(payload.get("diagnostic_result")),
+            "repair_recommendation": EquipmentService._clean_optional_text(payload.get("repair_recommendation")),
+            "refrigerant_type": EquipmentService._clean_optional_text(payload.get("refrigerant_type")),
+            "refrigerant_amount": EquipmentService._clean_optional_text(payload.get("refrigerant_amount")),
+            "not_repairable": bool(payload.get("not_repairable", False)),
+            "not_repairable_reason": EquipmentService._clean_optional_text(payload.get("not_repairable_reason")),
+            "notes": EquipmentService._clean_optional_text(payload.get("notes")),
+        }
+
+    @staticmethod
+    def _build_history_entry(*, equipment_id: int, payload: Dict[str, Any]) -> EquipmentServiceHistory:
+        return EquipmentServiceHistory(
+            equipment_id=equipment_id,
+            **EquipmentService._history_values_from_payload(payload),
+        )
+
+    @staticmethod
+    def _history_value_matches(entry: EquipmentServiceHistory, field: str, value: Any) -> bool:
+        current = getattr(entry, field)
+        if field == "event_type":
+            return EquipmentService._enum_value(current) == EquipmentService._enum_value(value)
+        return current == value
+
+    @staticmethod
+    def _apply_history_payload(entry: EquipmentServiceHistory, payload: Dict[str, Any]) -> bool:
+        changed = False
+        for field, value in EquipmentService._history_values_from_payload(payload).items():
+            if EquipmentService._history_value_matches(entry, field, value):
+                continue
+            setattr(entry, field, value)
+            changed = True
+        if changed:
+            entry.updated_at = datetime.now()
+        return changed
+
+    @staticmethod
+    def resolve_repair_order_history_sync_target(
+        existing_histories: list[EquipmentServiceHistory],
+        *,
+        equipment_id: int,
+        order_id: int,
+    ) -> Optional[EquipmentServiceHistory]:
+        """Idempotency policy for explicit repair-order -> equipment-history sync."""
+        histories = [
+            item
+            for item in existing_histories
+            if item.order_id is not None and int(item.order_id) == int(order_id)
+        ]
+        if not histories:
+            return None
+
+        if len(histories) > 1:
+            raise ValueError(f"Multiple equipment service history rows already exist for order #{order_id}")
+
+        existing = histories[0]
+        if int(existing.equipment_id) != int(equipment_id):
+            raise ValueError(
+                f"Equipment service history for order #{order_id} already belongs to "
+                f"equipment #{existing.equipment_id}"
+            )
+        return existing
+
+    @staticmethod
+    def _preserve_omitted_repair_history_overrides(
+        entry: EquipmentServiceHistory,
+        history_payload: Dict[str, Any],
+        request_payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        preserved_payload = dict(history_payload)
+        if "event_type" not in request_payload:
+            preserved_payload["event_type"] = entry.event_type
+        if "event_date" not in request_payload:
+            preserved_payload["event_date"] = entry.event_date
+        if "notes" not in request_payload:
+            preserved_payload["notes"] = entry.notes
+        return preserved_payload
 
     @staticmethod
     async def _ensure_customer_exists(session: AsyncSession, customer_id: int) -> Optional[Customer]:
@@ -365,6 +470,20 @@ class EquipmentService:
         }
 
     @staticmethod
+    async def _lock_order_for_history_sync(session: AsyncSession, *, order_id: int) -> None:
+        await session.execute(select(Order.id).where(Order.id == order_id).with_for_update())
+
+    @staticmethod
+    async def _list_history_for_order(session: AsyncSession, *, order_id: int) -> list[EquipmentServiceHistory]:
+        result = await session.execute(
+            select(EquipmentServiceHistory)
+            .where(EquipmentServiceHistory.order_id == order_id)
+            .order_by(EquipmentServiceHistory.id.asc())
+            .with_for_update()
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
     async def add_history(
         session: AsyncSession,
         *,
@@ -384,19 +503,9 @@ class EquipmentService:
             )
 
         event_type = EquipmentService._normalize_event_type(payload.get("event_type"))
-        entry = EquipmentServiceHistory(
+        entry = EquipmentService._build_history_entry(
             equipment_id=equipment_id,
-            order_id=int(order_id) if order_id is not None else None,
-            event_type=event_type,
-            event_date=EquipmentService._normalize_naive_datetime(payload.get("event_date")) or datetime.now(),
-            complaint_snapshot=EquipmentService._clean_optional_text(payload.get("complaint_snapshot")),
-            diagnostic_result=EquipmentService._clean_optional_text(payload.get("diagnostic_result")),
-            repair_recommendation=EquipmentService._clean_optional_text(payload.get("repair_recommendation")),
-            refrigerant_type=EquipmentService._clean_optional_text(payload.get("refrigerant_type")),
-            refrigerant_amount=EquipmentService._clean_optional_text(payload.get("refrigerant_amount")),
-            not_repairable=bool(payload.get("not_repairable", False)),
-            not_repairable_reason=EquipmentService._clean_optional_text(payload.get("not_repairable_reason")),
-            notes=EquipmentService._clean_optional_text(payload.get("notes")),
+            payload={**payload, "event_type": event_type},
         )
         session.add(entry)
         await session.commit()
@@ -501,14 +610,34 @@ class EquipmentService:
             equipment=equipment,
             order_id=int(payload["order_id"]),
         )
+        order_id = int(order.id)
+        await EquipmentService._lock_order_for_history_sync(session, order_id=order_id)
+        existing_histories = await EquipmentService._list_history_for_order(session, order_id=order_id)
+        existing_history = EquipmentService.resolve_repair_order_history_sync_target(
+            existing_histories,
+            equipment_id=equipment_id,
+            order_id=order_id,
+        )
         history_payload = EquipmentService.build_history_payload_from_repair_order(
             order,
             event_type=payload.get("event_type"),
             event_date=payload.get("event_date"),
             notes=payload.get("notes"),
         )
-        return await EquipmentService.add_history(
-            session,
-            equipment_id=equipment_id,
-            payload=history_payload,
-        )
+        if existing_history is not None:
+            history_payload = EquipmentService._preserve_omitted_repair_history_overrides(
+                existing_history,
+                history_payload,
+                payload,
+            )
+            if EquipmentService._apply_history_payload(existing_history, history_payload):
+                session.add(existing_history)
+                await session.commit()
+                await session.refresh(existing_history)
+            return EquipmentService._to_history_item(existing_history)
+
+        entry = EquipmentService._build_history_entry(equipment_id=equipment_id, payload=history_payload)
+        session.add(entry)
+        await session.commit()
+        await session.refresh(entry)
+        return EquipmentService._to_history_item(entry)

--- a/tests/integration/test_manager_equipment_api.py
+++ b/tests/integration/test_manager_equipment_api.py
@@ -3,7 +3,15 @@ from datetime import datetime
 from sqlmodel import select
 
 from core.config import settings
-from models import Customer, CustomerBranch, CustomerType, EquipmentServiceHistory, Order, OrderStatus
+from models import (
+    Customer,
+    CustomerBranch,
+    CustomerType,
+    EquipmentServiceEventType,
+    EquipmentServiceHistory,
+    Order,
+    OrderStatus,
+)
 
 
 async def _auth_headers(async_client):
@@ -180,6 +188,187 @@ async def test_manager_equipment_history_from_repair_order_maps_meta_and_allows_
     assert history["refrigerant_type"] == "R32"
     assert history["refrigerant_amount"] == "0,35 кг"
     assert history["notes"] == "Ремонт завершен."
+
+    repeat_resp = await async_client.post(
+        f"/api/manager/equipment/{equipment_id}/history/from-repair-order",
+        headers=headers,
+        json={"order_id": order.id},
+    )
+    assert repeat_resp.status_code == 201, repeat_resp.text
+    repeat_history = repeat_resp.json()
+    assert repeat_history["id"] == history["id"]
+    assert repeat_history["order_id"] == order.id
+
+    history_result = await db.execute(
+        select(EquipmentServiceHistory).where(EquipmentServiceHistory.order_id == order.id)
+    )
+    history_rows = history_result.scalars().all()
+    assert len(history_rows) == 1
+    assert history_rows[0].id == history["id"]
+
+
+@pytest.mark.asyncio
+async def test_manager_equipment_history_from_repair_order_preserves_omitted_overrides_on_repeat(async_client, db):
+    headers = await _auth_headers(async_client)
+    customer = Customer(name="Repair Sync Owner", phone="+375291110112", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    equipment_resp = await async_client.post(
+        "/api/manager/equipment",
+        headers=headers,
+        json={
+            "customer_id": customer.id,
+            "equipment_type": "split",
+            "brand": "Gree",
+            "model": "Bora",
+            "serial": "SN-SYNC-1",
+        },
+    )
+    assert equipment_resp.status_code == 201, equipment_resp.text
+    equipment_id = equipment_resp.json()["id"]
+
+    order = Order(
+        customer_id=customer.id,
+        customer_branch_id=None,
+        status=OrderStatus.NEGOTIATION,
+        workflow_type="repair",
+        updated_at=datetime(2026, 3, 5, 10, 0, 0),
+        technical_meta={
+            "repair": {
+                "repair_status": "completed",
+                "customer_complaint": "Шумит наружный блок",
+                "diagnostic_result": "Ослаблено крепление вентилятора.",
+                "repair_completion_note": "Крепление подтянуто.",
+            }
+        },
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    first_resp = await async_client.post(
+        f"/api/manager/equipment/{equipment_id}/history/from-repair-order",
+        headers=headers,
+        json={
+            "order_id": order.id,
+            "event_type": "recommendation",
+            "event_date": "2026-03-05T08:00:00",
+            "notes": "Ручная заметка менеджера.",
+        },
+    )
+    assert first_resp.status_code == 201, first_resp.text
+    first_history = first_resp.json()
+    assert first_history["event_type"] == "recommendation"
+    assert first_history["event_date"] == "2026-03-05T08:00:00"
+    assert first_history["notes"] == "Ручная заметка менеджера."
+
+    order.technical_meta = {
+        "repair": {
+            "repair_status": "completed",
+            "customer_complaint": "Шумит наружный блок",
+            "diagnostic_result": "Вентилятор закреплен, вибрация устранена.",
+            "repair_completion_note": "Повторная проверка без замечаний.",
+        }
+    }
+    order.updated_at = datetime(2026, 3, 6, 11, 0, 0)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    sync_resp = await async_client.post(
+        f"/api/manager/equipment/{equipment_id}/history/from-repair-order",
+        headers=headers,
+        json={"order_id": order.id},
+    )
+    assert sync_resp.status_code == 201, sync_resp.text
+    synced_history = sync_resp.json()
+    assert synced_history["id"] == first_history["id"]
+    assert synced_history["event_type"] == "recommendation"
+    assert synced_history["event_date"] == "2026-03-05T08:00:00"
+    assert synced_history["diagnostic_result"] == "Вентилятор закреплен, вибрация устранена."
+    assert synced_history["notes"] == "Ручная заметка менеджера."
+
+    history_result = await db.execute(
+        select(EquipmentServiceHistory).where(EquipmentServiceHistory.order_id == order.id)
+    )
+    assert len(history_result.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_equipment_history_from_repair_order_rejects_existing_history_on_other_equipment(
+    async_client,
+    db,
+):
+    headers = await _auth_headers(async_client)
+    customer = Customer(name="Repair Conflict Owner", phone="+375291110113", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    first_equipment_resp = await async_client.post(
+        "/api/manager/equipment",
+        headers=headers,
+        json={
+            "customer_id": customer.id,
+            "equipment_type": "split",
+            "brand": "Daikin",
+            "serial": "SN-CONFLICT-1",
+        },
+    )
+    assert first_equipment_resp.status_code == 201, first_equipment_resp.text
+    first_equipment_id = first_equipment_resp.json()["id"]
+
+    second_equipment_resp = await async_client.post(
+        "/api/manager/equipment",
+        headers=headers,
+        json={
+            "customer_id": customer.id,
+            "equipment_type": "split",
+            "brand": "Daikin",
+            "serial": "SN-CONFLICT-2",
+        },
+    )
+    assert second_equipment_resp.status_code == 201, second_equipment_resp.text
+    second_equipment_id = second_equipment_resp.json()["id"]
+
+    order = Order(
+        customer_id=customer.id,
+        customer_branch_id=None,
+        status=OrderStatus.NEGOTIATION,
+        workflow_type="repair",
+        technical_meta={"repair": {"repair_status": "completed", "customer_complaint": "Не охлаждает"}},
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    existing_history = EquipmentServiceHistory(
+        equipment_id=first_equipment_id,
+        order_id=order.id,
+        event_type=EquipmentServiceEventType.REPAIR,
+        event_date=datetime(2026, 3, 7, 9, 0, 0),
+        notes="Already synced to first equipment.",
+    )
+    db.add(existing_history)
+    await db.commit()
+    await db.refresh(existing_history)
+
+    conflict_resp = await async_client.post(
+        f"/api/manager/equipment/{second_equipment_id}/history/from-repair-order",
+        headers=headers,
+        json={"order_id": order.id},
+    )
+    assert conflict_resp.status_code == 400
+    assert f"already belongs to equipment #{first_equipment_id}" in conflict_resp.text
+
+    history_result = await db.execute(
+        select(EquipmentServiceHistory).where(EquipmentServiceHistory.order_id == order.id)
+    )
+    history_rows = history_result.scalars().all()
+    assert len(history_rows) == 1
+    assert history_rows[0].equipment_id == first_equipment_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_equipment_service.py
+++ b/tests/unit/test_equipment_service.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from models import EquipmentServiceEventType, Order, OrderStatus
+from models import EquipmentServiceEventType, EquipmentServiceHistory, Order, OrderStatus
 from services.equipment_service import EquipmentService
 
 
@@ -69,3 +69,56 @@ def test_build_history_payload_from_repair_order_rejects_non_repair_order():
 
     with pytest.raises(ValueError, match="Only repair orders"):
         EquipmentService.build_history_payload_from_repair_order(order)
+
+
+@pytest.mark.parametrize(
+    ("repair_status", "expected"),
+    [
+        ("completed", True),
+        ("not_repairable", True),
+        ("cancelled", False),
+        ("diagnostic_in_progress", False),
+        ("awaiting_customer_approval", False),
+    ],
+)
+def test_repair_order_history_sync_eligibility_policy_is_terminal_only(repair_status, expected):
+    order = Order(
+        status=OrderStatus.NEGOTIATION,
+        workflow_type="repair",
+        technical_meta={"repair": {"repair_status": repair_status}},
+    )
+
+    assert EquipmentService.is_repair_order_history_sync_eligible(order) is expected
+
+
+def test_repair_order_history_sync_eligibility_rejects_non_repair_order():
+    order = Order(
+        status=OrderStatus.NEW_LEAD,
+        workflow_type="sales_installation",
+        technical_meta={"repair": {"repair_status": "completed"}},
+    )
+
+    assert EquipmentService.is_repair_order_history_sync_eligible(order) is False
+
+
+def test_resolve_repair_order_history_sync_target_returns_same_equipment_history():
+    history = EquipmentServiceHistory(id=7, equipment_id=3, order_id=42)
+
+    result = EquipmentService.resolve_repair_order_history_sync_target(
+        [history],
+        equipment_id=3,
+        order_id=42,
+    )
+
+    assert result is history
+
+
+def test_resolve_repair_order_history_sync_target_rejects_other_equipment_history():
+    history = EquipmentServiceHistory(id=8, equipment_id=4, order_id=42)
+
+    with pytest.raises(ValueError, match="already belongs to equipment #4"):
+        EquipmentService.resolve_repair_order_history_sync_target(
+            [history],
+            equipment_id=3,
+            order_id=42,
+        )


### PR DESCRIPTION
## Summary

- Make explicit manager repair-order -> equipment service-history sync idempotent by `EquipmentServiceHistory.order_id`.
- Add a service-level milestone eligibility helper for future automation.
- Cover double POST, same-equipment refresh, cross-equipment rejection, and terminal-only policy tests.

## Idempotency behavior

- If no `EquipmentServiceHistory` exists for the repair order, the endpoint creates one after the existing customer/branch ownership checks pass.
- If exactly one history row exists for the same `order_id` and the same equipment, the endpoint returns that row and refreshes canonical repair-meta fields: complaint, diagnostic result, repair recommendation, refrigerant values, not-repairable flags/reason.
- On same-equipment refresh, omitted manual override fields preserve their existing values: `event_type`, `event_date`, and `notes`. If the request explicitly sends those fields, the supplied values are applied.
- If a history row for the same `order_id` belongs to another equipment item, the endpoint rejects the sync with a clear 400 error and does not move or duplicate history.
- If multiple history rows already exist for the same `order_id`, the service rejects the sync instead of guessing.

## Automation policy

Future automatic sync is intentionally limited to terminal repair statuses only: `completed` and `not_repairable`. `cancelled` and intermediate/diagnostic statuses are not eligible.

No broad automatic history creation on manager order patch was added in this PR.

## Tests run

- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass pytest tests/unit/test_equipment_service.py -q`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass BOT_TOKEN=test-token SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_manager_equipment_api.py -q`
- `git diff --check`

Closes #402.
