### PR TITLE
[codex] Parse supplier prices with currency suffixes

### DIFF
--- a/services/supplier_sync_service.py
+++ b/services/supplier_sync_service.py
@@ -42,7 +42,10 @@ def _parse_decimal(raw: str) -> Optional[Decimal]:
     if not value:
         return None
     value = value.replace(" ", "").replace(",", ".")
-    cleaned = "".join(ch for ch in value if ch.isdigit() or ch in ".-")
+    cleaned = "".join(ch for ch in value if ch.isdigit() or ch in ".-").strip(".")
+    if cleaned.count(".") > 1:
+        whole, fractional = cleaned.rsplit(".", 1)
+        cleaned = f"{whole.replace('.', '')}.{fractional}"
     if not cleaned:
         return None
     try:

--- a/tests/unit/test_supplier_sync_parsing.py
+++ b/tests/unit/test_supplier_sync_parsing.py
@@ -15,6 +15,8 @@ def test_parse_decimal_with_spaces_and_comma():
     assert _parse_decimal("2 670") == Decimal("2670")
     assert _parse_decimal("479,50") == Decimal("479.50")
     assert _parse_decimal(" 1\u00a0234.75 ") == Decimal("1234.75")
+    assert _parse_decimal("2\u00a0089,00р.") == Decimal("2089.00")
+    assert _parse_decimal("1\u00a0595,76 руб.") == Decimal("1595.76")
 
 
 def test_parse_qty_and_currency_normalization():


### PR DESCRIPTION
## Summary

- Fix supplier price decimal parsing for BYN/RUB currency suffixes such as `2 089,00р.` and `1 595,76 руб.`.
- Keep existing comma/dot/NBSP parsing behavior.
- Add regression coverage for the Pronto price-list format.

## Diagnosis

Production source #11 (`Пронто`, sheet `краткий прайс кондиционеры`, range `A4:I79`) read 76 rows successfully but skipped all 76 because RRC values in column D include a trailing currency suffix (`р.`). The old cleaner kept the final dot from `р.`, producing invalid values like `2089.00.`.

A no-write dry run with the patched parser on the real sheet gives `rows_total=76`, `would_upsert=60`, `would_skip=16`; the skipped rows are section/header rows without prices.

## Tests run

- `pytest tests/unit/test_supplier_sync_parsing.py -q`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 POSTGRES_PASSWORD=securepass BOT_TOKEN=test-token SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_manager_supplier_api.py -q`
- `git diff --check`
