### PR TITLE
[codex] Add R2 media storage migration path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ POSTGRES_PORT=5432
 POSTGRES_DB=air_conditioners
 # --- Backups ---
 BACKUP_FOLDER_ID=gdisk_folder_id
+# --- Product media storage (local by default; R2/S3 secrets are optional until enabled) ---
+PRODUCT_MEDIA_STORAGE_PROVIDER=local
+PRODUCT_MEDIA_LOCAL_VARIANT_DIR=media/products/variants
+PRODUCT_MEDIA_LOCAL_VARIANT_PUBLIC_PREFIX=/media/products/variants
+PRODUCT_MEDIA_S3_BUCKET=
+PRODUCT_MEDIA_S3_ENDPOINT_URL=
+PRODUCT_MEDIA_S3_REGION=auto
+PRODUCT_MEDIA_S3_ACCESS_KEY_ID=
+PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY=
+PRODUCT_MEDIA_S3_PUBLIC_BASE_URL=
+PRODUCT_MEDIA_S3_KEY_PREFIX=products/variants
+PRODUCT_MEDIA_S3_CACHE_CONTROL=public, max-age=31536000, immutable
 # --- Mail (Yandex app password, not the main account password) ---
 MAIL_IMAP_HOST=imap.yandex.ru
 MAIL_IMAP_PORT=993

--- a/core/config.py
+++ b/core/config.py
@@ -75,6 +75,20 @@ class Settings(BaseSettings):
     # Static Files
     STATIC_DIR: str = "static"
     UPLOAD_DIR: str = "static/uploads"
+
+    # Product media storage. Default stays local so CI/deploy do not require
+    # R2/S3 secrets unless PRODUCT_MEDIA_STORAGE_PROVIDER is changed.
+    PRODUCT_MEDIA_STORAGE_PROVIDER: str = "local"
+    PRODUCT_MEDIA_LOCAL_VARIANT_DIR: str = "media/products/variants"
+    PRODUCT_MEDIA_LOCAL_VARIANT_PUBLIC_PREFIX: str = "/media/products/variants"
+    PRODUCT_MEDIA_S3_BUCKET: str = ""
+    PRODUCT_MEDIA_S3_ENDPOINT_URL: str = ""
+    PRODUCT_MEDIA_S3_REGION: str = "auto"
+    PRODUCT_MEDIA_S3_ACCESS_KEY_ID: str = ""
+    PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY: str = ""
+    PRODUCT_MEDIA_S3_PUBLIC_BASE_URL: str = ""
+    PRODUCT_MEDIA_S3_KEY_PREFIX: str = "products/variants"
+    PRODUCT_MEDIA_S3_CACHE_CONTROL: str = "public, max-age=31536000, immutable"
     
     # Logging
     LOG_LEVEL: str = "INFO"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -155,6 +155,15 @@ After apply, smoke-check:
 - `/api/v1/products?limit=5`
 - `/api/v1/filters/config`
 
+## Product Media R2/S3 Rollout
+
+Product image variant storage can be switched from local files to R2/S3-compatible
+storage with `PRODUCT_MEDIA_STORAGE_PROVIDER=r2`. Keep it `local` until the
+owner approves rollout and the dry-run migration report has been reviewed.
+
+See `docs/media-storage-r2.md` for URL strategy, cache/versioning behavior,
+manual migration commands, secrets checklist, and rollback notes.
+
 ## Common Issues
 
 ### Issue: Catalog shows "Товары не найдены"

--- a/docs/media-storage-r2.md
+++ b/docs/media-storage-r2.md
@@ -1,0 +1,112 @@
+# Product Media Storage: R2/S3 Migration
+
+This project keeps local product image URLs working while moving generated
+variants to public S3-compatible object storage such as Cloudflare R2.
+
+## URL Strategy
+
+- `ProductImage.url`, `Product.main_image`, and legacy `Product.images` remain
+  local `/media/...` URLs during the transition.
+- Generated rows in `ProductImageVariant` can use `storage_provider=r2` (or
+  `s3`/`s3_compatible`) and public CDN URLs.
+- The public API already falls back to the original local URL when an approved
+  ready variant is absent, so local media remains the rollback path.
+- The first rollout uses stable public URLs from `PRODUCT_MEDIA_S3_PUBLIC_BASE_URL`.
+  Signed URLs and API proxying are intentionally out of scope for product
+  catalog images because storefront rendering needs cacheable public assets.
+
+## Cache And Versioning
+
+Objects are stored with content-addressed keys:
+
+```text
+{PRODUCT_MEDIA_S3_KEY_PREFIX}/{variant_type}/{sha256}.{extension}
+```
+
+The default cache header is:
+
+```text
+public, max-age=31536000, immutable
+```
+
+When a variant is regenerated and bytes change, the SHA-256 changes, the object
+key changes, and the database URL changes. CDN caches can keep old objects
+without serving stale images from current product responses. If bytes are
+identical, reusing the same key is safe.
+
+## Environment
+
+Local fallback is the default:
+
+```dotenv
+PRODUCT_MEDIA_STORAGE_PROVIDER=local
+```
+
+Cloudflare R2 example:
+
+```dotenv
+PRODUCT_MEDIA_STORAGE_PROVIDER=r2
+PRODUCT_MEDIA_S3_BUCKET=mvn-product-media
+PRODUCT_MEDIA_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+PRODUCT_MEDIA_S3_REGION=auto
+PRODUCT_MEDIA_S3_ACCESS_KEY_ID=<secret>
+PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY=<secret>
+PRODUCT_MEDIA_S3_PUBLIC_BASE_URL=https://cdn.mvn.by/media
+PRODUCT_MEDIA_S3_KEY_PREFIX=products/variants
+PRODUCT_MEDIA_S3_CACHE_CONTROL=public, max-age=31536000, immutable
+```
+
+Dry-run migration requires bucket, endpoint, public base URL, and key prefix so
+it can print target keys. Secret access keys are only required for writes.
+
+## Migration Command
+
+Report only:
+
+```bash
+python3 scripts/migrate_product_media_storage.py --provider r2 --limit 50
+```
+
+Scope to one product:
+
+```bash
+python3 scripts/migrate_product_media_storage.py --provider r2 --product-id 123 --limit 20
+```
+
+Execute a reviewed bounded batch:
+
+```bash
+python3 scripts/migrate_product_media_storage.py --provider r2 --limit 50 --execute
+```
+
+Production execution is manual-only. Start with dry-run output, verify target
+URLs and skipped rows, then execute a small product-scoped batch before broader
+runs.
+
+The command updates `ProductImageVariant` rows only. It does not rewrite
+`ProductImage.url`, `Product.main_image`, or `Product.images`, and it does not
+delete local media files.
+
+## Rollback
+
+1. Set `PRODUCT_MEDIA_STORAGE_PROVIDER=local` and redeploy/recreate the backend
+   containers. Newly generated variants will return to local storage.
+2. Existing local product image URLs continue to work because local `/media` is
+   still mounted and product original fields were not rewritten.
+3. If CDN variant URLs must be removed from responses, restore the pre-migration
+   database backup or mark affected variants non-approved/non-ready and re-run
+   variant processing with local provider.
+4. Keep local media mounted until the owner explicitly approves final cutover and
+   cleanup.
+
+## Deploy Checklist
+
+- Create an R2 bucket and a public custom domain or public base URL.
+- Set production env/secrets listed above in `/opt/air-api/.env`; do not commit
+  secret values.
+- Keep `PRODUCT_MEDIA_STORAGE_PROVIDER=local` until dry-run output is reviewed.
+- Deploy backend image and run smoke checks: `/health`,
+  `/api/v1/products?limit=5`, `/api/v1/filters/config`.
+- Run a dry-run migration inside the app container.
+- Execute only a small, reviewed batch after owner approval.
+- Verify product API responses and public CDN URLs before increasing batch size.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ asyncpg==0.31.0
 attrs==25.4.0
 bcrypt==5.0.0
 beautifulsoup4==4.14.3
+boto3==1.43.22
+botocore==1.43.22
 cachetools==6.2.4
 certifi==2026.1.4
 charset-normalizer==3.4.4
@@ -38,6 +40,7 @@ idna==3.11
 iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
+jmespath==1.1.0
 lxml==6.0.2
 magic-filter==1.0.12
 Mako==1.3.10
@@ -67,6 +70,7 @@ PyJWT==2.11.0
 pypdf==6.4.1
 pytesseract==0.3.13
 pyparsing==3.3.1
+python-dateutil==2.9.0.post0
 pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-env==1.2.0
@@ -78,7 +82,9 @@ RapidFuzz==3.14.3
 requests==2.32.5
 requests-oauthlib==2.0.0
 rsa==4.9.1
+s3transfer==0.18.0
 sentry-sdk==2.51.0
+six==1.17.0
 soupsieve==2.8.1
 SQLAlchemy==2.0.45
 sqlmodel==0.0.31

--- a/scripts/migrate_product_media_storage.py
+++ b/scripts/migrate_product_media_storage.py
@@ -1,0 +1,252 @@
+"""Migrate product image originals and variants to configured media storage.
+
+Default mode is dry-run. Use --execute only after reviewing the planned uploads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+sys.path.append(".")
+
+from services.media_storage_service import get_product_media_storage  # noqa: E402
+from services.product_image_processing_contract import ProductImageVariantType  # noqa: E402
+from services.product_media_migration_service import (  # noqa: E402
+    DEFAULT_MIGRATION_VARIANT_TYPES,
+    ProductMediaMigrationService,
+)
+
+
+STORAGE_PROVIDERS = ("local", "r2", "s3", "s3_compatible")
+MIGRATION_VARIANTS = tuple(
+    variant.value
+    for variant in (
+        ProductImageVariantType.PROCESSED,
+        ProductImageVariantType.CARD,
+        ProductImageVariantType.FULL,
+    )
+)
+
+
+async def migrate_product_media_storage(
+    *,
+    session: AsyncSession,
+    execute: bool,
+    provider: str | None,
+    limit: int,
+    product_id: int | None,
+    include_originals: bool,
+    include_variants: bool,
+    variant_types: list[str] | None,
+    include_non_ready: bool,
+    force: bool,
+) -> dict[str, Any]:
+    storage = get_product_media_storage(provider, require_write=execute)
+    return await ProductMediaMigrationService.migrate_to_storage(
+        session=session,
+        storage=storage,
+        execute=execute,
+        limit=limit,
+        product_id=product_id,
+        include_originals=include_originals,
+        include_variants=include_variants,
+        variant_types=variant_types or list(DEFAULT_MIGRATION_VARIANT_TYPES),
+        include_non_ready=include_non_ready,
+        force=force,
+    )
+
+
+async def run(
+    *,
+    execute: bool,
+    provider: str | None,
+    limit: int,
+    product_id: int | None,
+    include_originals: bool,
+    include_variants: bool,
+    variant_types: list[str] | None,
+    include_non_ready: bool,
+    force: bool,
+) -> dict[str, Any]:
+    from core.database import async_session_maker
+
+    async with async_session_maker() as session:
+        return await migrate_product_media_storage(
+            session=session,
+            execute=execute,
+            provider=provider,
+            limit=limit,
+            product_id=product_id,
+            include_originals=include_originals,
+            include_variants=include_variants,
+            variant_types=variant_types,
+            include_non_ready=include_non_ready,
+            force=force,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or execute upload of local product image originals and ready "
+            "variants to the configured media storage provider."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Upload files and update ProductImageVariant rows. Default is report-only.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Force report-only mode. This is already the default.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=STORAGE_PROVIDERS,
+        default=None,
+        help=(
+            "Storage provider override. Defaults to PRODUCT_MEDIA_STORAGE_PROVIDER. "
+            "Use r2 for Cloudflare R2."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum source records to inspect in this run (1-1000, default: 50).",
+    )
+    parser.add_argument(
+        "--product-id",
+        type=int,
+        default=None,
+        help="Limit migration plan to one product id.",
+    )
+    parser.add_argument(
+        "--include-originals",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Plan ProductImage original files into original variant rows.",
+    )
+    parser.add_argument(
+        "--include-variants",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Plan existing ready ProductImageVariant rows.",
+    )
+    parser.add_argument(
+        "--variant-type",
+        action="append",
+        choices=MIGRATION_VARIANTS,
+        default=None,
+        help=(
+            "Variant type to include. Repeat for multiple values. "
+            "Defaults to processed, card, and full."
+        ),
+    )
+    parser.add_argument(
+        "--include-non-ready",
+        action="store_true",
+        help="Also include non-ready variant rows that still point to local files.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-plan rows already marked with the target storage provider.",
+    )
+    return parser
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if args.execute and args.dry_run:
+        parser.error("--execute and --dry-run cannot be used together")
+    if args.limit < 1 or args.limit > 1000:
+        parser.error("--limit must be between 1 and 1000")
+    if args.product_id is not None and args.product_id < 1:
+        parser.error("--product-id must be a positive integer")
+    if not args.include_originals and not args.include_variants:
+        parser.error("At least one of --include-originals or --include-variants is required")
+
+
+def _print_result(result: dict[str, Any]) -> None:
+    mode = "DRY-RUN" if result["dry_run"] else "EXECUTE"
+    print("Product Media Storage Migration")
+    print(f"  mode={mode}")
+    print(f"  storage_provider={result['storage_provider']}")
+    print(f"  product_id={result.get('product_id') or 'all'}")
+    print(f"  limit={result['limit']}")
+    print(f"  include_originals={result['include_originals']}")
+    print(f"  include_variants={result['include_variants']}")
+    print(f"  variant_types={','.join(result['variant_types'])}")
+    print(f"  inspected={result['inspected']}")
+    print(f"  planned_uploads={result['planned_uploads']}")
+    print(f"  skipped={result['skipped_count']}")
+
+    for item in result.get("items") or []:
+        print(
+            "  - "
+            f"{item['source_kind']} image#{item['product_image_id']} "
+            f"product#{item['product_id']} type={item['variant_type']} "
+            f"{item['source_url']} -> {item['target_path']} "
+            f"({item['target_url']})"
+        )
+
+    skipped = result.get("skipped") or []
+    if skipped:
+        print("\nSkipped")
+        for item in skipped[:20]:
+            print(
+                "  - "
+                f"{item['source_kind']} image#{item['product_image_id']} "
+                f"type={item['variant_type']} reason={item['skip_reason']} "
+                f"url={item['source_url']}"
+            )
+        if len(skipped) > 20:
+            print(f"  ... {len(skipped) - 20} more skipped rows")
+
+    if result["dry_run"]:
+        print("\nDry run only. Use --execute after reviewing this bounded plan.")
+        return
+
+    print(f"\nuploaded={result.get('uploaded', 0)}")
+    print(f"updated_variants={result.get('updated_variants', 0)}")
+    errors = result.get("errors") or []
+    print(f"errors={len(errors)}")
+    for item in errors:
+        print(
+            "  - "
+            f"{item['source_kind']} image#{item['product_image_id']} "
+            f"type={item['variant_type']} error={item['error']}"
+        )
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    _validate_args(args, parser)
+
+    execute = bool(args.execute and not args.dry_run)
+    result = asyncio.run(
+        run(
+            execute=execute,
+            provider=args.provider,
+            limit=args.limit,
+            product_id=args.product_id,
+            include_originals=args.include_originals,
+            include_variants=args.include_variants,
+            variant_types=args.variant_type,
+            include_non_ready=args.include_non_ready,
+            force=args.force,
+        )
+    )
+    _print_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/media_storage_service.py
+++ b/services/media_storage_service.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import mimetypes
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
+from urllib.parse import quote
+
+from dotenv import load_dotenv
 
 
 @dataclass(frozen=True)
@@ -20,6 +24,15 @@ class StoredMediaObject:
 
 class ProductMediaStorage(Protocol):
     provider_name: str
+
+    def build_product_variant_object(
+        self,
+        *,
+        content_hash: str,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        """Return the deterministic storage target without writing content."""
 
     async def save_product_variant(
         self,
@@ -43,6 +56,26 @@ class LocalProductMediaStorage:
         self.public_prefix = public_prefix.rstrip("/") or "/media/products/variants"
         self._write_lock = asyncio.Lock()
 
+    def build_product_variant_object(
+        self,
+        *,
+        content_hash: str,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        safe_extension = _normalize_extension(extension)
+        safe_variant_type = _safe_path_segment(variant_type)
+        safe_hash = _normalize_content_hash(content_hash)
+        target_path = self.base_dir / safe_variant_type / f"{safe_hash}.{safe_extension}"
+        relative_path = str(target_path).replace(os.sep, "/")
+        public_url = f"{self.public_prefix}/{safe_variant_type}/{target_path.name}"
+        return StoredMediaObject(
+            url=public_url,
+            content_hash=safe_hash,
+            storage_provider=self.provider_name,
+            path=relative_path,
+        )
+
     async def save_product_variant(
         self,
         *,
@@ -53,36 +86,93 @@ class LocalProductMediaStorage:
         if not content:
             raise ValueError("Cannot store empty media content")
 
-        safe_extension = extension.lower().lstrip(".") or "webp"
         content_hash = hashlib.sha256(content).hexdigest()
-        target_dir = self.base_dir / variant_type
-        target_path = target_dir / f"{content_hash}.{safe_extension}"
+        stored = self.build_product_variant_object(
+            content_hash=content_hash,
+            variant_type=variant_type,
+            extension=extension,
+        )
+        target_path = Path(stored.path)
 
-        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
         if not target_path.exists():
             async with self._write_lock:
                 if not target_path.exists():
                     target_path.write_bytes(content)
 
-        relative_path = str(target_path).replace(os.sep, "/")
-        public_url = f"{self.public_prefix}/{variant_type}/{target_path.name}"
-        return StoredMediaObject(
-            url=public_url,
-            content_hash=content_hash,
-            storage_provider=self.provider_name,
-            path=relative_path,
-        )
+        return stored
 
 
 class S3CompatibleProductMediaStorage:
-    """Future adapter shape for S3/R2-compatible storage.
+    """S3-compatible product media storage, including Cloudflare R2.
 
-    The first image-variant PR only ships local storage. This placeholder keeps
-    the service contract explicit without introducing cloud credentials or SDK
-    dependencies into production.
+    URLs are intentionally public CDN URLs rather than signed proxy URLs. Object
+    keys are content-addressed, so regenerated variants get new URLs and can use
+    long immutable cache headers safely.
     """
 
-    provider_name = "s3_compatible"
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        endpoint_url: str,
+        public_base_url: str,
+        access_key_id: str = "",
+        secret_access_key: str = "",
+        region_name: str = "auto",
+        key_prefix: str = "products/variants",
+        cache_control: str = "public, max-age=31536000, immutable",
+        provider_name: str = "s3_compatible",
+        client: Any | None = None,
+    ) -> None:
+        self.provider_name = provider_name
+        self.bucket = bucket.strip()
+        self.endpoint_url = endpoint_url.strip()
+        self.public_base_url = public_base_url.strip().rstrip("/")
+        self.access_key_id = access_key_id.strip()
+        self.secret_access_key = secret_access_key.strip()
+        self.region_name = region_name.strip() or "auto"
+        self.key_prefix = _normalize_key_prefix(key_prefix)
+        self.cache_control = cache_control.strip() or "public, max-age=31536000, immutable"
+        self._client_override = client
+        self._client: Any | None = None
+
+        missing = [
+            name
+            for name, value in (
+                ("bucket", self.bucket),
+                ("endpoint_url", self.endpoint_url),
+                ("public_base_url", self.public_base_url),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                "S3/R2 media storage requires "
+                + ", ".join(missing)
+                + " configuration"
+            )
+
+    def build_product_variant_object(
+        self,
+        *,
+        content_hash: str,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        safe_extension = _normalize_extension(extension)
+        safe_variant_type = _safe_path_segment(variant_type)
+        safe_hash = _normalize_content_hash(content_hash)
+        filename = f"{safe_hash}.{safe_extension}"
+        key_parts = [part for part in (self.key_prefix, safe_variant_type, filename) if part]
+        key = "/".join(key_parts)
+        encoded_key = "/".join(quote(part, safe="") for part in key.split("/"))
+        return StoredMediaObject(
+            url=f"{self.public_base_url}/{encoded_key}",
+            content_hash=safe_hash,
+            storage_provider=self.provider_name,
+            path=key,
+        )
 
     async def save_product_variant(
         self,
@@ -91,4 +181,149 @@ class S3CompatibleProductMediaStorage:
         variant_type: str,
         extension: str = "webp",
     ) -> StoredMediaObject:
-        raise NotImplementedError("S3/R2-compatible storage is reserved for a later stage")
+        if not content:
+            raise ValueError("Cannot store empty media content")
+
+        content_hash = hashlib.sha256(content).hexdigest()
+        stored = self.build_product_variant_object(
+            content_hash=content_hash,
+            variant_type=variant_type,
+            extension=extension,
+        )
+        client = self._get_client()
+        await asyncio.to_thread(
+            client.put_object,
+            Bucket=self.bucket,
+            Key=stored.path,
+            Body=content,
+            ContentType=_content_type_for_extension(extension),
+            CacheControl=self.cache_control,
+            Metadata={
+                "sha256": stored.content_hash,
+                "variant_type": _safe_path_segment(variant_type),
+            },
+        )
+        return stored
+
+    def _get_client(self) -> Any:
+        if self._client_override is not None:
+            return self._client_override
+        if self._client is not None:
+            return self._client
+
+        if not self.access_key_id or not self.secret_access_key:
+            raise ValueError(
+                "S3/R2 media storage requires access key credentials for writes"
+            )
+
+        try:
+            import boto3
+            from botocore.config import Config
+        except ImportError as exc:
+            raise RuntimeError(
+                "boto3 is required for S3/R2 media storage. Install requirements first."
+            ) from exc
+
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            region_name=self.region_name,
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+            config=Config(
+                signature_version="s3v4",
+                s3={"addressing_style": "path"},
+            ),
+        )
+        return self._client
+
+
+def get_product_media_storage(
+    provider: str | None = None,
+    *,
+    require_write: bool = True,
+) -> ProductMediaStorage:
+    """Build the configured media storage adapter.
+
+    `require_write=False` is intended for dry-run planning where public target
+    URLs are needed but secret access keys should not be required.
+    """
+    load_dotenv()
+    selected_provider = (provider or _env("PRODUCT_MEDIA_STORAGE_PROVIDER", "local")).strip().lower()
+    if selected_provider == "local":
+        return LocalProductMediaStorage(
+            base_dir=_env("PRODUCT_MEDIA_LOCAL_VARIANT_DIR", "media/products/variants"),
+            public_prefix=_env(
+                "PRODUCT_MEDIA_LOCAL_VARIANT_PUBLIC_PREFIX",
+                "/media/products/variants",
+            ),
+        )
+
+    if selected_provider in {"r2", "s3", "s3_compatible"}:
+        access_key = _env("PRODUCT_MEDIA_S3_ACCESS_KEY_ID") if require_write else ""
+        secret_key = _env("PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY") if require_write else ""
+        return S3CompatibleProductMediaStorage(
+            provider_name=selected_provider,
+            bucket=_env("PRODUCT_MEDIA_S3_BUCKET"),
+            endpoint_url=_env("PRODUCT_MEDIA_S3_ENDPOINT_URL"),
+            public_base_url=_env("PRODUCT_MEDIA_S3_PUBLIC_BASE_URL"),
+            access_key_id=access_key,
+            secret_access_key=secret_key,
+            region_name=_env("PRODUCT_MEDIA_S3_REGION", "auto"),
+            key_prefix=_env("PRODUCT_MEDIA_S3_KEY_PREFIX", "products/variants"),
+            cache_control=_env(
+                "PRODUCT_MEDIA_S3_CACHE_CONTROL",
+                "public, max-age=31536000, immutable",
+            ),
+        )
+
+    raise ValueError(
+        "Unsupported PRODUCT_MEDIA_STORAGE_PROVIDER="
+        f"{selected_provider!r}. Allowed: local, r2, s3, s3_compatible"
+    )
+
+
+def _normalize_extension(extension: str) -> str:
+    safe_extension = (extension or "webp").lower().lstrip(".")
+    if not safe_extension or "/" in safe_extension or "\\" in safe_extension:
+        return "webp"
+    return safe_extension
+
+
+def _normalize_content_hash(content_hash: str) -> str:
+    value = (content_hash or "").strip().lower()
+    if not value:
+        raise ValueError("content_hash is required")
+    if any(ch not in "0123456789abcdef" for ch in value):
+        raise ValueError("content_hash must be hexadecimal")
+    return value
+
+
+def _safe_path_segment(value: str) -> str:
+    safe = "".join(
+        ch.lower() if ch.isalnum() else "-"
+        for ch in str(value or "").strip()
+        if ch.isalnum() or ch in {"-", "_"}
+    ).strip("-_")
+    return safe or "default"
+
+
+def _normalize_key_prefix(value: str) -> str:
+    parts = [
+        _safe_path_segment(part)
+        for part in str(value or "").replace("\\", "/").split("/")
+        if part.strip()
+    ]
+    return "/".join(parts)
+
+
+def _content_type_for_extension(extension: str) -> str:
+    safe_extension = _normalize_extension(extension)
+    if safe_extension == "webp":
+        return "image/webp"
+    guessed, _ = mimetypes.guess_type(f"file.{safe_extension}")
+    return guessed or "application/octet-stream"
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default)

--- a/services/product_image_variant_service.py
+++ b/services/product_image_variant_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models import ProductImage, ProductImageVariant
-from services.media_storage_service import LocalProductMediaStorage, ProductMediaStorage
+from services.media_storage_service import ProductMediaStorage, get_product_media_storage
 from services.product_image_processing_contract import (
     CATALOG_VARIANT_TYPES,
     ProductImageManualQualityStatus,
@@ -268,7 +268,7 @@ class ProductImageVariantService:
             return ProductImageVariantService.serialize_variant(variant)
 
         active_processor = processor or get_product_image_processor(normalized_provider)
-        active_storage = storage or LocalProductMediaStorage()
+        active_storage = storage or get_product_media_storage()
         try:
             source_content = source_path.read_bytes()
             processed = await active_processor.process(

--- a/services/product_media_migration_service.py
+++ b/services/product_media_migration_service.py
@@ -1,0 +1,324 @@
+"""Migration helpers for moving product media variants to configured storage."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import ProductImage, ProductImageVariant
+from services.media_storage_service import ProductMediaStorage
+from services.product_image_processing_contract import (
+    CATALOG_VARIANT_TYPES,
+    ProductImageManualQualityStatus,
+    ProductImageProcessingProvider,
+    ProductImageProcessingStage,
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
+from services.product_image_variant_service import ProductImageVariantService
+
+
+DEFAULT_MIGRATION_VARIANT_TYPES = tuple(sorted(CATALOG_VARIANT_TYPES))
+
+
+class ProductMediaMigrationService:
+    @staticmethod
+    async def migrate_to_storage(
+        session: AsyncSession,
+        *,
+        storage: ProductMediaStorage,
+        execute: bool,
+        limit: int = 50,
+        product_id: int | None = None,
+        include_originals: bool = True,
+        include_variants: bool = True,
+        variant_types: list[str] | tuple[str, ...] | None = None,
+        include_non_ready: bool = False,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        safe_limit = max(1, min(int(limit), 1000))
+        selected_variant_types = tuple(variant_types or DEFAULT_MIGRATION_VARIANT_TYPES)
+
+        plan = await ProductMediaMigrationService.build_migration_plan(
+            session,
+            storage=storage,
+            limit=safe_limit,
+            product_id=product_id,
+            include_originals=include_originals,
+            include_variants=include_variants,
+            variant_types=selected_variant_types,
+            include_non_ready=include_non_ready,
+            force=force,
+        )
+        plan["dry_run"] = not execute
+
+        if not execute:
+            return plan
+
+        uploaded: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        now = datetime.now()
+
+        for item in plan["items"]:
+            source_path = Path(item["source_path"])
+            try:
+                content = source_path.read_bytes()
+                stored = await storage.save_product_variant(
+                    content=content,
+                    variant_type=item["variant_type"],
+                    extension=item["extension"],
+                )
+                variant = await ProductMediaMigrationService._resolve_target_variant(
+                    session,
+                    item=item,
+                )
+                variant.url = stored.url
+                variant.storage_provider = stored.storage_provider
+                variant.content_hash = stored.content_hash
+                variant.updated_at = now
+
+                if item["source_kind"] == "original":
+                    variant.processing_status = ProductImageProcessingStatus.READY.value
+                    variant.processing_stage = ProductImageProcessingStage.ORIGINAL_INGEST.value
+                    variant.processing_provider = ProductImageProcessingProvider.MANUAL.value
+                    variant.manual_quality_status = (
+                        ProductImageManualQualityStatus.UNREVIEWED.value
+                    )
+                    variant.processing_error = None
+                    variant.processed_at = variant.processed_at or now
+
+                if variant.width is None or variant.height is None:
+                    width, height = ProductImageVariantService._image_size(content)
+                    variant.width = variant.width or width
+                    variant.height = variant.height or height
+
+                session.add(variant)
+                uploaded.append(
+                    {
+                        **item,
+                        "target_url": stored.url,
+                        "target_path": stored.path,
+                        "storage_provider": stored.storage_provider,
+                    }
+                )
+            except Exception as exc:
+                errors.append(
+                    {
+                        "source_kind": item["source_kind"],
+                        "product_image_id": item["product_image_id"],
+                        "variant_id": item.get("variant_id"),
+                        "variant_type": item["variant_type"],
+                        "source_url": item["source_url"],
+                        "error": str(exc),
+                    }
+                )
+
+        await session.commit()
+        return {
+            **plan,
+            "uploaded": len(uploaded),
+            "updated_variants": len(uploaded),
+            "uploaded_items": uploaded,
+            "errors": errors,
+        }
+
+    @staticmethod
+    async def build_migration_plan(
+        session: AsyncSession,
+        *,
+        storage: ProductMediaStorage,
+        limit: int,
+        product_id: int | None,
+        include_originals: bool,
+        include_variants: bool,
+        variant_types: tuple[str, ...],
+        include_non_ready: bool,
+        force: bool,
+    ) -> dict[str, Any]:
+        items: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        inspected = 0
+        remaining = max(1, min(int(limit), 1000))
+
+        if include_originals and remaining > 0:
+            stmt = select(ProductImage).order_by(ProductImage.id).limit(remaining)
+            if product_id is not None:
+                stmt = stmt.where(ProductImage.product_id == product_id)
+            rows = (await session.execute(stmt)).scalars().all()
+            inspected += len(rows)
+            for image in rows:
+                existing = await ProductMediaMigrationService._get_variant(
+                    session,
+                    product_image_id=image.id,
+                    variant_type=ProductImageVariantType.ORIGINAL.value,
+                )
+                item = ProductMediaMigrationService._plan_item(
+                    storage=storage,
+                    source_kind="original",
+                    product_image_id=image.id,
+                    product_id=image.product_id,
+                    variant_type=ProductImageVariantType.ORIGINAL.value,
+                    source_url=image.url,
+                    variant=existing,
+                    force=force,
+                )
+                if item["planned"]:
+                    items.append(item)
+                else:
+                    skipped.append(item)
+            remaining -= len(rows)
+
+        if include_variants and remaining > 0:
+            stmt = (
+                select(ProductImageVariant, ProductImage)
+                .join(ProductImage, ProductImage.id == ProductImageVariant.product_image_id)
+                .where(ProductImageVariant.url.is_not(None))
+                .where(ProductImageVariant.variant_type.in_(variant_types))
+                .order_by(ProductImageVariant.id)
+                .limit(remaining)
+            )
+            if product_id is not None:
+                stmt = stmt.where(ProductImage.product_id == product_id)
+            if not include_non_ready:
+                stmt = stmt.where(
+                    ProductImageVariant.processing_status
+                    == ProductImageProcessingStatus.READY.value
+                )
+
+            rows = (await session.execute(stmt)).all()
+            inspected += len(rows)
+            for variant, image in rows:
+                item = ProductMediaMigrationService._plan_item(
+                    storage=storage,
+                    source_kind="variant",
+                    product_image_id=image.id,
+                    product_id=image.product_id,
+                    variant_type=variant.variant_type,
+                    source_url=variant.url,
+                    variant=variant,
+                    force=force,
+                )
+                if item["planned"]:
+                    items.append(item)
+                else:
+                    skipped.append(item)
+
+        return {
+            "dry_run": True,
+            "storage_provider": storage.provider_name,
+            "limit": limit,
+            "product_id": product_id,
+            "include_originals": include_originals,
+            "include_variants": include_variants,
+            "variant_types": list(variant_types),
+            "include_non_ready": include_non_ready,
+            "force": force,
+            "inspected": inspected,
+            "planned_uploads": len(items),
+            "skipped_count": len(skipped),
+            "items": items,
+            "skipped": skipped,
+            "uploaded": 0,
+            "updated_variants": 0,
+            "uploaded_items": [],
+            "errors": [],
+        }
+
+    @staticmethod
+    def _plan_item(
+        *,
+        storage: ProductMediaStorage,
+        source_kind: str,
+        product_image_id: int,
+        product_id: int,
+        variant_type: str,
+        source_url: str | None,
+        variant: ProductImageVariant | None,
+        force: bool,
+    ) -> dict[str, Any]:
+        base = {
+            "planned": False,
+            "source_kind": source_kind,
+            "product_image_id": product_image_id,
+            "product_id": product_id,
+            "variant_id": variant.id if variant else None,
+            "variant_type": variant_type,
+            "source_url": source_url,
+            "current_storage_provider": variant.storage_provider if variant else None,
+            "current_variant_url": variant.url if variant else None,
+        }
+
+        if (
+            variant
+            and not force
+            and variant.storage_provider == storage.provider_name
+            and variant.url
+        ):
+            return {**base, "skip_reason": "already_on_target_provider"}
+
+        source_path = ProductImageVariantService._local_media_path_for_url(source_url or "")
+        if source_path is None:
+            return {**base, "skip_reason": "non_local_url"}
+        if not source_path.exists():
+            return {
+                **base,
+                "source_path": str(source_path),
+                "skip_reason": "missing_local_file",
+            }
+
+        content = source_path.read_bytes()
+        content_hash = hashlib.sha256(content).hexdigest()
+        extension = source_path.suffix.lower().lstrip(".") or "webp"
+        target = storage.build_product_variant_object(
+            content_hash=content_hash,
+            variant_type=variant_type,
+            extension=extension,
+        )
+        return {
+            **base,
+            "planned": True,
+            "source_path": str(source_path),
+            "extension": extension,
+            "content_hash": content_hash,
+            "target_url": target.url,
+            "target_path": target.path,
+            "target_storage_provider": target.storage_provider,
+        }
+
+    @staticmethod
+    async def _resolve_target_variant(
+        session: AsyncSession,
+        *,
+        item: dict[str, Any],
+    ) -> ProductImageVariant:
+        if item.get("variant_id"):
+            variant = await session.get(ProductImageVariant, item["variant_id"])
+            if variant:
+                return variant
+
+        return await ProductImageVariantService._get_or_create_variant(
+            session,
+            product_image_id=item["product_image_id"],
+            variant_type=item["variant_type"],
+        )
+
+    @staticmethod
+    async def _get_variant(
+        session: AsyncSession,
+        *,
+        product_image_id: int,
+        variant_type: str,
+    ) -> ProductImageVariant | None:
+        return (
+            await session.execute(
+                select(ProductImageVariant).where(
+                    ProductImageVariant.product_image_id == product_image_id,
+                    ProductImageVariant.variant_type == variant_type,
+                )
+            )
+        ).scalar_one_or_none()

--- a/tests/unit/test_media_storage_service.py
+++ b/tests/unit/test_media_storage_service.py
@@ -1,0 +1,113 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from services.media_storage_service import (
+    LocalProductMediaStorage,
+    S3CompatibleProductMediaStorage,
+    get_product_media_storage,
+)
+from services.product_image_processing_contract import ProductImageVariantType
+
+
+class FakeS3Client:
+    def __init__(self):
+        self.calls = []
+
+    def put_object(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_local_storage_builds_existing_fallback_url(tmp_path: Path):
+    storage = LocalProductMediaStorage(base_dir=tmp_path / "media/products/variants")
+    content_hash = "a" * 64
+
+    target = storage.build_product_variant_object(
+        content_hash=content_hash,
+        variant_type=ProductImageVariantType.CARD.value,
+        extension="webp",
+    )
+
+    assert target.storage_provider == "local"
+    assert target.url == f"/media/products/variants/card/{content_hash}.webp"
+    assert target.path.endswith(f"media/products/variants/card/{content_hash}.webp")
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_uses_content_addressed_r2_key_and_cache_headers():
+    fake_client = FakeS3Client()
+    storage = S3CompatibleProductMediaStorage(
+        provider_name="r2",
+        bucket="mvn-media",
+        endpoint_url="https://example-account.r2.cloudflarestorage.com",
+        public_base_url="https://cdn.mvn.by/media",
+        key_prefix="products/variants",
+        cache_control="public, max-age=31536000, immutable",
+        client=fake_client,
+    )
+    content = b"image-bytes"
+    content_hash = hashlib.sha256(content).hexdigest()
+
+    planned = storage.build_product_variant_object(
+        content_hash=content_hash,
+        variant_type=ProductImageVariantType.CARD.value,
+        extension=".webp",
+    )
+    stored = await storage.save_product_variant(
+        content=content,
+        variant_type=ProductImageVariantType.CARD.value,
+        extension="webp",
+    )
+
+    assert planned.url == f"https://cdn.mvn.by/media/products/variants/card/{content_hash}.webp"
+    assert planned.path == f"products/variants/card/{content_hash}.webp"
+    assert stored == planned
+    assert fake_client.calls == [
+        {
+            "Bucket": "mvn-media",
+            "Key": f"products/variants/card/{content_hash}.webp",
+            "Body": content,
+            "ContentType": "image/webp",
+            "CacheControl": "public, max-age=31536000, immutable",
+            "Metadata": {
+                "sha256": content_hash,
+                "variant_type": "card",
+            },
+        }
+    ]
+
+
+def test_storage_factory_keeps_local_as_default(monkeypatch):
+    monkeypatch.setenv("PRODUCT_MEDIA_STORAGE_PROVIDER", "local")
+
+    storage = get_product_media_storage()
+
+    assert isinstance(storage, LocalProductMediaStorage)
+
+
+@pytest.mark.asyncio
+async def test_r2_factory_allows_dry_run_without_access_key_secrets(monkeypatch):
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_BUCKET", "mvn-media")
+    monkeypatch.setenv(
+        "PRODUCT_MEDIA_S3_ENDPOINT_URL",
+        "https://example-account.r2.cloudflarestorage.com",
+    )
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_PUBLIC_BASE_URL", "https://cdn.mvn.by/media")
+    monkeypatch.delenv("PRODUCT_MEDIA_S3_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY", raising=False)
+
+    storage = get_product_media_storage("r2", require_write=False)
+    planned = storage.build_product_variant_object(
+        content_hash="b" * 64,
+        variant_type=ProductImageVariantType.FULL.value,
+        extension="webp",
+    )
+
+    assert planned.storage_provider == "r2"
+    assert planned.url == f"https://cdn.mvn.by/media/products/variants/full/{'b' * 64}.webp"
+    with pytest.raises(ValueError, match="access key credentials"):
+        await storage.save_product_variant(
+            content=b"content",
+            variant_type=ProductImageVariantType.FULL.value,
+        )

--- a/tests/unit/test_product_media_migration_service.py
+++ b/tests/unit/test_product_media_migration_service.py
@@ -1,0 +1,210 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Product, ProductImage, ProductImageVariant
+from services.media_storage_service import StoredMediaObject
+from services.product_image_processing_contract import (
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
+from services.product_media_migration_service import ProductMediaMigrationService
+
+
+class RecordingStorage:
+    provider_name = "r2"
+
+    def __init__(self):
+        self.uploads = []
+
+    def build_product_variant_object(
+        self,
+        *,
+        content_hash: str,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        path = f"products/variants/{variant_type}/{content_hash}.{extension}"
+        return StoredMediaObject(
+            url=f"https://cdn.mvn.by/{path}",
+            content_hash=content_hash,
+            storage_provider=self.provider_name,
+            path=path,
+        )
+
+    async def save_product_variant(
+        self,
+        *,
+        content: bytes,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        import hashlib
+
+        self.uploads.append(
+            {
+                "content": content,
+                "variant_type": variant_type,
+                "extension": extension,
+            }
+        )
+        return self.build_product_variant_object(
+            content_hash=hashlib.sha256(content).hexdigest(),
+            variant_type=variant_type,
+            extension=extension,
+        )
+
+
+def _image_bytes(color=(40, 90, 180), *, fmt: str = "WEBP") -> bytes:
+    image = Image.new("RGB", (12, 10), color)
+    output = BytesIO()
+    image.save(output, format=fmt)
+    return output.getvalue()
+
+
+async def _sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "media_migration.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    async for session in _sqlite_session(tmp_path):
+        yield session
+
+
+async def _make_product_with_media(
+    session: AsyncSession,
+    tmp_path: Path,
+) -> tuple[Product, ProductImage, ProductImageVariant]:
+    product = Product(
+        title="Migration product",
+        slug="migration-product",
+        price=1000,
+        area=20,
+        specs={},
+    )
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+
+    shared_dir = tmp_path / "media/products/shared"
+    variant_dir = tmp_path / "media/products/variants/card"
+    shared_dir.mkdir(parents=True, exist_ok=True)
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    original_path = shared_dir / "original.webp"
+    card_path = variant_dir / "card.webp"
+    original_path.write_bytes(_image_bytes())
+    card_path.write_bytes(_image_bytes((80, 20, 20)))
+
+    original_url = "/media/products/shared/original.webp"
+    card_url = "/media/products/variants/card/card.webp"
+    product.main_image = original_url
+    product.images = [original_url]
+    image = ProductImage(product_id=product.id, url=original_url)
+    session.add(image)
+    await session.flush()
+    variant = ProductImageVariant(
+        product_image_id=image.id,
+        variant_type=ProductImageVariantType.CARD.value,
+        url=card_url,
+        storage_provider="local",
+        processing_status=ProductImageProcessingStatus.READY.value,
+        processing_stage="storage_save",
+    )
+    session.add(variant)
+    await session.commit()
+    await session.refresh(product)
+    await session.refresh(image)
+    await session.refresh(variant)
+    return product, image, variant
+
+
+@pytest.mark.asyncio
+async def test_media_migration_dry_run_plans_uploads_without_db_writes(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product, image, variant = await _make_product_with_media(sqlite_session, tmp_path)
+    storage = RecordingStorage()
+
+    report = await ProductMediaMigrationService.migrate_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=False,
+        limit=10,
+    )
+    original_variant = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.product_image_id == image.id,
+                ProductImageVariant.variant_type == ProductImageVariantType.ORIGINAL.value,
+            )
+        )
+    ).scalar_one_or_none()
+    await sqlite_session.refresh(variant)
+    await sqlite_session.refresh(product)
+
+    assert report["dry_run"] is True
+    assert report["planned_uploads"] == 2
+    assert {item["variant_type"] for item in report["items"]} == {"original", "card"}
+    assert storage.uploads == []
+    assert original_variant is None
+    assert variant.url == "/media/products/variants/card/card.webp"
+    assert product.main_image == image.url
+    assert product.images == [image.url]
+
+
+@pytest.mark.asyncio
+async def test_media_migration_execute_updates_variants_but_preserves_product_urls(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    product, image, variant = await _make_product_with_media(sqlite_session, tmp_path)
+    storage = RecordingStorage()
+
+    report = await ProductMediaMigrationService.migrate_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=True,
+        limit=10,
+    )
+    original_variant = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.product_image_id == image.id,
+                ProductImageVariant.variant_type == ProductImageVariantType.ORIGINAL.value,
+            )
+        )
+    ).scalar_one()
+    await sqlite_session.refresh(variant)
+    await sqlite_session.refresh(product)
+    await sqlite_session.refresh(image)
+
+    assert report["dry_run"] is False
+    assert report["uploaded"] == 2
+    assert len(storage.uploads) == 2
+    assert original_variant.storage_provider == "r2"
+    assert original_variant.url.startswith("https://cdn.mvn.by/products/variants/original/")
+    assert variant.storage_provider == "r2"
+    assert variant.url.startswith("https://cdn.mvn.by/products/variants/card/")
+    assert product.main_image == "/media/products/shared/original.webp"
+    assert product.images == ["/media/products/shared/original.webp"]
+    assert image.url == "/media/products/shared/original.webp"


### PR DESCRIPTION
## Summary

Adds the first safe R2/S3-compatible migration path for product image storage while keeping local media as the default and fallback.

- Finishes the product media storage abstraction with local + S3-compatible/R2 adapters.
- Adds env-driven storage selection, bucket/endpoint/public base URL/key prefix/cache headers, and pinned boto3 dependencies.
- Switches variant processing to use the configured storage provider while defaulting to local.
- Adds a dry-run-first migration service and CLI for local originals plus existing ready variants.
- Documents public CDN URL strategy, content-addressed cache/versioning, deploy/secrets checklist, and rollback.

Refs #374.

## Architecture Notes

- `PRODUCT_MEDIA_STORAGE_PROVIDER=local` remains the default, so CI and backend deploy do not require R2/S3 secrets.
- R2/S3 writes are only attempted when the selected provider is enabled and a save/migration execute path runs.
- Dry-run planning for R2 requires bucket, endpoint, and public base URL so target URLs/keys can be printed, but access key secrets are not required unless writing.
- Public URLs are stable CDN URLs from `PRODUCT_MEDIA_S3_PUBLIC_BASE_URL`; signed URLs/proxying are intentionally not used for catalog images.
- Object keys are content-addressed: `{key_prefix}/{variant_type}/{sha256}.{extension}`. Regenerated bytes produce new URLs, allowing `public, max-age=31536000, immutable` without serving stale current variants.
- Migration updates `ProductImageVariant` rows only. `ProductImage.url`, `Product.main_image`, and legacy `Product.images` keep local `/media/...` URLs during transition.

## Config / Secrets Checklist

Set these only when enabling R2/S3:

- `PRODUCT_MEDIA_STORAGE_PROVIDER=r2`
- `PRODUCT_MEDIA_S3_BUCKET`
- `PRODUCT_MEDIA_S3_ENDPOINT_URL`
- `PRODUCT_MEDIA_S3_REGION=auto`
- `PRODUCT_MEDIA_S3_ACCESS_KEY_ID`
- `PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY`
- `PRODUCT_MEDIA_S3_PUBLIC_BASE_URL`
- `PRODUCT_MEDIA_S3_KEY_PREFIX=products/variants`
- `PRODUCT_MEDIA_S3_CACHE_CONTROL=public, max-age=31536000, immutable`

Do not commit secret values. Keep provider `local` until owner reviews dry-run output.

## Migration Commands

Dry-run/report:

```bash
python3 scripts/migrate_product_media_storage.py --provider r2 --limit 50
```

Bounded execute after owner approval:

```bash
python3 scripts/migrate_product_media_storage.py --provider r2 --limit 50 --execute
```

Production execution remains manual-only and outside this PR unless owner approves.

## Rollback

- Set `PRODUCT_MEDIA_STORAGE_PROVIDER=local` and recreate backend containers.
- Local `/media/...` product URLs continue to work because this PR does not rewrite original product fields.
- If CDN variants need to disappear from public responses, restore DB backup or mark affected variant rows non-approved/non-ready and regenerate locally.
- Keep local media mounted until explicit final cutover/cleanup approval.

## Tests

- `pytest tests/unit/test_media_storage_service.py tests/unit/test_product_media_migration_service.py tests/unit/test_product_image_variants.py -q` -> 19 passed
- `python3 -m py_compile services/media_storage_service.py services/product_media_migration_service.py scripts/migrate_product_media_storage.py`
- `git diff --check`
- `python3 -m pip install --dry-run -r requirements.txt`

## Residual Risks

- No live R2 upload was executed; adapter write behavior is covered with a fake S3 client and should be validated against a non-prod bucket before production rollout.
- Migration reads local files to hash/plan uploads; production should run bounded batches and review skipped rows before execute.
- CDN/DNS cutover and mass production migration remain manual owner decisions.
