### PR TITLE
[codex] Simplify lead qualification flow

### DIFF
--- a/manager_frontend/src/client/models/LeadsInboxItemResponse.ts
+++ b/manager_frontend/src/client/models/LeadsInboxItemResponse.ts
@@ -6,6 +6,7 @@ export type LeadsInboxItemResponse = {
     id: number;
     status: string;
     is_new: boolean;
+    customer_id?: (number | null);
     customer_name?: (string | null);
     phone?: (string | null);
     email?: (string | null);
@@ -14,8 +15,13 @@ export type LeadsInboxItemResponse = {
     no_answer_at?: (string | null);
     source_created_at?: (string | null);
     created_at: string;
-    customer_type?: string;
+    customer_type?: (string | null);
     customer_inn?: (string | null);
     customer_full_legal_name?: (string | null);
+    customer_delivery_address?: (string | null);
+    object_type?: (string | null);
+    service_type?: (string | null);
+    equipment_class?: (string | null);
+    marketing_source?: (string | null);
 };
 

--- a/manager_frontend/src/components/leads/LeadQualifyModal.vue
+++ b/manager_frontend/src/components/leads/LeadQualifyModal.vue
@@ -45,7 +45,9 @@ const cleanText = (value: unknown) => {
 const isLoading = ref(false);
 const attemptedSubmit = ref(false);
 
-const customerType = ref<CustomerTypeChoice>(isCustomerType(props.lead.customer_type) ? props.lead.customer_type : '');
+const initialCustomerType = isCustomerType(props.lead.customer_type) ? props.lead.customer_type : '';
+const customerType = ref<CustomerTypeChoice>(initialCustomerType);
+const customerTypeChosenByManager = ref(false);
 const serviceType = ref<ServiceTypeChoice>(normalizeServiceType(props.lead.service_type));
 
 const customerName = ref(props.lead.customer_name || props.lead.customer_full_legal_name || '');
@@ -108,6 +110,12 @@ const customerTypeOptions: Array<{ value: Exclude<CustomerTypeChoice, ''>; label
   { value: 'company', label: 'Юрлицо', hint: 'компания или ИП', icon: 'business' },
 ];
 
+const selectCustomerType = (value: Exclude<CustomerTypeChoice, ''>) => {
+  customerType.value = value;
+  customerTypeChosenByManager.value = true;
+  searchCustomer();
+};
+
 const resetBranches = () => {
   customerBranches.value = [];
   selectedBranchId.value = null;
@@ -152,7 +160,16 @@ const searchCustomer = async () => {
       existingCustomerId.value = match.id;
       foundCustomerName.value = match.name || match.full_legal_name || 'Неизвестно';
       searchStatus.value = 'found';
-      if (isCustomerType((match as any).type)) customerType.value = (match as any).type;
+      const matchType = isCustomerType(match.type) ? match.type : '';
+      const matchLooksCompany = matchType === 'company' || Boolean(match.inn || match.full_legal_name);
+      if (matchLooksCompany) {
+        customerType.value = 'company';
+      } else if (
+        matchType === 'individual'
+        && (initialCustomerType === 'individual' || (customerTypeChosenByManager.value && customerType.value === 'individual'))
+      ) {
+        customerType.value = 'individual';
+      }
       if (!customerName.value) customerName.value = match.name || match.full_legal_name || '';
       if (!customerEmail.value) customerEmail.value = match.email || '';
       if (!companyInn.value) companyInn.value = match.inn || '';
@@ -402,7 +419,7 @@ const submitQualify = async () => {
                   : attemptedSubmit && missingCustomerType
                     ? 'border-red-300 bg-red-50 text-slate-700 dark:border-red-500/50 dark:bg-red-500/10 dark:text-slate-200'
                     : 'border-slate-200 bg-white text-slate-700 hover:border-teal-300 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'"
-                @click="customerType = option.value; searchCustomer()"
+                @click="selectCustomerType(option.value)"
               >
                 <span class="material-icons-round text-[20px]">{{ option.icon }}</span>
                 <span class="min-w-0">

--- a/manager_frontend/src/components/leads/LeadQualifyModal.vue
+++ b/manager_frontend/src/components/leads/LeadQualifyModal.vue
@@ -15,17 +15,46 @@ const emit = defineEmits<{
   (e: 'success', orderId: number): void;
 }>();
 
-// Form State
+type CustomerTypeChoice = '' | 'individual' | 'company';
+type ServiceTypeChoice = '' | 'turnkey' | 'install_only' | 'pre_install' | 'maintenance' | 'repair' | 'dismantling';
+type OptionalSectionKey = 'contacts' | 'company' | 'branch' | 'extra';
+
+const isCustomerType = (value: unknown): value is Exclude<CustomerTypeChoice, ''> =>
+  value === 'individual' || value === 'company';
+
+const normalizeServiceType = (value: unknown): ServiceTypeChoice => {
+  const raw = String(value || '').trim();
+  if (
+    raw === 'turnkey'
+    || raw === 'install_only'
+    || raw === 'pre_install'
+    || raw === 'maintenance'
+    || raw === 'repair'
+    || raw === 'dismantling'
+  ) {
+    return raw;
+  }
+  return '';
+};
+
+const cleanText = (value: unknown) => {
+  const cleaned = String(value ?? '').trim();
+  return cleaned || undefined;
+};
+
 const isLoading = ref(false);
-const customerType = ref<'individual' | 'company'>(props.lead.customer_type as any || 'individual');
-const customerName = ref(props.lead.customer_name || '');
-// @ts-ignore (phone exists on the original response dynamically, we handle it if present)
-const customerPhone = ref((props.lead as any).customer_phone || (props.lead as any).phone || '');
-const customerEmail = ref((props.lead as any).customer_email || props.lead.email || '');
+const attemptedSubmit = ref(false);
+
+const customerType = ref<CustomerTypeChoice>(isCustomerType(props.lead.customer_type) ? props.lead.customer_type : '');
+const serviceType = ref<ServiceTypeChoice>(normalizeServiceType(props.lead.service_type));
+
+const customerName = ref(props.lead.customer_name || props.lead.customer_full_legal_name || '');
+const customerPhone = ref(props.lead.phone || '');
+const customerEmail = ref(props.lead.email || '');
 const phoneInputRef = ref<HTMLInputElement | null>(null);
 const { unmaskedValue: unmaskedPhone } = useBelarusPhoneMask(phoneInputRef, customerPhone, { lazy: false });
-const customerCity = ref('Витебск');
-const customerAddress = ref('');
+
+const customerDeliveryAddress = ref(props.lead.customer_delivery_address || '');
 const companyName = ref(props.lead.customer_name || '');
 const companyInn = ref(props.lead.customer_inn || '');
 const companyFullLegalName = ref(props.lead.customer_full_legal_name || '');
@@ -34,11 +63,18 @@ const companyIban = ref('');
 const companyBic = ref('');
 const companyBankName = ref('');
 
-const objectType = ref('apartment');
-const serviceType = ref('turnkey');
-const equipmentClass = ref('');
-const marketingSource = ref('');
+const objectType = ref(props.lead.object_type || '');
+const equipmentClass = ref(props.lead.equipment_class || '');
+const marketingSource = ref(props.lead.marketing_source || '');
 const managerComment = ref(props.lead.comment || '');
+
+const optionalSections = ref<Record<OptionalSectionKey, boolean>>({
+  contacts: false,
+  company: false,
+  branch: false,
+  extra: false,
+});
+
 const existingCustomerId = ref<number | null>(null);
 const customerBranches = ref<ManagerCustomerBranchItemResponse[]>([]);
 const selectedBranchId = ref<number | null>(null);
@@ -49,11 +85,28 @@ const creatingBranch = ref(false);
 
 const { lookupCompany, lookupBank, isEgrLoading, isBankLoading } = useB2BLookup();
 
-// Customer Search
 const searchTimeout = ref<number | null>(null);
 const searchStatus = ref<'idle' | 'searching' | 'found' | 'not_found'>('idle');
 const foundCustomerName = ref('');
 const selectedBranch = computed(() => customerBranches.value.find((branch) => branch.id === selectedBranchId.value) || null);
+
+const missingCustomerType = computed(() => !customerType.value);
+const missingServiceType = computed(() => !serviceType.value);
+const canSubmit = computed(() => !isLoading.value && !missingCustomerType.value && !missingServiceType.value);
+
+const serviceOptions: Array<{ value: ServiceTypeChoice; label: string; hint: string; icon: string }> = [
+  { value: 'turnkey', label: 'Покупка + монтаж', hint: 'нужно подобрать и установить', icon: 'shopping_cart' },
+  { value: 'install_only', label: 'Монтаж', hint: 'оборудование уже есть', icon: 'construction' },
+  { value: 'pre_install', label: 'Закладка трассы', hint: 'этап ремонта', icon: 'route' },
+  { value: 'maintenance', label: 'Обслуживание', hint: 'ТО, чистка, сервис', icon: 'ac_unit' },
+  { value: 'repair', label: 'Ремонт', hint: 'диагностика и восстановление', icon: 'build_circle' },
+  { value: 'dismantling', label: 'Демонтаж', hint: 'снять или перенести', icon: 'move_down' },
+];
+
+const customerTypeOptions: Array<{ value: Exclude<CustomerTypeChoice, ''>; label: string; hint: string; icon: string }> = [
+  { value: 'individual', label: 'Физлицо', hint: 'частный клиент', icon: 'person' },
+  { value: 'company', label: 'Юрлицо', hint: 'компания или ИП', icon: 'business' },
+];
 
 const resetBranches = () => {
   customerBranches.value = [];
@@ -70,7 +123,6 @@ const loadBranches = async (customerId: number) => {
     const hasCurrent = selectedBranchId.value
       ? customerBranches.value.some((branch) => branch.id === selectedBranchId.value)
       : false;
-    // UX: default to "Без филиала" to prevent accidental branch assignment.
     selectedBranchId.value = hasCurrent ? selectedBranchId.value : null;
   } catch (error) {
     console.error('Failed to load customer branches', error);
@@ -81,8 +133,8 @@ const loadBranches = async (customerId: number) => {
 };
 
 const searchCustomer = async () => {
-  const query = customerType.value === 'company' 
-    ? companyInn.value 
+  const query = customerType.value === 'company'
+    ? companyInn.value
     : (unmaskedPhone.value || customerPhone.value);
   if (!query || query.length < 5) {
     searchStatus.value = 'idle';
@@ -95,25 +147,23 @@ const searchCustomer = async () => {
   try {
     searchStatus.value = 'searching';
     const res = await api.getManagerCustomers(1, 1, query);
-    if (res.items && res.items.length > 0) {
-      const match = res.items[0];
-      if (match) {
-        existingCustomerId.value = match.id;
-        foundCustomerName.value = match.name || match.full_legal_name || 'Неизвестно';
-        searchStatus.value = 'found';
-        await loadBranches(match.id);
-      } else {
-        existingCustomerId.value = null;
-        searchStatus.value = 'not_found';
-        foundCustomerName.value = '';
-        resetBranches();
-      }
-    } else {
-      existingCustomerId.value = null;
-      searchStatus.value = 'not_found';
-      foundCustomerName.value = '';
-      resetBranches();
+    const match = res.items?.[0];
+    if (match) {
+      existingCustomerId.value = match.id;
+      foundCustomerName.value = match.name || match.full_legal_name || 'Неизвестно';
+      searchStatus.value = 'found';
+      if (isCustomerType((match as any).type)) customerType.value = (match as any).type;
+      if (!customerName.value) customerName.value = match.name || match.full_legal_name || '';
+      if (!customerEmail.value) customerEmail.value = match.email || '';
+      if (!companyInn.value) companyInn.value = match.inn || '';
+      if (!companyFullLegalName.value) companyFullLegalName.value = match.full_legal_name || '';
+      await loadBranches(match.id);
+      return;
     }
+    existingCustomerId.value = null;
+    searchStatus.value = 'not_found';
+    foundCustomerName.value = '';
+    resetBranches();
   } catch (e) {
     console.error('Customer search failed', e);
     searchStatus.value = 'idle';
@@ -128,30 +178,29 @@ const onSearchInput = () => {
   searchTimeout.value = window.setTimeout(searchCustomer, 500);
 };
 
-// Auto-search initially if phone exists
 watch(() => props.lead, () => {
-    if (customerPhone.value) {
-        searchCustomer();
-    }
+  if (customerPhone.value || companyInn.value) {
+    searchCustomer();
+  }
 }, { immediate: true });
 
 const onInnBlur = async () => {
-    if (!companyInn.value || companyInn.value.length !== 9) return;
-    const data = await lookupCompany(companyInn.value);
-    if (data) {
-        if (!companyFullLegalName.value) companyFullLegalName.value = data.fullLegalName || '';
-        if (!companyLegalAddress.value) companyLegalAddress.value = data.legalAddress || '';
-        if (!companyName.value) companyName.value = data.fullLegalName || '';
-    }
+  if (!companyInn.value || companyInn.value.length !== 9) return;
+  const data = await lookupCompany(companyInn.value);
+  if (data) {
+    if (!companyFullLegalName.value) companyFullLegalName.value = data.fullLegalName || '';
+    if (!companyLegalAddress.value) companyLegalAddress.value = data.legalAddress || '';
+    if (!companyName.value) companyName.value = data.fullLegalName || '';
+  }
 };
 
 const onIbanBlur = async () => {
-    if (!companyIban.value || companyIban.value.length < 15) return;
-    const data = await lookupBank(companyIban.value);
-    if (data) {
-        if (!companyBankName.value) companyBankName.value = data.bankName || '';
-        if (!companyBic.value) companyBic.value = data.bic || '';
-    }
+  if (!companyIban.value || companyIban.value.length < 15) return;
+  const data = await lookupBank(companyIban.value);
+  if (data) {
+    if (!companyBankName.value) companyBankName.value = data.bankName || '';
+    if (!companyBic.value) companyBic.value = data.bic || '';
+  }
 };
 
 const createBranchForExistingCustomer = async () => {
@@ -170,8 +219,7 @@ const createBranchForExistingCustomer = async () => {
     });
     customerBranches.value = [created, ...customerBranches.value.filter((branch) => branch.id !== created.id)];
     selectedBranchId.value = created.id;
-    customerAddress.value = created.delivery_address;
-    customerCity.value = '';
+    customerDeliveryAddress.value = created.delivery_address;
     newBranchName.value = '';
     newBranchAddress.value = '';
   } catch (error) {
@@ -185,47 +233,90 @@ const createBranchForExistingCustomer = async () => {
 const onSelectedBranchChange = () => {
   const branch = selectedBranch.value;
   if (!branch) return;
-  customerAddress.value = branch.delivery_address;
-  customerCity.value = '';
+  customerDeliveryAddress.value = branch.delivery_address;
 };
 
+const sectionSummary = (key: OptionalSectionKey) => {
+  if (key === 'contacts') {
+    return [customerName.value, customerPhone.value, customerEmail.value, customerDeliveryAddress.value]
+      .filter(Boolean)
+      .slice(0, 2)
+      .join(' · ') || 'можно заполнить позже';
+  }
+  if (key === 'company') {
+    return [companyInn.value ? `УНП ${companyInn.value}` : '', companyFullLegalName.value || companyName.value]
+      .filter(Boolean)
+      .join(' · ') || 'реквизиты не обязательны';
+  }
+  if (key === 'branch') {
+    return selectedBranch.value?.name || objectType.value || 'филиал и объект не обязательны';
+  }
+  return [marketingSource.value, equipmentClass.value].filter(Boolean).join(' · ') || 'дополнения не обязательны';
+};
+
+const buildPayload = (): ManagerOrderUpdatePayload => {
+  const payload: ManagerOrderUpdatePayload = {
+    status: 'negotiation',
+    customer_type: customerType.value || undefined,
+    service_type: serviceType.value || undefined,
+  };
+
+  if (existingCustomerId.value) {
+    payload.customer_id = existingCustomerId.value;
+  }
+  if (selectedBranchId.value !== null) {
+    payload.customer_branch_id = selectedBranchId.value;
+  }
+
+  const deliveryAddress = cleanText(customerDeliveryAddress.value || selectedBranch.value?.delivery_address);
+  if (deliveryAddress) payload.customer_delivery_address = deliveryAddress;
+
+  const name = cleanText(customerType.value === 'company'
+    ? (companyName.value || companyFullLegalName.value || customerName.value)
+    : customerName.value);
+  if (name) payload.customer_name = name;
+
+  const phone = cleanText(unmaskedPhone.value || customerPhone.value);
+  if (phone) payload.customer_phone = phone;
+
+  const email = cleanText(customerEmail.value);
+  if (email) payload.customer_email = email;
+
+  if (customerType.value === 'company') {
+    const inn = cleanText(companyInn.value);
+    const fullLegalName = cleanText(companyFullLegalName.value || companyName.value);
+    const legalAddress = cleanText(companyLegalAddress.value);
+    const iban = cleanText(companyIban.value);
+    const bic = cleanText(companyBic.value);
+    const bankName = cleanText(companyBankName.value);
+    if (inn) payload.customer_inn = inn;
+    if (fullLegalName) payload.customer_full_legal_name = fullLegalName;
+    if (legalAddress) payload.customer_legal_address = legalAddress;
+    if (iban) payload.customer_iban = iban;
+    if (bic) payload.customer_bic = bic;
+    if (bankName) payload.customer_bank_name = bankName;
+  }
+
+  const comment = cleanText(managerComment.value);
+  if (comment) payload.comment = comment;
+
+  const selectedObjectType = cleanText(objectType.value);
+  const selectedEquipmentClass = cleanText(equipmentClass.value);
+  const selectedMarketingSource = cleanText(marketingSource.value);
+  if (selectedObjectType) payload.object_type = selectedObjectType;
+  if (selectedEquipmentClass) payload.equipment_class = selectedEquipmentClass;
+  if (selectedMarketingSource) payload.marketing_source = selectedMarketingSource;
+
+  return payload;
+};
 
 const submitQualify = async () => {
+  attemptedSubmit.value = true;
+  if (!canSubmit.value) return;
+
   isLoading.value = true;
   try {
-    const manualDeliveryAddress = [customerCity.value, customerAddress.value].filter(Boolean).join(', ').trim();
-    const resolvedDeliveryAddress = manualDeliveryAddress || selectedBranch.value?.delivery_address || undefined;
-    const payload: ManagerOrderUpdatePayload = existingCustomerId.value ? {
-      status: 'negotiation',
-      customer_id: existingCustomerId.value,
-      customer_branch_id: selectedBranchId.value ?? null,
-      customer_delivery_address: resolvedDeliveryAddress,
-      comment: managerComment.value || undefined,
-      object_type: objectType.value || undefined,
-      service_type: serviceType.value || undefined,
-      equipment_class: equipmentClass.value || undefined,
-      marketing_source: marketingSource.value || undefined,
-    } : {
-      status: 'negotiation',
-      customer_type: customerType.value,
-      customer_name: customerName.value || undefined,
-      customer_phone: unmaskedPhone.value || customerPhone.value || undefined,
-      customer_email: customerEmail.value || undefined,
-      customer_delivery_address: manualDeliveryAddress || undefined,
-      customer_inn: customerType.value === 'company' ? (companyInn.value || undefined) : undefined,
-      customer_full_legal_name: customerType.value === 'company' ? (companyFullLegalName.value || companyName.value || undefined) : undefined,
-      customer_legal_address: customerType.value === 'company' ? (companyLegalAddress.value || undefined) : undefined,
-      customer_iban: customerType.value === 'company' ? (companyIban.value || undefined) : undefined,
-      customer_bic: customerType.value === 'company' ? (companyBic.value || undefined) : undefined,
-      customer_bank_name: customerType.value === 'company' ? (companyBankName.value || undefined) : undefined,
-      comment: managerComment.value || undefined,
-      object_type: objectType.value || undefined,
-      service_type: serviceType.value || undefined,
-      equipment_class: equipmentClass.value || undefined,
-      marketing_source: marketingSource.value || undefined,
-    };
-
-    await api.patchManagerOrder(props.lead.id, payload);
+    await api.patchManagerOrder(props.lead.id, buildPayload());
     emit('success', props.lead.id);
   } catch (e) {
     console.error(e);
@@ -237,67 +328,239 @@ const submitQualify = async () => {
 </script>
 
 <template>
-  <div class="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100] p-4 font-sans text-slate-800 dark:text-slate-200">
-    <div class="bg-white dark:bg-slate-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden">
-      <!-- Header -->
-      <div class="px-6 py-4 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between shrink-0 bg-slate-50/50 dark:bg-slate-900/50">
-        <div>
-          <h2 class="text-lg font-bold flex items-center gap-2">
-            <span class="material-icons-round text-teal-600 dark:text-teal-500">check_circle</span>
-            Квалификация: Заявка #{{ lead.id }}
+  <div class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4 font-sans text-slate-800 backdrop-blur-sm dark:text-slate-200">
+    <div class="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-slate-900">
+      <div class="flex shrink-0 items-center justify-between border-b border-slate-100 bg-slate-50/70 px-6 py-4 dark:border-slate-800 dark:bg-slate-900/60">
+        <div class="min-w-0">
+          <h2 class="flex items-center gap-2 text-lg font-bold">
+            <span class="material-icons-round text-teal-600 dark:text-teal-500">bolt</span>
+            Быстрая квалификация #{{ lead.id }}
           </h2>
-          <p class="text-xs text-slate-500 mt-1" v-if="(lead as any).source_display">Источник: {{ (lead as any).source_display }}</p>
+          <p class="mt-1 text-xs text-slate-500">Минимум для сделки: тип клиента и суть задачи.</p>
         </div>
-        <button @click="emit('close')" class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500 transition-colors">
+        <button
+          class="flex h-8 w-8 items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-slate-200 dark:hover:bg-slate-700"
+          @click="emit('close')"
+        >
           <span class="material-icons-round text-[18px]">close</span>
         </button>
       </div>
 
-      <!-- Body -->
-      <div class="p-6 overflow-y-auto flex-1 space-y-8">
-        
-        <!-- 1. Client Type Switcher -->
-        <div class="flex gap-2 p-1 bg-slate-100 dark:bg-slate-800 rounded-xl w-fit mx-auto">
-          <button 
-            class="px-5 py-2 rounded-lg text-sm font-semibold transition-all"
-            :class="customerType === 'individual' ? 'bg-white dark:bg-slate-700 shadow-sm text-teal-700 dark:text-teal-400' : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'"
-            @click="customerType = 'individual'; searchCustomer()"
-          >
-            👤 Физ. лицо
-          </button>
-          <button 
-            class="px-5 py-2 rounded-lg text-sm font-semibold transition-all"
-            :class="customerType === 'company' ? 'bg-white dark:bg-slate-700 shadow-sm text-teal-700 dark:text-teal-400' : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'"
-            @click="customerType = 'company'; searchCustomer()"
-          >
-            🏢 Юр. лицо
-          </button>
-        </div>
+      <div class="flex-1 space-y-5 overflow-y-auto p-6">
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p class="text-xs font-bold uppercase tracking-wide text-slate-400">Входящий запрос</p>
+              <p class="mt-1 text-sm font-semibold text-slate-900 dark:text-white">
+                {{ lead.customer_name || lead.customer_full_legal_name || customerPhone || customerEmail || 'Контакт не указан' }}
+              </p>
+              <div class="mt-2 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+                <span v-if="customerPhone" class="inline-flex items-center gap-1">
+                  <span class="material-icons-round text-[14px]">call</span>
+                  {{ customerPhone }}
+                </span>
+                <span v-if="customerEmail" class="inline-flex items-center gap-1">
+                  <span class="material-icons-round text-[14px]">email</span>
+                  {{ customerEmail }}
+                </span>
+                <span v-if="lead.source" class="inline-flex items-center gap-1">
+                  <span class="material-icons-round text-[14px]">campaign</span>
+                  {{ lead.source }}
+                </span>
+              </div>
+            </div>
+            <span
+              v-if="searchStatus === 'found'"
+              class="inline-flex items-center gap-1 rounded-full bg-teal-100 px-3 py-1 text-xs font-bold text-teal-700 dark:bg-teal-500/10 dark:text-teal-300"
+            >
+              <span class="material-icons-round text-[15px]">person_search</span>
+              Клиент найден
+            </span>
+          </div>
+          <p v-if="lead.comment" class="mt-3 whitespace-pre-line rounded-xl bg-white p-3 text-sm leading-relaxed text-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+            {{ lead.comment }}
+          </p>
+        </section>
 
-        <!-- Auto-detect Banner -->
-        <div v-if="searchStatus === 'found'" class="bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 text-teal-800 dark:text-teal-300 px-4 py-3 rounded-xl flex items-start gap-3 text-sm">
-          <span class="material-icons-round text-teal-500 mt-0.5">info</span>
+        <section class="space-y-4">
           <div>
-            <strong>Найден карточка клиента: {{ foundCustomerName }}</strong><br/>
-            Заказ будет автоматически привязан к этому профилю.
-            <a :href="'/manager/customers/profile?customerId=' + existingCustomerId" target="_blank" class="ml-2 underline hover:text-teal-600 dark:hover:text-teal-200 font-semibold" title="Открыть в новой вкладке">
-              Посмотреть профиль
+            <div class="mb-2 flex items-center justify-between gap-3">
+              <h3 class="flex items-center gap-2 text-sm font-bold text-slate-900 dark:text-white">
+                <span class="material-icons-round text-[18px] text-teal-600 dark:text-teal-400">person</span>
+                Клиент
+              </h3>
+              <span v-if="attemptedSubmit && missingCustomerType" class="text-xs font-semibold text-red-500">Выберите тип клиента</span>
+            </div>
+            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                v-for="option in customerTypeOptions"
+                :key="option.value"
+                type="button"
+                class="flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-all"
+                :class="customerType === option.value
+                  ? 'border-teal-500 bg-teal-50 text-teal-800 shadow-sm dark:border-teal-400 dark:bg-teal-500/10 dark:text-teal-200'
+                  : attemptedSubmit && missingCustomerType
+                    ? 'border-red-300 bg-red-50 text-slate-700 dark:border-red-500/50 dark:bg-red-500/10 dark:text-slate-200'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-teal-300 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'"
+                @click="customerType = option.value; searchCustomer()"
+              >
+                <span class="material-icons-round text-[20px]">{{ option.icon }}</span>
+                <span class="min-w-0">
+                  <span class="block text-sm font-bold">{{ option.label }}</span>
+                  <span class="block text-xs opacity-70">{{ option.hint }}</span>
+                </span>
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <div class="mb-2 flex items-center justify-between gap-3">
+              <h3 class="flex items-center gap-2 text-sm font-bold text-slate-900 dark:text-white">
+                <span class="material-icons-round text-[18px] text-teal-600 dark:text-teal-400">build</span>
+                Суть задачи
+              </h3>
+              <span v-if="attemptedSubmit && missingServiceType" class="text-xs font-semibold text-red-500">Выберите задачу</span>
+            </div>
+            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                v-for="option in serviceOptions"
+                :key="option.value"
+                type="button"
+                class="flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-all"
+                :class="serviceType === option.value
+                  ? 'border-teal-500 bg-teal-50 text-teal-800 shadow-sm dark:border-teal-400 dark:bg-teal-500/10 dark:text-teal-200'
+                  : attemptedSubmit && missingServiceType
+                    ? 'border-red-300 bg-red-50 text-slate-700 dark:border-red-500/50 dark:bg-red-500/10 dark:text-slate-200'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-teal-300 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'"
+                @click="serviceType = option.value"
+              >
+                <span class="material-icons-round text-[20px]">{{ option.icon }}</span>
+                <span class="min-w-0">
+                  <span class="block text-sm font-bold">{{ option.label }}</span>
+                  <span class="block text-xs opacity-70">{{ option.hint }}</span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <div v-if="searchStatus === 'found'" class="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 px-4 py-3 text-sm text-teal-800 dark:border-teal-800 dark:bg-teal-900/30 dark:text-teal-300">
+          <span class="material-icons-round mt-0.5 text-teal-500">info</span>
+          <div>
+            <strong>Найдена карточка клиента: {{ foundCustomerName }}</strong><br>
+            Сделка будет привязана к этому профилю.
+            <a
+              :href="'/manager/customers/profile?customerId=' + existingCustomerId"
+              target="_blank"
+              class="ml-2 font-semibold underline hover:text-teal-600 dark:hover:text-teal-200"
+              title="Открыть в новой вкладке"
+            >
+              Профиль
             </a>
           </div>
         </div>
 
-        <section v-if="existingCustomerId" class="space-y-3">
-          <h3 class="text-[11px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-2">
-            <span class="material-icons-round text-[14px]">account_tree</span>
-            Филиал клиента
-          </h3>
+        <section class="space-y-2">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700/70"
+            @click="optionalSections.contacts = !optionalSections.contacts"
+          >
+            <span>
+              <span class="block text-sm font-bold">Контакты и адрес</span>
+              <span class="block text-xs text-slate-500">{{ sectionSummary('contacts') }}</span>
+            </span>
+            <span class="material-icons-round text-slate-400">{{ optionalSections.contacts ? 'expand_less' : 'expand_more' }}</span>
+          </button>
+          <div v-if="optionalSections.contacts" class="grid grid-cols-1 gap-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60 md:grid-cols-2">
+            <label class="block text-xs font-semibold text-slate-500">
+              Имя / контакт
+              <input v-model="customerName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500">
+              Телефон
+              <input ref="phoneInputRef" v-model="customerPhone" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" @input="onSearchInput">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Email
+              <input v-model="customerEmail" type="email" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Адрес объекта / доставки
+              <input v-model="customerDeliveryAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Адрес можно добавить позже">
+            </label>
+          </div>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="md:col-span-2">
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Выбор филиала</label>
+          <button
+            v-if="customerType === 'company'"
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700/70"
+            @click="optionalSections.company = !optionalSections.company"
+          >
+            <span>
+              <span class="block text-sm font-bold">Реквизиты компании</span>
+              <span class="block text-xs text-slate-500">{{ sectionSummary('company') }}</span>
+            </span>
+            <span class="material-icons-round text-slate-400">{{ optionalSections.company ? 'expand_less' : 'expand_more' }}</span>
+          </button>
+          <div v-if="customerType === 'company' && optionalSections.company" class="grid grid-cols-1 gap-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60 md:grid-cols-2">
+            <label class="block text-xs font-semibold text-slate-500">
+              УНП
+              <span class="relative mt-1 block">
+                <input v-model="companyInn" type="text" class="w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="9 цифр" @input="onSearchInput" @blur="onInnBlur">
+                <span v-if="isEgrLoading" class="absolute right-3 top-2.5">
+                  <span class="material-icons-round animate-spin text-sm text-teal-500">refresh</span>
+                </span>
+              </span>
+            </label>
+            <label class="block text-xs font-semibold text-slate-500">
+              Короткое название
+              <input v-model="companyName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Полное юридическое название
+              <input v-model="companyFullLegalName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Юридический адрес
+              <input v-model="companyLegalAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              IBAN
+              <span class="relative mt-1 block">
+                <input v-model="companyIban" type="text" class="w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" @blur="onIbanBlur">
+                <span v-if="isBankLoading" class="absolute right-3 top-2.5">
+                  <span class="material-icons-round animate-spin text-sm text-teal-500">refresh</span>
+                </span>
+              </span>
+            </label>
+            <label class="block text-xs font-semibold text-slate-500">
+              BIC
+              <input v-model="companyBic" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+            <label class="block text-xs font-semibold text-slate-500">
+              Банк
+              <input v-model="companyBankName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+            </label>
+          </div>
+
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700/70"
+            @click="optionalSections.branch = !optionalSections.branch"
+          >
+            <span>
+              <span class="block text-sm font-bold">Филиал и объект</span>
+              <span class="block text-xs text-slate-500">{{ sectionSummary('branch') }}</span>
+            </span>
+            <span class="material-icons-round text-slate-400">{{ optionalSections.branch ? 'expand_less' : 'expand_more' }}</span>
+          </button>
+          <div v-if="optionalSections.branch" class="grid grid-cols-1 gap-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60 md:grid-cols-2">
+            <label v-if="existingCustomerId" class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Филиал клиента
               <select
                 v-model="selectedBranchId"
-                class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow"
+                class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900"
                 :disabled="branchesLoading"
                 @change="onSelectedBranchChange"
               >
@@ -306,204 +569,100 @@ const submitQualify = async () => {
                   {{ branch.name || `Филиал #${branch.id}` }} — {{ branch.delivery_address }}
                 </option>
               </select>
-              <p v-if="branchesLoading" class="mt-1 text-xs text-slate-500">Загрузка филиалов...</p>
-              <p v-else-if="!customerBranches.length" class="mt-1 text-xs text-slate-500">У клиента пока нет филиалов.</p>
-            </div>
-
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Новый филиал (название)</label>
-              <input
-                v-model="newBranchName"
-                type="text"
-                class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow"
-                placeholder="Склад / Объект"
-              >
-            </div>
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Новый филиал (адрес)</label>
-              <input
-                v-model="newBranchAddress"
-                type="text"
-                class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow"
-                placeholder="Минск, Ленина 1"
-              >
-            </div>
-            <div class="md:col-span-2">
-              <button
-                type="button"
-                class="px-4 py-2 rounded-xl border border-slate-200 text-slate-700 hover:bg-slate-100 transition-colors text-sm font-semibold disabled:opacity-50"
-                :disabled="creatingBranch || !existingCustomerId"
-                @click="createBranchForExistingCustomer"
-              >
-                {{ creatingBranch ? 'Создаем филиал...' : 'Создать филиал и выбрать' }}
-              </button>
-            </div>
-          </div>
-        </section>
-
-        <!-- 2. Who and Where -->
-        <section>
-          <h3 class="text-[11px] font-bold text-slate-400 uppercase tracking-wider mb-4 flex items-center gap-2">
-            <span class="material-icons-round text-[14px]">person_pin_circle</span>
-            Кто и Где
-          </h3>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <!-- Company fields -->
-            <template v-if="customerType === 'company'">
+              <span v-if="branchesLoading" class="mt-1 block text-xs text-slate-500">Загрузка филиалов...</span>
+              <span v-else-if="!customerBranches.length" class="mt-1 block text-xs text-slate-500">У клиента пока нет филиалов.</span>
+            </label>
+            <template v-if="existingCustomerId">
+              <label class="block text-xs font-semibold text-slate-500">
+                Новый филиал
+                <input v-model="newBranchName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Склад / Объект">
+              </label>
+              <label class="block text-xs font-semibold text-slate-500">
+                Адрес филиала
+                <input v-model="newBranchAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Минск, Ленина 1">
+              </label>
               <div class="md:col-span-2">
-                <label class="block text-xs font-semibold text-slate-500 mb-1">УНП</label>
-                <div class="relative">
-                  <input v-model="companyInn" type="text" @input="onSearchInput" @blur="onInnBlur" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow" placeholder="9 цифр">
-                  <div v-if="isEgrLoading" class="absolute right-3 top-2.5">
-                    <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                  </div>
-                </div>
-              </div>
-              <div class="md:col-span-2">
-                <label class="block text-xs font-semibold text-slate-500 mb-1">Короткое название (для списка)</label>
-                <input v-model="companyName" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow" placeholder="ООО Мастер Воздуха">
-              </div>
-              <div class="md:col-span-2">
-                <label class="block text-xs font-semibold text-slate-500 mb-1">Полное юридическое название</label>
-                <input v-model="companyFullLegalName" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-              </div>
-              <div class="md:col-span-2">
-                <label class="block text-xs font-semibold text-slate-500 mb-1">Юридический адрес</label>
-                <input v-model="companyLegalAddress" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-              </div>
-              <div class="md:col-span-2 grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="md:col-span-2">
-                  <label class="block text-xs font-semibold text-slate-500 mb-1">IBAN (Расчетный счет)</label>
-                  <div class="relative">
-                    <input v-model="companyIban" type="text" @blur="onIbanBlur" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-                    <div v-if="isBankLoading" class="absolute right-3 top-2.5">
-                      <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <label class="block text-xs font-semibold text-slate-500 mb-1">BIC</label>
-                  <input v-model="companyBic" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-                </div>
-              </div>
-              <div class="md:col-span-2">
-                <label class="block text-xs font-semibold text-slate-500 mb-1">Название банка</label>
-                <input v-model="companyBankName" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
+                <button
+                  type="button"
+                  class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700"
+                  :disabled="creatingBranch || !existingCustomerId"
+                  @click="createBranchForExistingCustomer"
+                >
+                  {{ creatingBranch ? 'Создаем филиал...' : 'Создать филиал и выбрать' }}
+                </button>
               </div>
             </template>
-
-            <!-- Base fields -->
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Имя (Контакт)</label>
-              <input v-model="customerName" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-            </div>
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Телефон</label>
-              <input ref="phoneInputRef" v-model="customerPhone" type="text" @input="onSearchInput" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm font-medium focus:ring-2 focus:ring-teal-500 transition-shadow">
-            </div>
-            <div class="md:col-span-2">
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Email</label>
-              <input v-model="customerEmail" type="email" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm font-medium focus:ring-2 focus:ring-teal-500 transition-shadow">
-            </div>
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Город</label>
-              <input v-model="customerCity" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow">
-            </div>
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-1">Адрес объекта</label>
-              <input v-model="customerAddress" type="text" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow" placeholder="ул. Ленина 5, кв 10">
-            </div>
-          </div>
-        </section>
-
-        <!-- 3. What -->
-        <section>
-          <h3 class="text-[11px] font-bold text-slate-400 uppercase tracking-wider mb-4 flex items-center gap-2">
-            <span class="material-icons-round text-[14px]">build</span>
-            Что делаем
-          </h3>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-2">Тип объекта</label>
-              <select v-model="objectType" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 appearance-none cursor-pointer">
-                <option value="apartment">🏢 Квартира (Стандарт)</option>
-                <option value="house">🏡 Частный дом (Леса/Фасад)</option>
-                <option value="office">🏬 Офис/Магазин</option>
-                <option value="industrial">🏭 Пром/Серверная</option>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Тип объекта
+              <select v-model="objectType" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+                <option value="">Не указано</option>
+                <option value="apartment">Квартира</option>
+                <option value="house">Частный дом</option>
+                <option value="office">Офис / магазин</option>
+                <option value="industrial">Пром / серверная</option>
               </select>
-            </div>
-            
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-2">Суть задачи</label>
-              <select v-model="serviceType" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 appearance-none cursor-pointer">
-                <option value="turnkey">📦 Покупка + Монтаж</option>
-                <option value="install_only">🔧 Только монтаж</option>
-                <option value="pre_install">🧱 Закладка трассы (Ремонт)</option>
-                <option value="maintenance">❄️ Сервис/ТО</option>
-                <option value="repair">🛠 Ремонт</option>
-              </select>
-            </div>
+            </label>
           </div>
-        </section>
 
-        <!-- 4. Details -->
-        <section>
-          <h3 class="text-[11px] font-bold text-slate-400 uppercase tracking-wider mb-4 flex items-center gap-2">
-            <span class="material-icons-round text-[14px]">info</span>
-            Детали
-          </h3>
-          
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-2">Источник</label>
-              <select v-model="marketingSource" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 appearance-none cursor-pointer">
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700/70"
+            @click="optionalSections.extra = !optionalSections.extra"
+          >
+            <span>
+              <span class="block text-sm font-bold">Дополнительно</span>
+              <span class="block text-xs text-slate-500">{{ sectionSummary('extra') }}</span>
+            </span>
+            <span class="material-icons-round text-slate-400">{{ optionalSections.extra ? 'expand_less' : 'expand_more' }}</span>
+          </button>
+          <div v-if="optionalSections.extra" class="grid grid-cols-1 gap-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60 md:grid-cols-2">
+            <label class="block text-xs font-semibold text-slate-500">
+              Источник
+              <select v-model="marketingSource" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
                 <option value="">Не указано</option>
                 <option value="site">Сайт</option>
                 <option value="instagram">Instagram / TikTok</option>
-                <option value="referral">Рекомендация (Сарафан)</option>
+                <option value="referral">Рекомендация</option>
                 <option value="onliner">Onliner</option>
                 <option value="kufar">Kufar / 103</option>
+                <option value="email">Email</option>
+                <option value="phone">Телефон</option>
+                <option value="manager">Менеджер</option>
               </select>
-            </div>
-            <div>
-              <label class="block text-xs font-semibold text-slate-500 mb-2">Предпочтения (Класс)</label>
-              <select v-model="equipmentClass" class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 appearance-none cursor-pointer">
-                <option value="">Не определился</option>
-                <option value="economy">Эконом (Лишь бы холодило)</option>
-                <option value="standard">Цена/Качество (Стандарт)</option>
-                <option value="premium">Премиум (Дизайн, тишина, Wi-Fi)</option>
-              </select>
-            </div>
-          </div>
-
-          <div>
-            <label class="block text-xs font-semibold text-slate-500 mb-2 flex justify-between">
-              Комментарий менеджера
-              <span class="text-[10px] text-slate-400 font-normal">для замерщика</span>
             </label>
-            <textarea 
-              v-model="managerComment" 
-              rows="3" 
-              class="w-full bg-slate-50 dark:bg-slate-800 border-none rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-teal-500 transition-shadow resize-y"
-              placeholder="Нужна автовышка, потолки 4 метра..."
-            ></textarea>
+            <label class="block text-xs font-semibold text-slate-500">
+              Предпочтения по классу
+              <select v-model="equipmentClass" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
+                <option value="">Не определился</option>
+                <option value="economy">Эконом</option>
+                <option value="standard">Цена / качество</option>
+                <option value="premium">Премиум</option>
+              </select>
+            </label>
+            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
+              Комментарий
+              <textarea
+                v-model="managerComment"
+                rows="3"
+                class="mt-1 w-full resize-y rounded-xl border-0 bg-white px-4 py-3 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900"
+                placeholder="Контекст для сделки, КП или выезда"
+              ></textarea>
+            </label>
           </div>
         </section>
       </div>
 
-      <!-- Footer Actions -->
-      <div class="px-6 py-4 bg-slate-50 dark:bg-slate-900 border-t border-slate-100 dark:border-slate-800 flex gap-3 shrink-0">
-        <button 
-          @click="submitQualify" 
+      <div class="flex shrink-0 gap-3 border-t border-slate-100 bg-slate-50 px-6 py-4 dark:border-slate-800 dark:bg-slate-900">
+        <button
+          class="flex flex-1 items-center justify-center gap-2 rounded-xl bg-teal-600 py-3 font-bold text-white transition-colors hover:bg-teal-700 disabled:opacity-50"
           :disabled="isLoading"
-          class="flex-1 py-3 bg-teal-600 hover:bg-teal-700 disabled:opacity-50 text-white rounded-xl font-bold flex items-center justify-center gap-2 transition-colors"
+          @click="submitQualify"
         >
           <span v-if="isLoading" class="material-icons-round animate-spin">refresh</span>
-          <span v-else class="material-icons-round">thumb_up</span>
-          Записать на Замер
+          <span v-else class="material-icons-round">arrow_forward</span>
+          Создать сделку
         </button>
       </div>
-
     </div>
   </div>
 </template>

--- a/manager_frontend/src/views/LeadInbox.vue
+++ b/manager_frontend/src/views/LeadInbox.vue
@@ -294,9 +294,10 @@ const onCreateInnBlur = async () => {
 
 // ── Qualify ───────────────────────────────────────────────────────────────────
 const handleQualifySuccess = async (orderId: number) => {
-  setToast(`Заявка #${orderId} переведена в Замер`);
   qualifyTarget.value = null;
-  await load();
+  setToast(`Сделка #${orderId} создана, открываем карточку`);
+  window.history.pushState({}, '', `/manager/orders/kanban?orderId=${orderId}`);
+  window.dispatchEvent(new PopStateEvent('popstate'));
 };
 
 // ── No Answer (Недозвон) ──────────────────────────────────────────────────────

--- a/openapi.json
+++ b/openapi.json
@@ -14169,6 +14169,17 @@
             "type": "boolean",
             "title": "Is New"
           },
+          "customer_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Id"
+          },
           "customer_name": {
             "anyOf": [
               {
@@ -14254,9 +14265,15 @@
             "title": "Created At"
           },
           "customer_type": {
-            "type": "string",
-            "title": "Customer Type",
-            "default": "individual"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Type"
           },
           "customer_inn": {
             "anyOf": [
@@ -14279,6 +14296,61 @@
               }
             ],
             "title": "Customer Full Legal Name"
+          },
+          "customer_delivery_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Delivery Address"
+          },
+          "object_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Type"
+          },
+          "service_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Type"
+          },
+          "equipment_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Equipment Class"
+          },
+          "marketing_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Marketing Source"
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -1922,6 +1922,7 @@ class LeadsInboxItemResponse(BaseModel):
     id: int
     status: str
     is_new: bool
+    customer_id: Optional[int] = None
     customer_name: Optional[str] = None
     phone: Optional[str] = None
     email: Optional[str] = None
@@ -1930,9 +1931,14 @@ class LeadsInboxItemResponse(BaseModel):
     no_answer_at: Optional[datetime] = None
     source_created_at: Optional[datetime] = None
     created_at: datetime
-    customer_type: str = "individual"
+    customer_type: Optional[str] = None
     customer_inn: Optional[str] = None
     customer_full_legal_name: Optional[str] = None
+    customer_delivery_address: Optional[str] = None
+    object_type: Optional[str] = None
+    service_type: Optional[str] = None
+    equipment_class: Optional[str] = None
+    marketing_source: Optional[str] = None
 
 
 class LeadsInboxListResponse(BaseModel):

--- a/services/email_lead_intake_service.py
+++ b/services/email_lead_intake_service.py
@@ -485,6 +485,8 @@ class EmailLeadIntakeService:
                 "email_subject": subject,
                 "email_date": email_date,
                 "email_ai_reason": EmailLeadIntakeService._clean_optional(classification.get("reason"), max_length=300),
+                "lead_customer_type_known": segment_hint in {"b2b", "b2c"} or bool(inn or company_name),
+                "lead_customer_type": customer_type if segment_hint in {"b2b", "b2c"} or inn or company_name else None,
             }
         )
         flag_modified(order, "technical_meta")

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -2265,6 +2265,16 @@ class OrderService:
                 if new_customer:
                     order.customer_id = payload.customer_id
                     customer_id_changed = True
+                    linked_customer_type = (
+                        new_customer.type.value
+                        if hasattr(new_customer.type, "value")
+                        else str(new_customer.type or "")
+                    )
+                    if linked_customer_type in {"individual", "company"}:
+                        order.technical_meta = dict(order.technical_meta or {})
+                        order.technical_meta["lead_customer_type_known"] = True
+                        order.technical_meta["lead_customer_type"] = linked_customer_type
+                        flag_modified(order, "technical_meta")
 
         # If customer was switched and branch wasn't explicitly provided, prevent stale cross-customer linkage.
         if customer_id_changed and "customer_branch_id" not in fields_set and order.customer_branch_id is not None:
@@ -2357,6 +2367,13 @@ class OrderService:
                     attr_name = customer_field_map[field_name]
                     setattr(customer, attr_name, _clean_optional(getattr(payload, field_name, None)))
                 session.add(customer)
+
+        incoming_customer_type = str(getattr(payload, "customer_type", "") or "").strip()
+        if "customer_type" in fields_set and incoming_customer_type in {"individual", "company"}:
+            order.technical_meta = dict(order.technical_meta or {})
+            order.technical_meta["lead_customer_type_known"] = True
+            order.technical_meta["lead_customer_type"] = incoming_customer_type
+            flag_modified(order, "technical_meta")
 
         # 3. Handle specific Order technical meta qualification updates
         meta_fields_map = {
@@ -2603,6 +2620,36 @@ class OrderService:
         return OrderService._parse_lead_inbox_datetime(raw_line)
 
     @staticmethod
+    def _lead_inbox_customer_type(order: Order) -> Optional[str]:
+        customer = order.customer
+        if not customer:
+            return None
+
+        customer_type = customer.type.value if hasattr(customer.type, "value") else str(customer.type or "")
+        if customer_type == "company" or customer.inn or customer.full_legal_name:
+            return "company"
+
+        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+        raw_meta_type = str(meta.get("lead_customer_type") or "").strip()
+        if raw_meta_type == "company":
+            return "company"
+        if raw_meta_type == "individual" and meta.get("lead_customer_type_known") is True:
+            return "individual"
+        if meta.get("lead_customer_type_known") is True and customer_type == "individual":
+            return "individual"
+
+        return None
+
+    @staticmethod
+    def _lead_inbox_meta_text(order: Order, key: str) -> Optional[str]:
+        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+        value = meta.get(key)
+        if value is None:
+            return None
+        cleaned = str(value).strip()
+        return cleaned or None
+
+    @staticmethod
     async def get_leads_inbox(
         session: AsyncSession,
         scope: str = "active",
@@ -2661,6 +2708,7 @@ class OrderService:
                     (order.status.value if hasattr(order.status, "value") else str(order.status))
                     == "new_lead"
                 ),
+                customer_id=order.customer_id,
                 customer_name=order.customer.name if order.customer else None,
                 phone=order.customer.phone if order.customer else None,
                 email=order.customer.email if order.customer else None,
@@ -2677,9 +2725,14 @@ class OrderService:
                 ),
                 source_created_at=OrderService._extract_email_source_created_at(order),
                 created_at=order.created_at,
-                customer_type=order.customer.type if order.customer else "individual",
+                customer_type=OrderService._lead_inbox_customer_type(order),
                 customer_inn=order.customer.inn if order.customer else None,
                 customer_full_legal_name=order.customer.full_legal_name if order.customer else None,
+                customer_delivery_address=order.delivery_address,
+                object_type=OrderService._lead_inbox_meta_text(order, "object_type"),
+                service_type=OrderService._lead_inbox_meta_text(order, "service_type"),
+                equipment_class=OrderService._lead_inbox_meta_text(order, "equipment_class"),
+                marketing_source=OrderService._lead_inbox_meta_text(order, "marketing_source"),
             )
             for order in orders
         ]

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -311,6 +311,58 @@ async def test_email_lead_intake_creates_visible_inbox_order_and_dedupes_by_mess
 
 
 @pytest.mark.asyncio
+async def test_email_lead_intake_marks_b2c_known_and_unknown_hint_unknown(sqlite_session, monkeypatch):
+    async def fake_classify(**kwargs):
+        if "B2C" in kwargs["subject"]:
+            return {
+                "is_potential_order": True,
+                "confidence": 0.9,
+                "name": "Анна",
+                "phone": "+375291111111",
+                "email": "anna@example.com",
+                "segment_hint": "b2c",
+                "request_text": "Частный клиент просит обслуживание кондиционера.",
+                "reason": "Есть запрос на обслуживание.",
+            }
+        return {
+            "is_potential_order": True,
+            "confidence": 0.9,
+            "name": "Клиент",
+            "phone": "+375292222222",
+            "email": "client@example.com",
+            "segment_hint": "unknown",
+            "request_text": "Клиент просит цену кондиционера.",
+            "reason": "Есть запрос цены, тип клиента не ясен.",
+        }
+
+    monkeypatch.setattr(EmailLeadIntakeService, "classify_email", fake_classify)
+
+    await EmailLeadIntakeService.process_email(
+        sqlite_session,
+        sender_email="anna@example.com",
+        sender_name="Анна",
+        subject="B2C обслуживание кондиционера",
+        raw_body="Нужно обслуживание кондиционера дома.",
+        message_id="<b2c-lead@example.test>",
+    )
+    await EmailLeadIntakeService.process_email(
+        sqlite_session,
+        sender_email="client@example.com",
+        sender_name="Клиент",
+        subject="Цена кондиционера",
+        raw_body="Добрый день, нужна цена кондиционера.",
+        message_id="<unknown-lead@example.test>",
+    )
+
+    orders = (await sqlite_session.execute(select(Order).order_by(Order.id))).scalars().all()
+
+    assert orders[0].technical_meta["lead_customer_type_known"] is True
+    assert orders[0].technical_meta["lead_customer_type"] == "individual"
+    assert orders[1].technical_meta["lead_customer_type_known"] is False
+    assert orders[1].technical_meta["lead_customer_type"] is None
+
+
+@pytest.mark.asyncio
 async def test_email_lead_intake_dry_run_does_not_create_order(sqlite_session, monkeypatch):
     async def fake_classify(**_kwargs):
         return {

--- a/tests/unit/test_order_service_leads_inbox.py
+++ b/tests/unit/test_order_service_leads_inbox.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from models import Customer, LeadSource, Order, OrderStatus
+from models import Customer, CustomerType, LeadSource, Order, OrderStatus
+from schemas import ManagerOrderUpdatePayload
 from services.order_service import OrderService
 
 
@@ -72,3 +73,115 @@ async def test_leads_inbox_extracts_legacy_email_date_from_comment(db):
     response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
 
     assert response.items[0].source_created_at == datetime(2026, 5, 11, 12, 33)
+
+
+@pytest.mark.asyncio
+async def test_leads_inbox_keeps_unknown_customer_type_and_task_essence_null(db):
+    customer = Customer(name="Default Individual", phone="+375290000001", type=CustomerType.individual)
+    db.add(customer)
+    await db.flush()
+    db.add(
+        Order(
+            customer_id=customer.id,
+            status=OrderStatus.NEW_LEAD,
+            lead_source=LeadSource.MANAGER,
+            comment="Нужно уточнить, кто клиент и что именно требуется.",
+            technical_meta={},
+        )
+    )
+    await db.commit()
+
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+
+    assert response.items[0].customer_id == customer.id
+    assert response.items[0].customer_type is None
+    assert response.items[0].service_type is None
+
+
+@pytest.mark.asyncio
+async def test_leads_inbox_returns_known_type_and_task_when_stored(db):
+    customer = Customer(
+        name="ООО Климат",
+        phone="+375293333333",
+        type=CustomerType.company,
+        inn="123456789",
+    )
+    db.add(customer)
+    await db.flush()
+    db.add(
+        Order(
+            customer_id=customer.id,
+            status=OrderStatus.NEW_LEAD,
+            lead_source=LeadSource.MANAGER,
+            delivery_address="Минск, объект 1",
+            technical_meta={
+                "service_type": "maintenance",
+                "object_type": "office",
+                "equipment_class": "standard",
+                "marketing_source": "referral",
+            },
+        )
+    )
+    await db.commit()
+
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+    item = response.items[0]
+
+    assert item.customer_type == "company"
+    assert item.service_type == "maintenance"
+    assert item.customer_delivery_address == "Минск, объект 1"
+    assert item.object_type == "office"
+    assert item.equipment_class == "standard"
+    assert item.marketing_source == "referral"
+
+
+@pytest.mark.asyncio
+async def test_leads_inbox_returns_confirmed_individual_customer_type(db):
+    customer = Customer(name="Иван", phone="+375294444444", type=CustomerType.individual)
+    db.add(customer)
+    await db.flush()
+    db.add(
+        Order(
+            customer_id=customer.id,
+            status=OrderStatus.NEW_LEAD,
+            lead_source=LeadSource.MANAGER,
+            technical_meta={
+                "lead_customer_type_known": True,
+                "lead_customer_type": "individual",
+            },
+        )
+    )
+    await db.commit()
+
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+
+    assert response.items[0].customer_type == "individual"
+
+
+@pytest.mark.asyncio
+async def test_linking_existing_individual_marks_lead_customer_type_known(db):
+    default_customer = Customer(name="Новый клиент", phone="", type=CustomerType.individual)
+    existing_customer = Customer(name="Постоянный клиент", phone="+375295555555", type=CustomerType.individual)
+    db.add(default_customer)
+    db.add(existing_customer)
+    await db.flush()
+    order = Order(
+        customer_id=default_customer.id,
+        status=OrderStatus.NEW_LEAD,
+        lead_source=LeadSource.MANAGER,
+        technical_meta={},
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    await OrderService.update_order_for_manager(
+        db,
+        int(order.id),
+        ManagerOrderUpdatePayload(customer_id=int(existing_customer.id)),
+    )
+
+    response = await OrderService.get_leads_inbox(db, scope="active", page=1, limit=10)
+
+    assert response.items[0].customer_id == existing_customer.id
+    assert response.items[0].customer_type == "individual"


### PR DESCRIPTION
## Summary

Simplifies Manager lead qualification for hot leads so managers only have to resolve the two blocking questions before moving into deal/proposal work:

- customer type: individual vs company
- task essence: purchase + install, install only, pre-install, maintenance, repair, dismantling

Before, the modal prefilled and submitted broad defaults like Vitebsk/apartment/turnkey and exposed many fields in the primary flow. Now optional contact, address, requisites, branch/object, and extra detail fields are collapsed and only submitted when they contain deliberate existing/user-provided values.

## API / contract

- `LeadsInboxItemResponse.customer_type` now supports `null` for unknown customer type instead of masking it as `individual`.
- Inbox response now includes preserved order qualification fields used by the modal: delivery address, object type, service type, equipment class, marketing source.
- Confirmed individual type is explicit via lead metadata; default-created individual customers remain unknown. Linking an existing individual customer marks the lead type as known.
- OpenAPI and the generated manager client were regenerated.

## UX behavior

- Leads with both known customer type and service/task essence can qualify with one primary action.
- Missing customer type or missing task essence is the only blocking UI.
- After success, Manager navigates to `/manager/orders/kanban?orderId=...` so the order drawer opens for proposal/КП work.
- Reject, no-answer, and email import behavior are unchanged.

## Validation

- `TEST_DB_HOST=127.0.0.1 TEST_DB_PORT=5433 pytest tests/unit/test_order_service_leads_inbox.py -q`
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_mail_services.py::test_email_lead_intake_marks_b2c_known_and_unknown_hint_unknown -q`
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api`
- `cd manager_frontend && npm run build`

Closes #408