### PR TITLE
[codex] Fix manager document PDF downloads

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -117,6 +117,50 @@ export type {
     ProductImageVariantResponse,
 };
 
+const parseContentDispositionFilename = (header: string | null): string | undefined => {
+    if (!header) return undefined;
+
+    const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8Match?.[1]) {
+        try {
+            return decodeURIComponent(utf8Match[1].trim());
+        } catch {
+            return utf8Match[1].trim();
+        }
+    }
+
+    const asciiMatch = header.match(/filename="?([^";]+)"?/i);
+    return asciiMatch?.[1]?.trim();
+};
+
+export const downloadManagerDocBlob = async (docId: number): Promise<{ blob: Blob; filename?: string }> => {
+    const url = `${OpenAPI.BASE}/api/manager/docs/${encodeURIComponent(String(docId))}/download`;
+    const response = await fetch(url, {
+        method: 'GET',
+        credentials: OpenAPI.WITH_CREDENTIALS ? OpenAPI.CREDENTIALS : 'same-origin',
+        headers: {
+            Accept: 'application/pdf',
+        },
+    });
+
+    if (!response.ok) {
+        let message = `Ошибка скачивания документа (${response.status})`;
+        try {
+            const payload = await response.json();
+            message = payload?.detail?.message || payload?.detail || payload?.message || message;
+        } catch {
+            const text = await response.text();
+            if (text) message = text;
+        }
+        throw new Error(message);
+    }
+
+    return {
+        blob: await response.blob(),
+        filename: parseContentDispositionFilename(response.headers.get('Content-Disposition')),
+    };
+};
+
 export interface ManagerProductFilterOptions {
     heatingMin?: number;
     hasWifi?: boolean;

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { ManagerContractsService, ManagerDocsService, ManagerOrdersService } from '../../client';
+import { downloadManagerDocBlob } from '../../api';
 import type {
   DocumentTemplateItem,
   ManagerCustomerContractItemResponse,
@@ -788,17 +789,17 @@ const handleAttachDocumentFile = async (doc: ManagerOrderDocumentItem, event: Ev
 const downloadDocument = async (doc: ManagerOrderDocumentItem) => {
   processingDocId.value = doc.id;
   try {
-    const response = await ManagerDocsService.getManagerDocDownload(doc.id);
-    const url = window.URL.createObjectURL(new Blob([response]));
+    const { blob, filename } = await downloadManagerDocBlob(doc.id);
+    const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.setAttribute('download', `${doc.number || doc.doc_type}.pdf`);
+    link.setAttribute('download', filename || `${doc.number || doc.doc_type}.pdf`);
     document.body.appendChild(link);
     link.click();
     link.remove();
     window.URL.revokeObjectURL(url);
   } catch (error) {
-    notify('Ошибка скачивания', 'error');
+    notify(`Ошибка скачивания: ${getApiErrorMessage(error)}`, 'error');
   } finally {
     processingDocId.value = null;
   }

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from io import BytesIO
 from datetime import datetime, timedelta
 from sqlmodel import select
 
@@ -1261,6 +1262,51 @@ async def test_manager_order_generate_document(async_client, db, monkeypatch):
     assert data["doc_type"] == "contract"
     assert data["edit_url"].startswith("https://docs.google.com")
     assert captured["contract_date"] == datetime(2026, 4, 20)
+
+
+@pytest.mark.asyncio
+async def test_manager_doc_download_returns_pdf_bytes(async_client, db, monkeypatch):
+    customer = Customer(name="Download", phone="+375297777777", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    document = OrderDocument(
+        order_id=order.id,
+        doc_type="contract",
+        number="Д-2026-001",
+        date=datetime(2026, 6, 4),
+        google_file_id="google-doc-id",
+        google_edit_url="https://docs.google.com/document/d/google-doc-id/edit",
+    )
+    db.add(document)
+    await db.commit()
+    await db.refresh(document)
+
+    pdf_bytes = b"%PDF-1.4\n%real pdf bytes\n%%EOF"
+
+    class _FakeGoogleService:
+        def export_file(self, file_id: str, mime_type: str = "application/pdf"):
+            assert file_id == "google-doc-id"
+            assert mime_type == "application/pdf"
+            return BytesIO(pdf_bytes)
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.get(f"/api/manager/docs/{document.id}/download", headers=headers)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")
+    assert response.content == pdf_bytes
+    assert "filename*=UTF-8''" in response.headers["content-disposition"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- Added a dedicated `downloadManagerDocBlob` helper that fetches manager documents as `Blob` instead of going through the generated OpenAPI client's text parser.
- Updated the order Documents panel download action to use the binary helper and preserve the server-provided filename.
- Added an integration test asserting the manager document download endpoint returns real PDF bytes and `application/pdf`.

## Root cause
The generated OpenAPI client treats non-JSON responses as `response.text()`. The manager UI then wrapped that string in a `Blob`, corrupting binary PDF bytes and producing empty/broken PDF downloads.

## Checks
- `npm run build` in `manager_frontend/`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py::test_manager_doc_download_returns_pdf_bytes -q`
