### PR TITLE
[codex] Add public AC service pages

### DIFF
--- a/web/src/pages/montaj-konditionerov.astro
+++ b/web/src/pages/montaj-konditionerov.astro
@@ -114,6 +114,33 @@ const { minStandardPrice, minBundlePrice } = await getInstallationPricingInfo();
                 </section>
 
                 <section class="mb-12">
+                    <h3>Если ремонт идет сейчас</h3>
+                    <p>
+                        Монтаж можно разделить на два этапа: сначала заложить
+                        коммуникации в штробу на черновом этапе, а после
+                        чистовой отделки довесить блоки и запустить систему.
+                        Если старый кондиционер мешает ремонту или замене,
+                        его лучше аккуратно снять заранее.
+                    </p>
+                    <div class="planning-links">
+                        <a href="/services/zakladka-kommunikaciy-kondicionera" class="planning-link">
+                            <span class="material-icons-round" aria-hidden="true">route</span>
+                            <span>
+                                <strong>Закладка коммуникаций</strong>
+                                <small>Трасса, дренаж, кабель и выводы под будущий монтаж.</small>
+                            </span>
+                        </a>
+                        <a href="/services/demontazh-kondicionera" class="planning-link">
+                            <span class="material-icons-round" aria-hidden="true">construction</span>
+                            <span>
+                                <strong>Демонтаж кондиционера</strong>
+                                <small>Снимем блоки и по возможности сохраним оборудование.</small>
+                            </span>
+                        </a>
+                    </div>
+                </section>
+
+                <section class="mb-12">
                     <h3>Термины и условия установки</h3>
                     <div class="terms-grid">
                         <div class="term-item">
@@ -295,6 +322,55 @@ const { minStandardPrice, minBundlePrice } = await getInstallationPricingInfo();
         font-weight: bold;
     }
 
+    .planning-links {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1rem;
+        margin-top: 1.5rem;
+    }
+    .planning-link {
+        align-items: flex-start;
+        background: var(--panel-glass-bg);
+        border: 1px solid var(--panel-glass-border);
+        border-radius: 8px;
+        box-shadow: var(--panel-glass-shadow);
+        color: var(--text);
+        display: flex;
+        gap: 1rem;
+        padding: 1.25rem;
+        text-decoration: none;
+        transition: border-color 0.2s, transform 0.2s;
+    }
+    .planning-link:hover {
+        border-color: var(--primary);
+        transform: translateY(-2px);
+    }
+    .planning-link > .material-icons-round {
+        align-items: center;
+        background: var(--panel-active-gradient);
+        border-radius: 8px;
+        color: var(--panel-active-text);
+        display: flex;
+        flex-shrink: 0;
+        height: 44px;
+        justify-content: center;
+        width: 44px;
+    }
+    .planning-link strong,
+    .planning-link small {
+        display: block;
+    }
+    .planning-link strong {
+        color: var(--primary);
+        font-size: 1rem;
+        line-height: 1.3;
+        margin-bottom: 0.35rem;
+    }
+    .planning-link small {
+        color: var(--text-muted);
+        line-height: 1.45;
+    }
+
     .terms-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -341,7 +417,14 @@ const { minStandardPrice, minBundlePrice } = await getInstallationPricingInfo();
     }
 
     @media (max-width: 900px) {
+        h1 {
+            font-size: 2.4rem;
+            line-height: 1.15;
+        }
         .detail-grid {
+            grid-template-columns: 1fr;
+        }
+        .planning-links {
             grid-template-columns: 1fr;
         }
         .sidebar {

--- a/web/src/pages/services/demontazh-kondicionera.astro
+++ b/web/src/pages/services/demontazh-kondicionera.astro
@@ -1,0 +1,238 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import ContactForm from "../../components/ContactForm.vue";
+---
+
+<Layout
+    title="Демонтаж кондиционера в Витебске"
+    description="Аккуратный демонтаж кондиционера: снимем внутренний и наружный блок, по возможности сохраним оборудование, трассу и фреон для переноса или ремонта."
+>
+    <section class="page-header">
+        <div class="container">
+            <h1 class="gradient-text">Демонтаж кондиционера</h1>
+            <p class="breadcrumbs">Главная / Услуги / Демонтаж кондиционера</p>
+        </div>
+    </section>
+
+    <section class="container detail-grid">
+        <div class="content">
+            <section class="service-intro">
+                <p class="eyebrow">Аккуратное снятие блоков</p>
+                <h2>Снимем кондиционер без лишнего риска для оборудования</h2>
+                <p>
+                    Демонтаж нужен при переезде, ремонте, замене кондиционера
+                    или подготовке техники к диагностике. Мы снимаем внутренний
+                    и наружный блок, оцениваем состояние трассы и по возможности
+                    сохраняем оборудование для дальнейшего переноса, ремонта или
+                    повторной установки.
+                </p>
+            </section>
+
+            <section class="info-grid" aria-label="Что входит в демонтаж">
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">hvac</span>
+                    <h3>Снимаем оба блока</h3>
+                    <p>
+                        Отсоединяем внутренний блок, наружный блок, крепеж и
+                        доступные элементы трассы без спешки и грубого среза.
+                    </p>
+                </div>
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">sync_alt</span>
+                    <h3>Сохраняем для переноса</h3>
+                    <p>
+                        Если состояние позволяет, бережно сохраняем соединения,
+                        трубки и оборудование под будущий монтаж на новом месте.
+                    </p>
+                </div>
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">verified_user</span>
+                    <h3>Работаем по ситуации</h3>
+                    <p>
+                        Учитываем доступ к наружному блоку, высоту, старые
+                        крепления и необходимость сохранить фреон или трассу.
+                    </p>
+                </div>
+            </section>
+
+            <section class="article-content">
+                <h3>От чего зависит цена демонтажа</h3>
+                <p>
+                    Стоимость рассчитывается после уточнения условий. На цену
+                    влияет доступ к наружному блоку, высота работ, состояние
+                    трассы, способ крепления, необходимость сохранить фреон,
+                    аккуратно разобрать коммуникации или подготовить комплект к
+                    перевозке.
+                </p>
+
+                <h3>Когда лучше вызвать мастера</h3>
+                <ul class="bullet-list">
+                    <li>перед ремонтом, чтобы снять блоки и не повредить их;</li>
+                    <li>при переезде, когда кондиционер нужно перенести;</li>
+                    <li>при замене старой сплит-системы на новую;</li>
+                    <li>если наружный блок установлен в сложном доступе.</li>
+                </ul>
+
+                <div class="note-box">
+                    <span class="material-icons-round" aria-hidden="true">info</span>
+                    <p>
+                        Если планируется новая установка после ремонта, можно
+                        сразу обсудить <a href="/services/zakladka-kommunikaciy-kondicionera">закладку коммуникаций</a>
+                        под будущий кондиционер.
+                    </p>
+                </div>
+            </section>
+        </div>
+
+        <div class="sidebar">
+            <ContactForm
+                client:visible
+                title="Заказать демонтаж"
+                subtitle="Уточним доступ к блоку и формат работ"
+                buttonText="Оставить заявку"
+                subject="Заказ демонтажа кондиционера"
+            />
+        </div>
+    </section>
+</Layout>
+
+<style>
+    .page-header {
+        background: var(--bg);
+        padding: 3rem 0 0;
+        margin-bottom: 2rem;
+    }
+    h1 {
+        font-size: 3rem;
+        font-weight: 800;
+    }
+    .breadcrumbs {
+        color: var(--text-muted);
+    }
+
+    .detail-grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 4rem;
+        margin-bottom: 6rem;
+    }
+
+    .service-intro {
+        margin-bottom: 2rem;
+    }
+    .eyebrow {
+        color: var(--primary);
+        font-size: 0.8rem;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        margin-bottom: 0.75rem;
+        text-transform: uppercase;
+    }
+    .service-intro h2 {
+        font-size: 2rem;
+        font-weight: 800;
+        line-height: 1.2;
+        margin-bottom: 1rem;
+    }
+    .service-intro p,
+    .article-content p {
+        color: var(--text-muted);
+        line-height: 1.7;
+    }
+
+    .info-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+        margin-bottom: 2.5rem;
+    }
+    .info-card,
+    .note-box {
+        border: 1px solid var(--panel-glass-border);
+        border-radius: 8px;
+        background: var(--panel-glass-bg);
+        box-shadow: var(--panel-glass-shadow);
+    }
+    .info-card {
+        padding: 1.25rem;
+    }
+    .info-card .material-icons-round {
+        color: var(--primary);
+        font-size: 2rem;
+        margin-bottom: 0.75rem;
+    }
+    .info-card h3 {
+        font-size: 1.1rem;
+        font-weight: 800;
+        margin: 0 0 0.5rem;
+    }
+    .info-card p {
+        color: var(--text-muted);
+        font-size: 0.95rem;
+        line-height: 1.55;
+        margin: 0;
+    }
+
+    .article-content h3 {
+        font-size: 1.5rem;
+        font-weight: 800;
+        margin: 2rem 0 1rem;
+    }
+    .bullet-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        list-style: none;
+        margin: 1rem 0 2rem;
+        padding: 0;
+    }
+    .bullet-list li {
+        color: var(--text-muted);
+        padding-left: 1.5rem;
+        position: relative;
+    }
+    .bullet-list li::before {
+        color: var(--primary);
+        content: "check";
+        font-family: "Material Icons Round";
+        font-size: 1rem;
+        left: 0;
+        position: absolute;
+        top: 0.05rem;
+    }
+
+    .note-box {
+        align-items: flex-start;
+        display: flex;
+        gap: 1rem;
+        padding: 1.25rem;
+    }
+    .note-box .material-icons-round {
+        color: var(--primary);
+        flex-shrink: 0;
+    }
+    .note-box p {
+        margin: 0;
+    }
+    .note-box a {
+        color: var(--primary);
+        font-weight: 800;
+        text-decoration: none;
+    }
+    .note-box a:hover {
+        text-decoration: underline;
+    }
+
+    @media (max-width: 900px) {
+        .detail-grid,
+        .info-grid {
+            grid-template-columns: 1fr;
+        }
+        .detail-grid {
+            gap: 2rem;
+        }
+        .sidebar {
+            order: 2;
+        }
+    }
+</style>

--- a/web/src/pages/services/index.astro
+++ b/web/src/pages/services/index.astro
@@ -23,6 +23,20 @@ const services = [
         icon: "engineering",
         image: "/img/services/repair.png",
     },
+    {
+        title: "Демонтаж кондиционера",
+        desc: "Аккуратно снимем внутренний и наружный блок, сохраним оборудование и трассу, когда это возможно.",
+        link: "/services/demontazh-kondicionera",
+        icon: "construction",
+        image: "/img/services/man_repair.png",
+    },
+    {
+        title: "Закладка коммуникаций",
+        desc: "Подготовим трассу, дренаж, кабель и выводы под будущий монтаж кондиционера на этапе ремонта.",
+        link: "/services/zakladka-kommunikaciy-kondicionera",
+        icon: "cable",
+        image: "/img/services/installation.png",
+    },
 ];
 ---
 
@@ -86,7 +100,7 @@ const services = [
 
     .services-grid {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
         gap: 2rem;
     }
 

--- a/web/src/pages/services/zakladka-kommunikaciy-kondicionera.astro
+++ b/web/src/pages/services/zakladka-kommunikaciy-kondicionera.astro
@@ -1,0 +1,272 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import ContactForm from "../../components/ContactForm.vue";
+---
+
+<Layout
+    title="Закладка коммуникаций под кондиционер в Витебске"
+    description="Закладка трассы, дренажа, кабеля и выводов под будущий монтаж кондиционера на этапе ремонта. До 3 м — 500 BYN, дальше +50 BYN/м."
+>
+    <section class="page-header">
+        <div class="container">
+            <h1 class="gradient-text">Закладка коммуникаций под кондиционер</h1>
+            <p class="breadcrumbs">Главная / Услуги / Закладка коммуникаций</p>
+        </div>
+    </section>
+
+    <section class="container detail-grid">
+        <div class="content">
+            <section class="service-intro">
+                <p class="eyebrow">Монтаж в два этапа</p>
+                <h2>Подготовим трассу на черновом этапе ремонта</h2>
+                <p>
+                    Если ремонт уже идет, кондиционер еще не обязательно должен
+                    быть куплен. Мы заранее закладываем межблочную трассу,
+                    дренаж, кабель и выводы под будущий монтаж, чтобы после
+                    чистовой отделки не штробить стены заново и не портить
+                    интерьер.
+                </p>
+            </section>
+
+            <section class="price-panel" aria-labelledby="preinstall-price-title">
+                <div>
+                    <p class="eyebrow">Базовая цена</p>
+                    <h3 id="preinstall-price-title">до 3 м — 500 <span class="price-byn"></span></h3>
+                    <p>
+                        Для небольших настенных кондиционеров. Каждый следующий
+                        метр трассы — +50 <span class="price-byn"></span>. Штробление
+                        считается отдельно.
+                    </p>
+                </div>
+                <span class="material-icons-round" aria-hidden="true">payments</span>
+            </section>
+
+            <section class="info-grid" aria-label="Что закладываем">
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">route</span>
+                    <h3>Межблочная трасса</h3>
+                    <p>
+                        Медные трубки и теплоизоляция под соединение внутреннего
+                        и наружного блока.
+                    </p>
+                </div>
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">water_drop</span>
+                    <h3>Дренаж</h3>
+                    <p>
+                        Вывод конденсата с учетом уклона и будущего расположения
+                        внутреннего блока.
+                    </p>
+                </div>
+                <div class="info-card">
+                    <span class="material-icons-round" aria-hidden="true">electrical_services</span>
+                    <h3>Кабель и выводы</h3>
+                    <p>
+                        Подготовка коммуникаций, чтобы финальная установка была
+                        быстрой и аккуратной.
+                    </p>
+                </div>
+            </section>
+
+            <section class="article-content">
+                <h3>Важный бонус при покупке кондиционера у нас</h3>
+                <p>
+                    Если после закладки коммуникаций вы покупаете кондиционер у
+                    «Мастера Воздуха», финальное довешивание и установка блока
+                    выполняются бесплатно. Вы оплачиваете подготовительный этап
+                    заранее, а чистовой монтаж проходит без лишних работ по
+                    отделке.
+                </p>
+
+                <h3>Если модель еще не выбрана</h3>
+                <p>
+                    Мы можем выполнить трассу под типовые параметры небольших
+                    настенных кондиционеров. Но для точного дизайна, правильных
+                    выводов и аккуратного расположения блоков лучше выбрать
+                    модель до закладки коммуникаций или хотя бы согласовать
+                    предполагаемую мощность.
+                </p>
+
+                <div class="note-box">
+                    <span class="material-icons-round" aria-hidden="true">construction</span>
+                    <p>
+                        Нужен полный монтаж после ремонта? Посмотрите условия
+                        <a href="/montaj-konditionerov">установки кондиционера</a>
+                        или оставьте заявку — подскажем оптимальную схему в два
+                        этапа.
+                    </p>
+                </div>
+            </section>
+        </div>
+
+        <div class="sidebar">
+            <ContactForm
+                client:visible
+                title="Заказать закладку"
+                subtitle="Согласуем трассу, длину и черновые работы"
+                buttonText="Оставить заявку"
+                subject="Заказ закладки коммуникаций под кондиционер"
+            />
+        </div>
+    </section>
+</Layout>
+
+<style>
+    .page-header {
+        background: var(--bg);
+        padding: 3rem 0 0;
+        margin-bottom: 2rem;
+    }
+    h1 {
+        font-size: 3rem;
+        font-weight: 800;
+        line-height: 1.15;
+    }
+    .breadcrumbs {
+        color: var(--text-muted);
+    }
+
+    .detail-grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 4rem;
+        margin-bottom: 6rem;
+    }
+
+    .service-intro {
+        margin-bottom: 2rem;
+    }
+    .eyebrow {
+        color: var(--primary);
+        font-size: 0.8rem;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        margin-bottom: 0.75rem;
+        text-transform: uppercase;
+    }
+    .service-intro h2 {
+        font-size: 2rem;
+        font-weight: 800;
+        line-height: 1.2;
+        margin-bottom: 1rem;
+    }
+    .service-intro p,
+    .article-content p {
+        color: var(--text-muted);
+        line-height: 1.7;
+    }
+
+    .price-panel {
+        align-items: center;
+        background: var(--panel-glass-bg);
+        border: 1px solid var(--panel-glass-border);
+        border-radius: 8px;
+        box-shadow: var(--panel-glass-shadow);
+        display: flex;
+        gap: 1.5rem;
+        justify-content: space-between;
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+    }
+    .price-panel h3 {
+        color: var(--primary);
+        font-size: 2rem;
+        font-weight: 800;
+        margin: 0 0 0.5rem;
+    }
+    .price-panel p:last-child {
+        color: var(--text-muted);
+        line-height: 1.6;
+        margin: 0;
+    }
+    .price-panel > .material-icons-round {
+        align-items: center;
+        background: var(--panel-active-gradient);
+        border-radius: 8px;
+        color: var(--panel-active-text);
+        display: flex;
+        flex-shrink: 0;
+        font-size: 2rem;
+        height: 56px;
+        justify-content: center;
+        width: 56px;
+    }
+
+    .info-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+        margin-bottom: 2.5rem;
+    }
+    .info-card,
+    .note-box {
+        border: 1px solid var(--panel-glass-border);
+        border-radius: 8px;
+        background: var(--panel-glass-bg);
+        box-shadow: var(--panel-glass-shadow);
+    }
+    .info-card {
+        padding: 1.25rem;
+    }
+    .info-card .material-icons-round {
+        color: var(--primary);
+        font-size: 2rem;
+        margin-bottom: 0.75rem;
+    }
+    .info-card h3 {
+        font-size: 1.1rem;
+        font-weight: 800;
+        margin: 0 0 0.5rem;
+    }
+    .info-card p {
+        color: var(--text-muted);
+        font-size: 0.95rem;
+        line-height: 1.55;
+        margin: 0;
+    }
+
+    .article-content h3 {
+        font-size: 1.5rem;
+        font-weight: 800;
+        margin: 2rem 0 1rem;
+    }
+    .note-box {
+        align-items: flex-start;
+        display: flex;
+        gap: 1rem;
+        margin-top: 2rem;
+        padding: 1.25rem;
+    }
+    .note-box .material-icons-round {
+        color: var(--primary);
+        flex-shrink: 0;
+    }
+    .note-box p {
+        margin: 0;
+    }
+    .note-box a {
+        color: var(--primary);
+        font-weight: 800;
+        text-decoration: none;
+    }
+    .note-box a:hover {
+        text-decoration: underline;
+    }
+
+    @media (max-width: 900px) {
+        .detail-grid,
+        .info-grid {
+            grid-template-columns: 1fr;
+        }
+        .detail-grid {
+            gap: 2rem;
+        }
+        .price-panel {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+        .sidebar {
+            order: 2;
+        }
+    }
+</style>


### PR DESCRIPTION
## Summary
- Added public storefront service pages for `Демонтаж кондиционера` and `Закладка коммуникаций под кондиционер`.
- Added both services to `/services` and linked them from the installation page as repair/preinstall-stage options.
- Used existing Astro storefront patterns, `ContactForm`, and theme tokens for new panel/card surfaces.

## Checks
- `cd web && npm run audit:theme` (prints pre-existing hardcode candidates in `InstallationCalculator.vue`, `ToastContainer.vue`, and `BentoCard.vue`; no new/touched-file violations added)
- `cd web && npm run build`
- `git diff --check`
- Browser smoke: `/services`, `/services/demontazh-kondicionera`, `/services/zakladka-kommunikaciy-kondicionera`, `/montaj-konditionerov` on desktop and 390px mobile; expected content/links present, no horizontal overflow after the mobile heading adjustment.

## Assumptions
- Reused existing service imagery instead of adding new assets.
- Left `/index.astro` untouched to avoid colliding with parallel work on #414.

Addresses #416