### PR TITLE
[codex] Add pre-install service tariffs

### DIFF
--- a/alembic/versions/8c4d2b6f1a90_seed_pre_install_tariff.py
+++ b/alembic/versions/8c4d2b6f1a90_seed_pre_install_tariff.py
@@ -1,0 +1,157 @@
+"""seed pre-install communication route tariff
+
+Revision ID: 8c4d2b6f1a90
+Revises: 2d6c4b8e9f31
+Create Date: 2026-06-04 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "8c4d2b6f1a90"
+down_revision: Union[str, Sequence[str], None] = "2d6c4b8e9f31"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PRE_INSTALL_TARIFF = {
+    "service_kind": "pre_install",
+    "selector_label": "Закладка коммуникаций под кондиционер до 3 м",
+    "estimate_template": "Закладка межблочной трассы под кондиционер, включая материалы до 3 м",
+    "category": "Wall",
+    "power_range": "07-12",
+    "base_price": 500,
+    "included_route_meters": 3.0,
+    "sort_order": 100,
+    "comment": (
+        "Дополнительная трасса сверх 3 м — 50 BYN/м. Штробление оплачивается отдельно. "
+        "При последующей покупке кондиционера у нас финальное довешивание выполняется без доплаты."
+    ),
+}
+
+PRE_INSTALL_ROUTE_RULE = {
+    "rule_type": "per_meter_over_included",
+    "name": "Дополнительная трасса сверх 3 м",
+    "line_template": "дополнительная трасса {qty} м",
+    "unit": "м",
+    "unit_price": 50.0,
+    "sort_order": 10,
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    tariff_id = bind.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM service_tariff
+            WHERE service_kind = :service_kind
+              AND selector_label = :selector_label
+            LIMIT 1
+            """
+        ),
+        {
+            "service_kind": PRE_INSTALL_TARIFF["service_kind"],
+            "selector_label": PRE_INSTALL_TARIFF["selector_label"],
+        },
+    ).scalar_one_or_none()
+
+    if tariff_id is None:
+        tariff_id = bind.execute(
+            sa.text(
+                """
+                INSERT INTO service_tariff (
+                    service_kind, selector_label, estimate_template, category, power_range,
+                    base_price, included_route_meters, is_active, sort_order, comment
+                ) VALUES (
+                    :service_kind, :selector_label, :estimate_template, :category, :power_range,
+                    :base_price, :included_route_meters, true, :sort_order, :comment
+                )
+                RETURNING id
+                """
+            ),
+            PRE_INSTALL_TARIFF,
+        ).scalar_one()
+
+    existing_rule_id = bind.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM service_tariff_rule
+            WHERE tariff_id = :tariff_id
+              AND rule_type = :rule_type
+              AND name = :name
+            LIMIT 1
+            """
+        ),
+        {
+            "tariff_id": int(tariff_id),
+            "rule_type": PRE_INSTALL_ROUTE_RULE["rule_type"],
+            "name": PRE_INSTALL_ROUTE_RULE["name"],
+        },
+    ).scalar_one_or_none()
+
+    if existing_rule_id is not None:
+        return
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO service_tariff_rule (
+                tariff_id, rule_type, name, line_template, unit, unit_price,
+                is_optional, is_favorite, is_active, sort_order, service_id
+            ) VALUES (
+                :tariff_id, :rule_type, :name, :line_template, :unit, :unit_price,
+                false, false, true, :sort_order, NULL
+            )
+            """
+        ),
+        {"tariff_id": int(tariff_id), **PRE_INSTALL_ROUTE_RULE},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    tariff_id = bind.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM service_tariff
+            WHERE service_kind = :service_kind
+              AND selector_label = :selector_label
+              AND estimate_template = :estimate_template
+              AND category = :category
+              AND power_range = :power_range
+              AND base_price = :base_price
+              AND included_route_meters = :included_route_meters
+              AND comment = :comment
+            LIMIT 1
+            """
+        ),
+        PRE_INSTALL_TARIFF,
+    ).scalar_one_or_none()
+    if tariff_id is None:
+        return
+
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM service_tariff_rule
+            WHERE tariff_id = :tariff_id
+              AND rule_type = :rule_type
+              AND name = :name
+              AND line_template = :line_template
+              AND unit = :unit
+              AND unit_price = :unit_price
+            """
+        ),
+        {"tariff_id": int(tariff_id), **PRE_INSTALL_ROUTE_RULE},
+    )
+    bind.execute(
+        sa.text("DELETE FROM service_tariff WHERE id = :tariff_id"),
+        {"tariff_id": int(tariff_id)},
+    )

--- a/manager_frontend/src/client/models/ManagerTariffServiceKind.ts
+++ b/manager_frontend/src/client/models/ManagerTariffServiceKind.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ManagerTariffServiceKind = 'installation' | 'dismantling' | 'maintenance' | 'repair';
+export type ManagerTariffServiceKind = 'installation' | 'pre_install' | 'dismantling' | 'maintenance' | 'repair';

--- a/manager_frontend/src/components/TariffEditModal.vue
+++ b/manager_frontend/src/components/TariffEditModal.vue
@@ -25,6 +25,7 @@ const error = ref('');
 
 const DEFAULT_TEMPLATES: Record<ManagerTariffServiceKind, string> = {
   installation: 'Монтаж сплит-системы, включая расходные материалы',
+  pre_install: 'Закладка межблочной трассы под кондиционер, включая материалы',
   dismantling: 'Демонтаж кондиционера',
   maintenance: 'Техническое обслуживание кондиционера',
   repair: 'Ремонт кондиционера',
@@ -32,23 +33,27 @@ const DEFAULT_TEMPLATES: Record<ManagerTariffServiceKind, string> = {
 
 const serviceKindOptions: Array<{ value: ManagerTariffServiceKind; label: string }> = [
   { value: 'installation', label: 'Монтаж' },
+  { value: 'pre_install', label: 'Закладка коммуникаций' },
   { value: 'dismantling', label: 'Демонтаж' },
   { value: 'maintenance', label: 'Обслуживание' },
   { value: 'repair', label: 'Ремонт' },
 ];
 
-const isInstallation = computed(() => formData.value.service_kind === 'installation');
+const ROUTE_AWARE_SERVICE_KINDS = new Set<ManagerTariffServiceKind>(['installation', 'pre_install']);
+const isRouteAwareServiceKind = computed(() => ROUTE_AWARE_SERVICE_KINDS.has(formData.value.service_kind as ManagerTariffServiceKind));
 
 const categoryPlaceholder = computed(() => {
   if (formData.value.service_kind === 'repair') return 'diagnostics / compressor / leak';
   if (formData.value.service_kind === 'maintenance') return 'split / cassette / duct';
   if (formData.value.service_kind === 'dismantling') return 'Wall / Cassette / Duct';
+  if (formData.value.service_kind === 'pre_install') return 'Wall';
   return 'Wall / Cassette / Duct';
 });
 
 const powerPlaceholder = computed(() => {
   if (formData.value.service_kind === 'repair') return 'бытовой / полупром / до 7 кВт';
   if (formData.value.service_kind === 'maintenance') return 'до 3.5 кВт / до 7 кВт';
+  if (formData.value.service_kind === 'pre_install') return '07-12 / до 3.5 кВт';
   return '07-12 / до 3.5 кВт';
 });
 
@@ -88,7 +93,7 @@ const resetForm = () => {
       category: '',
       power_range: '',
       base_price: 0,
-      included_route_meters: serviceKind === 'installation' ? 3 : 0,
+      included_route_meters: ROUTE_AWARE_SERVICE_KINDS.has(serviceKind) ? 3 : 0,
       is_active: true,
       sort_order: 0,
       comment: null,
@@ -103,7 +108,7 @@ const handleServiceKindChange = () => {
   if (!currentTemplate || Object.values(DEFAULT_TEMPLATES).includes(currentTemplate)) {
     formData.value.estimate_template = DEFAULT_TEMPLATES[serviceKind];
   }
-  if (serviceKind !== 'installation') {
+  if (!ROUTE_AWARE_SERVICE_KINDS.has(serviceKind)) {
     formData.value.included_route_meters = 0;
   } else if (!formData.value.included_route_meters) {
     formData.value.included_route_meters = 3;
@@ -135,7 +140,7 @@ const submit = async () => {
   loading.value = true;
   error.value = '';
   try {
-    const normalizedIncludedRoute = formData.value.service_kind === 'installation'
+    const normalizedIncludedRoute = ROUTE_AWARE_SERVICE_KINDS.has(formData.value.service_kind as ManagerTariffServiceKind)
       ? formData.value.included_route_meters
       : 0;
     if (props.tariff?.id) {
@@ -278,7 +283,7 @@ const submit = async () => {
                   :disabled="loading"
                 />
               </label>
-              <label v-if="isInstallation" class="block">
+              <label v-if="isRouteAwareServiceKind" class="block">
                 <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Включено трассы, м</span>
                 <input
                   v-model.number="formData.included_route_meters"

--- a/manager_frontend/src/components/TariffRuleEditModal.vue
+++ b/manager_frontend/src/components/TariffRuleEditModal.vue
@@ -109,10 +109,11 @@ const placeholderHints: PlaceholderHint[] = [
 ];
 
 const serviceKind = computed(() => props.tariff?.service_kind ?? 'installation');
-const isInstallation = computed(() => serviceKind.value === 'installation');
-const defaultRuleType = computed<ManagerTariffRuleType>(() => (isInstallation.value ? 'per_unit_manual' : 'fixed_once'));
+const ROUTE_AWARE_SERVICE_KINDS = new Set(['installation', 'pre_install']);
+const isRouteAwareServiceKind = computed(() => ROUTE_AWARE_SERVICE_KINDS.has(String(serviceKind.value)));
+const defaultRuleType = computed<ManagerTariffRuleType>(() => (isRouteAwareServiceKind.value ? 'per_unit_manual' : 'fixed_once'));
 const availableRuleTypeOptions = computed(() => {
-  const allowed = isInstallation.value
+  const allowed = isRouteAwareServiceKind.value
     ? ruleTypeOptions
     : ruleTypeOptions.filter((option) => option.value === 'fixed_once' || option.value === 'per_unit_manual');
   if (!allowed.some((option) => option.value === formData.value.rule_type)) {
@@ -124,7 +125,7 @@ const availableRuleTypeOptions = computed(() => {
   return allowed;
 });
 const displayedPlaceholderHints = computed(() =>
-  isInstallation.value
+  isRouteAwareServiceKind.value
     ? placeholderHints
     : placeholderHints.filter(
         (item) => !['{route_length_m}', '{included_route_meters}', '{extra_route_meters}', '{extra_holes_count}'].includes(item.token)

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -329,6 +329,7 @@ const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
 
 const serviceKindLabels: Record<string, string> = {
   installation: 'монтаж',
+  pre_install: 'закладка трассы',
   dismantling: 'демонтаж',
   maintenance: 'обслуживание',
   repair: 'ремонт',

--- a/manager_frontend/src/views/ServiceEstimatesView.vue
+++ b/manager_frontend/src/views/ServiceEstimatesView.vue
@@ -53,6 +53,7 @@ const selectedRules = computed(() => selectedTariff.value?.rules || []);
 const totalPages = computed(() => Math.max(1, Math.ceil(listTotal.value / listLimit.value)));
 const serviceKindOptions: Array<{ value: ManagerTariffServiceKind; label: string }> = [
   { value: 'installation', label: 'Монтаж' },
+  { value: 'pre_install', label: 'Закладка коммуникаций' },
   { value: 'dismantling', label: 'Демонтаж' },
   { value: 'maintenance', label: 'Обслуживание' },
   { value: 'repair', label: 'Ремонт' },

--- a/manager_frontend/src/views/TariffsView.vue
+++ b/manager_frontend/src/views/TariffsView.vue
@@ -31,6 +31,7 @@ const selectedTariff = computed(
 
 const serviceKindOptions: Array<{ value: ManagerTariffServiceKind; label: string }> = [
   { value: 'installation', label: 'Монтаж' },
+  { value: 'pre_install', label: 'Закладка коммуникаций' },
   { value: 'dismantling', label: 'Демонтаж' },
   { value: 'maintenance', label: 'Обслуживание' },
   { value: 'repair', label: 'Ремонт' },
@@ -39,7 +40,8 @@ const serviceKindOptions: Array<{ value: ManagerTariffServiceKind; label: string
 const serviceKindLabel = (kind: ManagerTariffServiceKind | string) =>
   serviceKindOptions.find((item) => item.value === kind)?.label ?? String(kind || 'Услуга');
 
-const shouldShowRouteColumn = computed(() => kindFilter.value === 'installation');
+const ROUTE_AWARE_SERVICE_KINDS = new Set<ManagerTariffServiceKind>(['installation', 'pre_install']);
+const shouldShowRouteColumn = computed(() => ROUTE_AWARE_SERVICE_KINDS.has(kindFilter.value));
 
 const setToast = (message: string) => {
   toast.value = message;

--- a/openapi.json
+++ b/openapi.json
@@ -21473,6 +21473,7 @@
         "type": "string",
         "enum": [
           "installation",
+          "pre_install",
           "dismantling",
           "maintenance",
           "repair"

--- a/schemas.py
+++ b/schemas.py
@@ -2082,6 +2082,7 @@ class ManagerSettingListResponse(BaseModel):
 
 class ManagerTariffServiceKind(str, Enum):
     installation = "installation"
+    pre_install = "pre_install"
     dismantling = "dismantling"
     maintenance = "maintenance"
     repair = "repair"

--- a/services/tariffs_service.py
+++ b/services/tariffs_service.py
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 
 class TariffsService:
+    ROUTE_AWARE_SERVICE_KINDS = {
+        ManagerTariffServiceKind.installation.value,
+        ManagerTariffServiceKind.pre_install.value,
+    }
+
     BTU_TO_KW_MAP = {
         7: 2.1,
         9: 2.6,
@@ -41,6 +46,11 @@ class TariffsService:
         if abs(number - round(number)) < 1e-9:
             return str(int(round(number)))
         return f"{number:.2f}".rstrip("0").rstrip(".").replace(".", ",")
+
+    @staticmethod
+    def supports_route_meters(service_kind: ManagerTariffServiceKind | str | None) -> bool:
+        kind_value = service_kind.value if hasattr(service_kind, "value") else str(service_kind or "")
+        return kind_value in TariffsService.ROUTE_AWARE_SERVICE_KINDS
 
     @staticmethod
     def _extract_power_label(power_range: str) -> Optional[str]:
@@ -81,7 +91,7 @@ class TariffsService:
             title = f"{title}, мощностью {power_label}"
 
         included_route = float(tariff.included_route_meters or 0)
-        if tariff.service_kind == ManagerTariffServiceKind.installation.value and included_route > 0 and "трасс" not in title.lower():
+        if TariffsService.supports_route_meters(tariff.service_kind) and included_route > 0 and "трасс" not in title.lower():
             title = f"{title}, включая трассу длиной до {TariffsService._format_number(included_route)} м"
         return title
 
@@ -196,7 +206,7 @@ class TariffsService:
     async def create_tariff(session: AsyncSession, payload: ManagerTariffCreatePayload) -> ServiceTariff:
         included_route_meters = (
             float(payload.included_route_meters or 0)
-            if payload.service_kind == ManagerTariffServiceKind.installation
+            if TariffsService.supports_route_meters(payload.service_kind)
             else 0.0
         )
         tariff = ServiceTariff(
@@ -235,7 +245,7 @@ class TariffsService:
                 setattr(tariff, key, (value or "").strip() or (None if key == "comment" else ""))
                 continue
             setattr(tariff, key, value)
-        if next_service_kind_value != ManagerTariffServiceKind.installation.value:
+        if not TariffsService.supports_route_meters(next_service_kind_value):
             tariff.included_route_meters = 0.0
 
         session.add(tariff)

--- a/services/yandex_business_price_list_service.py
+++ b/services/yandex_business_price_list_service.py
@@ -26,9 +26,11 @@ class YandexBusinessPriceListService:
         "dismantling": YandexCategory(id=202, title="Демонтаж"),
         "maintenance": YandexCategory(id=203, title="Обслуживание"),
         "repair": YandexCategory(id=204, title="Ремонт"),
+        "pre_install": YandexCategory(id=205, title="Закладка коммуникаций"),
     }
     SERVICE_KIND_URLS = {
         "installation": "/montaj-konditionerov",
+        "pre_install": "/services/zakladka-kommunikaciy-kondicionera",
         "maintenance": "/obslujivanie-kondicionerov",
         "repair": "/services/repair",
         "dismantling": "/services",
@@ -104,7 +106,7 @@ class YandexBusinessPriceListService:
             parts.append(f"Диапазон мощности: {tariff.power_range}.")
         if tariff.category:
             parts.append(f"Категория: {tariff.category}.")
-        if tariff.service_kind == "installation" and float(tariff.included_route_meters or 0) > 0:
+        if TariffsService.supports_route_meters(tariff.service_kind) and float(tariff.included_route_meters or 0) > 0:
             meters = TariffsService._format_number(tariff.included_route_meters)
             parts.append(f"В базовую стоимость включено до {meters} м трассы.")
         return " ".join(part.strip() for part in parts if part and part.strip())

--- a/tests/integration/test_manager_tariffs_api.py
+++ b/tests/integration/test_manager_tariffs_api.py
@@ -227,6 +227,57 @@ async def test_manager_tariffs_accept_repair_direction(async_client):
 
 
 @pytest.mark.asyncio
+async def test_manager_tariffs_accept_pre_install_direction_with_route(async_client):
+    headers = await _auth_headers(async_client)
+
+    create_resp = await async_client.post(
+        "/api/manager/tariffs",
+        headers=headers,
+        json={
+            "service_kind": "pre_install",
+            "selector_label": "Закладка коммуникаций под кондиционер",
+            "estimate_template": "Закладка межблочной трассы под кондиционер, включая материалы",
+            "category": "Wall",
+            "power_range": "07-12",
+            "base_price": 500,
+            "included_route_meters": 3,
+            "is_active": True,
+            "sort_order": 5,
+        },
+    )
+    assert create_resp.status_code == 201
+    created = create_resp.json()
+    assert created["service_kind"] == "pre_install"
+    assert created["included_route_meters"] == 3
+
+    rule_resp = await async_client.post(
+        f"/api/manager/tariffs/{created['id']}/rules",
+        headers=headers,
+        json={
+            "rule_type": "per_meter_over_included",
+            "name": "Дополнительная трасса сверх 3 м",
+            "line_template": "дополнительная трасса {qty} м",
+            "unit": "м",
+            "unit_price": 50,
+            "is_optional": False,
+            "is_active": True,
+            "sort_order": 10,
+        },
+    )
+    assert rule_resp.status_code == 201
+
+    quick_resp = await async_client.get(
+        "/api/manager/tariffs/quick-add?q=заклад&service_kind=pre_install",
+        headers=headers,
+    )
+    assert quick_resp.status_code == 200
+    quick_items = quick_resp.json()["items"]
+    assert len(quick_items) == 1
+    assert quick_items[0]["service_kind"] == "pre_install"
+    assert "трассу длиной до 3 м" in quick_items[0]["title"]
+
+
+@pytest.mark.asyncio
 async def test_manager_favorite_tariff_rules_by_direction(async_client):
     headers = await _auth_headers(async_client)
 

--- a/tests/integration/test_manager_yandex_business_price_list_api.py
+++ b/tests/integration/test_manager_yandex_business_price_list_api.py
@@ -55,6 +55,17 @@ async def test_manager_yandex_business_price_list_exports_products_and_tariffs(a
         is_active=True,
         sort_order=1,
     )
+    pre_install_tariff = ServiceTariff(
+        service_kind="pre_install",
+        selector_label="Закладка коммуникаций под кондиционер",
+        estimate_template="Закладка межблочной трассы под кондиционер, включая материалы до 3 м",
+        category="Wall",
+        power_range="07-12",
+        base_price=500,
+        included_route_meters=3,
+        is_active=True,
+        sort_order=2,
+    )
     inactive_tariff = ServiceTariff(
         service_kind="repair",
         selector_label="Архивный ремонт",
@@ -69,10 +80,12 @@ async def test_manager_yandex_business_price_list_exports_products_and_tariffs(a
     db.add(product)
     db.add(hidden_product)
     db.add(active_tariff)
+    db.add(pre_install_tariff)
     db.add(inactive_tariff)
     await db.commit()
     await db.refresh(product)
     await db.refresh(active_tariff)
+    await db.refresh(pre_install_tariff)
 
     headers = await _auth_headers(async_client)
     response = await async_client.get(
@@ -93,6 +106,10 @@ async def test_manager_yandex_business_price_list_exports_products_and_tariffs(a
         name and name.startswith("Монтаж настенного кондиционера")
         for name in offer_names
     )
+    assert any(
+        name and name.startswith("Закладка коммуникаций под кондиционер")
+        for name in offer_names
+    )
     assert "Архивный ремонт" not in offer_names
 
     product_offer = next(offer for offer in offers if offer.findtext("name") == "Daichi Alpha 12")
@@ -109,3 +126,13 @@ async def test_manager_yandex_business_price_list_exports_products_and_tariffs(a
     )
     assert service_offer.findtext("price") == "500"
     assert service_offer.findtext("url") == "https://example.mvn.by/montaj-konditionerov"
+
+    pre_install_offer = next(
+        offer
+        for offer in offers
+        if (offer.findtext("name") or "").startswith("Закладка коммуникаций")
+    )
+    assert pre_install_offer.findtext("price") == "500"
+    assert pre_install_offer.findtext("url") == (
+        "https://example.mvn.by/services/zakladka-kommunikaciy-kondicionera"
+    )

--- a/tests/unit/test_service_estimate_service.py
+++ b/tests/unit/test_service_estimate_service.py
@@ -221,3 +221,50 @@ async def test_calculate_repair_estimate_without_route_specific_lines(db):
     assert result.tariff.service_kind == "repair"
     assert result.subtotal == 200
     assert [line.name for line in result.lines] == ["Ремонт кондиционера", "Диагностика"]
+
+
+@pytest.mark.asyncio
+async def test_calculate_pre_install_estimate_with_extra_route(db):
+    tariff = ServiceTariff(
+        service_kind="pre_install",
+        selector_label="Закладка коммуникаций под кондиционер до 3 м",
+        estimate_template="Закладка межблочной трассы под кондиционер, включая материалы до 3 м",
+        category="Wall",
+        power_range="07-12",
+        base_price=500,
+        included_route_meters=3,
+    )
+    db.add(tariff)
+    await db.commit()
+    await db.refresh(tariff)
+
+    db.add(
+        ServiceTariffRule(
+            tariff_id=tariff.id,
+            rule_type="per_meter_over_included",
+            name="Дополнительная трасса сверх 3 м",
+            line_template="дополнительная трасса {qty} м",
+            unit="м",
+            unit_price=50,
+            is_optional=False,
+            is_active=True,
+            sort_order=10,
+        )
+    )
+    await db.commit()
+
+    payload = ManagerInstallEstimateCalculatePayload(
+        tariff_id=tariff.id,
+        route_length_m=5,
+        quantity=1,
+    )
+
+    result = await ServiceEstimateService.calculate_install_estimate(db, payload)
+
+    assert result.tariff.service_kind == "pre_install"
+    assert result.subtotal == 600
+    assert result.total == 600
+    assert [line.name for line in result.lines] == [
+        "Закладка коммуникаций под кондиционер до 3 м",
+        "дополнительная трасса 2 м",
+    ]

--- a/tests/unit/test_tariffs_service.py
+++ b/tests/unit/test_tariffs_service.py
@@ -34,6 +34,22 @@ def test_build_quick_add_title_keeps_specific_template_without_duplicate_route()
     assert TariffsService.build_quick_add_title(tariff) == "Монтаж настенного кондиционера до 3,5 кВт с трассой до 3 м"
 
 
+def test_build_quick_add_title_enriches_pre_install_tariff_with_route():
+    tariff = ServiceTariff(
+        service_kind="pre_install",
+        selector_label="Закладка коммуникаций под кондиционер",
+        estimate_template="Закладка межблочной трассы под кондиционер, включая материалы",
+        category="Wall",
+        power_range="07-12",
+        base_price=500,
+        included_route_meters=3,
+    )
+
+    assert TariffsService.build_quick_add_title(tariff) == (
+        "Закладка коммуникаций под кондиционер, мощностью до 3,5 кВт, включая трассу длиной до 3 м"
+    )
+
+
 def test_build_quick_add_title_does_not_add_route_for_repair_tariff():
     tariff = ServiceTariff(
         service_kind="repair",
@@ -94,6 +110,17 @@ async def test_list_quick_add_tariffs_filters_active_search_and_kind(db):
         is_active=True,
         sort_order=2,
     )
+    active_pre_install = ServiceTariff(
+        service_kind="pre_install",
+        selector_label="Закладка коммуникаций под кондиционер",
+        estimate_template="Закладка межблочной трассы под кондиционер, включая материалы",
+        category="Wall",
+        power_range="07-12",
+        base_price=500,
+        included_route_meters=3,
+        is_active=True,
+        sort_order=3,
+    )
     inactive_installation = ServiceTariff(
         service_kind="installation",
         selector_label="Монтаж архивный",
@@ -109,6 +136,7 @@ async def test_list_quick_add_tariffs_filters_active_search_and_kind(db):
     db.add(active_maintenance)
     db.add(active_dismantling)
     db.add(active_repair)
+    db.add(active_pre_install)
     db.add(inactive_installation)
     await db.commit()
 
@@ -124,3 +152,8 @@ async def test_list_quick_add_tariffs_filters_active_search_and_kind(db):
     repair = await TariffsService.list_quick_add_tariffs(db, service_kind="repair", q="ремонт", limit=10)
     assert [item.tariff_id for item in repair] == [active_repair.id]
     assert repair[0].service_kind == "repair"
+
+    pre_install = await TariffsService.list_quick_add_tariffs(db, service_kind="pre_install", q="заклад", limit=10)
+    assert [item.tariff_id for item in pre_install] == [active_pre_install.id]
+    assert pre_install[0].service_kind == "pre_install"
+    assert "трассу длиной до 3 м" in pre_install[0].title

--- a/tests/unit/test_yandex_business_price_list_service.py
+++ b/tests/unit/test_yandex_business_price_list_service.py
@@ -37,12 +37,24 @@ async def test_yandex_business_price_list_builds_catalog(monkeypatch):
         included_route_meters=0,
         is_active=True,
     )
+    pre_install_tariff = ServiceTariff(
+        id=4,
+        service_kind="pre_install",
+        selector_label="Закладка коммуникаций под кондиционер",
+        estimate_template="Закладка межблочной трассы под кондиционер, включая материалы до 3 м",
+        category="Wall",
+        power_range="07-12",
+        base_price=500,
+        included_route_meters=3,
+        comment="Штробление оплачивается отдельно.",
+        is_active=True,
+    )
 
     async def load_products(_session):
         return [product]
 
     async def load_tariffs(_session):
-        return [tariff]
+        return [tariff, pre_install_tariff]
 
     monkeypatch.setattr(YandexBusinessPriceListService, "_load_products", load_products)
     monkeypatch.setattr(YandexBusinessPriceListService, "_load_tariffs", load_tariffs)
@@ -59,6 +71,7 @@ async def test_yandex_business_price_list_builds_catalog(monkeypatch):
     }
     assert categories[100007] == "Бытовые кондиционеры"
     assert categories[203] == "Обслуживание"
+    assert categories[205] == "Закладка коммуникаций"
 
     product_offer = root.find("./shop/offers/offer[@id='11']")
     assert product_offer is not None
@@ -73,3 +86,12 @@ async def test_yandex_business_price_list_builds_catalog(monkeypatch):
     assert service_offer.findtext("price") == "120"
     assert service_offer.findtext("currencyId") == "BYN"
     assert service_offer.findtext("url") == "https://example.mvn.by/obslujivanie-kondicionerov"
+
+    pre_install_offer = root.find("./shop/offers/offer[@id='900000004']")
+    assert pre_install_offer is not None
+    assert pre_install_offer.findtext("price") == "500"
+    assert pre_install_offer.findtext("categoryId") == "205"
+    assert pre_install_offer.findtext("url") == (
+        "https://example.mvn.by/services/zakladka-kommunikaciy-kondicionera"
+    )
+    assert "В базовую стоимость включено до 3 м трассы." in (pre_install_offer.findtext("description") or "")


### PR DESCRIPTION
## Summary

- Adds `pre_install` as a manager tariff service kind and carries it through generated OpenAPI/client types.
- Allows route-aware tariff behavior for both `installation` and `pre_install`, including quick-add titles, preserved `included_route_meters`, and `per_meter_over_included` estimates.
- Seeds an idempotent base pre-install tariff plus the 50 BYN/m extra-route rule.
- Exports pre-install tariffs to the Yandex Business price list with a dedicated category and URL.
- Adds manager UI labels/options/defaults for pre-install tariffs and route-meter rule visibility.

## Checks

- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin python3 scripts/legacy/extract_openapi.py`
- `cd manager_frontend && npm run gen:api`
- `BOT_TOKEN=dummy SECRET_KEY=dummy ADMIN_USERNAME=admin ADMIN_PASSWORD=admin TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/unit/test_tariffs_service.py tests/unit/test_service_estimate_service.py tests/unit/test_yandex_business_price_list_service.py tests/integration/test_manager_tariffs_api.py tests/integration/test_manager_yandex_business_price_list_api.py -q` (`16 passed`)
- `cd manager_frontend && npm run build`
- `python3 -m py_compile schemas.py services/tariffs_service.py services/yandex_business_price_list_service.py alembic/versions/8c4d2b6f1a90_seed_pre_install_tariff.py`
- `git diff --check`

## Assumptions

- Seed uses `power_range = "07-12"` for the small wall unit range.
- Extra route is non-optional so the automatic estimate line is applied when route length exceeds 3 m.

Addresses #415