### PR TITLE
[codex] Reduce backend Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,13 @@ manager_frontend/*
 dist
 build
 
+# Runtime data and local artifacts mounted or generated outside the image
+backups
+.local_backups
+media
+logs
+generated_documents
+
 # Environment files
 .env
 .env.*


### PR DESCRIPTION
## Summary
- exclude local runtime/data artifacts from backend Docker build context
- keep `manager_frontend/dist` included for backend static serving
- prevent local media, backups, logs, generated docs, and `.env` from being baked into the backend image

## Verification
- `docker compose config --quiet`
- `docker compose build app`
  - build context now transfers `440.39kB` instead of multi-GB local context
- `docker run --rm mvn-app ...`
  - `/app/backups`: absent
  - `/app/media`: absent
  - `/app/logs`: absent
  - `/app/generated_documents`: absent
  - `/app/.env`: absent
  - `/app/manager_frontend/dist`: present
- `git diff --check`

## Notes
- Production `app` mounts `./media:/app/media`, so media remains runtime data, not image content.
- Production `bot` does not require baked media for product cards: it falls back to a public URL when local media is absent.
- R2 migration work remains tracked separately in #407.

Closes #421
