### PR TITLE
[codex] Prepare new VPS web deploy target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ env:
   # SSH_HOST_WEB (178.159.240.174)
   # SSH_USER_API (root)
   # SSH_USER_WEB (user2154318)
+  # Optional: SSH_WEB_TARGET (defaults to the legacy mvn-web path)
 
 jobs:
   # ======================================================
@@ -397,7 +398,10 @@ jobs:
 
           WEB_HOST="${{ secrets.SSH_HOST_WEB }}"
           WEB_USER="${{ secrets.SSH_USER_WEB }}"
-          WEB_TARGET="/var/www/${{ secrets.SSH_USER_WEB }}/data/www/mvn.by/"
+          WEB_TARGET="${{ secrets.SSH_WEB_TARGET }}"
+          if [ -z "${WEB_TARGET}" ]; then
+            WEB_TARGET="/var/www/${{ secrets.SSH_USER_WEB }}/data/www/mvn.by/"
+          fi
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
           MAX_ATTEMPTS=5
           PORT_FAILURES=0

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -7,6 +7,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   SSH_HOST_WEB: ${{ secrets.SSH_HOST_WEB }}
   SSH_USER_WEB: ${{ secrets.SSH_USER_WEB }}
+  SSH_WEB_TARGET: ${{ secrets.SSH_WEB_TARGET }}
 
 jobs:
   rebuild:
@@ -67,7 +68,10 @@ jobs:
 
           WEB_HOST="${SSH_HOST_WEB}"
           WEB_USER="${SSH_USER_WEB}"
-          WEB_TARGET="/var/www/${SSH_USER_WEB}/data/www/mvn.by/"
+          WEB_TARGET="${SSH_WEB_TARGET}"
+          if [ -z "${WEB_TARGET}" ]; then
+            WEB_TARGET="/var/www/${SSH_USER_WEB}/data/www/mvn.by/"
+          fi
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
           MAX_ATTEMPTS=5
           PORT_FAILURES=0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,13 +2,43 @@
 
 ## Server Configuration
 
-### Web Server
+### Current Web Server / Fallback
 - **Host alias:** `mvn-web`
 - **User:** `user2154318`
 - **IP:** `178.159.240.174`
 - **Production path:** `/var/www/user2154318/data/www/mvn.by`
 - **Dev path:** `/var/www/user2154318/data/www/dev.mvn.by`
 - **SSH Key:** `~/.ssh/id_ed25519`
+- **Role:** current public storefront target and fallback until the new VPS is proven and the owner approves DNS cutover.
+
+### Future Web VPS
+- **Host alias:** `mvn`
+- **User:** `deploy` for static deploys, `root` for server administration only
+- **IP:** `153.80.244.78`
+- **Hostname:** `www.mvn.by`
+- **Production path:** `/var/www/mvn.by/current`
+- **Nginx site:** `/etc/nginx/sites-available/mvn.by`
+- **Role:** prepared static nginx target for the future public Astro storefront. Do not point public DNS here until owner/manager cutover approval.
+
+Prepared server baseline:
+- Ubuntu 24.04 LTS
+- nginx serving `/var/www/mvn.by/current`
+- UFW active with inbound `22/tcp`, `80/tcp`, and `443/tcp` allowed; other inbound traffic denied
+- `deploy` user with SSH key auth and write access to the static root
+- SSH password authentication disabled after root and deploy key login were verified
+- fail2ban enabled for sshd
+- unattended upgrades enabled
+
+Pre-cutover checks from a local machine:
+
+```bash
+ssh mvn true
+ssh deploy@153.80.244.78 true
+curl -fsS -H 'Host: mvn.by' http://153.80.244.78/healthz
+curl -I -H 'Host: mvn.by' http://153.80.244.78/
+```
+
+Because `mvn.by` and `www.mvn.by` still resolve through Cloudflare and not to `153.80.244.78`, do not run normal HTTP-01 certbot issuance before cutover. TLS can be issued after DNS is pointed at the new VPS, or before cutover only with an approved DNS-01/Cloudflare validation token.
 
 ### API Server
 - **Host alias:** `mvn-api`
@@ -71,6 +101,39 @@ The workflow requires these env vars in the build step:
 
 1. **deploy-backend:** Builds and pushes Docker image, deploys to API server
 2. **deploy-frontend:** Builds Astro site, uploads to web server via rsync over SSH
+
+### New VPS Staging Deploy
+
+The web workflows default to the legacy `mvn-web` path. To stage or cut over the static deploy to the new VPS, set these GitHub secrets deliberately:
+
+```text
+SSH_HOST_WEB=153.80.244.78
+SSH_USER_WEB=deploy
+SSH_WEB_TARGET=/var/www/mvn.by/current/
+```
+
+Keep the old values recorded so rollback is just a secrets revert plus a manual rebuild:
+
+```text
+SSH_HOST_WEB=178.159.240.174
+SSH_USER_WEB=user2154318
+SSH_WEB_TARGET=
+```
+
+Recommended gated sequence:
+
+1. Confirm `check-web-ssh.yml` succeeds against `deploy@153.80.244.78`.
+2. Run `rebuild-web.yml` manually against the new VPS while public DNS still points to the old target.
+3. Verify the staged site by IP with Host header:
+
+   ```bash
+   curl -I -H 'Host: mvn.by' http://153.80.244.78/
+   curl -fsS -H 'Host: mvn.by' http://153.80.244.78/catalog/ | head
+   ```
+
+4. Request owner approval for DNS cutover. Do not change `mvn.by` or `www.mvn.by` DNS before approval.
+5. After cutover, issue/enable TLS for `mvn.by` and `www.mvn.by`, then verify HTTPS.
+6. Roll back by restoring DNS and/or GitHub secrets to the legacy `mvn-web` values and running the manual rebuild workflow.
 
 ### Web SSH Reliability
 


### PR DESCRIPTION
## Summary
- Add optional `SSH_WEB_TARGET` support to the production and manual web deploy workflows while preserving the legacy `mvn-web` path as the default.
- Document the prepared new VPS static nginx target, pre-cutover verification commands, secrets checklist, TLS timing, and rollback to old `mvn-web`.

## Server prep already completed
- Prepared `153.80.244.78` as a static nginx target for the future Astro storefront.
- Created `deploy` user with SSH key auth and write access to `/var/www/mvn.by/current`.
- Enabled UFW with inbound 22/80/443 only, fail2ban for sshd, and unattended upgrades.
- Disabled SSH password authentication after proving root and deploy key logins.

## Validation
- `git diff --check`
- Parsed `.github/workflows/deploy.yml`, `.github/workflows/rebuild-web.yml`, and `.github/workflows/check-web-ssh.yml` with PyYAML.
- Verified `ssh mvn true` and `ssh deploy@153.80.244.78 true`.
- Verified nginx placeholder and `/healthz` with `Host: mvn.by` against `http://153.80.244.78`.
- Verified rsync write/read/remove to `/var/www/mvn.by/current/` as `deploy`.

Refs #364