### PR TITLE
Continue R2 media backfill with image ID bounds

### DIFF
--- a/scripts/migrate_product_media_storage.py
+++ b/scripts/migrate_product_media_storage.py
@@ -40,6 +40,9 @@ async def migrate_product_media_storage(
     provider: str | None,
     limit: int,
     product_id: int | None,
+    after_image_id: int | None,
+    from_image_id: int | None,
+    to_image_id: int | None,
     include_originals: bool,
     include_variants: bool,
     variant_types: list[str] | None,
@@ -53,6 +56,9 @@ async def migrate_product_media_storage(
         execute=execute,
         limit=limit,
         product_id=product_id,
+        after_image_id=after_image_id,
+        from_image_id=from_image_id,
+        to_image_id=to_image_id,
         include_originals=include_originals,
         include_variants=include_variants,
         variant_types=variant_types or list(DEFAULT_MIGRATION_VARIANT_TYPES),
@@ -67,6 +73,9 @@ async def run(
     provider: str | None,
     limit: int,
     product_id: int | None,
+    after_image_id: int | None,
+    from_image_id: int | None,
+    to_image_id: int | None,
     include_originals: bool,
     include_variants: bool,
     variant_types: list[str] | None,
@@ -82,6 +91,9 @@ async def run(
             provider=provider,
             limit=limit,
             product_id=product_id,
+            after_image_id=after_image_id,
+            from_image_id=from_image_id,
+            to_image_id=to_image_id,
             include_originals=include_originals,
             include_variants=include_variants,
             variant_types=variant_types,
@@ -129,6 +141,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Limit migration plan to one product id.",
     )
     parser.add_argument(
+        "--after-image-id",
+        type=int,
+        default=None,
+        help=(
+            "Only inspect ProductImage rows with id greater than this value. "
+            "Use to continue after a previous bounded batch."
+        ),
+    )
+    parser.add_argument(
+        "--from-image-id",
+        type=int,
+        default=None,
+        help="Only inspect ProductImage rows with id greater than or equal to this value.",
+    )
+    parser.add_argument(
+        "--to-image-id",
+        type=int,
+        default=None,
+        help="Only inspect ProductImage rows with id less than or equal to this value.",
+    )
+    parser.add_argument(
         "--include-originals",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -170,6 +203,24 @@ def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
         parser.error("--limit must be between 1 and 1000")
     if args.product_id is not None and args.product_id < 1:
         parser.error("--product-id must be a positive integer")
+    for attr in ("after_image_id", "from_image_id", "to_image_id"):
+        value = getattr(args, attr)
+        if value is not None and value < 1:
+            parser.error(f"--{attr.replace('_', '-')} must be a positive integer")
+    if args.after_image_id is not None and args.from_image_id is not None:
+        parser.error("Use either --after-image-id or --from-image-id, not both")
+    if (
+        args.from_image_id is not None
+        and args.to_image_id is not None
+        and args.from_image_id > args.to_image_id
+    ):
+        parser.error("--from-image-id must be less than or equal to --to-image-id")
+    if (
+        args.after_image_id is not None
+        and args.to_image_id is not None
+        and args.after_image_id >= args.to_image_id
+    ):
+        parser.error("--after-image-id must be less than --to-image-id")
     if not args.include_originals and not args.include_variants:
         parser.error("At least one of --include-originals or --include-variants is required")
 
@@ -181,6 +232,9 @@ def _print_result(result: dict[str, Any]) -> None:
     print(f"  storage_provider={result['storage_provider']}")
     print(f"  product_id={result.get('product_id') or 'all'}")
     print(f"  limit={result['limit']}")
+    print(f"  after_image_id={result.get('after_image_id') or 'none'}")
+    print(f"  from_image_id={result.get('from_image_id') or 'none'}")
+    print(f"  to_image_id={result.get('to_image_id') or 'none'}")
     print(f"  include_originals={result['include_originals']}")
     print(f"  include_variants={result['include_variants']}")
     print(f"  variant_types={','.join(result['variant_types'])}")
@@ -238,6 +292,9 @@ def main() -> None:
             provider=args.provider,
             limit=args.limit,
             product_id=args.product_id,
+            after_image_id=args.after_image_id,
+            from_image_id=args.from_image_id,
+            to_image_id=args.to_image_id,
             include_originals=args.include_originals,
             include_variants=args.include_variants,
             variant_types=args.variant_type,

--- a/services/product_image_variant_service.py
+++ b/services/product_image_variant_service.py
@@ -383,9 +383,13 @@ class ProductImageVariantService:
 
     @staticmethod
     def _local_media_path_for_url(url: str) -> Path | None:
-        if not url or not url.startswith("/media/"):
+        if not url:
             return None
-        return Path(url.lstrip("/"))
+        if url.startswith("/media/"):
+            return Path(url.lstrip("/"))
+        if url.startswith("media/"):
+            return Path(url)
+        return None
 
     @staticmethod
     def _image_size(content: bytes) -> tuple[int | None, int | None]:

--- a/services/product_media_migration_service.py
+++ b/services/product_media_migration_service.py
@@ -35,6 +35,9 @@ class ProductMediaMigrationService:
         execute: bool,
         limit: int = 50,
         product_id: int | None = None,
+        after_image_id: int | None = None,
+        from_image_id: int | None = None,
+        to_image_id: int | None = None,
         include_originals: bool = True,
         include_variants: bool = True,
         variant_types: list[str] | tuple[str, ...] | None = None,
@@ -49,6 +52,9 @@ class ProductMediaMigrationService:
             storage=storage,
             limit=safe_limit,
             product_id=product_id,
+            after_image_id=after_image_id,
+            from_image_id=from_image_id,
+            to_image_id=to_image_id,
             include_originals=include_originals,
             include_variants=include_variants,
             variant_types=selected_variant_types,
@@ -134,6 +140,9 @@ class ProductMediaMigrationService:
         storage: ProductMediaStorage,
         limit: int,
         product_id: int | None,
+        after_image_id: int | None,
+        from_image_id: int | None,
+        to_image_id: int | None,
         include_originals: bool,
         include_variants: bool,
         variant_types: tuple[str, ...],
@@ -147,6 +156,12 @@ class ProductMediaMigrationService:
 
         if include_originals and remaining > 0:
             stmt = select(ProductImage).order_by(ProductImage.id).limit(remaining)
+            stmt = ProductMediaMigrationService._apply_image_id_bounds(
+                stmt,
+                after_image_id=after_image_id,
+                from_image_id=from_image_id,
+                to_image_id=to_image_id,
+            )
             if product_id is not None:
                 stmt = stmt.where(ProductImage.product_id == product_id)
             rows = (await session.execute(stmt)).scalars().all()
@@ -179,8 +194,14 @@ class ProductMediaMigrationService:
                 .join(ProductImage, ProductImage.id == ProductImageVariant.product_image_id)
                 .where(ProductImageVariant.url.is_not(None))
                 .where(ProductImageVariant.variant_type.in_(variant_types))
-                .order_by(ProductImageVariant.id)
+                .order_by(ProductImage.id, ProductImageVariant.id)
                 .limit(remaining)
+            )
+            stmt = ProductMediaMigrationService._apply_image_id_bounds(
+                stmt,
+                after_image_id=after_image_id,
+                from_image_id=from_image_id,
+                to_image_id=to_image_id,
             )
             if product_id is not None:
                 stmt = stmt.where(ProductImage.product_id == product_id)
@@ -213,6 +234,9 @@ class ProductMediaMigrationService:
             "storage_provider": storage.provider_name,
             "limit": limit,
             "product_id": product_id,
+            "after_image_id": after_image_id,
+            "from_image_id": from_image_id,
+            "to_image_id": to_image_id,
             "include_originals": include_originals,
             "include_variants": include_variants,
             "variant_types": list(variant_types),
@@ -228,6 +252,22 @@ class ProductMediaMigrationService:
             "uploaded_items": [],
             "errors": [],
         }
+
+    @staticmethod
+    def _apply_image_id_bounds(
+        stmt,
+        *,
+        after_image_id: int | None,
+        from_image_id: int | None,
+        to_image_id: int | None,
+    ):
+        if after_image_id is not None:
+            stmt = stmt.where(ProductImage.id > after_image_id)
+        if from_image_id is not None:
+            stmt = stmt.where(ProductImage.id >= from_image_id)
+        if to_image_id is not None:
+            stmt = stmt.where(ProductImage.id <= to_image_id)
+        return stmt
 
     @staticmethod
     def _plan_item(

--- a/tests/unit/test_product_media_migration_service.py
+++ b/tests/unit/test_product_media_migration_service.py
@@ -89,10 +89,23 @@ async def sqlite_session(tmp_path: Path):
 async def _make_product_with_media(
     session: AsyncSession,
     tmp_path: Path,
+    *,
+    suffix: str = "",
+    slashless_urls: bool = False,
 ) -> tuple[Product, ProductImage, ProductImageVariant]:
+    slug = "migration-product"
+    title = "Migration product"
+    original_filename = "original.webp"
+    card_filename = "card.webp"
+    if suffix:
+        slug = f"{slug}-{suffix}"
+        title = f"{title} {suffix}"
+        original_filename = f"original-{suffix}.webp"
+        card_filename = f"card-{suffix}.webp"
+
     product = Product(
-        title="Migration product",
-        slug="migration-product",
+        title=title,
+        slug=slug,
         price=1000,
         area=20,
         specs={},
@@ -105,13 +118,14 @@ async def _make_product_with_media(
     variant_dir = tmp_path / "media/products/variants/card"
     shared_dir.mkdir(parents=True, exist_ok=True)
     variant_dir.mkdir(parents=True, exist_ok=True)
-    original_path = shared_dir / "original.webp"
-    card_path = variant_dir / "card.webp"
+    original_path = shared_dir / original_filename
+    card_path = variant_dir / card_filename
     original_path.write_bytes(_image_bytes())
     card_path.write_bytes(_image_bytes((80, 20, 20)))
 
-    original_url = "/media/products/shared/original.webp"
-    card_url = "/media/products/variants/card/card.webp"
+    url_prefix = "" if slashless_urls else "/"
+    original_url = f"{url_prefix}media/products/shared/{original_filename}"
+    card_url = f"{url_prefix}media/products/variants/card/{card_filename}"
     product.main_image = original_url
     product.images = [original_url]
     image = ProductImage(product_id=product.id, url=original_url)
@@ -161,6 +175,9 @@ async def test_media_migration_dry_run_plans_uploads_without_db_writes(
     await sqlite_session.refresh(product)
 
     assert report["dry_run"] is True
+    assert report["after_image_id"] is None
+    assert report["from_image_id"] is None
+    assert report["to_image_id"] is None
     assert report["planned_uploads"] == 2
     assert {item["variant_type"] for item in report["items"]} == {"original", "card"}
     assert storage.uploads == []
@@ -208,3 +225,110 @@ async def test_media_migration_execute_updates_variants_but_preserves_product_ur
     assert product.main_image == "/media/products/shared/original.webp"
     assert product.images == ["/media/products/shared/original.webp"]
     assert image.url == "/media/products/shared/original.webp"
+
+
+@pytest.mark.asyncio
+async def test_media_migration_image_id_bounds_continue_after_previous_window(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    _, first_image, _ = await _make_product_with_media(
+        sqlite_session,
+        tmp_path,
+        suffix="first",
+    )
+    _, second_image, _ = await _make_product_with_media(
+        sqlite_session,
+        tmp_path,
+        suffix="second",
+    )
+    _, third_image, _ = await _make_product_with_media(
+        sqlite_session,
+        tmp_path,
+        suffix="third",
+    )
+    storage = RecordingStorage()
+
+    cursor_report = await ProductMediaMigrationService.migrate_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=False,
+        limit=10,
+        after_image_id=first_image.id,
+        to_image_id=second_image.id,
+    )
+    ranged_report = await ProductMediaMigrationService.migrate_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=False,
+        limit=10,
+        from_image_id=second_image.id,
+        to_image_id=third_image.id,
+        include_originals=False,
+    )
+
+    assert cursor_report["after_image_id"] == first_image.id
+    assert cursor_report["to_image_id"] == second_image.id
+    assert cursor_report["inspected"] == 2
+    assert cursor_report["planned_uploads"] == 2
+    assert {item["product_image_id"] for item in cursor_report["items"]} == {
+        second_image.id
+    }
+    assert {item["variant_type"] for item in cursor_report["items"]} == {
+        "original",
+        "card",
+    }
+
+    assert ranged_report["from_image_id"] == second_image.id
+    assert ranged_report["to_image_id"] == third_image.id
+    assert ranged_report["planned_uploads"] == 2
+    assert {
+        item["product_image_id"] for item in ranged_report["items"]
+    } == {second_image.id, third_image.id}
+    assert {item["source_kind"] for item in ranged_report["items"]} == {"variant"}
+    assert first_image.id not in {
+        item["product_image_id"] for item in ranged_report["items"]
+    }
+    assert storage.uploads == []
+
+
+@pytest.mark.asyncio
+async def test_media_migration_plans_slashless_media_products_urls(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    _, image, variant = await _make_product_with_media(
+        sqlite_session,
+        tmp_path,
+        slashless_urls=True,
+    )
+    storage = RecordingStorage()
+
+    report = await ProductMediaMigrationService.migrate_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=False,
+        limit=10,
+    )
+
+    assert report["planned_uploads"] == 2
+    assert {item["source_url"] for item in report["items"]} == {
+        "media/products/shared/original.webp",
+        "media/products/variants/card/card.webp",
+    }
+    assert {item["source_path"] for item in report["items"]} == {
+        "media/products/shared/original.webp",
+        "media/products/variants/card/card.webp",
+    }
+    assert not [
+        item
+        for item in report["skipped"]
+        if item.get("skip_reason") == "non_local_url"
+    ]
+    assert image.url == "media/products/shared/original.webp"
+    assert variant.url == "media/products/variants/card/card.webp"
+    assert storage.uploads == []


### PR DESCRIPTION
## Summary
- add ProductImage id cursor/range filters to the product media migration service
- expose bounded CLI flags for continuing R2 backfill after earlier windows
- treat slashless media/products/... URLs as local media paths
- cover continuation and slashless URL planning with focused unit tests

## Tests
- pytest tests/unit/test_product_media_migration_service.py -q
- pytest tests/unit/test_product_image_variants.py -q
- pytest tests/unit/test_media_storage_service.py -q
- python3 scripts/migrate_product_media_storage.py --help
- git diff --check

## Production notes
- No production migration was run in this PR.
- PRODUCT_MEDIA_STORAGE_PROVIDER remains local until owner separately approves the new-media write path.
- Example dry-run for the next bounded batch:
  python3 scripts/migrate_product_media_storage.py --provider r2 --dry-run --limit 1000 --after-image-id <last_seen_product_image_id> --to-image-id <window_end_product_image_id>

Refs #426