### PR TITLE
Add API VPS monitoring and migration runbooks

### DIFF
--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -1,0 +1,91 @@
+name: API VPS Health Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Check mode"
+        type: choice
+        required: true
+        default: "public-only"
+        options:
+          - public-only
+          - ssh
+      backup_max_age_hours:
+        description: "Backup freshness threshold in hours"
+        type: string
+        required: false
+        default: "36"
+      check_backups:
+        description: "Check Google Drive backup freshness in ssh mode"
+        type: boolean
+        required: false
+        default: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup API SSH Key
+        if: ${{ inputs.mode == 'ssh' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets for ssh mode: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/api_vps_health_key
+          chmod 600 ~/.ssh/api_vps_health_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+
+      - name: Run API VPS Health Check
+        env:
+          BASE_URL: https://api.mvn.by
+          BACKUP_MAX_AGE_HOURS: ${{ inputs.backup_max_age_hours }}
+          CHECK_BACKUPS: ${{ inputs.check_backups }}
+          API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
+          API_SSH_USER: ${{ secrets.SSH_USER_API }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ inputs.mode }}" = "public-only" ]; then
+            bash scripts/check_api_vps_health.sh --public-only | tee api-vps-health.log
+          else
+            API_SSH_KEY_PATH="${HOME}/.ssh/api_vps_health_key" bash scripts/check_api_vps_health.sh | tee api-vps-health.log
+          fi
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## API VPS Health Check"
+            echo "- mode: ${{ inputs.mode }}"
+            echo "- base_url: https://api.mvn.by"
+            echo "- backup_max_age_hours: ${{ inputs.backup_max_age_hours }}"
+            echo "- check_backups: ${{ inputs.check_backups }}"
+            echo "- log_artifact: api-vps-health-log-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Health Log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-vps-health-log-${{ github.run_id }}
+          path: api-vps-health.log
+          if-no-files-found: warn

--- a/docs/api-vps-migration-runbook.md
+++ b/docs/api-vps-migration-runbook.md
@@ -1,0 +1,548 @@
+# API Single-VPS Migration Runbook
+
+Owner/operator runbook for moving `api.mvn.by` from the current single API VPS to a new single API VPS.
+
+Related source material:
+
+- [Deployment guide](deployment.md)
+- [`docker-compose.prod.yml`](../docker-compose.prod.yml)
+- [Backend deploy workflow](../.github/workflows/deploy.yml)
+- [`scripts/deploy.sh`](../scripts/deploy.sh)
+- [`scripts/post_deploy_smoke_check.sh`](../scripts/post_deploy_smoke_check.sh)
+- [`services/backup_service.py`](../services/backup_service.py)
+- [`scripts/restore_db.py`](../scripts/restore_db.py)
+
+## Scope And Safety
+
+This runbook is for one production API origin running Docker Compose services:
+
+- `db`: PostgreSQL
+- `app`: FastAPI, static/media serving, manager UI, and in-process scheduler loops
+- `bot`: Telegram bot polling process
+
+Current production assumptions:
+
+- Production directory: `/opt/air-api`
+- Public API domain: `api.mvn.by`
+- Current old API IP from existing docs: `185.250.45.54`
+- Public access goes through Cloudflare/nginx to `127.0.0.1:8000`
+- Compose binds Postgres and FastAPI to localhost on the VPS
+
+Hard safety rules:
+
+- Do not run two active `bot` services against the same bot token.
+- Do not run two active production `app` services after the freeze, because the scheduler is started inside `app` lifecycle and can run price sync, backups, lead archival, supplier sync, and mail imports.
+- During cutover, stop old `app` and `bot` before starting the new production `app`.
+- Start the new `bot` only after the new `app` has passed app-only and public smoke checks.
+- If rollback is needed, stop new `app` and `bot` before restarting old `app` and `bot`.
+
+Issue #433 is expected to add stronger single-active controls later. Until then, the operator must enforce single-active behavior manually.
+
+## Variables
+
+Set these on the operator workstation before running local transfer commands:
+
+```bash
+OLD_API_HOST=185.250.45.54
+NEW_API_HOST=<new-vps-ip>
+API_USER=root
+MIGRATION_ID=api-migration-$(date +%Y%m%d%H%M%S)
+WORKDIR="$HOME/$MIGRATION_ID"
+COMMIT_SHA=<deployed-backend-commit-sha>
+IMAGE="ghcr.io/mvnby/air-api/backend:${COMMIT_SHA}"
+```
+
+Use a commit SHA that has already been built and pushed by GitHub Actions. The deploy workflow publishes both:
+
+```text
+ghcr.io/mvnby/air-api/backend:latest
+ghcr.io/mvnby/air-api/backend:<commit-sha>
+```
+
+Prefer the SHA tag for migration cutover so the old and new hosts run the same known image rather than whatever `latest` points to at the moment of migration.
+
+## Phase 1: Preflight Inventory
+
+Run inventory commands on the old API VPS. These commands avoid printing secret values.
+
+```bash
+ssh "${API_USER}@${OLD_API_HOST}"
+cd /opt/air-api
+```
+
+Confirm compose services and images:
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml images
+docker compose -f docker-compose.prod.yml config --services
+```
+
+Record `.env` key names without values:
+
+```bash
+awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/{print $1"=<redacted>"}' .env | sort
+```
+
+Confirm required runtime files exist:
+
+```bash
+for f in .env docker-compose.prod.yml token.json client_secret.json credentials.json; do
+  if [ -f "$f" ]; then
+    stat -c '%n %s bytes mode=%a owner=%U:%G' "$f"
+  else
+    echo "MISSING $f"
+  fi
+done
+```
+
+Inventory media and local backup directories:
+
+```bash
+du -sh media backups 2>/dev/null || true
+find media -type f | wc -l
+find backups -maxdepth 1 -type f -printf '%TY-%Tm-%Td %TH:%TM %s %p\n' 2>/dev/null | sort | tail -20
+```
+
+Inventory Postgres volume and DB size:
+
+```bash
+docker volume ls | grep postgres || true
+docker compose -f docker-compose.prod.yml exec -T db sh -c \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "select pg_size_pretty(pg_database_size(current_database())) as db_size;"'
+```
+
+Inventory Google Drive backup visibility from the app container:
+
+```bash
+docker compose -f docker-compose.prod.yml exec -T app python scripts/restore_db.py --list
+```
+
+This confirms `token.json` is usable and shows available DB/media backups. Do not use Drive backups as the primary migration source unless a direct frozen dump cannot be used; a fresh dump taken after the maintenance freeze is the least stale source of truth.
+
+## Phase 2: New VPS Baseline
+
+Prepare the new VPS before the maintenance window. Do not start production `app` or `bot` yet.
+
+Install baseline packages:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}"
+apt-get update
+apt-get install -y ca-certificates curl gnupg nginx certbot python3-certbot-dns-cloudflare
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable --now docker nginx
+```
+
+Configure the firewall to expose only SSH and HTTP(S):
+
+```bash
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+ufw status verbose
+```
+
+Create the application directory:
+
+```bash
+mkdir -p /opt/air-api
+chmod 700 /opt/air-api
+```
+
+Set up nginx to proxy only to the localhost-bound app:
+
+```bash
+cat >/etc/nginx/sites-available/api.mvn.by <<'NGINX'
+server {
+    listen 80;
+    server_name api.mvn.by;
+
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+NGINX
+ln -sf /etc/nginx/sites-available/api.mvn.by /etc/nginx/sites-enabled/api.mvn.by
+nginx -t
+systemctl reload nginx
+```
+
+TLS options:
+
+- Preferred: issue the certificate before DNS cutover with Cloudflare DNS-01, so `api.mvn.by` can be tested with `curl --resolve`.
+- Acceptable: issue/refresh TLS immediately after DNS cutover if DNS-01 is not available, but keep the old VPS ready for rollback until HTTPS passes.
+
+For DNS-01, keep the Cloudflare token file outside `/opt/air-api`, mode `600`, and do not print it in logs:
+
+```bash
+chmod 600 /root/cloudflare.ini
+certbot certonly --dns-cloudflare --dns-cloudflare-credentials /root/cloudflare.ini -d api.mvn.by
+```
+
+Then update nginx for HTTPS:
+
+```bash
+cat >/etc/nginx/sites-available/api.mvn.by <<'NGINX'
+server {
+    listen 80;
+    server_name api.mvn.by;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name api.mvn.by;
+
+    ssl_certificate /etc/letsencrypt/live/api.mvn.by/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.mvn.by/privkey.pem;
+
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+NGINX
+nginx -t
+systemctl reload nginx
+```
+
+## Phase 3: Stage Runtime Files
+
+From the operator workstation, create a local migration directory:
+
+```bash
+mkdir -p "$WORKDIR"
+chmod 700 "$WORKDIR"
+```
+
+Copy non-database runtime files from the old VPS without printing contents:
+
+```bash
+ssh "${API_USER}@${OLD_API_HOST}" '
+  set -euo pipefail
+  cd /opt/air-api
+  install -m 700 -d /root/api-migration-stage
+  tar -czf /root/api-migration-stage/runtime-files.tar.gz \
+    .env docker-compose.prod.yml token.json client_secret.json credentials.json
+  chmod 600 /root/api-migration-stage/runtime-files.tar.gz
+'
+
+scp "${API_USER}@${OLD_API_HOST}:/root/api-migration-stage/runtime-files.tar.gz" "$WORKDIR/"
+scp "$WORKDIR/runtime-files.tar.gz" "${API_USER}@${NEW_API_HOST}:/root/"
+
+ssh "${API_USER}@${NEW_API_HOST}" '
+  set -euo pipefail
+  cd /opt/air-api
+  tar -xzf /root/runtime-files.tar.gz
+  chmod 600 .env token.json client_secret.json credentials.json
+'
+```
+
+Create a SHA-pinned compose file on the new VPS:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}" "cd /opt/air-api && COMMIT_SHA='${COMMIT_SHA}' sh -s" <<'SH'
+set -euo pipefail
+test -n "${COMMIT_SHA}"
+sed "s#ghcr.io/mvnby/air-api/backend:latest#ghcr.io/mvnby/air-api/backend:${COMMIT_SHA}#g" \
+  docker-compose.prod.yml > docker-compose.cutover.yml
+grep -n 'image: ghcr.io/mvnby/air-api/backend:' docker-compose.cutover.yml
+SH
+```
+
+Pull the pinned image and start only the database on the new VPS:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}"
+cd /opt/air-api
+COMMIT_SHA=<deployed-backend-commit-sha>
+
+read -rsp "GHCR token: " GHCR_PAT
+printf '\n'
+printf '%s' "$GHCR_PAT" | docker login ghcr.io -u <github-username> --password-stdin
+unset GHCR_PAT
+
+docker manifest inspect "ghcr.io/mvnby/air-api/backend:${COMMIT_SHA}" >/dev/null
+docker compose -f docker-compose.cutover.yml pull app
+docker compose -f docker-compose.cutover.yml up -d db
+docker compose -f docker-compose.cutover.yml ps
+```
+
+Do not start `app` or `bot` yet.
+
+## Phase 4: Freeze Old API
+
+Schedule a maintenance window. The freeze starts when old `app` and `bot` are stopped.
+
+Announce the freeze to stakeholders. During the freeze:
+
+- Website/API writes are unavailable.
+- Telegram bot is unavailable.
+- No imports, manager edits, order changes, media uploads, or restore jobs should be started.
+
+On the old VPS:
+
+```bash
+ssh "${API_USER}@${OLD_API_HOST}"
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml stop bot app
+docker compose -f docker-compose.prod.yml ps
+```
+
+Confirm old localhost app is down:
+
+```bash
+curl -fsS http://127.0.0.1:8000/api/health && echo "UNEXPECTED: old app still responds" || echo "old app stopped"
+```
+
+The old `db` remains running only long enough to take the final dump.
+
+## Phase 5: Final DB And Media Backup
+
+On the old VPS, create a final frozen DB dump and media archive:
+
+```bash
+cd /opt/air-api
+install -m 700 -d /root/api-migration-final
+
+docker compose -f docker-compose.prod.yml exec -T db sh -c \
+  'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists' \
+  > /root/api-migration-final/db.sql
+
+tar -C /opt/air-api -czf /root/api-migration-final/media.tar.gz media
+chmod 600 /root/api-migration-final/db.sql /root/api-migration-final/media.tar.gz
+
+ls -lh /root/api-migration-final/db.sql /root/api-migration-final/media.tar.gz
+```
+
+Optional but recommended: keep a Drive backup as a second recovery source. This can take longer because it uploads DB and media to Google Drive:
+
+```bash
+docker compose -f docker-compose.prod.yml run -T --rm app python -c \
+  "from services.backup_service import backup_service; backup_service.perform_backup(cleanup=True)"
+```
+
+Only run this optional step if the longer maintenance window is acceptable. Use `docker compose run`, not `up -d app`, so the public old API and scheduler lifecycle do not restart during the freeze.
+
+Transfer final artifacts to the new VPS:
+
+```bash
+scp "${API_USER}@${OLD_API_HOST}:/root/api-migration-final/db.sql" "$WORKDIR/"
+scp "${API_USER}@${OLD_API_HOST}:/root/api-migration-final/media.tar.gz" "$WORKDIR/"
+scp "$WORKDIR/db.sql" "$WORKDIR/media.tar.gz" "${API_USER}@${NEW_API_HOST}:/root/"
+```
+
+## Phase 6: Restore On New VPS
+
+On the new VPS:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}"
+cd /opt/air-api
+docker compose -f docker-compose.cutover.yml up -d db
+```
+
+Restore the DB dump:
+
+```bash
+docker compose -f docker-compose.cutover.yml exec -T db sh -c \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' \
+  < /root/db.sql
+```
+
+Restore media:
+
+```bash
+rm -rf /opt/air-api/media
+tar -C /opt/air-api -xzf /root/media.tar.gz
+chown -R root:root /opt/air-api/media
+```
+
+Run migrations and required defaults with a one-off container. This does not start the long-running `app` service:
+
+```bash
+docker compose -f docker-compose.cutover.yml run -T --rm app alembic upgrade head
+docker compose -f docker-compose.cutover.yml run -T --rm app python3 scripts/ensure_global_config_defaults.py
+```
+
+## Phase 7: App-Only Smoke On New VPS
+
+At this point old `app` and old `bot` must still be stopped.
+
+Start the new app only:
+
+```bash
+docker compose -f docker-compose.cutover.yml up -d app
+docker compose -f docker-compose.cutover.yml ps
+docker compose -f docker-compose.cutover.yml logs --tail=120 app
+```
+
+Run local app smoke:
+
+```bash
+curl -fsS http://127.0.0.1:8000/api/health
+curl -fsS http://127.0.0.1:8000/api/v1/products?limit=5
+curl -fsS http://127.0.0.1:8000/api/v1/filters/config
+```
+
+Run nginx-origin smoke on the new VPS:
+
+```bash
+curl -fsS -H 'Host: api.mvn.by' http://127.0.0.1/api/health
+```
+
+If TLS was issued before DNS cutover, test from the operator workstation:
+
+```bash
+curl -fsS --resolve "api.mvn.by:443:${NEW_API_HOST}" https://api.mvn.by/api/health
+curl -fsS --resolve "api.mvn.by:443:${NEW_API_HOST}" "https://api.mvn.by/api/v1/products?limit=5"
+curl -fsS --resolve "api.mvn.by:443:${NEW_API_HOST}" https://api.mvn.by/api/v1/filters/config
+```
+
+Do not start `bot` yet.
+
+## Phase 8: DNS And Deploy Target Cutover
+
+In Cloudflare:
+
+1. Update `api.mvn.by` A record from the old IP to `NEW_API_HOST`.
+2. Keep the same proxy mode as the old record unless there is an explicit owner decision to change it.
+3. If using Cloudflare proxied DNS, TTL is automatic. If DNS-only, use the previously agreed low TTL.
+
+In GitHub repository secrets:
+
+1. Update `SSH_HOST_API` to `NEW_API_HOST`.
+2. Keep `SSH_USER_API` unchanged unless the new VPS uses a different deploy user.
+3. Do not run a deployment until public smoke passes unless the deployment itself is part of the approved cutover.
+
+After DNS starts resolving to the new origin, run public smoke from outside the VPS:
+
+```bash
+dig +short api.mvn.by
+curl -fsS https://api.mvn.by/api/health
+curl -fsS "https://api.mvn.by/api/v1/products?limit=5"
+curl -fsS https://api.mvn.by/api/v1/filters/config
+curl -fsS https://api.mvn.by/docs >/dev/null
+```
+
+If the public smoke is green, start the new bot:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}" '
+  set -euo pipefail
+  cd /opt/air-api
+  docker compose -f docker-compose.cutover.yml up -d bot
+  docker compose -f docker-compose.cutover.yml ps
+  docker compose -f docker-compose.cutover.yml logs --tail=120 bot
+'
+```
+
+Run one final public smoke:
+
+```bash
+curl -fsS https://api.mvn.by/api/health
+curl -fsS "https://api.mvn.by/api/v1/products?limit=5"
+curl -fsS https://api.mvn.by/api/v1/filters/config
+```
+
+## Phase 9: Post-Cutover Normalization
+
+The migration used `docker-compose.cutover.yml` with a SHA-pinned image. After the owner confirms the migration is stable, choose one of these paths:
+
+- Keep using the SHA-pinned cutover compose until the next planned backend deploy.
+- Run the GitHub backend deploy workflow from the approved branch/commit after `SSH_HOST_API` is updated. The workflow copies `docker-compose.prod.yml`, pulls images, runs migrations/defaults, recreates `app` and `bot`, and runs `scripts/post_deploy_smoke_check.sh`.
+
+Before running GitHub deploy, remember that the repository compose currently uses `backend:latest`. If the goal is to keep production pinned longer, update the deployment model first or continue using the manual cutover compose.
+
+Cleanup after the rollback window:
+
+```bash
+ssh "${API_USER}@${OLD_API_HOST}" 'docker compose -f /opt/air-api/docker-compose.prod.yml ps'
+ssh "${API_USER}@${NEW_API_HOST}" 'rm -f /root/db.sql /root/media.tar.gz /root/runtime-files.tar.gz'
+rm -rf "$WORKDIR"
+```
+
+Do not delete old VPS data or backups until the owner explicitly accepts the migration and the rollback window has ended.
+
+## Rollback
+
+Use rollback if app-only smoke, public smoke, bot startup, or early production monitoring fails.
+
+Critical order:
+
+1. Stop new `bot` and `app`.
+2. Point DNS back to the old IP.
+3. Restart old `app` and `bot`.
+4. Restore GitHub `SSH_HOST_API` to the old IP if it was changed.
+
+Commands:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}" '
+  set -euo pipefail
+  cd /opt/air-api
+  docker compose -f docker-compose.cutover.yml stop bot app || true
+  docker compose -f docker-compose.cutover.yml ps
+'
+```
+
+In Cloudflare, set `api.mvn.by` A record back to the old IP, for example `185.250.45.54`.
+
+On the old VPS:
+
+```bash
+ssh "${API_USER}@${OLD_API_HOST}" '
+  set -euo pipefail
+  cd /opt/air-api
+  docker compose -f docker-compose.prod.yml up -d app bot
+  docker compose -f docker-compose.prod.yml ps
+  curl -fsS http://127.0.0.1:8000/api/health
+'
+```
+
+Public rollback smoke:
+
+```bash
+dig +short api.mvn.by
+curl -fsS https://api.mvn.by/api/health
+curl -fsS "https://api.mvn.by/api/v1/products?limit=5"
+curl -fsS https://api.mvn.by/api/v1/filters/config
+```
+
+If the new API accepted writes, orders, imports, media uploads, or bot interactions before rollback, data may diverge. Decide whether to back-transfer a new dump/media archive from the new VPS to the old VPS before restarting old services, or accept losing those writes. The lowest-risk rollback is before the new bot starts and before ending the maintenance window.
+
+## Final Owner Checklist
+
+- Old and new VPS inventory captured.
+- Maintenance window approved.
+- `COMMIT_SHA` selected and confirmed available in GHCR.
+- New VPS has Docker, Compose, nginx, firewall, and TLS ready.
+- `/opt/air-api/.env`, compose, Google credential files, media, and final DB dump restored on new VPS.
+- Old `app` and `bot` stopped before new `app` starts.
+- New `app` passes localhost and nginx-origin smoke.
+- Cloudflare `api.mvn.by` points to new IP.
+- GitHub `SSH_HOST_API` points to new IP.
+- Public smoke passes.
+- New `bot` starts only after public smoke passes.
+- Rollback path remains available until the owner ends the rollback window.

--- a/docs/api-vps-monitoring.md
+++ b/docs/api-vps-monitoring.md
@@ -1,0 +1,232 @@
+# API VPS Monitoring Runbook
+
+This repo keeps API VPS monitoring cheap and explicit: one script checks public
+API health from anywhere, then optionally checks the host over SSH when a trusted
+runner has access. The checks are read-only and are designed not to print env
+values, private keys, tokens, database passwords, or Google credentials.
+
+## What Is Checked
+
+`scripts/check_api_vps_health.sh` always checks these public endpoints:
+
+```bash
+https://api.mvn.by/api/health
+https://api.mvn.by/api/v1/products?limit=5
+https://api.mvn.by/api/v1/filters/config
+```
+
+When `API_SSH_HOST` and `API_SSH_USER` are provided, it also checks the VPS:
+
+- root disk and inode usage;
+- `docker compose ps` for `/opt/air-api/docker-compose.prod.yml`;
+- `app`, `bot`, and `db` containers are running;
+- `pg_isready` inside the `db` container;
+- localhost app health at `http://127.0.0.1:8000/api/health`;
+- nginx origin certificate expiry on `127.0.0.1:443` with SNI `api.mvn.by`;
+- latest Google Drive DB and media backups from inside the `app` container.
+
+Backup freshness uses the existing app credentials mounted in production. Do not
+copy Drive secrets to a local machine or GitHub workflow just to run this check.
+Default freshness threshold is `BACKUP_MAX_AGE_HOURS=36`, which leaves room for
+the daily 03:00 backup job plus normal operational delay.
+
+## Manual Commands
+
+Public-only check from any machine:
+
+```bash
+bash scripts/check_api_vps_health.sh --public-only
+```
+
+Full check from a machine that can SSH to the API VPS:
+
+```bash
+API_SSH_HOST=mvn-api \
+API_SSH_USER=root \
+bash scripts/check_api_vps_health.sh
+```
+
+Full check with an explicit key path:
+
+```bash
+API_SSH_HOST=185.250.45.54 \
+API_SSH_USER=root \
+API_SSH_KEY_PATH=~/.ssh/id_ed25519 \
+bash scripts/check_api_vps_health.sh
+```
+
+Tighter or looser backup threshold:
+
+```bash
+API_SSH_HOST=mvn-api \
+API_SSH_USER=root \
+BACKUP_MAX_AGE_HOURS=48 \
+bash scripts/check_api_vps_health.sh
+```
+
+Temporarily skip backup freshness during a known Google Drive auth incident:
+
+```bash
+API_SSH_HOST=mvn-api \
+API_SSH_USER=root \
+CHECK_BACKUPS=false \
+bash scripts/check_api_vps_health.sh
+```
+
+Backup freshness can also be inspected manually on the VPS without exposing
+Drive secrets:
+
+```bash
+ssh mvn-api
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml exec -T app python3 - <<'PY'
+from datetime import datetime, timezone
+from services.backup_service import backup_service
+
+items = backup_service.list_backups(limit=100)
+now = datetime.now(timezone.utc)
+for kind in ("db", "media"):
+    latest = next((item for item in items if item.get("kind") == kind), None)
+    if latest is None:
+        print(f"{kind}: missing")
+        continue
+    created_at = latest["created_at"]
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    age_hours = (now - created_at).total_seconds() / 3600
+    print(f"{kind}: {created_at.isoformat()} age_hours={age_hours:.1f} name={latest['name']}")
+PY
+```
+
+## Cron Examples
+
+Public check every 5 minutes from any small external box:
+
+```cron
+*/5 * * * * cd /path/to/air-api && bash scripts/check_api_vps_health.sh --public-only >> /var/log/mvn-api-health.log 2>&1
+```
+
+Full hourly check from a trusted runner with SSH access:
+
+```cron
+7 * * * * cd /path/to/air-api && API_SSH_HOST=mvn-api API_SSH_USER=root bash scripts/check_api_vps_health.sh >> /var/log/mvn-api-vps-health.log 2>&1
+```
+
+Cron can route failures through `MAILTO`, a local MTA, or a webhook wrapper. Keep
+webhook URLs and bot tokens in the runner environment or secret store, and never
+echo them from the monitor command.
+
+## GitHub Actions
+
+Use the manual **API VPS Health Check** workflow for ad hoc checks from GitHub.
+It has two modes:
+
+- `public-only`: no SSH secrets needed; validates the public API.
+- `ssh`: uses existing `SSH_HOST_API`, `SSH_USER_API`, and `SSH_KEY` secrets and
+  runs the full host and backup freshness checks.
+
+This workflow is intentionally manual-only to avoid noisy failures until the
+owner chooses an alerting policy. If scheduled Actions alerts are desired, add a
+cron schedule to the workflow and route failed workflow notifications to the
+owner's chosen channel.
+
+## Alert Routing Options
+
+Pick one primary owner-visible channel and one fallback:
+
+- GitHub Actions failure notifications for the manual or future scheduled
+  workflow.
+- Cron `MAILTO` to an operations mailbox.
+- A small wrapper that posts only failure summaries to Telegram, Slack, Discord,
+  or another webhook.
+- Uptime-style public checks from a separate VPS if a second cheap host exists.
+
+Alert payloads should include the failing check names and timestamps, not env
+dumps, private keys, Drive folder IDs, tokens, or database connection strings.
+
+## Failure Triage
+
+Public `/api/health` fails:
+
+```bash
+ssh mvn-api
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --tail=120 app
+systemctl status nginx --no-pager
+```
+
+Products or filters config fail while health is green:
+
+```bash
+ssh mvn-api
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml logs --tail=120 app
+docker compose -f docker-compose.prod.yml exec -T db sh -lc 'pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+```
+
+SSH host checks fail:
+
+```bash
+ssh -o BatchMode=yes mvn-api true
+```
+
+If SSH fails only from GitHub Actions, treat it as network/firewall/key reachability
+first, not as an API application failure.
+
+Disk or inode usage is critical:
+
+```bash
+ssh mvn-api
+df -h /
+df -ih /
+docker system df
+journalctl --disk-usage
+```
+
+Do cleanup only after identifying the large files or Docker layers. Avoid broad
+deletes during an incident.
+
+Container or DB readiness fails:
+
+```bash
+ssh mvn-api
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs --tail=120 db app bot
+```
+
+TLS expiry warns or fails:
+
+```bash
+ssh mvn-api
+certbot certificates
+certbot renew --dry-run
+nginx -t
+```
+
+Backup freshness fails:
+
+```bash
+ssh mvn-api
+cd /opt/air-api
+docker compose -f docker-compose.prod.yml logs --tail=200 app | grep -i backup
+docker compose -f docker-compose.prod.yml exec -T app python3 - <<'PY'
+from services.backup_service import backup_service
+print(len(backup_service.list_backups(limit=100)))
+PY
+```
+
+Check that production still has `ENVIRONMENT=production`, `BACKUP_FOLDER_ID`,
+and the mounted Google credential files expected by `docker-compose.prod.yml`.
+Trigger a manual backup only after the owner approves a state-changing action.
+
+## Safety Notes
+
+- The monitor does not run `docker compose config`, because that can expand env
+  values into logs.
+- The monitor does not SSH unless `API_SSH_HOST` and `API_SSH_USER` are set.
+- The backup freshness check runs inside the existing `app` container and prints
+  only backup kind, age, creation time, and filename.
+- Public-only mode is safe for external cron and does not require production
+  credentials.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -287,6 +287,25 @@ After apply, smoke-check:
 - `/api/v1/products?limit=5`
 - `/api/v1/filters/config`
 
+## API VPS Monitoring
+
+Use `scripts/check_api_vps_health.sh` for cheap API VPS monitoring and runbook
+checks. It validates the public API endpoints, and when SSH is configured it
+also checks disk/inodes, Docker services, Postgres readiness, localhost app
+health, nginx TLS expiry, and Google Drive backup freshness from inside the app
+container.
+
+```bash
+# Public API only, safe from any machine
+bash scripts/check_api_vps_health.sh --public-only
+
+# Full VPS + backup freshness checks from a trusted machine
+API_SSH_HOST=mvn-api API_SSH_USER=root bash scripts/check_api_vps_health.sh
+```
+
+See `docs/api-vps-monitoring.md` for cron examples, the manual GitHub Actions
+workflow, alert routing options, and failure triage.
+
 ## Product Media R2/S3 Rollout
 
 Product image variant storage can be switched from local files to R2/S3-compatible

--- a/scripts/check_api_vps_health.sh
+++ b/scripts/check_api_vps_health.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://api.mvn.by}"
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
+
+API_SSH_HOST="${API_SSH_HOST:-}"
+API_SSH_USER="${API_SSH_USER:-}"
+API_SSH_PORT="${API_SSH_PORT:-22}"
+API_SSH_KEY_PATH="${API_SSH_KEY_PATH:-}"
+API_SSH_STRICT_HOST_KEY_CHECKING="${API_SSH_STRICT_HOST_KEY_CHECKING:-accept-new}"
+API_SSH_CONNECT_TIMEOUT="${API_SSH_CONNECT_TIMEOUT:-10}"
+API_PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+API_COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
+API_TLS_HOST="${API_TLS_HOST:-api.mvn.by}"
+
+DISK_WARN_PCT="${DISK_WARN_PCT:-80}"
+DISK_CRITICAL_PCT="${DISK_CRITICAL_PCT:-90}"
+INODE_WARN_PCT="${INODE_WARN_PCT:-80}"
+INODE_CRITICAL_PCT="${INODE_CRITICAL_PCT:-90}"
+TLS_WARN_DAYS="${TLS_WARN_DAYS:-14}"
+TLS_CRITICAL_DAYS="${TLS_CRITICAL_DAYS:-3}"
+BACKUP_MAX_AGE_HOURS="${BACKUP_MAX_AGE_HOURS:-36}"
+CHECK_BACKUPS="${CHECK_BACKUPS:-true}"
+
+PUBLIC_ONLY=false
+critical_failures=0
+warnings=0
+TMP_DIR=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/check_api_vps_health.sh [--public-only]
+
+Checks the current API VPS without printing secret values.
+
+Default behavior:
+  1. Always checks public API endpoints from BASE_URL.
+  2. Runs SSH host checks only when API_SSH_HOST and API_SSH_USER are set.
+  3. Works as public-only automatically when SSH env is absent.
+
+Options:
+  --public-only  Skip SSH, Docker, database, TLS-origin, and backup checks.
+  -h, --help     Show this help text.
+
+Common env:
+  BASE_URL=https://api.mvn.by
+  API_SSH_HOST=mvn-api
+  API_SSH_USER=root
+  API_SSH_KEY_PATH=~/.ssh/id_ed25519
+  BACKUP_MAX_AGE_HOURS=36
+  CHECK_BACKUPS=true
+
+Exit code:
+  0 when critical checks pass.
+  non-zero when public endpoints, SSH host checks, containers, DB readiness,
+  localhost health, TLS critical expiry, or backup freshness checks fail.
+USAGE
+}
+
+log() {
+  local stage="$1"
+  shift
+  printf '[api-vps][%s] %s\n' "${stage}" "$*"
+}
+
+ok() {
+  log ok "$*"
+}
+
+warn() {
+  warnings=$((warnings + 1))
+  log warn "$*"
+}
+
+fail() {
+  critical_failures=$((critical_failures + 1))
+  log fail "$*"
+}
+
+cleanup() {
+  if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+is_unsigned_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_unsigned_number() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+
+normalize_bool() {
+  case "$1" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On) printf 'true' ;;
+    false|FALSE|False|0|no|NO|No|off|OFF|Off) printf 'false' ;;
+    *) return 1 ;;
+  esac
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    --public-only)
+      PUBLIC_ONLY=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log error "unsupported argument: ${arg}"
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+BASE_URL="${BASE_URL%/}"
+if [[ "${API_SSH_KEY_PATH}" == "~/"* && -n "${HOME:-}" ]]; then
+  API_SSH_KEY_PATH="${HOME}/${API_SSH_KEY_PATH#~/}"
+fi
+if [[ -z "${BASE_URL}" ]]; then
+  fail "BASE_URL cannot be empty"
+fi
+
+if ! is_unsigned_int "${CURL_CONNECT_TIMEOUT}" || ! is_unsigned_int "${CURL_MAX_TIME}"; then
+  fail "CURL_CONNECT_TIMEOUT and CURL_MAX_TIME must be positive integers"
+fi
+if ! is_unsigned_int "${API_SSH_PORT}" || ! is_unsigned_int "${API_SSH_CONNECT_TIMEOUT}"; then
+  fail "API_SSH_PORT and API_SSH_CONNECT_TIMEOUT must be positive integers"
+fi
+if ! is_unsigned_int "${DISK_WARN_PCT}" || ! is_unsigned_int "${DISK_CRITICAL_PCT}"; then
+  fail "DISK_WARN_PCT and DISK_CRITICAL_PCT must be integer percentages"
+fi
+if ! is_unsigned_int "${INODE_WARN_PCT}" || ! is_unsigned_int "${INODE_CRITICAL_PCT}"; then
+  fail "INODE_WARN_PCT and INODE_CRITICAL_PCT must be integer percentages"
+fi
+if ! is_unsigned_int "${TLS_WARN_DAYS}" || ! is_unsigned_int "${TLS_CRITICAL_DAYS}"; then
+  fail "TLS_WARN_DAYS and TLS_CRITICAL_DAYS must be integer day counts"
+fi
+if ! is_unsigned_number "${BACKUP_MAX_AGE_HOURS}"; then
+  fail "BACKUP_MAX_AGE_HOURS must be a non-negative number"
+fi
+if ! CHECK_BACKUPS="$(normalize_bool "${CHECK_BACKUPS}")"; then
+  fail "CHECK_BACKUPS must be true or false"
+fi
+
+if (( critical_failures > 0 )); then
+  log summary "status=failed critical_failures=${critical_failures} warnings=${warnings}"
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  fail "curl is not installed locally"
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "python3 is not installed locally"
+fi
+if [[ "${PUBLIC_ONLY}" != "true" && ( -n "${API_SSH_HOST}" || -n "${API_SSH_USER}" ) ]]; then
+  if ! command -v ssh >/dev/null 2>&1; then
+    fail "ssh is not installed locally"
+  fi
+  if [[ -z "${API_SSH_HOST}" || -z "${API_SSH_USER}" ]]; then
+    fail "set both API_SSH_HOST and API_SSH_USER for SSH checks, or pass --public-only"
+  fi
+  if [[ -n "${API_SSH_KEY_PATH}" && ! -r "${API_SSH_KEY_PATH}" ]]; then
+    fail "API_SSH_KEY_PATH is not readable: ${API_SSH_KEY_PATH}"
+  fi
+fi
+
+if (( critical_failures > 0 )); then
+  log summary "status=failed critical_failures=${critical_failures} warnings=${warnings}"
+  exit 1
+fi
+
+curl_to_file() {
+  local label="$1"
+  local url="$2"
+  local output_file="$3"
+  local curl_output
+
+  log public "GET ${url}"
+  if curl_output="$(curl -fsS --connect-timeout "${CURL_CONNECT_TIMEOUT}" --max-time "${CURL_MAX_TIME}" -o "${output_file}" "${url}" 2>&1)"; then
+    ok "public ${label} responded"
+    return 0
+  fi
+
+  fail "public ${label} failed: ${curl_output}"
+  return 1
+}
+
+run_public_checks() {
+  local health_file products_file filters_file public_ok validation_output
+
+  TMP_DIR="$(mktemp -d)"
+  health_file="${TMP_DIR}/health.json"
+  products_file="${TMP_DIR}/products.json"
+  filters_file="${TMP_DIR}/filters.json"
+  public_ok=true
+
+  curl_to_file "health" "${BASE_URL}/api/health" "${health_file}" || public_ok=false
+  curl_to_file "products" "${BASE_URL}/api/v1/products?limit=5" "${products_file}" || public_ok=false
+  curl_to_file "filters config" "${BASE_URL}/api/v1/filters/config" "${filters_file}" || public_ok=false
+
+  if [[ "${public_ok}" != "true" ]]; then
+    return 0
+  fi
+
+  if validation_output="$(python3 - "${health_file}" "${products_file}" "${filters_file}" <<'PY' 2>&1
+import json
+import sys
+
+health_path, products_path, filters_path = sys.argv[1:4]
+
+with open(health_path, "r", encoding="utf-8") as fh:
+    health = json.load(fh)
+with open(products_path, "r", encoding="utf-8") as fh:
+    products = json.load(fh)
+with open(filters_path, "r", encoding="utf-8") as fh:
+    filters_cfg = json.load(fh)
+
+if health.get("status") != "ok":
+    raise SystemExit(f"health status is not ok: {health.get('status')!r}")
+if health.get("database") != "online":
+    raise SystemExit(f"database status is not online: {health.get('database')!r}")
+
+items = products.get("items")
+if not isinstance(items, list):
+    raise SystemExit("products payload missing list items")
+if len(items) < 1:
+    raise SystemExit("products endpoint returned zero items")
+
+for required_key in ("price", "area", "brands", "expert_tags"):
+    if required_key not in filters_cfg:
+        raise SystemExit(f"filters config missing key: {required_key}")
+
+print(f"public_health_status={health.get('status')}")
+print(f"public_database_status={health.get('database')}")
+print(f"public_products_count={len(items)}")
+print(f"public_filters_keys={','.join(sorted(filters_cfg.keys()))}")
+PY
+)"; then
+    while IFS= read -r line; do
+      if [[ -n "${line}" ]]; then
+        log public "${line}"
+      fi
+    done <<< "${validation_output}"
+    ok "public API payload validation passed"
+  else
+    fail "public API payload validation failed: ${validation_output}"
+  fi
+}
+
+run_ssh_checks() {
+  local ssh_cmd=(
+    ssh
+    -p "${API_SSH_PORT}"
+    -o BatchMode=yes
+    -o "StrictHostKeyChecking=${API_SSH_STRICT_HOST_KEY_CHECKING}"
+    -o "ConnectTimeout=${API_SSH_CONNECT_TIMEOUT}"
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=2
+  )
+
+  if [[ -n "${API_SSH_KEY_PATH}" ]]; then
+    ssh_cmd+=(-i "${API_SSH_KEY_PATH}")
+  fi
+  ssh_cmd+=("${API_SSH_USER}@${API_SSH_HOST}")
+
+  log ssh "running optional host checks on ${API_SSH_USER}@${API_SSH_HOST}:${API_SSH_PORT}"
+  if "${ssh_cmd[@]}" bash -s -- \
+    "${API_PROJECT_DIR}" \
+    "${API_COMPOSE_FILE}" \
+    "${DISK_WARN_PCT}" \
+    "${DISK_CRITICAL_PCT}" \
+    "${INODE_WARN_PCT}" \
+    "${INODE_CRITICAL_PCT}" \
+    "${TLS_WARN_DAYS}" \
+    "${TLS_CRITICAL_DAYS}" \
+    "${BACKUP_MAX_AGE_HOURS}" \
+    "${CHECK_BACKUPS}" \
+    "${API_TLS_HOST}" <<'REMOTE'
+set -euo pipefail
+
+PROJECT_DIR="$1"
+COMPOSE_FILE="$2"
+DISK_WARN_PCT="$3"
+DISK_CRITICAL_PCT="$4"
+INODE_WARN_PCT="$5"
+INODE_CRITICAL_PCT="$6"
+TLS_WARN_DAYS="$7"
+TLS_CRITICAL_DAYS="$8"
+BACKUP_MAX_AGE_HOURS="$9"
+CHECK_BACKUPS="${10}"
+API_TLS_HOST="${11}"
+
+remote_failures=0
+remote_warnings=0
+
+remote_log() {
+  local stage="$1"
+  shift
+  printf '[api-vps][ssh:%s] %s\n' "${stage}" "$*"
+}
+
+remote_ok() {
+  remote_log ok "$*"
+}
+
+remote_warn() {
+  remote_warnings=$((remote_warnings + 1))
+  remote_log warn "$*"
+}
+
+remote_fail() {
+  remote_failures=$((remote_failures + 1))
+  remote_log fail "$*"
+}
+
+is_int() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+print_prefixed() {
+  local stage="$1"
+  local content="$2"
+  while IFS= read -r line; do
+    if [[ -n "${line}" ]]; then
+      remote_log "${stage}" "${line}"
+    fi
+  done <<< "${content}"
+}
+
+check_pct() {
+  local label="$1"
+  local value="$2"
+  local warn_pct="$3"
+  local critical_pct="$4"
+  local detail="$5"
+
+  if ! is_int "${value}"; then
+    remote_warn "${label} usage is unavailable (${detail})"
+    return
+  fi
+
+  if (( value >= critical_pct )); then
+    remote_fail "${label} usage critical: ${value}% (${detail})"
+  elif (( value >= warn_pct )); then
+    remote_warn "${label} usage high: ${value}% (${detail})"
+  else
+    remote_ok "${label} usage ${value}% (${detail})"
+  fi
+}
+
+if [[ ! -d "${PROJECT_DIR}" ]]; then
+  remote_fail "project dir not found: ${PROJECT_DIR}"
+else
+  remote_ok "project dir exists: ${PROJECT_DIR}"
+fi
+
+if [[ -d "${PROJECT_DIR}" && ! -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]]; then
+  remote_fail "compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}"
+fi
+
+disk_pct="$(df -P / | awk 'NR == 2 {gsub("%", "", $5); print $5}' || true)"
+disk_detail="$(df -P / | awk 'NR == 2 {print "mount=" $6 " avail_kb=" $4}' || true)"
+check_pct "disk" "${disk_pct}" "${DISK_WARN_PCT}" "${DISK_CRITICAL_PCT}" "${disk_detail:-unknown}"
+
+inode_pct="$(df -Pi / | awk 'NR == 2 {gsub("%", "", $5); print $5}' || true)"
+inode_detail="$(df -Pi / | awk 'NR == 2 {print "mount=" $6 " iavail=" $4}' || true)"
+check_pct "inode" "${inode_pct}" "${INODE_WARN_PCT}" "${INODE_CRITICAL_PCT}" "${inode_detail:-unknown}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  remote_fail "docker is not installed"
+elif ! docker compose version >/dev/null 2>&1; then
+  remote_fail "docker compose is not available"
+elif [[ -d "${PROJECT_DIR}" && -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]]; then
+  cd "${PROJECT_DIR}"
+  COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+  if compose_ps_output="$("${COMPOSE[@]}" ps 2>&1)"; then
+    remote_ok "docker compose ps succeeded"
+    print_prefixed compose "${compose_ps_output}"
+  else
+    remote_fail "docker compose ps failed: ${compose_ps_output}"
+  fi
+
+  running_services="$("${COMPOSE[@]}" ps --services --filter status=running 2>/dev/null || true)"
+  for service in app bot db; do
+    if printf '%s\n' "${running_services}" | grep -Fxq "${service}"; then
+      remote_ok "container running: ${service}"
+    else
+      remote_fail "container is not running: ${service}"
+    fi
+  done
+
+  if "${COMPOSE[@]}" exec -T db sh -lc 'pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null' >/dev/null 2>&1; then
+    remote_ok "Postgres pg_isready passed inside db container"
+  else
+    remote_fail "Postgres pg_isready failed inside db container"
+  fi
+
+  if command -v curl >/dev/null 2>&1; then
+    if local_health_payload="$(curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8000/api/health 2>/dev/null)"; then
+      if command -v python3 >/dev/null 2>&1; then
+        if HEALTH_PAYLOAD="${local_health_payload}" python3 - <<'PY' >/dev/null 2>&1
+import json
+import os
+
+payload = json.loads(os.environ["HEALTH_PAYLOAD"])
+if payload.get("status") != "ok" or payload.get("database") != "online":
+    raise SystemExit(1)
+PY
+        then
+          remote_ok "localhost app health passed"
+        else
+          remote_fail "localhost app health returned an invalid payload"
+        fi
+      else
+        remote_ok "localhost app health responded; python3 unavailable on host so payload shape was not validated"
+      fi
+    else
+      remote_fail "localhost app health failed at http://127.0.0.1:8000/api/health"
+    fi
+  else
+    remote_warn "curl is not installed on host; localhost app health skipped"
+  fi
+
+  if command -v openssl >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    cert_end="$(
+      {
+        printf '' \
+          | timeout 15 openssl s_client -servername "${API_TLS_HOST}" -connect 127.0.0.1:443 2>/dev/null \
+          | openssl x509 -noout -enddate 2>/dev/null \
+          | sed 's/^notAfter=//'
+      } || true
+    )"
+    if [[ -z "${cert_end}" ]]; then
+      remote_warn "nginx TLS expiry could not be read from 127.0.0.1:443"
+    elif cert_epoch="$(date -d "${cert_end}" +%s 2>/dev/null)"; then
+      now_epoch="$(date +%s)"
+      days_left=$(( (cert_epoch - now_epoch) / 86400 ))
+      if (( days_left < 0 )); then
+        remote_fail "nginx TLS certificate is expired (${cert_end})"
+      elif (( days_left < TLS_CRITICAL_DAYS )); then
+        remote_fail "nginx TLS certificate expires in ${days_left} day(s) (${cert_end})"
+      elif (( days_left < TLS_WARN_DAYS )); then
+        remote_warn "nginx TLS certificate expires in ${days_left} day(s) (${cert_end})"
+      else
+        remote_ok "nginx TLS certificate has ${days_left} day(s) remaining"
+      fi
+    else
+      remote_warn "nginx TLS expiry date could not be parsed: ${cert_end}"
+    fi
+  else
+    remote_warn "openssl or timeout is unavailable on host; nginx TLS expiry skipped"
+  fi
+
+  if [[ "${CHECK_BACKUPS}" == "true" ]]; then
+    if backup_output="$("${COMPOSE[@]}" exec -T app python3 - "${BACKUP_MAX_AGE_HOURS}" <<'PY'
+import logging
+import sys
+from datetime import datetime, timezone
+
+logging.disable(logging.CRITICAL)
+
+try:
+    from services.backup_service import backup_service
+except Exception as exc:
+    print(f"backup_check_status=error error_type={type(exc).__name__}")
+    raise SystemExit(2)
+
+try:
+    max_age_hours = float(sys.argv[1])
+except (IndexError, ValueError):
+    print("backup_check_status=error error_type=InvalidMaxAge")
+    raise SystemExit(2)
+
+try:
+    items = backup_service.list_backups(limit=100)
+except Exception as exc:
+    print(f"backup_check_status=error error_type={type(exc).__name__}")
+    raise SystemExit(2)
+
+now = datetime.now(timezone.utc)
+failures = 0
+
+for kind in ("db", "media"):
+    latest = next((item for item in items if item.get("kind") == kind), None)
+    if latest is None:
+        print(f"backup_kind={kind} status=missing")
+        failures += 1
+        continue
+
+    created_at = latest.get("created_at")
+    if not isinstance(created_at, datetime):
+        print(f"backup_kind={kind} status=invalid_created_at")
+        failures += 1
+        continue
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+
+    age_hours = max(0.0, (now - created_at).total_seconds() / 3600)
+    status = "fresh" if age_hours <= max_age_hours else "stale"
+    name = str(latest.get("name") or "<unnamed>")
+    if len(name) > 120:
+        name = name[:117] + "..."
+
+    print(
+        f"backup_kind={kind} status={status} "
+        f"age_hours={age_hours:.1f} created_at={created_at.isoformat()} name={name}"
+    )
+    if status != "fresh":
+        failures += 1
+
+print(f"backup_items_seen={len(items)} max_age_hours={max_age_hours:g}")
+raise SystemExit(1 if failures else 0)
+PY
+)"; then
+      print_prefixed backup "${backup_output}"
+      remote_ok "backup freshness passed"
+    else
+      print_prefixed backup "${backup_output}"
+      remote_fail "backup freshness failed"
+    fi
+  else
+    remote_warn "backup freshness skipped because CHECK_BACKUPS=false"
+  fi
+fi
+
+if (( remote_failures > 0 )); then
+  remote_log summary "status=failed critical_failures=${remote_failures} warnings=${remote_warnings}"
+  exit 1
+fi
+
+remote_log summary "status=passed critical_failures=0 warnings=${remote_warnings}"
+REMOTE
+  then
+    ok "optional SSH host checks passed"
+  else
+    fail "optional SSH host checks failed"
+  fi
+}
+
+run_public_checks
+
+if [[ "${PUBLIC_ONLY}" == "true" ]]; then
+  log ssh "skipped (--public-only)"
+elif [[ -n "${API_SSH_HOST}" && -n "${API_SSH_USER}" ]]; then
+  run_ssh_checks
+else
+  log ssh "skipped (API_SSH_HOST/API_SSH_USER not set)"
+fi
+
+if (( critical_failures > 0 )); then
+  log summary "status=failed critical_failures=${critical_failures} warnings=${warnings}"
+  exit 1
+fi
+
+log summary "status=passed critical_failures=0 warnings=${warnings}"


### PR DESCRIPTION
## Summary
- add a repo-native API VPS health check script for public API, optional SSH host checks, container/db/TLS checks, and backup freshness
- add a manual GitHub Actions workflow for public-only or SSH-backed API VPS health checks
- document API VPS monitoring, alert routing, failure triage, and single-VPS API migration runbook
- link the monitoring runbook from deployment docs

## Validation
- `bash -n scripts/check_api_vps_health.sh`
- `bash scripts/check_api_vps_health.sh --help`
- `bash scripts/check_api_vps_health.sh --public-only`
- `env -u API_SSH_HOST -u API_SSH_USER bash scripts/check_api_vps_health.sh`
- `API_SSH_HOST=mvn-api API_SSH_USER=root bash scripts/check_api_vps_health.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/check-api-vps-health.yml")'`
- `git diff --check`
- Markdown fence/trailing whitespace checks on the new docs

## Notes
- Production state was not changed; the SSH check is read-only.
- The new workflow is manual-only until the owner chooses an alert channel.
- `generated_documents/` remains untracked and untouched.

Closes #431
Closes #432
