### PR TITLE
[codex] Add single-active scheduler and bot controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,15 @@ ADMIN_USERNAME=
 ADMIN_PASSWORD=
 SECRET_KEY=
 
+# --- Runtime role / single-active controls ---
+# Current primary/default behavior: APP_ROLE=primary, scheduler follows APP_ROLE,
+# bot polling follows APP_ROLE.
+# Standby API: set APP_ROLE=standby, SCHEDULER_ENABLED=false, BOT_ENABLED=false,
+# and do not start the bot service.
+APP_ROLE=primary
+# SCHEDULER_ENABLED=true
+# BOT_ENABLED=true
+
 # --- PostgreSQL ---
 POSTGRES_USER=
 POSTGRES_PASSWORD=

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -2,6 +2,7 @@ import asyncio
 from aiogram import types
 from .config import bot, dp
 from .handlers import base, catalog, orders, admin, favorites, cart
+from core.config import settings
 from core.logger import setup_logging
 
 # Setup logging with session-specific bot.log (cleared on restart)
@@ -11,10 +12,23 @@ logger = setup_logging(session_log_file="logs/bot.log", clear_session_log=True)
 @dp.error()
 async def error_handler(event: types.ErrorEvent):
     logger.exception(f"Bot error: {event.exception} for event {event.update}")
-    return True 
+    return True
 
-async def main():
-    logger.info("Starting bot...")
+async def _idle_when_disabled() -> None:
+    while True:
+        await asyncio.sleep(3600)
+
+
+async def main(*, wait_when_disabled: bool = True):
+    decision = settings.bot_control_decision
+    if not decision.enabled:
+        logger.warning("Telegram bot polling disabled: %s.", decision.reason)
+        if wait_when_disabled:
+            logger.info("Bot process is idling without polling to avoid restart loops.")
+            await _idle_when_disabled()
+        return
+
+    logger.info("Starting bot polling: %s.", decision.reason)
     # Register routers in specific order
     dp.include_router(base.router)
     dp.include_router(catalog.router)

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -21,12 +21,23 @@ async def _resume_catalog_import_jobs() -> None:
     await catalog_import_runtime_service.resume_pending_jobs()
 
 
-def _start_scheduler_loop() -> None:
+def _start_scheduler_loop() -> bool:
+    decision = settings.scheduler_control_decision
+    if not decision.enabled:
+        logger.warning("Scheduler startup skipped: %s.", decision.reason)
+        return False
+
+    logger.info(
+        "Scheduler startup enabled: %s. interval_hours=%s",
+        decision.reason,
+        settings.SCHEDULER_INTERVAL,
+    )
     from services.scheduler_service import scheduler_service
 
     asyncio.create_task(
         scheduler_service.start_loop(interval_hours=settings.SCHEDULER_INTERVAL)
     )
+    return True
 
 
 @asynccontextmanager

--- a/core/config.py
+++ b/core/config.py
@@ -1,8 +1,15 @@
 import os
 from dotenv import load_dotenv
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from core.runtime_controls import (
+    RuntimeControlDecision,
+    resolve_single_active_control,
+)
+
 load_dotenv()
+
 
 class Settings(BaseSettings):
     # Bot Settings
@@ -11,6 +18,7 @@ class Settings(BaseSettings):
     ADMIN_ID: int = 0
     SECRET_KEY: str
     ENVIRONMENT: str = "local"
+    APP_ROLE: str = "primary"
     
     # CORS Settings
     @property
@@ -96,6 +104,33 @@ class Settings(BaseSettings):
     
     # Automation
     SCHEDULER_INTERVAL: int = 6 # hours
+    SCHEDULER_ENABLED: bool | None = None
+    BOT_ENABLED: bool | None = None
+
+    @field_validator("SCHEDULER_ENABLED", "BOT_ENABLED", mode="before")
+    @classmethod
+    def _blank_runtime_switch_is_unset(cls, value: object) -> object | None:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
+    @property
+    def scheduler_control_decision(self) -> RuntimeControlDecision:
+        return resolve_single_active_control(
+            app_role=self.APP_ROLE,
+            explicit_enabled=self.SCHEDULER_ENABLED,
+            env_var_name="SCHEDULER_ENABLED",
+            process_label="scheduler loops",
+        )
+
+    @property
+    def bot_control_decision(self) -> RuntimeControlDecision:
+        return resolve_single_active_control(
+            app_role=self.APP_ROLE,
+            explicit_enabled=self.BOT_ENABLED,
+            env_var_name="BOT_ENABLED",
+            process_label="Telegram bot polling",
+        )
 
     # Monitoring
     SENTRY_DSN: str = ""

--- a/core/runtime_controls.py
+++ b/core/runtime_controls.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+
+ACTIVE_APP_ROLES = frozenset({"primary", "active"})
+STANDBY_APP_ROLES = frozenset({"standby", "passive", "readonly", "read-only", "read_only"})
+
+
+@dataclass(frozen=True)
+class RuntimeControlDecision:
+    enabled: bool
+    reason: str
+
+
+def normalize_app_role(app_role: str | None) -> str:
+    role = (app_role or "primary").strip().lower()
+    return role or "primary"
+
+
+def resolve_single_active_control(
+    *,
+    app_role: str | None,
+    explicit_enabled: bool | None,
+    env_var_name: str,
+    process_label: str,
+) -> RuntimeControlDecision:
+    if explicit_enabled is not None:
+        state = "true" if explicit_enabled else "false"
+        action = "enables" if explicit_enabled else "disables"
+        return RuntimeControlDecision(
+            enabled=bool(explicit_enabled),
+            reason=f"{env_var_name}={state} explicitly {action} {process_label}",
+        )
+
+    role = normalize_app_role(app_role)
+    if role in ACTIVE_APP_ROLES:
+        return RuntimeControlDecision(
+            enabled=True,
+            reason=f"APP_ROLE={role} allows active {process_label}",
+        )
+    if role in STANDBY_APP_ROLES:
+        return RuntimeControlDecision(
+            enabled=False,
+            reason=f"APP_ROLE={role} disables active {process_label}",
+        )
+
+    return RuntimeControlDecision(
+        enabled=False,
+        reason=(
+            f"APP_ROLE={role!r} is not an active role; "
+            f"{process_label} is disabled by default"
+        ),
+    )

--- a/docs/api-vps-migration-runbook.md
+++ b/docs/api-vps-migration-runbook.md
@@ -31,12 +31,46 @@ Current production assumptions:
 Hard safety rules:
 
 - Do not run two active `bot` services against the same bot token.
-- Do not run two active production `app` services after the freeze, because the scheduler is started inside `app` lifecycle and can run price sync, backups, lead archival, supplier sync, and mail imports.
-- During cutover, stop old `app` and `bot` before starting the new production `app`.
+- Do not run two active primary `app` services. A passive standby `app` is allowed only with `APP_ROLE=standby`, scheduler disabled, and no bot polling.
+- During cutover, stop old `app` and `bot` before promoting the new production `app`.
 - Start the new `bot` only after the new `app` has passed app-only and public smoke checks.
 - If rollback is needed, stop new `app` and `bot` before restarting old `app` and `bot`.
 
-Issue #433 is expected to add stronger single-active controls later. Until then, the operator must enforce single-active behavior manually.
+Runtime role controls:
+
+| Host mode | Services | Required env | Expected startup logs |
+| --- | --- | --- | --- |
+| Primary/current production | `db`, `app`, `bot` | `APP_ROLE=primary` or unset; `SCHEDULER_ENABLED`/`BOT_ENABLED` unset or `true` | `Scheduler startup enabled`; `Starting bot polling` |
+| Standby/passive API | `db`, `app` only | `APP_ROLE=standby`, `SCHEDULER_ENABLED=false`, `BOT_ENABLED=false` | `Scheduler startup skipped`; no bot polling |
+
+Unset or empty runtime env values follow `APP_ROLE`, and missing `APP_ROLE`
+defaults to `primary` for current production compatibility. `SCHEDULER_ENABLED`
+and `BOT_ENABLED` are explicit overrides. If they are set to `false`, they keep
+the scheduler or bot disabled even when `APP_ROLE=primary`. Remove the override
+or set it to `true` before promotion. If a standby `bot` container is
+accidentally started while `BOT_ENABLED=false` or `APP_ROLE=standby`, it stays
+idle without Telegram polling so Compose `restart: always` does not create a
+restart loop.
+
+These controls do not enable Cloudflare load balancing, automatic failover, or
+public standby cutover. Do not route public write traffic to a standby host.
+
+Passive standby verification is app-only and must not change Cloudflare, DNS, or
+load balancing:
+
+```bash
+ssh "${API_USER}@${NEW_API_HOST}"
+cd /opt/air-api
+printf '\nAPP_ROLE=standby\nSCHEDULER_ENABLED=false\nBOT_ENABLED=false\n' >> .env
+docker compose -f docker-compose.prod.yml up -d db app
+docker compose -f docker-compose.prod.yml stop bot || true
+docker compose -f docker-compose.prod.yml logs --tail=120 app | grep 'Scheduler startup skipped'
+curl -fsS http://127.0.0.1:8000/api/health
+```
+
+Use full `scripts/check_api_vps_health.sh` only for the primary host because it
+expects `app`, `bot`, and `db` to be running. For standby, use public/app-only
+health checks against the standby origin.
 
 ## Variables
 
@@ -291,6 +325,11 @@ docker compose -f docker-compose.cutover.yml ps
 
 Do not start `app` or `bot` yet.
 
+If this host was previously used for passive standby verification, leave
+`APP_ROLE=standby`, `SCHEDULER_ENABLED=false`, and `BOT_ENABLED=false` in place
+until the maintenance freeze. Before Phase 7 promotion, flip them to primary
+values as shown there.
+
 ## Phase 4: Freeze Old API
 
 Schedule a maintenance window. The freeze starts when old `app` and `bot` are stopped.
@@ -390,12 +429,30 @@ docker compose -f docker-compose.cutover.yml run -T --rm app python3 scripts/ens
 
 At this point old `app` and old `bot` must still be stopped.
 
+Promote the new host to primary before starting the long-running app. If standby
+vars were added earlier, remove the explicit disables or set them to `true`:
+
+```bash
+cd /opt/air-api
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path(".env")
+lines = path.read_text(encoding="utf-8").splitlines()
+drop = {"APP_ROLE", "SCHEDULER_ENABLED", "BOT_ENABLED"}
+kept = [line for line in lines if line.split("=", 1)[0].strip() not in drop]
+kept.extend(["APP_ROLE=primary", "SCHEDULER_ENABLED=true", "BOT_ENABLED=true"])
+path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+PY
+```
+
 Start the new app only:
 
 ```bash
 docker compose -f docker-compose.cutover.yml up -d app
 docker compose -f docker-compose.cutover.yml ps
 docker compose -f docker-compose.cutover.yml logs --tail=120 app
+docker compose -f docker-compose.cutover.yml logs --tail=120 app | grep 'Scheduler startup enabled'
 ```
 
 Run local app smoke:
@@ -503,6 +560,16 @@ ssh "${API_USER}@${NEW_API_HOST}" '
   set -euo pipefail
   cd /opt/air-api
   docker compose -f docker-compose.cutover.yml stop bot app || true
+  python3 - <<'"'"'PY'"'"'
+from pathlib import Path
+
+path = Path(".env")
+lines = path.read_text(encoding="utf-8").splitlines()
+drop = {"APP_ROLE", "SCHEDULER_ENABLED", "BOT_ENABLED"}
+kept = [line for line in lines if line.split("=", 1)[0].strip() not in drop]
+kept.extend(["APP_ROLE=standby", "SCHEDULER_ENABLED=false", "BOT_ENABLED=false"])
+path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+PY
   docker compose -f docker-compose.cutover.yml ps
 '
 ```
@@ -540,6 +607,8 @@ If the new API accepted writes, orders, imports, media uploads, or bot interacti
 - New VPS has Docker, Compose, nginx, firewall, and TLS ready.
 - `/opt/air-api/.env`, compose, Google credential files, media, and final DB dump restored on new VPS.
 - Old `app` and `bot` stopped before new `app` starts.
+- If the new host was used as standby, `APP_ROLE=primary`, `SCHEDULER_ENABLED=true`, and `BOT_ENABLED=true` are set before promotion.
+- New `app` logs `Scheduler startup enabled` during cutover.
 - New `app` passes localhost and nginx-origin smoke.
 - Cloudflare `api.mvn.by` points to new IP.
 - GitHub `SSH_HOST_API` points to new IP.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,37 @@ recreates `app` and `bot`, so the app binding change is applied by the deploy.
 The `db` container is intentionally not force-recreated on every deploy; apply
 the DB port binding during a short maintenance window.
 
+### API Runtime Roles
+
+The backend image has single-active runtime controls for future standby work.
+Current production does not need new env values: missing `APP_ROLE`,
+empty `APP_ROLE`, empty `SCHEDULER_ENABLED`, and empty `BOT_ENABLED` are treated
+as the active primary default.
+
+| Host mode | Services | Required env | Behavior |
+| --- | --- | --- | --- |
+| Primary/current production | `db`, `app`, `bot` | `APP_ROLE=primary` or unset; `SCHEDULER_ENABLED`/`BOT_ENABLED` unset or `true` | FastAPI starts scheduler loops; bot starts Telegram polling. |
+| Standby/passive API | `db`, `app` only | `APP_ROLE=standby`, `SCHEDULER_ENABLED=false`, `BOT_ENABLED=false` | FastAPI serves passive health/API checks without scheduler loops; bot must not be started. If started accidentally, it idles without polling. |
+
+`SCHEDULER_ENABLED` and `BOT_ENABLED` are explicit overrides. If either is set
+to `false`, that process stays disabled even when `APP_ROLE=primary`; remove the
+override or set it to `true` before promoting a standby host.
+
+These controls do not enable Cloudflare load balancing, automatic failover, or
+public standby cutover. Do not route public write traffic to a standby host.
+
+Passive standby smoke, without changing Cloudflare or enabling failover:
+
+```bash
+ssh <standby-api-host>
+cd /opt/air-api
+printf '\nAPP_ROLE=standby\nSCHEDULER_ENABLED=false\nBOT_ENABLED=false\n' >> .env
+docker compose -f docker-compose.prod.yml up -d db app
+docker compose -f docker-compose.prod.yml stop bot || true
+docker compose -f docker-compose.prod.yml logs --tail=120 app | grep 'Scheduler startup skipped'
+curl -fsS http://127.0.0.1:8000/api/health
+```
+
 Before merging or deploying a compose hardening change, save the current
 production compose file:
 

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -1,0 +1,114 @@
+import importlib
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from core.runtime_controls import resolve_single_active_control
+
+
+def _set_required_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123:test")
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("ADMIN_PASSWORD", "admin")
+
+
+def test_standby_role_disables_scheduler_by_default():
+    decision = resolve_single_active_control(
+        app_role="standby",
+        explicit_enabled=None,
+        env_var_name="SCHEDULER_ENABLED",
+        process_label="scheduler loops",
+    )
+
+    assert decision.enabled is False
+    assert "APP_ROLE=standby" in decision.reason
+
+
+def test_primary_role_enables_scheduler_by_default():
+    decision = resolve_single_active_control(
+        app_role="primary",
+        explicit_enabled=None,
+        env_var_name="SCHEDULER_ENABLED",
+        process_label="scheduler loops",
+    )
+
+    assert decision.enabled is True
+    assert "APP_ROLE=primary" in decision.reason
+
+
+def test_explicit_switch_overrides_app_role():
+    decision = resolve_single_active_control(
+        app_role="standby",
+        explicit_enabled=True,
+        env_var_name="SCHEDULER_ENABLED",
+        process_label="scheduler loops",
+    )
+
+    assert decision.enabled is True
+    assert "SCHEDULER_ENABLED=true" in decision.reason
+
+
+def test_unknown_app_role_fails_closed():
+    decision = resolve_single_active_control(
+        app_role="api",
+        explicit_enabled=None,
+        env_var_name="BOT_ENABLED",
+        process_label="Telegram bot polling",
+    )
+
+    assert decision.enabled is False
+    assert "not an active role" in decision.reason
+
+
+def test_empty_runtime_switch_env_values_are_unset(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    settings = config.Settings(
+        BOT_TOKEN="123:test",
+        SECRET_KEY="test-secret",
+        ADMIN_USERNAME="admin",
+        ADMIN_PASSWORD="admin",
+        SCHEDULER_ENABLED="",
+        BOT_ENABLED="",
+        _env_file=None,
+    )
+
+    assert settings.SCHEDULER_ENABLED is None
+    assert settings.BOT_ENABLED is None
+    assert settings.scheduler_control_decision.enabled is True
+    assert settings.bot_control_decision.enabled is True
+
+
+def test_start_scheduler_loop_skips_for_standby(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
+    create_task = Mock()
+    monkeypatch.setattr(app_lifespan.asyncio, "create_task", create_task)
+
+    assert app_lifespan._start_scheduler_loop() is False
+    create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_main_disabled_does_not_poll(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+    monkeypatch.setattr(config.settings, "BOT_TOKEN", "123:test", raising=False)
+    bot_main = importlib.import_module("bot_app.main")
+
+    monkeypatch.setattr(bot_main.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(bot_main.settings, "BOT_ENABLED", None, raising=False)
+    delete_webhook = AsyncMock()
+    start_polling = AsyncMock()
+    monkeypatch.setattr(bot_main.bot, "delete_webhook", delete_webhook)
+    monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
+
+    await bot_main.main(wait_when_disabled=False)
+
+    delete_webhook.assert_not_awaited()
+    start_polling.assert_not_awaited()


### PR DESCRIPTION
Closes #433.

## What changed
- Added `APP_ROLE`, `SCHEDULER_ENABLED`, and `BOT_ENABLED` runtime controls for scheduler loops and Telegram bot polling.
- Scheduler startup now logs whether it is enabled or skipped, and standby roles fail closed.
- Bot polling now honors the same single-active controls and idles without polling when disabled to avoid Compose restart loops.
- Hardened blank `SCHEDULER_ENABLED=` / `BOT_ENABLED=` env values so they behave like unset values.
- Updated deployment and migration docs with primary vs standby service/env matrices, passive smoke checks, promotion/rollback notes, and explicit Cloudflare/LB non-enablement warnings.

## Validation
- `python3 -m py_compile core/runtime_controls.py core/config.py core/app_lifespan.py bot_app/main.py tests/unit/test_runtime_controls.py`
- `BOT_TOKEN=123:test SECRET_KEY=x ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_runtime_controls.py tests/unit/test_notification_service.py tests/unit/test_manager_backups_api_unit.py -q`
- `git diff --check`

## Ops notes
- Primary/current production may leave the new env vars unset; defaults keep scheduler and bot polling active.
- Standby/passive API should run `db` + `app` with `APP_ROLE=standby`, `SCHEDULER_ENABLED=false`, and `BOT_ENABLED=false`; do not start `bot`.
- This PR does not enable Cloudflare load balancing, automatic failover, or public standby cutover.