### PR TITLE
[codex] Hide unpublished products from public detail

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -45,9 +45,13 @@ class ProductDAO:
         session: AsyncSession,
         product_id: int,
         *,
+        is_published: Optional[bool] = None,
         load_image_variants: bool = False,
     ) -> Optional[Product]:
-        stmt = select(Product).where(Product.id == product_id).options(
+        stmt = select(Product).where(Product.id == product_id)
+        if is_published is not None:
+            stmt = stmt.where(Product.is_published == is_published)
+        stmt = stmt.options(
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -60,9 +64,13 @@ class ProductDAO:
         session: AsyncSession,
         slug: str,
         *,
+        is_published: Optional[bool] = None,
         load_image_variants: bool = False,
     ) -> Optional[Product]:
-        stmt = select(Product).where(Product.slug == slug).options(
+        stmt = select(Product).where(Product.slug == slug)
+        if is_published is not None:
+            stmt = stmt.where(Product.is_published == is_published)
+        stmt = stmt.options(
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -122,7 +122,7 @@ async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_sess
 
 @router.get("/v1/products/{identifier}", response_model=ProductResponse, operation_id="get_product")
 async def get_product_by_identifier(identifier: str, session: AsyncSession = Depends(get_session)):
-    product = await ProductService.get_product_by_identifier(session, identifier)
+    product = await ProductService.get_public_product_by_identifier(session, identifier)
     if not product:
         raise HTTPException(status_code=404, detail=f"Product with identifier '{identifier}' not found")
     siblings = await ProductService.get_series_siblings(session, product, limit=8)

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -223,6 +223,24 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
         )
 
     @staticmethod
+    async def get_public_product_by_identifier(session: AsyncSession, identifier: str) -> Optional[Product]:
+        if identifier.isdigit():
+            product = await ProductDAO.get_by_id(
+                session,
+                int(identifier),
+                is_published=True,
+                load_image_variants=True,
+            )
+            if product:
+                return product
+        return await ProductDAO.get_by_slug(
+            session,
+            identifier,
+            is_published=True,
+            load_image_variants=True,
+        )
+
+    @staticmethod
     async def get_all(session: AsyncSession) -> List[Dict[str, Any]]:
         products = await ProductDAO.get_all_published(session)
         return [ProductReadService._to_dict(p) for p in products]

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -52,6 +52,41 @@ async def test_product_detail(async_client: AsyncClient, seed_product):
 
 
 @pytest.mark.asyncio
+async def test_public_product_detail_hides_unpublished_slug(async_client: AsyncClient, db):
+    product = Product(
+        title="Hidden Detail Product",
+        slug="hidden-detail-product",
+        price=1000,
+        area=25,
+        is_published=False,
+    )
+    db.add(product)
+    await db.commit()
+
+    response = await async_client.get(f"/api/v1/products/{product.slug}")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_public_product_detail_hides_unpublished_id(async_client: AsyncClient, db):
+    product = Product(
+        title="Hidden Detail Product By ID",
+        slug="hidden-detail-product-by-id",
+        price=1000,
+        area=25,
+        is_published=False,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    response = await async_client.get(f"/api/v1/products/{product.id}")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_public_product_payload_exposes_approved_ready_image_variants(async_client: AsyncClient, db):
     product = Product(
         title="Approved Variant Product",

--- a/tests/integration/test_manager_products_visibility_api.py
+++ b/tests/integration/test_manager_products_visibility_api.py
@@ -1,0 +1,41 @@
+import pytest
+
+from core.config import settings
+from models import Product
+
+
+async def _auth_headers(async_client):
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_manager_products_list_can_show_unpublished_product(async_client, db):
+    headers = await _auth_headers(async_client)
+    marker = "MANAGERHIDDEN466"
+    product = Product(
+        title=f"{marker} Draft Product",
+        slug=f"{marker.lower()}-draft-product",
+        price=1000,
+        area=25,
+        is_published=False,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    response = await async_client.get(
+        "/api/manager/products/list",
+        headers=headers,
+        params={"search": marker, "limit": 100},
+    )
+
+    assert response.status_code == 200, response.text
+    items = response.json()["items"]
+    match = next(item for item in items if item["id"] == product.id)
+    assert match["is_published"] is False

--- a/tests/unit/test_public_product_availability_api.py
+++ b/tests/unit/test_public_product_availability_api.py
@@ -68,7 +68,7 @@ async def test_public_product_detail_includes_city_availability(monkeypatch):
     async def override_get_session():
         yield object()
 
-    async def fake_get_product_by_identifier(*args, **kwargs):
+    async def fake_get_public_product_by_identifier(*args, **kwargs):
         return product
 
     async def fake_get_series_siblings(*args, **kwargs):
@@ -83,7 +83,7 @@ async def test_public_product_detail_includes_city_availability(monkeypatch):
             }
         }
 
-    monkeypatch.setattr(ProductService, "get_product_by_identifier", fake_get_product_by_identifier)
+    monkeypatch.setattr(ProductService, "get_public_product_by_identifier", fake_get_public_product_by_identifier)
     monkeypatch.setattr(ProductService, "get_series_siblings", fake_get_series_siblings)
     monkeypatch.setattr(ProductService, "get_supply_metrics_map", fake_get_supply_metrics_map)
     app.dependency_overrides[get_session] = override_get_session


### PR DESCRIPTION
## Summary
- add a public-only product detail lookup that requires `is_published=true`
- keep the existing generic product lookup available for manager/internal flows
- cover public slug/id 404 behavior for unpublished products and manager list visibility for drafts

## Root cause
Public `/api/v1/products/{identifier}` used the generic product lookup, which fetched products by id/slug without applying the publication filter already used by catalog/list endpoints.

## Tests
- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_public_product_availability_api.py -q`
- `BOT_TOKEN=test SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_catalog_api.py tests/integration/test_manager_products_visibility_api.py -q`
- `git diff --check`

Closes #466