### PR TITLE
[codex] Add staging Astro SSR runtime spike

### DIFF
--- a/deployment/nginx/mvn-ssr-staging-location.conf
+++ b/deployment/nginx/mvn-ssr-staging-location.conf
@@ -1,0 +1,32 @@
+# Include this snippet inside /etc/nginx/sites-available/mvn.by for the first
+# Astro SSR runtime spike only. It must not replace the production static root.
+#
+# Basic auth setup:
+#   apt-get install -y apache2-utils
+#   htpasswd -c /etc/nginx/.htpasswd-ssr-staging <user>
+#
+# Optional IP allowlist can be used instead of, or in addition to, basic auth:
+#   allow <office-or-vpn-ip>;
+#   deny all;
+
+location = /__ssr-staging {
+    return 301 /__ssr-staging/;
+}
+
+location ^~ /__ssr-staging/ {
+    auth_basic "mvn.by SSR staging";
+    auth_basic_user_file /etc/nginx/.htpasswd-ssr-staging;
+
+    add_header X-Robots-Tag "noindex, nofollow" always;
+    add_header Cache-Control "no-store" always;
+
+    proxy_pass http://127.0.0.1:4321;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /__ssr-staging;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -1,13 +1,33 @@
-version: '3.8'
-
 services:
-  web:
+  web-ssr-staging:
     build:
       context: ./web
       dockerfile: Dockerfile.prod
-    restart: always
+      args:
+        INTERNAL_API_URL: ${SSR_INTERNAL_API_URL:-https://api.mvn.by/api/v1}
+        PUBLIC_API_URL: ${PUBLIC_API_URL:-https://api.mvn.by/api/v1}
+        PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+        PUBLIC_GTM_ID: ${PUBLIC_GTM_ID:-}
+        SSR_STAGING_BASE_PATH: ${SSR_STAGING_BASE_PATH:-/__ssr-staging}
+    image: mvn-web-ssr-staging:local
+    restart: unless-stopped
     ports:
-      - "4321:4321"
+      - "127.0.0.1:${SSR_STAGING_PORT:-4321}:4321"
     environment:
-      - PUBLIC_API_URL=https://api.mvn.by/api/v1
-      - INTERNAL_API_URL=https://api.mvn.by/api/v1
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 4321
+      INTERNAL_API_URL: ${SSR_INTERNAL_API_URL:-https://api.mvn.by/api/v1}
+      PUBLIC_API_URL: ${PUBLIC_API_URL:-https://api.mvn.by/api/v1}
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      SSR_STAGING_BASE_PATH: ${SSR_STAGING_BASE_PATH:-/__ssr-staging}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"const p=process.env.SSR_STAGING_BASE_PATH||'/__ssr-staging'; fetch('http://127.0.0.1:'+(process.env.PORT||4321)+p+'/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s

--- a/docs/astro-ssr-staging-runbook.md
+++ b/docs/astro-ssr-staging-runbook.md
@@ -1,0 +1,195 @@
+# Astro SSR Staging Spike Runbook
+
+Related issue: #464
+
+This spike proves the Astro Node runtime on the new web VPS without moving the
+public `mvn.by` production root away from the current static deploy.
+
+## Guardrails
+
+- Public production `mvn.by` remains static from `/var/www/mvn.by/current`.
+- Existing `web/astro.config.mjs`, `npm run build`, `deploy.yml`, and
+  `rebuild-web.yml` keep their static behavior.
+- The SSR runtime is exposed only under `/__ssr-staging/` and should be guarded
+  by basic auth or an IP allowlist.
+- The first spike uses public `https://api.mvn.by/api/v1` for both build-time
+  prerendering and runtime SSR fetches.
+
+## What This PR Implements
+
+- `web/astro.config.ssr.mjs`: separate Astro Node standalone server config.
+- `web/package.json`: explicit `build:ssr:staging`, `start:ssr:staging`, and
+  `smoke:ssr:staging` scripts.
+- `web/Dockerfile.prod`: builds the staging SSR server output; static GitHub
+  Actions deploys do not use this image path.
+- `docker-compose.web.yml`: localhost-bound Docker Compose service for the
+  staging Node runtime.
+- `deployment/nginx/mvn-ssr-staging-location.conf`: hidden nginx location
+  snippet for `/__ssr-staging/`.
+- `web/scripts/smoke-ssr-staging.mjs`: smoke checks for `/`, `/catalog/`, a
+  query catalog URL, `/brands/`, one product URL, and one `/_astro/*` asset.
+
+## Route Policy
+
+Prerendered/static in the staging SSR build:
+
+- `/`
+- product detail pages under `/product/[slug]`
+- service pages and service landing pages
+- brand detail pages under `/brands/[slug]`
+- popular catalog SEO pages under `/catalog/[virtual]`
+- blog, legal, cart, checkout, success, contact, and static content shells
+
+Runtime SSR in the staging build:
+
+- `/catalog/`
+- `/catalog/?...` query pages
+- `/brands/`
+
+This is intentionally conservative. It gives the spike a real request-time
+freshness path for catalog and brand lists while preserving the most important
+SEO/static entry points.
+
+## Local Smoke
+
+From `web/`:
+
+```bash
+INTERNAL_API_URL=https://api.mvn.by/api/v1 \
+PUBLIC_API_URL=https://api.mvn.by/api/v1 \
+SSR_STAGING_BASE_PATH=/__ssr-staging \
+npm run build:ssr:staging
+
+HOST=127.0.0.1 PORT=4321 npm run start:ssr:staging
+```
+
+In another shell:
+
+```bash
+SSR_SMOKE_BASE_URL=http://127.0.0.1:4321/__ssr-staging \
+SSR_SMOKE_API_URL=https://api.mvn.by/api/v1 \
+npm run smoke:ssr:staging
+```
+
+If the API catalog lookup should not choose the product automatically, set:
+
+```bash
+SSR_SMOKE_PRODUCT_PATH=/product/<known-slug>/ npm run smoke:ssr:staging
+```
+
+## Web VPS Staging Deploy
+
+On the new web VPS:
+
+```bash
+cd /opt/air-api
+git pull
+SSR_INTERNAL_API_URL=https://api.mvn.by/api/v1 \
+PUBLIC_API_URL=https://api.mvn.by/api/v1 \
+PUBLIC_SITE_URL=https://mvn.by \
+SSR_STAGING_BASE_PATH=/__ssr-staging \
+SSR_STAGING_PORT=4321 \
+docker compose -f docker-compose.web.yml up -d --build web-ssr-staging
+```
+
+The service binds to `127.0.0.1:4321`; do not expose it directly to the public
+internet.
+
+Install the nginx snippet inside the existing `mvn.by` server block:
+
+```bash
+cp deployment/nginx/mvn-ssr-staging-location.conf /etc/nginx/snippets/mvn-ssr-staging-location.conf
+sed -i '/server_name mvn.by www.mvn.by;/a\\    include /etc/nginx/snippets/mvn-ssr-staging-location.conf;' /etc/nginx/sites-available/mvn.by
+nginx -t
+systemctl reload nginx
+```
+
+Run origin smoke:
+
+```bash
+SSR_SMOKE_BASE_URL=http://127.0.0.1:4321/__ssr-staging \
+npm --prefix web run smoke:ssr:staging
+```
+
+Run hidden nginx smoke from an allowed/authenticated context:
+
+```bash
+SSR_SMOKE_BASE_URL=https://mvn.by/__ssr-staging \
+SSR_SMOKE_BASIC_AUTH='<user>:<password>' \
+SSR_SMOKE_PRODUCT_PATH=/product/<known-slug>/ \
+npm --prefix web run smoke:ssr:staging
+```
+
+## Hybrid Freshness Design
+
+High-freshness public data:
+
+- product price and old price;
+- product availability and stock-derived status;
+- product publication state;
+- catalog membership and sort order;
+- brand/product list counts.
+
+Current spike behavior:
+
+- `/catalog/`, query catalog pages, and `/brands/` fetch from the API at request
+  time in the Node runtime.
+- Product detail pages remain prerendered for SEO/performance; client-side price
+  and availability refresh remains a safety layer, but detail HTML freshness is
+  not promoted in this issue.
+- Corrected prices and publication changes should be validated through catalog
+  and brand list pages before any public SSR cutover.
+
+Follow-up freshness work to investigate:
+
+- API/catalog revision endpoint, for example `/api/v1/catalog/revision`, bumped
+  by manager writes that affect public catalog output.
+- SSR data cache keyed by revision plus route/query, with short TTL fallback.
+- Explicit invalidation trigger from manager after price, availability,
+  publication, or product-list updates.
+- Product detail runtime mode or partial hydration strategy that prevents
+  unpublished products and corrected prices from lingering in initial HTML.
+
+Suggested initial cache rules for future promotion:
+
+- `/_astro/*`: `Cache-Control: public, max-age=31536000, immutable`.
+- SSR HTML containing price, availability, or publication state: start with
+  `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` or bypass
+  Cloudflare until behavior is measured.
+- Query catalog pages: `noindex,follow` and bypass or very short edge TTL.
+- Cart, checkout, lead/order POSTs, API, and manager paths: no edge caching.
+- During the hidden staging spike: nginx sends `Cache-Control: no-store`.
+
+## Static Rollback Retention
+
+Keep at least three static releases on disk:
+
+```text
+/var/www/mvn.by/releases/<timestamp-a>
+/var/www/mvn.by/releases/<timestamp-b>
+/var/www/mvn.by/releases/<timestamp-c>
+/var/www/mvn.by/current -> /var/www/mvn.by/releases/<active>
+```
+
+Fast rollback to static-only:
+
+```bash
+cd /var/www/mvn.by
+ln -sfn /var/www/mvn.by/releases/<known-good> current
+rm -f /etc/nginx/snippets/mvn-ssr-staging-location.conf
+nginx -t
+systemctl reload nginx
+cd /opt/air-api
+docker compose -f docker-compose.web.yml stop web-ssr-staging
+```
+
+Then smoke the static production root:
+
+```bash
+curl -I https://mvn.by/
+curl -I https://mvn.by/catalog/
+curl -I https://www.mvn.by/
+```
+
+The existing manual `rebuild-web.yml` workflow remains the GitHub rollback path
+for rebuilding and rsyncing static `web/dist/` to `SSH_WEB_TARGET`.

--- a/docs/astro-ssr-vps-plan.md
+++ b/docs/astro-ssr-vps-plan.md
@@ -2,6 +2,11 @@
 
 Related issue: #461
 
+Issue #464 staging spike implementation now lives in
+[`docs/astro-ssr-staging-runbook.md`](astro-ssr-staging-runbook.md). The
+production recommendation remains unchanged: keep public `mvn.by` static until
+the staging runtime, cache behavior, and rollback path are proven.
+
 This is a planning document for using the new web VPS capabilities safely. It
 does not change production, Cloudflare, DNS, VPS state, secrets, or env.
 

--- a/web/Dockerfile.prod
+++ b/web/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:21-slim AS base
+FROM node:20-slim AS base
 WORKDIR /app
 
 COPY package*.json ./
@@ -11,14 +11,25 @@ RUN npm install
 
 FROM build-deps AS build
 COPY . .
-RUN npm run build
+ARG INTERNAL_API_URL=https://api.mvn.by/api/v1
+ARG PUBLIC_API_URL=https://api.mvn.by/api/v1
+ARG PUBLIC_SITE_URL=https://mvn.by
+ARG PUBLIC_GTM_ID=
+ARG SSR_STAGING_BASE_PATH=/__ssr-staging
+ENV INTERNAL_API_URL=${INTERNAL_API_URL}
+ENV PUBLIC_API_URL=${PUBLIC_API_URL}
+ENV PUBLIC_SITE_URL=${PUBLIC_SITE_URL}
+ENV PUBLIC_GTM_ID=${PUBLIC_GTM_ID}
+ENV SSR_STAGING_BASE_PATH=${SSR_STAGING_BASE_PATH}
+RUN npm run build:ssr:staging
 
 FROM base AS runtime
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
+ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=4321
 EXPOSE 4321
 
-CMD ["node", "./dist/server/entry.mjs"]
+CMD ["npm", "run", "start:ssr:staging"]

--- a/web/astro.config.ssr.mjs
+++ b/web/astro.config.ssr.mjs
@@ -1,0 +1,24 @@
+import { defineConfig } from 'astro/config';
+import vue from '@astrojs/vue';
+import mdx from '@astrojs/mdx';
+import tailwind from '@astrojs/tailwind';
+import sitemap from '@astrojs/sitemap';
+import node from '@astrojs/node';
+
+const normalizeBasePath = (value) => {
+  const raw = String(value || '/__ssr-staging').trim();
+  if (!raw || raw === '/') return '/';
+  return `/${raw.replace(/^\/+|\/+$/g, '')}`;
+};
+
+const stagingBasePath = normalizeBasePath(process.env.SSR_STAGING_BASE_PATH);
+
+// Staging-only Astro Node runtime config for issue #464.
+// Keep web/astro.config.mjs and npm run build static until a production cutover is approved.
+export default defineConfig({
+  site: process.env.PUBLIC_SITE_URL || 'https://mvn.by',
+  base: stagingBasePath,
+  integrations: [vue(), mdx(), tailwind(), sitemap()],
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
+});

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,9 @@
     "check-api": "node scripts/check-api.js",
     "audit:theme": "bash ../scripts/audit_theme_hardcodes.sh",
     "build": "npm run check-api && astro build",
+    "build:ssr:staging": "npm run check-api && astro build --config astro.config.ssr.mjs",
+    "start:ssr:staging": "node ./dist/server/entry.mjs",
+    "smoke:ssr:staging": "node scripts/smoke-ssr-staging.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/web/scripts/smoke-ssr-staging.mjs
+++ b/web/scripts/smoke-ssr-staging.mjs
@@ -1,0 +1,113 @@
+const DEFAULT_BASE_URL = 'http://127.0.0.1:4321/__ssr-staging';
+
+const rawBaseUrl = process.argv[2] || process.env.SSR_SMOKE_BASE_URL || DEFAULT_BASE_URL;
+const baseUrl = new URL(rawBaseUrl.endsWith('/') ? rawBaseUrl : `${rawBaseUrl}/`);
+
+const normalizeApiV1Base = (raw) => {
+  const base = String(raw || '').trim().replace(/\/$/, '');
+  if (!base) return '';
+  if (base.endsWith('/api/v1')) return base;
+  return `${base.replace(/\/api\/v1$/, '')}/api/v1`;
+};
+
+const apiBase = normalizeApiV1Base(
+  process.env.SSR_SMOKE_API_URL ||
+    process.env.INTERNAL_API_URL ||
+    process.env.PUBLIC_API_URL ||
+    'https://api.mvn.by/api/v1',
+);
+const basicAuth = String(process.env.SSR_SMOKE_BASIC_AUTH || '').trim();
+const smokeHeaders = basicAuth
+  ? { Authorization: `Basic ${Buffer.from(basicAuth).toString('base64')}` }
+  : {};
+
+const checked = [];
+
+function resolveSmokeUrl(path) {
+  const marker = new URL(path, 'http://smoke.local');
+  const prefix = baseUrl.pathname.replace(/\/$/, '');
+  const url = new URL(baseUrl.origin);
+  url.pathname = `${prefix}${marker.pathname}`.replace(/\/{2,}/g, '/');
+  url.search = marker.search;
+  return url;
+}
+
+async function fetchRequired(url, label, options = {}) {
+  const response = await fetch(url, {
+    method: options.method || 'GET',
+    headers: smokeHeaders,
+    redirect: options.redirect || 'manual',
+  });
+  checked.push(`${label}: ${response.status} ${url}`);
+
+  if (!response.ok) {
+    throw new Error(`${label} failed with ${response.status}: ${url}`);
+  }
+
+  if (options.text) {
+    return await response.text();
+  }
+
+  return response;
+}
+
+async function resolveProductPath() {
+  const configured = String(process.env.SSR_SMOKE_PRODUCT_PATH || '').trim();
+  if (configured) return configured.startsWith('/') ? configured : `/${configured}`;
+
+  const catalogUrl = `${apiBase}/catalog?limit=1`;
+  const response = await fetch(catalogUrl);
+  if (!response.ok) {
+    throw new Error(`Product smoke lookup failed with ${response.status}: ${catalogUrl}`);
+  }
+
+  const data = await response.json();
+  const slug = data?.items?.find((item) => item?.slug)?.slug;
+  if (!slug) {
+    throw new Error(`Product smoke lookup returned no slug: ${catalogUrl}`);
+  }
+
+  return `/product/${slug}/`;
+}
+
+function resolveAssetUrl(assetRef) {
+  if (!assetRef) {
+    throw new Error('No /_astro asset reference found in SSR HTML.');
+  }
+
+  return new URL(assetRef, baseUrl);
+}
+
+const checks = [
+  ['/', 'home'],
+  ['/catalog/', 'catalog'],
+  ['/catalog/?area_max=35&tag_slugs=cat-household', 'catalog query'],
+  ['/brands/', 'brands'],
+];
+
+try {
+  const homeHtml = await fetchRequired(resolveSmokeUrl('/'), 'home', { text: true });
+
+  for (const [path, label] of checks.slice(1)) {
+    await fetchRequired(resolveSmokeUrl(path), label);
+  }
+
+  const productPath = await resolveProductPath();
+  await fetchRequired(resolveSmokeUrl(productPath), `product ${productPath}`);
+
+  const assetRef = homeHtml.match(/(?:href|src)="([^"]*\/_astro\/[^"]+)"/)?.[1];
+  const assetUrl = resolveAssetUrl(assetRef);
+  await fetchRequired(assetUrl, 'astro asset', { method: 'GET' });
+
+  console.log('SSR staging smoke passed.');
+  for (const line of checked) {
+    console.log(`- ${line}`);
+  }
+} catch (error) {
+  console.error('SSR staging smoke failed.');
+  for (const line of checked) {
+    console.error(`- ${line}`);
+  }
+  console.error(error.message);
+  process.exit(1);
+}

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 
+export const prerender = true;
+
 Astro.response.status = 404;
 ---
 

--- a/web/src/pages/blog/[...slug].astro
+++ b/web/src/pages/blog/[...slug].astro
@@ -2,6 +2,8 @@
 import { getCollection } from 'astro:content';
 import ArticleLayout from '../../layouts/ArticleLayout.astro';
 
+export const prerender = true;
+
 // 1. Генерируем пути для всех статей (Static Site Generation)
 export async function getStaticPaths() {
   const posts = await getCollection('blog');

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -3,6 +3,8 @@ import Layout from "../../layouts/Layout.astro";
 import ArticlePreview from "../../components/blog/ArticlePreview.astro";
 import { getCollection } from "astro:content";
 
+export const prerender = true;
+
 // Получаем все статьи и сортируем по дате (сначала новые)
 const allPosts = await getCollection("blog");
 const sortedPosts = allPosts.sort(

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -6,6 +6,8 @@ import { getCatalog, getFiltersConfig, getPublicBrandBySlug, getPublicBrands, re
 import { formatBrandProductCount } from "../../utils/brands";
 import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 
+export const prerender = true;
+
 interface PublicBrand {
     id: number;
     title: string;

--- a/web/src/pages/cart.astro
+++ b/web/src/pages/cart.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import CartPageFn from "../components/cart/CartPage.vue";
+
+export const prerender = true;
 ---
 
 <Layout title="Корзина">

--- a/web/src/pages/catalog/[virtual].astro
+++ b/web/src/pages/catalog/[virtual].astro
@@ -8,6 +8,8 @@ import { getCatalog, getFiltersConfig } from "../../utils/api";
 import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 import { buildCatalogQueryFromVirtual } from "../../utils/virtual-category";
 
+export const prerender = true;
+
 export async function getStaticPaths() {
     return VIRTUAL_CATEGORIES.map((category) => ({
         params: { virtual: category.slug },

--- a/web/src/pages/checkout.astro
+++ b/web/src/pages/checkout.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import CheckoutFormFn from "../components/checkout/CheckoutForm.vue";
+
+export const prerender = true;
 ---
 
 <Layout title="Оформление заказа">

--- a/web/src/pages/contacts.astro
+++ b/web/src/pages/contacts.astro
@@ -3,6 +3,8 @@ import Layout from "../layouts/Layout.astro";
 import ContactForm from "../components/ContactForm.vue";
 import { getGlobalConfig } from "../utils/api";
 
+export const prerender = true;
+
 const config = await getGlobalConfig();
 const phone = config["phone"] || "+375 (29) 000-00-00";
 const email = config["email"] || "info@master-air.by";

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,6 +4,8 @@ import ProductGroup from "../components/ProductGroup.astro";
 import FeaturedArticles from "../components/blog/FeaturedArticles.astro";
 import { getInstallationPricingInfo } from "../utils/api";
 
+export const prerender = true;
+
 const { minBundlePrice } = await getInstallationPricingInfo();
 
 const heroServices = [

--- a/web/src/pages/kak-vybrat-konditsioner.astro
+++ b/web/src/pages/kak-vybrat-konditsioner.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import PowerCalculator from "../components/PowerCalculator.vue";
+
+export const prerender = true;
 ---
 
 <Layout

--- a/web/src/pages/montaj-konditionerov.astro
+++ b/web/src/pages/montaj-konditionerov.astro
@@ -4,6 +4,8 @@ import ContactForm from "../components/ContactForm.vue";
 import InstallationCalculator from "../components/InstallationCalculator.vue";
 import { getInstallationPricingInfo } from "../utils/api";
 
+export const prerender = true;
+
 const { minStandardPrice, minBundlePrice } = await getInstallationPricingInfo();
 ---
 

--- a/web/src/pages/obslujivanie-kondicionerov.astro
+++ b/web/src/pages/obslujivanie-kondicionerov.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import ContactForm from "../components/ContactForm.vue";
+
+export const prerender = true;
 ---
 
 <Layout

--- a/web/src/pages/offer.astro
+++ b/web/src/pages/offer.astro
@@ -2,6 +2,8 @@
 import Layout from "../layouts/Layout.astro";
 import { getGlobalConfig } from "../utils/api";
 
+export const prerender = true;
+
 const config = await getGlobalConfig();
 const email = config["email"] || "info@mvn.by";
 const phone = config["phone"] || "+375 (29) 000-00-00";

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -2,6 +2,8 @@
 import Layout from "../layouts/Layout.astro";
 import { getGlobalConfig } from "../utils/api";
 
+export const prerender = true;
+
 const config = await getGlobalConfig();
 const email = config["email"] || "info@mvn.by";
 const address = config["address"] || "г. Витебск";

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -17,6 +17,8 @@ import {
 } from "../../utils/spec-dictionary";
 import { generateBentoCards } from "../../utils/bento-cards";
 
+export const prerender = true;
+
 export async function getStaticPaths() {
     const products = await getProducts();
     if (!Array.isArray(products) || products.length === 0) {

--- a/web/src/pages/services/[slug].astro
+++ b/web/src/pages/services/[slug].astro
@@ -2,6 +2,8 @@
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.vue";
 
+export const prerender = true;
+
 type ServicePage = {
     slug: string;
     title: string;

--- a/web/src/pages/services/demontazh-kondicionera.astro
+++ b/web/src/pages/services/demontazh-kondicionera.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.vue";
+
+export const prerender = true;
 ---
 
 <Layout

--- a/web/src/pages/services/index.astro
+++ b/web/src/pages/services/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 
+export const prerender = true;
+
 const services = [
     {
         title: "Монтаж кондиционеров",

--- a/web/src/pages/services/repair.astro
+++ b/web/src/pages/services/repair.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.vue";
+
+export const prerender = true;
 ---
 
 <Layout

--- a/web/src/pages/services/zakladka-kommunikaciy-kondicionera.astro
+++ b/web/src/pages/services/zakladka-kommunikaciy-kondicionera.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.vue";
+
+export const prerender = true;
 ---
 
 <Layout

--- a/web/src/pages/success.astro
+++ b/web/src/pages/success.astro
@@ -1,5 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
+
+export const prerender = true;
 ---
 
 <Layout title="Заказ оформлен">

--- a/web/src/pages/terms.astro
+++ b/web/src/pages/terms.astro
@@ -2,6 +2,8 @@
 import Layout from "../layouts/Layout.astro";
 import { getGlobalConfig } from "../utils/api";
 
+export const prerender = true;
+
 const config = await getGlobalConfig();
 const email = config["email"] || "info@mvn.by";
 const phone = config["phone"] || "+375 (29) 000-00-00";


### PR DESCRIPTION
## Summary

Refs #464.

Adds a staging-only Astro Node runtime spike for the new web VPS while keeping the current production static storefront path intact.

## What changed

- Added a separate `web/astro.config.ssr.mjs` Node standalone config with staging base `/__ssr-staging`.
- Added explicit web scripts: `build:ssr:staging`, `start:ssr:staging`, and `smoke:ssr:staging`.
- Updated `web/Dockerfile.prod` and `docker-compose.web.yml` for a localhost-bound staging SSR process.
- Added an nginx include snippet for hidden `/__ssr-staging/` exposure with basic auth.
- Added a runbook documenting route policy, freshness design, cache/TTL direction, staging deploy, smoke checks, and static rollback retention of at least 3 releases.
- Marked existing SEO/static entry routes with `prerender = true` for the SSR build so product/service/brand detail and popular catalog landing pages stay prerendered.

## Runtime freshness scope

Implemented in the staging SSR build:

- `/catalog/`
- `/catalog/?...` query pages
- `/brands/`

Kept prerendered/static in the staging SSR build:

- `/`
- `/product/[slug]`
- `/brands/[slug]`
- `/catalog/[virtual]`
- service, blog, legal, cart/checkout, success, contact, and static shells

## Validation

- `cd web && INTERNAL_API_URL=https://api.mvn.by/api/v1 PUBLIC_API_URL=https://api.mvn.by/api/v1 npm run build`
- `cd web && INTERNAL_API_URL=https://api.mvn.by/api/v1 PUBLIC_API_URL=https://api.mvn.by/api/v1 SSR_STAGING_BASE_PATH=/__ssr-staging npm run build:ssr:staging`
- `cd web && HOST=127.0.0.1 PORT=4321 INTERNAL_API_URL=https://api.mvn.by/api/v1 PUBLIC_API_URL=https://api.mvn.by/api/v1 SSR_STAGING_BASE_PATH=/__ssr-staging npm run start:ssr:staging`
- `cd web && SSR_SMOKE_BASE_URL=http://127.0.0.1:4321/__ssr-staging SSR_SMOKE_API_URL=https://api.mvn.by/api/v1 npm run smoke:ssr:staging`
- `docker compose -f docker-compose.web.yml config`
- `git diff --check`

Smoke covered `/`, `/catalog/`, one query catalog URL, `/brands/`, `/product/elb07pn/`, and one `/_astro/*` asset.

## Non-goals / guardrails

- No public production `mvn.by` SSR cutover.
- No backend/API changes.
- Existing static `npm run build`, `deploy.yml`, and `rebuild-web.yml` behavior remains intact.
- Product detail initial HTML remains prerendered in this spike; product detail runtime freshness/publication-state hardening is documented as follow-up work.
