### PR TITLE
[codex] Expose brand navigation in storefront

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -52,6 +52,7 @@ class ProductDAO:
         if is_published is not None:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
+            selectinload(Product.brand),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -71,6 +72,7 @@ class ProductDAO:
         if is_published is not None:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
+            selectinload(Product.brand),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -85,6 +87,7 @@ class ProductDAO:
         load_image_variants: bool = False,
     ) -> List[Product]:
         stmt = select(Product).where(Product.is_published == True).options(
+            selectinload(Product.brand),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -102,6 +105,7 @@ class ProductDAO:
         if not product_ids:
             return []
         stmt = select(Product).where(Product.id.in_(product_ids)).options(
+            selectinload(Product.brand),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
@@ -455,6 +459,7 @@ class ProductDAO:
         load_image_variants: bool = False,
     ) -> List[Product]:
         stmt = select(Product).options(
+            selectinload(Product.brand),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -204,6 +204,7 @@ export type { PaymentCurrency } from './models/PaymentCurrency';
 export type { PaymentResponse } from './models/PaymentResponse';
 export type { ProductAvailabilityLeadPayload } from './models/ProductAvailabilityLeadPayload';
 export type { ProductAvailabilityLeadResponse } from './models/ProductAvailabilityLeadResponse';
+export type { ProductBrandResponse } from './models/ProductBrandResponse';
 export type { ProductImageResponse } from './models/ProductImageResponse';
 export type { ProductImageVariantBatchProcessResponse } from './models/ProductImageVariantBatchProcessResponse';
 export type { ProductImageVariantCandidateResponse } from './models/ProductImageVariantCandidateResponse';

--- a/manager_frontend/src/client/models/ProductBrandResponse.ts
+++ b/manager_frontend/src/client/models/ProductBrandResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductBrandResponse = {
+    id: number;
+    title: string;
+    slug: string;
+    logo_url?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ProductResponse.ts
+++ b/manager_frontend/src/client/models/ProductResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductBrandResponse } from './ProductBrandResponse';
 import type { ProductImageResponse } from './ProductImageResponse';
 import type { ProductManualResponse } from './ProductManualResponse';
 import type { ProductSiblingResponse } from './ProductSiblingResponse';
@@ -23,6 +24,7 @@ export type ProductResponse = {
     vitebsk_qty?: number;
     minsk_qty?: number;
     availability_status?: (string | null);
+    brand?: (ProductBrandResponse | null);
     tags?: Array<TagResponse>;
     specs?: Record<string, any>;
     images?: Array<string>;

--- a/openapi.json
+++ b/openapi.json
@@ -23177,6 +23177,40 @@
         ],
         "title": "ProductAvailabilityLeadResponse"
       },
+      "ProductBrandResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logo Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug"
+        ],
+        "title": "ProductBrandResponse"
+      },
       "ProductImageResponse": {
         "properties": {
           "id": {
@@ -23772,6 +23806,16 @@
               }
             ],
             "title": "Availability Status"
+          },
+          "brand": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProductBrandResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "tags": {
             "items": {

--- a/schemas.py
+++ b/schemas.py
@@ -100,10 +100,18 @@ class ProductSiblingResponse(BaseModel):
     main_image: Optional[str]
 
 
+class ProductBrandResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+    logo_url: Optional[str] = None
+
+
 class ProductResponse(ProductBase):
     vitebsk_qty: int = 0
     minsk_qty: int = 0
     availability_status: Optional[str] = None
+    brand: Optional[ProductBrandResponse] = None
     tags: List[TagResponse] = []
     specs: Dict[str, Any] = {}
     images: List[str] = [] # Legacy

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -6,6 +6,7 @@ from models import Product
 from schemas import (
     ProductImageResponse,
     ProductManualResponse,
+    ProductBrandResponse,
     ProductResponse,
     ProductSiblingResponse,
     TagGroupResponse,
@@ -150,6 +151,16 @@ def map_product_to_response(
         vitebsk_qty=int((supply_metrics or {}).get("vitebsk_qty", 0) or 0),
         minsk_qty=int((supply_metrics or {}).get("minsk_qty", 0) or 0),
         availability_status=(supply_metrics or {}).get("availability_status"),
+        brand=(
+            ProductBrandResponse(
+                id=product.brand.id,
+                title=product.brand.title,
+                slug=product.brand.slug,
+                logo_url=product.brand.logo_url,
+            )
+            if product.brand
+            else None
+        ),
         tags=tags_payload,
         specs=specs or {},
         images=images or [],

--- a/tests/integration/test_catalog_api.py
+++ b/tests/integration/test_catalog_api.py
@@ -52,6 +52,40 @@ async def test_product_detail(async_client: AsyncClient, seed_product):
 
 
 @pytest.mark.asyncio
+async def test_public_product_detail_includes_canonical_brand(async_client: AsyncClient, db):
+    brand = Brand(
+        title="Haier",
+        slug="haier",
+        logo_url="/media/brands/haier.svg",
+        is_published=True,
+    )
+    db.add(brand)
+    await db.flush()
+
+    product = Product(
+        title="Haier Brand Detail Product",
+        slug="haier-brand-detail-product",
+        price=1200,
+        area=25,
+        brand_id=brand.id,
+        is_published=True,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    response = await async_client.get(f"/api/v1/products/{product.slug}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["brand"] == {
+        "id": brand.id,
+        "title": "Haier",
+        "slug": "haier",
+        "logo_url": "/media/brands/haier.svg",
+    }
+
+
+@pytest.mark.asyncio
 async def test_public_product_detail_hides_unpublished_slug(async_client: AsyncClient, db):
     product = Product(
         title="Hidden Detail Product",

--- a/web/src/components/ui/MobileMenu.vue
+++ b/web/src/components/ui/MobileMenu.vue
@@ -48,6 +48,13 @@
                 >
                   Полупром
                 </a>
+                <a
+                  href="/brands"
+                  class="nav-subitem"
+                  @click="isOpen = false"
+                >
+                  Бренды
+                </a>
               </div>
               <a href="/services" class="nav-item" @click="isOpen = false">
                 <span class="material-icons-round icon">handyman</span>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -166,6 +166,7 @@ const address = config["address"] || SITE_CONFIG.address;
 							<a href="/catalog?tag_slugs=cat-household">Бытовые</a>
 							<a href="/catalog?tag_slugs=cat-multi">Мультисплит</a>
 							<a href="/catalog?tag_slugs=cat-industrial">Полупром</a>
+							<a href="/brands">Бренды</a>
 						</div>
 					</div>
 					<a href="/services">Услуги</a>
@@ -254,6 +255,7 @@ const address = config["address"] || SITE_CONFIG.address;
 					<h4>Меню</h4>
 					<ul class="footer-links">
 						<li><a href="/catalog">Каталог</a></li>
+						<li><a href="/brands">Бренды</a></li>
 						<li><a href="/services">Услуги</a></li>
 						<li><a href="/contacts">О нас</a></li>
 						<li><a href="/offer">Публичная оферта</a></li>

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import CatalogApp from "../../components/CatalogApp.vue";
 import ProductCard from "../../components/ProductCard.astro";
 import { getCatalog, getFiltersConfig, getPublicBrandBySlug, getPublicBrands, resolveImageUrl } from "../../utils/api";
-import { formatBrandProductCount } from "../../utils/brands";
+import { formatBrandProductCount, getBrandIntro } from "../../utils/brands";
 import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 
 export const prerender = true;
@@ -83,6 +83,7 @@ const logoUrl = brand.logo_url ? resolveImageUrl(brand.logo_url) : "";
 const brandProductCount = formatBrandProductCount(brand.products_count);
 const brandLogoLabel = logoUrl ? `Логотип ${brand.title}` : `${brand.title}: логотип не загружен`;
 const brandInitials = brand.title.trim().slice(0, 2).toUpperCase();
+const brandIntro = getBrandIntro(brand.title, brand.description);
 const seoDescription = `${h1}: подбор, продажа, монтаж и обслуживание. В каталоге ${brandProductCount} с актуальными характеристиками.`;
 const lockedFilters = { brand_slugs: [brand.slug] };
 ---
@@ -107,7 +108,7 @@ const lockedFilters = { brand_slugs: [brand.slug] };
                 <div class="brand-hero-copy">
                     <h1 class="gradient-text">{h1}</h1>
                     <p class="header-description">
-                        {brand.description || `Модели ${brand.title} для квартиры, дома и офиса: подбор по площади, продажа, монтаж и обслуживание в Витебске.`}
+                        {brandIntro}
                     </p>
                     <div class="brand-hero-meta">
                         <span>{brandProductCount}</span>
@@ -127,7 +128,7 @@ const lockedFilters = { brand_slugs: [brand.slug] };
             initialPopularProducts={popularProducts}
             initialFilters={lockedFilters}
             forcedTitle={h1}
-            forcedDescription={seoDescription}
+            forcedDescription={brandIntro}
             lockedInitialFilters={lockedFilters}
             initialCategorySlug=""
             initialBrands={filtersConfig?.brands || []}

--- a/web/src/pages/brands/index.astro
+++ b/web/src/pages/brands/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { getPublicBrands, resolveImageUrl } from "../../utils/api";
-import { formatBrandProductCount } from "../../utils/brands";
+import { formatBrandProductCount, getBrandIntro } from "../../utils/brands";
 
 interface PublicBrand {
     id: number;
@@ -65,7 +65,7 @@ const brandListSchema = {
                             </div>
                             <div class="brand-card-copy">
                                 <h2>{brand.title}</h2>
-                                <p>{brand.description || `Кондиционеры ${brand.title}: подбор по площади, продажа, монтаж и обслуживание в Витебске.`}</p>
+                                <p>{getBrandIntro(brand.title, brand.description)}</p>
                                 <span>{formatBrandProductCount(brand.products_count)} в каталоге</span>
                             </div>
                         </a>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2,11 +2,30 @@
 import Layout from "../layouts/Layout.astro";
 import ProductGroup from "../components/ProductGroup.astro";
 import FeaturedArticles from "../components/blog/FeaturedArticles.astro";
-import { getInstallationPricingInfo } from "../utils/api";
+import { getInstallationPricingInfo, getPublicBrands, resolveImageUrl } from "../utils/api";
+import { formatBrandProductCount, getBrandConfig } from "../utils/brands";
 
 export const prerender = true;
 
 const { minBundlePrice } = await getInstallationPricingInfo();
+
+interface PublicBrand {
+	id: number;
+	title: string;
+	slug: string;
+	logo_url?: string | null;
+	products_count: number;
+	sort_order: number;
+}
+
+const publicBrands = (await getPublicBrands()) as PublicBrand[];
+const homepageBrands = publicBrands
+	.filter((brand) => Number(brand.products_count || 0) > 0)
+	.slice(0, 12);
+const getHomepageBrandLogo = (brand: PublicBrand) =>
+	brand.logo_url ? resolveImageUrl(brand.logo_url) : getBrandConfig(brand.slug).logo || "";
+const getBrandInitials = (brand: PublicBrand) =>
+	brand.title.trim().slice(0, 2).toUpperCase();
 
 const heroServices = [
 	{
@@ -189,6 +208,43 @@ const businessBenefits = [
 			</div>
 		</div>
 	</section>
+
+	{
+		homepageBrands.length > 0 && (
+			<section class="container brand-discovery-section" aria-labelledby="brand-discovery-title">
+				<div class="brand-discovery-head">
+					<div>
+						<p class="section-kicker">Бренды</p>
+						<h2 id="brand-discovery-title">Быстрый переход к моделям</h2>
+					</div>
+					<a href="/brands" class="brand-discovery-all">
+						Все бренды
+						<span class="material-icons-round" aria-hidden="true">arrow_forward</span>
+					</a>
+				</div>
+				<div class="brand-logo-strip" aria-label="Бренды кондиционеров">
+					{homepageBrands.map((brand) => {
+						const logo = getHomepageBrandLogo(brand);
+						return (
+							<a class="brand-logo-link" href={`/brands/${brand.slug}/`} aria-label={`Открыть бренд ${brand.title}`}>
+								<span class="brand-logo-mark">
+									{logo ? (
+										<img src={logo} alt={brand.title} loading="lazy" />
+									) : (
+										<span>{getBrandInitials(brand)}</span>
+									)}
+								</span>
+								<span class="brand-logo-copy">
+									<strong>{brand.title}</strong>
+									<small>{formatBrandProductCount(brand.products_count)}</small>
+								</span>
+							</a>
+						);
+					})}
+				</div>
+			</section>
+		)
+	}
 
 	<section class="container workflow-section">
 		<div class="workflow-panel">
@@ -472,7 +528,7 @@ const businessBenefits = [
 		position: relative;
 		z-index: 2;
 		margin-top: -1rem;
-		margin-bottom: 4rem;
+		margin-bottom: 2.8rem;
 	}
 
 	.bundle-card {
@@ -600,6 +656,114 @@ const businessBenefits = [
 		width: fit-content;
 		background: rgba(var(--surface-rgb), 0.9);
 		color: var(--primary);
+	}
+
+	.brand-discovery-section {
+		margin-bottom: 4rem;
+	}
+
+	.brand-discovery-head {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.brand-discovery-head h2 {
+		margin: 0;
+		color: var(--text);
+		font-family: "Space Grotesk", sans-serif;
+		font-size: 1.45rem;
+		line-height: 1.2;
+	}
+
+	.brand-discovery-all {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		color: var(--primary);
+		font-weight: 800;
+		white-space: nowrap;
+	}
+
+	.brand-discovery-all:hover {
+		color: var(--primary-dark);
+	}
+
+	.brand-logo-strip {
+		display: grid;
+		grid-auto-flow: column;
+		grid-auto-columns: minmax(164px, 1fr);
+		gap: 0.75rem;
+		overflow-x: auto;
+		padding: 0.15rem 0 0.65rem;
+		scroll-snap-type: x proximity;
+		scrollbar-width: thin;
+	}
+
+	.brand-logo-link {
+		display: grid;
+		grid-template-columns: 54px minmax(0, 1fr);
+		align-items: center;
+		gap: 0.75rem;
+		min-height: 78px;
+		padding: 0.7rem 0.85rem;
+		border-radius: 8px;
+		background: var(--panel-glass-bg);
+		border: 1px solid var(--panel-glass-border);
+		box-shadow: var(--panel-glass-shadow);
+		scroll-snap-align: start;
+	}
+
+	.brand-logo-link:hover {
+		border-color: var(--panel-chip-hover-border);
+		transform: translateY(-1px);
+	}
+
+	.brand-logo-mark {
+		width: 54px;
+		height: 54px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 8px;
+		background: var(--panel-chip-bg);
+		border: 1px solid var(--panel-chip-border);
+		color: var(--primary);
+		font-family: "Space Grotesk", sans-serif;
+		font-weight: 800;
+	}
+
+	.brand-logo-mark img {
+		max-width: 42px;
+		max-height: 30px;
+		object-fit: contain;
+	}
+
+	.brand-logo-copy {
+		min-width: 0;
+	}
+
+	.brand-logo-copy strong,
+	.brand-logo-copy small {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.brand-logo-copy strong {
+		color: var(--text);
+		font-size: 0.95rem;
+		line-height: 1.2;
+	}
+
+	.brand-logo-copy small {
+		margin-top: 0.18rem;
+		color: var(--text-muted);
+		font-size: 0.78rem;
+		font-weight: 700;
 	}
 
 	.workflow-section {
@@ -1065,6 +1229,7 @@ const businessBenefits = [
 
 	@media (max-width: 1360px) {
 		.bundle-section,
+		.brand-discovery-section,
 		.workflow-section,
 		.services-section,
 		.audience-section,
@@ -1311,6 +1476,16 @@ const businessBenefits = [
 			width: 100%;
 		}
 
+		.brand-discovery-head {
+			align-items: flex-start;
+		}
+
+		.brand-logo-strip {
+			grid-auto-columns: minmax(152px, 70vw);
+			margin-right: -1.5rem;
+			padding-right: 1.5rem;
+		}
+
 		.workflow-media {
 			min-height: 18rem;
 			padding: 0.9rem;
@@ -1345,6 +1520,21 @@ const businessBenefits = [
 
 		.bundle-stat-value {
 			font-size: 2.45rem;
+		}
+
+		.brand-discovery-head {
+			display: grid;
+		}
+
+		.brand-logo-link {
+			grid-template-columns: 48px minmax(0, 1fr);
+			min-height: 72px;
+			padding: 0.65rem;
+		}
+
+		.brand-logo-mark {
+			width: 48px;
+			height: 48px;
 		}
 	}
 	</style>

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -1050,7 +1050,7 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
         color: var(--text-muted);
         font-size: 0.74rem;
         text-transform: uppercase;
-        letter-spacing: 0.02em;
+        letter-spacing: 0;
     }
 
     .product-brand-arrow {

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -42,6 +42,46 @@ if (!product) {
     return Astro.redirect("/404");
 }
 
+const CATEGORY_BREADCRUMBS: Record<string, { title: string; href: string }> = {
+    "cat-household": {
+        title: "Бытовые кондиционеры",
+        href: "/catalog?tag_slugs=cat-household",
+    },
+    "cat-multi": {
+        title: "Мультисплит",
+        href: "/catalog?tag_slugs=cat-multi",
+    },
+    "cat-industrial": {
+        title: "Полупромышленные кондиционеры",
+        href: "/catalog?tag_slugs=cat-industrial",
+    },
+};
+
+const findTagByGroup = (groupSlug: string) =>
+    (product.tags || []).find((tag: any) => {
+        const tagGroupSlug = tag?.group?.slug || tag?.group_slug;
+        return tagGroupSlug === groupSlug;
+    });
+
+const categoryTag = findTagByGroup("category");
+const categoryBreadcrumb = categoryTag?.slug
+    ? CATEGORY_BREADCRUMBS[String(categoryTag.slug)]
+    : null;
+const brandTag = findTagByGroup("brand");
+const productBrand = product.brand || (
+    brandTag?.slug
+        ? {
+              id: brandTag.id,
+              title: brandTag.title,
+              slug: brandTag.slug,
+              logo_url: null,
+          }
+        : null
+);
+const productBrandLogo = productBrand?.logo_url
+    ? resolveImageUrl(productBrand.logo_url)
+    : "";
+
 const specs = product.specs || {};
 const manuals = (product.manuals || [])
     .map((item: any) => ({
@@ -100,6 +140,22 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
             <span class="sep">/</span>
             <a href="/catalog">Каталог</a>
             <span class="sep">/</span>
+            {
+                categoryBreadcrumb && (
+                    <>
+                        <a href={categoryBreadcrumb.href}>{categoryBreadcrumb.title}</a>
+                        <span class="sep">/</span>
+                    </>
+                )
+            }
+            {
+                productBrand && (
+                    <>
+                        <a href={`/brands/${productBrand.slug}/`}>{productBrand.title}</a>
+                        <span class="sep">/</span>
+                    </>
+                )
+            }
             <span class="active">{product.title}</span>
         </nav>
 
@@ -124,6 +180,25 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
             <!-- Right: Info -->
             <div class="info-col">
                 <div class="header-section">
+                    {
+                        productBrand && (
+                            <a class="product-brand-link" href={`/brands/${productBrand.slug}/`}>
+                                {
+                                    productBrandLogo ? (
+                                        <span class="product-brand-logo">
+                                            <img src={productBrandLogo} alt={productBrand.title} loading="lazy" />
+                                        </span>
+                                    ) : (
+                                        <span class="product-brand-text-kicker">Бренд</span>
+                                    )
+                                }
+                                <span>{productBrand.title}</span>
+                                <span class="material-icons-round product-brand-arrow" aria-hidden="true">
+                                    arrow_forward
+                                </span>
+                            </a>
+                        )
+                    }
                     <div class="badges">
                         {
                             publicTags.map((tag: any) => {
@@ -902,6 +977,7 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
         display: flex;
         gap: 0.5rem;
         align-items: center;
+        flex-wrap: wrap;
     }
     .breadcrumb a:hover {
         color: var(--primary, #007f80);
@@ -930,6 +1006,56 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
     /* Info Column */
     .header-section {
         margin-bottom: 2rem;
+    }
+
+    .product-brand-link {
+        width: fit-content;
+        min-height: 38px;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.65rem;
+        border-radius: 8px;
+        background: var(--panel-chip-bg);
+        border: 1px solid var(--panel-chip-border);
+        color: var(--text);
+        font-size: 0.9rem;
+        font-weight: 800;
+        margin-bottom: 0.65rem;
+    }
+
+    .product-brand-link:hover {
+        border-color: var(--panel-chip-hover-border);
+        color: var(--primary);
+    }
+
+    .product-brand-logo {
+        width: 48px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 6px;
+        background: rgba(var(--surface-rgb), 0.64);
+        border: 1px solid var(--panel-chip-border);
+    }
+
+    .product-brand-logo img {
+        max-width: 38px;
+        max-height: 16px;
+        object-fit: contain;
+    }
+
+    .product-brand-text-kicker {
+        color: var(--text-muted);
+        font-size: 0.74rem;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+    }
+
+    .product-brand-arrow {
+        font-size: 1rem;
+        color: var(--text-muted);
     }
 
     h1 {

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -130,12 +130,28 @@ export async function getFiltersConfig() {
 }
 
 export async function getPublicBrands() {
+    if (import.meta.env.SSR) {
+        for (const baseUrl of getSsgApiCandidates()) {
+            const data = await fetchJson(`${baseUrl}/content/brands`);
+            if (Array.isArray(data)) return data;
+        }
+        return [];
+    }
+
     const data = await fetchJson(`${API_V1}/content/brands`);
     return Array.isArray(data) ? data : [];
 }
 
 export async function getPublicBrandBySlug(slug) {
     if (!slug) return null;
+    if (import.meta.env.SSR) {
+        for (const baseUrl of getSsgApiCandidates()) {
+            const data = await fetchJson(`${baseUrl}/content/brands/${encodeURIComponent(slug)}`);
+            if (data) return data;
+        }
+        return null;
+    }
+
     return await fetchJson(`${API_V1}/content/brands/${encodeURIComponent(slug)}`);
 }
 

--- a/web/src/utils/brands.ts
+++ b/web/src/utils/brands.ts
@@ -30,3 +30,11 @@ export const formatBrandProductCount = (count: number): string => {
 
     return `${normalized} ${noun}`;
 };
+
+export const getBrandIntro = (title: string, description?: string | null): string => {
+    const ownDescription = String(description || "").trim();
+    if (ownDescription) return ownDescription;
+
+    const brandTitle = String(title || "").trim() || "бренда";
+    return `Подбор кондиционеров ${brandTitle} в Витебске: поможем выбрать модель под площадь помещения, условия монтажа и бюджет. Перед заказом уточним наличие и параметры установки.`;
+};


### PR DESCRIPTION
Closes #470

## What changed
- Added a compact brand discovery strip on the storefront homepage with links to public brand pages.
- Added brand links to catalog dropdown, mobile menu, and footer.
- Added short brand landing copy using Manager/API descriptions first, with a safe fallback.
- Added compact product detail brand link and fuller breadcrumbs using category + brand routes.
- Exposed canonical product brand data in the public ProductResponse and regenerated OpenAPI/manager client.

## Verification
- cd web && npm run audit:theme
- cd web && npm run build
- git diff --check
- pytest tests/unit/test_product_response_mapper_variants.py tests/unit/test_product_manuals_payloads.py -q
- Browser preview QA: homepage mobile strip, dark mobile strip, product page breadcrumbs/brand link, brand navigation.

## Notes
- Local integration test for ProductResponse brand was added, but direct local run requires the repo test Postgres hostname db_test to be resolvable.
- npm install reported existing audit findings in web/manager dependency trees; not changed in this PR.
