### PR TITLE
[codex] Add catalog revision endpoint

### DIFF
--- a/crud/catalog_revision.py
+++ b/crud/catalog_revision.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from typing import Iterable, NamedTuple, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import GlobalConfig
+
+
+CATALOG_REVISION_KEY = "catalog_revision"
+CATALOG_REVISION_EPOCH = datetime(1970, 1, 1)
+CATALOG_REVISION_DESCRIPTION = "Monotonic public catalog revision for storefront cache freshness."
+
+
+class CatalogRevisionSnapshot(NamedTuple):
+    revision: int
+    updated_at: datetime
+
+
+def _parse_revision(value: str | None) -> int:
+    try:
+        return max(0, int(str(value or "0")))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _scope_description(scope: str) -> str:
+    normalized_scope = str(scope or "catalog").strip() or "catalog"
+    return f"{CATALOG_REVISION_DESCRIPTION} Last scope: {normalized_scope}."
+
+
+class CatalogRevisionDAO:
+    @staticmethod
+    async def get_current(session: AsyncSession) -> CatalogRevisionSnapshot:
+        row = (
+            await session.execute(
+                select(GlobalConfig).where(GlobalConfig.key == CATALOG_REVISION_KEY)
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return CatalogRevisionSnapshot(revision=0, updated_at=CATALOG_REVISION_EPOCH)
+        return CatalogRevisionSnapshot(
+            revision=_parse_revision(row.value),
+            updated_at=row.updated_at or CATALOG_REVISION_EPOCH,
+        )
+
+    @staticmethod
+    async def bump(
+        session: AsyncSession,
+        *,
+        scope: str,
+        product_ids: Optional[Iterable[int]] = None,
+        slugs: Optional[Iterable[str]] = None,
+        brand_slugs: Optional[Iterable[str]] = None,
+    ) -> CatalogRevisionSnapshot:
+        stmt = select(GlobalConfig).where(GlobalConfig.key == CATALOG_REVISION_KEY).with_for_update()
+        row = (await session.execute(stmt)).scalar_one_or_none()
+        now = datetime.now()
+
+        if row is None:
+            row = GlobalConfig(
+                key=CATALOG_REVISION_KEY,
+                value="0",
+                updated_at=now,
+                description=_scope_description(scope),
+            )
+            session.add(row)
+            await session.flush()
+
+        revision = _parse_revision(row.value) + 1
+        row.value = str(revision)
+        row.updated_at = now
+        row.description = _scope_description(scope)
+
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return CatalogRevisionSnapshot(
+            revision=revision,
+            updated_at=row.updated_at or now,
+        )

--- a/crud/catalog_revision.py
+++ b/crud/catalog_revision.py
@@ -73,8 +73,7 @@ class CatalogRevisionDAO:
         row.description = _scope_description(scope)
 
         session.add(row)
-        await session.commit()
-        await session.refresh(row)
+        await session.flush()
         return CatalogRevisionSnapshot(
             revision=revision,
             updated_at=row.updated_at or now,

--- a/crud/product.py
+++ b/crud/product.py
@@ -549,13 +549,21 @@ class ProductDAO:
         return result.scalar_one() or 0
 
     @staticmethod
-    async def update_price(session: AsyncSession, product_id: int, new_price: int) -> bool:
+    async def update_price(
+        session: AsyncSession,
+        product_id: int,
+        new_price: int,
+        commit: bool = True,
+    ) -> bool:
         product = await session.get(Product, product_id)
         if not product:
             return False
         product.price = new_price
         session.add(product)
-        await session.commit()
+        if commit:
+            await session.commit()
+        else:
+            await session.flush()
         return True
 
     @staticmethod

--- a/crud/product.py
+++ b/crud/product.py
@@ -573,6 +573,7 @@ class ProductDAO:
         product_id: int,
         update_data: Dict[str, Any],
         tag_ids: Optional[List[int]] = None,
+        commit: bool = True,
     ) -> Optional[Product]:
         stmt = (
             select(Product)
@@ -593,8 +594,11 @@ class ProductDAO:
             product.tags = list(tag_result.scalars().all())
 
         session.add(product)
-        await session.commit()
-        await session.refresh(product)
+        if commit:
+            await session.commit()
+            await session.refresh(product)
+        else:
+            await session.flush()
         return product
 
     @staticmethod

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -37,6 +37,7 @@ export type { CatalogImportJobStatusResponse } from './models/CatalogImportJobSt
 export type { CatalogImportPayload } from './models/CatalogImportPayload';
 export type { CatalogImportResultResponse } from './models/CatalogImportResultResponse';
 export type { CatalogResponse } from './models/CatalogResponse';
+export type { CatalogRevisionResponse } from './models/CatalogRevisionResponse';
 export type { CommonGalleryImageResponse } from './models/CommonGalleryImageResponse';
 export type { CustomerPayload } from './models/CustomerPayload';
 export type { DashboardBankReceiptReviewItem } from './models/DashboardBankReceiptReviewItem';

--- a/manager_frontend/src/client/models/CatalogRevisionResponse.ts
+++ b/manager_frontend/src/client/models/CatalogRevisionResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type CatalogRevisionResponse = {
+    revision: number;
+    updated_at: string;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -5,6 +5,7 @@
 import type { AddressSuggestResponse } from '../models/AddressSuggestResponse';
 import type { ArticleResponse } from '../models/ArticleResponse';
 import type { CatalogResponse } from '../models/CatalogResponse';
+import type { CatalogRevisionResponse } from '../models/CatalogRevisionResponse';
 import type { FiltersConfigResponse } from '../models/FiltersConfigResponse';
 import type { OrderPayload } from '../models/OrderPayload';
 import type { OrderResponse } from '../models/OrderResponse';
@@ -106,6 +107,17 @@ export class ApiService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/health',
+        });
+    }
+    /**
+     * Get Catalog Revision
+     * @returns CatalogRevisionResponse Successful Response
+     * @throws ApiError
+     */
+    public static getCatalogRevision(): CancelablePromise<CatalogRevisionResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/catalog/revision',
         });
     }
     /**

--- a/openapi.json
+++ b/openapi.json
@@ -250,6 +250,28 @@
         }
       }
     },
+    "/api/v1/catalog/revision": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Get Catalog Revision",
+        "operationId": "get_catalog_revision",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogRevisionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/content/articles": {
       "get": {
         "tags": [
@@ -12322,6 +12344,25 @@
           "meta"
         ],
         "title": "CatalogResponse"
+      },
+      "CatalogRevisionResponse": {
+        "properties": {
+          "revision": {
+            "type": "integer",
+            "title": "Revision"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "revision",
+          "updated_at"
+        ],
+        "title": "CatalogRevisionResponse"
       },
       "CommonGalleryImageResponse": {
         "properties": {

--- a/routers/api.py
+++ b/routers/api.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter
 
 from routers.api_admin import router as admin_router
+from routers.api_catalog_revision import router as catalog_revision_router
 from routers.api_content import router as content_router
 from routers.api_leads import router as leads_router
 from routers.api_orders import router as orders_router
@@ -10,6 +11,7 @@ from routers.api_proxy import router as proxy_router
 
 router = APIRouter(prefix="/api", tags=["api"])
 router.include_router(admin_router)
+router.include_router(catalog_revision_router)
 router.include_router(content_router)
 router.include_router(leads_router)
 router.include_router(orders_router)

--- a/routers/api_catalog_revision.py
+++ b/routers/api_catalog_revision.py
@@ -1,0 +1,20 @@
+"""Public catalog revision endpoint."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
+from schemas import CatalogRevisionResponse
+from services.catalog_revision_service import CatalogRevisionService
+
+
+router = APIRouter(tags=["api"])
+
+
+@router.get(
+    "/v1/catalog/revision",
+    response_model=CatalogRevisionResponse,
+    operation_id="get_catalog_revision",
+)
+async def get_catalog_revision(session: AsyncSession = Depends(get_session)):
+    return await CatalogRevisionService.get_current(session)

--- a/schemas.py
+++ b/schemas.py
@@ -133,6 +133,12 @@ class CatalogResponse(BaseModel):
     items: List[ProductResponse]
     meta: Meta
 
+
+class CatalogRevisionResponse(BaseModel):
+    revision: int
+    updated_at: datetime
+
+
 class BulkSpecUpdate(BaseModel):
     product_ids: List[int]
     specs: Dict[str, Any]  # Словарь характеристик для добавления/обновления

--- a/services/catalog_revision_service.py
+++ b/services/catalog_revision_service.py
@@ -1,0 +1,36 @@
+from typing import Any, Iterable, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from crud.catalog_revision import CatalogRevisionDAO, CatalogRevisionSnapshot
+
+
+class CatalogRevisionService:
+    @staticmethod
+    def _serialize(row: CatalogRevisionSnapshot) -> dict[str, Any]:
+        return {
+            "revision": row.revision,
+            "updated_at": row.updated_at,
+        }
+
+    @staticmethod
+    async def get_current(session: AsyncSession) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.get_current(session)
+        return CatalogRevisionService._serialize(row)
+
+    @staticmethod
+    async def bump(
+        session: AsyncSession,
+        scope: str,
+        product_ids: Optional[Iterable[int]] = None,
+        slugs: Optional[Iterable[str]] = None,
+        brand_slugs: Optional[Iterable[str]] = None,
+    ) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.bump(
+            session,
+            scope=scope,
+            product_ids=product_ids,
+            slugs=slugs,
+            brand_slugs=brand_slugs,
+        )
+        return CatalogRevisionService._serialize(row)

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import Brand, Product, ProductSeries, ProductTagLink, Tag, TagGroup
+from services.catalog_revision_service import CatalogRevisionService
 
 
 class ManagerBrandService:
@@ -60,6 +61,11 @@ class ManagerBrandService:
 
         await session.commit()
         await session.refresh(brand)
+        await CatalogRevisionService.bump(
+            session,
+            scope="brand_create",
+            brand_slugs=[brand.slug],
+        )
         return ManagerBrandService._serialize_brand(brand, products_count=0)
 
     @staticmethod
@@ -115,6 +121,14 @@ class ManagerBrandService:
 
         await session.commit()
         await session.refresh(brand)
+        changed_slugs = [previous_slug]
+        if brand.slug != previous_slug:
+            changed_slugs.append(brand.slug)
+        await CatalogRevisionService.bump(
+            session,
+            scope="brand_update",
+            brand_slugs=changed_slugs,
+        )
 
         products_count = (
             await session.execute(
@@ -176,8 +190,15 @@ class ManagerBrandService:
                 )
             await session.delete(brand_tag)
 
+        brand_slug = brand.slug
+
         await session.delete(brand)
         await session.commit()
+        await CatalogRevisionService.bump(
+            session,
+            scope="brand_delete",
+            brand_slugs=[brand_slug],
+        )
 
     @staticmethod
     def _serialize_brand(brand: Brand, *, products_count: int = 0) -> Dict[str, Any]:

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -58,14 +58,13 @@ class ManagerBrandService:
         await session.flush()
 
         await ManagerBrandService._sync_brand_tag(session, brand=brand, previous_slug=None)
-
-        await session.commit()
-        await session.refresh(brand)
         await CatalogRevisionService.bump(
             session,
             scope="brand_create",
             brand_slugs=[brand.slug],
         )
+        await session.commit()
+        await session.refresh(brand)
         return ManagerBrandService._serialize_brand(brand, products_count=0)
 
     @staticmethod
@@ -119,8 +118,6 @@ class ManagerBrandService:
 
         await ManagerBrandService._sync_brand_tag(session, brand=brand, previous_slug=previous_slug)
 
-        await session.commit()
-        await session.refresh(brand)
         changed_slugs = [previous_slug]
         if brand.slug != previous_slug:
             changed_slugs.append(brand.slug)
@@ -129,6 +126,8 @@ class ManagerBrandService:
             scope="brand_update",
             brand_slugs=changed_slugs,
         )
+        await session.commit()
+        await session.refresh(brand)
 
         products_count = (
             await session.execute(
@@ -193,12 +192,12 @@ class ManagerBrandService:
         brand_slug = brand.slug
 
         await session.delete(brand)
-        await session.commit()
         await CatalogRevisionService.bump(
             session,
             scope="brand_delete",
             brand_slugs=[brand_slug],
         )
+        await session.commit()
 
     @staticmethod
     def _serialize_brand(brand: Brand, *, products_count: int = 0) -> Dict[str, Any]:

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -8,6 +8,7 @@ from sqlmodel import select
 
 from crud.product import ProductDAO
 from models.product import Product, Tag
+from services.catalog_revision_service import CatalogRevisionService
 from services.product_serialization import sanitize_specs
 from services.product_supply_metrics_service import ProductSupplyMetricsService
 
@@ -281,6 +282,7 @@ class ProductManagerService:
         product = await session.get(Product, product_id)
         if not product:
             return False
+        product_slug = product.slug
             
         # Check if product is used in any orders
         link_check = await session.execute(
@@ -314,6 +316,12 @@ class ProductManagerService:
         
         await session.delete(product)
         await session.commit()
+        await CatalogRevisionService.bump(
+            session,
+            scope="product_delete",
+            product_ids=[product_id],
+            slugs=[product_slug] if product_slug else None,
+        )
         return True
 
     @staticmethod

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -315,13 +315,13 @@ class ProductManagerService:
         )
         
         await session.delete(product)
-        await session.commit()
         await CatalogRevisionService.bump(
             session,
             scope="product_delete",
             product_ids=[product_id],
             slugs=[product_slug] if product_slug else None,
         )
+        await session.commit()
         return True
 
     @staticmethod

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -29,13 +29,14 @@ class ProductService(ProductReadService, ProductWriteService, ProductManagerServ
         product_id: int,
         new_price: int,
     ) -> bool:
-        updated = await ProductDAO.update_price(session, product_id, new_price)
+        updated = await ProductDAO.update_price(session, product_id, new_price, commit=False)
         if updated:
             await CatalogRevisionService.bump(
                 session,
                 scope="product_price",
                 product_ids=[product_id],
             )
+            await session.commit()
         return updated
 
     @staticmethod

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -12,6 +12,7 @@ from sqlmodel import select
 
 from crud.product import ProductDAO
 from models.product import Product
+from services.catalog_revision_service import CatalogRevisionService
 from services.product_manager_service import ProductManagerService
 from services.product_read_service import ProductReadService
 from services.product_write_service import ProductWriteService
@@ -28,7 +29,14 @@ class ProductService(ProductReadService, ProductWriteService, ProductManagerServ
         product_id: int,
         new_price: int,
     ) -> bool:
-        return await ProductDAO.update_price(session, product_id, new_price)
+        updated = await ProductDAO.update_price(session, product_id, new_price)
+        if updated:
+            await CatalogRevisionService.bump(
+                session,
+                scope="product_price",
+                product_ids=[product_id],
+            )
+        return updated
 
     @staticmethod
     async def delete(session: AsyncSession, product_id: int) -> bool:

--- a/services/product_write_service.py
+++ b/services/product_write_service.py
@@ -9,6 +9,7 @@ from sqlmodel import select
 from crud.product import ProductDAO
 from models import Product, ProductImage, Tag
 from services.brand_series_service import sync_product_brand_series
+from services.catalog_revision_service import CatalogRevisionService
 from services.product_attachment_service import replace_manuals
 from services.spec_normalizer import normalize_specs
 from services.product_supply_metrics_service import ProductSupplyMetricsService
@@ -38,6 +39,12 @@ class ProductWriteService:
         product.main_image = ImageService.get_web_path(db_path)
         session.add(product)
         await session.commit()
+        await CatalogRevisionService.bump(
+            session,
+            scope="product_media",
+            product_ids=[product.id],
+            slugs=[product.slug],
+        )
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
@@ -78,7 +85,7 @@ class ProductWriteService:
                 title=payload.get("title") or (existing_product.title if existing_product else ""),
             )
 
-        product = await ProductDAO.update_full(session, product_id, payload, tag_ids)
+        product = await ProductDAO.update_full(session, product_id, payload, tag_ids, commit=False)
         if not product:
             return None
 
@@ -101,12 +108,20 @@ class ProductWriteService:
             explicit_brand_override=explicit_brand_override,
         )
         await session.commit()
+        await CatalogRevisionService.bump(
+            session,
+            scope="product_update",
+            product_ids=[product.id],
+            slugs=[product.slug],
+        )
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
     async def bulk_round_prices(session: AsyncSession, product_ids: List[int]) -> Dict[str, Any]:
         products = await ProductDAO.get_by_ids(session, product_ids)
         updated_count = 0
+        updated_product_ids: List[int] = []
+        updated_slugs: List[str] = []
 
         for product in products:
             new_price = (product.price // 50) * 50
@@ -114,9 +129,19 @@ class ProductWriteService:
                 product.price = new_price
                 session.add(product)
                 updated_count += 1
+                if product.id is not None:
+                    updated_product_ids.append(int(product.id))
+                if product.slug:
+                    updated_slugs.append(product.slug)
 
         if updated_count > 0:
             await session.commit()
+            await CatalogRevisionService.bump(
+                session,
+                scope="product_price_bulk_round",
+                product_ids=updated_product_ids,
+                slugs=updated_slugs,
+            )
 
         return {"message": "Prices rounded", "updated_count": updated_count}
 
@@ -126,6 +151,8 @@ class ProductWriteService:
         metrics = await ProductSupplyMetricsService.compute_for_products(session, products)
         updated_count = 0
         skipped_count = 0
+        updated_product_ids: List[int] = []
+        updated_slugs: List[str] = []
 
         for product in products:
             recommended_price = metrics.get(product.id, {}).get("recommended_price_byn")
@@ -142,9 +169,19 @@ class ProductWriteService:
                 product.price = new_price
                 session.add(product)
                 updated_count += 1
+                if product.id is not None:
+                    updated_product_ids.append(int(product.id))
+                if product.slug:
+                    updated_slugs.append(product.slug)
 
         if updated_count > 0:
             await session.commit()
+            await CatalogRevisionService.bump(
+                session,
+                scope="product_price_bulk_rrc",
+                product_ids=updated_product_ids,
+                slugs=updated_slugs,
+            )
 
         processed_count = len(products)
         unchanged_count = processed_count - updated_count - skipped_count
@@ -186,6 +223,13 @@ class ProductWriteService:
             created_ids.append(product_image.id)
 
         await session.commit()
+        if created_ids:
+            await CatalogRevisionService.bump(
+                session,
+                scope="product_gallery",
+                product_ids=[product.id],
+                slugs=[product.slug],
+            )
         return created_ids
 
     @staticmethod
@@ -211,4 +255,11 @@ class ProductWriteService:
                 product.tags = [tag for tag in product.tags if tag.id not in tag_ids]
 
         await session.commit()
+        if products:
+            await CatalogRevisionService.bump(
+                session,
+                scope="product_tags",
+                product_ids=[product.id for product in products if product.id is not None],
+                slugs=[product.slug for product in products if product.slug],
+            )
         return len(products)

--- a/services/product_write_service.py
+++ b/services/product_write_service.py
@@ -38,13 +38,13 @@ class ProductWriteService:
         )
         product.main_image = ImageService.get_web_path(db_path)
         session.add(product)
-        await session.commit()
         await CatalogRevisionService.bump(
             session,
             scope="product_media",
             product_ids=[product.id],
             slugs=[product.slug],
         )
+        await session.commit()
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
@@ -107,13 +107,13 @@ class ProductWriteService:
             explicit_brand_id=explicit_brand_id,
             explicit_brand_override=explicit_brand_override,
         )
-        await session.commit()
         await CatalogRevisionService.bump(
             session,
             scope="product_update",
             product_ids=[product.id],
             slugs=[product.slug],
         )
+        await session.commit()
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
@@ -135,13 +135,13 @@ class ProductWriteService:
                     updated_slugs.append(product.slug)
 
         if updated_count > 0:
-            await session.commit()
             await CatalogRevisionService.bump(
                 session,
                 scope="product_price_bulk_round",
                 product_ids=updated_product_ids,
                 slugs=updated_slugs,
             )
+            await session.commit()
 
         return {"message": "Prices rounded", "updated_count": updated_count}
 
@@ -175,13 +175,13 @@ class ProductWriteService:
                     updated_slugs.append(product.slug)
 
         if updated_count > 0:
-            await session.commit()
             await CatalogRevisionService.bump(
                 session,
                 scope="product_price_bulk_rrc",
                 product_ids=updated_product_ids,
                 slugs=updated_slugs,
             )
+            await session.commit()
 
         processed_count = len(products)
         unchanged_count = processed_count - updated_count - skipped_count
@@ -222,7 +222,6 @@ class ProductWriteService:
             await session.flush()
             created_ids.append(product_image.id)
 
-        await session.commit()
         if created_ids:
             await CatalogRevisionService.bump(
                 session,
@@ -230,6 +229,7 @@ class ProductWriteService:
                 product_ids=[product.id],
                 slugs=[product.slug],
             )
+        await session.commit()
         return created_ids
 
     @staticmethod
@@ -254,7 +254,6 @@ class ProductWriteService:
             elif action == "remove":
                 product.tags = [tag for tag in product.tags if tag.id not in tag_ids]
 
-        await session.commit()
         if products:
             await CatalogRevisionService.bump(
                 session,
@@ -262,4 +261,5 @@ class ProductWriteService:
                 product_ids=[product.id for product in products if product.id is not None],
                 slugs=[product.slug for product in products if product.slug],
             )
+        await session.commit()
         return len(products)

--- a/tests/unit/test_catalog_revision.py
+++ b/tests/unit/test_catalog_revision.py
@@ -116,6 +116,42 @@ async def test_product_update_and_brand_update_bump_revision(sqlite_session):
 
 
 @pytest.mark.asyncio
+async def test_product_update_rolls_back_when_revision_bump_fails(sqlite_session, monkeypatch):
+    product = Product(
+        title="Rollback Revision Product",
+        slug="rollback-revision-product",
+        description="Demo",
+        price=1000,
+        area=25,
+        is_published=True,
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+
+    before = await CatalogRevisionService.get_current(sqlite_session)
+
+    async def fail_bump(*args, **kwargs):
+        raise RuntimeError("revision bump failed")
+
+    monkeypatch.setattr(CatalogRevisionService, "bump", fail_bump)
+
+    with pytest.raises(RuntimeError, match="revision bump failed"):
+        await ProductWriteService.update_product(
+            sqlite_session,
+            product.id,
+            {"price": 1250},
+        )
+
+    await sqlite_session.rollback()
+    await sqlite_session.refresh(product)
+    after = await CatalogRevisionService.get_current(sqlite_session)
+
+    assert product.price == 1000
+    assert after == before
+
+
+@pytest.mark.asyncio
 async def test_public_product_detail_still_hides_unpublished_product(sqlite_session):
     product = Product(
         title="Hidden Revision Product",

--- a/tests/unit/test_catalog_revision.py
+++ b/tests/unit/test_catalog_revision.py
@@ -1,0 +1,137 @@
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("ADMIN_USERNAME", "admin")
+os.environ.setdefault("ADMIN_PASSWORD", "password")
+
+from core.database import get_session
+from models import Product
+from routers.api_catalog_revision import router as catalog_revision_router
+from routers.api_products import router as api_products_router
+from services.catalog_revision_service import CatalogRevisionService
+from services.manager_brand_service import ManagerBrandService
+from services.product_write_service import ProductWriteService
+
+
+@pytest_asyncio.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "catalog_revision.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def _make_public_app(session: AsyncSession) -> FastAPI:
+    app = FastAPI()
+    app.include_router(catalog_revision_router, prefix="/api")
+    app.include_router(api_products_router, prefix="/api")
+
+    async def override_get_session():
+        yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    return app
+
+
+@pytest.mark.asyncio
+async def test_public_revision_endpoint_shape_and_reads_do_not_bump(sqlite_session):
+    app = _make_public_app(sqlite_session)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get("/api/v1/catalog/revision")
+        second = await client.get("/api/v1/catalog/revision")
+
+    assert first.status_code == 200
+    first_payload = first.json()
+    second_payload = second.json()
+    assert set(first_payload) == {"revision", "updated_at"}
+    assert first_payload["revision"] == 0
+    assert first_payload == second_payload
+
+    before_manager_read = await CatalogRevisionService.get_current(sqlite_session)
+    brands = await ManagerBrandService.list_brands(sqlite_session)
+    after_manager_read = await CatalogRevisionService.get_current(sqlite_session)
+    assert brands == []
+    assert after_manager_read == before_manager_read
+
+
+@pytest.mark.asyncio
+async def test_product_update_and_brand_update_bump_revision(sqlite_session):
+    product = Product(
+        title="Revision Product",
+        slug="revision-product",
+        description="Demo",
+        price=1000,
+        area=25,
+        is_published=True,
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+
+    before = await CatalogRevisionService.get_current(sqlite_session)
+
+    result = await ProductWriteService.update_product(
+        sqlite_session,
+        product.id,
+        {"price": 1250},
+    )
+    assert result == {"message": "Product updated", "id": product.id}
+
+    after_product_update = await CatalogRevisionService.get_current(sqlite_session)
+    assert after_product_update["revision"] == before["revision"] + 1
+    assert after_product_update["updated_at"] >= before["updated_at"]
+
+    brand = await ManagerBrandService.create_brand(
+        sqlite_session,
+        {"title": "Revision Brand", "slug": "revision-brand"},
+    )
+    after_brand_create = await CatalogRevisionService.get_current(sqlite_session)
+
+    await ManagerBrandService.update_brand(
+        sqlite_session,
+        brand["id"],
+        {"title": "Revision Brand Updated"},
+    )
+    after_brand_update = await CatalogRevisionService.get_current(sqlite_session)
+    assert after_brand_create["revision"] == after_product_update["revision"] + 1
+    assert after_brand_update["revision"] == after_brand_create["revision"] + 1
+
+
+@pytest.mark.asyncio
+async def test_public_product_detail_still_hides_unpublished_product(sqlite_session):
+    product = Product(
+        title="Hidden Revision Product",
+        slug="hidden-revision-product",
+        description="Draft",
+        price=1000,
+        area=25,
+        is_published=False,
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+
+    app = _make_public_app(sqlite_session)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/v1/products/{product.slug}")
+
+    assert response.status_code == 404


### PR DESCRIPTION
Closes #474

## What changed
- Added public `GET /api/v1/catalog/revision` with stable `{ revision, updated_at }` response.
- Added `CatalogRevisionService.get_current(...)` and `CatalogRevisionService.bump(scope, product_ids=None, slugs=None, brand_slugs=None)`.
- Stores the revision in existing `GlobalConfig` under `catalog_revision`; `value` is the monotonic integer and `updated_at` is the freshness timestamp.
- Regenerated `openapi.json` and the manager frontend API client.

## Bump hooks included
- Product update / visibility changes through `ProductWriteService.update_product`.
- Product price operations through `ProductWriteService.bulk_round_prices`, `ProductWriteService.bulk_set_prices_to_rrc`, and the existing single-price `ProductService.update_price` path.
- Manager product delete through `ProductManagerService.delete_for_manager`.
- Product write helpers in `product_write_service.py` for main image, gallery image add, and bulk tags.
- Brand create/update/delete/publish changes through `ManagerBrandService`.

## Follow-up hooks intentionally left out
- Importer product create/update hooks.
- Supplier sync / supplier offer hooks.
- Manager media-orchestrator endpoints outside `product_write_service.py`.
- Bulk specs normalization/update endpoints outside the required first hook set.

These are catalog-affecting in some workflows, but they are broader than the reviewer checklist for this first contract and should be wired in focused follow-ups.

## Not included
- No Cloudflare purge implementation.
- No storefront runtime behavior switch.
- No expensive catalog-wide revision computation.

## Verification
- `pytest tests/unit/test_catalog_revision.py -q` -> 3 passed.
- `BOT_TOKEN=test-token SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=password pytest tests/unit/test_catalog_revision.py tests/unit/test_public_product_availability_api.py tests/unit/test_product_manuals_payloads.py -q` -> 6 passed.
- `BOT_TOKEN=test-token SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=password python3 scripts/legacy/extract_openapi.py` -> OK.
- `cd manager_frontend && npm run gen:api` -> OK after `npm install` made the local codegen binary available.
- `git diff --check` and staged `git diff --cached --check` -> OK.

## Local test note
- Tried the existing integration checks for unpublished product detail, but local `db_test` is not resolvable in this worktree (`socket.gaierror: nodename nor servname provided`). The new sqlite unit test covers the unpublished detail 404 path locally.
