### PR TITLE
[codex] Add Cloudflare catalog purge integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,15 @@ CORS_ORIGINS=["https://mvn.by","https://dev.mvn.by","http://localhost:4321"]
 # For local overrides, create .env.development.local from .env.development.local.example.
 # Production manager build gets WEBSITE_URL from GitHub Actions deploy workflow.
 WEBSITE_URL=http://localhost:4321
+# Public storefront base URL used by backend catalog freshness purges.
+PUBLIC_SITE_URL=https://mvn.by
+
+# --- Cloudflare catalog cache purge ---
+# Safe defaults: disabled + dry-run, even if credentials are present.
+CLOUDFLARE_PURGE_ENABLED=false
+CLOUDFLARE_PURGE_DRY_RUN=true
+CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_API_TOKEN=
 
 # Google OAuth callback. Set this on production and add the same URI to
 # Google Cloud Console -> OAuth client -> Authorized redirect URIs.

--- a/docs/web-runtime-freshness-runbook.md
+++ b/docs/web-runtime-freshness-runbook.md
@@ -289,6 +289,14 @@ Cloudflare purge strategy:
 - Do not use purge-everything for normal manager writes.
 - Rate-limit bulk purge calls and coalesce changes from imports/supplier sync.
 
+Backend purge env contract:
+
+- `CLOUDFLARE_PURGE_ENABLED=false` by default.
+- `CLOUDFLARE_PURGE_DRY_RUN=true` by default.
+- `CLOUDFLARE_ZONE_ID` for the `mvn.by` zone.
+- `CLOUDFLARE_API_TOKEN` with cache purge permission only.
+- `PUBLIC_SITE_URL=https://mvn.by` for exact storefront URL generation.
+
 Nginx policy:
 
 - Do not enable nginx HTML caching in the first public runtime cutover.

--- a/services/catalog_purge_service.py
+++ b/services/catalog_purge_service.py
@@ -1,0 +1,371 @@
+"""Cloudflare purge helpers for public catalog freshness."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional, Protocol
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PUBLIC_SITE_URL = "https://mvn.by"
+CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4"
+CLOUDFLARE_PURGE_FILES_LIMIT = 30
+CLOUDFLARE_PURGE_MAX_URLS_PER_EVENT = 120
+CLOUDFLARE_PURGE_MIN_INTERVAL_SECONDS = 0.25
+CLOUDFLARE_PURGE_TIMEOUT_SECONDS = 10.0
+
+
+class AsyncHttpClient(Protocol):
+    async def __aenter__(self) -> "AsyncHttpClient":
+        ...
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        ...
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+    ) -> Any:
+        ...
+
+
+HttpClientFactory = Callable[..., AsyncHttpClient]
+
+
+@dataclass(frozen=True)
+class CloudflarePurgeConfig:
+    zone_id: str = ""
+    api_token: str = field(default="", repr=False)
+    enabled: bool = False
+    dry_run: bool = True
+    public_site_url: str = DEFAULT_PUBLIC_SITE_URL
+    batch_size: int = CLOUDFLARE_PURGE_FILES_LIMIT
+    max_urls_per_event: int = CLOUDFLARE_PURGE_MAX_URLS_PER_EVENT
+    min_interval_seconds: float = CLOUDFLARE_PURGE_MIN_INTERVAL_SECONDS
+    timeout_seconds: float = CLOUDFLARE_PURGE_TIMEOUT_SECONDS
+
+    @classmethod
+    def from_env(cls) -> "CloudflarePurgeConfig":
+        return cls(
+            zone_id=os.getenv("CLOUDFLARE_ZONE_ID", "").strip(),
+            api_token=os.getenv("CLOUDFLARE_API_TOKEN", "").strip(),
+            enabled=_env_bool("CLOUDFLARE_PURGE_ENABLED", default=False),
+            dry_run=_env_bool("CLOUDFLARE_PURGE_DRY_RUN", default=True),
+            public_site_url=(
+                os.getenv("PUBLIC_SITE_URL", "").strip()
+                or os.getenv("WEBSITE_URL", "").strip()
+                or DEFAULT_PUBLIC_SITE_URL
+            ),
+            batch_size=_env_int("CLOUDFLARE_PURGE_BATCH_SIZE", CLOUDFLARE_PURGE_FILES_LIMIT),
+            max_urls_per_event=_env_int(
+                "CLOUDFLARE_PURGE_MAX_URLS_PER_EVENT",
+                CLOUDFLARE_PURGE_MAX_URLS_PER_EVENT,
+            ),
+            min_interval_seconds=_env_float(
+                "CLOUDFLARE_PURGE_MIN_INTERVAL_SECONDS",
+                CLOUDFLARE_PURGE_MIN_INTERVAL_SECONDS,
+            ),
+            timeout_seconds=_env_float(
+                "CLOUDFLARE_PURGE_TIMEOUT_SECONDS",
+                CLOUDFLARE_PURGE_TIMEOUT_SECONDS,
+            ),
+        )
+
+    @property
+    def has_credentials(self) -> bool:
+        return bool(self.zone_id and self.api_token)
+
+    @property
+    def mode(self) -> str:
+        if not self.enabled:
+            return "disabled"
+        if self.dry_run:
+            return "dry_run"
+        if not self.has_credentials:
+            return "missing_config"
+        return "live"
+
+    @property
+    def should_call_cloudflare(self) -> bool:
+        return self.mode == "live"
+
+
+@dataclass(frozen=True)
+class CloudflarePurgeResult:
+    mode: str
+    url_count: int
+    attempted_batches: int = 0
+    failed_batches: int = 0
+    errors: tuple[str, ...] = ()
+
+
+def build_catalog_purge_urls(
+    public_site_url: str,
+    *,
+    product_slugs: Optional[Iterable[str]] = None,
+    brand_slugs: Optional[Iterable[str]] = None,
+) -> tuple[str, ...]:
+    base_url = _normalize_public_site_url(public_site_url)
+    paths: list[str] = []
+
+    for slug in _unique_slugs(product_slugs):
+        paths.append(f"/product/{quote(slug, safe='')}/")
+    for slug in _unique_slugs(brand_slugs):
+        paths.append(f"/brands/{quote(slug, safe='')}/")
+
+    paths.append("/brands/")
+    paths.append("/catalog/")
+    return tuple(_dedupe(f"{base_url}{path}" for path in paths))
+
+
+class CloudflareCatalogPurgeService:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._last_request_at = 0.0
+
+    async def purge_after_revision(
+        self,
+        *,
+        scope: str,
+        revision: int,
+        product_slugs: Optional[Iterable[str]] = None,
+        brand_slugs: Optional[Iterable[str]] = None,
+        config: Optional[CloudflarePurgeConfig] = None,
+        http_client_factory: Optional[HttpClientFactory] = None,
+    ) -> CloudflarePurgeResult:
+        purge_config = config or CloudflarePurgeConfig.from_env()
+        urls = build_catalog_purge_urls(
+            purge_config.public_site_url,
+            product_slugs=product_slugs,
+            brand_slugs=brand_slugs,
+        )
+        urls = self._cap_urls(urls, purge_config.max_urls_per_event, scope=scope, revision=revision)
+
+        if not purge_config.should_call_cloudflare:
+            logger.info(
+                "Cloudflare catalog purge skipped mode=%s scope=%s revision=%s url_count=%s",
+                purge_config.mode,
+                scope,
+                revision,
+                len(urls),
+            )
+            return CloudflarePurgeResult(mode=purge_config.mode, url_count=len(urls))
+
+        try:
+            return await self._purge_live(
+                urls=urls,
+                scope=scope,
+                revision=revision,
+                config=purge_config,
+                http_client_factory=http_client_factory,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Cloudflare catalog purge failed after commit scope=%s revision=%s url_count=%s error=%s",
+                scope,
+                revision,
+                len(urls),
+                exc,
+            )
+            return CloudflarePurgeResult(
+                mode="live",
+                url_count=len(urls),
+                failed_batches=1,
+                errors=(str(exc),),
+            )
+
+    async def _purge_live(
+        self,
+        *,
+        urls: tuple[str, ...],
+        scope: str,
+        revision: int,
+        config: CloudflarePurgeConfig,
+        http_client_factory: Optional[HttpClientFactory],
+    ) -> CloudflarePurgeResult:
+        endpoint = f"{CLOUDFLARE_API_BASE_URL}/zones/{config.zone_id}/purge_cache"
+        factory = http_client_factory or httpx.AsyncClient
+        batch_size = max(1, min(int(config.batch_size), CLOUDFLARE_PURGE_FILES_LIMIT))
+        batches = [
+            urls[index : index + batch_size]
+            for index in range(0, len(urls), batch_size)
+        ]
+        attempted_batches = 0
+        failed_batches = 0
+        errors: list[str] = []
+
+        for batch in batches:
+            attempted_batches += 1
+            await self._wait_for_rate_limit(config.min_interval_seconds)
+            async with factory(timeout=config.timeout_seconds) as client:
+                response = await client.post(
+                    endpoint,
+                    headers={
+                        "Authorization": f"Bearer {config.api_token}",
+                        "Content-Type": "application/json",
+                    },
+                    json={"files": list(batch)},
+                )
+
+            success, error_summary = _parse_cloudflare_response(response)
+            if success:
+                logger.info(
+                    "Cloudflare catalog purge ok scope=%s revision=%s batch_urls=%s status_code=%s",
+                    scope,
+                    revision,
+                    len(batch),
+                    getattr(response, "status_code", None),
+                )
+            else:
+                failed_batches += 1
+                errors.append(error_summary)
+                logger.warning(
+                    "Cloudflare catalog purge batch failed scope=%s revision=%s batch_urls=%s status_code=%s error=%s",
+                    scope,
+                    revision,
+                    len(batch),
+                    getattr(response, "status_code", None),
+                    error_summary,
+                )
+
+        return CloudflarePurgeResult(
+            mode="live",
+            url_count=len(urls),
+            attempted_batches=attempted_batches,
+            failed_batches=failed_batches,
+            errors=tuple(errors),
+        )
+
+    async def _wait_for_rate_limit(self, min_interval_seconds: float) -> None:
+        min_interval = max(0.0, float(min_interval_seconds or 0))
+        if min_interval <= 0:
+            return
+
+        async with self._lock:
+            now = time.monotonic()
+            delay = self._last_request_at + min_interval - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+            self._last_request_at = time.monotonic()
+
+    @staticmethod
+    def _cap_urls(
+        urls: tuple[str, ...],
+        max_urls: int,
+        *,
+        scope: str,
+        revision: int,
+    ) -> tuple[str, ...]:
+        normalized_max = max(1, int(max_urls or CLOUDFLARE_PURGE_MAX_URLS_PER_EVENT))
+        if len(urls) <= normalized_max:
+            return urls
+        logger.warning(
+            "Cloudflare catalog purge URL list capped scope=%s revision=%s url_count=%s max_urls=%s",
+            scope,
+            revision,
+            len(urls),
+            normalized_max,
+        )
+        return urls[:normalized_max]
+
+
+def _normalize_public_site_url(raw_url: str) -> str:
+    value = (raw_url or DEFAULT_PUBLIC_SITE_URL).strip()
+    if not value:
+        value = DEFAULT_PUBLIC_SITE_URL
+    if "://" not in value:
+        value = f"https://{value}"
+
+    parsed = urlsplit(value)
+    scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "https"
+    netloc = parsed.netloc or parsed.path
+    return urlunsplit((scheme, netloc, "", "", "")).rstrip("/")
+
+
+def _unique_slugs(values: Optional[Iterable[str]]) -> tuple[str, ...]:
+    slugs: list[str] = []
+    for value in values or []:
+        slug = str(value or "").strip().strip("/")
+        if not slug or slug.lower() in {"none", "null"}:
+            continue
+        slugs.append(slug)
+    return tuple(_dedupe(slugs))
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return max(0.0, float(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_cloudflare_response(response: Any) -> tuple[bool, str]:
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    success = 200 <= status_code < 300 and bool(payload.get("success", True))
+    if success:
+        return True, ""
+
+    errors = payload.get("errors") if isinstance(payload, dict) else None
+    if isinstance(errors, list) and errors:
+        messages = []
+        for item in errors[:3]:
+            if isinstance(item, dict):
+                code = item.get("code")
+                message = item.get("message") or item.get("error")
+                messages.append(": ".join(str(part) for part in (code, message) if part))
+            else:
+                messages.append(str(item))
+        return False, "; ".join(messages)
+
+    return False, f"Cloudflare purge HTTP {status_code}"
+
+
+cloudflare_catalog_purge_service = CloudflareCatalogPurgeService()

--- a/services/catalog_revision_service.py
+++ b/services/catalog_revision_service.py
@@ -1,8 +1,15 @@
+import logging
 from typing import Any, Iterable, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from crud.catalog_revision import CatalogRevisionDAO, CatalogRevisionSnapshot
+from models import Brand, Product
+from services.catalog_purge_service import cloudflare_catalog_purge_service
+
+
+logger = logging.getLogger(__name__)
 
 
 class CatalogRevisionService:
@@ -34,3 +41,112 @@ class CatalogRevisionService:
             brand_slugs=brand_slugs,
         )
         return CatalogRevisionService._serialize(row)
+
+    @staticmethod
+    async def bump_commit_and_purge(
+        session: AsyncSession,
+        scope: str,
+        product_ids: Optional[Iterable[int]] = None,
+        slugs: Optional[Iterable[str]] = None,
+        brand_slugs: Optional[Iterable[str]] = None,
+    ) -> dict[str, Any]:
+        product_id_values = CatalogRevisionService._normalize_ints(product_ids)
+        product_slug_values = CatalogRevisionService._normalize_strings(slugs)
+        explicit_brand_slug_values = CatalogRevisionService._normalize_strings(brand_slugs)
+
+        (
+            resolved_product_slug_values,
+            resolved_brand_slug_values,
+        ) = await CatalogRevisionService.get_product_purge_targets(session, product_id_values)
+        purge_product_slugs = CatalogRevisionService._dedupe_strings(
+            [*product_slug_values, *resolved_product_slug_values]
+        )
+        purge_brand_slugs = CatalogRevisionService._dedupe_strings(
+            [*explicit_brand_slug_values, *resolved_brand_slug_values]
+        )
+
+        revision = await CatalogRevisionService.bump(
+            session,
+            scope=scope,
+            product_ids=product_id_values,
+            slugs=purge_product_slugs,
+            brand_slugs=purge_brand_slugs,
+        )
+        await session.commit()
+
+        try:
+            await cloudflare_catalog_purge_service.purge_after_revision(
+                scope=scope,
+                revision=int(revision["revision"]),
+                product_slugs=purge_product_slugs,
+                brand_slugs=purge_brand_slugs,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Catalog purge failed after committed revision scope=%s revision=%s error=%s",
+                scope,
+                revision["revision"],
+                exc,
+            )
+
+        return revision
+
+    @staticmethod
+    async def get_product_purge_targets(
+        session: AsyncSession,
+        product_ids: Optional[Iterable[int]],
+    ) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        product_id_values = CatalogRevisionService._normalize_ints(product_ids)
+        if not product_id_values:
+            return (), ()
+
+        rows = (
+            await session.execute(
+                select(Product.slug, Brand.slug)
+                .outerjoin(Brand, Product.brand_id == Brand.id)
+                .where(Product.id.in_(product_id_values))
+            )
+        ).all()
+
+        product_slugs = CatalogRevisionService._normalize_strings(row[0] for row in rows)
+        brand_slugs = CatalogRevisionService._normalize_strings(row[1] for row in rows)
+        return product_slugs, brand_slugs
+
+    @staticmethod
+    async def get_product_brand_slugs(
+        session: AsyncSession,
+        product_ids: Optional[Iterable[int]],
+    ) -> tuple[str, ...]:
+        _, brand_slugs = await CatalogRevisionService.get_product_purge_targets(session, product_ids)
+        return brand_slugs
+
+    @staticmethod
+    def _normalize_ints(values: Optional[Iterable[int]]) -> tuple[int, ...]:
+        result: list[int] = []
+        for value in values or []:
+            try:
+                normalized = int(value)
+            except (TypeError, ValueError):
+                continue
+            result.append(normalized)
+        return tuple(dict.fromkeys(result))
+
+    @staticmethod
+    def _normalize_strings(values: Optional[Iterable[str]]) -> tuple[str, ...]:
+        result: list[str] = []
+        for value in values or []:
+            normalized = str(value or "").strip()
+            if normalized:
+                result.append(normalized)
+        return CatalogRevisionService._dedupe_strings(result)
+
+    @staticmethod
+    def _dedupe_strings(values: Iterable[str]) -> tuple[str, ...]:
+        result: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return tuple(result)

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -58,12 +58,11 @@ class ManagerBrandService:
         await session.flush()
 
         await ManagerBrandService._sync_brand_tag(session, brand=brand, previous_slug=None)
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="brand_create",
             brand_slugs=[brand.slug],
         )
-        await session.commit()
         await session.refresh(brand)
         return ManagerBrandService._serialize_brand(brand, products_count=0)
 
@@ -121,12 +120,11 @@ class ManagerBrandService:
         changed_slugs = [previous_slug]
         if brand.slug != previous_slug:
             changed_slugs.append(brand.slug)
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="brand_update",
             brand_slugs=changed_slugs,
         )
-        await session.commit()
         await session.refresh(brand)
 
         products_count = (
@@ -192,12 +190,11 @@ class ManagerBrandService:
         brand_slug = brand.slug
 
         await session.delete(brand)
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="brand_delete",
             brand_slugs=[brand_slug],
         )
-        await session.commit()
 
     @staticmethod
     def _serialize_brand(brand: Brand, *, products_count: int = 0) -> Dict[str, Any]:

--- a/services/product_main_image_cleanup_service.py
+++ b/services/product_main_image_cleanup_service.py
@@ -251,13 +251,14 @@ class ProductMainImageCleanupService:
             approved.append(item)
 
         if updated_product_ids:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_main_image_cleanup_approval",
                 product_ids=updated_product_ids,
                 slugs=updated_slugs,
             )
-        await session.commit()
+        else:
+            await session.commit()
         return {
             "updated_count": len(approved),
             "skipped_count": len(skipped),

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -283,6 +283,10 @@ class ProductManagerService:
         if not product:
             return False
         product_slug = product.slug
+        brand_slugs = await CatalogRevisionService.get_product_brand_slugs(
+            session,
+            [product_id],
+        )
             
         # Check if product is used in any orders
         link_check = await session.execute(
@@ -315,13 +319,13 @@ class ProductManagerService:
         )
         
         await session.delete(product)
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="product_delete",
             product_ids=[product_id],
             slugs=[product_slug] if product_slug else None,
+            brand_slugs=brand_slugs,
         )
-        await session.commit()
         return True
 
     @staticmethod

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -31,12 +31,11 @@ class ProductService(ProductReadService, ProductWriteService, ProductManagerServ
     ) -> bool:
         updated = await ProductDAO.update_price(session, product_id, new_price, commit=False)
         if updated:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_price",
                 product_ids=[product_id],
             )
-            await session.commit()
         return updated
 
     @staticmethod

--- a/services/product_write_service.py
+++ b/services/product_write_service.py
@@ -38,13 +38,12 @@ class ProductWriteService:
         )
         product.main_image = ImageService.get_web_path(db_path)
         session.add(product)
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="product_media",
             product_ids=[product.id],
             slugs=[product.slug],
         )
-        await session.commit()
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
@@ -85,6 +84,10 @@ class ProductWriteService:
                 title=payload.get("title") or (existing_product.title if existing_product else ""),
             )
 
+        previous_brand_slugs = await CatalogRevisionService.get_product_brand_slugs(
+            session,
+            [product_id],
+        )
         product = await ProductDAO.update_full(session, product_id, payload, tag_ids, commit=False)
         if not product:
             return None
@@ -107,13 +110,13 @@ class ProductWriteService:
             explicit_brand_id=explicit_brand_id,
             explicit_brand_override=explicit_brand_override,
         )
-        await CatalogRevisionService.bump(
+        await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="product_update",
             product_ids=[product.id],
             slugs=[product.slug],
+            brand_slugs=previous_brand_slugs,
         )
-        await session.commit()
         return {"message": "Product updated", "id": product.id}
 
     @staticmethod
@@ -135,13 +138,12 @@ class ProductWriteService:
                     updated_slugs.append(product.slug)
 
         if updated_count > 0:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_price_bulk_round",
                 product_ids=updated_product_ids,
                 slugs=updated_slugs,
             )
-            await session.commit()
 
         return {"message": "Prices rounded", "updated_count": updated_count}
 
@@ -175,13 +177,12 @@ class ProductWriteService:
                     updated_slugs.append(product.slug)
 
         if updated_count > 0:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_price_bulk_rrc",
                 product_ids=updated_product_ids,
                 slugs=updated_slugs,
             )
-            await session.commit()
 
         processed_count = len(products)
         unchanged_count = processed_count - updated_count - skipped_count
@@ -223,13 +224,14 @@ class ProductWriteService:
             created_ids.append(product_image.id)
 
         if created_ids:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_gallery",
                 product_ids=[product.id],
                 slugs=[product.slug],
             )
-        await session.commit()
+        else:
+            await session.commit()
         return created_ids
 
     @staticmethod
@@ -255,11 +257,12 @@ class ProductWriteService:
                 product.tags = [tag for tag in product.tags if tag.id not in tag_ids]
 
         if products:
-            await CatalogRevisionService.bump(
+            await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="product_tags",
                 product_ids=[product.id for product in products if product.id is not None],
                 slugs=[product.slug for product in products if product.slug],
             )
-        await session.commit()
+        else:
+            await session.commit()
         return len(products)

--- a/tests/unit/test_catalog_purge_service.py
+++ b/tests/unit/test_catalog_purge_service.py
@@ -1,0 +1,108 @@
+import pytest
+
+from services.catalog_purge_service import (
+    CloudflareCatalogPurgeService,
+    CloudflarePurgeConfig,
+    build_catalog_purge_urls,
+)
+
+
+def test_build_catalog_purge_urls_exact_paths_and_dedupes():
+    urls = build_catalog_purge_urls(
+        "https://mvn.by/some/path?ignored=true",
+        product_slugs=["alpha", "/beta/", "alpha"],
+        brand_slugs=["daikin", "daikin"],
+    )
+
+    assert urls == (
+        "https://mvn.by/product/alpha/",
+        "https://mvn.by/product/beta/",
+        "https://mvn.by/brands/daikin/",
+        "https://mvn.by/brands/",
+        "https://mvn.by/catalog/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_purge_defaults_to_safe_noop_without_env(monkeypatch):
+    for name in (
+        "CLOUDFLARE_PURGE_ENABLED",
+        "CLOUDFLARE_PURGE_DRY_RUN",
+        "CLOUDFLARE_ZONE_ID",
+        "CLOUDFLARE_API_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    def fail_factory(**kwargs):
+        raise AssertionError("HTTP client must not be created in no-env mode")
+
+    result = await CloudflareCatalogPurgeService().purge_after_revision(
+        scope="product_update",
+        revision=1,
+        product_slugs=["alpha"],
+        http_client_factory=fail_factory,
+    )
+
+    assert result.mode == "disabled"
+    assert result.url_count == 3
+    assert result.attempted_batches == 0
+
+
+@pytest.mark.asyncio
+async def test_live_purge_posts_files_to_cloudflare_with_mocked_http():
+    requests = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"success": True, "result": {"id": "purge-id"}}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            requests.append({"factory_kwargs": kwargs})
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, *, headers, json):
+            requests.append({"url": url, "headers": headers, "json": json})
+            return FakeResponse()
+
+    config = CloudflarePurgeConfig(
+        zone_id="zone-123",
+        api_token="secret-token",
+        enabled=True,
+        dry_run=False,
+        public_site_url="https://mvn.by",
+        min_interval_seconds=0,
+    )
+
+    result = await CloudflareCatalogPurgeService().purge_after_revision(
+        scope="product_update",
+        revision=5,
+        product_slugs=["alpha"],
+        brand_slugs=["daikin"],
+        config=config,
+        http_client_factory=FakeClient,
+    )
+
+    post_request = requests[1]
+    assert result.mode == "live"
+    assert result.attempted_batches == 1
+    assert result.failed_batches == 0
+    assert post_request["url"] == (
+        "https://api.cloudflare.com/client/v4/zones/zone-123/purge_cache"
+    )
+    assert post_request["headers"]["Authorization"] == "Bearer secret-token"
+    assert post_request["json"] == {
+        "files": [
+            "https://mvn.by/product/alpha/",
+            "https://mvn.by/brands/daikin/",
+            "https://mvn.by/brands/",
+            "https://mvn.by/catalog/",
+        ]
+    }

--- a/tests/unit/test_catalog_revision.py
+++ b/tests/unit/test_catalog_revision.py
@@ -20,6 +20,7 @@ from routers.api_catalog_revision import router as catalog_revision_router
 from routers.api_products import router as api_products_router
 from services.catalog_revision_service import CatalogRevisionService
 from services.manager_brand_service import ManagerBrandService
+from services.product_service import ProductService
 from services.product_write_service import ProductWriteService
 
 
@@ -149,6 +150,85 @@ async def test_product_update_rolls_back_when_revision_bump_fails(sqlite_session
 
     assert product.price == 1000
     assert after == before
+
+
+@pytest.mark.asyncio
+async def test_product_update_purges_after_commit_and_ignores_purge_failure(sqlite_session, monkeypatch):
+    product = Product(
+        title="Post Commit Purge Product",
+        slug="post-commit-purge-product",
+        description="Demo",
+        price=1000,
+        area=25,
+        is_published=True,
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+
+    before = await CatalogRevisionService.get_current(sqlite_session)
+    purge_calls = []
+
+    async def fail_purge(**kwargs):
+        purge_calls.append(
+            {
+                **kwargs,
+                "in_transaction": sqlite_session.in_transaction(),
+            }
+        )
+        raise RuntimeError("cloudflare is temporarily unavailable")
+
+    monkeypatch.setattr(
+        "services.catalog_revision_service.cloudflare_catalog_purge_service.purge_after_revision",
+        fail_purge,
+    )
+
+    result = await ProductWriteService.update_product(
+        sqlite_session,
+        product.id,
+        {"price": 1250},
+    )
+    after = await CatalogRevisionService.get_current(sqlite_session)
+
+    assert result == {"message": "Product updated", "id": product.id}
+    assert after["revision"] == before["revision"] + 1
+    assert len(purge_calls) == 1
+    assert purge_calls[0]["scope"] == "product_update"
+    assert purge_calls[0]["revision"] == after["revision"]
+    assert purge_calls[0]["product_slugs"] == ("post-commit-purge-product",)
+    assert purge_calls[0]["in_transaction"] is False
+
+
+@pytest.mark.asyncio
+async def test_product_price_update_resolves_product_slug_for_purge(sqlite_session, monkeypatch):
+    product = Product(
+        title="Price Purge Product",
+        slug="price-purge-product",
+        description="Demo",
+        price=1000,
+        area=25,
+        is_published=True,
+    )
+    sqlite_session.add(product)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+
+    purge_calls = []
+
+    async def record_purge(**kwargs):
+        purge_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "services.catalog_revision_service.cloudflare_catalog_purge_service.purge_after_revision",
+        record_purge,
+    )
+
+    updated = await ProductService.update_price(sqlite_session, product.id, 1300)
+
+    assert updated is True
+    assert len(purge_calls) == 1
+    assert purge_calls[0]["scope"] == "product_price"
+    assert purge_calls[0]["product_slugs"] == ("price-purge-product",)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_product_main_image_cleanup_service.py
+++ b/tests/unit/test_product_main_image_cleanup_service.py
@@ -115,6 +115,7 @@ async def test_create_batch_generates_candidates_and_records_skip_reasons(
 @pytest.mark.asyncio
 async def test_approval_updates_main_image_and_preserves_original_metadata(
     sqlite_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     original_url = "/media/products/shared/original.png"
     product = await _make_product(sqlite_session, 11, main_image=original_url)
@@ -129,6 +130,21 @@ async def test_approval_updates_main_image_and_preserves_original_metadata(
     await sqlite_session.commit()
     await sqlite_session.refresh(item)
     before_revision = await CatalogRevisionService.get_current(sqlite_session)
+    purge_calls = []
+
+    async def fail_purge(**kwargs):
+        purge_calls.append(
+            {
+                **kwargs,
+                "in_transaction": sqlite_session.in_transaction(),
+            }
+        )
+        raise RuntimeError("cloudflare is temporarily unavailable")
+
+    monkeypatch.setattr(
+        "services.catalog_revision_service.cloudflare_catalog_purge_service.purge_after_revision",
+        fail_purge,
+    )
 
     result = await ProductMainImageCleanupService.approve_items(
         sqlite_session,
@@ -147,11 +163,17 @@ async def test_approval_updates_main_image_and_preserves_original_metadata(
     assert item.approved_at is not None
     after_revision = await CatalogRevisionService.get_current(sqlite_session)
     assert after_revision["revision"] == before_revision["revision"] + 1
+    assert len(purge_calls) == 1
+    assert purge_calls[0]["scope"] == "product_main_image_cleanup_approval"
+    assert purge_calls[0]["revision"] == after_revision["revision"]
+    assert purge_calls[0]["product_slugs"] == ("cleanup-product-11",)
+    assert purge_calls[0]["in_transaction"] is False
 
 
 @pytest.mark.asyncio
 async def test_rejection_does_not_change_public_main_image(
     sqlite_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     original_url = "/media/products/shared/reject-original.png"
     product = await _make_product(sqlite_session, 21, main_image=original_url)
@@ -165,6 +187,15 @@ async def test_rejection_does_not_change_public_main_image(
     await sqlite_session.commit()
     await sqlite_session.refresh(item)
     before_revision = await CatalogRevisionService.get_current(sqlite_session)
+    purge_calls = []
+
+    async def record_purge(**kwargs):
+        purge_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "services.catalog_revision_service.cloudflare_catalog_purge_service.purge_after_revision",
+        record_purge,
+    )
 
     result = await ProductMainImageCleanupService.reject_items(
         sqlite_session,
@@ -180,6 +211,7 @@ async def test_rejection_does_not_change_public_main_image(
     assert item.reject_reason == "bad crop"
     after_revision = await CatalogRevisionService.get_current(sqlite_session)
     assert after_revision == before_revision
+    assert purge_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Refs #475.

Adds a backend Cloudflare purge integration for catalog freshness after committed catalog revision bumps.

## What changed

- Added `CloudflareCatalogPurgeService` for exact URL purges only: product detail, brand detail, `/brands/`, and `/catalog/`.
- Added safe env controls with disabled/dry-run defaults and no secret logging.
- Added `CatalogRevisionService.bump_commit_and_purge(...)` so existing product/brand mutation hooks commit DB changes first, then attempt purge without rolling back catalog changes on purge failure.
- Added URL dedupe, batching, capping, and a small inter-request interval for bulk-safe behavior.
- Documented the backend purge env contract in `.env.example` and the freshness runbook.

## Validation

- `pytest tests/unit/test_catalog_purge_service.py tests/unit/test_catalog_revision.py tests/unit/test_product_manuals_payloads.py -q`
- `git diff --check`
