### PR TITLE
Support data-driven brand intro markdown

### DIFF
--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -288,6 +288,9 @@ onMounted(() => {
                     <label class="text-sm space-y-1 block">
                         <span class="text-gray-600 dark:text-slate-300 font-medium">Описание</span>
                         <textarea v-model="form.description" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        <span class="block text-xs text-gray-500 dark:text-slate-400">
+                            Можно использовать Markdown: абзацы, списки, ссылки, **жирный**, *курсив*.
+                        </span>
                     </label>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                         <label class="text-sm space-y-1 block">

--- a/scripts/backfill_brand_descriptions.py
+++ b/scripts/backfill_brand_descriptions.py
@@ -1,0 +1,129 @@
+import argparse
+import asyncio
+import sys
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from models import Brand
+
+
+BRAND_DESCRIPTIONS: dict[str, str] = {
+    "mdv": (
+        "**MDV** часто смотрят, когда нужен спокойный выбор по цене и функциям: настенные модели, "
+        "мульти-сплит и решения для небольших коммерческих помещений. Поможем сравнить серии по шуму, "
+        "обогреву, Wi-Fi и реальным условиям монтажа."
+    ),
+    "tcl": (
+        "**TCL** обычно выбирают для квартиры, спальни или офиса, когда хочется понятную модель без "
+        "лишнего усложнения. При подборе смотрим мощность, уровень шума, наличие Wi-Fi и как наружный "
+        "блок встанет на конкретном объекте."
+    ),
+    "chigo": (
+        "**Chigo** подходит тем, кто ищет практичный кондиционер для дома или небольшого рабочего "
+        "помещения. Сравним модели по площади, режиму обогрева и бюджету, чтобы не переплачивать "
+        "за ненужные опции."
+    ),
+    "lg": (
+        "**LG** чаще рассматривают для жилых комнат и офисов, где важны аккуратный внутренний блок "
+        "и удобное повседневное управление. Подскажем, какие модели лучше подходят под площадь, "
+        "шумовые ожидания и сценарий использования."
+    ),
+    "haier": (
+        "**Haier** смотрят для квартир, домов и офисов, когда важны разные варианты по дизайну, "
+        "мощности и набору функций. Поможем выбрать серию под помещение, место установки и требования "
+        "к обогреву в межсезонье."
+    ),
+    "kinghome": (
+        "**KINGHOME** можно рассматривать для базового охлаждения и обогрева в квартире, кабинете "
+        "или небольшом магазине. При подборе сверяем площадь, запас мощности и доступность конкретной "
+        "модели."
+    ),
+    "ultima": (
+        "**Ultima** пригодится, когда нужен простой и понятный кондиционер для повседневного "
+        "использования. Поможем проверить характеристики, наличие и стоимость установки до заказа."
+    ),
+    "energolux": (
+        "**Energolux** представлен моделями для бытовых и более сложных задач: от настенных "
+        "сплит-систем до полупромышленных решений. Подберем вариант по типу внутреннего блока, "
+        "мощности и условиям монтажа."
+    ),
+}
+
+
+def _normalize_key(value: str | None) -> str:
+    return str(value or "").strip().lower()
+
+
+def _is_empty(value: str | None) -> bool:
+    return not str(value or "").strip()
+
+
+async def run_backfill(*, execute: bool) -> None:
+    engine = create_async_engine(settings.DATABASE_URL)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        brands = (await session.execute(select(Brand).order_by(Brand.sort_order, Brand.title))).scalars().all()
+        brands_by_key: dict[str, Brand] = {}
+        for brand in brands:
+            brands_by_key[_normalize_key(brand.slug)] = brand
+            brands_by_key[_normalize_key(brand.title)] = brand
+
+        updated: list[str] = []
+        skipped_existing: list[str] = []
+        missing: list[str] = []
+
+        for key, description in BRAND_DESCRIPTIONS.items():
+            brand = brands_by_key.get(key)
+            if not brand:
+                missing.append(key)
+                continue
+
+            label = f"{brand.title} ({brand.slug})"
+            if not _is_empty(brand.description):
+                skipped_existing.append(label)
+                continue
+
+            updated.append(label)
+            if execute:
+                brand.description = description
+                session.add(brand)
+
+        if execute:
+            await session.commit()
+        else:
+            await session.rollback()
+
+    await engine.dispose()
+
+    mode = "APPLY" if execute else "DRY-RUN"
+    action = "updated" if execute else "would_update"
+    print(f"[{mode}] {action}={len(updated)}, skipped_existing={len(skipped_existing)}, missing={len(missing)}")
+    if updated:
+        print(f"[{mode}] {action}: {', '.join(updated)}")
+    if skipped_existing:
+        print(f"[{mode}] skipped existing descriptions: {', '.join(skipped_existing)}")
+    if missing:
+        print(f"[{mode}] configured brands not found: {', '.join(missing)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fill empty Brand.description values with short markdown intros for current brands."
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Commit changes. Without this flag the script only reports what would be updated.",
+    )
+    args = parser.parse_args()
+    asyncio.run(run_backfill(execute=args.execute))
+
+
+if __name__ == "__main__":
+    main()

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
+    "test:brands": "node tests/brand-markdown.test.mjs",
     "check-api": "node scripts/check-api.js",
     "audit:theme": "bash ../scripts/audit_theme_hardcodes.sh",
     "build": "npm run check-api && astro build",

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import CatalogApp from "../../components/CatalogApp.vue";
 import ProductCard from "../../components/ProductCard.astro";
 import { getCatalog, getFiltersConfig, getPublicBrandBySlug, getPublicBrands, resolveImageUrl } from "../../utils/api";
-import { formatBrandProductCount, getBrandIntro } from "../../utils/brands";
+import { formatBrandProductCount, getBrandIntro, getBrandIntroPlainText, renderBrandIntroMarkdown } from "../../utils/brands";
 import { buildCatalogItemListSchema } from "../../utils/catalog-seo";
 
 export const prerender = true;
@@ -84,6 +84,8 @@ const brandProductCount = formatBrandProductCount(brand.products_count);
 const brandLogoLabel = logoUrl ? `Логотип ${brand.title}` : `${brand.title}: логотип не загружен`;
 const brandInitials = brand.title.trim().slice(0, 2).toUpperCase();
 const brandIntro = getBrandIntro(brand.title, brand.description);
+const brandIntroHtml = renderBrandIntroMarkdown(brandIntro);
+const brandIntroText = getBrandIntroPlainText(brandIntro);
 const seoDescription = `${h1}: подбор, продажа, монтаж и обслуживание. В каталоге ${brandProductCount} с актуальными характеристиками.`;
 const lockedFilters = { brand_slugs: [brand.slug] };
 ---
@@ -107,9 +109,7 @@ const lockedFilters = { brand_slugs: [brand.slug] };
             <div class="brand-hero">
                 <div class="brand-hero-copy">
                     <h1 class="gradient-text">{h1}</h1>
-                    <p class="header-description">
-                        {brandIntro}
-                    </p>
+                    <div class="header-description brand-intro-markdown" set:html={brandIntroHtml} />
                     <div class="brand-hero-meta">
                         <span>{brandProductCount}</span>
                         <span>наличие и монтаж уточняем перед заказом</span>
@@ -128,7 +128,7 @@ const lockedFilters = { brand_slugs: [brand.slug] };
             initialPopularProducts={popularProducts}
             initialFilters={lockedFilters}
             forcedTitle={h1}
-            forcedDescription={brandIntro}
+            forcedDescription={brandIntroText}
             lockedInitialFilters={lockedFilters}
             initialCategorySlug=""
             initialBrands={filtersConfig?.brands || []}
@@ -218,6 +218,26 @@ const lockedFilters = { brand_slugs: [brand.slug] };
         color: var(--text-muted);
         margin: 0;
         line-height: 1.7;
+    }
+    .brand-intro-markdown :global(p) {
+        margin: 0 0 0.65rem;
+    }
+    .brand-intro-markdown :global(p:last-child),
+    .brand-intro-markdown :global(ul:last-child) {
+        margin-bottom: 0;
+    }
+    .brand-intro-markdown :global(ul) {
+        margin: 0.55rem 0 0.65rem;
+        padding-left: 1.2rem;
+    }
+    .brand-intro-markdown :global(li + li) {
+        margin-top: 0.25rem;
+    }
+    .brand-intro-markdown :global(a) {
+        color: var(--primary);
+        font-weight: 700;
+        text-decoration: underline;
+        text-underline-offset: 0.2em;
     }
     .brand-hero-meta {
         display: flex;

--- a/web/src/pages/brands/index.astro
+++ b/web/src/pages/brands/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { getPublicBrands, resolveImageUrl } from "../../utils/api";
-import { formatBrandProductCount, getBrandIntro } from "../../utils/brands";
+import { formatBrandProductCount, getBrandIntro, getBrandIntroPlainText } from "../../utils/brands";
 
 interface PublicBrand {
     id: number;
@@ -65,7 +65,7 @@ const brandListSchema = {
                             </div>
                             <div class="brand-card-copy">
                                 <h2>{brand.title}</h2>
-                                <p>{getBrandIntro(brand.title, brand.description)}</p>
+                                <p>{getBrandIntroPlainText(getBrandIntro(brand.title, brand.description))}</p>
                                 <span>{formatBrandProductCount(brand.products_count)} в каталоге</span>
                             </div>
                         </a>

--- a/web/src/utils/brands.ts
+++ b/web/src/utils/brands.ts
@@ -54,15 +54,30 @@ const isSafeMarkdownUrl = (value: string): boolean => {
 };
 
 const renderInlineMarkdown = (value: string): string => {
-    let html = escapeHtml(value);
+    const renderText = (text: string): string => {
+        let html = escapeHtml(text);
+        html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+        html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+        return html;
+    };
 
-    html = html.replace(/\[([^\]]+)]\(([^)]+)\)/g, (match, label: string, url: string) => {
-        const trimmedUrl = url.trim();
-        if (!isSafeMarkdownUrl(trimmedUrl)) return label;
-        return `<a href="${escapeHtml(trimmedUrl)}" rel="noopener noreferrer">${label}</a>`;
-    });
-    html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-    html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+    let html = "";
+    let lastIndex = 0;
+    const linkPattern = /\[([^\]]+)]\(([^)\s]+)\)/g;
+    for (const match of value.matchAll(linkPattern)) {
+        const fullMatch = match[0];
+        const matchIndex = match.index || 0;
+        const label = match[1];
+        const trimmedUrl = match[2].trim();
+
+        html += renderText(value.slice(lastIndex, matchIndex));
+        html += isSafeMarkdownUrl(trimmedUrl)
+            ? `<a href="${escapeHtml(trimmedUrl)}" rel="noopener noreferrer">${renderText(label)}</a>`
+            : renderText(label);
+        lastIndex = matchIndex + fullMatch.length;
+    }
+
+    html += renderText(value.slice(lastIndex));
 
     return html;
 };

--- a/web/src/utils/brands.ts
+++ b/web/src/utils/brands.ts
@@ -31,6 +31,93 @@ export const formatBrandProductCount = (count: number): string => {
     return `${normalized} ${noun}`;
 };
 
+const escapeHtml = (value: string): string =>
+    value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+
+const isSafeMarkdownUrl = (value: string): boolean => {
+    const url = value.trim();
+    if (!url || /[\u0000-\u001F\s]/.test(url)) return false;
+    if (url.startsWith("/")) return !url.startsWith("//");
+    if (url.startsWith("#")) return true;
+
+    try {
+        const parsed = new URL(url);
+        return ["http:", "https:", "mailto:", "tel:"].includes(parsed.protocol);
+    } catch {
+        return false;
+    }
+};
+
+const renderInlineMarkdown = (value: string): string => {
+    let html = escapeHtml(value);
+
+    html = html.replace(/\[([^\]]+)]\(([^)]+)\)/g, (match, label: string, url: string) => {
+        const trimmedUrl = url.trim();
+        if (!isSafeMarkdownUrl(trimmedUrl)) return label;
+        return `<a href="${escapeHtml(trimmedUrl)}" rel="noopener noreferrer">${label}</a>`;
+    });
+    html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+
+    return html;
+};
+
+export const renderBrandIntroMarkdown = (markdown: string): string => {
+    const lines = String(markdown || "").replace(/\r\n/g, "\n").split("\n");
+    const blocks: string[] = [];
+    let paragraph: string[] = [];
+    let listItems: string[] = [];
+
+    const flushParagraph = () => {
+        if (!paragraph.length) return;
+        blocks.push(`<p>${renderInlineMarkdown(paragraph.join(" "))}</p>`);
+        paragraph = [];
+    };
+    const flushList = () => {
+        if (!listItems.length) return;
+        blocks.push(`<ul>${listItems.map((item) => `<li>${renderInlineMarkdown(item)}</li>`).join("")}</ul>`);
+        listItems = [];
+    };
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            flushParagraph();
+            flushList();
+            continue;
+        }
+
+        const listMatch = /^[-*]\s+(.+)$/.exec(trimmed);
+        if (listMatch) {
+            flushParagraph();
+            listItems.push(listMatch[1]);
+            continue;
+        }
+
+        flushList();
+        paragraph.push(trimmed);
+    }
+
+    flushParagraph();
+    flushList();
+
+    return blocks.join("");
+};
+
+export const getBrandIntroPlainText = (markdown: string): string =>
+    String(markdown || "")
+        .replace(/\[([^\]]+)]\(([^)]+)\)/g, "$1")
+        .replace(/\*\*([^*]+)\*\*/g, "$1")
+        .replace(/(^|[^*])\*([^*\n]+)\*/g, "$1$2")
+        .replace(/^[-*]\s+/gm, "")
+        .replace(/\s+/g, " ")
+        .trim();
+
 export const getBrandIntro = (title: string, description?: string | null): string => {
     const ownDescription = String(description || "").trim();
     if (ownDescription) return ownDescription;

--- a/web/tests/brand-markdown.test.mjs
+++ b/web/tests/brand-markdown.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import ts from "typescript";
+
+const sourceUrl = new URL("../src/utils/brands.ts", import.meta.url);
+const source = await readFile(sourceUrl, "utf8");
+const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+    },
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const { getBrandIntroPlainText, renderBrandIntroMarkdown } = await import(moduleUrl);
+
+describe("brand intro markdown rendering", () => {
+    it("escapes raw HTML before rendering", () => {
+        const html = renderBrandIntroMarkdown('Intro <script>alert("x")</script> <b>bold</b>');
+
+        assert.equal(html.includes("<script>"), false);
+        assert.equal(html.includes("<b>bold</b>"), false);
+        assert.match(html, /&lt;script&gt;alert\(&quot;x&quot;\)&lt;\/script&gt;/);
+        assert.match(html, /&lt;b&gt;bold&lt;\/b&gt;/);
+    });
+
+    it("does not emit href attributes for unsafe links", () => {
+        const html = renderBrandIntroMarkdown(
+            "Bad [script](javascript:alert) and [protocol](//evil.example/path)."
+        );
+
+        assert.equal(html.includes('href="javascript:'), false);
+        assert.equal(html.includes('href="//evil.example'), false);
+        assert.match(html, /Bad script and protocol\./);
+    });
+
+    it("renders safe links", () => {
+        const html = renderBrandIntroMarkdown(
+            "Links: [http](http://example.com), [https](https://example.com/a?b=1&c=2), [relative](/brands/tcl/), [hash](#models), [mail](mailto:sales@example.com)."
+        );
+
+        assert.match(html, /<a href="http:\/\/example\.com" rel="noopener noreferrer">http<\/a>/);
+        assert.match(html, /<a href="https:\/\/example\.com\/a\?b=1&amp;c=2" rel="noopener noreferrer">https<\/a>/);
+        assert.match(html, /<a href="\/brands\/tcl\/" rel="noopener noreferrer">relative<\/a>/);
+        assert.match(html, /<a href="#models" rel="noopener noreferrer">hash<\/a>/);
+        assert.match(html, /<a href="mailto:sales@example\.com" rel="noopener noreferrer">mail<\/a>/);
+    });
+
+    it("renders paragraphs, lists, strong and emphasis", () => {
+        const html = renderBrandIntroMarkdown("First **bold** and *em*.\n\n- one\n- two");
+
+        assert.equal(
+            html,
+            "<p>First <strong>bold</strong> and <em>em</em>.</p><ul><li>one</li><li>two</li></ul>"
+        );
+    });
+
+    it("strips markdown to plain text for previews", () => {
+        const text = getBrandIntroPlainText(
+            "Intro **bold** and *em* with [link](https://example.com).\n\n- one\n- two"
+        );
+
+        assert.equal(text, "Intro bold and em with link. one two");
+    });
+});


### PR DESCRIPTION
## Что сделано

Refs #484

- Витрина теперь использует `Brand.description` как основной источник intro и рендерит его как безопасный markdown на `/brands/{slug}/`.
- Generic fallback оставлен только для брендов без `description`; frontend hardcoded map удален.
- Добавлен компактный markdown subset: абзацы, списки, ссылки, `strong`/`em`. Raw HTML сначала экранируется; ссылки пропускают только `http`, `https`, `mailto`, `tel`, относительные `/...` и `#...`.
- Inline markdown renderer сегментно обрабатывает ссылки: обычный текст и link label экранируются отдельно, unsafe URL превращается в plain label без `href`.
- Добавлен focused safety test `npm run test:brands` без новых зависимостей: Node script транспилирует `web/src/utils/brands.ts` in-memory через уже имеющийся `typescript` и проверяет реальные exports.
- В Manager форме бренда добавлена подсказка, что описание поддерживает Markdown.
- Добавлен `scripts/backfill_brand_descriptions.py`: по умолчанию dry-run, с `--execute` заполняет только пустые `Brand.description` для MDV, TCL, Chigo, LG, Haier, KINGHOME, Ultima, Energolux и не затирает ручные описания.

## Scope note

- PR намеренно не меняет SEO metadata, canonical URLs, legacy redirects или sitemap-логику; это оставлено для отдельного #486.
- Потенциальное пересечение с #486 только по файлу `web/src/pages/brands/[slug].astro`: здесь изменен видимый intro-блок и стили markdown, но не `title`, `seoDescription`, `canonical` или redirect behavior.
- Ветка обновлена rebase поверх `origin/main` `84f1769`; конфликтов не было.

## Проверки

- `cd web && npm run test:brands` — pass, 5 tests: raw HTML escaping, unsafe `javascript:`/`//` links, safe links, paragraphs/lists/strong/em, plain-text stripping.
- `cd web && npm run audit:theme` — pass.
- `cd web && npm run build` — pass; во время SSG остаются существующие fallback-логи к `http://app:8000`, сборка успешна.
- `cd manager_frontend && npm run build` — pass.
- `python3 -m py_compile scripts/backfill_brand_descriptions.py` — pass.
- `git diff --check` — pass.
- Backfill dry-run локально: would update 7 брендов, `Ultima` не найдена в текущей dev-БД.
- Backfill apply локально к dev-БД и rebuild: `/brands/tcl/`, `/brands/chigo/`, `/brands/lg/`, `/brands/haier/` получили разные intro в собранном HTML.

## Риски / данные

- Для production нужно один раз запустить `python3 scripts/backfill_brand_descriptions.py --execute` в app-контейнере или заполнить описания вручную через Manager. Скрипт не перезаписывает уже заполненные `description`.
- В локальной dev-БД `Ultima` отсутствует, поэтому скрипт сообщает `configured brands not found: ultima`.
