### PR TITLE
[codex] Add classical main-image cleanup provider

### DIFF
--- a/docs/media-storage-r2.md
+++ b/docs/media-storage-r2.md
@@ -57,6 +57,26 @@ key changes, and the database URL changes. CDN caches can keep old objects
 without serving stale images from current product responses. If bytes are
 identical, reusing the same key is safe.
 
+## Main Image Cleanup Candidates
+
+Manager main-image cleanup batches create review-only candidates under the
+`main_cleanup` product variant type. These writes go through the same
+`PRODUCT_MEDIA_STORAGE_PROVIDER` adapter as other generated variants, so local
+storage writes to `/media/products/variants/main_cleanup/...` and R2/S3 writes
+to `{PRODUCT_MEDIA_S3_KEY_PREFIX}/main_cleanup/...`.
+
+The `classical_trim` processor is intentionally bounded. It uses Pillow-only
+foreground heuristics to trim safe transparent or near-white margins, keeps
+padding around indoor/outdoor units, exports WebP when available with PNG
+fallback, and records confidence/quality scores for manager review. It does not
+rewrite `Product.main_image`, `ProductImage.url`, or source files; approval is
+still a separate manager action.
+
+Full ML background removal remains future work. Add it as an explicitly disabled
+or opt-in processor adapter after fixture coverage against real HVAC supplier
+images, especially white indoor units on white backgrounds, mirrored showroom
+photos, and images with supplier watermarks.
+
 ## Environment
 
 Local fallback is the default:

--- a/services/product_main_image_cleanup_contract.py
+++ b/services/product_main_image_cleanup_contract.py
@@ -16,6 +16,7 @@ class ProductMainImageCleanupStatus(str, Enum):
 
 
 class ProductMainImageCleanupProcessor(str, Enum):
+    CLASSICAL_TRIM = "classical_trim"
     MANUAL = "manual"
     NOOP = "noop"
 

--- a/services/product_main_image_cleanup_provider.py
+++ b/services/product_main_image_cleanup_provider.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from PIL import Image, ImageChops, ImageFilter
+
 from services.product_image_processing_provider import (
+    PROCESSED_MAX_EDGE,
     ProductImageProcessingContext,
     ProductImageProcessingResult,
+    _export_image,
+    _open_source_image,
     _process_image_bytes,
+    _resize_to_max_edge,
 )
 from services.product_main_image_cleanup_contract import (
     DEFAULT_MAIN_IMAGE_CLEANUP_PROCESSOR_VERSION,
@@ -16,6 +22,23 @@ from services.product_main_image_cleanup_contract import (
     ProductMainImageCleanupProcessor,
     normalize_cleanup_processor,
 )
+
+
+CLASSICAL_MAIN_IMAGE_CLEANUP_PROCESSOR_VERSION = "main-cleanup-classical-trim-v1"
+WHITE_DELTA_THRESHOLD = 18
+EDGE_DELTA_THRESHOLD = 20
+ALPHA_CONTENT_THRESHOLD = 16
+MIN_CROP_REDUCTION_RATIO = 0.08
+MAX_TINY_OBJECT_CROP_REDUCTION_RATIO = 0.92
+MIN_OBJECT_AREA_RATIO_FOR_AGGRESSIVE_CROP = 0.02
+PADDING_RATIO = 0.10
+MIN_PADDING_RATIO = 0.04
+MAX_PADDING_RATIO = 0.18
+EXPECTED_MIN_ASPECT_RATIO = 0.25
+EXPECTED_MAX_ASPECT_RATIO = 4.0
+
+
+ImageBox = tuple[int, int, int, int]
 
 
 @dataclass(frozen=True)
@@ -88,10 +111,48 @@ class ManualMainImageCleanupProcessor(NoopMainImageCleanupProcessor):
     processor_method = ProductMainImageCleanupProcessor.MANUAL.value
 
 
+class ClassicalTrimMainImageCleanupProcessor:
+    """Trim safe transparent/white margins and keep manual approval in front."""
+
+    processor_method = ProductMainImageCleanupProcessor.CLASSICAL_TRIM.value
+    processor_version = CLASSICAL_MAIN_IMAGE_CLEANUP_PROCESSOR_VERSION
+
+    async def process(
+        self,
+        *,
+        source_content: bytes,
+        context: ProductMainImageCleanupContext,
+    ) -> ProductMainImageCleanupResult:
+        image = _open_source_image(source_content)
+        detected_box = _detect_content_box(image)
+        crop_box = _safe_crop_box(image, detected_box)
+        cropped = image.crop(crop_box) if crop_box != _full_box(image) else image.copy()
+        resized = _resize_to_max_edge(cropped, PROCESSED_MAX_EDGE)
+        content, extension = _export_image(resized)
+        scores = _score_classical_result(
+            original_size=image.size,
+            detected_box=detected_box,
+            crop_box=crop_box,
+            output_size=resized.size,
+        )
+        return ProductMainImageCleanupResult(
+            content=content,
+            extension=extension,
+            width=resized.width,
+            height=resized.height,
+            processor_method=self.processor_method,
+            processor_version=self.processor_version,
+            confidence_score=scores.confidence_score,
+            quality_score=scores.quality_score,
+        )
+
+
 def get_main_image_cleanup_processor(
     processor: str | None,
 ) -> ProductMainImageCleanupProcessorAdapter:
     normalized = normalize_cleanup_processor(processor)
+    if normalized == ProductMainImageCleanupProcessor.CLASSICAL_TRIM.value:
+        return ClassicalTrimMainImageCleanupProcessor()
     if normalized == ProductMainImageCleanupProcessor.NOOP.value:
         return NoopMainImageCleanupProcessor()
     if normalized == ProductMainImageCleanupProcessor.MANUAL.value:
@@ -110,3 +171,184 @@ def _heuristic_quality_score(width: int | None, height: int | None) -> float | N
     if short_edge >= 300:
         return 0.65
     return 0.45
+
+
+@dataclass(frozen=True)
+class _CleanupScores:
+    confidence_score: float
+    quality_score: float
+
+
+def _detect_content_box(image: Image.Image) -> ImageBox | None:
+    boxes: list[ImageBox] = []
+    source_area = _image_area(image.size)
+
+    alpha_mask = _alpha_mask(image)
+    if alpha_mask is not None:
+        alpha_box = alpha_mask.getbbox()
+        if alpha_box and _box_area(alpha_box) / source_area < 0.98:
+            boxes.append(alpha_box)
+
+    foreground_mask = _near_white_foreground_mask(image)
+    if alpha_mask is not None:
+        foreground_mask = ImageChops.multiply(foreground_mask, alpha_mask)
+    foreground_box = foreground_mask.getbbox()
+    if foreground_box and _box_area(foreground_box) / source_area < 0.98:
+        boxes.append(foreground_box)
+
+    edge_mask = _edge_foreground_mask(image)
+    if alpha_mask is not None:
+        edge_mask = ImageChops.multiply(edge_mask, alpha_mask)
+    edge_box = edge_mask.getbbox()
+    if edge_box and _box_area(edge_box) / source_area < 0.98:
+        boxes.append(edge_box)
+
+    if not boxes:
+        return None
+    return _union_boxes(boxes)
+
+
+def _safe_crop_box(image: Image.Image, detected_box: ImageBox | None) -> ImageBox:
+    full_box = _full_box(image)
+    if detected_box is None:
+        return full_box
+
+    source_area = _image_area(image.size)
+    object_area_ratio = _box_area(detected_box) / source_area
+    content_width = detected_box[2] - detected_box[0]
+    content_height = detected_box[3] - detected_box[1]
+    if content_width <= 0 or content_height <= 0:
+        return full_box
+
+    padding = _padding_for_box(image, detected_box)
+    crop_box = (
+        max(0, detected_box[0] - padding),
+        max(0, detected_box[1] - padding),
+        min(image.width, detected_box[2] + padding),
+        min(image.height, detected_box[3] + padding),
+    )
+    crop_reduction_ratio = 1.0 - (_box_area(crop_box) / source_area)
+    if crop_reduction_ratio < MIN_CROP_REDUCTION_RATIO:
+        return full_box
+    if (
+        crop_reduction_ratio > MAX_TINY_OBJECT_CROP_REDUCTION_RATIO
+        and object_area_ratio < MIN_OBJECT_AREA_RATIO_FOR_AGGRESSIVE_CROP
+    ):
+        return full_box
+    return crop_box
+
+
+def _score_classical_result(
+    *,
+    original_size: tuple[int, int],
+    detected_box: ImageBox | None,
+    crop_box: ImageBox,
+    output_size: tuple[int, int],
+) -> _CleanupScores:
+    output_width, output_height = output_size
+    output_area = _image_area(output_size)
+    original_area = _image_area(original_size)
+    crop_area = _box_area(crop_box)
+    crop_reduction_ratio = 1.0 - (crop_area / original_area)
+    aspect_ratio = output_width / output_height if output_height else 0
+    dimensions_sane = output_width > 0 and output_height > 0 and output_area > 0
+    aspect_sane = EXPECTED_MIN_ASPECT_RATIO <= aspect_ratio <= EXPECTED_MAX_ASPECT_RATIO
+
+    object_area_ratio = 0.0
+    if detected_box is not None:
+        object_area_ratio = _box_area(detected_box) / original_area
+
+    confidence = 0.25
+    if dimensions_sane:
+        confidence += 0.15
+    if detected_box is not None:
+        confidence += 0.22
+    if 0.02 <= object_area_ratio <= 0.96:
+        confidence += 0.15
+    elif 0.005 <= object_area_ratio <= 0.98:
+        confidence += 0.07
+    if aspect_sane:
+        confidence += 0.12
+    if crop_reduction_ratio <= 0.75:
+        confidence += 0.08
+    elif crop_reduction_ratio <= 0.88:
+        confidence += 0.04
+    if crop_reduction_ratio >= MIN_CROP_REDUCTION_RATIO:
+        confidence += 0.05
+
+    quality = _heuristic_quality_score(output_width, output_height) or 0.45
+    if aspect_sane:
+        quality += 0.08
+    else:
+        quality -= 0.12
+    if 0.04 <= object_area_ratio <= 0.88:
+        quality += 0.10
+    elif detected_box is None or object_area_ratio < 0.01:
+        quality -= 0.18
+    if crop_reduction_ratio > 0.88:
+        quality -= 0.12
+    elif crop_reduction_ratio >= MIN_CROP_REDUCTION_RATIO:
+        quality += 0.04
+
+    if detected_box is None:
+        confidence = min(confidence, 0.55)
+        quality = min(quality, 0.60)
+
+    return _CleanupScores(
+        confidence_score=_clamp_score(confidence),
+        quality_score=_clamp_score(quality),
+    )
+
+
+def _alpha_mask(image: Image.Image) -> Image.Image | None:
+    if image.mode != "RGBA":
+        return None
+    return image.getchannel("A").point(
+        lambda value: 255 if value > ALPHA_CONTENT_THRESHOLD else 0
+    )
+
+
+def _near_white_foreground_mask(image: Image.Image) -> Image.Image:
+    rgb = image.convert("RGB")
+    white = Image.new("RGB", image.size, (255, 255, 255))
+    delta = ImageChops.difference(rgb, white).convert("L")
+    return delta.point(lambda value: 255 if value > WHITE_DELTA_THRESHOLD else 0)
+
+
+def _edge_foreground_mask(image: Image.Image) -> Image.Image:
+    edges = image.convert("RGB").convert("L").filter(ImageFilter.FIND_EDGES)
+    return edges.point(lambda value: 255 if value > EDGE_DELTA_THRESHOLD else 0)
+
+
+def _padding_for_box(image: Image.Image, box: ImageBox) -> int:
+    content_edge = max(box[2] - box[0], box[3] - box[1])
+    image_edge = min(image.width, image.height)
+    min_padding = max(1, int(round(image_edge * MIN_PADDING_RATIO)))
+    max_padding = max(min_padding, int(round(image_edge * MAX_PADDING_RATIO)))
+    padding = int(round(content_edge * PADDING_RATIO))
+    return max(min_padding, min(max_padding, padding))
+
+
+def _union_boxes(boxes: list[ImageBox]) -> ImageBox:
+    return (
+        min(box[0] for box in boxes),
+        min(box[1] for box in boxes),
+        max(box[2] for box in boxes),
+        max(box[3] for box in boxes),
+    )
+
+
+def _full_box(image: Image.Image) -> ImageBox:
+    return (0, 0, image.width, image.height)
+
+
+def _image_area(size: tuple[int, int]) -> int:
+    return max(1, int(size[0]) * int(size[1]))
+
+
+def _box_area(box: ImageBox) -> int:
+    return max(0, box[2] - box[0]) * max(0, box[3] - box[1])
+
+
+def _clamp_score(value: float) -> float:
+    return round(max(0.0, min(1.0, value)), 3)

--- a/tests/integration/test_manager_main_image_cleanup_api.py
+++ b/tests/integration/test_manager_main_image_cleanup_api.py
@@ -23,7 +23,8 @@ from models import Product, ProductImage
 
 
 def _image_bytes() -> bytes:
-    image = Image.new("RGB", (24, 18), (80, 140, 200))
+    image = Image.new("RGB", (80, 60), (255, 255, 255))
+    image.paste((80, 140, 200), box=(26, 22, 54, 38))
     output = BytesIO()
     image.save(output, format="PNG")
     return output.getvalue()
@@ -103,7 +104,7 @@ async def test_manager_main_image_cleanup_create_list_and_approve(
     headers = await _auth_headers(async_client)
     create_response = await async_client.post(
         "/api/manager/main-image-cleanup/batches",
-        json={"limit": 5, "processor_method": "noop"},
+        json={"limit": 5, "processor_method": "classical_trim"},
         headers=headers,
     )
     assert create_response.status_code == 200
@@ -112,6 +113,10 @@ async def test_manager_main_image_cleanup_create_list_and_approve(
     item = payload["items"][0]
     assert item["status"] == "candidate_ready"
     assert item["candidate_image_url"] != source_url
+    assert item["processor_method"] == "classical_trim"
+    assert item["candidate_width"] < 80
+    assert item["candidate_height"] < 60
+    assert item["confidence_score"] >= 0.75
     assert item["product_title"] == "Cleanup API product"
     assert item["product_slug"] == "cleanup-api-product"
     assert item["product_current_main_image"] == source_url

--- a/tests/unit/test_product_main_image_cleanup_provider.py
+++ b/tests/unit/test_product_main_image_cleanup_provider.py
@@ -1,0 +1,105 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from services.product_main_image_cleanup_contract import (
+    ProductMainImageCleanupProcessor,
+    normalize_cleanup_processor,
+)
+from services.product_main_image_cleanup_provider import (
+    ClassicalTrimMainImageCleanupProcessor,
+    ProductMainImageCleanupContext,
+    get_main_image_cleanup_processor,
+)
+
+
+def _context() -> ProductMainImageCleanupContext:
+    return ProductMainImageCleanupContext(
+        product_id=1,
+        source_url="/media/products/shared/source.png",
+        source_product_image_id=10,
+    )
+
+
+def _image_bytes(image: Image.Image, *, fmt: str = "PNG") -> bytes:
+    output = BytesIO()
+    image.save(output, format=fmt)
+    return output.getvalue()
+
+
+def _opened_size(content: bytes) -> tuple[int, int]:
+    with Image.open(BytesIO(content)) as image:
+        return image.size
+
+
+@pytest.mark.asyncio
+async def test_classical_trim_crops_transparent_margin_and_preserves_padding():
+    image = Image.new("RGBA", (120, 90), (255, 255, 255, 0))
+    image.paste((35, 110, 200, 255), box=(30, 25, 90, 65))
+
+    result = await ClassicalTrimMainImageCleanupProcessor().process(
+        source_content=_image_bytes(image),
+        context=_context(),
+    )
+
+    assert result.processor_method == ProductMainImageCleanupProcessor.CLASSICAL_TRIM.value
+    assert result.processor_version == "main-cleanup-classical-trim-v1"
+    assert result.extension in {"webp", "png"}
+    assert result.width is not None
+    assert result.height is not None
+    assert result.width < 120
+    assert result.height < 90
+    assert result.width > 60
+    assert result.height > 40
+    assert _opened_size(result.content) == (result.width, result.height)
+    assert result.confidence_score is not None
+    assert result.confidence_score >= 0.75
+    assert result.quality_score is not None
+    assert 0.40 <= result.quality_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_classical_trim_crops_white_margin_for_colored_product():
+    image = Image.new("RGB", (160, 120), (255, 255, 255))
+    image.paste((70, 120, 190), box=(50, 45, 110, 75))
+
+    result = await ClassicalTrimMainImageCleanupProcessor().process(
+        source_content=_image_bytes(image),
+        context=_context(),
+    )
+
+    assert result.width is not None
+    assert result.height is not None
+    assert result.width < 160
+    assert result.height < 120
+    assert result.width > 60
+    assert result.height > 30
+    assert result.confidence_score is not None
+    assert result.confidence_score >= 0.75
+
+
+@pytest.mark.asyncio
+async def test_classical_trim_keeps_empty_looking_source_and_lowers_confidence():
+    image = Image.new("RGB", (90, 80), (255, 255, 255))
+
+    result = await ClassicalTrimMainImageCleanupProcessor().process(
+        source_content=_image_bytes(image),
+        context=_context(),
+    )
+
+    assert (result.width, result.height) == (90, 80)
+    assert _opened_size(result.content) == (90, 80)
+    assert result.confidence_score is not None
+    assert result.confidence_score <= 0.55
+    assert result.quality_score is not None
+    assert result.quality_score <= 0.60
+
+
+def test_processor_factory_keeps_noop_default_and_accepts_classical_trim():
+    assert normalize_cleanup_processor(None) == ProductMainImageCleanupProcessor.NOOP.value
+    assert get_main_image_cleanup_processor(None).processor_method == "noop"
+    assert (
+        get_main_image_cleanup_processor("classical_trim").processor_method
+        == ProductMainImageCleanupProcessor.CLASSICAL_TRIM.value
+    )


### PR DESCRIPTION
## Summary

Closes #496.

Adds a bounded `classical_trim` product main-image cleanup processor behind the existing cleanup provider interface while keeping `noop` as the default. The provider creates review-only candidates and does not replace public product images until manager approval.

## What changed

- Added `classical_trim` to the main-image cleanup processor contract.
- Implemented a Pillow-only classical processor that trims safe transparent or near-white margins, preserves padding, caps output size via the existing product image processing path, and exports WebP with PNG fallback.
- Stores candidates through the existing `main_cleanup` variant type and media storage adapter.
- Records confidence and quality scores based on valid output, sane dimensions/aspect ratio, foreground bbox health, crop reduction, and empty-looking source detection.
- Added docs clarifying storage behavior and the future ML/background-removal follow-up.

## Validation

- `pytest tests/unit/test_product_main_image_cleanup_provider.py -q`
- `pytest tests/unit/test_product_main_image_cleanup_provider.py tests/unit/test_product_main_image_cleanup_service.py tests/integration/test_manager_main_image_cleanup_api.py -q`
- `pytest tests/unit/test_product_image_variants.py tests/unit/test_media_storage_service.py -q`
- `git diff --check`

## Notes / risks

The classical detector is intentionally conservative. Real supplier HVAC images may still need manager rejection or future ML handling when white indoor units sit on white backgrounds, watermarks are large, showroom reflections are prominent, or JPEG noise makes the whole canvas look like foreground. ML background removal remains out of this slice and should be added as an opt-in/disabled adapter with fixture coverage before production use.