### PR TITLE
[codex] Add safe main-image background cleanup

### DIFF
--- a/manager_frontend/src/views/ProductMainImageCleanupView.vue
+++ b/manager_frontend/src/views/ProductMainImageCleanupView.vue
@@ -17,6 +17,7 @@ import {
 import { getApiErrorMessage } from '../utils/api-errors';
 
 type StatusFilter = 'all' | 'candidate_ready' | 'failed' | 'skipped' | 'rejected' | 'approved';
+type CleanupProcessorMethod = 'safe_bg_cleanup' | 'noop' | 'manual';
 
 const batches = ref<ProductMainImageCleanupBatchResponse[]>([]);
 const items = ref<ProductMainImageCleanupItemResponse[]>([]);
@@ -24,7 +25,7 @@ const selectedBatchId = ref<number | null>(null);
 const selectedIds = ref<number[]>([]);
 const statusFilter = ref<StatusFilter>('all');
 const batchLimit = ref(50);
-const processorMethod = ref('noop');
+const processorMethod = ref<CleanupProcessorMethod>('safe_bg_cleanup');
 const rejectReason = ref('Не подходит для публичной карточки');
 const loadingBatches = ref(false);
 const loadingItems = ref(false);
@@ -52,6 +53,16 @@ const statusClasses: Record<string, string> = {
   rejected: 'border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300',
   approved: 'border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-500/30 dark:bg-teal-500/10 dark:text-teal-300',
 };
+
+const processorOptions = [
+  { value: 'safe_bg_cleanup', label: 'Безопасная чистка фона' },
+  { value: 'noop', label: 'Только нормализация' },
+  { value: 'manual', label: 'Ручной кандидат' },
+] as const satisfies Array<{ value: CleanupProcessorMethod; label: string }>;
+
+const processorLabels: Record<string, string> = Object.fromEntries(
+  processorOptions.map((option) => [option.value, option.label]),
+);
 
 const actionableItems = computed(() => items.value.filter((item) => item.status === 'candidate_ready' && item.id));
 const selectedActionableIds = computed(() => selectedIds.value.filter((id) => {
@@ -117,6 +128,7 @@ const lowScore = (item: ProductMainImageCleanupItemResponse) => {
 
 const statusLabel = (status: string) => statusLabels[status] || status;
 const statusClass = (status: string) => statusClasses[status] || statusClasses.pending;
+const processorLabel = (value?: string | null) => (value ? processorLabels[value] || value : '—');
 
 const formatDate = (value?: string | null) => {
   if (!value) return '—';
@@ -233,7 +245,7 @@ const createBatch = async () => {
   try {
     const response = await api.createMainImageCleanupBatch({
       limit: Math.max(1, Math.min(Number(batchLimit.value) || 50, 50)),
-      processor_method: processorMethod.value.trim() || 'noop',
+      processor_method: processorMethod.value,
     });
     selectedBatchId.value = response.batch.id || null;
     items.value = response.items || [];
@@ -310,9 +322,13 @@ onMounted(async () => {
           Лимит
           <input v-model.number="batchLimit" min="1" max="50" type="number" class="field-input h-9 py-1.5 text-sm" />
         </label>
-        <label class="field-label w-32">
+        <label class="field-label w-56">
           Процессор
-          <input v-model="processorMethod" type="text" class="field-input h-9 py-1.5 text-sm" />
+          <select v-model="processorMethod" class="field-input h-9 py-1.5 text-sm">
+            <option v-for="option in processorOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
         </label>
         <button
           type="button"
@@ -364,7 +380,7 @@ onMounted(async () => {
               </span>
             </div>
             <div class="mt-1 text-xs text-gray-500 dark:text-slate-400">
-              {{ batch.processor_method }} / {{ batch.processor_version || '—' }}
+              {{ processorLabel(batch.processor_method) }} / {{ batch.processor_version || '—' }}
             </div>
             <div class="mt-1 flex justify-between text-xs text-gray-500 dark:text-slate-400">
               <span>Лимит {{ batch.requested_limit }}</span>
@@ -505,7 +521,8 @@ onMounted(async () => {
                   </div>
                 </td>
                 <td class="max-w-[180px] px-3 py-3 text-xs text-gray-600 dark:text-slate-300">
-                  <div class="font-semibold">{{ item.processor_method || '—' }}</div>
+                  <div class="font-semibold">{{ processorLabel(item.processor_method) }}</div>
+                  <div v-if="item.processor_method" class="mt-1 text-gray-400">{{ item.processor_method }}</div>
                   <div class="mt-1 break-words text-gray-500 dark:text-slate-400">{{ item.processor_version || '—' }}</div>
                   <div v-if="item.candidate_storage_provider" class="mt-1 text-gray-400">{{ item.candidate_storage_provider }}</div>
                 </td>

--- a/services/product_main_image_cleanup_contract.py
+++ b/services/product_main_image_cleanup_contract.py
@@ -18,6 +18,7 @@ class ProductMainImageCleanupStatus(str, Enum):
 class ProductMainImageCleanupProcessor(str, Enum):
     MANUAL = "manual"
     NOOP = "noop"
+    SAFE_BG_CLEANUP = "safe_bg_cleanup"
 
 
 class ProductMainImageCleanupSkipReason(str, Enum):

--- a/services/product_main_image_cleanup_provider.py
+++ b/services/product_main_image_cleanup_provider.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 from typing import Protocol
 
+from PIL import Image, ImageChops
+
 from services.product_image_processing_provider import (
+    CARD_CANVAS_SIZE,
     ProductImageProcessingContext,
     ProductImageProcessingResult,
+    _export_image,
+    _normalize_card_canvas,
+    _open_source_image,
     _process_image_bytes,
+    _trim_transparent_borders,
 )
 from services.product_main_image_cleanup_contract import (
     DEFAULT_MAIN_IMAGE_CLEANUP_PROCESSOR_VERSION,
@@ -16,6 +24,20 @@ from services.product_main_image_cleanup_contract import (
     ProductMainImageCleanupProcessor,
     normalize_cleanup_processor,
 )
+
+
+SAFE_BG_CLEANUP_PROCESSOR_VERSION = "safe-bg-cleanup-v1"
+SAFE_BG_CLEANUP_MAX_SOURCE_BYTES = 24 * 1024 * 1024
+SAFE_BG_CLEANUP_MAX_SOURCE_PIXELS = 16_000_000
+SAFE_BG_CLEANUP_ANALYSIS_MAX_EDGE = 720
+SAFE_BG_CLEANUP_MIN_EDGE_WHITE_RATIO = 0.58
+SAFE_BG_CLEANUP_MIN_BACKGROUND_RATIO = 0.08
+SAFE_BG_CLEANUP_MAX_BACKGROUND_RATIO = 0.9
+SAFE_BG_CLEANUP_MIN_FOREGROUND_RATIO = 0.035
+SAFE_BG_CLEANUP_MAX_FOREGROUND_RATIO = 0.94
+NEAR_WHITE_MIN_CHANNEL = 235
+NEAR_WHITE_MIN_AVERAGE = 242
+NEAR_WHITE_MAX_CHANNEL_DELTA = 28
 
 
 @dataclass(frozen=True)
@@ -88,6 +110,33 @@ class ManualMainImageCleanupProcessor(NoopMainImageCleanupProcessor):
     processor_method = ProductMainImageCleanupProcessor.MANUAL.value
 
 
+class SafeBackgroundCleanupProcessor:
+    """Conservative Pillow-only cleanup for border-connected white backgrounds."""
+
+    processor_method = ProductMainImageCleanupProcessor.SAFE_BG_CLEANUP.value
+    processor_version = SAFE_BG_CLEANUP_PROCESSOR_VERSION
+
+    async def process(
+        self,
+        *,
+        source_content: bytes,
+        context: ProductMainImageCleanupContext,
+    ) -> ProductMainImageCleanupResult:
+        cleanup = _safe_background_cleanup_image(source_content)
+        canvas = _normalize_card_canvas(cleanup.image)
+        content, extension = _export_image(canvas)
+        return ProductMainImageCleanupResult(
+            content=content,
+            extension=extension,
+            width=canvas.width,
+            height=canvas.height,
+            processor_method=self.processor_method,
+            processor_version=self.processor_version,
+            confidence_score=cleanup.confidence_score,
+            quality_score=_cleanup_quality_score(canvas, cleanup.confidence_score),
+        )
+
+
 def get_main_image_cleanup_processor(
     processor: str | None,
 ) -> ProductMainImageCleanupProcessorAdapter:
@@ -96,6 +145,8 @@ def get_main_image_cleanup_processor(
         return NoopMainImageCleanupProcessor()
     if normalized == ProductMainImageCleanupProcessor.MANUAL.value:
         return ManualMainImageCleanupProcessor()
+    if normalized == ProductMainImageCleanupProcessor.SAFE_BG_CLEANUP.value:
+        return SafeBackgroundCleanupProcessor()
     raise ValueError(f"Unsupported cleanup processor={processor!r}")
 
 
@@ -110,3 +161,280 @@ def _heuristic_quality_score(width: int | None, height: int | None) -> float | N
     if short_edge >= 300:
         return 0.65
     return 0.45
+
+
+@dataclass(frozen=True)
+class _SafeBackgroundCleanupResult:
+    image: Image.Image
+    confidence_score: float
+
+
+@dataclass(frozen=True)
+class _BorderWhiteMask:
+    mask: Image.Image
+    edge_white_ratio: float
+    background_ratio: float
+
+
+def _safe_background_cleanup_image(source_content: bytes) -> _SafeBackgroundCleanupResult:
+    if len(source_content) > SAFE_BG_CLEANUP_MAX_SOURCE_BYTES:
+        raise ValueError("Source image is too large for safe main-image cleanup")
+
+    source = _open_source_image(source_content)
+    if source.width * source.height > SAFE_BG_CLEANUP_MAX_SOURCE_PIXELS:
+        raise ValueError("Source image has too many pixels for safe main-image cleanup")
+
+    transparent_trim_ratio = _transparent_trim_ratio(source)
+    image = _trim_transparent_borders(source)
+    border_mask = _build_border_connected_white_mask(image)
+    if border_mask is None:
+        return _SafeBackgroundCleanupResult(
+            image=image,
+            confidence_score=0.92 if transparent_trim_ratio >= 0.04 else 0.42,
+        )
+
+    foreground_bbox = _foreground_bbox_after_mask(image, border_mask.mask)
+    if not _is_safe_white_cleanup_candidate(
+        image=image,
+        border_mask=border_mask,
+        foreground_bbox=foreground_bbox,
+    ):
+        return _SafeBackgroundCleanupResult(
+            image=image,
+            confidence_score=_low_confidence_score(border_mask, transparent_trim_ratio),
+        )
+
+    cleaned = _apply_transparency_mask(image, border_mask.mask)
+    cleaned = _trim_transparent_borders(cleaned)
+    confidence = _white_cleanup_confidence_score(border_mask, transparent_trim_ratio)
+    return _SafeBackgroundCleanupResult(
+        image=cleaned,
+        confidence_score=confidence,
+    )
+
+
+def _transparent_trim_ratio(image: Image.Image) -> float:
+    if image.mode != "RGBA":
+        return 0.0
+    bbox = image.getchannel("A").getbbox()
+    if not bbox:
+        return 0.0
+    full_area = image.width * image.height
+    if full_area <= 0:
+        return 0.0
+    bbox_area = max(0, bbox[2] - bbox[0]) * max(0, bbox[3] - bbox[1])
+    return max(0.0, min(1.0, 1.0 - (bbox_area / full_area)))
+
+
+def _build_border_connected_white_mask(image: Image.Image) -> _BorderWhiteMask | None:
+    if image.width <= 0 or image.height <= 0:
+        return None
+
+    analysis_image = image.convert("RGBA")
+    scale = min(
+        1.0,
+        SAFE_BG_CLEANUP_ANALYSIS_MAX_EDGE / max(analysis_image.width, analysis_image.height),
+    )
+    if scale < 1.0:
+        analysis_size = (
+            max(1, int(round(analysis_image.width * scale))),
+            max(1, int(round(analysis_image.height * scale))),
+        )
+        analysis_image = analysis_image.resize(analysis_size, Image.Resampling.BOX)
+
+    candidate = _near_white_candidate_map(analysis_image)
+    edge_white_ratio = _edge_candidate_ratio(candidate, analysis_image.size)
+    if edge_white_ratio < SAFE_BG_CLEANUP_MIN_EDGE_WHITE_RATIO:
+        return None
+
+    connected = _connected_border_mask(candidate, analysis_image.size)
+    connected_mask = Image.frombytes("L", analysis_image.size, bytes(connected))
+    if connected_mask.size != image.size:
+        connected_mask = connected_mask.resize(image.size, Image.Resampling.NEAREST)
+
+    histogram = connected_mask.histogram()
+    background_ratio = histogram[255] / max(1, image.width * image.height)
+    if background_ratio <= 0:
+        return None
+    return _BorderWhiteMask(
+        mask=connected_mask,
+        edge_white_ratio=edge_white_ratio,
+        background_ratio=background_ratio,
+    )
+
+
+def _near_white_candidate_map(image: Image.Image) -> bytearray:
+    candidate = bytearray(image.width * image.height)
+    raw = image.tobytes()
+    for offset in range(0, len(raw), 4):
+        index = offset // 4
+        red = raw[offset]
+        green = raw[offset + 1]
+        blue = raw[offset + 2]
+        alpha = raw[offset + 3]
+        if alpha < 16:
+            continue
+        channel_min = min(red, green, blue)
+        channel_max = max(red, green, blue)
+        channel_average = (red + green + blue) / 3
+        if (
+            channel_min >= NEAR_WHITE_MIN_CHANNEL
+            and channel_average >= NEAR_WHITE_MIN_AVERAGE
+            and channel_max - channel_min <= NEAR_WHITE_MAX_CHANNEL_DELTA
+        ):
+            candidate[index] = 1
+    return candidate
+
+
+def _edge_candidate_ratio(candidate: bytearray, size: tuple[int, int]) -> float:
+    width, height = size
+    if width <= 0 or height <= 0:
+        return 0.0
+
+    edge_indices: list[int] = []
+    edge_indices.extend(range(width))
+    if height > 1:
+        edge_indices.extend(range((height - 1) * width, height * width))
+    for y in range(1, max(1, height - 1)):
+        edge_indices.append(y * width)
+        if width > 1:
+            edge_indices.append(y * width + width - 1)
+
+    if not edge_indices:
+        return 0.0
+    return sum(1 for index in edge_indices if candidate[index]) / len(edge_indices)
+
+
+def _connected_border_mask(candidate: bytearray, size: tuple[int, int]) -> bytearray:
+    width, height = size
+    total = width * height
+    output = bytearray(total)
+    visited = bytearray(total)
+    queue: deque[int] = deque()
+
+    def enqueue(index: int) -> None:
+        if candidate[index] and not visited[index]:
+            visited[index] = 1
+            queue.append(index)
+
+    for x in range(width):
+        enqueue(x)
+        enqueue((height - 1) * width + x)
+    for y in range(1, height - 1):
+        enqueue(y * width)
+        enqueue(y * width + width - 1)
+
+    while queue:
+        index = queue.popleft()
+        output[index] = 255
+        x = index % width
+        if x > 0:
+            enqueue(index - 1)
+        if x + 1 < width:
+            enqueue(index + 1)
+        if index >= width:
+            enqueue(index - width)
+        if index + width < total:
+            enqueue(index + width)
+
+    return output
+
+
+def _foreground_bbox_after_mask(
+    image: Image.Image,
+    background_mask: Image.Image,
+) -> tuple[int, int, int, int] | None:
+    rgba = image.convert("RGBA")
+    alpha = rgba.getchannel("A")
+    remaining_alpha = ImageChops.subtract(alpha, background_mask)
+    return remaining_alpha.getbbox()
+
+
+def _is_safe_white_cleanup_candidate(
+    *,
+    image: Image.Image,
+    border_mask: _BorderWhiteMask,
+    foreground_bbox: tuple[int, int, int, int] | None,
+) -> bool:
+    if foreground_bbox is None:
+        return False
+    if not (
+        SAFE_BG_CLEANUP_MIN_BACKGROUND_RATIO
+        <= border_mask.background_ratio
+        <= SAFE_BG_CLEANUP_MAX_BACKGROUND_RATIO
+    ):
+        return False
+
+    foreground_area = max(0, foreground_bbox[2] - foreground_bbox[0]) * max(
+        0,
+        foreground_bbox[3] - foreground_bbox[1],
+    )
+    foreground_ratio = foreground_area / max(1, image.width * image.height)
+    if not (
+        SAFE_BG_CLEANUP_MIN_FOREGROUND_RATIO
+        <= foreground_ratio
+        <= SAFE_BG_CLEANUP_MAX_FOREGROUND_RATIO
+    ):
+        return False
+
+    width_ratio = max(0, foreground_bbox[2] - foreground_bbox[0]) / max(1, image.width)
+    height_ratio = max(0, foreground_bbox[3] - foreground_bbox[1]) / max(1, image.height)
+    return width_ratio >= 0.08 and height_ratio >= 0.08
+
+
+def _apply_transparency_mask(image: Image.Image, background_mask: Image.Image) -> Image.Image:
+    rgba = image.convert("RGBA")
+    red, green, blue, alpha = rgba.split()
+    cleaned_alpha = ImageChops.subtract(alpha, background_mask)
+    return Image.merge("RGBA", (red, green, blue, cleaned_alpha))
+
+
+def _low_confidence_score(
+    border_mask: _BorderWhiteMask,
+    transparent_trim_ratio: float,
+) -> float:
+    score = 0.46
+    if border_mask.edge_white_ratio >= SAFE_BG_CLEANUP_MIN_EDGE_WHITE_RATIO:
+        score += 0.08
+    if border_mask.background_ratio >= SAFE_BG_CLEANUP_MIN_BACKGROUND_RATIO:
+        score += 0.06
+    if transparent_trim_ratio >= 0.04:
+        score += 0.08
+    return round(min(score, 0.72), 4)
+
+
+def _white_cleanup_confidence_score(
+    border_mask: _BorderWhiteMask,
+    transparent_trim_ratio: float,
+) -> float:
+    edge_component = min(1.0, border_mask.edge_white_ratio) * 0.12
+    coverage_component = min(1.0, border_mask.background_ratio / 0.45) * 0.08
+    transparency_component = min(transparent_trim_ratio, 0.2) * 0.25
+    score = 0.76 + edge_component + coverage_component + transparency_component
+    return round(min(0.96, score), 4)
+
+
+def _cleanup_quality_score(image: Image.Image, confidence_score: float) -> float | None:
+    dimension_score = _heuristic_quality_score(image.width, image.height)
+    if dimension_score is None:
+        return None
+
+    alpha_bbox = image.convert("RGBA").getchannel("A").getbbox()
+    if not alpha_bbox:
+        return 0.1
+
+    width_ratio = max(0, alpha_bbox[2] - alpha_bbox[0]) / max(1, image.width)
+    height_ratio = max(0, alpha_bbox[3] - alpha_bbox[1]) / max(1, image.height)
+    longest_ratio = max(width_ratio, height_ratio)
+    shortest_ratio = min(width_ratio, height_ratio)
+    if longest_ratio < 0.35 or shortest_ratio < 0.18:
+        occupancy_score = 0.52
+    elif longest_ratio > 0.96:
+        occupancy_score = 0.64
+    elif longest_ratio > 0.88:
+        occupancy_score = 0.78
+    else:
+        occupancy_score = 0.88
+
+    score = (dimension_score * 0.4) + (occupancy_score * 0.35) + (confidence_score * 0.25)
+    return round(max(0.1, min(0.98, score)), 4)

--- a/tests/integration/test_manager_main_image_cleanup_api.py
+++ b/tests/integration/test_manager_main_image_cleanup_api.py
@@ -74,6 +74,22 @@ async def test_manager_main_image_cleanup_requires_auth(async_client: AsyncClien
 
 
 @pytest.mark.asyncio
+async def test_manager_main_image_cleanup_rejects_unsupported_processor(
+    async_client: AsyncClient,
+):
+    headers = await _auth_headers(async_client)
+
+    response = await async_client.post(
+        "/api/manager/main-image-cleanup/batches",
+        json={"limit": 1, "processor_method": "magic_cleanup"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported cleanup processor" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_manager_main_image_cleanup_create_list_and_approve(
     async_client: AsyncClient,
     db,

--- a/tests/unit/test_product_main_image_cleanup_service.py
+++ b/tests/unit/test_product_main_image_cleanup_service.py
@@ -10,7 +10,16 @@ from sqlmodel import SQLModel, select
 from models import Product, ProductImage, ProductMainImageCleanupItem
 from services.media_storage_service import LocalProductMediaStorage
 from services.catalog_revision_service import CatalogRevisionService
-from services.product_main_image_cleanup_contract import ProductMainImageCleanupStatus
+from services.product_image_processing_provider import CARD_CANVAS_SIZE
+from services.product_main_image_cleanup_contract import (
+    ProductMainImageCleanupProcessor,
+    ProductMainImageCleanupStatus,
+)
+from services.product_main_image_cleanup_provider import (
+    ProductMainImageCleanupContext,
+    SafeBackgroundCleanupProcessor,
+    get_main_image_cleanup_processor,
+)
 from services.product_main_image_cleanup_service import ProductMainImageCleanupService
 
 
@@ -19,6 +28,49 @@ def _image_bytes() -> bytes:
     output = BytesIO()
     image.save(output, format="PNG")
     return output.getvalue()
+
+
+def _encoded_image_bytes(image: Image.Image) -> bytes:
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _transparent_border_fixture() -> bytes:
+    image = Image.new("RGBA", (120, 90), (255, 255, 255, 0))
+    image.paste((50, 110, 200, 255), box=(48, 16, 78, 76))
+    return _encoded_image_bytes(image)
+
+
+def _near_white_border_fixture() -> bytes:
+    image = Image.new("RGB", (160, 100), (247, 247, 244))
+    image.paste((45, 115, 205), box=(68, 18, 98, 78))
+    return _encoded_image_bytes(image)
+
+
+def _complex_background_fixture() -> bytes:
+    image = Image.new("RGB", (160, 100), (80, 110, 150))
+    for y in range(image.height):
+        for x in range(image.width):
+            image.putpixel(
+                (x, y),
+                (70 + (x % 50), 92 + (y % 45), 130 + ((x + y) % 55)),
+            )
+    image.paste((210, 55, 45), box=(68, 18, 98, 78))
+    return _encoded_image_bytes(image)
+
+
+def _processor_context() -> ProductMainImageCleanupContext:
+    return ProductMainImageCleanupContext(
+        product_id=1,
+        source_url="/media/products/shared/source.png",
+        source_product_image_id=1,
+    )
+
+
+def _alpha_bbox(content: bytes) -> tuple[int, int, int, int] | None:
+    with Image.open(BytesIO(content)) as output:
+        return output.convert("RGBA").getchannel("A").getbbox()
 
 
 @pytest.fixture
@@ -66,6 +118,73 @@ def _write_source(tmp_path: Path, name: str) -> str:
 
 
 @pytest.mark.asyncio
+async def test_safe_bg_cleanup_trims_transparent_fields_to_card_canvas():
+    processor = SafeBackgroundCleanupProcessor()
+
+    result = await processor.process(
+        source_content=_transparent_border_fixture(),
+        context=_processor_context(),
+    )
+    bbox = _alpha_bbox(result.content)
+
+    assert result.width == CARD_CANVAS_SIZE[0]
+    assert result.height == CARD_CANVAS_SIZE[1]
+    assert result.processor_method == ProductMainImageCleanupProcessor.SAFE_BG_CLEANUP.value
+    assert result.confidence_score is not None
+    assert result.confidence_score >= 0.9
+    assert bbox is not None
+    assert bbox[0] > 0
+    assert bbox[1] > 0
+    assert bbox[2] < CARD_CANVAS_SIZE[0]
+    assert bbox[3] < CARD_CANVAS_SIZE[1]
+    assert (bbox[3] - bbox[1]) > (bbox[2] - bbox[0])
+
+
+@pytest.mark.asyncio
+async def test_safe_bg_cleanup_removes_near_white_border_when_confident():
+    processor = SafeBackgroundCleanupProcessor()
+
+    result = await processor.process(
+        source_content=_near_white_border_fixture(),
+        context=_processor_context(),
+    )
+    bbox = _alpha_bbox(result.content)
+
+    assert result.width == CARD_CANVAS_SIZE[0]
+    assert result.height == CARD_CANVAS_SIZE[1]
+    assert result.confidence_score is not None
+    assert result.confidence_score >= 0.8
+    assert result.quality_score is not None
+    assert result.quality_score >= 0.75
+    assert bbox is not None
+    assert (bbox[3] - bbox[1]) > (bbox[2] - bbox[0])
+
+
+@pytest.mark.asyncio
+async def test_safe_bg_cleanup_keeps_complex_background_low_confidence():
+    processor = SafeBackgroundCleanupProcessor()
+
+    result = await processor.process(
+        source_content=_complex_background_fixture(),
+        context=_processor_context(),
+    )
+    bbox = _alpha_bbox(result.content)
+
+    assert result.width == CARD_CANVAS_SIZE[0]
+    assert result.height == CARD_CANVAS_SIZE[1]
+    assert result.confidence_score is not None
+    assert result.confidence_score < 0.75
+    assert bbox is not None
+    assert (bbox[2] - bbox[0]) > (bbox[3] - bbox[1])
+    assert (bbox[2] - bbox[0]) >= int(CARD_CANVAS_SIZE[0] * 0.8)
+
+
+def test_unsupported_cleanup_processor_is_rejected():
+    with pytest.raises(ValueError, match="Unsupported cleanup processor"):
+        get_main_image_cleanup_processor("magic_cleanup")
+
+
+@pytest.mark.asyncio
 async def test_create_batch_generates_candidates_and_records_skip_reasons(
     sqlite_session: AsyncSession,
     tmp_path: Path,
@@ -92,6 +211,7 @@ async def test_create_batch_generates_candidates_and_records_skip_reasons(
     result = await ProductMainImageCleanupService.create_batch(
         sqlite_session,
         limit=10,
+        processor_method=ProductMainImageCleanupProcessor.SAFE_BG_CLEANUP.value,
         storage=LocalProductMediaStorage(base_dir=tmp_path / "media/products/variants"),
     )
 
@@ -102,6 +222,7 @@ async def test_create_batch_generates_candidates_and_records_skip_reasons(
     by_product = {item["product_id"]: item for item in result["items"]}
     assert by_product[good.id]["status"] == ProductMainImageCleanupStatus.CANDIDATE_READY.value
     assert by_product[good.id]["candidate_image_url"] != good_url
+    assert by_product[good.id]["processor_method"] == "safe_bg_cleanup"
     assert by_product[missing.id]["status"] == ProductMainImageCleanupStatus.SKIPPED.value
     assert by_product[missing.id]["skip_reason"] == "missing_local_source"
     assert result["skipped_existing"][0]["product_id"] == existing.id


### PR DESCRIPTION
## What changed

- Added `safe_bg_cleanup` as a bounded Pillow-only main-image cleanup processor.
- Keeps `noop` and `manual` behavior intact while generating review-only candidates under the existing approval lifecycle.
- Removes only border-connected near-white backgrounds when confidence is safe, trims transparent borders, normalizes candidates onto the card canvas, and records confidence/quality scores for review sorting.
- Replaced the manager cleanup processor text input with a select whose values match supported backend processors.

## Why

Issue #496 calls for the first real conservative processor for `/manager/media/main-image-cleanup` without automatically replacing public `product.main_image`. This keeps replacement behind explicit operator approval and avoids aggressive cleanup on complex/low-confidence backgrounds.

Parent epic: #478.

## Validation

- `pytest tests/unit/test_product_main_image_cleanup_service.py tests/integration/test_manager_main_image_cleanup_api.py -q`
- `npm run build` in `manager_frontend/`
- `git diff --check`