### PR TITLE
[codex] Skip already transparent main-image cleanup sources

### DIFF
--- a/services/product_main_image_cleanup_contract.py
+++ b/services/product_main_image_cleanup_contract.py
@@ -23,6 +23,7 @@ class ProductMainImageCleanupProcessor(str, Enum):
 
 class ProductMainImageCleanupSkipReason(str, Enum):
     ALREADY_PROCESSED = "already_processed"
+    ALREADY_TRANSPARENT = "already_transparent"
     MISSING_MAIN_IMAGE = "missing_main_image"
     MISSING_LOCAL_SOURCE = "missing_local_source"
     REMOTE_SOURCE_UNSUPPORTED = "remote_source_unsupported"

--- a/services/product_main_image_cleanup_service.py
+++ b/services/product_main_image_cleanup_service.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from PIL import Image, ImageOps, UnidentifiedImageError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from crud.product_main_image_cleanup import ProductMainImageCleanupDAO
@@ -122,6 +123,13 @@ class ProductMainImageCleanupService:
                 ProductMainImageCleanupService._mark_skipped(
                     item,
                     ProductMainImageCleanupSkipReason.MISSING_LOCAL_SOURCE.value,
+                )
+                items.append(item)
+                continue
+            if ProductMainImageCleanupService._source_is_already_transparent(source_path):
+                ProductMainImageCleanupService._mark_skipped(
+                    item,
+                    ProductMainImageCleanupSkipReason.ALREADY_TRANSPARENT.value,
                 )
                 items.append(item)
                 continue
@@ -536,6 +544,50 @@ class ProductMainImageCleanupService:
         if url.startswith("media/"):
             return Path(url)
         return None
+
+    @staticmethod
+    def _source_is_already_transparent(source_path: Path) -> bool:
+        try:
+            with Image.open(source_path) as image:
+                transposed = ImageOps.exif_transpose(image)
+                has_alpha = transposed.mode in {"RGBA", "LA"} or (
+                    transposed.mode == "P" and "transparency" in transposed.info
+                )
+                if not has_alpha:
+                    return False
+
+                rgba = transposed.convert("RGBA")
+                alpha = rgba.getchannel("A")
+                bbox = alpha.getbbox()
+                if bbox is None:
+                    return True
+
+                full_area = rgba.width * rgba.height
+                if full_area <= 0:
+                    return False
+                bbox_area = max(0, bbox[2] - bbox[0]) * max(0, bbox[3] - bbox[1])
+                transparent_ratio = 1.0 - (bbox_area / full_area)
+                return (
+                    transparent_ratio >= 0.02
+                    and ProductMainImageCleanupService._alpha_border_has_transparency(alpha)
+                )
+        except (OSError, UnidentifiedImageError, ValueError):
+            return False
+
+    @staticmethod
+    def _alpha_border_has_transparency(alpha: Image.Image) -> bool:
+        width, height = alpha.size
+        if width <= 0 or height <= 0:
+            return False
+
+        edge_crops = [alpha.crop((0, 0, width, 1))]
+        if height > 1:
+            edge_crops.append(alpha.crop((0, height - 1, width, height)))
+        if height > 2:
+            edge_crops.append(alpha.crop((0, 1, 1, height - 1)))
+            if width > 1:
+                edge_crops.append(alpha.crop((width - 1, 1, width, height - 1)))
+        return any(crop.getextrema()[0] < 250 for crop in edge_crops)
 
     @staticmethod
     def _normalize_ids(item_ids: list[int]) -> list[int]:

--- a/tests/unit/test_product_main_image_cleanup_service.py
+++ b/tests/unit/test_product_main_image_cleanup_service.py
@@ -117,6 +117,13 @@ def _write_source(tmp_path: Path, name: str) -> str:
     return f"/media/products/shared/{name}"
 
 
+def _write_transparent_source(tmp_path: Path, name: str) -> str:
+    source_dir = tmp_path / "media/products/shared"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / name).write_bytes(_transparent_border_fixture())
+    return f"/media/products/shared/{name}"
+
+
 @pytest.mark.asyncio
 async def test_safe_bg_cleanup_trims_transparent_fields_to_card_canvas():
     processor = SafeBackgroundCleanupProcessor()
@@ -231,6 +238,36 @@ async def test_create_batch_generates_candidates_and_records_skip_reasons(
     await sqlite_session.refresh(existing)
     assert good.main_image == good_url
     assert existing.main_image == existing_url
+
+
+@pytest.mark.asyncio
+async def test_create_batch_skips_already_transparent_sources(
+    sqlite_session: AsyncSession,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.chdir(tmp_path)
+    transparent_url = _write_transparent_source(tmp_path, "already-clean.png")
+    product = await _make_product(sqlite_session, 4, main_image=transparent_url)
+
+    result = await ProductMainImageCleanupService.create_batch(
+        sqlite_session,
+        limit=10,
+        processor_method=ProductMainImageCleanupProcessor.SAFE_BG_CLEANUP.value,
+        storage=LocalProductMediaStorage(base_dir=tmp_path / "media/products/variants"),
+    )
+
+    assert result["created_count"] == 1
+    assert result["candidate_ready_count"] == 0
+    assert result["skipped_count"] == 1
+    item = result["items"][0]
+    assert item["product_id"] == product.id
+    assert item["status"] == ProductMainImageCleanupStatus.SKIPPED.value
+    assert item["skip_reason"] == "already_transparent"
+    assert item["candidate_image_url"] is None
+
+    await sqlite_session.refresh(product)
+    assert product.main_image == transparent_url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the last concrete #478 acceptance gap before we park the epic for weekend testing.

- Adds already_transparent as a main-image cleanup skip reason.
- Skips local source images that already have meaningful border transparency instead of creating another candidate.
- Keeps public main_image unchanged for skipped transparent sources.

## Validation

- pytest tests/unit/test_product_main_image_cleanup_service.py tests/integration/test_manager_main_image_cleanup_api.py -q
- git diff --check

## Notes

This is intentionally conservative: only local sources with alpha transparency and visible edge transparency are treated as already clean. Non-alpha images continue through the selected cleanup processor.