### PR TITLE
Add brand series navigation

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -53,6 +53,7 @@ class ProductDAO:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
             selectinload(Product.brand),
+            selectinload(Product.series),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -73,6 +74,7 @@ class ProductDAO:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
             selectinload(Product.brand),
+            selectinload(Product.series),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -88,6 +90,7 @@ class ProductDAO:
     ) -> List[Product]:
         stmt = select(Product).where(Product.is_published == True).options(
             selectinload(Product.brand),
+            selectinload(Product.series),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -106,6 +109,7 @@ class ProductDAO:
             return []
         stmt = select(Product).where(Product.id.in_(product_ids)).options(
             selectinload(Product.brand),
+            selectinload(Product.series),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
@@ -460,6 +464,7 @@ class ProductDAO:
     ) -> List[Product]:
         stmt = select(Product).options(
             selectinload(Product.brand),
+            selectinload(Product.series),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -229,6 +229,7 @@ export type { ProductMainImageCleanupSkipReasonsResponse } from './models/Produc
 export type { ProductManualPayload } from './models/ProductManualPayload';
 export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';
+export type { ProductSeriesResponse } from './models/ProductSeriesResponse';
 export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';
 export type { PublicBrandResponse } from './models/PublicBrandResponse';

--- a/manager_frontend/src/client/models/ProductResponse.ts
+++ b/manager_frontend/src/client/models/ProductResponse.ts
@@ -5,6 +5,7 @@
 import type { ProductBrandResponse } from './ProductBrandResponse';
 import type { ProductImageResponse } from './ProductImageResponse';
 import type { ProductManualResponse } from './ProductManualResponse';
+import type { ProductSeriesResponse } from './ProductSeriesResponse';
 import type { ProductSiblingResponse } from './ProductSiblingResponse';
 import type { TagResponse } from './TagResponse';
 export type ProductResponse = {
@@ -25,6 +26,7 @@ export type ProductResponse = {
     minsk_qty?: number;
     availability_status?: (string | null);
     brand?: (ProductBrandResponse | null);
+    series?: (ProductSeriesResponse | null);
     tags?: Array<TagResponse>;
     specs?: Record<string, any>;
     images?: Array<string>;

--- a/manager_frontend/src/client/models/ProductSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductSeriesResponse = {
+    id: number;
+    title: string;
+    slug: string;
+    description?: (string | null);
+    hero_image?: (string | null);
+};
+

--- a/openapi.json
+++ b/openapi.json
@@ -24875,6 +24875,16 @@
               }
             ]
           },
+          "series": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProductSeriesResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/TagResponse"
@@ -24937,6 +24947,51 @@
           "created_at"
         ],
         "title": "ProductResponse"
+      },
+      "ProductSeriesResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hero_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug"
+        ],
+        "title": "ProductSeriesResponse"
       },
       "ProductSiblingResponse": {
         "properties": {

--- a/schemas.py
+++ b/schemas.py
@@ -107,11 +107,20 @@ class ProductBrandResponse(BaseModel):
     logo_url: Optional[str] = None
 
 
+class ProductSeriesResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+    description: Optional[str] = None
+    hero_image: Optional[str] = None
+
+
 class ProductResponse(ProductBase):
     vitebsk_qty: int = 0
     minsk_qty: int = 0
     availability_status: Optional[str] = None
     brand: Optional[ProductBrandResponse] = None
+    series: Optional[ProductSeriesResponse] = None
     tags: List[TagResponse] = []
     specs: Dict[str, Any] = {}
     images: List[str] = [] # Legacy

--- a/services/catalog.py
+++ b/services/catalog.py
@@ -32,6 +32,7 @@ class CatalogService:
             .join(ProductLocalStock, Product.id == ProductLocalStock.product_id)
             .options(
                 selectinload(Product.brand).load_only(Brand.id, Brand.title, Brand.slug, Brand.logo_url),
+                selectinload(Product.series),
                 selectinload(Product.tags).selectinload(Tag.group),
                 selectinload(Product.gallery_images).selectinload(ProductImage.variants),
                 selectinload(Product.attachments),

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -8,6 +8,7 @@ from schemas import (
     ProductManualResponse,
     ProductBrandResponse,
     ProductResponse,
+    ProductSeriesResponse,
     ProductSiblingResponse,
     TagGroupResponse,
     TagResponse,
@@ -122,6 +123,19 @@ def map_product_to_response(
         for item in (series_siblings or [])
     ]
 
+    series = product.series if product.series_id else None
+    series_payload = (
+        ProductSeriesResponse(
+            id=series.id,
+            title=series.title,
+            slug=series.slug,
+            description=series.description,
+            hero_image=series.hero_image,
+        )
+        if series and series.is_published
+        else None
+    )
+
     manuals_payload = [
         ProductManualResponse(
             id=item.id,
@@ -161,6 +175,7 @@ def map_product_to_response(
             if product.brand
             else None
         ),
+        series=series_payload,
         tags=tags_payload,
         specs=specs or {},
         images=images or [],

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -40,7 +40,7 @@ class ProductSeriesService:
         stmt = stmt.options(selectinload(Product.tags).selectinload(Tag.group))
         candidates = list((await session.execute(stmt)).scalars().all())
 
-        def score(item: Product) -> tuple[int, int]:
+        def score(item: Product) -> tuple[int, float, float, float, str, int]:
             same_brand = 1
             if product.brand_id and item.brand_id:
                 same_brand = 0 if product.brand_id == item.brand_id else 1
@@ -54,7 +54,24 @@ class ProductSeriesService:
                     if tag.group and tag.group.slug == "brand"
                 }
                 same_brand = 0 if (product_brand_ids and item_brand_ids.intersection(product_brand_ids)) else 1
-            return (same_brand, item.price or 0)
+
+            def numeric(value) -> float:
+                if value is None:
+                    return float("inf")
+                try:
+                    number = float(value)
+                except (TypeError, ValueError):
+                    return float("inf")
+                return number if number > 0 else float("inf")
+
+            return (
+                same_brand,
+                numeric(item.area),
+                numeric(item.power_cooling),
+                numeric(item.price),
+                (item.title or "").casefold(),
+                item.id or 0,
+            )
 
         candidates.sort(key=score)
         return candidates[:limit]

--- a/tests/integration/test_product_series_siblings.py
+++ b/tests/integration/test_product_series_siblings.py
@@ -1,6 +1,6 @@
 import pytest
 
-from models import Product, ProductTagLink, Tag, TagGroup
+from models import Brand, Product, ProductSeries, ProductTagLink, Tag, TagGroup
 
 
 @pytest.mark.asyncio
@@ -55,3 +55,79 @@ async def test_product_detail_contains_series_siblings(async_client, db):
     assert len(siblings) == 2
     assert siblings[0]["slug"] == "sibling-a"
     assert siblings[1]["slug"] == "sibling-b"
+
+
+@pytest.mark.asyncio
+async def test_product_detail_contains_series_and_series_id_siblings(async_client, db):
+    brand = Brand(title="TCL", slug="tcl", is_published=True)
+    db.add(brand)
+    await db.flush()
+
+    series = ProductSeries(
+        title="FreshIN",
+        slug="freshin",
+        brand_id=brand.id,
+        description="Fresh air product line",
+        hero_image="/media/series/freshin.webp",
+        is_published=True,
+    )
+    db.add(series)
+    await db.flush()
+
+    main = Product(
+        title="TCL FreshIN 35",
+        slug="tcl-freshin-35",
+        price=1900,
+        area=35,
+        power_cooling=3.5,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    sibling_25 = Product(
+        title="TCL FreshIN 25",
+        slug="tcl-freshin-25",
+        price=1500,
+        area=25,
+        power_cooling=2.6,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    sibling_50 = Product(
+        title="TCL FreshIN 50",
+        slug="tcl-freshin-50",
+        price=2600,
+        area=50,
+        power_cooling=5.2,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    other_series = Product(
+        title="TCL Elite 25",
+        slug="tcl-elite-25",
+        price=1300,
+        area=25,
+        brand_id=brand.id,
+        is_published=True,
+    )
+    db.add_all([main, sibling_50, sibling_25, other_series])
+    await db.commit()
+    await db.refresh(main)
+
+    response = await async_client.get(f"/api/v1/products/{main.slug}")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["series"] == {
+        "id": series.id,
+        "title": "FreshIN",
+        "slug": "freshin",
+        "description": "Fresh air product line",
+        "hero_image": "/media/series/freshin.webp",
+    }
+
+    sibling_slugs = [item["slug"] for item in data["series_siblings"]]
+    assert sibling_slugs[:2] == ["tcl-freshin-25", "tcl-freshin-50"]
+    assert "tcl-elite-25" not in sibling_slugs

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -1,6 +1,6 @@
 import pytest
 
-from models import Product, ProductImage, ProductImageVariant
+from models import Product, ProductImage, ProductImageVariant, ProductSeries
 from services.product_image_processing_contract import (
     ProductImageManualQualityStatus,
     ProductImageProcessingStatus,
@@ -127,3 +127,60 @@ def test_map_product_to_response_keeps_legacy_product_without_variants_unchanged
     assert payload.gallery_images[0].url == "/media/products/legacy.webp"
     assert payload.gallery_images[0].card_variant_url is None
     assert payload.gallery_images[0].full_variant_url is None
+
+
+def test_map_product_to_response_serializes_public_series():
+    series = ProductSeries(
+        id=7,
+        title="Elite",
+        slug="elite",
+        description="Quiet inverter product line",
+        hero_image="/media/series/elite.webp",
+        is_published=True,
+    )
+    product = Product(
+        id=1,
+        title="Elite 25",
+        slug="elite-25",
+        description="",
+        price=1200,
+        area=25,
+        is_published=True,
+        series_id=series.id,
+    )
+    product.series = series
+
+    payload = map_product_to_response(product)
+
+    assert payload.series is not None
+    assert payload.series.model_dump() == {
+        "id": 7,
+        "title": "Elite",
+        "slug": "elite",
+        "description": "Quiet inverter product line",
+        "hero_image": "/media/series/elite.webp",
+    }
+
+
+def test_map_product_to_response_hides_unpublished_series():
+    series = ProductSeries(
+        id=8,
+        title="Draft",
+        slug="draft",
+        is_published=False,
+    )
+    product = Product(
+        id=1,
+        title="Draft 25",
+        slug="draft-25",
+        description="",
+        price=1200,
+        area=25,
+        is_published=True,
+        series_id=series.id,
+    )
+    product.series = series
+
+    payload = map_product_to_response(product)
+
+    assert payload.series is None

--- a/tests/unit/test_public_product_series_payloads.py
+++ b/tests/unit/test_public_product_series_payloads.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from crud.product import ProductDAO
+from models import Brand, Product, ProductLocalStock, ProductSeries
+from services.catalog import CatalogService
+from services.product_response_mapper import map_product_to_response
+from services.product_series_service import ProductSeriesService
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "public_product_series_payloads.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _seed_series_products(session: AsyncSession) -> dict[str, Product]:
+    brand = Brand(title="MDV", slug="mdv", is_published=True)
+    session.add(brand)
+    await session.flush()
+
+    series = ProductSeries(
+        title="Elite",
+        slug="elite",
+        brand_id=brand.id,
+        description="Quiet inverter product line",
+        hero_image="/media/series/elite.webp",
+        is_published=True,
+    )
+    session.add(series)
+    await session.flush()
+
+    main = Product(
+        title="MDV Elite 35",
+        slug="mdv-elite-35",
+        price=1900,
+        area=35,
+        power_cooling=3.5,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    sibling_25 = Product(
+        title="MDV Elite 25",
+        slug="mdv-elite-25",
+        price=1500,
+        area=25,
+        power_cooling=2.6,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    sibling_50 = Product(
+        title="MDV Elite 50",
+        slug="mdv-elite-50",
+        price=2600,
+        area=50,
+        power_cooling=5.2,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    other = Product(
+        title="MDV Other 25",
+        slug="mdv-other-25",
+        price=1300,
+        area=25,
+        brand_id=brand.id,
+        is_published=True,
+    )
+    session.add_all([main, sibling_25, sibling_50, other])
+    await session.flush()
+
+    session.add(
+        ProductLocalStock(
+            product_id=main.id,
+            warehouse_code="vitebsk",
+            qty=2,
+            updated_by="test",
+        )
+    )
+    await session.commit()
+
+    return {
+        "main": main,
+        "sibling_25": sibling_25,
+        "sibling_50": sibling_50,
+        "other": other,
+    }
+
+
+@pytest.mark.asyncio
+async def test_public_product_queries_eager_load_series_and_siblings(sqlite_session):
+    seeded = await _seed_series_products(sqlite_session)
+
+    detail = await ProductDAO.get_by_slug(
+        sqlite_session,
+        seeded["main"].slug,
+        is_published=True,
+        load_image_variants=True,
+    )
+
+    assert detail is not None
+    assert "series" not in inspect(detail).unloaded
+    detail_payload = map_product_to_response(detail)
+    assert detail_payload.series is not None
+    assert detail_payload.series.model_dump() == {
+        "id": detail.series_id,
+        "title": "Elite",
+        "slug": "elite",
+        "description": "Quiet inverter product line",
+        "hero_image": "/media/series/elite.webp",
+    }
+
+    catalog_products = await ProductDAO.get_filtered(
+        sqlite_session,
+        is_published=True,
+        sort="area_asc",
+        limit=10,
+        load_image_variants=True,
+    )
+    catalog_main = next(item for item in catalog_products if item.slug == seeded["main"].slug)
+    assert "series" not in inspect(catalog_main).unloaded
+    assert map_product_to_response(catalog_main).series.slug == "elite"
+
+    featured = await CatalogService.get_vitebsk_featured_products(sqlite_session, limit=3)
+    featured_main = next(item for item in featured if item.slug == seeded["main"].slug)
+    assert "series" not in inspect(featured_main).unloaded
+    assert map_product_to_response(featured_main).series.slug == "elite"
+
+    siblings = await ProductSeriesService.get_series_siblings(sqlite_session, detail, limit=8)
+    assert [item.slug for item in siblings] == ["mdv-elite-25", "mdv-elite-50"]

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -42,6 +42,14 @@ interface Product {
     availability_status?: string | null;
     is_inverter?: boolean;
     area?: number;
+    specs?: Record<string, any>;
+    series?: {
+        id?: number;
+        title?: string | null;
+        slug?: string | null;
+        description?: string | null;
+        hero_image?: string | null;
+    } | null;
     badges?: Array<{ text: string; class?: string }>;
     tags?: Array<{
         title: string;
@@ -105,6 +113,65 @@ const brandIntroHtml = renderBrandIntroMarkdown(brandIntro);
 const brandIntroText = getBrandIntroPlainText(brandIntro);
 const seoDescription = buildBrandMetaDescription(brand);
 const lockedFilters = { brand_slugs: [brand.slug] };
+const asText = (value: unknown) => String(value || "").trim();
+const slugifySeriesFallback = (value: string) =>
+    value
+        .toLowerCase()
+        .replace(/ё/g, "е")
+        .replace(/[^\p{Letter}\p{Number}]+/gu, "-")
+        .replace(/^-+|-+$/g, "");
+const getProductSeriesTitle = (product: Product) =>
+    asText(product.series?.title) || asText(product.specs?.series);
+const getProductSeriesKey = (product: Product) => {
+    const title = getProductSeriesTitle(product);
+    if (!title) return "";
+    return asText(product.series?.slug) || slugifySeriesFallback(title) || title.toLowerCase();
+};
+const formatSeriesProductCount = (count: number) => {
+    const mod10 = count % 10;
+    const mod100 = count % 100;
+    if (mod10 === 1 && mod100 !== 11) return `${count} модель`;
+    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${count} модели`;
+    return `${count} моделей`;
+};
+const seriesGroupsMap = new Map<
+    string,
+    {
+        key: string;
+        title: string;
+        description: string;
+        products: Product[];
+    }
+>();
+const seriesSourceProducts = popularProducts.length > 0 ? popularProducts : products;
+const productsWithoutSeries: Product[] = [];
+
+for (const product of seriesSourceProducts) {
+    const title = getProductSeriesTitle(product);
+    const key = getProductSeriesKey(product);
+
+    if (!title || !key) {
+        productsWithoutSeries.push(product);
+        continue;
+    }
+
+    if (!seriesGroupsMap.has(key)) {
+        seriesGroupsMap.set(key, {
+            key,
+            title,
+            description: asText(product.series?.description),
+            products: [],
+        });
+    }
+
+    const group = seriesGroupsMap.get(key);
+    if (group) {
+        if (!group.description) group.description = asText(product.series?.description);
+        group.products.push(product);
+    }
+}
+
+const seriesGroups = Array.from(seriesGroupsMap.values());
 ---
 
 <Layout
@@ -152,20 +219,53 @@ const lockedFilters = { brand_slugs: [brand.slug] };
         >
             <div class="catalog-static-content">
                 {
-                    products.length > 0 ? (
-                        <section class="catalog-section all-products-section" aria-labelledby="brand-products-title">
+                    seriesSourceProducts.length > 0 ? (
+                        <section class="catalog-section brand-series-section" aria-labelledby="brand-products-title">
                             <div class="catalog-section-head">
                                 <h2 id="brand-products-title">Модели {brand.title}</h2>
                             </div>
-                            <div class="catalog-grid">
-                                {products.map((product) => (
-                                    <ProductCard
-                                        product={product}
-                                        variant="default"
-                                        showInstallation={true}
-                                        refreshProductOnMount={false}
-                                    />
+                            <div class="brand-series-list">
+                                {seriesGroups.map((group) => (
+                                    <section class="brand-series-group" aria-labelledby={`brand-series-${group.key}`}>
+                                        <div class="brand-series-head">
+                                            <div>
+                                                <h3 id={`brand-series-${group.key}`}>{group.title}</h3>
+                                                {group.description && <p>{group.description}</p>}
+                                            </div>
+                                            <span>{formatSeriesProductCount(group.products.length)}</span>
+                                        </div>
+                                        <div class="catalog-grid series-products-grid">
+                                            {group.products.map((product) => (
+                                                <ProductCard
+                                                    product={product}
+                                                    variant="default"
+                                                    showInstallation={true}
+                                                    refreshProductOnMount={false}
+                                                />
+                                            ))}
+                                        </div>
+                                    </section>
                                 ))}
+                                {productsWithoutSeries.length > 0 && (
+                                    <section class="brand-series-group" aria-labelledby="brand-series-other">
+                                        <div class="brand-series-head">
+                                            <div>
+                                                <h3 id="brand-series-other">Другие модели</h3>
+                                            </div>
+                                            <span>{formatSeriesProductCount(productsWithoutSeries.length)}</span>
+                                        </div>
+                                        <div class="catalog-grid series-products-grid">
+                                            {productsWithoutSeries.map((product) => (
+                                                <ProductCard
+                                                    product={product}
+                                                    variant="default"
+                                                    showInstallation={true}
+                                                    refreshProductOnMount={false}
+                                                />
+                                            ))}
+                                        </div>
+                                    </section>
+                                )}
                             </div>
                         </section>
                     ) : (
@@ -307,10 +407,55 @@ const lockedFilters = { brand_slugs: [brand.slug] };
         font-size: 1.35rem;
         line-height: 1.2;
     }
+    .brand-series-list {
+        display: grid;
+        gap: 2rem;
+    }
+    .brand-series-group {
+        display: grid;
+        gap: 1rem;
+        padding-top: 1.1rem;
+        border-top: 1px solid var(--panel-glass-border);
+    }
+    .brand-series-head {
+        display: flex;
+        align-items: start;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+    .brand-series-head h3 {
+        margin: 0;
+        color: var(--text);
+        font-size: 1.16rem;
+        line-height: 1.25;
+    }
+    .brand-series-head p {
+        max-width: 780px;
+        margin: 0.4rem 0 0;
+        color: var(--text-muted);
+        font-size: 0.94rem;
+        line-height: 1.6;
+    }
+    .brand-series-head > span {
+        display: inline-flex;
+        align-items: center;
+        min-height: 30px;
+        padding: 0.25rem 0.6rem;
+        border-radius: 8px;
+        background: var(--panel-chip-bg);
+        border: 1px solid var(--panel-chip-border);
+        color: var(--text-muted);
+        font-size: 0.82rem;
+        font-weight: 800;
+        white-space: nowrap;
+    }
     .catalog-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
         gap: 1.3rem;
+    }
+    .series-products-grid {
+        grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
     }
     .empty-status {
         text-align: center;
@@ -344,6 +489,13 @@ const lockedFilters = { brand_slugs: [brand.slug] };
             min-height: 108px;
             justify-content: flex-start;
             padding: 1rem;
+        }
+        .brand-series-head {
+            flex-direction: column;
+            gap: 0.6rem;
+        }
+        .brand-series-head > span {
+            white-space: normal;
         }
     }
 </style>

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -48,9 +48,19 @@ interface Props {
 const runtimeFreshness = await createRuntimeFreshnessContext();
 const runtimeFreshnessOption = runtimeFreshness ? { runtimeFreshness } : undefined;
 const { product: initialProduct } = Astro.props as Props;
+const productSlug = Astro.params.slug || "";
+const hasInitialSeriesInfo = Boolean(
+    initialProduct?.series?.title
+        || initialProduct?.specs?.series
+        || (initialProduct?.tags || []).some((tag: any) => (tag?.group?.slug || tag?.group_slug) === "series")
+);
+const hasInitialSeriesSiblings =
+    Array.isArray(initialProduct?.series_siblings) && initialProduct.series_siblings.length > 0;
 const product = runtimeFreshness
-    ? await getProductBySlug(Astro.params.slug || "", runtimeFreshnessOption)
-    : initialProduct;
+    ? await getProductBySlug(productSlug, runtimeFreshnessOption)
+    : hasInitialSeriesSiblings || !hasInitialSeriesInfo
+        ? initialProduct
+        : (await getProductBySlug(productSlug)) || initialProduct;
 
 if (!product) {
     return createRuntimeNotFoundResponse(Astro.response, runtimeFreshness);
@@ -130,7 +140,34 @@ const bentoCards = generateBentoCards(product);
 
 const publicTags = (product.tags || []).filter((t: any) => t.is_public);
 const seoDescription = buildProductMetaDescription(product);
-	---
+const asText = (value: unknown) => String(value || "").trim();
+const formatSeriesPrice = (value: unknown) => {
+    const price = Number(value);
+    return Number.isFinite(price) && price > 0
+        ? `${price.toLocaleString("ru-RU")} Br`
+        : "Цена по запросу";
+};
+const formatSeriesArea = (item: any) => {
+    const rawArea = item?.area ?? item?.specs?.area_m2;
+    const area = Number(rawArea);
+    if (Number.isFinite(area) && area > 0) return `до ${area} м²`;
+    const textArea = asText(rawArea);
+    return textArea ? `до ${textArea}` : "";
+};
+const resolveSeriesCompressorLabel = (item: any) => {
+    const raw = asText(item?.specs?.compressor_type_norm).toLowerCase();
+    if (raw === "full_dc") return "Full DC Inverter";
+    if (raw === "on_off") return "On/Off";
+    if (raw === "inverter") return "Инвертор";
+    if (item?.is_inverter === true) return "Инвертор";
+    if (item?.is_inverter === false) return "On/Off";
+    return "";
+};
+const seriesTitle = asText(product.series?.title) || asText(specs.series);
+const seriesSiblings = Array.isArray(product.series_siblings)
+    ? product.series_siblings.filter((item: any) => item?.slug && item.slug !== product.slug)
+    : [];
+---
 
 <Layout
     title={product.title}
@@ -950,6 +987,58 @@ const seoDescription = buildProductMetaDescription(product);
                 </details>
             </div>
         </div>
+
+        {
+            seriesSiblings.length > 0 && (
+                <section class="series-siblings-section" aria-labelledby="series-siblings-title">
+                    <div class="series-siblings-head">
+                        <div>
+                            <p class="section-kicker">Серия</p>
+                            <h2 id="series-siblings-title">
+                                Другие модели серии {seriesTitle || "этой линейки"}
+                            </h2>
+                        </div>
+                        {productBrand && (
+                            <a class="series-brand-link" href={`/brands/${productBrand.slug}/`}>
+                                Все модели {productBrand.title}
+                                <span class="material-icons-round" aria-hidden="true">arrow_forward</span>
+                            </a>
+                        )}
+                    </div>
+                    <div class="series-siblings-grid">
+                        {seriesSiblings.map((item: any) => {
+                            const image = resolveImageUrl(item.card_image || item.main_image || item.full_image);
+                            const areaLabel = formatSeriesArea(item);
+                            const compressorLabel = resolveSeriesCompressorLabel(item);
+
+                            return (
+                                <a class="series-sibling-card" href={`/product/${item.slug}/`}>
+                                    <span class="series-sibling-image">
+                                        <img
+                                            src={image}
+                                            alt={item.title}
+                                            width="240"
+                                            height="180"
+                                            loading="lazy"
+                                        />
+                                    </span>
+                                    <span class="series-sibling-info">
+                                        <span class="series-sibling-title">{item.title}</span>
+                                        <span class="series-sibling-meta">
+                                            {areaLabel && <span>{areaLabel}</span>}
+                                            {compressorLabel && <span>{compressorLabel}</span>}
+                                        </span>
+                                        <span class="series-sibling-price">
+                                            {formatSeriesPrice(item.price)}
+                                        </span>
+                                    </span>
+                                </a>
+                            );
+                        })}
+                    </div>
+                </section>
+            )
+        }
     </div>
 </Layout>
 
@@ -1011,6 +1100,141 @@ const seoDescription = buildProductMetaDescription(product);
         grid-template-columns: 42% 1fr; /* User requested ~40% for gallery */
         gap: 4rem;
         align-items: start;
+    }
+
+    .series-siblings-section {
+        margin-top: 3rem;
+        padding-top: 1.6rem;
+        border-top: 1px solid var(--panel-glass-border);
+    }
+
+    .series-siblings-head {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .section-kicker {
+        margin: 0 0 0.25rem;
+        color: var(--primary);
+        font-size: 0.78rem;
+        font-weight: 800;
+        letter-spacing: 0;
+        text-transform: uppercase;
+    }
+
+    .series-siblings-head h2 {
+        margin: 0;
+        color: var(--text);
+        font-size: 1.35rem;
+        line-height: 1.2;
+    }
+
+    .series-brand-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+        font-weight: 700;
+        white-space: nowrap;
+    }
+
+    .series-brand-link:hover {
+        color: var(--primary);
+    }
+
+    .series-brand-link .material-icons-round {
+        font-size: 1rem;
+    }
+
+    .series-siblings-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+        gap: 0.85rem;
+    }
+
+    .series-sibling-card {
+        min-width: 0;
+        display: grid;
+        grid-template-columns: 88px minmax(0, 1fr);
+        gap: 0.85rem;
+        align-items: center;
+        padding: 0.75rem;
+        border-radius: 12px;
+        border: 1px solid var(--panel-chip-border);
+        background: var(--panel-chip-bg);
+        color: var(--text);
+        transition:
+            border-color 0.2s ease,
+            transform 0.2s ease,
+            box-shadow 0.2s ease;
+    }
+
+    .series-sibling-card:hover {
+        border-color: var(--panel-chip-hover-border);
+        transform: translateY(-2px);
+        box-shadow: var(--panel-glass-shadow);
+    }
+
+    .series-sibling-image {
+        width: 88px;
+        aspect-ratio: 4 / 3;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        background: rgba(var(--surface-rgb), 0.58);
+        border: 1px solid var(--panel-chip-border);
+        overflow: hidden;
+    }
+
+    .series-sibling-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        padding: 0.45rem;
+    }
+
+    .series-sibling-info {
+        min-width: 0;
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    .series-sibling-title {
+        color: var(--text);
+        font-weight: 800;
+        line-height: 1.25;
+        overflow-wrap: anywhere;
+    }
+
+    .series-sibling-meta {
+        min-height: 1.45rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+    }
+
+    .series-sibling-meta span {
+        display: inline-flex;
+        align-items: center;
+        min-height: 22px;
+        padding: 0.18rem 0.45rem;
+        border-radius: 7px;
+        background: var(--panel-pill-bg);
+        color: var(--text-muted);
+        font-size: 0.78rem;
+        font-weight: 700;
+    }
+
+    .series-sibling-price {
+        color: var(--primary);
+        font-size: 0.98rem;
+        font-weight: 900;
+        font-variant-numeric: tabular-nums;
     }
 
     .visuals-col {
@@ -1750,6 +1974,27 @@ const seoDescription = buildProductMetaDescription(product);
         .product-page {
             padding: 1rem; /* Aligned with global container */
             padding-bottom: 6rem;
+        }
+
+        .series-siblings-section {
+            margin-top: 2rem;
+        }
+
+        .series-siblings-head {
+            align-items: flex-start;
+            flex-direction: column;
+        }
+
+        .series-brand-link {
+            white-space: normal;
+        }
+
+        .series-sibling-card {
+            grid-template-columns: 78px minmax(0, 1fr);
+        }
+
+        .series-sibling-image {
+            width: 78px;
         }
 
         .header-section h1 {


### PR DESCRIPTION
## Summary
- expose published product series in the public product API payload
- sort same-series siblings by brand, area, power and price for product detail pages
- group brand catalog pages by series and add sibling navigation on product pages
- regenerate OpenAPI and manager frontend client types

## Verification
- pytest tests/unit/test_product_response_mapper_variants.py tests/unit/test_public_product_series_payloads.py -q
- cd web && npm run audit:theme
- cd manager_frontend && npm run build
- cd web && PUBLIC_API_URL=https://api.mvn.by/api/v1 INTERNAL_API_URL=https://api.mvn.by/api/v1 npm run build
- Browser smoke: /brands/tcl/ mobile 412px, /brands/mdv/ desktop 1440px, /product/tcl-elite-tac-09chsa-xab1n/ mobile+desktop

## Notes
- Local integration test tests/integration/test_product_series_siblings.py could not run here because db_test:5432 is not resolvable outside the test DB environment.
- Static web build now takes about 104s because product pages with series hints fetch detail payloads to include siblings; V2 should move this into catalog/batch payloads or SSR freshness.