### PR TITLE
Phase 2: optimize product series navigation for SSG

### DIFF
--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -229,6 +229,8 @@ export type { ProductMainImageCleanupSkipReasonsResponse } from './models/Produc
 export type { ProductManualPayload } from './models/ProductManualPayload';
 export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';
+export type { ProductSeriesNavigationItemResponse } from './models/ProductSeriesNavigationItemResponse';
+export type { ProductSeriesNavigationResponse } from './models/ProductSeriesNavigationResponse';
 export type { ProductSeriesResponse } from './models/ProductSeriesResponse';
 export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';

--- a/manager_frontend/src/client/models/ProductSeriesNavigationItemResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesNavigationItemResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProductSeriesResponse } from './ProductSeriesResponse';
+import type { ProductSiblingResponse } from './ProductSiblingResponse';
+export type ProductSeriesNavigationItemResponse = {
+    series?: (ProductSeriesResponse | null);
+    series_siblings?: Array<ProductSiblingResponse>;
+};
+

--- a/manager_frontend/src/client/models/ProductSeriesNavigationResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesNavigationResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProductSeriesNavigationItemResponse } from './ProductSeriesNavigationItemResponse';
+export type ProductSeriesNavigationResponse = {
+    products?: Record<string, ProductSeriesNavigationItemResponse>;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -12,6 +12,7 @@ import type { OrderResponse } from '../models/OrderResponse';
 import type { ProductAvailabilityLeadPayload } from '../models/ProductAvailabilityLeadPayload';
 import type { ProductAvailabilityLeadResponse } from '../models/ProductAvailabilityLeadResponse';
 import type { ProductResponse } from '../models/ProductResponse';
+import type { ProductSeriesNavigationResponse } from '../models/ProductSeriesNavigationResponse';
 import type { PublicBrandResponse } from '../models/PublicBrandResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
 import type { SpecsKeysResponse } from '../models/SpecsKeysResponse';
@@ -459,6 +460,17 @@ export class ApiService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/products/vitebsk-featured',
+        });
+    }
+    /**
+     * Get Product Series Navigation
+     * @returns ProductSeriesNavigationResponse Successful Response
+     * @throws ApiError
+     */
+    public static getProductSeriesNavigation(): CancelablePromise<ProductSeriesNavigationResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/product-series/navigation',
         });
     }
     /**

--- a/openapi.json
+++ b/openapi.json
@@ -1275,6 +1275,28 @@
         }
       }
     },
+    "/api/v1/product-series/navigation": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Get Product Series Navigation",
+        "operationId": "get_product_series_navigation",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductSeriesNavigationResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/products/{identifier}": {
       "get": {
         "tags": [
@@ -24947,6 +24969,44 @@
           "created_at"
         ],
         "title": "ProductResponse"
+      },
+      "ProductSeriesNavigationItemResponse": {
+        "properties": {
+          "series": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProductSeriesResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "series_siblings": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSiblingResponse"
+            },
+            "type": "array",
+            "title": "Series Siblings",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "ProductSeriesNavigationItemResponse"
+      },
+      "ProductSeriesNavigationResponse": {
+        "properties": {
+          "products": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProductSeriesNavigationItemResponse"
+            },
+            "type": "object",
+            "title": "Products",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "title": "ProductSeriesNavigationResponse"
       },
       "ProductSeriesResponse": {
         "properties": {

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -11,6 +11,7 @@ from schemas import (
     CatalogResponse,
     FiltersConfigResponse,
     Meta,
+    ProductSeriesNavigationResponse,
     ProductResponse,
     SpecsKeysResponse,
 )
@@ -118,6 +119,15 @@ async def get_vitebsk_featured_products(session: AsyncSession = Depends(get_sess
         )
         for product in products
     ]
+
+
+@router.get(
+    "/v1/product-series/navigation",
+    response_model=ProductSeriesNavigationResponse,
+    operation_id="get_product_series_navigation",
+)
+async def get_product_series_navigation(session: AsyncSession = Depends(get_session)):
+    return await ProductService.get_series_navigation(session)
 
 
 @router.get("/v1/products/{identifier}", response_model=ProductResponse, operation_id="get_product")

--- a/schemas.py
+++ b/schemas.py
@@ -115,6 +115,15 @@ class ProductSeriesResponse(BaseModel):
     hero_image: Optional[str] = None
 
 
+class ProductSeriesNavigationItemResponse(BaseModel):
+    series: Optional[ProductSeriesResponse] = None
+    series_siblings: List[ProductSiblingResponse] = []
+
+
+class ProductSeriesNavigationResponse(BaseModel):
+    products: Dict[str, ProductSeriesNavigationItemResponse] = {}
+
+
 class ProductResponse(ProductBase):
     vitebsk_qty: int = 0
     minsk_qty: int = 0

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -1,15 +1,104 @@
 """Series/siblings product service operations."""
 
-from typing import List
+from typing import Dict, List
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from models import Product, ProductTagLink, Tag
+from schemas import (
+    ProductSeriesNavigationItemResponse,
+    ProductSeriesNavigationResponse,
+    ProductSeriesResponse,
+    ProductSiblingResponse,
+)
 
 
 class ProductSeriesService:
+    @staticmethod
+    def _sort_series_candidates(reference: Product, candidates: List[Product]) -> List[Product]:
+        def score(item: Product) -> tuple[int, float, float, float, str, int]:
+            same_brand = 1
+            if reference.brand_id and item.brand_id:
+                same_brand = 0 if reference.brand_id == item.brand_id else 1
+            else:
+                reference_brand_ids = {
+                    tag.id for tag in (reference.tags or [])
+                    if tag.group and tag.group.slug == "brand"
+                }
+                item_brand_ids = {
+                    tag.id for tag in (item.tags or [])
+                    if tag.group and tag.group.slug == "brand"
+                }
+                same_brand = 0 if (reference_brand_ids and item_brand_ids.intersection(reference_brand_ids)) else 1
+
+            def numeric(value) -> float:
+                if value is None:
+                    return float("inf")
+                try:
+                    number = float(value)
+                except (TypeError, ValueError):
+                    return float("inf")
+                return number if number > 0 else float("inf")
+
+            return (
+                same_brand,
+                numeric(item.area),
+                numeric(item.power_cooling),
+                numeric(item.price),
+                (item.title or "").casefold(),
+                item.id or 0,
+            )
+
+        return sorted(candidates, key=score)
+
+    @staticmethod
+    def _sibling_payload(item: Product) -> ProductSiblingResponse:
+        return ProductSiblingResponse(
+            id=item.id,
+            title=item.title,
+            slug=item.slug,
+            price=item.price,
+            old_price=item.old_price,
+            area=item.area,
+            is_inverter=item.is_inverter,
+            main_image=item.main_image,
+        )
+
+    @staticmethod
+    def _series_payload(product: Product) -> ProductSeriesResponse | None:
+        series = product.series if product.series_id else None
+        if not series or not series.is_published:
+            return None
+        return ProductSeriesResponse(
+            id=series.id,
+            title=series.title,
+            slug=series.slug,
+            description=series.description,
+            hero_image=series.hero_image,
+        )
+
+    @staticmethod
+    def _series_group_keys(product: Product) -> List[str]:
+        if product.series_id:
+            return [f"series:{product.series_id}"]
+
+        keys = [
+            f"tag:{tag.id}"
+            for tag in (product.tags or [])
+            if tag.id and tag.group and tag.group.slug == "series"
+        ]
+
+        specs = product.specs if isinstance(product.specs, dict) else {}
+        specs_series = specs.get("series")
+        if specs_series:
+            normalized_series = " ".join(str(specs_series).casefold().split())
+            if normalized_series:
+                keys.append(f"specs:{normalized_series}")
+
+        return keys
+
     @staticmethod
     async def get_series_siblings(
         session: AsyncSession,
@@ -39,39 +128,59 @@ class ProductSeriesService:
 
         stmt = stmt.options(selectinload(Product.tags).selectinload(Tag.group))
         candidates = list((await session.execute(stmt)).scalars().all())
+        return ProductSeriesService._sort_series_candidates(product, candidates)[:limit]
 
-        def score(item: Product) -> tuple[int, float, float, float, str, int]:
-            same_brand = 1
-            if product.brand_id and item.brand_id:
-                same_brand = 0 if product.brand_id == item.brand_id else 1
-            else:
-                product_brand_ids = {
-                    tag.id for tag in (product.tags or [])
-                    if tag.group and tag.group.slug == "brand"
-                }
-                item_brand_ids = {
-                    tag.id for tag in (item.tags or [])
-                    if tag.group and tag.group.slug == "brand"
-                }
-                same_brand = 0 if (product_brand_ids and item_brand_ids.intersection(product_brand_ids)) else 1
+    @staticmethod
+    async def get_series_navigation(
+        session: AsyncSession,
+        limit_per_product: int = 8,
+    ) -> ProductSeriesNavigationResponse:
+        stmt = (
+            select(Product)
+            .where(Product.is_published == True)
+            .options(
+                selectinload(Product.series),
+                selectinload(Product.tags).selectinload(Tag.group),
+            )
+        )
+        products = list((await session.execute(stmt)).scalars().all())
 
-            def numeric(value) -> float:
-                if value is None:
-                    return float("inf")
-                try:
-                    number = float(value)
-                except (TypeError, ValueError):
-                    return float("inf")
-                return number if number > 0 else float("inf")
+        product_group_keys: Dict[int, List[str]] = {}
+        groups: Dict[str, List[Product]] = {}
+        for product in products:
+            if not product.id:
+                continue
 
-            return (
-                same_brand,
-                numeric(item.area),
-                numeric(item.power_cooling),
-                numeric(item.price),
-                (item.title or "").casefold(),
-                item.id or 0,
+            keys = ProductSeriesService._series_group_keys(product)
+            product_group_keys[product.id] = keys
+            for key in keys:
+                groups.setdefault(key, []).append(product)
+
+        products_payload: Dict[str, ProductSeriesNavigationItemResponse] = {}
+        for product in products:
+            if not product.slug:
+                continue
+
+            group_keys = product_group_keys.get(product.id or 0, [])
+            if not group_keys:
+                continue
+
+            siblings_by_id: Dict[int, Product] = {}
+            for key in group_keys:
+                for candidate in groups.get(key, []):
+                    if candidate.id and candidate.id != product.id:
+                        siblings_by_id[candidate.id] = candidate
+
+            siblings = ProductSeriesService._sort_series_candidates(
+                product,
+                list(siblings_by_id.values()),
+            )[:limit_per_product]
+            products_payload[product.slug] = ProductSeriesNavigationItemResponse(
+                series=ProductSeriesService._series_payload(product),
+                series_siblings=[
+                    ProductSeriesService._sibling_payload(item)
+                    for item in siblings
+                ],
             )
 
-        candidates.sort(key=score)
-        return candidates[:limit]
+        return ProductSeriesNavigationResponse(products=products_payload)

--- a/tests/unit/test_public_product_series_payloads.py
+++ b/tests/unit/test_public_product_series_payloads.py
@@ -7,7 +7,15 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from crud.product import ProductDAO
-from models import Brand, Product, ProductLocalStock, ProductSeries
+from models import (
+    Brand,
+    Product,
+    ProductLocalStock,
+    ProductSeries,
+    ProductTagLink,
+    Tag,
+    TagGroup,
+)
 from services.catalog import CatalogService
 from services.product_response_mapper import map_product_to_response
 from services.product_series_service import ProductSeriesService
@@ -143,3 +151,80 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
 
     siblings = await ProductSeriesService.get_series_siblings(sqlite_session, detail, limit=8)
     assert [item.slug for item in siblings] == ["mdv-elite-25", "mdv-elite-50"]
+
+
+@pytest.mark.asyncio
+async def test_public_series_navigation_builds_slug_sibling_map(sqlite_session):
+    seeded = await _seed_series_products(sqlite_session)
+
+    navigation = await ProductSeriesService.get_series_navigation(sqlite_session)
+
+    main_item = navigation.products[seeded["main"].slug]
+    assert main_item.series is not None
+    assert main_item.series.slug == "elite"
+    assert [item.slug for item in main_item.series_siblings] == [
+        "mdv-elite-25",
+        "mdv-elite-50",
+    ]
+
+    sibling_item = navigation.products[seeded["sibling_25"].slug]
+    assert [item.slug for item in sibling_item.series_siblings] == [
+        "mdv-elite-35",
+        "mdv-elite-50",
+    ]
+    assert seeded["other"].slug not in navigation.products
+
+
+@pytest.mark.asyncio
+async def test_public_series_navigation_covers_legacy_series_sources(sqlite_session):
+    specs_main = Product(
+        title="Legacy Line 35",
+        slug="legacy-line-35",
+        price=1700,
+        area=35,
+        specs={"series": "Legacy Line"},
+        is_published=True,
+    )
+    specs_sibling = Product(
+        title="Legacy Line 25",
+        slug="legacy-line-25",
+        price=1400,
+        area=25,
+        specs={"series": "Legacy Line"},
+        is_published=True,
+    )
+    specs_single = Product(
+        title="Solo Line 25",
+        slug="solo-line-25",
+        price=1200,
+        area=25,
+        specs={"series": "Solo Line"},
+        is_published=True,
+    )
+    tag_single = Product(
+        title="Tagged Series 25",
+        slug="tagged-series-25",
+        price=1300,
+        area=25,
+        is_published=True,
+    )
+    tag_group = TagGroup(title="Series", slug="series")
+    tag = Tag(title="Tagged Series", slug="tagged-series")
+    sqlite_session.add_all([specs_main, specs_sibling, specs_single, tag_single, tag_group])
+    await sqlite_session.flush()
+
+    tag.group_id = tag_group.id
+    sqlite_session.add(tag)
+    await sqlite_session.flush()
+    sqlite_session.add(ProductTagLink(product_id=tag_single.id, tag_id=tag.id))
+    await sqlite_session.commit()
+
+    navigation = await ProductSeriesService.get_series_navigation(sqlite_session)
+
+    assert [item.slug for item in navigation.products[specs_main.slug].series_siblings] == [
+        "legacy-line-25",
+    ]
+    assert navigation.products[specs_single.slug].series is None
+    assert navigation.products[specs_single.slug].series_siblings == []
+    assert navigation.products[tag_single.slug].series is None
+    assert navigation.products[tag_single.slug].series_siblings == []

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -6,6 +6,7 @@ import {
     createRuntimeNotFoundResponse,
     getProductBySlug,
     getProducts,
+    getProductSeriesNavigationForSsg,
     isRuntimeFreshnessEnabled,
     resolveImageUrl,
 } from "../../utils/api";
@@ -33,33 +34,49 @@ export async function getStaticPaths() {
     if (!Array.isArray(products) || products.length === 0) {
         throw new Error("[SSG] Product static paths generation failed: no products returned from API.");
     }
+    const seriesNavigation = await getProductSeriesNavigationForSsg();
+    const seriesNavigationBySlug = seriesNavigation?.products || {};
 
     return products.map((product: any) => ({
         params: { slug: product.slug },
-        props: { product },
+        props: {
+            product,
+            seriesNavigationItem: seriesNavigationBySlug[product.slug] || null,
+        },
     }));
 }
 
 // Define Props
 interface Props {
     product: any;
+    seriesNavigationItem?: any;
 }
 
 const runtimeFreshness = await createRuntimeFreshnessContext();
 const runtimeFreshnessOption = runtimeFreshness ? { runtimeFreshness } : undefined;
-const { product: initialProduct } = Astro.props as Props;
+const { product: initialProduct, seriesNavigationItem } = Astro.props as Props;
 const productSlug = Astro.params.slug || "";
+const initialProductWithSeriesNavigation = seriesNavigationItem
+    ? {
+          ...initialProduct,
+          series: seriesNavigationItem.series || initialProduct?.series,
+          series_siblings: Array.isArray(seriesNavigationItem.series_siblings)
+              ? seriesNavigationItem.series_siblings
+              : initialProduct?.series_siblings,
+      }
+    : initialProduct;
 const hasInitialSeriesInfo = Boolean(
-    initialProduct?.series?.title
-        || initialProduct?.specs?.series
-        || (initialProduct?.tags || []).some((tag: any) => (tag?.group?.slug || tag?.group_slug) === "series")
+    initialProductWithSeriesNavigation?.series?.title
+        || initialProductWithSeriesNavigation?.specs?.series
+        || (initialProductWithSeriesNavigation?.tags || []).some((tag: any) => (tag?.group?.slug || tag?.group_slug) === "series")
 );
 const hasInitialSeriesSiblings =
-    Array.isArray(initialProduct?.series_siblings) && initialProduct.series_siblings.length > 0;
+    Array.isArray(initialProductWithSeriesNavigation?.series_siblings)
+    && initialProductWithSeriesNavigation.series_siblings.length > 0;
 const product = runtimeFreshness
     ? await getProductBySlug(productSlug, runtimeFreshnessOption)
-    : hasInitialSeriesSiblings || !hasInitialSeriesInfo
-        ? initialProduct
+    : seriesNavigationItem || hasInitialSeriesSiblings || !hasInitialSeriesInfo
+        ? initialProductWithSeriesNavigation
         : (await getProductBySlug(productSlug)) || initialProduct;
 
 if (!product) {

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -269,6 +269,37 @@ export async function getCatalogForSsg(params = {}) {
     return await getCatalog(params);
 }
 
+async function getProductSeriesNavigationStrictForSsg() {
+    const candidates = getSsgApiCandidates();
+
+    for (const baseUrl of candidates) {
+        const data = await fetchJson(`${baseUrl}/product-series/navigation`);
+        if (data && data.products && typeof data.products === "object") {
+            return data;
+        }
+    }
+
+    return null;
+}
+
+export async function getProductSeriesNavigation(options = {}) {
+    const runtimeFreshness = getRuntimeFreshnessOption(options);
+    const data = await fetchJsonWithRuntimeCache(
+        `${API_V1}/product-series/navigation`,
+        {},
+        true,
+        runtimeFreshness,
+    );
+    return data && data.products ? data : { products: {} };
+}
+
+export async function getProductSeriesNavigationForSsg() {
+    if (import.meta.env.SSR) {
+        return await getProductSeriesNavigationStrictForSsg();
+    }
+    return await getProductSeriesNavigation();
+}
+
 export async function getVitebskFeaturedProducts() {
     const url = `${API_V1}/products/vitebsk-featured`;
     const data = await fetchJson(url);


### PR DESCRIPTION
## Summary
- add public `GET /api/v1/product-series/navigation` for slug-keyed product series/sibling navigation
- build product page SSG props from the navigation map to avoid per-product detail fetches for series siblings
- cover canonical `series_id`, legacy series tags, and `specs.series` sources
- regenerate OpenAPI and manager client types

## Verification
- `pytest tests/unit/test_public_product_series_payloads.py tests/unit/test_product_response_mapper_variants.py -q` -> 13 passed
- `python3 -m compileall schemas.py routers/api_products.py services/product_series_service.py`
- `cd web && npm run audit:theme`
- `cd manager_frontend && npm run build`
- `cd web && PUBLIC_API_URL=https://api.mvn.by/api/v1 INTERNAL_API_URL=https://api.mvn.by/api/v1 npm run build` -> passes against old prod API fallback, ~199s
- proxy smoke with navigation endpoint available: storefront build ~19s, proxy counters `nav=1 detail=1`

## Notes
- Full local `pytest tests/unit -q` is not conclusive in this environment: 328 passed, 44 setup errors because `db_test` host is not resolvable.
- After this PR is merged/deployed, Phase 2 should pause for production validation before Phase 3.