### PR TITLE
Phase 3: editable brand series content

### DIFF
--- a/alembic/versions/7d1e9c4a2f63_add_product_series_features.py
+++ b/alembic/versions/7d1e9c4a2f63_add_product_series_features.py
@@ -1,0 +1,30 @@
+"""add product series features
+
+Revision ID: 7d1e9c4a2f63
+Revises: 4a2b6c8d0e91
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7d1e9c4a2f63"
+down_revision: Union[str, Sequence[str], None] = "4a2b6c8d0e91"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "product_series",
+        sa.Column("features", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.alter_column("product_series", "features", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("product_series", "features")

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -63,6 +63,9 @@ import {
     type CatalogImportJobStatusResponse,
     type ManagerBrandResponse,
     type ManagerBrandCreatePayload,
+    type ManagerBrandSeriesCreatePayload,
+    type ManagerBrandSeriesResponse,
+    type ManagerBrandSeriesUpdatePayload,
     type ManagerBrandUpdatePayload,
     type ProductImageVariantBatchProcessResponse,
     type ProductImageVariantCandidateResponse,
@@ -111,10 +114,14 @@ export type {
 };
 
 type ManagerBrand = ManagerBrandResponse;
+type ManagerBrandSeries = ManagerBrandSeriesResponse;
 
 export type {
     ManagerBrand,
     ManagerBrandCreatePayload,
+    ManagerBrandSeries,
+    ManagerBrandSeriesCreatePayload,
+    ManagerBrandSeriesUpdatePayload,
     ManagerBrandUpdatePayload,
 };
 export type {
@@ -866,6 +873,47 @@ export const api = {
 
     async deleteManagerBrand(brandId: number): Promise<{ message: string }> {
         return await ManagerBrandsService.deleteManagerBrand(brandId);
+    },
+
+    async listManagerBrandSeries(brandId: number): Promise<{ items: ManagerBrandSeries[] }> {
+        const response = await ManagerBrandsService.listManagerBrandSeries(brandId);
+        return {
+            ...response,
+            items: (response.items || []).map((series) => ({
+                ...series,
+                features: series.features || [],
+                products_count: series.products_count ?? 0,
+            })),
+        };
+    },
+
+    async createManagerBrandSeries(
+        brandId: number,
+        payload: ManagerBrandSeriesCreatePayload,
+    ): Promise<ManagerBrandSeries> {
+        const series = await ManagerBrandsService.createManagerBrandSeries(brandId, payload);
+        return {
+            ...series,
+            features: series.features || [],
+            products_count: series.products_count ?? 0,
+        };
+    },
+
+    async updateManagerBrandSeries(
+        brandId: number,
+        seriesId: number,
+        payload: ManagerBrandSeriesUpdatePayload,
+    ): Promise<ManagerBrandSeries> {
+        const series = await ManagerBrandsService.updateManagerBrandSeries(brandId, seriesId, payload);
+        return {
+            ...series,
+            features: series.features || [],
+            products_count: series.products_count ?? 0,
+        };
+    },
+
+    async deleteManagerBrandSeries(brandId: number, seriesId: number): Promise<{ message: string }> {
+        return await ManagerBrandsService.deleteManagerBrandSeries(brandId, seriesId);
     },
     // Leads Inbox (Order-based triage)
     async getLeadsCounter() {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -78,6 +78,10 @@ export type { ManagerBackupRunStatusResponse } from './models/ManagerBackupRunSt
 export type { ManagerBrandCreatePayload } from './models/ManagerBrandCreatePayload';
 export type { ManagerBrandListResponse } from './models/ManagerBrandListResponse';
 export type { ManagerBrandResponse } from './models/ManagerBrandResponse';
+export type { ManagerBrandSeriesCreatePayload } from './models/ManagerBrandSeriesCreatePayload';
+export type { ManagerBrandSeriesListResponse } from './models/ManagerBrandSeriesListResponse';
+export type { ManagerBrandSeriesResponse } from './models/ManagerBrandSeriesResponse';
+export type { ManagerBrandSeriesUpdatePayload } from './models/ManagerBrandSeriesUpdatePayload';
 export type { ManagerBrandUpdatePayload } from './models/ManagerBrandUpdatePayload';
 export type { ManagerBulkDeleteProductsError } from './models/ManagerBulkDeleteProductsError';
 export type { ManagerBulkDeleteProductsResponse } from './models/ManagerBulkDeleteProductsResponse';

--- a/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
@@ -2,12 +2,13 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ProductSeriesResponse = {
-    id: number;
+export type ManagerBrandSeriesCreatePayload = {
     title: string;
-    slug: string;
+    slug?: (string | null);
     description?: (string | null);
     hero_image?: (string | null);
     features?: Array<string>;
+    is_published?: boolean;
+    sort_order?: number;
 };
 

--- a/manager_frontend/src/client/models/ManagerBrandSeriesListResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesListResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerBrandSeriesResponse } from './ManagerBrandSeriesResponse';
+export type ManagerBrandSeriesListResponse = {
+    items: Array<ManagerBrandSeriesResponse>;
+};
+

--- a/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
@@ -2,12 +2,17 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ProductSeriesResponse = {
+export type ManagerBrandSeriesResponse = {
     id: number;
+    brand_id?: (number | null);
     title: string;
     slug: string;
     description?: (string | null);
     hero_image?: (string | null);
     features?: Array<string>;
+    is_published: boolean;
+    sort_order: number;
+    created_at: string;
+    products_count?: number;
 };
 

--- a/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerBrandSeriesUpdatePayload = {
+    title?: (string | null);
+    slug?: (string | null);
+    description?: (string | null);
+    hero_image?: (string | null);
+    features?: (Array<string> | null);
+    is_published?: (boolean | null);
+    sort_order?: (number | null);
+};
+

--- a/manager_frontend/src/client/services/ManagerBrandsService.ts
+++ b/manager_frontend/src/client/services/ManagerBrandsService.ts
@@ -6,6 +6,10 @@ import type { ManagerActionMessageResponse } from '../models/ManagerActionMessag
 import type { ManagerBrandCreatePayload } from '../models/ManagerBrandCreatePayload';
 import type { ManagerBrandListResponse } from '../models/ManagerBrandListResponse';
 import type { ManagerBrandResponse } from '../models/ManagerBrandResponse';
+import type { ManagerBrandSeriesCreatePayload } from '../models/ManagerBrandSeriesCreatePayload';
+import type { ManagerBrandSeriesListResponse } from '../models/ManagerBrandSeriesListResponse';
+import type { ManagerBrandSeriesResponse } from '../models/ManagerBrandSeriesResponse';
+import type { ManagerBrandSeriesUpdatePayload } from '../models/ManagerBrandSeriesUpdatePayload';
 import type { ManagerBrandUpdatePayload } from '../models/ManagerBrandUpdatePayload';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -79,6 +83,100 @@ export class ManagerBrandsService {
             url: '/api/manager/brands/{brand_id}',
             path: {
                 'brand_id': brandId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * List Manager Brand Series
+     * @param brandId
+     * @returns ManagerBrandSeriesListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listManagerBrandSeries(
+        brandId: number,
+    ): CancelablePromise<ManagerBrandSeriesListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/brands/{brand_id}/series',
+            path: {
+                'brand_id': brandId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Manager Brand Series
+     * @param brandId
+     * @param requestBody
+     * @returns ManagerBrandSeriesResponse Successful Response
+     * @throws ApiError
+     */
+    public static createManagerBrandSeries(
+        brandId: number,
+        requestBody: ManagerBrandSeriesCreatePayload,
+    ): CancelablePromise<ManagerBrandSeriesResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/brands/{brand_id}/series',
+            path: {
+                'brand_id': brandId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Manager Brand Series
+     * @param brandId
+     * @param seriesId
+     * @param requestBody
+     * @returns ManagerBrandSeriesResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateManagerBrandSeries(
+        brandId: number,
+        seriesId: number,
+        requestBody: ManagerBrandSeriesUpdatePayload,
+    ): CancelablePromise<ManagerBrandSeriesResponse> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/manager/brands/{brand_id}/series/{series_id}',
+            path: {
+                'brand_id': brandId,
+                'series_id': seriesId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Manager Brand Series
+     * @param brandId
+     * @param seriesId
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static deleteManagerBrandSeries(
+        brandId: number,
+        seriesId: number,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/brands/{brand_id}/series/{series_id}',
+            path: {
+                'brand_id': brandId,
+                'series_id': seriesId,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-import { api, type ManagerBrand } from '../api';
+import { computed, onMounted, ref, watch } from 'vue';
+import { api, type ManagerBrand, type ManagerBrandSeries } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 type BrandForm = {
@@ -8,6 +8,16 @@ type BrandForm = {
     slug: string;
     logo_url: string;
     description: string;
+    sort_order: number;
+    is_published: boolean;
+};
+
+type SeriesForm = {
+    title: string;
+    slug: string;
+    description: string;
+    hero_image: string;
+    featuresText: string;
     sort_order: number;
     is_published: boolean;
 };
@@ -20,11 +30,27 @@ const error = ref('');
 const toast = ref('');
 const modalOpen = ref(false);
 const editingBrand = ref<ManagerBrand | null>(null);
+const selectedBrandId = ref<number | null>(null);
+const seriesItems = ref<ManagerBrandSeries[]>([]);
+const seriesLoading = ref(false);
+const seriesSaving = ref(false);
+const seriesError = ref('');
+const seriesModalOpen = ref(false);
+const editingSeries = ref<ManagerBrandSeries | null>(null);
 const form = ref<BrandForm>({
     title: '',
     slug: '',
     logo_url: '',
     description: '',
+    sort_order: 0,
+    is_published: true,
+});
+const seriesForm = ref<SeriesForm>({
+    title: '',
+    slug: '',
+    description: '',
+    hero_image: '',
+    featuresText: '',
     sort_order: 0,
     is_published: true,
 });
@@ -40,12 +66,29 @@ const filteredBrands = computed(() => {
     });
 });
 
+const selectedBrand = computed(() => {
+    if (!selectedBrandId.value) return null;
+    return brands.value.find((item) => item.id === selectedBrandId.value) || null;
+});
+
 const resetForm = () => {
     form.value = {
         title: '',
         slug: '',
         logo_url: '',
         description: '',
+        sort_order: 0,
+        is_published: true,
+    };
+};
+
+const resetSeriesForm = () => {
+    seriesForm.value = {
+        title: '',
+        slug: '',
+        description: '',
+        hero_image: '',
+        featuresText: '',
         sort_order: 0,
         is_published: true,
     };
@@ -64,11 +107,39 @@ const fetchBrands = async () => {
     try {
         const res = await api.listManagerBrands();
         brands.value = [...(res.items || [])];
+        if (selectedBrandId.value && !brands.value.some((item) => item.id === selectedBrandId.value)) {
+            selectedBrandId.value = null;
+        }
+        if (!selectedBrandId.value && brands.value.length > 0) {
+            selectedBrandId.value = brands.value[0]?.id || null;
+        }
     } catch (err) {
         error.value = getApiErrorMessage(err);
     } finally {
         loading.value = false;
     }
+};
+
+const fetchSeries = async () => {
+    if (!selectedBrandId.value) {
+        seriesItems.value = [];
+        return;
+    }
+
+    seriesLoading.value = true;
+    seriesError.value = '';
+    try {
+        const res = await api.listManagerBrandSeries(selectedBrandId.value);
+        seriesItems.value = [...(res.items || [])];
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        seriesLoading.value = false;
+    }
+};
+
+const selectBrand = (brand: ManagerBrand) => {
+    selectedBrandId.value = brand.id;
 };
 
 const openCreate = () => {
@@ -96,6 +167,48 @@ const closeModal = () => {
     modalOpen.value = false;
     editingBrand.value = null;
     resetForm();
+};
+
+const openSeriesCreate = () => {
+    editingSeries.value = null;
+    resetSeriesForm();
+    seriesModalOpen.value = true;
+    seriesError.value = '';
+};
+
+const openSeriesEdit = (series: ManagerBrandSeries) => {
+    editingSeries.value = series;
+    seriesForm.value = {
+        title: String(series.title || ''),
+        slug: String(series.slug || ''),
+        description: String(series.description || ''),
+        hero_image: String(series.hero_image || ''),
+        featuresText: (series.features || []).join('\n'),
+        sort_order: Number(series.sort_order || 0),
+        is_published: Boolean(series.is_published),
+    };
+    seriesModalOpen.value = true;
+    seriesError.value = '';
+};
+
+const closeSeriesModal = () => {
+    seriesModalOpen.value = false;
+    editingSeries.value = null;
+    resetSeriesForm();
+};
+
+const normalizeFeatures = (value: string) => {
+    const seen = new Set<string>();
+    return String(value || '')
+        .split('\n')
+        .map((item) => item.trim())
+        .filter((item) => {
+            if (!item) return false;
+            const key = item.toLowerCase();
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
 };
 
 const saveBrand = async () => {
@@ -143,6 +256,61 @@ const deleteBrand = async (brand: ManagerBrand) => {
         error.value = getApiErrorMessage(err);
     }
 };
+
+const saveSeries = async () => {
+    if (!selectedBrandId.value) return;
+
+    const title = String(seriesForm.value.title || '').trim();
+    if (!title) {
+        seriesError.value = 'Название серии обязательно.';
+        return;
+    }
+
+    seriesSaving.value = true;
+    seriesError.value = '';
+    try {
+        const wasEditing = Boolean(editingSeries.value?.id);
+        const payload = {
+            title,
+            slug: String(seriesForm.value.slug || '').trim() || undefined,
+            description: String(seriesForm.value.description || '').trim() || undefined,
+            hero_image: String(seriesForm.value.hero_image || '').trim() || undefined,
+            features: normalizeFeatures(seriesForm.value.featuresText),
+            sort_order: Number(seriesForm.value.sort_order || 0),
+            is_published: Boolean(seriesForm.value.is_published),
+        };
+        if (editingSeries.value?.id) {
+            await api.updateManagerBrandSeries(selectedBrandId.value, editingSeries.value.id, payload);
+        } else {
+            await api.createManagerBrandSeries(selectedBrandId.value, payload);
+        }
+        await fetchSeries();
+        closeSeriesModal();
+        setToast(wasEditing ? 'Серия обновлена' : 'Серия создана');
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        seriesSaving.value = false;
+    }
+};
+
+const deleteSeries = async (series: ManagerBrandSeries) => {
+    if (!selectedBrandId.value) return;
+    if (!confirm(`Удалить серию "${series.title}"?`)) return;
+
+    seriesError.value = '';
+    try {
+        await api.deleteManagerBrandSeries(selectedBrandId.value, series.id);
+        await fetchSeries();
+        setToast('Серия удалена');
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    }
+};
+
+watch(selectedBrandId, () => {
+    fetchSeries();
+});
 
 onMounted(() => {
     fetchBrands();
@@ -205,7 +373,9 @@ onMounted(() => {
                         <tr
                             v-for="brand in filteredBrands"
                             :key="brand.id"
-                            class="border-b border-gray-100 dark:border-slate-800/80"
+                            class="border-b border-gray-100 dark:border-slate-800/80 cursor-pointer transition-colors"
+                            :class="selectedBrandId === brand.id ? 'bg-teal-50/80 dark:bg-teal-900/20' : 'hover:bg-gray-50 dark:hover:bg-slate-800'"
+                            @click="selectBrand(brand)"
                         >
                             <td class="py-2 pr-3">
                                 <div class="flex items-center gap-2 min-w-[220px]">
@@ -239,7 +409,14 @@ onMounted(() => {
                                     <button
                                         type="button"
                                         class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-gray-50 dark:hover:bg-slate-700"
-                                        @click="openEdit(brand)"
+                                        @click.stop="selectBrand(brand)"
+                                    >
+                                        Серии
+                                    </button>
+                                    <button
+                                        type="button"
+                                        class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-gray-50 dark:hover:bg-slate-700"
+                                        @click.stop="openEdit(brand)"
                                     >
                                         Изменить
                                     </button>
@@ -247,7 +424,7 @@ onMounted(() => {
                                         type="button"
                                         class="px-2.5 py-1 rounded border border-red-200 text-red-600 text-xs font-semibold hover:bg-red-50 disabled:opacity-50"
                                         :disabled="(brand.products_count ?? 0) > 0"
-                                        @click="deleteBrand(brand)"
+                                        @click.stop="deleteBrand(brand)"
                                     >
                                         Удалить
                                     </button>
@@ -256,6 +433,103 @@ onMounted(() => {
                         </tr>
                     </tbody>
                 </table>
+            </div>
+        </div>
+
+        <div class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800/70 p-4 space-y-4">
+            <div class="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-xs uppercase tracking-[0.18em] font-bold text-teal-600 dark:text-teal-300">Серии бренда</p>
+                    <h2 class="text-lg font-bold text-gray-900 dark:text-white">
+                        {{ selectedBrand ? selectedBrand.title : 'Выберите бренд' }}
+                    </h2>
+                    <p class="text-sm text-gray-500 dark:text-slate-400">
+                        Описания и фичи попадут на брендовые страницы и в блок связанных моделей.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-500 transition-all disabled:opacity-50"
+                    :disabled="!selectedBrand"
+                    @click="openSeriesCreate"
+                >
+                    <span class="material-icons-round text-[18px]">add</span>
+                    Новая серия
+                </button>
+            </div>
+
+            <div v-if="seriesError" class="rounded-lg border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+                {{ seriesError }}
+            </div>
+
+            <div v-if="!selectedBrand" class="py-6 text-sm text-gray-500 dark:text-slate-400">
+                Выберите бренд в таблице выше.
+            </div>
+            <div v-else-if="seriesLoading" class="py-6 text-sm text-gray-500 dark:text-slate-400">
+                Загрузка серий...
+            </div>
+            <div v-else-if="seriesItems.length === 0" class="rounded-xl border border-dashed border-gray-300 dark:border-slate-700 px-4 py-8 text-sm text-gray-500 dark:text-slate-400">
+                У бренда пока нет серий. Можно добавить первую вручную.
+            </div>
+            <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                <article
+                    v-for="series in seriesItems"
+                    :key="series.id"
+                    class="rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 p-4 space-y-3"
+                >
+                    <div class="flex items-start gap-3">
+                        <img
+                            v-if="series.hero_image"
+                            :src="series.hero_image"
+                            :alt="series.title"
+                            class="w-16 h-16 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
+                        />
+                        <div class="min-w-0 flex-1">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <h3 class="font-bold text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
+                                <span
+                                    class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+                                    :class="series.is_published ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'"
+                                >
+                                    {{ series.is_published ? 'Публичная' : 'Скрыта' }}
+                                </span>
+                            </div>
+                            <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
+                            <p v-if="series.description" class="mt-2 text-sm text-gray-600 dark:text-slate-300 line-clamp-3">
+                                {{ series.description }}
+                            </p>
+                        </div>
+                    </div>
+                    <div v-if="series.features?.length" class="flex flex-wrap gap-2">
+                        <span
+                            v-for="feature in series.features"
+                            :key="feature"
+                            class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2.5 py-1 text-xs font-semibold text-teal-700 dark:text-teal-200"
+                        >
+                            {{ feature }}
+                        </span>
+                    </div>
+                    <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500 dark:text-slate-400">
+                        <span>{{ series.products_count }} товаров · порядок {{ series.sort_order }}</span>
+                        <div class="inline-flex items-center gap-1">
+                            <button
+                                type="button"
+                                class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
+                                @click="openSeriesEdit(series)"
+                            >
+                                Изменить
+                            </button>
+                            <button
+                                type="button"
+                                class="px-2.5 py-1 rounded border border-red-200 text-red-600 text-xs font-semibold hover:bg-red-50 disabled:opacity-50"
+                                :disabled="(series.products_count ?? 0) > 0"
+                                @click="deleteSeries(series)"
+                            >
+                                Удалить
+                            </button>
+                        </div>
+                    </div>
+                </article>
             </div>
         </div>
 
@@ -309,6 +583,66 @@ onMounted(() => {
                     </button>
                     <button type="button" class="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50" :disabled="saving" @click="saveBrand">
                         {{ saving ? 'Сохранение...' : 'Сохранить' }}
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div
+            v-if="seriesModalOpen"
+            class="fixed inset-0 z-[70] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+            @click.self="closeSeriesModal"
+        >
+            <div class="w-full max-w-3xl rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-2xl overflow-hidden">
+                <header class="px-5 py-4 border-b border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60">
+                    <h2 class="text-lg font-bold text-gray-900 dark:text-slate-100">
+                        {{ editingSeries ? 'Редактирование серии' : 'Новая серия' }}
+                    </h2>
+                    <p v-if="selectedBrand" class="text-sm text-gray-500 dark:text-slate-400">{{ selectedBrand.title }}</p>
+                </header>
+                <div class="p-5 space-y-3">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <label class="text-sm space-y-1">
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Название</span>
+                            <input v-model="seriesForm.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        </label>
+                        <label class="text-sm space-y-1">
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Slug</span>
+                            <input v-model="seriesForm.slug" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        </label>
+                    </div>
+                    <label class="text-sm space-y-1 block">
+                        <span class="text-gray-600 dark:text-slate-300 font-medium">Hero image (URL)</span>
+                        <input v-model="seriesForm.hero_image" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                    </label>
+                    <label class="text-sm space-y-1 block">
+                        <span class="text-gray-600 dark:text-slate-300 font-medium">Описание серии</span>
+                        <textarea v-model="seriesForm.description" rows="5" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        <span class="block text-xs text-gray-500 dark:text-slate-400">
+                            Короткий текст для страницы бренда и карточки товара.
+                        </span>
+                    </label>
+                    <label class="text-sm space-y-1 block">
+                        <span class="text-gray-600 dark:text-slate-300 font-medium">Фичи серии</span>
+                        <textarea v-model="seriesForm.featuresText" rows="5" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна фича на строку" />
+                    </label>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <label class="text-sm space-y-1 block">
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Sort order</span>
+                            <input v-model.number="seriesForm.sort_order" type="number" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        </label>
+                        <label class="text-sm flex items-center gap-2 pt-6">
+                            <input v-model="seriesForm.is_published" type="checkbox" class="rounded border-gray-300 dark:border-slate-700" />
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Публиковать серию</span>
+                        </label>
+                    </div>
+                </div>
+                <footer class="px-5 py-4 border-t border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60 flex items-center justify-end gap-2">
+                    <button type="button" class="px-4 py-2 rounded-lg text-sm font-medium text-gray-600 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700" @click="closeSeriesModal">
+                        Отмена
+                    </button>
+                    <button type="button" class="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-teal-600 hover:bg-teal-700 disabled:opacity-50" :disabled="seriesSaving" @click="saveSeries">
+                        {{ seriesSaving ? 'Сохранение...' : 'Сохранить' }}
                     </button>
                 </footer>
             </div>

--- a/models/brand.py
+++ b/models/brand.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import Column, Text, UniqueConstraint
+from sqlalchemy import Column, JSON, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -36,6 +36,7 @@ class ProductSeries(SQLModel, table=True):
     slug: str = Field(index=True)
     description: Optional[str] = Field(default=None, sa_column=Column(Text))
     hero_image: Optional[str] = Field(default=None)
+    features: List[str] = Field(default=[], sa_column=Column(JSON))
     is_published: bool = Field(default=True, index=True)
     sort_order: int = Field(default=0)
     created_at: datetime = Field(default_factory=datetime.now)

--- a/openapi.json
+++ b/openapi.json
@@ -9131,6 +9131,228 @@
         }
       }
     },
+    "/api/manager/brands/{brand_id}/series": {
+      "get": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "List Manager Brand Series",
+        "operationId": "list_manager_brand_series",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandSeriesListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Create Manager Brand Series",
+        "operationId": "create_manager_brand_series",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerBrandSeriesCreatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandSeriesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/brands/{brand_id}/series/{series_id}": {
+      "put": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Update Manager Brand Series",
+        "operationId": "update_manager_brand_series",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          },
+          {
+            "name": "series_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Series Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerBrandSeriesUpdatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandSeriesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Delete Manager Brand Series",
+        "operationId": "delete_manager_brand_series",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          },
+          {
+            "name": "series_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Series Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/settings": {
       "get": {
         "tags": [
@@ -15244,6 +15466,255 @@
           "created_at"
         ],
         "title": "ManagerBrandResponse"
+      },
+      "ManagerBrandSeriesCreatePayload": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hero_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image"
+          },
+          "features": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Features"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ManagerBrandSeriesCreatePayload"
+      },
+      "ManagerBrandSeriesListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerBrandSeriesResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "ManagerBrandSeriesListResponse"
+      },
+      "ManagerBrandSeriesResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "brand_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hero_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image"
+          },
+          "features": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Features"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "products_count": {
+            "type": "integer",
+            "title": "Products Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "is_published",
+          "sort_order",
+          "created_at"
+        ],
+        "title": "ManagerBrandSeriesResponse"
+      },
+      "ManagerBrandSeriesUpdatePayload": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "hero_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image"
+          },
+          "features": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Features"
+          },
+          "is_published": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Published"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          }
+        },
+        "type": "object",
+        "title": "ManagerBrandSeriesUpdatePayload"
       },
       "ManagerBrandUpdatePayload": {
         "properties": {
@@ -25043,6 +25514,13 @@
               }
             ],
             "title": "Hero Image"
+          },
+          "features": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Features"
           }
         },
         "type": "object",

--- a/routers/manager_brands.py
+++ b/routers/manager_brands.py
@@ -4,9 +4,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.security import get_current_username
 from routers.manager_operation_ids import (
+    CREATE_MANAGER_BRAND_SERIES,
     CREATE_MANAGER_BRAND,
+    DELETE_MANAGER_BRAND_SERIES,
     DELETE_MANAGER_BRAND,
+    LIST_MANAGER_BRAND_SERIES,
     LIST_MANAGER_BRANDS,
+    UPDATE_MANAGER_BRAND_SERIES,
     UPDATE_MANAGER_BRAND,
 )
 from schemas import (
@@ -14,6 +18,10 @@ from schemas import (
     ManagerBrandCreatePayload,
     ManagerBrandListResponse,
     ManagerBrandResponse,
+    ManagerBrandSeriesCreatePayload,
+    ManagerBrandSeriesListResponse,
+    ManagerBrandSeriesResponse,
+    ManagerBrandSeriesUpdatePayload,
     ManagerBrandUpdatePayload,
 )
 from services.manager_brand_service import ManagerBrandService
@@ -60,6 +68,75 @@ async def update_manager_brand(
         payload=payload.model_dump(exclude_unset=True),
     )
     return ManagerBrandResponse(**updated)
+
+
+@router.get(
+    "/{brand_id}/series",
+    response_model=ManagerBrandSeriesListResponse,
+    operation_id=LIST_MANAGER_BRAND_SERIES,
+)
+async def list_manager_brand_series(
+    brand_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    items = await ManagerBrandService.list_brand_series(session=session, brand_id=brand_id)
+    return ManagerBrandSeriesListResponse(items=items)
+
+
+@router.post(
+    "/{brand_id}/series",
+    response_model=ManagerBrandSeriesResponse,
+    operation_id=CREATE_MANAGER_BRAND_SERIES,
+)
+async def create_manager_brand_series(
+    brand_id: int,
+    payload: ManagerBrandSeriesCreatePayload,
+    session: AsyncSession = Depends(get_session),
+):
+    created = await ManagerBrandService.create_brand_series(
+        session=session,
+        brand_id=brand_id,
+        payload=payload.model_dump(exclude_unset=True),
+    )
+    return ManagerBrandSeriesResponse(**created)
+
+
+@router.put(
+    "/{brand_id}/series/{series_id}",
+    response_model=ManagerBrandSeriesResponse,
+    operation_id=UPDATE_MANAGER_BRAND_SERIES,
+)
+async def update_manager_brand_series(
+    brand_id: int,
+    series_id: int,
+    payload: ManagerBrandSeriesUpdatePayload,
+    session: AsyncSession = Depends(get_session),
+):
+    updated = await ManagerBrandService.update_brand_series(
+        session=session,
+        brand_id=brand_id,
+        series_id=series_id,
+        payload=payload.model_dump(exclude_unset=True),
+    )
+    return ManagerBrandSeriesResponse(**updated)
+
+
+@router.delete(
+    "/{brand_id}/series/{series_id}",
+    response_model=ManagerActionMessageResponse,
+    operation_id=DELETE_MANAGER_BRAND_SERIES,
+)
+async def delete_manager_brand_series(
+    brand_id: int,
+    series_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    await ManagerBrandService.delete_brand_series(
+        session=session,
+        brand_id=brand_id,
+        series_id=series_id,
+    )
+    return ManagerActionMessageResponse(message="Серия успешно удалена")
 
 
 @router.delete(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -170,6 +170,10 @@ LIST_MANAGER_BRANDS = "list_manager_brands"
 CREATE_MANAGER_BRAND = "create_manager_brand"
 UPDATE_MANAGER_BRAND = "update_manager_brand"
 DELETE_MANAGER_BRAND = "delete_manager_brand"
+LIST_MANAGER_BRAND_SERIES = "list_manager_brand_series"
+CREATE_MANAGER_BRAND_SERIES = "create_manager_brand_series"
+UPDATE_MANAGER_BRAND_SERIES = "update_manager_brand_series"
+DELETE_MANAGER_BRAND_SERIES = "delete_manager_brand_series"
 LIST_SUPPLIERS = "list_suppliers"
 CREATE_SUPPLIER = "create_supplier"
 PATCH_SUPPLIER = "patch_supplier"
@@ -344,6 +348,10 @@ ALL_MANAGER_OPERATION_IDS = (
     CREATE_MANAGER_BRAND,
     UPDATE_MANAGER_BRAND,
     DELETE_MANAGER_BRAND,
+    LIST_MANAGER_BRAND_SERIES,
+    CREATE_MANAGER_BRAND_SERIES,
+    UPDATE_MANAGER_BRAND_SERIES,
+    DELETE_MANAGER_BRAND_SERIES,
     LIST_SUPPLIERS,
     CREATE_SUPPLIER,
     PATCH_SUPPLIER,

--- a/schemas.py
+++ b/schemas.py
@@ -113,6 +113,7 @@ class ProductSeriesResponse(BaseModel):
     slug: str
     description: Optional[str] = None
     hero_image: Optional[str] = None
+    features: List[str] = Field(default_factory=list)
 
 
 class ProductSeriesNavigationItemResponse(BaseModel):
@@ -1518,6 +1519,44 @@ class ManagerBrandUpdatePayload(BaseModel):
     slug: Optional[str] = None
     logo_url: Optional[str] = None
     description: Optional[str] = None
+    is_published: Optional[bool] = None
+    sort_order: Optional[int] = None
+
+
+class ManagerBrandSeriesResponse(BaseModel):
+    id: int
+    brand_id: Optional[int] = None
+    title: str
+    slug: str
+    description: Optional[str] = None
+    hero_image: Optional[str] = None
+    features: List[str] = Field(default_factory=list)
+    is_published: bool
+    sort_order: int
+    created_at: datetime
+    products_count: int = 0
+
+
+class ManagerBrandSeriesListResponse(BaseModel):
+    items: List[ManagerBrandSeriesResponse]
+
+
+class ManagerBrandSeriesCreatePayload(BaseModel):
+    title: str
+    slug: Optional[str] = None
+    description: Optional[str] = None
+    hero_image: Optional[str] = None
+    features: List[str] = Field(default_factory=list)
+    is_published: bool = True
+    sort_order: int = 0
+
+
+class ManagerBrandSeriesUpdatePayload(BaseModel):
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    description: Optional[str] = None
+    hero_image: Optional[str] = None
+    features: Optional[List[str]] = None
     is_published: Optional[bool] = None
     sort_order: Optional[int] = None
 

--- a/scripts/seed_tcl_series_content.py
+++ b/scripts/seed_tcl_series_content.py
@@ -1,0 +1,261 @@
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from typing import Iterable
+
+from slugify import slugify
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from models import Brand, ProductSeries
+from services.catalog_revision_service import CatalogRevisionService
+
+
+@dataclass(frozen=True)
+class SeriesSeed:
+    title: str
+    match_slugs: tuple[str, ...]
+    description: str
+    features: tuple[str, ...]
+
+
+TCL_SERIES: tuple[SeriesSeed, ...] = (
+    SeriesSeed(
+        title="FreshIN 3.0",
+        match_slugs=("freshin-3-0", "freshin", "fci"),
+        description=(
+            "Флагманская инверторная серия TCL с подачей свежего воздуха FreshIN+, "
+            "фильтрами QuadriPuri, индикатором качества воздуха и тихим ночным режимом."
+        ),
+        features=(
+            "Подача свежего воздуха FreshIN+",
+            "Фильтры QuadriPuri",
+            "Индикатор качества воздуха",
+            "Голосовое управление",
+            "Gentle Breeze",
+            "Самоочистка внутреннего и наружного блоков",
+            "Wi-Fi управление TCL Home",
+        ),
+    ),
+    SeriesSeed(
+        title="X-Fresh",
+        match_slugs=("x-fresh", "xfresh", "fai"),
+        description=(
+            "Инверторная серия с притоком свежего воздуха до 60 м3/ч, высокой "
+            "энергоэффективностью и отдельным режимом вентиляции без охлаждения или обогрева."
+        ),
+        features=(
+            "Подача свежего воздуха Fresh Air",
+            "Режим вентиляции без охлаждения",
+            "Умное энергосбережение T-AI",
+            "Дежурный обогрев 8 °C",
+            "Самоочистка",
+            "Wi-Fi управление",
+        ),
+    ),
+    SeriesSeed(
+        title="SaveIN AI",
+        match_slugs=("savein-ai", "save-in-ai", "zg11", "zg41"),
+        description=(
+            "Серия TCL SaveIN AI делает упор на экономичную инверторную работу, "
+            "мягкое распределение воздуха и удобное управление для квартиры или дома."
+        ),
+        features=(
+            "Умное энергосбережение",
+            "Gentle Breeze",
+            "Smart Inverter",
+            "Самоочистка",
+            "Режим ECO",
+            "Wi-Fi управление",
+        ),
+    ),
+    SeriesSeed(
+        title="BreezeIN 2.0",
+        match_slugs=("breezein-2-0", "breeze-in-2-0", "ug11v3ah"),
+        description=(
+            "Инверторная серия BreezeIN 2.0 подходит для ежедневного охлаждения и обогрева: "
+            "мягкий поток воздуха, самоочистка и стабильная работа в широком диапазоне температур."
+        ),
+        features=(
+            "Gentle Breeze",
+            "Smart Airflow",
+            "Самоочистка",
+            "Режим ECO",
+            "Wi-Fi управление",
+            "Обогрев в холодное межсезонье",
+        ),
+    ),
+    SeriesSeed(
+        title="BreezeIN 1.0",
+        match_slugs=("breezein-1-0", "breeze-in-1-0", "tph11ihb"),
+        description=(
+            "Базовая инверторная линейка BreezeIN для спокойного бытового использования: "
+            "охлаждение, обогрев, осушение и понятный набор повседневных функций."
+        ),
+        features=(
+            "Smart Inverter",
+            "Режим ECO",
+            "3D Airflow",
+            "Режим сна",
+            "Функция I FEEL",
+            "Самодиагностика",
+        ),
+    ),
+    SeriesSeed(
+        title="Ocarina",
+        match_slugs=("ocarina", "tpg21i3ahb"),
+        description=(
+            "Дизайнерская инверторная серия TCL с расширенными функциями комфорта, "
+            "очистки воздуха и автоматического распределения потока."
+        ),
+        features=(
+            "Умное энергосбережение",
+            "Gentle Breeze",
+            "УФ-лампа и биполярный ионизатор",
+            "Самоочистка",
+            "Smart Airflow",
+            "Wi-Fi управление",
+        ),
+    ),
+    SeriesSeed(
+        title="Elite Inverter",
+        match_slugs=("elite-inverter", "elite-invertor", "xa71if", "xa71in"),
+        description=(
+            "Практичная инверторная серия TCL Elite для помещений, где нужны базовая "
+            "надежность, экономичная работа компрессора и понятное управление."
+        ),
+        features=(
+            "Smart Inverter",
+            "Режим ECO",
+            "3D Airflow",
+            "Режим сна",
+            "Функция I FEEL",
+            "Wi-Fi управление опционально",
+        ),
+    ),
+    SeriesSeed(
+        title="SaveIN",
+        match_slugs=("savein", "save-in", "zg31"),
+        description=(
+            "Доступная серия TCL On/Off для базового охлаждения и обогрева без лишней "
+            "сложности, с привычными режимами для дома и небольшого офиса."
+        ),
+        features=(
+            "Режим ECO",
+            "Режим сна",
+            "Осушение",
+            "Таймер 24 ч",
+            "Самодиагностика",
+            "Авторестарт",
+        ),
+    ),
+    SeriesSeed(
+        title="Elite",
+        match_slugs=("elite", "xab1"),
+        description=(
+            "Базовая серия TCL On/Off: простой кондиционер для стандартных задач "
+            "охлаждения, обогрева и осушения в квартире или офисе."
+        ),
+        features=(
+            "8 режимов подачи воздуха вверх-вниз",
+            "3D Airflow",
+            "Осушение",
+            "Таймер 24 ч",
+            "Самодиагностика",
+            "Wi-Fi управление опционально",
+        ),
+    ),
+)
+
+
+def _norm(value: str) -> str:
+    return slugify(value or "", lowercase=True)
+
+
+def _matches(series: ProductSeries, seed: SeriesSeed) -> bool:
+    current = {_norm(series.slug), _norm(series.title)}
+    candidates = {_norm(seed.title), *(_norm(item) for item in seed.match_slugs)}
+    return bool(current & candidates)
+
+
+def _needs_update(series: ProductSeries, seed: SeriesSeed, *, overwrite: bool) -> bool:
+    if overwrite:
+        return True
+    return not (series.description or "").strip() or not list(series.features or [])
+
+
+async def seed_tcl_series(
+    *,
+    execute: bool,
+    overwrite: bool,
+    seeds: Iterable[SeriesSeed] = TCL_SERIES,
+) -> None:
+    db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(db_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        brand = (
+            await session.execute(select(Brand).where(Brand.slug == "tcl"))
+        ).scalar_one_or_none()
+        if brand is None:
+            print("[skip] TCL brand not found")
+            await engine.dispose()
+            return
+
+        series_rows = (
+            await session.execute(select(ProductSeries).where(ProductSeries.brand_id == brand.id))
+        ).scalars().all()
+
+        updated = 0
+        missed: list[str] = []
+        for seed in seeds:
+            matched = [item for item in series_rows if _matches(item, seed)]
+            if not matched:
+                missed.append(seed.title)
+                continue
+
+            for series in matched:
+                if not _needs_update(series, seed, overwrite=overwrite):
+                    print(f"[keep] {series.title} ({series.slug}) already has content")
+                    continue
+                series.description = seed.description
+                series.features = list(seed.features)
+                session.add(series)
+                updated += 1
+                print(f"[update] {series.title} ({series.slug}) <- {seed.title}")
+
+        if updated:
+            await CatalogRevisionService.bump_commit_and_purge(
+                session,
+                scope="tcl_series_content_seed",
+                brand_slugs=[brand.slug],
+            )
+
+        if execute:
+            await session.commit()
+        else:
+            await session.rollback()
+
+    await engine.dispose()
+    mode = "APPLY" if execute else "DRY-RUN"
+    print(f"[{mode}] updated={updated}, missed={len(missed)}")
+    if missed:
+        print("[missed] " + ", ".join(missed))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed TCL product series descriptions and features")
+    parser.add_argument("--execute", action="store_true", help="Commit changes")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing descriptions/features")
+    args = parser.parse_args()
+    asyncio.run(seed_tcl_series(execute=args.execute, overwrite=args.overwrite))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -197,6 +197,158 @@ class ManagerBrandService:
         )
 
     @staticmethod
+    async def list_brand_series(
+        session: AsyncSession,
+        brand_id: int,
+    ) -> List[Dict[str, Any]]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        rows = (
+            await session.execute(
+                select(ProductSeries, func.count(Product.id).label("products_count"))
+                .outerjoin(Product, Product.series_id == ProductSeries.id)
+                .where(ProductSeries.brand_id == brand_id)
+                .group_by(ProductSeries.id)
+                .order_by(ProductSeries.sort_order.asc(), ProductSeries.title.asc())
+            )
+        ).all()
+        return [
+            ManagerBrandService._serialize_series(series, products_count=int(products_count or 0))
+            for series, products_count in rows
+        ]
+
+    @staticmethod
+    async def create_brand_series(
+        session: AsyncSession,
+        brand_id: int,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        title = str(payload.get("title") or "").strip()
+        if not title:
+            raise HTTPException(status_code=400, detail="Название серии не может быть пустым.")
+
+        series_slug = ManagerBrandService._build_series_slug(payload.get("slug"), title)
+        await ManagerBrandService._ensure_series_slug_available(
+            session,
+            brand_id=brand_id,
+            slug=series_slug,
+        )
+
+        series = ProductSeries(
+            brand_id=brand_id,
+            title=title,
+            slug=series_slug,
+            description=ManagerBrandService._clean_optional_text(payload.get("description")),
+            hero_image=ManagerBrandService._clean_optional_text(payload.get("hero_image")),
+            features=ManagerBrandService._normalize_features(payload.get("features")),
+            is_published=bool(payload.get("is_published", True)),
+            sort_order=int(payload.get("sort_order") or 0),
+        )
+        session.add(series)
+        await session.flush()
+
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_series_create",
+            brand_slugs=[brand.slug],
+        )
+        await session.refresh(series)
+        return ManagerBrandService._serialize_series(series, products_count=0)
+
+    @staticmethod
+    async def update_brand_series(
+        session: AsyncSession,
+        brand_id: int,
+        series_id: int,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        series = await ManagerBrandService._get_brand_series(session, brand_id, series_id)
+
+        if "title" in payload and payload["title"] is not None:
+            title = str(payload["title"]).strip()
+            if not title:
+                raise HTTPException(status_code=400, detail="Название серии не может быть пустым.")
+            series.title = title
+
+        if "slug" in payload and payload["slug"] is not None:
+            new_slug = ManagerBrandService._build_series_slug(payload["slug"], series.title)
+            if new_slug != series.slug:
+                await ManagerBrandService._ensure_series_slug_available(
+                    session,
+                    brand_id=brand_id,
+                    slug=new_slug,
+                    exclude_series_id=series_id,
+                )
+                series.slug = new_slug
+
+        if "description" in payload:
+            series.description = ManagerBrandService._clean_optional_text(payload["description"])
+        if "hero_image" in payload:
+            series.hero_image = ManagerBrandService._clean_optional_text(payload["hero_image"])
+        if "features" in payload and payload["features"] is not None:
+            series.features = ManagerBrandService._normalize_features(payload["features"])
+        if "is_published" in payload and payload["is_published"] is not None:
+            series.is_published = bool(payload["is_published"])
+        if "sort_order" in payload and payload["sort_order"] is not None:
+            series.sort_order = int(payload["sort_order"])
+
+        session.add(series)
+        await session.flush()
+
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_series_update",
+            brand_slugs=[brand.slug],
+        )
+        await session.refresh(series)
+
+        products_count = (
+            await session.execute(
+                select(func.count(Product.id)).where(Product.series_id == series.id)
+            )
+        ).scalar_one()
+        return ManagerBrandService._serialize_series(series, products_count=int(products_count or 0))
+
+    @staticmethod
+    async def delete_brand_series(
+        session: AsyncSession,
+        brand_id: int,
+        series_id: int,
+    ) -> None:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        series = await ManagerBrandService._get_brand_series(session, brand_id, series_id)
+        products_count = (
+            await session.execute(
+                select(func.count(Product.id)).where(Product.series_id == series.id)
+            )
+        ).scalar_one()
+        if int(products_count or 0) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Нельзя удалить серию: к ней привязаны товары. Скройте серию вместо удаления.",
+            )
+
+        await session.delete(series)
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_series_delete",
+            brand_slugs=[brand.slug],
+        )
+
+    @staticmethod
     def _serialize_brand(brand: Brand, *, products_count: int = 0) -> Dict[str, Any]:
         return {
             "id": brand.id,
@@ -209,6 +361,94 @@ class ManagerBrandService:
             "created_at": brand.created_at,
             "products_count": int(products_count or 0),
         }
+
+    @staticmethod
+    def _serialize_series(series: ProductSeries, *, products_count: int = 0) -> Dict[str, Any]:
+        return {
+            "id": series.id,
+            "brand_id": series.brand_id,
+            "title": series.title,
+            "slug": series.slug,
+            "description": series.description,
+            "hero_image": series.hero_image,
+            "features": ManagerBrandService._normalize_features(series.features),
+            "is_published": series.is_published,
+            "sort_order": series.sort_order,
+            "created_at": series.created_at,
+            "products_count": int(products_count or 0),
+        }
+
+    @staticmethod
+    async def _get_brand_series(
+        session: AsyncSession,
+        brand_id: int,
+        series_id: int,
+    ) -> ProductSeries:
+        series = (
+            await session.execute(
+                select(ProductSeries).where(
+                    ProductSeries.id == series_id,
+                    ProductSeries.brand_id == brand_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if series is None:
+            raise HTTPException(status_code=404, detail="Серия не найдена.")
+        return series
+
+    @staticmethod
+    async def _ensure_series_slug_available(
+        session: AsyncSession,
+        *,
+        brand_id: int,
+        slug: str,
+        exclude_series_id: Optional[int] = None,
+    ) -> None:
+        query = select(ProductSeries).where(
+            ProductSeries.brand_id == brand_id,
+            ProductSeries.slug == slug,
+        )
+        if exclude_series_id is not None:
+            query = query.where(ProductSeries.id != exclude_series_id)
+        existing = (await session.execute(query)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Серия со slug '{slug}' уже существует у этого бренда.",
+            )
+
+    @staticmethod
+    def _build_series_slug(value: Any, fallback_title: str) -> str:
+        requested_slug = str(value or "").strip()
+        series_slug = requested_slug or slugify(fallback_title, lowercase=True)
+        if not series_slug:
+            raise HTTPException(status_code=400, detail="Не удалось сформировать slug серии.")
+        return series_slug
+
+    @staticmethod
+    def _clean_optional_text(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _normalize_features(value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+
+        features: List[str] = []
+        seen: set[str] = set()
+        for item in value:
+            text = str(item or "").strip()
+            if not text:
+                continue
+            dedupe_key = text.casefold()
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            features.append(text)
+        return features
 
     @staticmethod
     async def _ensure_brand_group(session: AsyncSession) -> TagGroup:

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -131,6 +131,7 @@ def map_product_to_response(
             slug=series.slug,
             description=series.description,
             hero_image=series.hero_image,
+            features=series.features or [],
         )
         if series and series.is_published
         else None

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -77,6 +77,7 @@ class ProductSeriesService:
             slug=series.slug,
             description=series.description,
             hero_image=series.hero_image,
+            features=series.features or [],
         )
 
     @staticmethod

--- a/tests/integration/test_manager_brands_api.py
+++ b/tests/integration/test_manager_brands_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from core.config import settings
-from models import Product
+from models import Product, ProductSeries
 
 
 async def _auth_headers(async_client):
@@ -82,5 +82,137 @@ async def test_manager_brand_delete_forbidden_when_products_linked(async_client,
     await db.commit()
 
     delete_resp = await async_client.delete(f"/api/manager/brands/{brand_id}", headers=headers)
+    assert delete_resp.status_code == 400
+    assert "привязаны товары" in delete_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_manager_brand_series_crud(async_client):
+    headers = await _auth_headers(async_client)
+
+    brand_resp = await async_client.post(
+        "/api/manager/brands",
+        headers=headers,
+        json={"title": "Series Brand", "slug": "series-brand"},
+    )
+    assert brand_resp.status_code == 200
+    brand_id = brand_resp.json()["id"]
+
+    create_resp = await async_client.post(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+        json={
+            "title": "FreshIN",
+            "description": "Fresh air product line",
+            "hero_image": "/media/series/freshin.webp",
+            "features": [" fresh air ", "", "Wi-Fi", "Wi-Fi"],
+            "sort_order": 10,
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    created = create_resp.json()
+    assert created["title"] == "FreshIN"
+    assert created["slug"] == "freshin"
+    assert created["features"] == ["fresh air", "Wi-Fi"]
+    assert created["products_count"] == 0
+    series_id = created["id"]
+
+    list_resp = await async_client.get(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+    )
+    assert list_resp.status_code == 200
+    assert [item["id"] for item in list_resp.json()["items"]] == [series_id]
+
+    update_resp = await async_client.put(
+        f"/api/manager/brands/{brand_id}/series/{series_id}",
+        headers=headers,
+        json={
+            "title": "FreshIN Updated",
+            "slug": "freshin-updated",
+            "features": ["Fresh air", "Self-cleaning"],
+            "is_published": False,
+            "sort_order": 3,
+        },
+    )
+    assert update_resp.status_code == 200, update_resp.text
+    updated = update_resp.json()
+    assert updated["title"] == "FreshIN Updated"
+    assert updated["slug"] == "freshin-updated"
+    assert updated["features"] == ["Fresh air", "Self-cleaning"]
+    assert updated["is_published"] is False
+    assert updated["sort_order"] == 3
+
+    delete_resp = await async_client.delete(
+        f"/api/manager/brands/{brand_id}/series/{series_id}",
+        headers=headers,
+    )
+    assert delete_resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_manager_brand_series_slug_unique_per_brand(async_client):
+    headers = await _auth_headers(async_client)
+
+    brand_resp = await async_client.post(
+        "/api/manager/brands",
+        headers=headers,
+        json={"title": "Unique Series Brand", "slug": "unique-series-brand"},
+    )
+    assert brand_resp.status_code == 200
+    brand_id = brand_resp.json()["id"]
+
+    first_resp = await async_client.post(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+        json={"title": "Elite", "slug": "elite"},
+    )
+    assert first_resp.status_code == 200
+
+    duplicate_resp = await async_client.post(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+        json={"title": "Elite Copy", "slug": "elite"},
+    )
+    assert duplicate_resp.status_code == 400
+    assert "у этого бренда" in duplicate_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_manager_brand_series_delete_forbidden_when_products_linked(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    brand_resp = await async_client.post(
+        "/api/manager/brands",
+        headers=headers,
+        json={"title": "Linked Series Brand", "slug": "linked-series-brand"},
+    )
+    assert brand_resp.status_code == 200
+    brand_id = brand_resp.json()["id"]
+
+    series = ProductSeries(
+        title="Linked Series",
+        slug="linked-series",
+        brand_id=brand_id,
+        is_published=True,
+    )
+    db.add(series)
+    await db.flush()
+
+    product = Product(
+        title="Linked Series Product",
+        slug="linked-series-product",
+        price=1000,
+        area=20,
+        brand_id=brand_id,
+        series_id=series.id,
+    )
+    db.add(product)
+    await db.commit()
+
+    delete_resp = await async_client.delete(
+        f"/api/manager/brands/{brand_id}/series/{series.id}",
+        headers=headers,
+    )
     assert delete_resp.status_code == 400
     assert "привязаны товары" in delete_resp.json()["detail"].lower()

--- a/tests/integration/test_product_series_siblings.py
+++ b/tests/integration/test_product_series_siblings.py
@@ -69,6 +69,7 @@ async def test_product_detail_contains_series_and_series_id_siblings(async_clien
         brand_id=brand.id,
         description="Fresh air product line",
         hero_image="/media/series/freshin.webp",
+        features=["Fresh air intake", "Self-cleaning"],
         is_published=True,
     )
     db.add(series)
@@ -126,6 +127,7 @@ async def test_product_detail_contains_series_and_series_id_siblings(async_clien
         "slug": "freshin",
         "description": "Fresh air product line",
         "hero_image": "/media/series/freshin.webp",
+        "features": ["Fresh air intake", "Self-cleaning"],
     }
 
     sibling_slugs = [item["slug"] for item in data["series_siblings"]]

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -159,6 +159,7 @@ def test_map_product_to_response_serializes_public_series():
         "slug": "elite",
         "description": "Quiet inverter product line",
         "hero_image": "/media/series/elite.webp",
+        "features": [],
     }
 
 

--- a/tests/unit/test_public_product_series_payloads.py
+++ b/tests/unit/test_public_product_series_payloads.py
@@ -46,6 +46,7 @@ async def _seed_series_products(session: AsyncSession) -> dict[str, Product]:
         brand_id=brand.id,
         description="Quiet inverter product line",
         hero_image="/media/series/elite.webp",
+        features=["Quiet mode", "Wi-Fi ready"],
         is_published=True,
     )
     session.add(series)
@@ -131,6 +132,7 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
         "slug": "elite",
         "description": "Quiet inverter product line",
         "hero_image": "/media/series/elite.webp",
+        "features": ["Quiet mode", "Wi-Fi ready"],
     }
 
     catalog_products = await ProductDAO.get_filtered(

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -49,6 +49,7 @@ interface Product {
         slug?: string | null;
         description?: string | null;
         hero_image?: string | null;
+        features?: string[] | null;
     } | null;
     badges?: Array<{ text: string; class?: string }>;
     tags?: Array<{
@@ -122,6 +123,10 @@ const slugifySeriesFallback = (value: string) =>
         .replace(/^-+|-+$/g, "");
 const getProductSeriesTitle = (product: Product) =>
     asText(product.series?.title) || asText(product.specs?.series);
+const normalizeSeriesFeatures = (value: unknown) =>
+    Array.isArray(value)
+        ? value.map((item) => asText(item)).filter(Boolean)
+        : [];
 const getProductSeriesKey = (product: Product) => {
     const title = getProductSeriesTitle(product);
     if (!title) return "";
@@ -140,6 +145,8 @@ const seriesGroupsMap = new Map<
         key: string;
         title: string;
         description: string;
+        heroImage: string;
+        features: string[];
         products: Product[];
     }
 >();
@@ -160,6 +167,8 @@ for (const product of seriesSourceProducts) {
             key,
             title,
             description: asText(product.series?.description),
+            heroImage: asText(product.series?.hero_image),
+            features: normalizeSeriesFeatures(product.series?.features),
             products: [],
         });
     }
@@ -167,6 +176,10 @@ for (const product of seriesSourceProducts) {
     const group = seriesGroupsMap.get(key);
     if (group) {
         if (!group.description) group.description = asText(product.series?.description);
+        if (!group.heroImage) group.heroImage = asText(product.series?.hero_image);
+        if (group.features.length === 0) {
+            group.features = normalizeSeriesFeatures(product.series?.features);
+        }
         group.products.push(product);
     }
 }
@@ -228,9 +241,27 @@ const seriesGroups = Array.from(seriesGroupsMap.values());
                                 {seriesGroups.map((group) => (
                                     <section class="brand-series-group" aria-labelledby={`brand-series-${group.key}`}>
                                         <div class="brand-series-head">
-                                            <div>
-                                                <h3 id={`brand-series-${group.key}`}>{group.title}</h3>
-                                                {group.description && <p>{group.description}</p>}
+                                            <div class="brand-series-summary">
+                                                {group.heroImage && (
+                                                    <span class="brand-series-thumb">
+                                                        <img
+                                                            src={resolveImageUrl(group.heroImage)}
+                                                            alt={`Серия ${group.title}`}
+                                                            loading="lazy"
+                                                        />
+                                                    </span>
+                                                )}
+                                                <div>
+                                                    <h3 id={`brand-series-${group.key}`}>{group.title}</h3>
+                                                    {group.description && <p>{group.description}</p>}
+                                                    {group.features.length > 0 && (
+                                                        <ul class="brand-series-features" aria-label={`Особенности серии ${group.title}`}>
+                                                            {group.features.map((feature) => (
+                                                                <li>{feature}</li>
+                                                            ))}
+                                                        </ul>
+                                                    )}
+                                                </div>
                                             </div>
                                             <span>{formatSeriesProductCount(group.products.length)}</span>
                                         </div>
@@ -423,6 +454,29 @@ const seriesGroups = Array.from(seriesGroupsMap.values());
         justify-content: space-between;
         gap: 1rem;
     }
+    .brand-series-summary {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        min-width: 0;
+    }
+    .brand-series-thumb {
+        width: 82px;
+        height: 62px;
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border: 1px solid var(--panel-chip-border);
+        border-radius: 10px;
+        background: var(--panel-chip-bg);
+    }
+    .brand-series-thumb img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
     .brand-series-head h3 {
         margin: 0;
         color: var(--text);
@@ -435,6 +489,26 @@ const seriesGroups = Array.from(seriesGroupsMap.values());
         color: var(--text-muted);
         font-size: 0.94rem;
         line-height: 1.6;
+    }
+    .brand-series-features {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        margin: 0.7rem 0 0;
+        padding: 0;
+        list-style: none;
+    }
+    .brand-series-features li {
+        display: inline-flex;
+        align-items: center;
+        min-height: 30px;
+        padding: 0.25rem 0.6rem;
+        border-radius: 8px;
+        background: var(--panel-chip-bg);
+        border: 1px solid var(--panel-chip-border);
+        color: var(--text);
+        font-size: 0.82rem;
+        font-weight: 700;
     }
     .brand-series-head > span {
         display: inline-flex;
@@ -493,6 +567,9 @@ const seriesGroups = Array.from(seriesGroupsMap.values());
         .brand-series-head {
             flex-direction: column;
             gap: 0.6rem;
+        }
+        .brand-series-summary {
+            flex-direction: column;
         }
         .brand-series-head > span {
             white-space: normal;

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -181,6 +181,11 @@ const resolveSeriesCompressorLabel = (item: any) => {
     return "";
 };
 const seriesTitle = asText(product.series?.title) || asText(specs.series);
+const seriesDescription = asText(product.series?.description);
+const seriesHeroImage = asText(product.series?.hero_image);
+const seriesFeatures = Array.isArray(product.series?.features)
+    ? product.series.features.map((item: unknown) => asText(item)).filter(Boolean)
+    : [];
 const seriesSiblings = Array.isArray(product.series_siblings)
     ? product.series_siblings.filter((item: any) => item?.slug && item.slug !== product.slug)
     : [];
@@ -1022,6 +1027,29 @@ const seriesSiblings = Array.isArray(product.series_siblings)
                             </a>
                         )}
                     </div>
+                    {(seriesDescription || seriesFeatures.length > 0 || seriesHeroImage) && (
+                        <div class="series-context-card">
+                            {seriesHeroImage && (
+                                <span class="series-context-image">
+                                    <img
+                                        src={resolveImageUrl(seriesHeroImage)}
+                                        alt={`Серия ${seriesTitle || "кондиционеров"}`}
+                                        loading="lazy"
+                                    />
+                                </span>
+                            )}
+                            <div class="series-context-copy">
+                                {seriesDescription && <p>{seriesDescription}</p>}
+                                {seriesFeatures.length > 0 && (
+                                    <ul class="series-context-features" aria-label="Особенности серии">
+                                        {seriesFeatures.map((feature) => (
+                                            <li>{feature}</li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+                        </div>
+                    )}
                     <div class="series-siblings-grid">
                         {seriesSiblings.map((item: any) => {
                             const image = resolveImageUrl(item.card_image || item.main_image || item.full_image);
@@ -1165,6 +1193,68 @@ const seriesSiblings = Array.isArray(product.series_siblings)
 
     .series-brand-link .material-icons-round {
         font-size: 1rem;
+    }
+
+    .series-context-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 1rem;
+        margin: 0 0 1rem;
+        padding: 1rem;
+        border: 1px solid var(--panel-chip-border);
+        border-radius: 14px;
+        background: var(--panel-glass-bg);
+    }
+
+    .series-context-image {
+        width: 104px;
+        height: 78px;
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        border: 1px solid var(--panel-chip-border);
+        border-radius: 10px;
+        background: var(--panel-chip-bg);
+    }
+
+    .series-context-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .series-context-copy {
+        min-width: 0;
+    }
+
+    .series-context-copy p {
+        margin: 0;
+        color: var(--text-muted);
+        line-height: 1.6;
+    }
+
+    .series-context-features {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        margin: 0.7rem 0 0;
+        padding: 0;
+        list-style: none;
+    }
+
+    .series-context-features li {
+        display: inline-flex;
+        align-items: center;
+        min-height: 30px;
+        padding: 0.25rem 0.6rem;
+        border-radius: 8px;
+        background: var(--panel-chip-bg);
+        border: 1px solid var(--panel-chip-border);
+        color: var(--text);
+        font-size: 0.82rem;
+        font-weight: 700;
     }
 
     .series-siblings-grid {
@@ -2004,6 +2094,10 @@ const seriesSiblings = Array.isArray(product.series_siblings)
 
         .series-brand-link {
             white-space: normal;
+        }
+
+        .series-context-card {
+            flex-direction: column;
         }
 
         .series-sibling-card {


### PR DESCRIPTION
## Summary
- add editable ProductSeries features and manager CRUD endpoints under brands
- add manager UI for selecting a brand and editing series descriptions, hero image URLs, features, order, and publication state
- render series descriptions/features on brand pages and product sibling sections
- add TCL series content seed script for controlled post-deploy/manual fill

## Test plan
- python3 scripts/legacy/extract_openapi.py
- cd manager_frontend && npm run gen:api
- pytest tests/unit/test_manager_operation_ids_contract.py tests/unit/test_product_response_mapper_variants.py tests/unit/test_public_product_series_payloads.py -q
- cd manager_frontend && npm run build
- cd web && npm run audit:theme
- cd web && INTERNAL_API_URL=https://api.mvn.by/api/v1 PUBLIC_API_URL=https://api.mvn.by/api/v1 npm run build
- Browser QA: /brands/tcl/ desktop and mobile, product series sibling section

## Notes
- Local integration tests that require db_test could not run here because Docker daemon is not available and db_test does not resolve from the host environment.
- TCL descriptions/features are intentionally in scripts/seed_tcl_series_content.py, not a migration, so we can dry-run and apply explicitly after deploy without overwriting manual edits unless --overwrite is used.
