### PR TITLE
Keep TCL series seed dry-run read-only

### DIFF
--- a/scripts/seed_tcl_series_content.py
+++ b/scripts/seed_tcl_series_content.py
@@ -237,7 +237,7 @@ async def seed_tcl_series(
                 updated += 1
                 print(f"[update] {series.title} ({series.slug}) <- {seed.title}")
 
-        if updated:
+        if updated and execute:
             await CatalogRevisionService.bump_commit_and_purge(
                 session,
                 scope="tcl_series_content_seed",


### PR DESCRIPTION
## Summary\n- avoid catalog revision bump and internal commit during TCL series seed dry-runs\n- keep --execute as the only mode that can write content and purge catalog caches\n\n## Verification\n- python3 -m py_compile scripts/seed_tcl_series_content.py\n- git diff --check