### PR TITLE
[codex] Improve brand series sync and manager sorting UI

### DIFF
--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -43,6 +43,7 @@ const draggedBrandId = ref<number | null>(null);
 const brandDropTargetId = ref<number | null>(null);
 const draggedSeriesId = ref<number | null>(null);
 const seriesDropTargetId = ref<number | null>(null);
+const expandedSeriesIds = ref<Set<number>>(new Set());
 const form = ref<BrandForm>({
     title: '',
     slug: '',
@@ -108,6 +109,18 @@ const moveItemById = <T extends { id: number }>(items: T[], draggedId: number, t
     if (!moved) return items;
     next.splice(targetIndex, 0, moved);
     return next;
+};
+
+const isSeriesExpanded = (seriesId: number) => expandedSeriesIds.value.has(seriesId);
+
+const toggleSeriesExpanded = (seriesId: number) => {
+    const next = new Set(expandedSeriesIds.value);
+    if (next.has(seriesId)) {
+        next.delete(seriesId);
+    } else {
+        next.add(seriesId);
+    }
+    expandedSeriesIds.value = next;
 };
 
 const withSortOrder = <T extends { sort_order: number }>(items: T[]) => (
@@ -182,6 +195,8 @@ const fetchSeries = async () => {
     try {
         const res = await api.listManagerBrandSeries(selectedBrandId.value);
         seriesItems.value = [...(res.items || [])];
+        const existingIds = new Set(seriesItems.value.map((item) => item.id));
+        expandedSeriesIds.value = new Set([...expandedSeriesIds.value].filter((id) => existingIds.has(id)));
     } catch (err) {
         seriesError.value = getApiErrorMessage(err);
     } finally {
@@ -651,11 +666,11 @@ onMounted(() => {
             <div v-else-if="seriesItems.length === 0" class="rounded-xl border border-dashed border-gray-300 dark:border-slate-700 px-4 py-8 text-sm text-gray-500 dark:text-slate-400">
                 У бренда пока нет серий. Можно добавить первую вручную.
             </div>
-            <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div v-else class="space-y-2">
                 <article
                     v-for="series in seriesItems"
                     :key="series.id"
-                    class="rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 p-4 space-y-3"
+                    class="rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 px-3 py-2.5"
                     :class="[
                         seriesDropTargetId === series.id ? 'outline outline-2 outline-teal-400 outline-offset-2' : '',
                         draggedSeriesId === series.id ? 'opacity-50' : '',
@@ -667,10 +682,10 @@ onMounted(() => {
                     @drop.prevent="onSeriesDrop(series)"
                     @dragend="resetSeriesDragState"
                 >
-                    <div class="flex items-start gap-3">
+                    <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
                         <button
                             type="button"
-                            class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-500 transition-colors"
+                            class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-500 transition-colors"
                             :class="isSeriesReorderDisabled ? 'cursor-not-allowed opacity-40' : 'cursor-grab hover:bg-white hover:text-teal-600 dark:hover:bg-slate-800 dark:hover:text-teal-300 active:cursor-grabbing'"
                             :disabled="isSeriesReorderDisabled"
                             title="Перетащите серию выше или ниже"
@@ -682,36 +697,49 @@ onMounted(() => {
                             v-if="series.hero_image"
                             :src="series.hero_image"
                             :alt="series.title"
-                            class="w-16 h-16 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
+                            class="h-10 w-10 shrink-0 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
                         />
                         <div class="min-w-0 flex-1">
                             <div class="flex flex-wrap items-center gap-2">
-                                <h3 class="font-bold text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
+                                <h3 class="font-bold leading-tight text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
                                 <span
                                     class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
                                     :class="series.is_published ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'"
                                 >
                                     {{ series.is_published ? 'Публичная' : 'Скрыта' }}
                                 </span>
+                                <span class="text-xs text-gray-500 dark:text-slate-400">{{ series.products_count }} товаров</span>
                             </div>
                             <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
-                            <p v-if="series.description" class="mt-2 text-sm text-gray-600 dark:text-slate-300 line-clamp-3">
-                                {{ series.description }}
-                            </p>
                         </div>
-                    </div>
-                    <div v-if="series.features?.length" class="flex flex-wrap gap-2">
-                        <span
-                            v-for="feature in series.features"
-                            :key="feature"
-                            class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2.5 py-1 text-xs font-semibold text-teal-700 dark:text-teal-200"
-                        >
-                            {{ feature }}
-                        </span>
-                    </div>
-                    <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500 dark:text-slate-400">
-                        <span>{{ series.products_count }} товаров</span>
-                        <div class="inline-flex items-center gap-1">
+                        <div v-if="series.features?.length" class="flex min-w-0 flex-1 flex-wrap gap-1.5 lg:max-w-[34%]">
+                            <span
+                                v-for="feature in series.features.slice(0, isSeriesExpanded(series.id) ? series.features.length : 3)"
+                                :key="feature"
+                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
+                            >
+                                {{ feature }}
+                            </span>
+                            <span
+                                v-if="!isSeriesExpanded(series.id) && series.features.length > 3"
+                                class="rounded-full border border-gray-200 dark:border-slate-700 px-2 py-0.5 text-xs font-semibold text-gray-500 dark:text-slate-400"
+                            >
+                                +{{ series.features.length - 3 }}
+                            </span>
+                        </div>
+                        <div class="inline-flex shrink-0 items-center gap-1">
+                            <button
+                                v-if="series.description || series.features?.length"
+                                type="button"
+                                class="inline-flex items-center gap-1 px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
+                                :aria-expanded="isSeriesExpanded(series.id)"
+                                @click="toggleSeriesExpanded(series.id)"
+                            >
+                                <span class="material-icons-round text-[16px]">
+                                    {{ isSeriesExpanded(series.id) ? 'expand_less' : 'expand_more' }}
+                                </span>
+                                Детали
+                            </button>
                             <button
                                 type="button"
                                 class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
@@ -727,6 +755,23 @@ onMounted(() => {
                             >
                                 Удалить
                             </button>
+                        </div>
+                    </div>
+                    <div
+                        v-if="isSeriesExpanded(series.id)"
+                        class="mt-2 border-t border-gray-200 dark:border-slate-700 pt-2 text-sm text-gray-600 dark:text-slate-300"
+                    >
+                        <p v-if="series.description">
+                            {{ series.description }}
+                        </p>
+                        <div v-if="series.features?.length" class="mt-2 flex flex-wrap gap-1.5">
+                            <span
+                                v-for="feature in series.features"
+                                :key="feature"
+                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
+                            >
+                                {{ feature }}
+                            </span>
                         </div>
                     </div>
                 </article>

--- a/services/brand_series_service.py
+++ b/services/brand_series_service.py
@@ -22,11 +22,37 @@ SERIES_SPEC_KEYS = (
     "series",
     "Серия",
     "серия",
+    "Серия модели",
+    "серия модели",
+    "Серия кондиционера",
+    "серия кондиционера",
     "Линейка",
     "линейка",
+    "Линейка модели",
+    "линейка модели",
+    "Модельная серия",
+    "модельная серия",
     "Модельный ряд",
     "model_series",
 )
+
+SERIES_VALUE_STOP_PATTERN = re.compile(
+    r"(?i)(?:"
+    r"\b(?:inverter|invertor|инвертор\w*|r32|r410a|wi[\s-]?fi|wifi|технология)\b"
+    r"|[-−]\s*\d+\s*°?\s*c\b"
+    r")"
+)
+
+TITLE_SERIES_STOP_WORDS = {
+    "кондиционер",
+    "сплит",
+    "сплит-система",
+    "система",
+    "настенный",
+    "настенная",
+    "инверторный",
+    "инверторная",
+}
 
 
 def _to_text(value: Any) -> str:
@@ -55,6 +81,71 @@ def _first_non_empty(specs: Dict[str, Any], keys: Iterable[str]) -> Optional[str
 
 def _primary_token(value: str) -> str:
     return re.split(r"[,/|;]", _to_text(value), maxsplit=1)[0].strip()
+
+
+def _clean_series_value(value: str) -> str:
+    text = _primary_token(value)
+    if not text:
+        return ""
+
+    marker = SERIES_VALUE_STOP_PATTERN.search(text)
+    if marker:
+        if marker.start() == 0:
+            return re.sub(r"\s+", " ", text).strip(" -–—.,;:")
+        text = text[: marker.start()].strip()
+
+    return re.sub(r"\s+", " ", text).strip(" -–—.,;:")
+
+
+def _looks_like_model_code(value: str) -> bool:
+    token = _to_text(value).strip("()[]{}.,;:!?'\"`")
+    if not token:
+        return True
+    if "/" in token or "+" in token or "_" in token:
+        return True
+    if re.fullmatch(r"\d+(?:[.,]\d+)+", token):
+        return False
+    if re.fullmatch(r"\d+", token):
+        return True
+    if any(char.isdigit() for char in token):
+        if re.search(r"[A-ZА-Я]{2,}", token) or "-" in token or len(token) > 5:
+            return True
+        return False
+    if token.isupper() and len(token) > 4:
+        return True
+    return False
+
+
+def _extract_series_from_title(title: str, brand_name: Optional[str]) -> Optional[str]:
+    title_text = re.sub(r"\s+", " ", _to_text(title))
+    brand_text = re.sub(r"\s+", " ", _to_text(brand_name))
+    if not title_text or not brand_text:
+        return None
+
+    if not title_text.casefold().startswith(f"{brand_text.casefold()} "):
+        return None
+
+    tail = title_text[len(brand_text) :].strip()
+    if not tail:
+        return None
+
+    parts: list[str] = []
+    for raw_token in tail.split():
+        token = raw_token.strip("()[]{}.,;:!?'\"`")
+        if not token:
+            break
+        normalized = token.casefold()
+        if normalized in TITLE_SERIES_STOP_WORDS:
+            break
+        if _looks_like_model_code(token):
+            break
+        parts.append(token)
+        if len(parts) >= 3:
+            break
+
+    if not parts:
+        return None
+    return " ".join(parts)
 
 
 def _safe_group_slug(tag: Tag, group_slug_by_id: Dict[int, str]) -> Optional[str]:
@@ -100,11 +191,13 @@ def extract_series_name(
     tags: Optional[Sequence[Tag]] = None,
     *,
     group_slug_by_id: Optional[Dict[int, str]] = None,
+    title: str = "",
+    brand_name: Optional[str] = None,
 ) -> Optional[str]:
     specs = specs or {}
     raw = _first_non_empty(specs, SERIES_SPEC_KEYS)
     if raw:
-        series = _primary_token(raw)
+        series = _clean_series_value(raw)
         if series:
             return series
 
@@ -112,6 +205,10 @@ def extract_series_name(
     for tag in tags or []:
         if _safe_group_slug(tag, slug_map) == "series" and _to_text(getattr(tag, "title", "")):
             return _to_text(tag.title)
+
+    title_series = _extract_series_from_title(title, brand_name)
+    if title_series:
+        return title_series
     return None
 
 
@@ -453,6 +550,8 @@ async def sync_product_brand_series(
         specs=data_specs,
         tags=tag_list,
         group_slug_by_id=group_slug_by_id,
+        title=product_title,
+        brand_name=brand_name,
     )
     if series_name:
         series = await ensure_series(session, title=series_name, brand_id=product.brand_id)

--- a/tests/unit/test_brand_series_service.py
+++ b/tests/unit/test_brand_series_service.py
@@ -18,6 +18,22 @@ def test_extract_series_name_from_russian_key():
     assert name == "BreezeIN 2.0"
 
 
+def test_extract_series_name_cleans_marketing_suffix_from_specs():
+    assert extract_series_name({"series": "COSMO inverter R32 WI-FI"}) == "COSMO"
+    assert extract_series_name({"series": "COSMO NORDIC inverter R32  WI-FI -25°C"}) == "COSMO NORDIC"
+    assert extract_series_name({"series": "LUNA Matt inverter R32  WI-FI"}) == "LUNA Matt"
+
+
+def test_extract_series_name_keeps_values_when_stop_marker_is_series_prefix():
+    assert extract_series_name({"series": "R32 Deluxe"}) == "R32 Deluxe"
+    assert extract_series_name({"series": "Wi-Fi Ready"}) == "Wi-Fi Ready"
+
+
+def test_extract_series_name_supports_extended_russian_keys():
+    name = extract_series_name({"Серия кондиционера": "VIOLA inverter R32 WI-FI"})
+    assert name == "VIOLA"
+
+
 def test_extract_series_name_from_series_tag_fallback():
     tag = SimpleNamespace(
         title="Elite",
@@ -25,6 +41,36 @@ def test_extract_series_name_from_series_tag_fallback():
     )
     name = extract_series_name({}, [tag])
     assert name == "Elite"
+
+
+def test_extract_series_name_from_title_after_brand_fallback():
+    name = extract_series_name({}, title="KINGHOME Cosmo KWH24AWDXE-K6DNA3A", brand_name="KINGHOME")
+    assert name == "Cosmo"
+
+
+def test_extract_series_name_title_fallback_ignores_model_code_after_brand():
+    name = extract_series_name({}, title="KINGHOME KUD100ZD1/A-S+ KUD100W1/NhA-S", brand_name="KINGHOME")
+    assert name is None
+
+
+def test_extract_series_name_title_fallback_keeps_series_version_and_inverter_word():
+    assert (
+        extract_series_name({}, title="TCL BreezeIN 2.0 A+++ TAC-09CHSD", brand_name="TCL")
+        == "BreezeIN 2.0"
+    )
+    assert (
+        extract_series_name({}, title="LG Dual Inverter S09EQ", brand_name="LG")
+        == "Dual Inverter"
+    )
+
+
+def test_extract_series_name_title_fallback_stops_before_capacity_tokens():
+    assert extract_series_name({}, title="Gree Bora 09 GWH09AAA-K6DNA1A", brand_name="Gree") == "Bora"
+    assert extract_series_name({}, title="AUX Halo 12 ASW-H12A4", brand_name="AUX") == "Halo"
+    assert (
+        extract_series_name({}, title="Midea Xtreme Save 09 MSAG-09HRN8", brand_name="Midea")
+        == "Xtreme Save"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Normalize product series names from specs before creating/linking `ProductSeries`, including KINGHOME-style values such as `COSMO inverter R32 WI-FI`.
- Add cautious title fallback for series detection after the brand name while avoiding model-code tokens.
- Make the manager brand series list compact and single-column for desktop sorting, with description/features hidden behind a `Details` toggle.

## Why

The manager brand pages were missing series links for products whose specs contained marketing-heavy `series` strings, and the brand-series UI used a two-column layout that made drag sorting ambiguous on desktop.

## Validation

- `npm run build` in `manager_frontend/`
- `pytest` scoped pure unit tests for `extract_series_name` cases: 7 passed
- In-app Browser QA against local mock manager API:
  - desktop 1224x601: series render as one vertical compact list
  - `Details` expands description and full feature list
  - mobile 390x844: rows remain readable
  - no console warnings/errors during QA

## Notes

Full async `tests/unit/test_brand_series_service.py` was not runnable in this local environment because the configured `db_test` host is not resolvable outside the test container setup. Existing untracked `logs/` were intentionally left out of the commit.

A separate Codex tech-lead agent is running review/test verification before merge; this PR is draft until that review is complete.