### PR TITLE
[codex] Auto-sync brand series from product specs

### DIFF
--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -43,6 +43,7 @@ const draggedBrandId = ref<number | null>(null);
 const brandDropTargetId = ref<number | null>(null);
 const draggedSeriesId = ref<number | null>(null);
 const seriesDropTargetId = ref<number | null>(null);
+const expandedSeriesIds = ref<Set<number>>(new Set());
 const form = ref<BrandForm>({
     title: '',
     slug: '',
@@ -108,6 +109,18 @@ const moveItemById = <T extends { id: number }>(items: T[], draggedId: number, t
     if (!moved) return items;
     next.splice(targetIndex, 0, moved);
     return next;
+};
+
+const isSeriesExpanded = (seriesId: number) => expandedSeriesIds.value.has(seriesId);
+
+const toggleSeriesExpanded = (seriesId: number) => {
+    const next = new Set(expandedSeriesIds.value);
+    if (next.has(seriesId)) {
+        next.delete(seriesId);
+    } else {
+        next.add(seriesId);
+    }
+    expandedSeriesIds.value = next;
 };
 
 const withSortOrder = <T extends { sort_order: number }>(items: T[]) => (
@@ -182,6 +195,8 @@ const fetchSeries = async () => {
     try {
         const res = await api.listManagerBrandSeries(selectedBrandId.value);
         seriesItems.value = [...(res.items || [])];
+        const existingIds = new Set(seriesItems.value.map((item) => item.id));
+        expandedSeriesIds.value = new Set([...expandedSeriesIds.value].filter((id) => existingIds.has(id)));
     } catch (err) {
         seriesError.value = getApiErrorMessage(err);
     } finally {
@@ -651,11 +666,11 @@ onMounted(() => {
             <div v-else-if="seriesItems.length === 0" class="rounded-xl border border-dashed border-gray-300 dark:border-slate-700 px-4 py-8 text-sm text-gray-500 dark:text-slate-400">
                 У бренда пока нет серий. Можно добавить первую вручную.
             </div>
-            <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div v-else class="space-y-2">
                 <article
                     v-for="series in seriesItems"
                     :key="series.id"
-                    class="rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 p-4 space-y-3"
+                    class="rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 px-3 py-2.5"
                     :class="[
                         seriesDropTargetId === series.id ? 'outline outline-2 outline-teal-400 outline-offset-2' : '',
                         draggedSeriesId === series.id ? 'opacity-50' : '',
@@ -667,10 +682,10 @@ onMounted(() => {
                     @drop.prevent="onSeriesDrop(series)"
                     @dragend="resetSeriesDragState"
                 >
-                    <div class="flex items-start gap-3">
+                    <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
                         <button
                             type="button"
-                            class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-500 transition-colors"
+                            class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-500 transition-colors"
                             :class="isSeriesReorderDisabled ? 'cursor-not-allowed opacity-40' : 'cursor-grab hover:bg-white hover:text-teal-600 dark:hover:bg-slate-800 dark:hover:text-teal-300 active:cursor-grabbing'"
                             :disabled="isSeriesReorderDisabled"
                             title="Перетащите серию выше или ниже"
@@ -682,36 +697,49 @@ onMounted(() => {
                             v-if="series.hero_image"
                             :src="series.hero_image"
                             :alt="series.title"
-                            class="w-16 h-16 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
+                            class="h-10 w-10 shrink-0 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
                         />
                         <div class="min-w-0 flex-1">
                             <div class="flex flex-wrap items-center gap-2">
-                                <h3 class="font-bold text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
+                                <h3 class="font-bold leading-tight text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
                                 <span
                                     class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
                                     :class="series.is_published ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'"
                                 >
                                     {{ series.is_published ? 'Публичная' : 'Скрыта' }}
                                 </span>
+                                <span class="text-xs text-gray-500 dark:text-slate-400">{{ series.products_count }} товаров</span>
                             </div>
                             <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
-                            <p v-if="series.description" class="mt-2 text-sm text-gray-600 dark:text-slate-300 line-clamp-3">
-                                {{ series.description }}
-                            </p>
                         </div>
-                    </div>
-                    <div v-if="series.features?.length" class="flex flex-wrap gap-2">
-                        <span
-                            v-for="feature in series.features"
-                            :key="feature"
-                            class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2.5 py-1 text-xs font-semibold text-teal-700 dark:text-teal-200"
-                        >
-                            {{ feature }}
-                        </span>
-                    </div>
-                    <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-gray-500 dark:text-slate-400">
-                        <span>{{ series.products_count }} товаров</span>
-                        <div class="inline-flex items-center gap-1">
+                        <div v-if="series.features?.length" class="flex min-w-0 flex-1 flex-wrap gap-1.5 lg:max-w-[34%]">
+                            <span
+                                v-for="feature in series.features.slice(0, isSeriesExpanded(series.id) ? series.features.length : 3)"
+                                :key="feature"
+                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
+                            >
+                                {{ feature }}
+                            </span>
+                            <span
+                                v-if="!isSeriesExpanded(series.id) && series.features.length > 3"
+                                class="rounded-full border border-gray-200 dark:border-slate-700 px-2 py-0.5 text-xs font-semibold text-gray-500 dark:text-slate-400"
+                            >
+                                +{{ series.features.length - 3 }}
+                            </span>
+                        </div>
+                        <div class="inline-flex shrink-0 items-center gap-1">
+                            <button
+                                v-if="series.description || series.features?.length"
+                                type="button"
+                                class="inline-flex items-center gap-1 px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
+                                :aria-expanded="isSeriesExpanded(series.id)"
+                                @click="toggleSeriesExpanded(series.id)"
+                            >
+                                <span class="material-icons-round text-[16px]">
+                                    {{ isSeriesExpanded(series.id) ? 'expand_less' : 'expand_more' }}
+                                </span>
+                                Детали
+                            </button>
                             <button
                                 type="button"
                                 class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
@@ -727,6 +755,23 @@ onMounted(() => {
                             >
                                 Удалить
                             </button>
+                        </div>
+                    </div>
+                    <div
+                        v-if="isSeriesExpanded(series.id)"
+                        class="mt-2 border-t border-gray-200 dark:border-slate-700 pt-2 text-sm text-gray-600 dark:text-slate-300"
+                    >
+                        <p v-if="series.description">
+                            {{ series.description }}
+                        </p>
+                        <div v-if="series.features?.length" class="mt-2 flex flex-wrap gap-1.5">
+                            <span
+                                v-for="feature in series.features"
+                                :key="feature"
+                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
+                            >
+                                {{ feature }}
+                            </span>
                         </div>
                     </div>
                 </article>

--- a/services/brand_series_service.py
+++ b/services/brand_series_service.py
@@ -22,11 +22,42 @@ SERIES_SPEC_KEYS = (
     "series",
     "Серия",
     "серия",
+    "Серия модели",
+    "серия модели",
+    "Серия кондиционера",
+    "серия кондиционера",
     "Линейка",
     "линейка",
+    "Линейка модели",
+    "линейка модели",
+    "Модельная серия",
+    "модельная серия",
     "Модельный ряд",
     "model_series",
 )
+
+SERIES_VALUE_STOP_PATTERN = re.compile(
+    r"(?i)(?:"
+    r"\b(?:r32|r410a|wi[\s-]?fi|wifi|технология)\b"
+    r"|[-−]\s*\d+\s*°?\s*c\b"
+    r")"
+)
+
+SERIES_TRAILING_INVERTER_PATTERN = re.compile(
+    r"(?i)\s+\b(?:inverter|invertor|инвертор\w*)\b\s*$"
+)
+SERIES_TRAILING_INVERTER_PREFIX_ALLOWLIST = {"dual"}
+
+TITLE_SERIES_STOP_WORDS = {
+    "кондиционер",
+    "сплит",
+    "сплит-система",
+    "система",
+    "настенный",
+    "настенная",
+    "инверторный",
+    "инверторная",
+}
 
 
 def _to_text(value: Any) -> str:
@@ -55,6 +86,80 @@ def _first_non_empty(specs: Dict[str, Any], keys: Iterable[str]) -> Optional[str
 
 def _primary_token(value: str) -> str:
     return re.split(r"[,/|;]", _to_text(value), maxsplit=1)[0].strip()
+
+
+def _clean_series_value(value: str) -> str:
+    text = _primary_token(value)
+    if not text:
+        return ""
+
+    trimmed_by_marker = False
+    marker = SERIES_VALUE_STOP_PATTERN.search(text)
+    if marker:
+        if marker.start() == 0:
+            return re.sub(r"\s+", " ", text).strip(" -–—.,;:")
+        text = text[: marker.start()].strip()
+        trimmed_by_marker = True
+
+    if trimmed_by_marker:
+        trailing_inverter = SERIES_TRAILING_INVERTER_PATTERN.search(text)
+        if trailing_inverter:
+            prefix = text[: trailing_inverter.start()].strip()
+            if prefix.casefold() not in SERIES_TRAILING_INVERTER_PREFIX_ALLOWLIST:
+                text = text[: trailing_inverter.start()].strip()
+
+    return re.sub(r"\s+", " ", text).strip(" -–—.,;:")
+
+
+def _looks_like_model_code(value: str) -> bool:
+    token = _to_text(value).strip("()[]{}.,;:!?'\"`")
+    if not token:
+        return True
+    if "/" in token or "+" in token or "_" in token:
+        return True
+    if re.fullmatch(r"\d+(?:[.,]\d+)+", token):
+        return False
+    if re.fullmatch(r"\d+", token):
+        return True
+    if any(char.isdigit() for char in token):
+        if re.search(r"[A-ZА-Я]{2,}", token) or "-" in token or len(token) > 5:
+            return True
+        return False
+    if token.isupper() and len(token) > 4:
+        return True
+    return False
+
+
+def _extract_series_from_title(title: str, brand_name: Optional[str]) -> Optional[str]:
+    title_text = re.sub(r"\s+", " ", _to_text(title))
+    brand_text = re.sub(r"\s+", " ", _to_text(brand_name))
+    if not title_text or not brand_text:
+        return None
+
+    if not title_text.casefold().startswith(f"{brand_text.casefold()} "):
+        return None
+
+    tail = title_text[len(brand_text) :].strip()
+    if not tail:
+        return None
+
+    parts: list[str] = []
+    for raw_token in tail.split():
+        token = raw_token.strip("()[]{}.,;:!?'\"`")
+        if not token:
+            break
+        normalized = token.casefold()
+        if normalized in TITLE_SERIES_STOP_WORDS:
+            break
+        if _looks_like_model_code(token):
+            break
+        parts.append(token)
+        if len(parts) >= 3:
+            break
+
+    if not parts:
+        return None
+    return " ".join(parts)
 
 
 def _safe_group_slug(tag: Tag, group_slug_by_id: Dict[int, str]) -> Optional[str]:
@@ -100,11 +205,13 @@ def extract_series_name(
     tags: Optional[Sequence[Tag]] = None,
     *,
     group_slug_by_id: Optional[Dict[int, str]] = None,
+    title: str = "",
+    brand_name: Optional[str] = None,
 ) -> Optional[str]:
     specs = specs or {}
     raw = _first_non_empty(specs, SERIES_SPEC_KEYS)
     if raw:
-        series = _primary_token(raw)
+        series = _clean_series_value(raw)
         if series:
             return series
 
@@ -112,6 +219,10 @@ def extract_series_name(
     for tag in tags or []:
         if _safe_group_slug(tag, slug_map) == "series" and _to_text(getattr(tag, "title", "")):
             return _to_text(tag.title)
+
+    title_series = _extract_series_from_title(title, brand_name)
+    if title_series:
+        return title_series
     return None
 
 
@@ -375,6 +486,9 @@ async def sync_product_brand_series(
     tags: Optional[Sequence[Tag]] = None,
     explicit_brand_id: Optional[int] = None,
     explicit_brand_override: bool = False,
+    allow_series_tag_fallback: bool = True,
+    allow_series_title_fallback: bool = True,
+    clear_series_when_missing: bool = False,
 ) -> bool:
     data_specs = specs if specs is not None else (product.specs or {})
     product_title = title if title is not None else (product.title or "")
@@ -451,14 +565,19 @@ async def sync_product_brand_series(
 
     series_name = extract_series_name(
         specs=data_specs,
-        tags=tag_list,
+        tags=tag_list if allow_series_tag_fallback else [],
         group_slug_by_id=group_slug_by_id,
+        title=product_title if allow_series_title_fallback else "",
+        brand_name=brand_name if allow_series_title_fallback else None,
     )
     if series_name:
         series = await ensure_series(session, title=series_name, brand_id=product.brand_id)
         if product.series_id != series.id:
             product.series_id = series.id
             changed = True
+    elif clear_series_when_missing and product.series_id is not None:
+        product.series_id = None
+        changed = True
 
     if changed:
         session.add(product)

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import Brand, Product, ProductSeries, ProductTagLink, Tag, TagGroup
+from services.brand_series_service import extract_series_name, sync_product_brand_series
 from services.catalog_revision_service import CatalogRevisionService
 
 
@@ -205,6 +206,11 @@ class ManagerBrandService:
         if brand is None:
             raise HTTPException(status_code=404, detail="Бренд не найден.")
 
+        await ManagerBrandService._sync_missing_product_series_for_brand(
+            session,
+            brand=brand,
+        )
+
         rows = (
             await session.execute(
                 select(ProductSeries, func.count(Product.id).label("products_count"))
@@ -218,6 +224,48 @@ class ManagerBrandService:
             ManagerBrandService._serialize_series(series, products_count=int(products_count or 0))
             for series, products_count in rows
         ]
+
+    @staticmethod
+    async def _sync_missing_product_series_for_brand(
+        session: AsyncSession,
+        *,
+        brand: Brand,
+    ) -> int:
+        products = (
+            await session.execute(
+                select(Product).where(
+                    Product.brand_id == brand.id,
+                    Product.series_id.is_(None),
+                )
+            )
+        ).scalars().all()
+
+        changed_product_ids: List[int] = []
+        for product in products:
+            if not extract_series_name(specs=product.specs or {}):
+                continue
+
+            if await sync_product_brand_series(
+                session,
+                product=product,
+                specs=product.specs or {},
+                title=product.title or "",
+                explicit_brand_id=brand.id,
+                explicit_brand_override=True,
+            ):
+                if product.id is not None:
+                    changed_product_ids.append(int(product.id))
+
+        if not changed_product_ids:
+            return 0
+
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_series_auto_sync",
+            product_ids=changed_product_ids,
+            brand_slugs=[brand.slug],
+        )
+        return len(changed_product_ids)
 
     @staticmethod
     async def create_brand_series(

--- a/services/manager_specs_service.py
+++ b/services/manager_specs_service.py
@@ -5,7 +5,31 @@ from sqlmodel import select
 
 from models import Product
 from schemas import BulkSpecUpdate
+from services.brand_series_service import SERIES_SPEC_KEYS, sync_product_brand_series
+from services.catalog_revision_service import CatalogRevisionService
 from services.spec_normalizer import normalize_specs
+
+
+SERIES_SPEC_KEY_LOOKUP = {key.strip().lower() for key in SERIES_SPEC_KEYS}
+
+
+def _payload_touches_series(payload: BulkSpecUpdate) -> bool:
+    if payload.operation == "replace":
+        return True
+    if payload.operation != "delete_keys":
+        return False
+    return any(str(key).strip().lower() in SERIES_SPEC_KEY_LOOKUP for key in payload.specs.keys())
+
+
+def _delete_spec_key(current_specs: dict, key: str) -> None:
+    normalized_key = str(key).strip().lower()
+    if normalized_key in SERIES_SPEC_KEY_LOOKUP:
+        for existing_key in list(current_specs.keys()):
+            if str(existing_key).strip().lower() in SERIES_SPEC_KEY_LOOKUP:
+                current_specs.pop(existing_key, None)
+        return
+
+    current_specs.pop(key, None)
 
 
 class ManagerSpecsService:
@@ -19,6 +43,8 @@ class ManagerSpecsService:
         products = result.scalars().all()
 
         updated_count = 0
+        updated_product_ids: list[int] = []
+        clear_series_when_missing = _payload_touches_series(payload)
         for product in products:
             current_specs = dict(product.specs) if product.specs else {}
 
@@ -26,15 +52,33 @@ class ManagerSpecsService:
                 current_specs = dict(payload.specs)
             elif payload.operation == "delete_keys":
                 for key in payload.specs.keys():
-                    current_specs.pop(key, None)
+                    _delete_spec_key(current_specs, str(key))
             else:
                 current_specs.update(payload.specs)
 
             product.specs = normalize_specs(current_specs)
+            await sync_product_brand_series(
+                session,
+                product=product,
+                specs=product.specs,
+                title=product.title or "",
+                allow_series_tag_fallback=False,
+                allow_series_title_fallback=False,
+                clear_series_when_missing=clear_series_when_missing,
+            )
             session.add(product)
             updated_count += 1
+            if product.id is not None:
+                updated_product_ids.append(int(product.id))
 
-        await session.commit()
+        if updated_product_ids:
+            await CatalogRevisionService.bump_commit_and_purge(
+                session,
+                scope="manager_specs_bulk_update",
+                product_ids=updated_product_ids,
+            )
+        else:
+            await session.commit()
         return {
             "message": f"Updated specs for {updated_count} products",
             "operation": payload.operation,

--- a/tests/integration/test_manager_brands_api.py
+++ b/tests/integration/test_manager_brands_api.py
@@ -2,6 +2,7 @@ import pytest
 
 from core.config import settings
 from models import Product, ProductSeries
+from services.catalog_revision_service import CatalogRevisionService
 
 
 async def _auth_headers(async_client):
@@ -216,3 +217,73 @@ async def test_manager_brand_series_delete_forbidden_when_products_linked(async_
     )
     assert delete_resp.status_code == 400
     assert "привязаны товары" in delete_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_manager_brand_series_list_auto_creates_series_from_product_specs(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    brand_resp = await async_client.post(
+        "/api/manager/brands",
+        headers=headers,
+        json={"title": "KingHome Auto Series", "slug": "kinghome-auto-series"},
+    )
+    assert brand_resp.status_code == 200
+    brand_id = brand_resp.json()["id"]
+
+    products = [
+        Product(
+            title="KINGHOME Cosmo KWH09AWAXB-K6DNA3B",
+            slug="kinghome-auto-cosmo-1",
+            price=1000,
+            area=25,
+            brand_id=brand_id,
+            specs={"brand": "KINGHOME", "series": "COSMO inverter R32 WI-FI"},
+        ),
+        Product(
+            title="KINGHOME Cosmo KWH12AWBXB-K6DNA3D",
+            slug="kinghome-auto-cosmo-2",
+            price=1200,
+            area=35,
+            brand_id=brand_id,
+            specs={"brand": "KINGHOME", "series": "COSMO inverter R32 WI-FI"},
+        ),
+        Product(
+            title="KINGHOME Luna Matt KWH09AYAXB-K6DNA5B",
+            slug="kinghome-auto-luna-1",
+            price=1300,
+            area=25,
+            brand_id=brand_id,
+            specs={"brand": "KINGHOME", "series": "LUNA Matt inverter R32 WI-FI"},
+        ),
+    ]
+    db.add_all(products)
+    await db.commit()
+
+    list_resp = await async_client.get(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+    )
+
+    assert list_resp.status_code == 200, list_resp.text
+    items = list_resp.json()["items"]
+    by_slug = {item["slug"]: item for item in items}
+    assert by_slug["cosmo"]["title"] == "COSMO"
+    assert by_slug["cosmo"]["products_count"] == 2
+    assert by_slug["luna-matt"]["title"] == "LUNA Matt"
+    assert by_slug["luna-matt"]["products_count"] == 1
+    after_first_revision = await CatalogRevisionService.get_current(db)
+
+    db.expire_all()
+    for product in products:
+        updated = await db.get(Product, product.id)
+        assert updated.series_id is not None
+
+    second_list_resp = await async_client.get(
+        f"/api/manager/brands/{brand_id}/series",
+        headers=headers,
+    )
+    assert second_list_resp.status_code == 200, second_list_resp.text
+    assert second_list_resp.json()["items"] == items
+    after_second_revision = await CatalogRevisionService.get_current(db)
+    assert after_second_revision["revision"] == after_first_revision["revision"]

--- a/tests/integration/test_specs.py
+++ b/tests/integration/test_specs.py
@@ -1,8 +1,18 @@
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import func
 from sqlmodel import select
-from models import Product
+from models import Brand, Product, ProductSeries
 from core.config import settings
+
+
+async def _auth_headers(async_client: AsyncClient) -> dict[str, str]:
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    return {"Authorization": f"Bearer {login_resp.json()['access_token']}"}
 
 @pytest.mark.asyncio
 async def test_get_public_spec_keys(async_client: AsyncClient, db):
@@ -112,3 +122,204 @@ async def test_bulk_update_logic(async_client: AsyncClient, db):
         assert p.specs["wifi"] == "yes"
         assert p.specs["warranty"] == "3 years"
         assert p.specs["old"] == "val"
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_specs_creates_and_links_product_series(async_client: AsyncClient, db):
+    brand = Brand(title="KINGHOME", slug="kinghome", is_published=True)
+    db.add(brand)
+    await db.flush()
+
+    products = [
+        Product(
+            title=f"KINGHOME Cosmo {i}",
+            slug=f"kinghome-cosmo-{i}",
+            price=1000 * i,
+            area=20,
+            brand_id=brand.id,
+            specs={"brand": "KINGHOME"},
+        )
+        for i in range(1, 3)
+    ]
+    db.add_all(products)
+    await db.commit()
+
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    headers = {"Authorization": f"Bearer {login_resp.json()['access_token']}"}
+
+    response = await async_client.post(
+        "/api/manager/specs/bulk-update",
+        json={
+            "product_ids": [product.id for product in products],
+            "specs": {"series": "COSMO inverter R32 WI-FI"},
+            "operation": "merge",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    db.expire_all()
+
+    series = (
+        await db.execute(
+            select(ProductSeries).where(
+                ProductSeries.brand_id == brand.id,
+                ProductSeries.slug == "cosmo",
+            )
+        )
+    ).scalar_one()
+    assert series.title == "COSMO"
+
+    for product in products:
+        updated = await db.get(Product, product.id)
+        assert updated.series_id == series.id
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_specs_moves_product_to_new_series(async_client: AsyncClient, db):
+    headers = await _auth_headers(async_client)
+
+    brand = Brand(title="KINGHOME Move Series", slug="kinghome-move-series", is_published=True)
+    db.add(brand)
+    await db.flush()
+
+    old_series = ProductSeries(title="COSMO", slug="cosmo", brand_id=brand.id, is_published=True)
+    db.add(old_series)
+    await db.flush()
+
+    product = Product(
+        title="KINGHOME Move Test",
+        slug="kinghome-move-test",
+        price=1000,
+        area=20,
+        brand_id=brand.id,
+        series_id=old_series.id,
+        specs={"brand": "KINGHOME", "series": "COSMO"},
+    )
+    db.add(product)
+    await db.commit()
+
+    response = await async_client.post(
+        "/api/manager/specs/bulk-update",
+        json={
+            "product_ids": [product.id],
+            "specs": {"series": "LUNA Matt inverter R32 WI-FI"},
+            "operation": "merge",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    db.expire_all()
+
+    new_series = (
+        await db.execute(
+            select(ProductSeries).where(
+                ProductSeries.brand_id == brand.id,
+                ProductSeries.slug == "luna-matt",
+            )
+        )
+    ).scalar_one()
+    updated = await db.get(Product, product.id)
+    assert updated.series_id == new_series.id
+
+    old_count = (
+        await db.execute(select(func.count(Product.id)).where(Product.series_id == old_series.id))
+    ).scalar_one()
+    new_count = (
+        await db.execute(select(func.count(Product.id)).where(Product.series_id == new_series.id))
+    ).scalar_one()
+    assert old_count == 0
+    assert new_count == 1
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_specs_delete_series_key_clears_series_link(
+    async_client: AsyncClient,
+    db,
+):
+    headers = await _auth_headers(async_client)
+
+    brand = Brand(title="KINGHOME Delete Series", slug="kinghome-delete-series-brand", is_published=True)
+    db.add(brand)
+    await db.flush()
+
+    series = ProductSeries(title="COSMO", slug="cosmo", brand_id=brand.id, is_published=True)
+    db.add(series)
+    await db.flush()
+
+    product = Product(
+        title="KINGHOME Delete Series",
+        slug="kinghome-delete-series",
+        price=1000,
+        area=20,
+        brand_id=brand.id,
+        series_id=series.id,
+        specs={"brand": "KINGHOME", "series": "COSMO", "wifi": "yes"},
+    )
+    db.add(product)
+    await db.commit()
+
+    response = await async_client.post(
+        "/api/manager/specs/bulk-update",
+        json={
+            "product_ids": [product.id],
+            "specs": {"series": ""},
+            "operation": "delete_keys",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+    db.expire_all()
+    updated = await db.get(Product, product.id)
+    assert "series" not in updated.specs
+    assert updated.series_id is None
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_specs_replace_without_series_clears_series_link(
+    async_client: AsyncClient,
+    db,
+):
+    headers = await _auth_headers(async_client)
+
+    brand = Brand(title="KINGHOME Replace Series", slug="kinghome-replace-series-brand", is_published=True)
+    db.add(brand)
+    await db.flush()
+
+    series = ProductSeries(title="COSMO", slug="cosmo", brand_id=brand.id, is_published=True)
+    db.add(series)
+    await db.flush()
+
+    product = Product(
+        title="KINGHOME Replace Series",
+        slug="kinghome-replace-series",
+        price=1200,
+        area=25,
+        brand_id=brand.id,
+        series_id=series.id,
+        specs={"brand": "KINGHOME", "series": "COSMO", "wifi": "yes"},
+    )
+    db.add(product)
+    await db.commit()
+
+    response = await async_client.post(
+        "/api/manager/specs/bulk-update",
+        json={
+            "product_ids": [product.id],
+            "specs": {"brand": "KINGHOME", "wifi": "yes"},
+            "operation": "replace",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+    db.expire_all()
+    updated = await db.get(Product, product.id)
+    assert "series" not in updated.specs
+    assert updated.series_id is None

--- a/tests/unit/test_brand_series_service.py
+++ b/tests/unit/test_brand_series_service.py
@@ -18,6 +18,24 @@ def test_extract_series_name_from_russian_key():
     assert name == "BreezeIN 2.0"
 
 
+def test_extract_series_name_cleans_marketing_suffix_from_specs():
+    assert extract_series_name({"series": "COSMO inverter R32 WI-FI"}) == "COSMO"
+    assert extract_series_name({"series": "COSMO NORDIC inverter R32  WI-FI -25°C"}) == "COSMO NORDIC"
+    assert extract_series_name({"series": "LUNA Matt inverter R32  WI-FI"}) == "LUNA Matt"
+
+
+def test_extract_series_name_keeps_values_when_stop_marker_is_series_prefix():
+    assert extract_series_name({"series": "R32 Deluxe"}) == "R32 Deluxe"
+    assert extract_series_name({"series": "Wi-Fi Ready"}) == "Wi-Fi Ready"
+    assert extract_series_name({"series": "Dual Inverter"}) == "Dual Inverter"
+    assert extract_series_name({"series": "Dual Inverter R32 WI-FI"}) == "Dual Inverter"
+
+
+def test_extract_series_name_supports_extended_russian_keys():
+    name = extract_series_name({"Серия кондиционера": "VIOLA inverter R32 WI-FI"})
+    assert name == "VIOLA"
+
+
 def test_extract_series_name_from_series_tag_fallback():
     tag = SimpleNamespace(
         title="Elite",
@@ -25,6 +43,36 @@ def test_extract_series_name_from_series_tag_fallback():
     )
     name = extract_series_name({}, [tag])
     assert name == "Elite"
+
+
+def test_extract_series_name_from_title_after_brand_fallback():
+    name = extract_series_name({}, title="KINGHOME Cosmo KWH24AWDXE-K6DNA3A", brand_name="KINGHOME")
+    assert name == "Cosmo"
+
+
+def test_extract_series_name_title_fallback_ignores_model_code_after_brand():
+    name = extract_series_name({}, title="KINGHOME KUD100ZD1/A-S+ KUD100W1/NhA-S", brand_name="KINGHOME")
+    assert name is None
+
+
+def test_extract_series_name_title_fallback_keeps_series_version_and_inverter_word():
+    assert (
+        extract_series_name({}, title="TCL BreezeIN 2.0 A+++ TAC-09CHSD", brand_name="TCL")
+        == "BreezeIN 2.0"
+    )
+    assert (
+        extract_series_name({}, title="LG Dual Inverter S09EQ", brand_name="LG")
+        == "Dual Inverter"
+    )
+
+
+def test_extract_series_name_title_fallback_stops_before_capacity_tokens():
+    assert extract_series_name({}, title="Gree Bora 09 GWH09AAA-K6DNA1A", brand_name="Gree") == "Bora"
+    assert extract_series_name({}, title="AUX Halo 12 ASW-H12A4", brand_name="AUX") == "Halo"
+    assert (
+        extract_series_name({}, title="Midea Xtreme Save 09 MSAG-09HRN8", brand_name="Midea")
+        == "Xtreme Save"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Auto-create and link product series when manager bulk specs updates write `series` into product specs.
- Backfill missing `Product.series_id` links when opening a brand series list, but only for products that already have an explicit series value in specs.
- Expand series extraction to handle common Russian spec key variants and trim marketing suffixes like inverter/R32/Wi-Fi while preserving real series names.
- Keep the manager series sorter compact: one row per series on desktop, with description/features revealed via Details.

## Root cause

Existing products could receive `specs.series`, but the manager bulk specs path only normalized and saved specs. It did not call `sync_product_brand_series`, so `ProductSeries` rows were not created and products stayed unlinked until a series existed through some other path.

## Validation

- `python3 -m py_compile services/manager_brand_service.py services/manager_specs_service.py services/brand_series_service.py`
- `.venv/bin/pytest tests/unit/test_brand_series_service.py -q -k 'extract_series_name'`
- `npm run build` in `manager_frontend/`
- Added integration coverage for bulk specs auto-linking and brand-list lazy sync. Local run is blocked at setup because `db_test` does not resolve in this environment.
