### PR TITLE
[codex] Add staff profiles and manager auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ GOOGLE_VISION_PROJECT_ID=
 BOT_TOKEN=
 ADMIN_ID=
 ADMIN_IDS=
+# Public Telegram bot username for the manager login widget, without @.
+# The signature is still checked on the backend with BOT_TOKEN.
+VITE_TELEGRAM_LOGIN_BOT_USERNAME=
 
 # --- Web Admin Auth ---
 ADMIN_USERNAME=

--- a/alembic/versions/f6a7b8c9d0e2_expand_staff_users_for_manager_auth.py
+++ b/alembic/versions/f6a7b8c9d0e2_expand_staff_users_for_manager_auth.py
@@ -1,0 +1,111 @@
+"""Expand staff users for manager auth
+
+Revision ID: f6a7b8c9d0e2
+Revises: e2b7c9d4a6f1
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f6a7b8c9d0e2"
+down_revision: Union[str, Sequence[str], None] = "e2b7c9d4a6f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _indexes(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _constraints(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {constraint["name"] for constraint in inspector.get_unique_constraints(table_name)}
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name in _columns(table_name):
+        return
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.add_column(column)
+
+
+def _create_index_if_missing(index_name: str, table_name: str, columns: list[str]) -> None:
+    if index_name not in _indexes(table_name):
+        op.create_index(index_name, table_name, columns, unique=False)
+
+
+def upgrade() -> None:
+    _add_column_if_missing("staff_users", sa.Column("primary_role", sa.String(), nullable=True))
+    _add_column_if_missing("staff_users", sa.Column("username", sa.String(), nullable=True))
+    _add_column_if_missing("staff_users", sa.Column("password_hash", sa.String(), nullable=True))
+    _add_column_if_missing("staff_users", sa.Column("telegram_username", sa.String(), nullable=True))
+    _add_column_if_missing("staff_users", sa.Column("last_login_at", sa.DateTime(), nullable=True))
+
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        conn.execute(
+            sa.text(
+                """
+                UPDATE staff_users
+                SET primary_role = CASE
+                    WHEN roles::text LIKE '%owner%' OR roles::text LIKE '%admin%' THEN 'owner'
+                    WHEN roles::text LIKE '%manager%' THEN 'manager'
+                    ELSE 'installer'
+                END
+                WHERE primary_role IS NULL OR primary_role = ''
+                """
+            )
+        )
+    else:
+        conn.execute(
+            sa.text(
+                """
+                UPDATE staff_users
+                SET primary_role = CASE
+                    WHEN roles LIKE '%owner%' OR roles LIKE '%admin%' THEN 'owner'
+                    WHEN roles LIKE '%manager%' THEN 'manager'
+                    ELSE 'installer'
+                END
+                WHERE primary_role IS NULL OR primary_role = ''
+                """
+            )
+        )
+
+    with op.batch_alter_table("staff_users") as batch_op:
+        batch_op.alter_column("primary_role", existing_type=sa.String(), nullable=False, server_default="installer")
+
+    _create_index_if_missing("ix_staff_users_primary_role", "staff_users", ["primary_role"])
+    _create_index_if_missing("ix_staff_users_telegram_username", "staff_users", ["telegram_username"])
+
+    if "uq_staff_users_username" not in _constraints("staff_users"):
+        with op.batch_alter_table("staff_users") as batch_op:
+            batch_op.create_unique_constraint("uq_staff_users_username", ["username"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("staff_users") as batch_op:
+        if "uq_staff_users_username" in _constraints("staff_users"):
+            batch_op.drop_constraint("uq_staff_users_username", type_="unique")
+
+    if "ix_staff_users_telegram_username" in _indexes("staff_users"):
+        op.drop_index("ix_staff_users_telegram_username", table_name="staff_users")
+    if "ix_staff_users_primary_role" in _indexes("staff_users"):
+        op.drop_index("ix_staff_users_primary_role", table_name="staff_users")
+
+    existing_columns = _columns("staff_users")
+    with op.batch_alter_table("staff_users") as batch_op:
+        for column_name in ("last_login_at", "telegram_username", "password_hash", "username", "primary_role"):
+            if column_name in existing_columns:
+                batch_op.drop_column(column_name)

--- a/core/security.py
+++ b/core/security.py
@@ -1,11 +1,15 @@
 """JWT and cookie authentication helpers for protected API endpoints."""
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 import jwt
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
+from core.database import get_session
+from services.staff_user_service import StaffUserService
 
 # JWT CONFIG
 # TODO: Move to settings in the future
@@ -17,6 +21,16 @@ reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl="/login/access-token",
     auto_error=False
 )
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    username: str
+    auth_source: str
+    staff_user_id: int | None = None
+    role: str | None = None
+    display_name: str | None = None
+
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a new JWT access token."""
@@ -30,21 +44,8 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
-def get_current_user(
-    request: Request,
-    token: Optional[str] = Depends(reusable_oauth2)
-) -> str:
-    """
-    Unified Dependency for Authentication.
-    Checks:
-    1. Authorization Header (Bearer ...)
-    2. Cookie (access_token)
-    """
-    
-    # 1. Try Token from Header (OAuth2PasswordBearer)
+def _extract_token(request: Request, token: Optional[str]) -> str:
     token_to_validate = token
-
-    # 2. If no header, try Cookie
     if not token_to_validate and request:
         token_to_validate = request.cookies.get("access_token")
         if token_to_validate and token_to_validate.startswith("Bearer "):
@@ -56,23 +57,60 @@ def get_current_user(
             detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    return token_to_validate
+
+
+async def get_current_auth_context(
+    request: Request,
+    token: Optional[str] = Depends(reusable_oauth2),
+    session: AsyncSession = Depends(get_session),
+) -> AuthenticatedUser:
+    """
+    Unified Dependency for Authentication.
+    Checks:
+    1. Authorization Header (Bearer ...)
+    2. Cookie (access_token)
+    """
+    token_to_validate = _extract_token(request, token)
         
     try:
         payload = jwt.decode(token_to_validate, settings.SECRET_KEY, algorithms=[ALGORITHM])
         username: str = payload.get("sub")
         if username is None:
              raise HTTPException(status_code=401, detail="Invalid token")
-             
-        # Optional: Verify username against settings
+
+        auth_source = str(payload.get("auth_source") or "legacy")
+        staff_user_id = payload.get("staff_user_id")
+        if staff_user_id is not None:
+            staff_user = await StaffUserService.get_by_id(session, int(staff_user_id))
+            if staff_user is None or not StaffUserService.is_active(staff_user):
+                raise HTTPException(status_code=401, detail="Invalid user")
+            role = StaffUserService.primary_role(staff_user)
+            if username != staff_user.username and username != str(staff_user.telegram_id or ""):
+                raise HTTPException(status_code=401, detail="Invalid user")
+            return AuthenticatedUser(
+                username=username,
+                staff_user_id=int(staff_user.id or 0),
+                role=role,
+                display_name=staff_user.display_name,
+                auth_source=auth_source,
+            )
+
         if username != settings.ADMIN_USERNAME:
              raise HTTPException(status_code=401, detail="Invalid user")
-             
-        return username
-        
+
+        return AuthenticatedUser(username=username, auth_source="legacy")
+
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expired")
     except jwt.PyJWTError:
         raise HTTPException(status_code=401, detail="Could not validate credentials")
+
+
+async def get_current_user(
+    auth: AuthenticatedUser = Depends(get_current_auth_context),
+) -> str:
+    return auth.username
 
 
 # Alias for backward compatibility if needed, but we should refactor usages.

--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onMounted, onBeforeUnmount, ref } from 'vue';
+import { computed, defineAsyncComponent, nextTick, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText, Image as ImageIcon } from 'lucide-vue-next';
 import { api } from './api';
 import { getApiErrorMessage } from './utils/api-errors';
+import type { TelegramLoginPayload } from './api';
 
 const ProductsView = defineAsyncComponent(() => import('./views/ProductsView.vue'));
 const ProductMainImageCleanupView = defineAsyncComponent(() => import('./views/ProductMainImageCleanupView.vue'));
@@ -29,6 +30,8 @@ const loginUsername = ref('');
 const loginPassword = ref('');
 const loginLoading = ref(false);
 const loginError = ref('');
+const telegramLoginLoading = ref(false);
+const telegramLoginContainer = ref<HTMLElement | null>(null);
 const rebuildLoading = ref(false);
 const isMobileNavOpen = ref(false);
 const isDesktopNavCollapsed = ref(false);
@@ -39,6 +42,14 @@ const toastType = ref<'success' | 'error'>('success');
 
 const currentLocation = ref(`${window.location.pathname}${window.location.search}`);
 const THEME_STORAGE_KEY = 'manager_theme';
+const telegramLoginBotUsername = String(import.meta.env.VITE_TELEGRAM_LOGIN_BOT_USERNAME || '').trim();
+const telegramCallbackName = 'onTelegramManagerAuth';
+
+declare global {
+  interface Window {
+    onTelegramManagerAuth?: (user: TelegramLoginPayload) => void;
+  }
+}
 
 const navItems = [
   { path: '/manager', label: 'Главная', icon: Home },
@@ -48,7 +59,7 @@ const navItems = [
   { path: '/manager/products', label: 'Кондиционеры', icon: Package },
   { path: '/manager/media/main-image-cleanup', label: 'Main-image', icon: ImageIcon },
   { path: '/manager/customers', label: 'Клиенты', icon: Users },
-  { path: '/manager/installers', label: 'Сотрудники', icon: Users },
+  { path: '/manager/staff', label: 'Сотрудники', icon: Users },
   { path: '/manager/tariffs', label: 'Тарифы услуг', icon: Wallet },
   { path: '/manager/service-estimates', label: 'Сметы услуг', icon: Calculator },
   { path: '/manager/payments', label: 'Платежи', icon: ReceiptText },
@@ -69,7 +80,7 @@ const currentView = computed(() => {
   if (path.startsWith('/manager/media/main-image-cleanup')) return 'main-image-cleanup';
   if (path.startsWith('/manager/customers/profile')) return 'customer-profile';
   if (path.startsWith('/manager/customers')) return 'customers';
-  if (path.startsWith('/manager/installers')) return 'installers';
+  if (path.startsWith('/manager/staff') || path.startsWith('/manager/users') || path.startsWith('/manager/installers')) return 'installers';
   if (path.startsWith('/manager/settings/backup')) return 'settings-backup';
   if (path.startsWith('/manager/settings')) return 'settings';
   if (path.startsWith('/manager/tariffs')) return 'tariffs';
@@ -127,11 +138,49 @@ const handleLogin = async () => {
     await api.login(loginUsername.value, loginPassword.value);
     isAuthenticated.value = true;
     showLoginModal.value = false;
+    loginPassword.value = '';
+    void fetchLeadsCount();
   } catch {
-    loginError.value = 'Invalid credentials';
+    loginError.value = 'Неверный логин или пароль';
   } finally {
     loginLoading.value = false;
   }
+};
+
+const handleTelegramLogin = async (payload: TelegramLoginPayload) => {
+  telegramLoginLoading.value = true;
+  loginError.value = '';
+  try {
+    await api.loginTelegram(payload);
+    isAuthenticated.value = true;
+    showLoginModal.value = false;
+    void fetchLeadsCount();
+  } catch (err) {
+    loginError.value = getApiErrorMessage(err) || 'Не удалось войти через Telegram';
+  } finally {
+    telegramLoginLoading.value = false;
+  }
+};
+
+const renderTelegramLogin = async () => {
+  if (!telegramLoginBotUsername || !showLoginModal.value) return;
+  await nextTick();
+  const container = telegramLoginContainer.value;
+  if (!container) return;
+  container.innerHTML = '';
+  window[telegramCallbackName] = (user: TelegramLoginPayload) => {
+    void handleTelegramLogin(user);
+  };
+
+  const script = document.createElement('script');
+  script.src = 'https://telegram.org/js/telegram-widget.js?22';
+  script.async = true;
+  script.setAttribute('data-telegram-login', telegramLoginBotUsername);
+  script.setAttribute('data-size', 'large');
+  script.setAttribute('data-userpic', 'false');
+  script.setAttribute('data-request-access', 'write');
+  script.setAttribute('data-onauth', `${telegramCallbackName}(user)`);
+  container.appendChild(script);
 };
 
 const handleRebuild = async () => {
@@ -184,6 +233,13 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('popstate', onPopState);
+  delete window[telegramCallbackName];
+});
+
+watch(showLoginModal, (visible) => {
+  if (visible) {
+    void renderTelegramLogin();
+  }
 });
 </script>
 
@@ -195,26 +251,26 @@ onBeforeUnmount(() => {
           <Package class="w-6 h-6 text-white" />
         </div>
       </div>
-      <h2 class="text-2xl font-bold mb-6 text-center text-gray-900">Manager Login</h2>
+      <h2 class="text-2xl font-bold mb-6 text-center text-gray-900">Вход в менеджер</h2>
       <form @submit.prevent="handleLogin" class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Логин</label>
           <input
             v-model="loginUsername"
             type="text"
             required
             class="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
-            placeholder="Enter username"
+            placeholder="Введите логин"
           />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Пароль</label>
           <input
             v-model="loginPassword"
             type="password"
             required
             class="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent"
-            placeholder="Enter password"
+            placeholder="Введите пароль"
           />
         </div>
         <div v-if="loginError" class="text-red-600 text-sm">{{ loginError }}</div>
@@ -223,8 +279,20 @@ onBeforeUnmount(() => {
           :disabled="loginLoading"
           class="w-full bg-teal-600 text-white py-2.5 rounded-lg hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
         >
-          {{ loginLoading ? 'Logging in...' : 'Login' }}
+          {{ loginLoading ? 'Входим...' : 'Войти' }}
         </button>
+        <div v-if="telegramLoginBotUsername" class="pt-2">
+          <div class="mb-3 flex items-center gap-3 text-xs uppercase tracking-[0.18em] text-gray-400">
+            <span class="h-px flex-1 bg-gray-200" />
+            <span>или</span>
+            <span class="h-px flex-1 bg-gray-200" />
+          </div>
+          <div
+            ref="telegramLoginContainer"
+            class="flex min-h-[44px] justify-center"
+            :class="telegramLoginLoading ? 'pointer-events-none opacity-60' : ''"
+          />
+        </div>
       </form>
     </div>
   </div>

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -6,6 +6,7 @@ import {
     ManagerLeadsService,
     ManagerDashboardService,
     ManagerInstallersService,
+    ManagerStaffService,
     ManagerSettingsService,
     ManagerGoogleAuthService,
     ManagerBackupsService,
@@ -24,6 +25,10 @@ import {
     type DashboardTouchpoint,
     type ManagerInstallerCreatePayload,
     type ManagerInstallerUpdatePayload,
+    type ManagerStaffCreatePayload,
+    type ManagerStaffResponse,
+    type ManagerStaffUpdatePayload,
+    type TelegramLoginPayload,
     type LeadCreatePayload,
     type LeadUpdatePayload,
     type LeadQualifyPayload,
@@ -90,6 +95,7 @@ export type DashboardView = 'kanban' | 'list';
 export { type Product, type DashboardStatsResponse, type DashboardTouchpoint };
 export type { LeadsInboxItemResponse };
 export type { ManagerGoogleAuthStatusResponse, ManagerGoogleAuthUrlResponse };
+export type { ManagerStaffCreatePayload, ManagerStaffResponse, ManagerStaffUpdatePayload, TelegramLoginPayload };
 export type {
     ManagerBackupListResponse,
     ManagerBackupRunStartResponse,
@@ -199,6 +205,10 @@ export const api = {
         return await LoginService.loginAccessToken({ username, password });
     },
 
+    async loginTelegram(payload: TelegramLoginPayload) {
+        return await LoginService.loginTelegram(payload);
+    },
+
     async checkAuth() {
         return await ManagerService.readUserMe();
     },
@@ -301,6 +311,19 @@ export const api = {
 
     async searchManagerInstallers(q: string, limit = 50) {
         return await ManagerInstallersService.searchManagerInstallers(q, limit);
+    },
+
+    // Staff users
+    async listManagerStaff(page = 1, limit = 100, search?: string) {
+        return await ManagerStaffService.listManagerStaff(page, limit, search);
+    },
+
+    async createManagerStaff(payload: ManagerStaffCreatePayload) {
+        return await ManagerStaffService.createManagerStaff(payload);
+    },
+
+    async patchManagerStaff(id: number, payload: ManagerStaffUpdatePayload) {
+        return await ManagerStaffService.patchManagerStaff(id, payload);
     },
 
     // Settings

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -174,6 +174,10 @@ export type { ManagerSettingCreatePayload } from './models/ManagerSettingCreateP
 export type { ManagerSettingListResponse } from './models/ManagerSettingListResponse';
 export type { ManagerSettingResponse } from './models/ManagerSettingResponse';
 export type { ManagerSettingUpdatePayload } from './models/ManagerSettingUpdatePayload';
+export type { ManagerStaffCreatePayload } from './models/ManagerStaffCreatePayload';
+export type { ManagerStaffListResponse } from './models/ManagerStaffListResponse';
+export type { ManagerStaffResponse } from './models/ManagerStaffResponse';
+export type { ManagerStaffUpdatePayload } from './models/ManagerStaffUpdatePayload';
 export type { ManagerTagCreatePayload } from './models/ManagerTagCreatePayload';
 export type { ManagerTagGroupCreatePayload } from './models/ManagerTagGroupCreatePayload';
 export type { ManagerTagGroupResponse } from './models/ManagerTagGroupResponse';
@@ -273,6 +277,7 @@ export type { SupplierSyncRunResponse } from './models/SupplierSyncRunResponse';
 export type { SupplierUpdatePayload } from './models/SupplierUpdatePayload';
 export type { TagGroupResponse } from './models/TagGroupResponse';
 export type { TagResponse } from './models/TagResponse';
+export type { TelegramLoginPayload } from './models/TelegramLoginPayload';
 export type { ValidationError } from './models/ValidationError';
 
 export { ApiService } from './services/ApiService';
@@ -295,6 +300,7 @@ export { ManagerOrdersService } from './services/ManagerOrdersService';
 export { ManagerRepairComplaintsService } from './services/ManagerRepairComplaintsService';
 export { ManagerServiceEstimatesService } from './services/ManagerServiceEstimatesService';
 export { ManagerSettingsService } from './services/ManagerSettingsService';
+export { ManagerStaffService } from './services/ManagerStaffService';
 export { ManagerTagsService } from './services/ManagerTagsService';
 export { ManagerTariffsService } from './services/ManagerTariffsService';
 export { ManagerYandexBusinessService } from './services/ManagerYandexBusinessService';

--- a/manager_frontend/src/client/models/ManagerAuthStatusResponse.ts
+++ b/manager_frontend/src/client/models/ManagerAuthStatusResponse.ts
@@ -5,5 +5,9 @@
 export type ManagerAuthStatusResponse = {
     username: string;
     status: string;
+    staff_user_id?: (number | null);
+    role?: (string | null);
+    display_name?: (string | null);
+    auth_source?: string;
 };
 

--- a/manager_frontend/src/client/models/ManagerStaffCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerStaffCreatePayload.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerStaffCreatePayload = {
+    display_name: string;
+    status?: string;
+    primary_role?: string;
+    username?: (string | null);
+    phone?: (string | null);
+    email?: (string | null);
+    telegram_id?: (number | null);
+    telegram_username?: (string | null);
+    is_assignable_installer?: boolean;
+    default_rate?: (number | null);
+    password?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerStaffListResponse.ts
+++ b/manager_frontend/src/client/models/ManagerStaffListResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerStaffResponse } from './ManagerStaffResponse';
+import type { Meta } from './Meta';
+export type ManagerStaffListResponse = {
+    items: Array<ManagerStaffResponse>;
+    meta: Meta;
+};
+

--- a/manager_frontend/src/client/models/ManagerStaffResponse.ts
+++ b/manager_frontend/src/client/models/ManagerStaffResponse.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerStaffResponse = {
+    display_name: string;
+    status?: string;
+    primary_role?: string;
+    username?: (string | null);
+    phone?: (string | null);
+    email?: (string | null);
+    telegram_id?: (number | null);
+    telegram_username?: (string | null);
+    is_assignable_installer?: boolean;
+    default_rate?: (number | null);
+    id: number;
+    has_password?: boolean;
+    legacy_installer_id?: (number | null);
+    created_at: string;
+    updated_at?: (string | null);
+    last_login_at?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerStaffUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerStaffUpdatePayload.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerStaffUpdatePayload = {
+    display_name?: (string | null);
+    status?: (string | null);
+    primary_role?: (string | null);
+    username?: (string | null);
+    password?: (string | null);
+    phone?: (string | null);
+    email?: (string | null);
+    telegram_id?: (number | null);
+    telegram_username?: (string | null);
+    is_assignable_installer?: (boolean | null);
+    default_rate?: (number | null);
+};
+

--- a/manager_frontend/src/client/models/TelegramLoginPayload.ts
+++ b/manager_frontend/src/client/models/TelegramLoginPayload.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type TelegramLoginPayload = {
+    id: number;
+    first_name?: (string | null);
+    last_name?: (string | null);
+    username?: (string | null);
+    photo_url?: (string | null);
+    auth_date: number;
+    hash: string;
+};
+

--- a/manager_frontend/src/client/services/LoginService.ts
+++ b/manager_frontend/src/client/services/LoginService.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { Body_login_access_token } from '../models/Body_login_access_token';
+import type { TelegramLoginPayload } from '../models/TelegramLoginPayload';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -23,6 +24,25 @@ export class LoginService {
             url: '/login/access-token',
             formData: formData,
             mediaType: 'application/x-www-form-urlencoded',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Login Telegram
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static loginTelegram(
+        requestBody: TelegramLoginPayload,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/login/telegram',
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/client/services/ManagerStaffService.ts
+++ b/manager_frontend/src/client/services/ManagerStaffService.ts
@@ -1,0 +1,82 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerStaffCreatePayload } from '../models/ManagerStaffCreatePayload';
+import type { ManagerStaffListResponse } from '../models/ManagerStaffListResponse';
+import type { ManagerStaffResponse } from '../models/ManagerStaffResponse';
+import type { ManagerStaffUpdatePayload } from '../models/ManagerStaffUpdatePayload';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ManagerStaffService {
+    /**
+     * List Staff
+     * @param page
+     * @param limit
+     * @param search
+     * @returns ManagerStaffListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listManagerStaff(
+        page: number = 1,
+        limit: number = 100,
+        search?: (string | null),
+    ): CancelablePromise<ManagerStaffListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/staff',
+            query: {
+                'page': page,
+                'limit': limit,
+                'search': search,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Staff
+     * @param requestBody
+     * @returns ManagerStaffResponse Successful Response
+     * @throws ApiError
+     */
+    public static createManagerStaff(
+        requestBody: ManagerStaffCreatePayload,
+    ): CancelablePromise<ManagerStaffResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/staff',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Patch Staff
+     * @param staffUserId
+     * @param requestBody
+     * @returns ManagerStaffResponse Successful Response
+     * @throws ApiError
+     */
+    public static patchManagerStaff(
+        staffUserId: number,
+        requestBody: ManagerStaffUpdatePayload,
+    ): CancelablePromise<ManagerStaffResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/manager/staff/{staff_user_id}',
+            path: {
+                'staff_user_id': staffUserId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/manager_frontend/src/components/InstallerEditModal.vue
+++ b/manager_frontend/src/components/InstallerEditModal.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { api } from '../api';
-import type { ManagerInstallerResponse } from '../client';
+import { api, type ManagerStaffCreatePayload, type ManagerStaffResponse, type ManagerStaffUpdatePayload } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 const props = defineProps<{
     modelValue: boolean;
-    installer?: ManagerInstallerResponse | null;
+    staffUser?: ManagerStaffResponse | null;
 }>();
 
 const emit = defineEmits<{
@@ -18,52 +17,90 @@ const loading = ref(false);
 const error = ref('');
 
 const formData = ref({
-    name: '',
-    default_rate: null as number | null,
+    display_name: '',
+    primary_role: 'installer',
+    status: 'active',
+    username: '',
+    password: '',
+    phone: '',
+    email: '',
     telegram_id: null as number | null,
-    is_active: true,
+    telegram_username: '',
+    is_assignable_installer: false,
+    default_rate: null as number | null,
 });
 
 watch(() => props.modelValue, (val) => {
-    if (val) {
-        if (props.installer) {
-            formData.value = {
-                name: props.installer.name,
-                default_rate: props.installer.default_rate ?? null,
-                telegram_id: props.installer.telegram_id ?? null,
-                is_active: props.installer.is_active ?? true,
-            };
-        } else {
-            formData.value = {
-                name: '',
-                default_rate: null,
-                telegram_id: null,
-                is_active: true,
-            };
-        }
-        error.value = '';
+    if (!val) return;
+    if (props.staffUser) {
+        formData.value = {
+            display_name: props.staffUser.display_name,
+            primary_role: props.staffUser.primary_role || 'installer',
+            status: props.staffUser.status || 'active',
+            username: props.staffUser.username || '',
+            password: '',
+            phone: props.staffUser.phone || '',
+            email: props.staffUser.email || '',
+            telegram_id: props.staffUser.telegram_id ?? null,
+            telegram_username: props.staffUser.telegram_username || '',
+            is_assignable_installer: props.staffUser.is_assignable_installer ?? false,
+            default_rate: props.staffUser.default_rate ?? null,
+        };
+    } else {
+        formData.value = {
+            display_name: '',
+            primary_role: 'installer',
+            status: 'active',
+            username: '',
+            password: '',
+            phone: '',
+            email: '',
+            telegram_id: null,
+            telegram_username: '',
+            is_assignable_installer: false,
+            default_rate: null,
+        };
     }
+    error.value = '';
 });
 
 const close = () => {
-    if (!loading.value) {
-        emit('update:modelValue', false);
-    }
+    if (!loading.value) emit('update:modelValue', false);
 };
 
+const nullableText = (value: string) => {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+};
+
+const buildPayload = (): ManagerStaffCreatePayload | ManagerStaffUpdatePayload => ({
+    display_name: formData.value.display_name.trim(),
+    primary_role: formData.value.primary_role,
+    status: formData.value.status,
+    username: nullableText(formData.value.username),
+    password: formData.value.password.trim() || null,
+    phone: nullableText(formData.value.phone),
+    email: nullableText(formData.value.email),
+    telegram_id: formData.value.telegram_id,
+    telegram_username: nullableText(formData.value.telegram_username.replace(/^@/, '')),
+    is_assignable_installer: formData.value.is_assignable_installer,
+    default_rate: formData.value.default_rate,
+});
+
 const submit = async () => {
-    if (!formData.value.name.trim()) {
-        error.value = 'Имя обязательно';
+    if (!formData.value.display_name.trim()) {
+        error.value = 'Имя сотрудника обязательно';
         return;
     }
-    
+
     loading.value = true;
     error.value = '';
     try {
-        if (props.installer?.id) {
-            await api.updateManagerInstaller(props.installer.id, formData.value);
+        const payload = buildPayload();
+        if (props.staffUser?.id) {
+            await api.patchManagerStaff(props.staffUser.id, payload);
         } else {
-            await api.createManagerInstaller(formData.value);
+            await api.createManagerStaff(payload as ManagerStaffCreatePayload);
         }
         emit('success');
         close();
@@ -79,66 +116,109 @@ const submit = async () => {
     <Teleport to="body">
         <Transition name="modal-fade">
             <div v-if="modelValue" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" @click.self="close">
-                <div class="modal-content bg-white dark:bg-[#1e293b] rounded-xl shadow-xl w-full max-w-md overflow-hidden border border-gray-200 dark:border-slate-700/60 flex flex-col">
+                <div class="modal-content bg-white dark:bg-[#1e293b] rounded-xl shadow-xl w-full max-w-3xl max-h-[92vh] overflow-hidden border border-gray-200 dark:border-slate-700/60 flex flex-col">
                     <div class="px-6 py-4 border-b border-gray-200 dark:border-slate-700/50 flex justify-between items-center bg-gray-50 dark:bg-slate-800/50">
-                        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-                            {{ installer ? 'Редактировать сотрудника' : 'Новый сотрудник' }}
-                        </h3>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                                {{ staffUser ? 'Редактировать сотрудника' : 'Новый сотрудник' }}
+                            </h3>
+                            <p class="text-xs text-gray-500 dark:text-slate-400">Профиль, доступ в менеджер и Telegram</p>
+                        </div>
                         <button @click="close" class="text-gray-400 hover:text-gray-600 dark:text-slate-400 dark:hover:text-white transition-colors" :disabled="loading">
                             <span class="material-icons-round text-xl">close</span>
                         </button>
                     </div>
 
-                    <div class="p-6 space-y-4">
+                    <div class="p-6 space-y-6 overflow-y-auto">
                         <div v-if="error" class="p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-500/50 rounded-lg text-sm text-red-600 dark:text-red-400">
                             {{ error }}
                         </div>
 
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Имя сотрудника или бригады *</label>
-                            <input
-                                v-model="formData.name"
-                                type="text"
-                                class="w-full bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors"
-                                placeholder="Иван Иванов"
-                                :disabled="loading"
-                            />
-                        </div>
+                        <section class="space-y-3">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Профиль</h4>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Имя сотрудника *</span>
+                                    <input v-model="formData.display_name" type="text" class="field-input" placeholder="Иван Иванов" :disabled="loading" />
+                                </label>
 
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Базовая ставка (BYN)</label>
-                            <input
-                                v-model.number="formData.default_rate"
-                                type="number"
-                                class="w-full bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors"
-                                placeholder="Например, 350"
-                                :disabled="loading"
-                            />
-                        </div>
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Роль</span>
+                                    <select v-model="formData.primary_role" class="field-input" :disabled="loading">
+                                        <option value="owner">Владелец</option>
+                                        <option value="manager">Менеджер</option>
+                                        <option value="installer">Монтажник</option>
+                                    </select>
+                                </label>
 
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Telegram ID (опционально)</label>
-                            <input
-                                v-model.number="formData.telegram_id"
-                                type="number"
-                                class="w-full bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-lg px-3 py-2 text-gray-900 dark:text-slate-200 focus:outline-none focus:border-teal-500 transition-colors"
-                                placeholder="Например, 123456789"
-                                :disabled="loading"
-                            />
-                        </div>
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Телефон</span>
+                                    <input v-model="formData.phone" type="text" class="field-input" placeholder="+375..." :disabled="loading" />
+                                </label>
 
-                        <label class="flex items-center gap-3 cursor-pointer pt-2 group" :class="{'opacity-50': loading}">
-                            <div class="relative">
-                                <input type="checkbox" v-model="formData.is_active" class="sr-only" :disabled="loading" />
-                                <div class="w-10 h-6 bg-gray-300 dark:bg-slate-600 rounded-full transition-colors duration-200"
-                                     :class="{'bg-teal-500': formData.is_active}"></div>
-                                <div class="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform duration-200"
-                                     :class="{'translate-x-4': formData.is_active}"></div>
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Email</span>
+                                    <input v-model="formData.email" type="email" class="field-input" placeholder="name@example.com" :disabled="loading" />
+                                </label>
                             </div>
-                            <span class="text-sm font-medium text-gray-700 dark:text-slate-300 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">
-                                Активен (доступен для новых назначений)
-                            </span>
-                        </label>
+                        </section>
+
+                        <section class="space-y-3">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Доступ в менеджер</h4>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Логин</span>
+                                    <input v-model="formData.username" type="text" autocomplete="username" class="field-input" placeholder="ivan" :disabled="loading" />
+                                </label>
+
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Новый пароль</span>
+                                    <input v-model="formData.password" type="password" autocomplete="new-password" class="field-input" :placeholder="staffUser?.has_password ? 'Оставьте пустым, чтобы не менять' : 'Минимум 6 символов'" :disabled="loading" />
+                                </label>
+                            </div>
+                        </section>
+
+                        <section class="space-y-3">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Telegram</h4>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Telegram ID</span>
+                                    <input v-model.number="formData.telegram_id" type="number" class="field-input" placeholder="123456789" :disabled="loading" />
+                                </label>
+
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Username</span>
+                                    <input v-model="formData.telegram_username" type="text" class="field-input" placeholder="@username" :disabled="loading" />
+                                </label>
+                            </div>
+                        </section>
+
+                        <section class="space-y-3">
+                            <h4 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">Работы и статус</h4>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Статус</span>
+                                    <select v-model="formData.status" class="field-input" :disabled="loading">
+                                        <option value="active">Активен</option>
+                                        <option value="inactive">В архиве</option>
+                                        <option value="blocked">Заблокирован</option>
+                                    </select>
+                                </label>
+
+                                <label class="block">
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Базовая ставка, BYN</span>
+                                    <input v-model.number="formData.default_rate" type="number" class="field-input" placeholder="Например, 350" :disabled="loading || !formData.is_assignable_installer" />
+                                </label>
+                            </div>
+
+                            <label class="flex items-start gap-3 cursor-pointer pt-1 group" :class="{ 'opacity-50': loading }">
+                                <input type="checkbox" v-model="formData.is_assignable_installer" class="mt-1 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500" :disabled="loading" />
+                                <span>
+                                    <span class="block text-sm font-medium text-gray-700 dark:text-slate-300">Можно назначать на работы</span>
+                                    <span class="block text-xs text-gray-500 dark:text-slate-500">Для такого сотрудника сохраняется совместимость с монтажниками в заказах и календаре.</span>
+                                </span>
+                            </label>
+                        </section>
                     </div>
 
                     <div class="px-6 py-4 border-t border-gray-200 dark:border-slate-700/50 bg-gray-50 dark:bg-slate-800/30 flex justify-end gap-3">
@@ -152,7 +232,7 @@ const submit = async () => {
                         <button
                             @click="submit"
                             class="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-teal-600 hover:bg-teal-500 active:bg-teal-700 transition-colors rounded-lg disabled:opacity-50 shadow-lg shadow-teal-900/30"
-                            :disabled="loading || !formData.name.trim()"
+                            :disabled="loading || !formData.display_name.trim()"
                         >
                             <span v-if="loading" class="material-icons-round text-sm animate-spin">refresh</span>
                             <span v-else class="material-icons-round text-sm">save</span>
@@ -166,6 +246,28 @@ const submit = async () => {
 </template>
 
 <style scoped>
+.field-input {
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid rgb(209 213 219);
+    background: rgb(255 255 255);
+    padding: 0.5rem 0.75rem;
+    color: rgb(17 24 39);
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+.field-input:focus {
+    border-color: rgb(20 184 166);
+    box-shadow: 0 0 0 3px rgb(20 184 166 / 0.12);
+}
+.field-input:disabled {
+    opacity: 0.6;
+}
+:global(.dark) .field-input {
+    border-color: rgb(71 85 105);
+    background: rgb(15 23 42);
+    color: rgb(226 232 240);
+}
 .modal-fade-enter-active,
 .modal-fade-leave-active {
     transition: opacity 0.2s ease;

--- a/manager_frontend/src/views/InstallersView.vue
+++ b/manager_frontend/src/views/InstallersView.vue
@@ -1,39 +1,49 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { api } from '../api';
-import type { ManagerInstallerResponse } from '../client';
+import { onMounted, ref } from 'vue';
+import { api, type ManagerStaffResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
 import InstallerEditModal from '../components/InstallerEditModal.vue';
 
-const installers = ref<ManagerInstallerResponse[]>([]);
+const staff = ref<ManagerStaffResponse[]>([]);
 const loading = ref(false);
 const error = ref('');
 const toast = ref('');
 
 const showModal = ref(false);
-const editingInstaller = ref<ManagerInstallerResponse | null>(null);
+const editingStaff = ref<ManagerStaffResponse | null>(null);
 
-const getEmployeeStatusLabel = (inst: ManagerInstallerResponse) => (
-    inst.is_active ? 'Активен' : 'В архиве'
-);
+const roleLabels: Record<string, string> = {
+    owner: 'Владелец',
+    manager: 'Менеджер',
+    installer: 'Монтажник',
+};
 
-const getEmployeeStatusClasses = (inst: ManagerInstallerResponse) => (
-    inst.is_active
+const statusLabel = (item: ManagerStaffResponse) => (item.status === 'active' ? 'Активен' : 'В архиве');
+const roleLabel = (role?: string | null) => roleLabels[role || 'installer'] || 'Монтажник';
+
+const statusClasses = (item: ManagerStaffResponse) => (
+    item.status === 'active'
         ? 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:border-emerald-500/30'
         : 'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-700/60 dark:text-slate-300 dark:border-slate-600'
 );
 
+const roleClasses = (role?: string | null) => {
+    if (role === 'owner') return 'bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-500/10 dark:text-violet-300 dark:border-violet-500/30';
+    if (role === 'manager') return 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-500/10 dark:text-sky-300 dark:border-sky-500/30';
+    return 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/10 dark:text-amber-300 dark:border-amber-500/30';
+};
+
 const setToast = (msg: string) => {
     toast.value = msg;
     window.setTimeout(() => { toast.value = ''; }, 3000);
-}
+};
 
-const loadInstallers = async () => {
+const loadStaff = async () => {
     loading.value = true;
     error.value = '';
     try {
-        const res = await api.getManagerInstallers(1, 100);
-        installers.value = res.items;
+        const res = await api.listManagerStaff(1, 100);
+        staff.value = res.items;
     } catch (e) {
         error.value = getApiErrorMessage(e);
     } finally {
@@ -42,38 +52,38 @@ const loadInstallers = async () => {
 };
 
 const openAddModal = () => {
-    editingInstaller.value = null;
+    editingStaff.value = null;
     showModal.value = true;
 };
 
-const openEditModal = (inst: ManagerInstallerResponse) => {
-    editingInstaller.value = inst;
+const openEditModal = (item: ManagerStaffResponse) => {
+    editingStaff.value = item;
     showModal.value = true;
 };
 
 const handleSuccess = () => {
     setToast('Сотрудник сохранен');
-    loadInstallers();
+    loadStaff();
 };
 
-const toggleActive = async (inst: ManagerInstallerResponse) => {
+const toggleActive = async (item: ManagerStaffResponse) => {
+    const nextStatus = item.status === 'active' ? 'inactive' : 'active';
     try {
-        await api.updateManagerInstaller(inst.id, { is_active: !inst.is_active });
-        inst.is_active = !inst.is_active;
+        const updated = await api.patchManagerStaff(item.id, { status: nextStatus });
+        Object.assign(item, updated);
         setToast('Статус обновлен');
     } catch (e) {
-        console.error('Failed to toggle active status', e);
+        error.value = getApiErrorMessage(e);
     }
 };
 
 onMounted(() => {
-    loadInstallers();
+    loadStaff();
 });
 </script>
 
 <template>
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 w-full">
-        <!-- Toast Notification -->
         <Transition name="toast">
             <div v-if="toast" class="fixed top-20 right-8 z-50 bg-teal-600 border border-teal-500 text-white px-4 py-3 rounded-lg shadow-xl shadow-teal-900/30 flex items-center gap-3">
                 <span class="material-icons-round text-xl">check_circle</span>
@@ -81,121 +91,127 @@ onMounted(() => {
             </div>
         </Transition>
 
-        <div class="flex justify-between items-center mb-8">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-8">
             <div>
                 <h1 class="text-2xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3">
-                    <span class="material-icons-round text-teal-600 dark:text-teal-400">engineering</span>
+                    <span class="material-icons-round text-teal-600 dark:text-teal-400">badge</span>
                     Сотрудники
                 </h1>
                 <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">
-                    Управление сотрудниками-исполнителями, ставками и доступностью для заказов
+                    Профили, доступ в менеджер, Telegram и назначение на работы
                 </p>
             </div>
-            
-            <button 
+
+            <button
                 @click="openAddModal"
-                class="flex items-center gap-2 bg-teal-600 hover:bg-teal-500 active:bg-teal-700 text-white font-medium py-2.5 px-4 rounded-lg shadow-lg shadow-teal-900/40 transition-all text-sm"
+                class="inline-flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-500 active:bg-teal-700 text-white font-medium py-2.5 px-4 rounded-lg shadow-lg shadow-teal-900/30 transition-all text-sm"
             >
                 <span class="material-icons-round text-[18px]">add</span>
                 Добавить
             </button>
         </div>
 
-        <div v-if="error" class="bg-red-500/10 border border-red-500/50 text-red-400 p-4 rounded-xl mb-6">
+        <div v-if="error" class="bg-red-500/10 border border-red-500/50 text-red-500 dark:text-red-300 p-4 rounded-xl mb-6">
             {{ error }}
         </div>
 
-        <div v-if="loading && !installers.length" class="flex justify-center py-20">
-            <div class="w-8 h-8 rounded-full border-4 border-slate-700 border-t-teal-500 animate-spin"></div>
+        <div v-if="loading && !staff.length" class="flex justify-center py-20">
+            <div class="w-8 h-8 rounded-full border-4 border-slate-200 dark:border-slate-700 border-t-teal-500 animate-spin"></div>
         </div>
 
         <div v-else class="bg-white dark:bg-[#1e293b] rounded-xl shadow-sm border border-gray-200 dark:border-slate-700/60 overflow-hidden">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-slate-700/50">
-                <thead class="bg-gray-50 dark:bg-slate-800/80">
-                    <tr>
-                        <th class="px-6 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider w-1/3">
-                            Имя
-                        </th>
-                        <th class="px-6 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider hidden sm:table-cell">
-                            Телеграм ID
-                        </th>
-                        <th class="px-6 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider hidden sm:table-cell">
-                            Базовая ставка
-                        </th>
-                        <th class="px-6 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">
-                            Статус
-                        </th>
-                        <th class="px-6 py-4 text-right text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">
-                            Действия
-                        </th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200 dark:divide-slate-700/50 bg-white dark:bg-[#1e293b]">
-                    <tr v-for="inst in installers" :key="inst.id" class="hover:bg-gray-50 dark:hover:bg-slate-800/50 transition-colors group">
-                        <td class="px-6 py-4">
-                            <div class="flex items-center">
-                                <div class="h-8 w-8 rounded-full bg-gray-100 dark:bg-slate-700 flex items-center justify-center border border-gray-200 dark:border-slate-600 text-gray-600 dark:text-slate-300 font-bold text-xs ring-2 ring-transparent group-hover:ring-gray-200 dark:group-hover:ring-slate-600 transition-all flex-shrink-0">
-                                    {{ inst.name.substring(0, 2).toUpperCase() }}
-                                </div>
-                                <div class="ml-4">
-                                    <div class="text-sm font-medium text-gray-900 dark:text-slate-100">{{ inst.name }}</div>
-                                    <div class="text-xs text-gray-500 dark:text-slate-500 sm:hidden mt-0.5">
-                                        {{ inst.default_rate ? inst.default_rate + ' BYN' : 'Ставка не задана' }}
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-slate-700/50">
+                    <thead class="bg-gray-50 dark:bg-slate-800/80">
+                        <tr>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">Сотрудник</th>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">Роль</th>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider hidden lg:table-cell">Доступ</th>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider hidden md:table-cell">Telegram</th>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider hidden xl:table-cell">Работы</th>
+                            <th class="px-5 py-4 text-left text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">Статус</th>
+                            <th class="px-5 py-4 text-right text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wider">Действия</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-slate-700/50 bg-white dark:bg-[#1e293b]">
+                        <tr v-for="item in staff" :key="item.id" class="hover:bg-gray-50 dark:hover:bg-slate-800/50 transition-colors group">
+                            <td class="px-5 py-4">
+                                <div class="flex items-center min-w-[220px]">
+                                    <div class="h-9 w-9 rounded-full bg-gray-100 dark:bg-slate-700 flex items-center justify-center border border-gray-200 dark:border-slate-600 text-gray-600 dark:text-slate-300 font-bold text-xs shrink-0">
+                                        {{ item.display_name.substring(0, 2).toUpperCase() }}
                                     </div>
-                                    <div class="mt-1 sm:hidden">
-                                        <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium" :class="getEmployeeStatusClasses(inst)">
-                                            {{ getEmployeeStatusLabel(inst) }}
-                                        </span>
+                                    <div class="ml-3 min-w-0">
+                                        <div class="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">{{ item.display_name }}</div>
+                                        <div class="text-xs text-gray-500 dark:text-slate-500 truncate">
+                                            {{ item.phone || item.email || 'Контакты не заполнены' }}
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        </td>
-                        <td class="px-6 py-4 hidden sm:table-cell">
-                            <span v-if="inst.telegram_id" class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-500/20">
-                                {{ inst.telegram_id }}
-                            </span>
-                            <span v-else class="text-gray-400 dark:text-slate-500 text-sm italic">-</span>
-                        </td>
-                        <td class="px-6 py-4 hidden sm:table-cell">
-                            <div class="text-sm text-gray-700 dark:text-slate-300">
-                                <span v-if="inst.default_rate" class="font-medium text-emerald-600 dark:text-emerald-400">{{ inst.default_rate }} BYN</span>
-                                <span v-else class="text-gray-500 dark:text-slate-500 italic">Не задана</span>
-                            </div>
-                        </td>
-                        <td class="px-6 py-4">
-                            <div class="flex items-center gap-3">
-                                <span class="hidden sm:inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium" :class="getEmployeeStatusClasses(inst)">
-                                    {{ getEmployeeStatusLabel(inst) }}
+                            </td>
+                            <td class="px-5 py-4">
+                                <span class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium whitespace-nowrap" :class="roleClasses(item.primary_role)">
+                                    {{ roleLabel(item.primary_role) }}
                                 </span>
-                                <label class="relative inline-flex items-center cursor-pointer" @click.prevent="toggleActive(inst)" :title="inst.is_active ? 'Перевести в архив' : 'Вернуть в активные'">
-                                    <input type="checkbox" :checked="inst.is_active" class="sr-only peer" />
-                                    <div class="w-9 h-5 bg-gray-200 dark:bg-slate-600 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-500 transition-colors"></div>
-                                </label>
-                            </div>
-                        </td>
-                        <td class="px-6 py-4 text-right">
-                            <button
-                                @click="openEditModal(inst)"
-                                class="p-2 text-gray-500 hover:text-gray-900 border-gray-200 hover:bg-gray-50 dark:text-slate-400 dark:hover:text-white bg-white dark:bg-slate-800 dark:hover:bg-slate-700 rounded-lg border dark:border-slate-600 transition-colors inline-flex items-center shadow-sm"
-                                title="Редактировать"
-                            >
-                                <span class="material-icons-round text-sm">edit</span>
-                            </button>
-                        </td>
-                    </tr>
-                    
-                    <tr v-if="installers.length === 0 && !loading">
-                        <td colspan="5" class="px-6 py-12 text-center text-gray-500 dark:text-slate-400">
-                            Сотрудники не найдены. Добавьте первого сотрудника.
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                            </td>
+                            <td class="px-5 py-4 hidden lg:table-cell">
+                                <div class="text-sm text-gray-700 dark:text-slate-300">
+                                    <div>{{ item.username || 'Логин не задан' }}</div>
+                                    <div class="text-xs text-gray-500 dark:text-slate-500">
+                                        {{ item.has_password ? 'Пароль задан' : 'Пароль не задан' }}
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="px-5 py-4 hidden md:table-cell">
+                                <div class="text-sm text-gray-700 dark:text-slate-300">
+                                    <div v-if="item.telegram_id">{{ item.telegram_id }}</div>
+                                    <div v-else class="text-gray-400 dark:text-slate-500">Не привязан</div>
+                                    <div v-if="item.telegram_username" class="text-xs text-blue-600 dark:text-blue-400">@{{ item.telegram_username }}</div>
+                                </div>
+                            </td>
+                            <td class="px-5 py-4 hidden xl:table-cell">
+                                <div class="text-sm text-gray-700 dark:text-slate-300">
+                                    <span v-if="item.is_assignable_installer" class="font-medium text-emerald-600 dark:text-emerald-400">Можно назначать</span>
+                                    <span v-else class="text-gray-500 dark:text-slate-500">Офисный профиль</span>
+                                    <div class="text-xs text-gray-500 dark:text-slate-500">
+                                        {{ item.default_rate ? item.default_rate + ' BYN' : 'Ставка не задана' }}
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="px-5 py-4">
+                                <div class="flex items-center gap-3">
+                                    <span class="hidden sm:inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium whitespace-nowrap" :class="statusClasses(item)">
+                                        {{ statusLabel(item) }}
+                                    </span>
+                                    <label class="relative inline-flex items-center cursor-pointer" @click.prevent="toggleActive(item)" :title="item.status === 'active' ? 'Перевести в архив' : 'Вернуть в активные'">
+                                        <input type="checkbox" :checked="item.status === 'active'" class="sr-only peer" />
+                                        <div class="w-9 h-5 bg-gray-200 dark:bg-slate-600 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-500 transition-colors"></div>
+                                    </label>
+                                </div>
+                            </td>
+                            <td class="px-5 py-4 text-right">
+                                <button
+                                    @click="openEditModal(item)"
+                                    class="p-2 text-gray-500 hover:text-gray-900 border-gray-200 hover:bg-gray-50 dark:text-slate-400 dark:hover:text-white bg-white dark:bg-slate-800 dark:hover:bg-slate-700 rounded-lg border dark:border-slate-600 transition-colors inline-flex items-center shadow-sm"
+                                    title="Редактировать"
+                                >
+                                    <span class="material-icons-round text-sm">edit</span>
+                                </button>
+                            </td>
+                        </tr>
+
+                        <tr v-if="staff.length === 0 && !loading">
+                            <td colspan="7" class="px-6 py-12 text-center text-gray-500 dark:text-slate-400">
+                                Сотрудники не найдены. Добавьте первого сотрудника.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
-        <InstallerEditModal 
+        <InstallerEditModal
             v-model="showModal"
-            :installer="editingInstaller"
+            :staff-user="editingStaff"
             @success="handleSuccess"
         />
     </div>

--- a/models/staff.py
+++ b/models/staff.py
@@ -12,15 +12,21 @@ class StaffUser(SQLModel, table=True):
     display_name: str = Field(index=True)
     status: str = Field(default="active", sa_column=Column(String, index=True, nullable=False))
     roles: List[str] = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    primary_role: str = Field(default="installer", sa_column=Column(String, index=True, nullable=False))
+
+    username: Optional[str] = Field(default=None, sa_column=Column(String, unique=True, nullable=True))
+    password_hash: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
 
     phone: Optional[str] = Field(default=None, index=True)
     email: Optional[str] = Field(default=None, index=True)
     telegram_id: Optional[int] = Field(default=None, sa_column=Column(BigInteger, unique=True, nullable=True))
+    telegram_username: Optional[str] = Field(default=None, index=True)
 
     legacy_installer_id: Optional[int] = Field(default=None, foreign_key="installers.id", unique=True, index=True)
     default_rate: Optional[float] = Field(default=None)
 
     created_at: datetime = Field(default_factory=datetime.now)
+    last_login_at: Optional[datetime] = Field(default=None)
     updated_at: Optional[datetime] = Field(
         default_factory=datetime.now,
         sa_column_kwargs={"onupdate": datetime.now},

--- a/openapi.json
+++ b/openapi.json
@@ -47,6 +47,47 @@
         }
       }
     },
+    "/login/telegram": {
+      "post": {
+        "tags": [
+          "login"
+        ],
+        "summary": "Login Telegram",
+        "operationId": "login_telegram",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TelegramLoginPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Login Telegram"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -9062,6 +9103,184 @@
         }
       }
     },
+    "/api/manager/staff": {
+      "get": {
+        "tags": [
+          "manager-staff"
+        ],
+        "summary": "List Staff",
+        "operationId": "list_manager_staff",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerStaffListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "manager-staff"
+        ],
+        "summary": "Create Staff",
+        "operationId": "create_manager_staff",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerStaffCreatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerStaffResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/staff/{staff_user_id}": {
+      "patch": {
+        "tags": [
+          "manager-staff"
+        ],
+        "summary": "Patch Staff",
+        "operationId": "patch_manager_staff",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "staff_user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Staff User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerStaffUpdatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerStaffResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/brands": {
       "get": {
         "tags": [
@@ -15626,6 +15845,44 @@
           "status": {
             "type": "string",
             "title": "Status"
+          },
+          "staff_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Staff User Id"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "auth_source": {
+            "type": "string",
+            "title": "Auth Source",
+            "default": "legacy"
           }
         },
         "type": "object",
@@ -22171,6 +22428,403 @@
         ],
         "title": "ManagerSettingUpdatePayload"
       },
+      "ManagerStaffCreatePayload": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "active"
+          },
+          "primary_role": {
+            "type": "string",
+            "title": "Primary Role",
+            "default": "installer"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "telegram_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Id"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "is_assignable_installer": {
+            "type": "boolean",
+            "title": "Is Assignable Installer",
+            "default": false
+          },
+          "default_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Rate"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "display_name"
+        ],
+        "title": "ManagerStaffCreatePayload"
+      },
+      "ManagerStaffListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerStaffResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "meta"
+        ],
+        "title": "ManagerStaffListResponse"
+      },
+      "ManagerStaffResponse": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "active"
+          },
+          "primary_role": {
+            "type": "string",
+            "title": "Primary Role",
+            "default": "installer"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "telegram_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Id"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "is_assignable_installer": {
+            "type": "boolean",
+            "title": "Is Assignable Installer",
+            "default": false
+          },
+          "default_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Rate"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "has_password": {
+            "type": "boolean",
+            "title": "Has Password",
+            "default": false
+          },
+          "legacy_installer_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Legacy Installer Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "last_login_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Login At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "display_name",
+          "id",
+          "created_at"
+        ],
+        "title": "ManagerStaffResponse"
+      },
+      "ManagerStaffUpdatePayload": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "primary_role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Role"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "telegram_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Id"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "is_assignable_installer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Assignable Installer"
+          },
+          "default_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Rate"
+          }
+        },
+        "type": "object",
+        "title": "ManagerStaffUpdatePayload"
+      },
       "ManagerTagCreatePayload": {
         "properties": {
           "group_id": {
@@ -27595,6 +28249,73 @@
           "slug"
         ],
         "title": "TagResponse"
+      },
+      "TelegramLoginPayload": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "first_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Name"
+          },
+          "last_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Name"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo Url"
+          },
+          "auth_date": {
+            "type": "integer",
+            "title": "Auth Date"
+          },
+          "hash": {
+            "type": "string",
+            "title": "Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "auth_date",
+          "hash"
+        ],
+        "title": "TelegramLoginPayload"
       },
       "ValidationError": {
         "properties": {

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -3,22 +3,62 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status, Response
 from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.ext.asyncio import AsyncSession
 from core.security import create_access_token, ACCESS_TOKEN_EXPIRE_MINUTES
 from core.config import settings
+from core.database import get_session
+from schemas import TelegramLoginPayload
+from services.staff_user_service import StaffUserService
 import secrets
 
 router = APIRouter(tags=["login"])
 
+
+def _set_auth_cookie(response: Response, access_token: str, expires_delta: timedelta) -> None:
+    response.set_cookie(
+        key="access_token",
+        value=f"Bearer {access_token}",
+        httponly=True,
+        max_age=int(expires_delta.total_seconds()),
+        expires=int(expires_delta.total_seconds()),
+        samesite="lax",
+        secure=settings.is_production,
+    )
+
+
+def _token_response(response: Response, token_data: dict[str, Any]) -> dict[str, str]:
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(data=token_data, expires_delta=access_token_expires)
+    _set_auth_cookie(response, access_token, access_token_expires)
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+    }
+
 @router.post("/login/access-token", operation_id="login_access_token")
-def login_access_token(
+async def login_access_token(
     response: Response,
-    form_data: OAuth2PasswordRequestForm = Depends()
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    session: AsyncSession = Depends(get_session),
 ) -> Any:
     """
     OAuth2 compatible token login, get an access token for future requests.
     Sets 'access_token' cookie as well.
     """
-    # 1. Validate Credentials
+    staff_user = await StaffUserService.authenticate_password(session, form_data.username, form_data.password)
+    if staff_user is not None:
+        username = staff_user.username or str(staff_user.telegram_id or staff_user.id)
+        return _token_response(
+            response,
+            {
+                "sub": username,
+                "staff_user_id": staff_user.id,
+                "role": StaffUserService.primary_role(staff_user),
+                "auth_source": "staff_password",
+            },
+        )
+
+    # Legacy emergency access from env.
     username_correct = secrets.compare_digest(
         form_data.username.encode("utf8"),
         settings.ADMIN_USERNAME.encode("utf8")
@@ -30,29 +70,30 @@ def login_access_token(
     
     if not (username_correct and password_correct):
         raise HTTPException(status_code=400, detail="Incorrect username or password")
-    
-    # 2. Create Token
-    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = create_access_token(
-        data={"sub": form_data.username}, expires_delta=access_token_expires
+
+    return _token_response(response, {"sub": form_data.username, "auth_source": "legacy"})
+
+
+@router.post("/login/telegram", operation_id="login_telegram")
+async def login_telegram(
+    payload: TelegramLoginPayload,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    staff_user = await StaffUserService.authenticate_telegram_login(
+        session,
+        payload.model_dump(exclude_none=True),
     )
-    
-    # 3. Set Cookie
-    # We set "Bearer <token>" or just "<token>"?
-    # User request: value=f"Bearer {access_token}"
-    cookie_value = f"Bearer {access_token}"
-    
-    response.set_cookie(
-        key="access_token",
-        value=cookie_value,
-        httponly=True,
-        max_age=int(access_token_expires.total_seconds()),
-        expires=int(access_token_expires.total_seconds()),
-        samesite="lax",
-        secure=settings.is_production, # Set to True in Prod with HTTPS
+    if staff_user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Telegram login is not allowed")
+
+    username = staff_user.username or str(staff_user.telegram_id or staff_user.id)
+    return _token_response(
+        response,
+        {
+            "sub": username,
+            "staff_user_id": staff_user.id,
+            "role": StaffUserService.primary_role(staff_user),
+            "auth_source": "telegram",
+        },
     )
-    
-    return {
-        "access_token": access_token,
-        "token_type": "bearer",
-    }

--- a/routers/manager.py
+++ b/routers/manager.py
@@ -20,6 +20,7 @@ from routers import manager_specs
 from routers import manager_installers
 from routers import manager_settings
 from routers import manager_service_estimates
+from routers import manager_staff
 from routers import manager_tariffs
 from routers import manager_tags
 from routers import manager_supply
@@ -44,6 +45,7 @@ router.include_router(manager_contracts.router)
 router.include_router(manager_calendar.router)
 router.include_router(manager_dashboard.router)
 router.include_router(manager_installers.router)
+router.include_router(manager_staff.router)
 router.include_router(manager_brands.router)
 router.include_router(manager_settings.router)
 router.include_router(manager_tariffs.router)

--- a/routers/manager_auth.py
+++ b/routers/manager_auth.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from core.security import get_current_username
+from core.security import AuthenticatedUser, get_current_auth_context
 from routers.manager_operation_ids import READ_USER_ME
 from schemas import ManagerAuthStatusResponse
 
@@ -9,9 +9,16 @@ router = APIRouter(prefix="/api/manager", tags=["manager"])
 
 
 @router.get("/me", response_model=ManagerAuthStatusResponse, operation_id=READ_USER_ME)
-async def check_auth_status(username: str = Depends(get_current_username)):
+async def check_auth_status(auth: AuthenticatedUser = Depends(get_current_auth_context)):
     """
     Check if current user is authenticated.
     Returns username if valid, 401 otherwise (via Depends).
     """
-    return {"username": username, "status": "authenticated"}
+    return {
+        "username": auth.username,
+        "status": "authenticated",
+        "staff_user_id": auth.staff_user_id,
+        "role": auth.role,
+        "display_name": auth.display_name,
+        "auth_source": auth.auth_source,
+    }

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -124,6 +124,9 @@ GET_MANAGER_INSTALLERS = "get_manager_installers"
 CREATE_MANAGER_INSTALLER = "create_manager_installer"
 UPDATE_MANAGER_INSTALLER = "update_manager_installer"
 SEARCH_MANAGER_INSTALLERS = "search_manager_installers"
+LIST_MANAGER_STAFF = "list_manager_staff"
+CREATE_MANAGER_STAFF = "create_manager_staff"
+PATCH_MANAGER_STAFF = "patch_manager_staff"
 
 LIST_MANAGER_SETTINGS = "list_manager_settings"
 GET_FX_RATE = "get_fx_rate"
@@ -307,6 +310,9 @@ ALL_MANAGER_OPERATION_IDS = (
     CREATE_MANAGER_INSTALLER,
     UPDATE_MANAGER_INSTALLER,
     SEARCH_MANAGER_INSTALLERS,
+    LIST_MANAGER_STAFF,
+    CREATE_MANAGER_STAFF,
+    PATCH_MANAGER_STAFF,
     LIST_MANAGER_SETTINGS,
     CREATE_MANAGER_SETTING,
     GET_FX_RATE,

--- a/routers/manager_staff.py
+++ b/routers/manager_staff.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
+from core.security import get_current_username
+from routers.manager_operation_ids import CREATE_MANAGER_STAFF, LIST_MANAGER_STAFF, PATCH_MANAGER_STAFF
+from schemas import ManagerStaffCreatePayload, ManagerStaffListResponse, ManagerStaffResponse, ManagerStaffUpdatePayload
+from services.staff_user_service import StaffUserService
+
+
+router = APIRouter(prefix="/api/manager/staff", tags=["manager-staff"])
+
+
+@router.get("", response_model=ManagerStaffListResponse, operation_id=LIST_MANAGER_STAFF)
+async def list_staff(
+    page: int = Query(1, ge=1),
+    limit: int = Query(100, ge=1, le=100),
+    search: Optional[str] = Query(None),
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    return await StaffUserService.list_staff(session=session, page=page, limit=limit, search=search)
+
+
+@router.post("", response_model=ManagerStaffResponse, operation_id=CREATE_MANAGER_STAFF)
+async def create_staff(
+    payload: ManagerStaffCreatePayload,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    try:
+        return await StaffUserService.create_staff(session=session, payload=payload)
+    except IntegrityError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail="Логин или Telegram ID уже используется") from exc
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/{staff_user_id}", response_model=ManagerStaffResponse, operation_id=PATCH_MANAGER_STAFF)
+async def patch_staff(
+    staff_user_id: int,
+    payload: ManagerStaffUpdatePayload,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    try:
+        staff_user = await StaffUserService.update_staff(session=session, staff_user_id=staff_user_id, payload=payload)
+    except IntegrityError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail="Логин или Telegram ID уже используется") from exc
+    except ValueError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if staff_user is None:
+        raise HTTPException(status_code=404, detail="Сотрудник не найден")
+    return staff_user

--- a/schemas.py
+++ b/schemas.py
@@ -356,6 +356,64 @@ class ManagerInstallerListResponse(BaseModel):
     items: List[ManagerInstallerResponse]
     meta: Meta
 
+
+# --- STAFF USERS ---
+
+class ManagerStaffBase(BaseModel):
+    display_name: str
+    status: str = "active"
+    primary_role: str = "installer"
+    username: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+    telegram_id: Optional[int] = None
+    telegram_username: Optional[str] = None
+    is_assignable_installer: bool = False
+    default_rate: Optional[float] = None
+
+
+class ManagerStaffCreatePayload(ManagerStaffBase):
+    password: Optional[str] = None
+
+
+class ManagerStaffUpdatePayload(BaseModel):
+    display_name: Optional[str] = None
+    status: Optional[str] = None
+    primary_role: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+    telegram_id: Optional[int] = None
+    telegram_username: Optional[str] = None
+    is_assignable_installer: Optional[bool] = None
+    default_rate: Optional[float] = None
+
+
+class ManagerStaffResponse(ManagerStaffBase):
+    id: int
+    has_password: bool = False
+    legacy_installer_id: Optional[int] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    last_login_at: Optional[datetime] = None
+
+
+class ManagerStaffListResponse(BaseModel):
+    items: List[ManagerStaffResponse]
+    meta: Meta
+
+
+class TelegramLoginPayload(BaseModel):
+    id: int
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    username: Optional[str] = None
+    photo_url: Optional[str] = None
+    auth_date: int
+    hash: str
+
+
 # --- ORDERS ---
 
 class OrderCustomerBrief(BaseModel):
@@ -1033,6 +1091,10 @@ class LeadQualifyResponse(BaseModel):
 class ManagerAuthStatusResponse(BaseModel):
     username: str
     status: str
+    staff_user_id: Optional[int] = None
+    role: Optional[str] = None
+    display_name: Optional[str] = None
+    auth_source: str = "legacy"
 
 
 class ManagerCatalogProductImageResponse(BaseModel):

--- a/services/staff_user_service.py
+++ b/services/staff_user_service.py
@@ -1,12 +1,18 @@
 import logging
 import json
+from datetime import datetime, timedelta, timezone
+import hashlib
+import hmac
 from typing import Iterable, Optional
+from urllib.parse import parse_qsl
 
+import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import select, func, or_
 
 from core.config import settings
 from models import Installer, StaffUser
+from schemas import ManagerStaffCreatePayload, ManagerStaffUpdatePayload, ManagerStaffResponse, ManagerStaffListResponse, Meta
 
 logger = logging.getLogger(__name__)
 
@@ -26,16 +32,9 @@ class StaffUserService:
     STATUS_INACTIVE = "inactive"
     STATUS_BLOCKED = "blocked"
 
-    ROLES = {
-        ROLE_OWNER,
-        ROLE_ADMIN,
-        ROLE_MANAGER,
-        ROLE_INSTALLER,
-        ROLE_MAINTENANCE,
-        ROLE_REPAIR,
-        ROLE_MEASURER,
-    }
-    OWNER_ADMIN_ROLES = {ROLE_OWNER, ROLE_ADMIN}
+    PRIMARY_ROLES = {ROLE_OWNER, ROLE_MANAGER, ROLE_INSTALLER}
+    ROLES = PRIMARY_ROLES | {ROLE_ADMIN, ROLE_MAINTENANCE, ROLE_REPAIR, ROLE_MEASURER}
+    OWNER_ADMIN_ROLES = {ROLE_OWNER, ROLE_MANAGER}
     MANAGEMENT_ROLES = {ROLE_OWNER, ROLE_ADMIN, ROLE_MANAGER}
     EXECUTOR_ROLES = {ROLE_INSTALLER, ROLE_MAINTENANCE, ROLE_REPAIR, ROLE_MEASURER}
     STATUSES = {STATUS_ACTIVE, STATUS_INACTIVE, STATUS_BLOCKED}
@@ -43,6 +42,35 @@ class StaffUserService:
     @classmethod
     def normalize_role(cls, role: str) -> str:
         return str(role or "").strip().lower()
+
+    @classmethod
+    def normalize_primary_role(cls, role: str | None, roles: Iterable[str] | None = None) -> str:
+        value = cls.normalize_role(role or "")
+        if value == cls.ROLE_ADMIN:
+            return cls.ROLE_OWNER
+        if value in {cls.ROLE_OWNER, cls.ROLE_MANAGER}:
+            return value
+
+        legacy_roles = set(cls.normalize_roles(roles))
+        if cls.ROLE_OWNER in legacy_roles or cls.ROLE_ADMIN in legacy_roles:
+            return cls.ROLE_OWNER
+        if cls.ROLE_MANAGER in legacy_roles:
+            return cls.ROLE_MANAGER
+        if value == cls.ROLE_INSTALLER:
+            return cls.ROLE_INSTALLER
+        return cls.ROLE_INSTALLER
+
+    @classmethod
+    def primary_role(cls, staff_user: StaffUser) -> str:
+        return cls.normalize_primary_role(getattr(staff_user, "primary_role", None), getattr(staff_user, "roles", []))
+
+    @classmethod
+    def roles_for_primary(cls, primary_role: str, *, assignable_as_installer: bool = False) -> list[str]:
+        normalized = cls.normalize_primary_role(primary_role)
+        roles = [normalized]
+        if assignable_as_installer and cls.ROLE_INSTALLER not in roles:
+            roles.append(cls.ROLE_INSTALLER)
+        return roles
 
     @classmethod
     def normalize_roles(cls, roles: Iterable[str] | None) -> list[str]:
@@ -86,7 +114,7 @@ class StaffUserService:
         return (
             cls.is_active(staff_user)
             and bool(getattr(staff_user, "telegram_id", None))
-            and cls.has_any_role(staff_user, cls.OWNER_ADMIN_ROLES)
+            and cls.primary_role(staff_user) in cls.OWNER_ADMIN_ROLES
         )
 
     @classmethod
@@ -95,11 +123,297 @@ class StaffUserService:
 
     @classmethod
     def can_be_executor(cls, staff_user: StaffUser, role: str) -> bool:
-        return cls.is_active(staff_user) and cls.has_role(staff_user, role)
+        return (
+            cls.is_active(staff_user)
+            and getattr(staff_user, "legacy_installer_id", None) is not None
+            and cls.has_role(staff_user, role)
+        )
 
     @classmethod
     def can_be_any_executor(cls, staff_user: StaffUser) -> bool:
-        return cls.is_active(staff_user) and cls.has_any_role(staff_user, cls.EXECUTOR_ROLES)
+        return (
+            cls.is_active(staff_user)
+            and getattr(staff_user, "legacy_installer_id", None) is not None
+            and cls.has_any_role(staff_user, cls.EXECUTOR_ROLES)
+        )
+
+    @staticmethod
+    def normalize_username(username: str | None) -> str | None:
+        value = str(username or "").strip().lower()
+        return value or None
+
+    @staticmethod
+    def hash_password(password: str) -> str:
+        value = str(password or "")
+        if len(value) < 6:
+            raise ValueError("Пароль должен быть не короче 6 символов")
+        return bcrypt.hashpw(value.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+    @staticmethod
+    def verify_password(password: str, password_hash: str | None) -> bool:
+        if not password_hash:
+            return False
+        try:
+            return bcrypt.checkpw(str(password or "").encode("utf-8"), password_hash.encode("utf-8"))
+        except ValueError:
+            return False
+
+    @classmethod
+    def _response(cls, user: StaffUser) -> ManagerStaffResponse:
+        return ManagerStaffResponse(
+            id=int(user.id or 0),
+            display_name=user.display_name,
+            status=cls.normalize_status(user.status),
+            primary_role=cls.primary_role(user),
+            username=user.username,
+            has_password=bool(user.password_hash),
+            phone=user.phone,
+            email=user.email,
+            telegram_id=user.telegram_id,
+            telegram_username=user.telegram_username,
+            is_assignable_installer=user.legacy_installer_id is not None,
+            legacy_installer_id=user.legacy_installer_id,
+            default_rate=user.default_rate,
+            created_at=user.created_at,
+            updated_at=user.updated_at,
+            last_login_at=user.last_login_at,
+        )
+
+    @classmethod
+    async def authenticate_password(cls, session: AsyncSession, username: str, password: str) -> StaffUser | None:
+        normalized_username = cls.normalize_username(username)
+        if not normalized_username:
+            return None
+
+        result = await session.execute(select(StaffUser).where(StaffUser.username == normalized_username))
+        user = result.scalar_one_or_none()
+        if user is None or not cls.is_active(user):
+            return None
+        if not cls.verify_password(password, user.password_hash):
+            return None
+
+        user.last_login_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        user.primary_role = cls.primary_role(user)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+    @classmethod
+    async def authenticate_telegram_login(
+        cls,
+        session: AsyncSession,
+        payload: dict[str, str | int],
+        *,
+        max_age: timedelta = timedelta(minutes=10),
+    ) -> StaffUser | None:
+        if not cls.verify_telegram_login_payload(payload, max_age=max_age):
+            return None
+
+        telegram_id = payload.get("id")
+        try:
+            normalized_telegram_id = int(telegram_id)
+        except (TypeError, ValueError):
+            return None
+
+        result = await session.execute(select(StaffUser).where(StaffUser.telegram_id == normalized_telegram_id))
+        user = result.scalar_one_or_none()
+        if user is None or not cls.is_active(user):
+            return None
+
+        username = str(payload.get("username") or "").strip() or None
+        if username and user.telegram_username != username:
+            user.telegram_username = username
+        user.last_login_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        user.primary_role = cls.primary_role(user)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+    @staticmethod
+    def _telegram_payload_items(payload: dict[str, str | int] | str) -> dict[str, str]:
+        if isinstance(payload, str):
+            return {key: value for key, value in parse_qsl(payload, keep_blank_values=True)}
+        return {str(key): str(value) for key, value in payload.items() if value is not None}
+
+    @classmethod
+    def verify_telegram_login_payload(
+        cls,
+        payload: dict[str, str | int] | str,
+        *,
+        max_age: timedelta = timedelta(minutes=10),
+    ) -> bool:
+        values = cls._telegram_payload_items(payload)
+        received_hash = values.pop("hash", "")
+        if not received_hash:
+            return False
+
+        try:
+            auth_date = datetime.fromtimestamp(int(values.get("auth_date", "0")), tz=timezone.utc)
+        except (TypeError, ValueError, OSError):
+            return False
+        if datetime.now(timezone.utc) - auth_date > max_age:
+            return False
+
+        data_check_string = "\n".join(f"{key}={values[key]}" for key in sorted(values))
+        secret_key = hashlib.sha256(settings.BOT_TOKEN.encode("utf-8")).digest()
+        expected_hash = hmac.new(secret_key, data_check_string.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected_hash, received_hash)
+
+    @classmethod
+    async def get_by_id(cls, session: AsyncSession, staff_user_id: int) -> StaffUser | None:
+        return await session.get(StaffUser, staff_user_id)
+
+    @classmethod
+    async def list_staff(
+        cls,
+        session: AsyncSession,
+        page: int = 1,
+        limit: int = 100,
+        search: Optional[str] = None,
+    ) -> ManagerStaffListResponse:
+        stmt = select(StaffUser)
+        if search:
+            query = f"%{search.strip().lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(StaffUser.display_name).like(query),
+                    func.lower(StaffUser.username).like(query),
+                    func.lower(StaffUser.email).like(query),
+                    func.lower(StaffUser.phone).like(query),
+                    func.lower(StaffUser.telegram_username).like(query),
+                )
+            )
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total_res = await session.execute(count_stmt)
+        total = total_res.scalar() or 0
+
+        result = await session.execute(
+            stmt.order_by(StaffUser.display_name.asc()).offset((page - 1) * limit).limit(limit)
+        )
+        items = [cls._response(user) for user in result.scalars().all()]
+        pages = (total + limit - 1) // limit if total > 0 else 1
+        return ManagerStaffListResponse(items=items, meta=Meta(total=total, page=page, limit=limit, pages=pages))
+
+    @classmethod
+    async def create_staff(
+        cls,
+        session: AsyncSession,
+        payload: ManagerStaffCreatePayload,
+    ) -> ManagerStaffResponse:
+        username = cls.normalize_username(payload.username)
+        primary_role = cls.normalize_primary_role(payload.primary_role)
+        assignable = bool(payload.is_assignable_installer)
+        display_name = payload.display_name.strip()
+        if not display_name:
+            raise ValueError("Имя сотрудника обязательно")
+        staff_user = StaffUser(
+            display_name=display_name,
+            status=cls.normalize_status(payload.status),
+            primary_role=primary_role,
+            roles=cls.roles_for_primary(primary_role, assignable_as_installer=assignable),
+            username=username,
+            password_hash=cls.hash_password(payload.password) if payload.password else None,
+            phone=payload.phone,
+            email=payload.email,
+            telegram_id=payload.telegram_id,
+            telegram_username=payload.telegram_username,
+            default_rate=payload.default_rate,
+        )
+        session.add(staff_user)
+        await session.flush()
+        await cls._sync_installer_link(session, staff_user, assignable)
+        await session.commit()
+        await session.refresh(staff_user)
+        return cls._response(staff_user)
+
+    @classmethod
+    async def update_staff(
+        cls,
+        session: AsyncSession,
+        staff_user_id: int,
+        payload: ManagerStaffUpdatePayload,
+    ) -> ManagerStaffResponse | None:
+        staff_user = await cls.get_by_id(session, staff_user_id)
+        if staff_user is None:
+            return None
+
+        changed_fields = payload.model_fields_set
+
+        if "display_name" in changed_fields and payload.display_name is not None:
+            display_name = payload.display_name.strip()
+            if not display_name:
+                raise ValueError("Имя сотрудника обязательно")
+            staff_user.display_name = display_name
+        if "status" in changed_fields:
+            staff_user.status = cls.normalize_status(payload.status)
+        if "primary_role" in changed_fields:
+            staff_user.primary_role = cls.normalize_primary_role(payload.primary_role)
+        else:
+            staff_user.primary_role = cls.primary_role(staff_user)
+        if "username" in changed_fields:
+            staff_user.username = cls.normalize_username(payload.username)
+        if payload.password:
+            staff_user.password_hash = cls.hash_password(payload.password)
+        if "phone" in changed_fields:
+            staff_user.phone = payload.phone or None
+        if "email" in changed_fields:
+            staff_user.email = payload.email or None
+        if "telegram_id" in changed_fields:
+            staff_user.telegram_id = payload.telegram_id
+        if "telegram_username" in changed_fields:
+            staff_user.telegram_username = payload.telegram_username or None
+        if "default_rate" in changed_fields:
+            staff_user.default_rate = payload.default_rate
+
+        assignable = (
+            bool(payload.is_assignable_installer)
+            if "is_assignable_installer" in changed_fields
+            else staff_user.legacy_installer_id is not None
+        )
+        staff_user.roles = cls.roles_for_primary(staff_user.primary_role, assignable_as_installer=assignable)
+        session.add(staff_user)
+        await session.flush()
+        await cls._sync_installer_link(session, staff_user, assignable)
+        await session.commit()
+        await session.refresh(staff_user)
+        return cls._response(staff_user)
+
+    @classmethod
+    async def _sync_installer_link(
+        cls,
+        session: AsyncSession,
+        staff_user: StaffUser,
+        assignable: bool,
+    ) -> None:
+        if assignable:
+            installer: Installer | None = None
+            if staff_user.legacy_installer_id:
+                installer = await session.get(Installer, staff_user.legacy_installer_id)
+            if installer is None:
+                installer = Installer(name=staff_user.display_name)
+                session.add(installer)
+                await session.flush()
+                staff_user.legacy_installer_id = installer.id
+            installer.name = staff_user.display_name
+            installer.is_active = cls.is_active(staff_user)
+            installer.default_rate = staff_user.default_rate
+            installer.telegram_id = staff_user.telegram_id
+            session.add(installer)
+            session.add(staff_user)
+            await session.flush()
+            return
+
+        if staff_user.legacy_installer_id:
+            installer = await session.get(Installer, staff_user.legacy_installer_id)
+            if installer is not None:
+                installer.is_active = False
+                session.add(installer)
+        staff_user.legacy_installer_id = None
+        session.add(staff_user)
+        await session.flush()
 
     @classmethod
     async def find_active_executors_by_role(
@@ -226,6 +540,7 @@ class StaffUserService:
             staff_user = StaffUser(
                 display_name=installer.name,
                 status=cls.STATUS_ACTIVE if installer.is_active else cls.STATUS_INACTIVE,
+                primary_role=cls.ROLE_INSTALLER,
                 roles=[cls.ROLE_INSTALLER],
                 telegram_id=installer.telegram_id,
                 legacy_installer_id=installer.id,
@@ -238,6 +553,7 @@ class StaffUserService:
         staff_user.display_name = installer.name
         staff_user.default_rate = installer.default_rate
         staff_user.telegram_id = installer.telegram_id
+        staff_user.primary_role = cls.primary_role(staff_user)
         roles = cls.normalize_roles(staff_user.roles)
         if cls.ROLE_INSTALLER not in roles:
             roles.append(cls.ROLE_INSTALLER)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,6 +1,8 @@
 import pytest
 from httpx import AsyncClient
 from core.config import settings
+from models import StaffUser
+from services.staff_user_service import StaffUserService
 
 @pytest.mark.asyncio
 async def test_login_success(async_client: AsyncClient):
@@ -17,6 +19,36 @@ async def test_login_success(async_client: AsyncClient):
     assert data["token_type"] == "bearer"
     # Verify cookie is set
     assert "access_token" in response.cookies
+
+
+@pytest.mark.asyncio
+async def test_login_success_with_staff_user(async_client: AsyncClient, db):
+    db.add(
+        StaffUser(
+            display_name="Manager",
+            status="active",
+            primary_role="manager",
+            roles=["manager"],
+            username="manager",
+            password_hash=StaffUserService.hash_password("secret123"),
+        )
+    )
+    await db.commit()
+
+    response = await async_client.post(
+        "/login/access-token",
+        data={"username": "manager", "password": "secret123"},
+    )
+
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    me_response = await async_client.get("/api/manager/me", headers={"Authorization": f"Bearer {token}"})
+    assert me_response.status_code == 200
+    payload = me_response.json()
+    assert payload["username"] == "manager"
+    assert payload["role"] == "manager"
+    assert payload["display_name"] == "Manager"
+    assert payload["auth_source"] == "staff_password"
 
 @pytest.mark.asyncio
 async def test_login_failure(async_client: AsyncClient):

--- a/tests/integration/test_manager_staff_api.py
+++ b/tests/integration/test_manager_staff_api.py
@@ -1,0 +1,82 @@
+import pytest
+
+from core.config import settings
+
+
+async def _auth_headers(async_client):
+    login_resp = await async_client.post(
+        "/login/access-token",
+        data={"username": settings.ADMIN_USERNAME, "password": settings.ADMIN_PASSWORD},
+    )
+    assert login_resp.status_code == 200
+    return {"Authorization": f"Bearer {login_resp.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_manager_staff_crud_hides_password_hash_and_changes_password(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    create_response = await async_client.post(
+        "/api/manager/staff",
+        json={
+            "display_name": "Офис Менеджер",
+            "primary_role": "manager",
+            "status": "active",
+            "username": "office",
+            "password": "secret123",
+            "phone": "+375291112233",
+            "email": "office@example.com",
+            "telegram_id": 123456,
+            "telegram_username": "office_mvn",
+            "is_assignable_installer": False,
+        },
+        headers=headers,
+    )
+
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created["primary_role"] == "manager"
+    assert created["has_password"] is True
+    assert created["is_assignable_installer"] is False
+    assert "password_hash" not in created
+
+    login_response = await async_client.post(
+        "/login/access-token",
+        data={"username": "office", "password": "secret123"},
+    )
+    assert login_response.status_code == 200
+
+    patch_response = await async_client.patch(
+        f"/api/manager/staff/{created['id']}",
+        json={
+            "password": "newsecret123",
+            "primary_role": "owner",
+            "is_assignable_installer": True,
+            "default_rate": 250,
+        },
+        headers=headers,
+    )
+
+    assert patch_response.status_code == 200
+    patched = patch_response.json()
+    assert patched["primary_role"] == "owner"
+    assert patched["is_assignable_installer"] is True
+    assert patched["legacy_installer_id"] is not None
+
+    old_login = await async_client.post(
+        "/login/access-token",
+        data={"username": "office", "password": "secret123"},
+    )
+    assert old_login.status_code == 400
+
+    new_login = await async_client.post(
+        "/login/access-token",
+        data={"username": "office", "password": "newsecret123"},
+    )
+    assert new_login.status_code == 200
+
+    list_response = await async_client.get("/api/manager/staff", headers=headers)
+    assert list_response.status_code == 200
+    item = list_response.json()["items"][0]
+    assert item["display_name"] == "Офис Менеджер"
+    assert "password_hash" not in item

--- a/tests/unit/test_staff_user_service.py
+++ b/tests/unit/test_staff_user_service.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+import hashlib
+import hmac
+import time
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -29,8 +32,13 @@ def test_staff_role_and_status_helpers():
     active_admin = StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101)
     blocked_admin = StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=102)
     inactive_installer = StaffUser(display_name="Inactive", status="inactive", roles=["installer"])
-    maintenance_executor = StaffUser(display_name="Maintenance", status="active", roles=["maintenance"])
-    repair_executor = StaffUser(display_name="Repair", status="active", roles=["repair"])
+    maintenance_executor = StaffUser(
+        display_name="Maintenance",
+        status="active",
+        roles=["maintenance"],
+        legacy_installer_id=1,
+    )
+    repair_executor = StaffUser(display_name="Repair", status="active", roles=["repair"], legacy_installer_id=2)
     manager = StaffUser(display_name="Manager", status="active", roles=["manager"])
     json_roles_admin = StaffUser(display_name="JSON Admin", status="active", roles='["admin"]', telegram_id=103)
 
@@ -52,12 +60,42 @@ def test_staff_role_and_status_helpers():
     assert StaffUserService.can_be_any_executor(repair_executor)
     assert not StaffUserService.can_be_any_executor(manager)
     assert StaffUserService.has_role(json_roles_admin, "admin")
+    assert StaffUserService.primary_role(json_roles_admin) == "owner"
+
+
+def test_staff_password_hash_and_verify():
+    password_hash = StaffUserService.hash_password("secret123")
+
+    assert password_hash != "secret123"
+    assert StaffUserService.verify_password("secret123", password_hash)
+    assert not StaffUserService.verify_password("wrong", password_hash)
+
+
+def test_telegram_login_payload_signature(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_TOKEN", "123:token", raising=False)
+    payload = {
+        "id": "101",
+        "first_name": "Max",
+        "username": "mvn",
+        "auth_date": str(int(time.time())),
+    }
+    data_check_string = "\n".join(f"{key}={payload[key]}" for key in sorted(payload))
+    secret_key = hashlib.sha256(settings.BOT_TOKEN.encode("utf-8")).digest()
+    payload["hash"] = hmac.new(secret_key, data_check_string.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    assert StaffUserService.verify_telegram_login_payload(payload)
+
+    payload["username"] = "attacker"
+    assert not StaffUserService.verify_telegram_login_payload(payload)
 
 
 @pytest.mark.asyncio
 async def test_find_active_executors_by_role_excludes_inactive_and_blocked(sqlite_staff_session):
+    installer = Installer(name="Active Legacy", is_active=True)
+    sqlite_staff_session.add(installer)
+    await sqlite_staff_session.flush()
     sqlite_staff_session.add(
-        StaffUser(display_name="Active Installer", status="active", roles=["installer"], legacy_installer_id=None)
+        StaffUser(display_name="Active Installer", status="active", roles=["installer"], legacy_installer_id=installer.id)
     )
     sqlite_staff_session.add(StaffUser(display_name="Inactive Installer", status="inactive", roles=["installer"]))
     sqlite_staff_session.add(StaffUser(display_name="Blocked Installer", status="blocked", roles=["installer"]))
@@ -79,13 +117,14 @@ async def test_admin_recipients_use_active_db_owner_admin_before_legacy_fallback
 
     sqlite_staff_session.add(StaffUser(display_name="Owner", status="active", roles=["owner"], telegram_id=101))
     sqlite_staff_session.add(StaffUser(display_name="Admin", status="active", roles=["admin"], telegram_id=202))
+    sqlite_staff_session.add(StaffUser(display_name="Manager", status="active", roles=["manager"], telegram_id=505))
     sqlite_staff_session.add(StaffUser(display_name="Blocked", status="blocked", roles=["admin"], telegram_id=303))
     sqlite_staff_session.add(StaffUser(display_name="Installer", status="active", roles=["installer"], telegram_id=404))
     await sqlite_staff_session.commit()
 
     recipients = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(sqlite_staff_session)
 
-    assert recipients == [101, 202]
+    assert recipients == [101, 202, 505]
 
 
 @pytest.mark.asyncio
@@ -106,7 +145,7 @@ async def test_telegram_admin_check_uses_active_owner_admin_and_blocks_non_admin
     assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 101)
     assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 202)
     assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 303)
-    assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 404)
+    assert await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 404)
     assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 505)
     assert not await StaffUserService.is_active_owner_admin_telegram_user(sqlite_staff_session, 606)
 
@@ -161,6 +200,7 @@ async def test_ensure_for_installer_creates_compatibility_staff_user(sqlite_staf
     assert staff_user.legacy_installer_id == installer.id
     assert staff_user.display_name == "Legacy Installer"
     assert staff_user.status == "active"
+    assert staff_user.primary_role == "installer"
     assert staff_user.roles == ["installer"]
     assert staff_user.telegram_id == 777
 


### PR DESCRIPTION
## What changed
- Expanded `StaffUser` into a real manager employee profile with username/password auth, primary role, Telegram metadata, login timestamp, status, contacts, and installer assignability.
- Added staff password login before the legacy env fallback and added Telegram Login Widget backend verification via `/login/telegram`.
- Added manager staff CRUD API at `/api/manager/staff` and regenerated OpenAPI/manager client.
- Reworked the manager “Сотрудники” screen to edit profiles instead of the old installer wrapper while keeping the old installer API compatible for order assignment.
- Updated bot/admin notification checks so office admin actions are available for active `owner`/`manager`, not installers.
- Added Alembic migration and focused tests for auth, staff CRUD, Telegram signature verification, and installer compatibility.

## Rollout notes
- Legacy `ADMIN_USERNAME`/`ADMIN_PASSWORD` login remains as an emergency fallback.
- After deploy, create or update the owner profile in Manager → Сотрудники with username/password, Telegram ID, and `owner` role.
- Telegram login button appears only when `VITE_TELEGRAM_LOGIN_BOT_USERNAME` is configured for the manager frontend build.

## Validation
- `python3 -m py_compile core/security.py routers/auth.py routers/manager_staff.py services/staff_user_service.py schemas.py alembic/versions/f6a7b8c9d0e2_expand_staff_users_for_manager_auth.py`
- `POSTGRES_PASSWORD=... TEST_DB_HOST=127.0.0.1 TEST_DB_PORT=5433 pytest tests/unit/test_staff_user_service.py tests/integration/test_auth.py tests/integration/test_manager_staff_api.py tests/integration/test_manager_installers_api.py -q`
- `cd manager_frontend && npm run build`
- `git diff --check HEAD~1 HEAD`
