### PR TITLE
[codex] Add staff Telegram bot workflows

### DIFF
--- a/bot_app/handlers/base.py
+++ b/bot_app/handlers/base.py
@@ -1,9 +1,23 @@
 from aiogram import Router, types
 from aiogram.filters import Command
-from ..keyboards import main_menu
+from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
+from ..keyboards import get_staff_main_menu
 
 router = Router()
 
 @router.message(Command("start"))
 async def cmd_start(message: types.Message):
-    await message.answer("Магазин климата ❄️", reply_markup=main_menu)
+    async with async_session_maker() as session:
+        context = await BotAccessService.get_context(
+            session,
+            message.from_user.id if message.from_user else None,
+        )
+    if not context.is_staff:
+        await message.answer("Этот бот теперь только для сотрудников MVN.")
+        return
+    name = context.display_name or "коллега"
+    await message.answer(
+        f"Рабочий бот MVN. Привет, {name}.",
+        reply_markup=get_staff_main_menu(context),
+    )

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -7,6 +7,7 @@ from aiogram.filters import Command, StateFilter
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
 from services.product_service import ProductService
 from services.staff_user_service import StaffUserService
 from ..keyboards import area_selection_kb, type_selection_kb, winter_selection_kb, wifi_selection_kb
@@ -15,6 +16,21 @@ from ..states import ShopState
 
 router = Router()
 logger = logging.getLogger(__name__)
+
+
+async def _get_access_context(user_id: int | None):
+    async with async_session_maker() as session:
+        return await BotAccessService.get_context(session, user_id)
+
+
+async def _is_staff_user(user_id: int | None) -> bool:
+    context = await _get_access_context(user_id)
+    return context.is_staff
+
+
+async def _is_manager_user(user_id: int | None) -> bool:
+    context = await _get_access_context(user_id)
+    return context.is_staff and context.is_manager
 
 
 def _is_inline_search_query(text: str) -> bool:
@@ -76,6 +92,9 @@ async def _render_search_results(message: types.Message, query: str, products: l
 
 @router.message(F.text == "🏆 Умный подбор")
 async def start_selection(message: types.Message, state: FSMContext):
+    if not await _is_manager_user(message.from_user.id if message.from_user else None):
+        await message.answer("Подбор доступен сотрудникам MVN.")
+        return
     await state.set_state(ShopState.select_area)
     await message.answer(
         "Давайте подберем идеальный кондиционер! 🌬️\n\n"
@@ -182,6 +201,9 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
 @router.message(F.text == "🔎 Поиск")
 @router.message(Command("search"))
 async def search_start(message: types.Message, state: FSMContext):
+    if not await _is_staff_user(message.from_user.id if message.from_user else None):
+        await message.answer("Этот бот теперь только для сотрудников MVN.")
+        return
     await state.set_state(ShopState.waiting_for_search)
     logger.info("BOT_SEARCH_START user_id=%s", message.from_user.id if message.from_user else None)
     await message.answer("Введите бренд и мощность, например: Midea 12")
@@ -189,6 +211,9 @@ async def search_start(message: types.Message, state: FSMContext):
 
 @router.callback_query(F.data.startswith("search_details_"))
 async def search_details(callback: CallbackQuery):
+    if not await _is_staff_user(callback.from_user.id):
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
     product_id = int(callback.data.split("_")[-1])
     async with async_session_maker() as session:
         product = await ProductService.get_by_id(session, product_id)
@@ -203,6 +228,10 @@ async def search_details(callback: CallbackQuery):
 
 @router.message(ShopState.waiting_for_search)
 async def search_process(message: types.Message, state: FSMContext):
+    if not await _is_staff_user(message.from_user.id if message.from_user else None):
+        await message.answer("Этот бот теперь только для сотрудников MVN.")
+        await state.clear()
+        return
     query = (message.text or "").strip()
     user_id = message.from_user.id if message.from_user else None
     if not query:
@@ -231,6 +260,8 @@ async def auto_search_process(message: types.Message):
     query = (message.text or "").strip()
     user_id = message.from_user.id if message.from_user else None
     if not _is_inline_search_query(query):
+        return
+    if not await _is_staff_user(user_id):
         return
 
     async with async_session_maker() as session:

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -1,0 +1,202 @@
+from aiogram import F, Router, types
+from aiogram.fsm.context import FSMContext
+from aiogram.filters import Command
+from aiogram.types import CallbackQuery, ReplyKeyboardRemove
+
+from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
+from services.bot_product_selection_service import BotProductSelectionService
+from services.bot_quick_order_service import BotQuickOrderService
+from services.bot_task_service import BotTaskService
+from ..keyboards import quick_order_confirm_keyboard, task_actions_keyboard
+from ..states import ShopState
+
+router = Router()
+
+
+async def _access_context(user_id: int | None):
+    async with async_session_maker() as session:
+        return await BotAccessService.get_context(session, user_id)
+
+
+async def _require_staff(message: types.Message):
+    context = await _access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await message.answer("Этот бот теперь только для сотрудников MVN.")
+        return None
+    return context
+
+
+@router.message(F.text == "⚡ Быстрый заказ")
+@router.message(Command("quick_order"))
+async def quick_order_start(message: types.Message, state: FSMContext):
+    context = await _require_staff(message)
+    if not context:
+        return
+    if not context.is_manager:
+        await message.answer("Быстрый заказ доступен менеджерам и администраторам.")
+        return
+    await state.set_state(ShopState.waiting_for_quick_order)
+    await message.answer(
+        "Пришлите текст звонка одним сообщением.\n"
+        "Например: ТО, Иван, +375 29 123-45-67, Победы 15, завтра 14:00",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+
+
+@router.message(ShopState.waiting_for_quick_order)
+async def quick_order_parse(message: types.Message, state: FSMContext):
+    context = await _require_staff(message)
+    if not context or not context.is_manager:
+        await state.clear()
+        return
+    text = (message.text or "").strip()
+    if not text:
+        await message.answer("Нужен текст заявки.")
+        return
+    draft = await BotQuickOrderService.parse_text(text)
+    await state.update_data(quick_order_draft=draft)
+    await message.answer(
+        BotQuickOrderService.format_draft_preview(draft),
+        parse_mode="HTML",
+        reply_markup=quick_order_confirm_keyboard(),
+    )
+
+
+@router.callback_query(F.data == "quick_order_create")
+async def quick_order_create(callback: CallbackQuery, state: FSMContext):
+    context = await _access_context(callback.from_user.id)
+    if not context.is_staff or not context.is_manager:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+    data = await state.get_data()
+    draft = data.get("quick_order_draft")
+    if not isinstance(draft, dict):
+        await callback.answer("Черновик не найден", show_alert=True)
+        return
+    try:
+        async with async_session_maker() as session:
+            order = await BotQuickOrderService.create_order_from_draft(session, draft)
+    except Exception as exc:
+        await callback.answer(str(exc), show_alert=True)
+        return
+
+    await state.clear()
+    await callback.message.edit_text(
+        f"✅ Заказ #{order['id']} создан.\n"
+        "Он уже доступен в менеджере и календаре, если дата была указана."
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "quick_order_retry")
+async def quick_order_retry(callback: CallbackQuery, state: FSMContext):
+    await state.set_state(ShopState.waiting_for_quick_order)
+    await callback.message.answer("Пришлите исправленный текст заявки одним сообщением.")
+    await callback.answer()
+
+
+@router.callback_query(F.data == "quick_order_cancel")
+async def quick_order_cancel(callback: CallbackQuery, state: FSMContext):
+    await state.clear()
+    await callback.message.edit_text("Быстрый заказ отменен.")
+    await callback.answer()
+
+
+@router.message(F.text == "🎯 Подбор")
+@router.message(Command("selection"))
+async def selection_start(message: types.Message, state: FSMContext):
+    context = await _require_staff(message)
+    if not context:
+        return
+    if not context.is_manager:
+        await message.answer("Подбор для клиента доступен менеджерам и администраторам.")
+        return
+    await state.set_state(ShopState.waiting_for_selection)
+    await message.answer(
+        "Напишите запрос: например, 20 м² и 35 м², нужны бюджетный, оптимальный и премиум варианты.",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+
+
+@router.message(ShopState.waiting_for_selection)
+async def selection_process(message: types.Message, state: FSMContext):
+    context = await _require_staff(message)
+    if not context or not context.is_manager:
+        await state.clear()
+        return
+    query = (message.text or "").strip()
+    async with async_session_maker() as session:
+        selection = await BotProductSelectionService.build_selection(session, query)
+    await message.answer(BotProductSelectionService.format_selection(selection), parse_mode="HTML")
+    await state.clear()
+
+
+@router.message(F.text == "📅 Календарь")
+async def calendar_hint(message: types.Message):
+    context = await _require_staff(message)
+    if not context:
+        return
+    await message.answer("Календарь ведем в Manager. Быстрые заказы с датой автоматически появляются там.")
+
+
+@router.message(F.text == "🧰 Мои задачи")
+@router.message(Command("tasks"))
+async def my_tasks(message: types.Message):
+    context = await _require_staff(message)
+    if not context:
+        return
+    async with async_session_maker() as session:
+        tasks = await BotTaskService.list_my_tasks(session, message.from_user.id if message.from_user else None)
+    await message.answer(
+        BotTaskService.format_tasks(tasks),
+        parse_mode="HTML",
+        reply_markup=task_actions_keyboard(tasks),
+    )
+
+
+@router.callback_query(F.data.startswith("task_accept_") | F.data.startswith("task_done_"))
+async def update_task_status(callback: CallbackQuery):
+    data = callback.data or ""
+    status = "in_progress" if data.startswith("task_accept_") else "completed"
+    stage_id = int(data.rsplit("_", 1)[-1])
+    async with async_session_maker() as session:
+        ok = await BotTaskService.update_stage_status(
+            session,
+            stage_id,
+            status,
+            telegram_id=callback.from_user.id,
+        )
+    if not ok:
+        await callback.answer("Задача не найдена или нет доступа", show_alert=True)
+        return
+    await callback.answer("Готово")
+    await callback.message.answer("Статус задачи обновлен.")
+
+
+@router.callback_query(F.data.startswith("task_report_"))
+async def task_report_start(callback: CallbackQuery, state: FSMContext):
+    stage_id = int((callback.data or "").rsplit("_", 1)[-1])
+    await state.update_data(task_report_stage_id=stage_id)
+    await state.set_state(ShopState.waiting_for_task_report)
+    await callback.message.answer("Пришлите комментарий/отчет по задаче.")
+    await callback.answer()
+
+
+@router.message(ShopState.waiting_for_task_report)
+async def task_report_finish(message: types.Message, state: FSMContext):
+    data = await state.get_data()
+    stage_id = int(data.get("task_report_stage_id") or 0)
+    report = (message.text or "").strip()
+    if not stage_id or not report:
+        await message.answer("Отчет пустой, попробуйте еще раз.")
+        return
+    async with async_session_maker() as session:
+        ok = await BotTaskService.save_stage_report(
+            session,
+            stage_id,
+            report,
+            telegram_id=message.from_user.id if message.from_user else None,
+        )
+    await state.clear()
+    await message.answer("Отчет сохранен." if ok else "Задача не найдена или нет доступа.")

--- a/bot_app/keyboards.py
+++ b/bot_app/keyboards.py
@@ -2,11 +2,30 @@ from aiogram.types import (
     ReplyKeyboardMarkup, KeyboardButton, 
     InlineKeyboardMarkup, InlineKeyboardButton
 )
+from services.bot_access_service import BotAccessContext
+from services.bot_product_selection_service import BotProductSelectionService
+
+
+def get_staff_main_menu(context: BotAccessContext) -> ReplyKeyboardMarkup:
+    rows: list[list[KeyboardButton]] = []
+    if context.is_manager:
+        rows.extend(
+            [
+                [KeyboardButton(text="⚡ Быстрый заказ"), KeyboardButton(text="🎯 Подбор")],
+                [KeyboardButton(text="🔎 Поиск"), KeyboardButton(text="📅 Календарь")],
+            ]
+        )
+    if context.is_executor:
+        rows.append([KeyboardButton(text="🧰 Мои задачи")])
+    if not rows:
+        rows.append([KeyboardButton(text="🔎 Поиск")])
+    return ReplyKeyboardMarkup(keyboard=rows, resize_keyboard=True)
+
 
 main_menu = ReplyKeyboardMarkup(
     keyboard=[
-        [KeyboardButton(text="🏆 Умный подбор"), KeyboardButton(text="🔎 Поиск")],
-        [KeyboardButton(text="⭐ Избранное"), KeyboardButton(text="🛒 Корзина")]
+        [KeyboardButton(text="⚡ Быстрый заказ"), KeyboardButton(text="🎯 Подбор")],
+        [KeyboardButton(text="🔎 Поиск"), KeyboardButton(text="📅 Календарь")],
     ],
     resize_keyboard=True
 )
@@ -47,7 +66,23 @@ wifi_selection_kb = InlineKeyboardMarkup(
     ]
 )
 
-def get_product_keyboard(product_id, is_admin=False, in_favorites=False):
+def get_product_keyboard(product_id, is_admin=False, in_favorites=False, product=None, staff_mode=True):
+    product = product or {}
+    url = BotProductSelectionService.product_url(product) if product.get("slug") else None
+    if staff_mode:
+        buttons = []
+        if url:
+            buttons.append([InlineKeyboardButton(text="Открыть на сайте", url=url)])
+        buttons.append([InlineKeyboardButton(text="Подробнее", callback_data=f"search_details_{product_id}")])
+        if is_admin:
+            buttons.append(
+                [
+                    InlineKeyboardButton(text="✏️ Цена", callback_data=f"edit_price_{product_id}"),
+                    InlineKeyboardButton(text="❌ Удалить", callback_data=f"del_confirm_{product_id}"),
+                ]
+            )
+        return InlineKeyboardMarkup(inline_keyboard=buttons)
+
     fav_text = "💔 Убрать" if in_favorites else "❤️ В избранное"
     buttons = [
         [InlineKeyboardButton(text="🛒 В корзину", callback_data=f"buy_{product_id}")],
@@ -67,7 +102,34 @@ def get_search_result_keyboard(product_id: int):
         inline_keyboard=[
             [
                 InlineKeyboardButton(text="Подробнее", callback_data=f"search_details_{product_id}"),
-                InlineKeyboardButton(text="В корзину", callback_data=f"buy_{product_id}"),
             ]
         ]
     )
+
+
+def quick_order_confirm_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="Создать", callback_data="quick_order_create"),
+                InlineKeyboardButton(text="Исправить", callback_data="quick_order_retry"),
+            ],
+            [InlineKeyboardButton(text="Отмена", callback_data="quick_order_cancel")],
+        ]
+    )
+
+
+def task_actions_keyboard(tasks: list[dict]) -> InlineKeyboardMarkup | None:
+    rows: list[list[InlineKeyboardButton]] = []
+    for task in tasks[:5]:
+        if task.get("kind") != "stage":
+            continue
+        stage_id = task.get("id")
+        rows.append(
+            [
+                InlineKeyboardButton(text=f"Принял #{task['order_id']}", callback_data=f"task_accept_{stage_id}"),
+                InlineKeyboardButton(text=f"Выполнено #{task['order_id']}", callback_data=f"task_done_{stage_id}"),
+            ]
+        )
+        rows.append([InlineKeyboardButton(text=f"Отчет #{task['order_id']}", callback_data=f"task_report_{stage_id}")])
+    return InlineKeyboardMarkup(inline_keyboard=rows) if rows else None

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 from aiogram import types
 from .config import bot, dp
-from .handlers import base, catalog, orders, admin, favorites, cart
+from .handlers import admin, base, catalog, work
 from core.config import settings
 from core.logger import setup_logging
 
@@ -31,10 +31,8 @@ async def main(*, wait_when_disabled: bool = True):
     logger.info("Starting bot polling: %s.", decision.reason)
     # Register routers in specific order
     dp.include_router(base.router)
+    dp.include_router(work.router)
     dp.include_router(catalog.router)
-    dp.include_router(cart.router)
-    dp.include_router(orders.router)
-    dp.include_router(favorites.router)
     dp.include_router(admin.router)
     
     await bot.delete_webhook(drop_pending_updates=True)

--- a/bot_app/states.py
+++ b/bot_app/states.py
@@ -4,8 +4,10 @@ class ShopState(StatesGroup):
     edit_price = State()
     waiting_for_phone = State()
     waiting_for_search = State()
+    waiting_for_quick_order = State()
+    waiting_for_selection = State()
+    waiting_for_task_report = State()
     select_area = State()
     select_type = State()
     select_winter = State()  # Выбор зимнего обогрева
     select_wifi = State()    # Выбор Wi-Fi
-

--- a/bot_app/utils.py
+++ b/bot_app/utils.py
@@ -3,8 +3,7 @@ import os
 from pathlib import Path
 from aiogram import types
 from aiogram.types import FSInputFile
-from core.database import async_session_maker
-from services.favorite_service import FavoriteService
+from services.bot_product_selection_service import BotProductSelectionService
 from .keyboards import get_product_keyboard
 
 
@@ -26,6 +25,12 @@ def _availability_badge(product: dict) -> str:
     return "✅ <b>В наличии</b>\n" if in_stock else "⛔ <b>Нет в наличии</b>\n"
 
 
+def _availability_details(product: dict) -> str:
+    if not any(key in product for key in ("availability_status", "vitebsk_qty", "minsk_qty")):
+        return ""
+    return f"📦 {BotProductSelectionService.availability_text(product)}\n"
+
+
 def format_caption(product):
     # Пытаемся достать характеристики
     specs_str = ""
@@ -36,21 +41,17 @@ def format_caption(product):
     return (
         f"❄️ <b>{product['title']}</b>\n"
         f"{_availability_badge(product)}"
+        f"{_availability_details(product)}"
         f"💰 <b>{product['price']} руб.</b>\n"
         f"🏠 Площадь: {product.get('area', '-')} м²\n"
         f"{specs_str}"
-        f"📝 {product.get('description', '')[:200]}"
+        f"📝 {product.get('description', '')[:200]}\n"
+        f"🔗 {BotProductSelectionService.product_url(product)}"
     )
 
-async def send_product_card(message_or_callback, product, is_admin):
-    user_id = message_or_callback.from_user.id
-    
-    # Use new Service Layer
-    async with async_session_maker() as session:
-        in_fav = await FavoriteService.is_favorite(session, user_id, product['id'])
-    
+async def send_product_card(message_or_callback, product, is_admin, *, staff_mode=True):
     caption = format_caption(product)
-    kb = get_product_keyboard(product['id'], is_admin, in_favorites=in_fav)
+    kb = get_product_keyboard(product['id'], is_admin, product=product, staff_mode=staff_mode)
     
     target = message_or_callback.answer if isinstance(message_or_callback, types.Message) else message_or_callback.message.answer
     

--- a/core/config.py
+++ b/core/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     # Static Files
     STATIC_DIR: str = "static"
     UPLOAD_DIR: str = "static/uploads"
+    PUBLIC_SITE_URL: str = "https://mvn.by"
 
     # Product media storage. Default stays local so CI/deploy do not require
     # R2/S3 secrets unless PRODUCT_MEDIA_STORAGE_PROVIDER is changed.

--- a/services/bot_access_service.py
+++ b/services/bot_access_service.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from core.config import settings
+from models import StaffUser
+from services.staff_user_service import StaffUserService
+
+
+@dataclass
+class BotAccessContext:
+    telegram_id: int
+    is_staff: bool = False
+    display_name: str = ""
+    primary_role: str = ""
+    roles: list[str] = field(default_factory=list)
+    legacy_installer_id: Optional[int] = None
+
+    @property
+    def is_manager(self) -> bool:
+        return self.primary_role in {
+            StaffUserService.ROLE_OWNER,
+            StaffUserService.ROLE_ADMIN,
+            StaffUserService.ROLE_MANAGER,
+        }
+
+    @property
+    def is_executor(self) -> bool:
+        return bool(self.legacy_installer_id) or any(
+            role in StaffUserService.EXECUTOR_ROLES for role in self.roles
+        )
+
+
+class BotAccessService:
+    @staticmethod
+    async def get_context(
+        session: AsyncSession,
+        telegram_id: int | str | None,
+    ) -> BotAccessContext:
+        try:
+            normalized_telegram_id = int(telegram_id) if telegram_id is not None else 0
+        except (TypeError, ValueError):
+            normalized_telegram_id = 0
+
+        context = BotAccessContext(telegram_id=normalized_telegram_id)
+        if not normalized_telegram_id:
+            return context
+
+        result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id == normalized_telegram_id)
+            .order_by(StaffUser.id.asc())
+        )
+        user = result.scalars().first()
+        if user and StaffUserService.is_active(user):
+            roles = StaffUserService.normalize_roles(user.roles)
+            primary_role = StaffUserService.primary_role(user)
+            return BotAccessContext(
+                telegram_id=normalized_telegram_id,
+                is_staff=True,
+                display_name=user.display_name,
+                primary_role=primary_role,
+                roles=roles,
+                legacy_installer_id=user.legacy_installer_id,
+            )
+
+        if settings.is_admin_user(normalized_telegram_id):
+            return BotAccessContext(
+                telegram_id=normalized_telegram_id,
+                is_staff=True,
+                display_name="Администратор",
+                primary_role=StaffUserService.ROLE_OWNER,
+                roles=[StaffUserService.ROLE_OWNER],
+            )
+
+        return context

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -1,0 +1,136 @@
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from services.product_service import ProductService
+
+
+class BotProductSelectionService:
+    TIERS = (
+        ("budget", "Бюджетнее", {"is_inverter": False, "sort": "price"}),
+        ("optimal", "Оптимально", {"is_inverter": True, "sort": "balanced"}),
+        ("premium", "Премиум", {"is_inverter": True, "sort": "premium"}),
+    )
+
+    @staticmethod
+    def product_url(product: dict[str, Any]) -> str:
+        slug = str(product.get("slug") or "").strip()
+        base = settings.PUBLIC_SITE_URL.rstrip("/") if getattr(settings, "PUBLIC_SITE_URL", "") else "https://mvn.by"
+        return f"{base}/product/{slug}/" if slug else base
+
+    @staticmethod
+    def parse_areas(text: str) -> list[int]:
+        areas: list[int] = []
+        for match in re.finditer(r"\b(\d{1,3})\s*(?:м2|м²|кв|квадрат|квадратов)?\b", text.casefold()):
+            value = int(match.group(1))
+            if 8 <= value <= 120 and value not in areas:
+                areas.append(value)
+        return areas[:4]
+
+    @staticmethod
+    def availability_rank(product: dict[str, Any]) -> int:
+        if int(product.get("vitebsk_qty") or 0) > 0:
+            return 0
+        if int(product.get("minsk_qty") or 0) > 0:
+            return 1
+        availability = str(product.get("availability_status") or "").strip().lower()
+        if availability == "in_stock_now":
+            return 0
+        if availability == "available_2_3_days":
+            return 1
+        if availability == "check_availability":
+            return 2
+        return 3
+
+    @staticmethod
+    def _sort_for_tier(products: list[dict[str, Any]], tier_key: str) -> list[dict[str, Any]]:
+        def price(product: dict[str, Any]) -> int:
+            return int(product.get("price") or 0)
+
+        if tier_key == "budget":
+            return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), price(item)))
+        if tier_key == "premium":
+            return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), -price(item)))
+        return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), abs(price(item))))
+
+    @staticmethod
+    def availability_text(product: dict[str, Any]) -> str:
+        vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+        minsk_qty = int(product.get("minsk_qty") or 0)
+        availability = str(product.get("availability_status") or "").strip().lower()
+        if vitebsk_qty > 0:
+            return f"Витебск: {vitebsk_qty} шт."
+        if minsk_qty > 0:
+            return f"Минск: {minsk_qty} шт., обычно 2-3 дня"
+        if availability == "in_stock_now":
+            return "В наличии"
+        if availability == "available_2_3_days":
+            return "Доступно 2-3 дня"
+        if availability == "check_availability":
+            return "Наличие уточнить"
+        return "Нет в наличии"
+
+    @classmethod
+    async def build_selection(
+        cls,
+        session: AsyncSession,
+        query: str,
+        *,
+        limit_per_tier: int = 1,
+    ) -> dict[str, Any]:
+        areas = cls.parse_areas(query)
+        if not areas:
+            return {"areas": [], "message": "Не нашел площадь. Напишите, например: подбор 20 и 35 м²."}
+
+        result: dict[str, Any] = {"areas": []}
+        for area in areas:
+            area_payload = {"area": area, "tiers": []}
+            seen_ids: set[int] = set()
+            for tier_key, label, options in cls.TIERS:
+                products = await ProductService.get_curated(
+                    session,
+                    area=area,
+                    is_inverter=bool(options["is_inverter"]),
+                    limit=12,
+                )
+                sorted_products = [
+                    product
+                    for product in cls._sort_for_tier(products, tier_key)
+                    if int(product.get("id") or 0) not in seen_ids
+                ]
+                picked = sorted_products[:limit_per_tier]
+                for product in picked:
+                    seen_ids.add(int(product.get("id") or 0))
+                area_payload["tiers"].append(
+                    {
+                        "key": tier_key,
+                        "label": label,
+                        "products": picked,
+                    }
+                )
+            result["areas"].append(area_payload)
+        return result
+
+    @classmethod
+    def format_selection(cls, selection: dict[str, Any]) -> str:
+        if not selection.get("areas"):
+            return selection.get("message") or "Ничего не подобрал."
+
+        lines = ["<b>Подбор кондиционеров для клиента</b>"]
+        for area in selection["areas"]:
+            lines.extend(["", f"<b>{area['area']} м²</b>"])
+            for tier in area["tiers"]:
+                products = tier.get("products") or []
+                if not products:
+                    lines.append(f"{tier['label']}: нет подходящих моделей")
+                    continue
+                product = products[0]
+                reason = cls.availability_text(product)
+                lines.append(
+                    f"{tier['label']}: {product.get('title')} - {product.get('price')} руб.\n"
+                    f"{reason}\n"
+                    f"{cls.product_url(product)}"
+                )
+        return "\n".join(lines)

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -1,0 +1,280 @@
+import json
+import re
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from schemas import ManagerOrderCreatePayload, OrderWorkStageCreatePayload
+from services.order_service import OrderService
+
+
+class BotQuickOrderService:
+    SERVICE_LABELS = {
+        "turnkey": "Продажа + монтаж",
+        "install_only": "Монтаж",
+        "pre_install": "Закладка трассы",
+        "maintenance": "Обслуживание",
+        "repair": "Ремонт",
+        "dismantling": "Демонтаж",
+    }
+
+    @staticmethod
+    def _clean_optional(value: Any) -> Optional[str]:
+        cleaned = " ".join(str(value or "").split())
+        return cleaned or None
+
+    @staticmethod
+    def _extract_json_object(content: str) -> dict[str, Any]:
+        text = str(content or "").strip()
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+            if not match:
+                raise ValueError("AI response does not contain JSON")
+            parsed = json.loads(match.group(0))
+        if not isinstance(parsed, dict):
+            raise ValueError("AI response JSON must be an object")
+        return parsed
+
+    @staticmethod
+    def _extract_phone(text: str) -> Optional[str]:
+        match = re.search(r"(\+?\d[\d\s().-]{6,}\d)", text)
+        if not match:
+            return None
+        phone = re.sub(r"\s+", " ", match.group(1)).strip()
+        return phone
+
+    @staticmethod
+    def _infer_service_type(text: str) -> Optional[str]:
+        value = text.casefold()
+        if any(marker in value for marker in ("демонтаж", "снять кондиционер")):
+            return "dismantling"
+        if any(marker in value for marker in ("ремонт", "не работает", "не холодит", "ошибк", "диагност")):
+            return "repair"
+        if any(marker in value for marker in ("обслуж", " то ", "то,", "то.", "сервис", "чистк")):
+            return "maintenance"
+        if any(marker in value for marker in ("заклад", "трасс")):
+            return "pre_install"
+        if any(marker in value for marker in ("монтаж", "установ")):
+            return "install_only"
+        if any(marker in value for marker in ("куп", "подбор", "кондиционер", "сплит")):
+            return "turnkey"
+        return None
+
+    @staticmethod
+    def _parse_date(text: str, *, now: Optional[datetime] = None) -> Optional[datetime]:
+        now = now or datetime.now()
+        value = text.casefold()
+        day: Optional[datetime] = None
+        if "послезавтра" in value:
+            day = now + timedelta(days=2)
+        elif "завтра" in value:
+            day = now + timedelta(days=1)
+        elif "сегодня" in value:
+            day = now
+        else:
+            match = re.search(r"\b(\d{1,2})[./-](\d{1,2})(?:[./-](\d{2,4}))?\b", value)
+            if match:
+                day_num = int(match.group(1))
+                month_num = int(match.group(2))
+                year_num = int(match.group(3)) if match.group(3) else now.year
+                if year_num < 100:
+                    year_num += 2000
+                try:
+                    day = now.replace(year=year_num, month=month_num, day=day_num)
+                except ValueError:
+                    day = None
+
+        if day is None:
+            return None
+
+        time_match = re.search(r"\b(?:в\s*)?(\d{1,2})(?::(\d{2}))\b", value)
+        if time_match:
+            hour = int(time_match.group(1))
+            minute = int(time_match.group(2) or 0)
+        else:
+            hour = 9
+            minute = 0
+        if hour > 23 or minute > 59:
+            return day.replace(hour=9, minute=0, second=0, microsecond=0)
+        return day.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+    @staticmethod
+    def _extract_name(text: str, phone: Optional[str]) -> Optional[str]:
+        cleaned = text.replace(phone, " ") if phone else text
+        for marker in ("клиент", "имя", "зовут"):
+            match = re.search(rf"{marker}\s*[:,-]?\s*([А-ЯA-Z][а-яa-zА-ЯA-Z-]{{2,}})", cleaned)
+            if match:
+                return match.group(1)
+        parts = [part.strip() for part in re.split(r"[,;\n]", cleaned) if part.strip()]
+        for part in parts:
+            if re.fullmatch(r"[А-ЯA-Z][а-яa-zА-ЯA-Z-]{2,}(?:\s+[А-ЯA-Z][а-яa-zА-ЯA-Z-]{2,})?", part):
+                return part
+        return None
+
+    @staticmethod
+    def _extract_address(text: str) -> Optional[str]:
+        match = re.search(
+            r"(?:адрес|объект)\s*[:,-]?\s*(.+?)(?:$|тел|телефон|\+?\d[\d\s().-]{6,}\d)",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            return BotQuickOrderService._clean_optional(match.group(1).strip(" ,.;"))
+
+        markers = ("ул", "улица", "пр-т", "проспект", "пер", "переулок", "победы", "московский")
+        parts = [part.strip(" ,.;") for part in re.split(r"[,;\n]", text) if part.strip()]
+        for part in parts:
+            lowered = part.casefold()
+            if any(marker in lowered for marker in markers) and re.search(r"\d", part):
+                return BotQuickOrderService._clean_optional(part)
+        return None
+
+    @classmethod
+    def parse_text_fallback(cls, text: str, *, now: Optional[datetime] = None) -> dict[str, Any]:
+        phone = cls._extract_phone(text)
+        service_type = cls._infer_service_type(text)
+        target_date = cls._parse_date(text, now=now)
+        name = cls._extract_name(text, phone)
+        address = cls._extract_address(text)
+        return {
+            "name": name,
+            "phone": phone,
+            "address": address,
+            "service_type": service_type,
+            "target_date": target_date.isoformat() if target_date else None,
+            "request_text": cls._clean_optional(text) or "",
+            "parser": "fallback",
+        }
+
+    @classmethod
+    def build_ai_prompt(cls, text: str) -> str:
+        return (
+            "Ты извлекаешь черновик CRM-заказа из сообщения менеджера Telegram. "
+            "Компания занимается продажей, монтажом, ремонтом и обслуживанием кондиционеров. "
+            "Верни только JSON без markdown со структурой: "
+            '{"name": string|null, "phone": string|null, "address": string|null, '
+            '"service_type": "turnkey"|"install_only"|"pre_install"|"maintenance"|"repair"|"dismantling"|null, '
+            '"target_date": ISO datetime string|null, "request_text": string}. '
+            "Не выдумывай данные. Если дата относительная, считай от текущей даты сервера. "
+            f"Сообщение: {json.dumps(text, ensure_ascii=False)}"
+        )
+
+    @classmethod
+    async def parse_text(cls, text: str) -> dict[str, Any]:
+        fallback = cls.parse_text_fallback(text)
+        token = settings.DEEPSEEK_TOKEN.strip()
+        if not token:
+            return fallback
+
+        try:
+            async with httpx.AsyncClient(timeout=12.0) as client:
+                response = await client.post(
+                    settings.DEEPSEEK_API_URL,
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={
+                        "model": settings.DEEPSEEK_MODEL,
+                        "messages": [
+                            {"role": "system", "content": "Возвращай только валидный JSON."},
+                            {"role": "user", "content": cls.build_ai_prompt(text)},
+                        ],
+                        "temperature": 0,
+                    },
+                )
+                response.raise_for_status()
+                content = response.json()["choices"][0]["message"]["content"]
+            parsed = cls._extract_json_object(content)
+        except Exception:
+            return fallback
+
+        merged = dict(fallback)
+        for key in ("name", "phone", "address", "service_type", "target_date", "request_text"):
+            value = parsed.get(key)
+            if value:
+                merged[key] = value
+        merged["parser"] = "ai"
+        return cls.normalize_draft(merged)
+
+    @classmethod
+    def normalize_draft(cls, draft: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(draft or {})
+        normalized["name"] = cls._clean_optional(normalized.get("name"))
+        normalized["phone"] = cls._clean_optional(normalized.get("phone"))
+        normalized["address"] = cls._clean_optional(normalized.get("address"))
+        normalized["request_text"] = cls._clean_optional(normalized.get("request_text")) or ""
+        service_type = cls._clean_optional(normalized.get("service_type"))
+        normalized["service_type"] = service_type if service_type in cls.SERVICE_LABELS else None
+        target_date = normalized.get("target_date")
+        if isinstance(target_date, datetime):
+            normalized["target_date"] = target_date.isoformat()
+        elif target_date:
+            try:
+                normalized["target_date"] = datetime.fromisoformat(str(target_date).replace("Z", "+00:00")).isoformat()
+            except ValueError:
+                normalized["target_date"] = None
+        else:
+            normalized["target_date"] = None
+        return normalized
+
+    @classmethod
+    def format_draft_preview(cls, draft: dict[str, Any]) -> str:
+        target_date = draft.get("target_date")
+        if target_date:
+            try:
+                dt = datetime.fromisoformat(str(target_date).replace("Z", "+00:00"))
+                target_date = dt.strftime("%d.%m.%Y %H:%M")
+            except ValueError:
+                pass
+        service_type = draft.get("service_type")
+        lines = [
+            "<b>Черновик заказа</b>",
+            f"Клиент: {draft.get('name') or 'не указан'}",
+            f"Телефон: {draft.get('phone') or 'не указан'}",
+            f"Адрес: {draft.get('address') or 'не указан'}",
+            f"Услуга: {cls.SERVICE_LABELS.get(service_type, 'не указана')}",
+            f"Дата: {target_date or 'не указана'}",
+            "",
+            f"<i>{draft.get('request_text') or ''}</i>",
+        ]
+        return "\n".join(lines)
+
+    @classmethod
+    async def create_order_from_draft(
+        cls,
+        session: AsyncSession,
+        draft: dict[str, Any],
+    ) -> dict[str, Any]:
+        normalized = cls.normalize_draft(draft)
+        target_date = None
+        if normalized.get("target_date"):
+            target_date = datetime.fromisoformat(str(normalized["target_date"]).replace("Z", "+00:00"))
+
+        payload = ManagerOrderCreatePayload(
+            source="bot",
+            request_text=normalized["request_text"] or "Быстрый заказ из Telegram",
+            name=normalized.get("name"),
+            phone=normalized.get("phone"),
+            address=normalized.get("address"),
+            service_type=normalized.get("service_type"),
+            target_date=target_date,
+            customer_type="individual",
+        )
+        order = await OrderService.create_manager_order(session=session, payload=payload)
+        if not order:
+            raise ValueError("Не удалось создать заказ")
+
+        service_type = normalized.get("service_type")
+        if target_date and service_type != "maintenance":
+            stage_payload = OrderWorkStageCreatePayload(
+                name=cls.SERVICE_LABELS.get(service_type, "Рабочая задача"),
+                start_time=target_date,
+                manager_comment=normalized["request_text"],
+            )
+            updated = await OrderService.add_order_stage(session, int(order["id"]), stage_payload)
+            return updated or order
+
+        return order

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,0 +1,179 @@
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models import Order, OrderInstaller, OrderStageStatus, OrderWorkStage, StaffUser
+from services.staff_user_service import StaffUserService
+
+
+class BotTaskService:
+    @staticmethod
+    async def _staff_by_telegram_id(session: AsyncSession, telegram_id: int | str | None) -> StaffUser | None:
+        try:
+            normalized_telegram_id = int(telegram_id) if telegram_id is not None else 0
+        except (TypeError, ValueError):
+            return None
+        if not normalized_telegram_id:
+            return None
+        result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id == normalized_telegram_id)
+            .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+        )
+        return result.scalars().first()
+
+    @classmethod
+    async def list_my_tasks(
+        cls,
+        session: AsyncSession,
+        telegram_id: int | str | None,
+        *,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        staff = await cls._staff_by_telegram_id(session, telegram_id)
+        if not staff or not staff.legacy_installer_id:
+            return []
+
+        now = datetime.now() - timedelta(days=1)
+        until = datetime.now() + timedelta(days=30)
+        installer_id = int(staff.legacy_installer_id)
+
+        stage_result = await session.execute(
+            select(OrderWorkStage)
+            .join(Order, Order.id == OrderWorkStage.order_id)
+            .where(OrderWorkStage.installer_id == installer_id)
+            .where(
+                or_(
+                    OrderWorkStage.start_time.is_(None),
+                    (OrderWorkStage.start_time >= now) & (OrderWorkStage.start_time <= until),
+                )
+            )
+            .where(OrderWorkStage.status != OrderStageStatus.COMPLETED)
+            .where(OrderWorkStage.status != OrderStageStatus.CANCELED)
+            .options(
+                selectinload(OrderWorkStage.order).selectinload(Order.customer),
+                selectinload(OrderWorkStage.installer),
+            )
+            .order_by(OrderWorkStage.start_time.asc().nullslast(), OrderWorkStage.id.asc())
+            .limit(limit)
+        )
+        tasks = [cls._map_stage(stage) for stage in stage_result.scalars().all()]
+        if tasks:
+            return tasks
+
+        order_result = await session.execute(
+            select(Order)
+            .join(OrderInstaller, OrderInstaller.order_id == Order.id)
+            .where(OrderInstaller.installer_id == installer_id)
+            .where(
+                or_(
+                    Order.installation_date.is_(None),
+                    (Order.installation_date >= now) & (Order.installation_date <= until),
+                )
+            )
+            .options(selectinload(Order.customer), selectinload(Order.installers))
+            .order_by(Order.installation_date.asc().nullslast(), Order.id.asc())
+            .limit(limit)
+        )
+        return [cls._map_order(order) for order in order_result.scalars().all()]
+
+    @staticmethod
+    def _customer_phone(order: Order) -> str | None:
+        customer = getattr(order, "customer", None)
+        return getattr(customer, "phone", None) if customer else None
+
+    @staticmethod
+    def _customer_name(order: Order) -> str:
+        customer = getattr(order, "customer", None)
+        return getattr(customer, "name", None) or "Клиент"
+
+    @classmethod
+    def _map_stage(cls, stage: OrderWorkStage) -> dict[str, Any]:
+        order = stage.order
+        return {
+            "kind": "stage",
+            "id": int(stage.id or 0),
+            "order_id": int(stage.order_id),
+            "title": stage.name,
+            "status": stage.status.value if hasattr(stage.status, "value") else str(stage.status),
+            "start_time": stage.start_time,
+            "address": order.delivery_address if order else None,
+            "customer_name": cls._customer_name(order) if order else "Клиент",
+            "customer_phone": cls._customer_phone(order) if order else None,
+            "comment": stage.manager_comment,
+        }
+
+    @classmethod
+    def _map_order(cls, order: Order) -> dict[str, Any]:
+        return {
+            "kind": "order",
+            "id": int(order.id or 0),
+            "order_id": int(order.id or 0),
+            "title": order.title or "Монтаж",
+            "status": order.status.value if hasattr(order.status, "value") else str(order.status),
+            "start_time": order.installation_date,
+            "address": order.delivery_address,
+            "customer_name": cls._customer_name(order),
+            "customer_phone": cls._customer_phone(order),
+            "comment": order.comment,
+        }
+
+    @staticmethod
+    def format_tasks(tasks: list[dict[str, Any]]) -> str:
+        if not tasks:
+            return "У вас нет ближайших задач."
+        lines = ["<b>Мои ближайшие задачи</b>"]
+        for task in tasks:
+            dt = task.get("start_time")
+            date_text = dt.strftime("%d.%m.%Y %H:%M") if dt else "время не назначено"
+            lines.extend(
+                [
+                    "",
+                    f"<b>#{task['order_id']} - {task['title']}</b>",
+                    f"Дата: {date_text}",
+                    f"Клиент: {task.get('customer_name') or 'Клиент'}",
+                    f"Телефон: {task.get('customer_phone') or 'не указан'}",
+                    f"Адрес: {task.get('address') or 'не указан'}",
+                ]
+            )
+            if task.get("comment"):
+                lines.append(f"Комментарий: {task['comment']}")
+        return "\n".join(lines)
+
+    @staticmethod
+    async def update_stage_status(
+        session: AsyncSession,
+        stage_id: int,
+        status: str,
+        *,
+        telegram_id: int | str | None,
+    ) -> bool:
+        staff = await BotTaskService._staff_by_telegram_id(session, telegram_id)
+        stage = await session.get(OrderWorkStage, stage_id)
+        if not staff or not stage or stage.installer_id != staff.legacy_installer_id:
+            return False
+        stage.status = OrderStageStatus(status)
+        session.add(stage)
+        await session.commit()
+        return True
+
+    @staticmethod
+    async def save_stage_report(
+        session: AsyncSession,
+        stage_id: int,
+        report: str,
+        *,
+        telegram_id: int | str | None,
+    ) -> bool:
+        staff = await BotTaskService._staff_by_telegram_id(session, telegram_id)
+        stage = await session.get(OrderWorkStage, stage_id)
+        if not staff or not stage or stage.installer_id != staff.legacy_installer_id:
+            return False
+        stage.installer_report = report.strip()
+        session.add(stage)
+        await session.commit()
+        return True

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -1,0 +1,160 @@
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import StaffUser
+from services.bot_access_service import BotAccessService
+from services.bot_product_selection_service import BotProductSelectionService
+from services.bot_quick_order_service import BotQuickOrderService
+from services.product_service import ProductService
+from bot_app.utils import format_caption
+
+
+@pytest.fixture
+async def sqlite_staff_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'bot_staff.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def test_quick_order_fallback_parses_service_phone_address_and_date():
+    draft = BotQuickOrderService.parse_text_fallback(
+        "ТО, Иван, +375 29 123-45-67, Победы 15, завтра 14:00",
+        now=datetime(2026, 6, 14, 10, 0),
+    )
+
+    assert draft["service_type"] == "maintenance"
+    assert draft["phone"] == "+375 29 123-45-67"
+    assert draft["name"] == "Иван"
+    assert draft["address"] == "Победы 15"
+    assert draft["target_date"] == "2026-06-15T14:00:00"
+
+
+def test_product_caption_contains_public_product_link(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+
+    caption = format_caption(
+        {
+            "id": 1,
+            "title": "Midea 12",
+            "slug": "midea-12",
+            "price": 1200,
+            "area": 35,
+            "description": "",
+        }
+    )
+
+    assert "https://example.test/product/midea-12/" in caption
+
+
+def test_product_selection_sorts_by_vitebsk_then_minsk_then_unknown():
+    products = [
+        {"id": 1, "price": 1000, "vitebsk_qty": 0, "minsk_qty": 0, "availability_status": "check_availability"},
+        {"id": 2, "price": 1500, "vitebsk_qty": 0, "minsk_qty": 3, "availability_status": "available_2_3_days"},
+        {"id": 3, "price": 1800, "vitebsk_qty": 1, "minsk_qty": 0, "availability_status": "in_stock_now"},
+    ]
+
+    sorted_products = BotProductSelectionService._sort_for_tier(products, "budget")
+
+    assert [item["id"] for item in sorted_products] == [3, 2, 1]
+
+
+def test_product_selection_parse_areas():
+    assert BotProductSelectionService.parse_areas("подбор 20 м² и 35 квадратов") == [20, 35]
+
+
+@pytest.mark.asyncio
+async def test_bot_access_context_for_staff_and_non_staff(sqlite_staff_session):
+    sqlite_staff_session.add(
+        StaffUser(
+            display_name="Менеджер",
+            status="active",
+            primary_role="manager",
+            roles=["manager"],
+            telegram_id=777,
+        )
+    )
+    await sqlite_staff_session.commit()
+
+    staff = await BotAccessService.get_context(sqlite_staff_session, 777)
+    outsider = await BotAccessService.get_context(sqlite_staff_session, 888)
+
+    assert staff.is_staff
+    assert staff.is_manager
+    assert staff.display_name == "Менеджер"
+    assert not outsider.is_staff
+
+
+@pytest.mark.asyncio
+async def test_product_selection_builds_tiers(monkeypatch):
+    async def fake_get_curated(session, area, is_inverter, limit=12, **kwargs):
+        if is_inverter:
+            return [
+                {"id": area * 10 + 1, "title": f"Premium {area}", "slug": f"premium-{area}", "price": 2000, "vitebsk_qty": 0, "minsk_qty": 2},
+                {"id": area * 10 + 2, "title": f"Optimal {area}", "slug": f"optimal-{area}", "price": 1500, "vitebsk_qty": 1, "minsk_qty": 0},
+            ]
+        return [
+            {"id": area * 10 + 3, "title": f"Budget {area}", "slug": f"budget-{area}", "price": 1000, "vitebsk_qty": 1, "minsk_qty": 0}
+        ]
+
+    monkeypatch.setattr(ProductService, "get_curated", fake_get_curated)
+
+    selection = await BotProductSelectionService.build_selection(object(), "20 и 35 м²")
+
+    assert [area["area"] for area in selection["areas"]] == [20, 35]
+    assert [tier["label"] for tier in selection["areas"][0]["tiers"]] == ["Бюджетнее", "Оптимально", "Премиум"]
+
+
+@pytest.mark.asyncio
+async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(monkeypatch):
+    calls = {}
+
+    async def fake_create_manager_order(session, payload):
+        calls["payload"] = payload
+        return {"id": 42}
+
+    async def fake_add_order_stage(session, order_id, payload):
+        calls["stage_order_id"] = order_id
+        calls["stage_payload"] = payload
+        return {"id": order_id, "work_stages": [{"name": payload.name}]}
+
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.OrderService.create_manager_order",
+        fake_create_manager_order,
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.OrderService.add_order_stage",
+        fake_add_order_stage,
+    )
+
+    order = await BotQuickOrderService.create_order_from_draft(
+        object(),
+        {
+            "name": "Иван",
+            "phone": "+375291234567",
+            "address": "Победы 15",
+            "service_type": "install_only",
+            "target_date": "2026-06-15T14:00:00",
+            "request_text": "Монтаж, Иван, Победы 15",
+        },
+    )
+
+    assert order["id"] == 42
+    assert calls["payload"].source == "bot"
+    assert calls["payload"].service_type == "install_only"
+    assert calls["stage_order_id"] == 42
+    assert calls["stage_payload"].name == "Монтаж"


### PR DESCRIPTION
## What changed

- Converted the Telegram bot entrypoint to staff-first workflows and stopped registering the old customer cart/favorites/order handlers.
- Added role-aware staff menus, quick order creation from free-form call text, manager product selection with public product links, and installer task views/actions.
- Added bot service layers for access, quick orders, product selection, and task handling.
- Added `PUBLIC_SITE_URL` config fallback for product links.
- Added focused unit coverage for bot access, quick order parsing/creation, product links, and selection sorting.

## Impact

The bot is now a working tool for managers/admins/installers. Non-staff users only see a short staff-only message. Existing admin OCR requisites recognition and notification services remain connected.

## Validation

- `python3 -m compileall bot_app services/bot_access_service.py services/bot_quick_order_service.py services/bot_product_selection_service.py services/bot_task_service.py`
- `pytest tests/unit/test_bot_work_services.py tests/unit/test_bot_auto_search_query.py tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_admin_handler.py -q` -> `21 passed`

Note: broader order-service tests that depend on the Docker `db_test` host could not run in this local shell because `db_test` is not resolvable outside the compose network.