### PR TITLE
Improve staff bot product selection by power class

### DIFF
--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -13,6 +13,37 @@ class BotProductSelectionService:
         ("optimal", "Оптимально", {"is_inverter": True, "sort": "balanced"}),
         ("premium", "Премиум", {"is_inverter": True, "sort": "premium"}),
     )
+    INVERTER_TIERS = (
+        ("optimal", "Оптимально", {"is_inverter": True, "sort": "balanced"}),
+        ("premium", "Премиум", {"is_inverter": True, "sort": "premium"}),
+    )
+    ONOFF_TIERS = (
+        ("onoff", "ON-OFF", {"is_inverter": False, "sort": "price"}),
+    )
+    DEFAULT_TAG_SLUGS = ["cat-household"]
+    POWER_CLASSES = {
+        "7": {"kw": 1.9, "area": (15, 24)},
+        "9": {"kw": 2.6, "area": (25, 32)},
+        "12": {"kw": 3.5, "area": (33, 42)},
+        "18": {"kw": 5.3, "area": (45, 60)},
+        "24": {"kw": 7.0, "area": (65, 80)},
+        "36": {"kw": 10.5, "area": (90, 110)},
+    }
+    POWER_CLASS_ALIASES = {
+        "7": ("семерка", "семерки", "семерок", "семерочка", "семерочки"),
+        "9": ("девятка", "девятки", "девяток"),
+        "12": ("двенашка", "двенашки", "двенадцатка", "двенадцатки"),
+        "18": ("восемнашка", "восемнашки"),
+        "24": ("двадцатьчетверка", "двадцатьчетверки"),
+    }
+    COUNT_WORDS = {
+        "одна": 1,
+        "один": 1,
+        "две": 2,
+        "два": 2,
+        "три": 3,
+        "четыре": 4,
+    }
 
     @staticmethod
     def product_url(product: dict[str, Any]) -> str:
@@ -28,6 +59,112 @@ class BotProductSelectionService:
             if 8 <= value <= 120 and value not in areas:
                 areas.append(value)
         return areas[:4]
+
+    @classmethod
+    def _normalize_text(cls, text: str) -> str:
+        return (text or "").casefold().replace("ё", "е")
+
+    @classmethod
+    def _normalize_power_code(cls, value: str) -> str | None:
+        normalized = str(value or "").strip().lstrip("0") or "0"
+        return normalized if normalized in cls.POWER_CLASSES else None
+
+    @classmethod
+    def _target_for_power_class(cls, code: str) -> dict[str, Any]:
+        config = cls.POWER_CLASSES[code]
+        area_min = int(config["area"][0])
+        area_max = int(config["area"][1])
+        kw = float(config["kw"])
+        kw_text = str(kw).replace(".", ",")
+        return {
+            "kind": "power_class",
+            "code": code,
+            "label": f"{code} ({kw_text} кВт)",
+            "area": area_min,
+            "area_min": area_min,
+            "area_max": area_max,
+            "kw": kw,
+        }
+
+    @classmethod
+    def _target_for_area(cls, area: int) -> dict[str, Any]:
+        return {
+            "kind": "area",
+            "area": area,
+            "area_min": area,
+            "area_max": None,
+            "label": f"{area} м²",
+        }
+
+    @classmethod
+    def parse_selection_request(cls, text: str) -> dict[str, Any]:
+        normalized = cls._normalize_text(text)
+        targets: list[dict[str, Any]] = []
+
+        alias_to_code = {
+            alias: code
+            for code, aliases in cls.POWER_CLASS_ALIASES.items()
+            for alias in aliases
+        }
+        alias_pattern = "|".join(sorted((re.escape(alias) for alias in alias_to_code), key=len, reverse=True))
+        token_pattern = re.compile(
+            rf"(?:(?P<count>\b\d{{1,2}}\b|{'|'.join(cls.COUNT_WORDS)})\s+)?(?P<alias>{alias_pattern})\b"
+            r"|(?P<number>\b\d{1,3}\b)\s*(?P<unit>м2|м²|кв\.?|квадрат(?:ов|а)?|квадратный метр(?:ов|а)?)?",
+            re.IGNORECASE,
+        )
+
+        for match in token_pattern.finditer(normalized):
+            alias = match.group("alias")
+            if alias:
+                count_raw = match.group("count")
+                count = cls.COUNT_WORDS.get(str(count_raw or "").strip(), None)
+                if count is None:
+                    count = int(count_raw) if str(count_raw or "").isdigit() else 1
+                count = max(1, min(count, 6))
+                code = alias_to_code[alias]
+                targets.extend(cls._target_for_power_class(code) for _ in range(count))
+                continue
+
+            number_raw = match.group("number")
+            if not number_raw:
+                continue
+            value = int(number_raw)
+            unit = match.group("unit")
+            power_code = cls._normalize_power_code(number_raw)
+            if unit:
+                if 8 <= value <= 120:
+                    targets.append(cls._target_for_area(value))
+            elif power_code:
+                targets.append(cls._target_for_power_class(power_code))
+            elif 8 <= value <= 120:
+                targets.append(cls._target_for_area(value))
+
+            if len(targets) >= 6:
+                targets = targets[:6]
+                break
+
+        compressor_mode = "mixed"
+        mode_reason = ""
+        if re.search(r"\b(серверн\w*|on[\s-]?off|он[\s-]?офф|он[\s-]?оф|неинвертор\w*)\b", normalized):
+            compressor_mode = "onoff_only"
+            mode_reason = "серверная" if "серверн" in normalized else "ON-OFF"
+        elif re.search(r"\b(инвертор\w*|inverter\w*)\b", normalized):
+            compressor_mode = "inverter_only"
+            mode_reason = "инверторы"
+
+        return {
+            "targets": targets,
+            "compressor_mode": compressor_mode,
+            "mode_reason": mode_reason,
+        }
+
+    @classmethod
+    def _tiers_for_mode(cls, compressor_mode: str):
+        if compressor_mode == "inverter_only":
+            return cls.INVERTER_TIERS
+        if compressor_mode == "onoff_only":
+            return cls.ONOFF_TIERS
+        return cls.TIERS
 
     @staticmethod
     def availability_rank(product: dict[str, Any]) -> int:
@@ -49,7 +186,7 @@ class BotProductSelectionService:
         def price(product: dict[str, Any]) -> int:
             return int(product.get("price") or 0)
 
-        if tier_key == "budget":
+        if tier_key in {"budget", "onoff"}:
             return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), price(item)))
         if tier_key == "premium":
             return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), -price(item)))
@@ -80,19 +217,34 @@ class BotProductSelectionService:
         *,
         limit_per_tier: int = 1,
     ) -> dict[str, Any]:
-        areas = cls.parse_areas(query)
-        if not areas:
-            return {"areas": [], "message": "Не нашел площадь. Напишите, например: подбор 20 и 35 м²."}
+        parsed = cls.parse_selection_request(query)
+        targets = parsed["targets"]
+        if not targets:
+            return {"areas": [], "message": "Не нашел мощность или площадь. Напишите, например: подбор 7,7,12 или 20 и 35 м²."}
 
-        result: dict[str, Any] = {"areas": []}
-        for area in areas:
-            area_payload = {"area": area, "tiers": []}
+        result: dict[str, Any] = {
+            "areas": [],
+            "compressor_mode": parsed["compressor_mode"],
+            "mode_reason": parsed["mode_reason"],
+        }
+        tiers = cls._tiers_for_mode(parsed["compressor_mode"])
+        for target in targets:
+            area_payload = {
+                "area": target["area"],
+                "label": target["label"],
+                "kind": target["kind"],
+                "code": target.get("code"),
+                "tiers": [],
+            }
             seen_ids: set[int] = set()
-            for tier_key, label, options in cls.TIERS:
+            for tier_key, label, options in tiers:
                 products = await ProductService.get_curated(
                     session,
-                    area=area,
+                    area=target["area"],
+                    area_min=target["area_min"],
+                    area_max=target["area_max"],
                     is_inverter=bool(options["is_inverter"]),
+                    tag_slugs=cls.DEFAULT_TAG_SLUGS,
                     limit=12,
                 )
                 sorted_products = [
@@ -119,8 +271,15 @@ class BotProductSelectionService:
             return selection.get("message") or "Ничего не подобрал."
 
         lines = ["<b>Подбор кондиционеров для клиента</b>"]
+        mode = selection.get("compressor_mode")
+        if mode == "inverter_only":
+            lines.append("Режим: только инверторы")
+        elif mode == "onoff_only":
+            reason = f" ({selection.get('mode_reason')})" if selection.get("mode_reason") else ""
+            lines.append(f"Режим: только ON-OFF{reason}")
         for area in selection["areas"]:
-            lines.extend(["", f"<b>{area['area']} м²</b>"])
+            area_label = area.get("label") or f"{area['area']} м²"
+            lines.extend(["", f"<b>{area_label}</b>"])
             for tier in area["tiers"]:
                 products = tier.get("products") or []
                 if not products:

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -99,6 +99,7 @@ class BotProductSelectionService:
     @classmethod
     def parse_selection_request(cls, text: str) -> dict[str, Any]:
         normalized = cls._normalize_text(text)
+        max_targets = 6
         targets: list[dict[str, Any]] = []
 
         alias_to_code = {
@@ -123,29 +124,31 @@ class BotProductSelectionService:
                 count = max(1, min(count, 6))
                 code = alias_to_code[alias]
                 targets.extend(cls._target_for_power_class(code) for _ in range(count))
-                continue
-
-            number_raw = match.group("number")
-            if not number_raw:
-                continue
-            value = int(number_raw)
-            unit = match.group("unit")
-            power_code = cls._normalize_power_code(number_raw)
-            if unit:
-                if 8 <= value <= 120:
+            else:
+                number_raw = match.group("number")
+                if not number_raw:
+                    continue
+                value = int(number_raw)
+                unit = match.group("unit")
+                power_code = cls._normalize_power_code(number_raw)
+                if unit:
+                    if 8 <= value <= 120:
+                        targets.append(cls._target_for_area(value))
+                elif power_code:
+                    targets.append(cls._target_for_power_class(power_code))
+                elif 8 <= value <= 120:
                     targets.append(cls._target_for_area(value))
-            elif power_code:
-                targets.append(cls._target_for_power_class(power_code))
-            elif 8 <= value <= 120:
-                targets.append(cls._target_for_area(value))
 
-            if len(targets) >= 6:
-                targets = targets[:6]
+            if len(targets) >= max_targets:
+                targets = targets[:max_targets]
                 break
 
         compressor_mode = "mixed"
         mode_reason = ""
-        if re.search(r"\b(серверн\w*|on[\s-]?off|он[\s-]?офф|он[\s-]?оф|неинвертор\w*)\b", normalized):
+        if re.search(
+            r"\b(серверн\w*|on[\s/-]?off|он[\s-]?офф|он[\s-]?оф|не\s+инвертор\w*|неинвертор\w*)\b",
+            normalized,
+        ):
             compressor_mode = "onoff_only"
             mode_reason = "серверная" if "серверн" in normalized else "ON-OFF"
         elif re.search(r"\b(инвертор\w*|inverter\w*)\b", normalized):

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -154,7 +154,7 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
     @staticmethod
     async def get_curated(
         session: AsyncSession,
-        area: int,
+        area: Optional[int],
         is_inverter: bool,
         tag_slugs: Optional[List[str]] = None,
         heating_min: Optional[int] = None,
@@ -162,6 +162,8 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
         has_fresh_air: Optional[bool] = None,
         min_price: Optional[int] = None,
         max_price: Optional[int] = None,
+        area_min: Optional[int] = None,
+        area_max: Optional[int] = None,
         limit: int = 5,
     ) -> List[Dict[str, Any]]:
         faceted_tag_ids = None
@@ -170,7 +172,8 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
 
         products = await ProductDAO.get_filtered(
             session,
-            area_min=area,
+            area_min=area_min if area_min is not None else area,
+            area_max=area_max,
             is_inverter=is_inverter,
             heating_min=heating_min,
             has_wifi=has_wifi,

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -77,6 +77,31 @@ def test_product_selection_parse_areas():
     assert BotProductSelectionService.parse_areas("подбор 20 м² и 35 квадратов") == [20, 35]
 
 
+def test_product_selection_parse_power_classes_preserves_repeats():
+    parsed = BotProductSelectionService.parse_selection_request("подбор 7,7,12")
+
+    assert [target["code"] for target in parsed["targets"]] == ["7", "7", "12"]
+    assert [target["kw"] for target in parsed["targets"]] == [1.9, 1.9, 3.5]
+    assert parsed["targets"][0]["label"] == "7 (1,9 кВт)"
+    assert parsed["compressor_mode"] == "mixed"
+
+
+def test_product_selection_parse_power_class_words_and_inverter_mode():
+    parsed = BotProductSelectionService.parse_selection_request("нужно две семёрки и двенашка, инвертора")
+
+    assert [target["code"] for target in parsed["targets"]] == ["7", "7", "12"]
+    assert parsed["compressor_mode"] == "inverter_only"
+    assert parsed["mode_reason"] == "инверторы"
+
+
+def test_product_selection_parse_server_room_forces_onoff_mode():
+    parsed = BotProductSelectionService.parse_selection_request("серверная, 7 и 12, только on-off")
+
+    assert [target["code"] for target in parsed["targets"]] == ["7", "12"]
+    assert parsed["compressor_mode"] == "onoff_only"
+    assert parsed["mode_reason"] == "серверная"
+
+
 @pytest.mark.asyncio
 async def test_bot_access_context_for_staff_and_non_staff(sqlite_staff_session):
     sqlite_staff_session.add(
@@ -117,6 +142,70 @@ async def test_product_selection_builds_tiers(monkeypatch):
 
     assert [area["area"] for area in selection["areas"]] == [20, 35]
     assert [tier["label"] for tier in selection["areas"][0]["tiers"]] == ["Бюджетнее", "Оптимально", "Премиум"]
+
+
+@pytest.mark.asyncio
+async def test_product_selection_builds_power_classes_and_inverter_only(monkeypatch):
+    calls = []
+
+    async def fake_get_curated(session, area, is_inverter, limit=12, **kwargs):
+        calls.append(
+            {
+                "area": area,
+                "area_min": kwargs.get("area_min"),
+                "area_max": kwargs.get("area_max"),
+                "is_inverter": is_inverter,
+                "tag_slugs": kwargs.get("tag_slugs"),
+            }
+        )
+        return [
+            {
+                "id": len(calls),
+                "title": f"Picked {area}",
+                "slug": f"picked-{area}-{len(calls)}",
+                "price": 1500,
+                "vitebsk_qty": 1,
+                "minsk_qty": 0,
+            }
+        ]
+
+    monkeypatch.setattr(ProductService, "get_curated", fake_get_curated)
+
+    selection = await BotProductSelectionService.build_selection(object(), "7,12 инвертора")
+
+    assert [area["label"] for area in selection["areas"]] == ["7 (1,9 кВт)", "12 (3,5 кВт)"]
+    assert [tier["key"] for tier in selection["areas"][0]["tiers"]] == ["optimal", "premium"]
+    assert {call["is_inverter"] for call in calls} == {True}
+    assert calls[0]["area_min"] == 15
+    assert calls[0]["area_max"] == 24
+    assert calls[0]["tag_slugs"] == ["cat-household"]
+
+
+@pytest.mark.asyncio
+async def test_product_selection_builds_onoff_only_for_server_room(monkeypatch):
+    calls = []
+
+    async def fake_get_curated(session, area, is_inverter, limit=12, **kwargs):
+        calls.append({"is_inverter": is_inverter, "area_min": kwargs.get("area_min"), "area_max": kwargs.get("area_max")})
+        return [
+            {
+                "id": 1,
+                "title": "Server ON-OFF",
+                "slug": "server-onoff",
+                "price": 1000,
+                "vitebsk_qty": 1,
+                "minsk_qty": 0,
+            }
+        ]
+
+    monkeypatch.setattr(ProductService, "get_curated", fake_get_curated)
+
+    selection = await BotProductSelectionService.build_selection(object(), "серверная 12")
+    formatted = BotProductSelectionService.format_selection(selection)
+
+    assert [tier["key"] for tier in selection["areas"][0]["tiers"]] == ["onoff"]
+    assert calls == [{"is_inverter": False, "area_min": 33, "area_max": 42}]
+    assert "Режим: только ON-OFF (серверная)" in formatted
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -102,6 +102,23 @@ def test_product_selection_parse_server_room_forces_onoff_mode():
     assert parsed["mode_reason"] == "серверная"
 
 
+def test_product_selection_parse_non_inverter_wording_forces_onoff_mode():
+    for query in ("не инвертор 12", "не инверторный 12", "on/off 12"):
+        parsed = BotProductSelectionService.parse_selection_request(query)
+
+        assert [target["code"] for target in parsed["targets"]] == ["12"]
+        assert parsed["compressor_mode"] == "onoff_only"
+        assert parsed["mode_reason"] == "ON-OFF"
+
+
+def test_product_selection_parse_limits_word_repeats():
+    parsed = BotProductSelectionService.parse_selection_request(
+        "две семерки две девятки две двенашки две восемнашки"
+    )
+
+    assert [target["code"] for target in parsed["targets"]] == ["7", "7", "9", "9", "12", "12"]
+
+
 @pytest.mark.asyncio
 async def test_bot_access_context_for_staff_and_non_staff(sqlite_staff_session):
     sqlite_staff_session.add(


### PR DESCRIPTION
## Summary
- teach staff bot selection to understand internal power-class requests like `7,7,12` while preserving repeated units
- map `7` to `1.9 кВт` and search by configured area ranges for each power class
- support compressor intent: inverter-only for `инвертор`, ON-OFF-only for `on-off`, `on/off`, `не инвертор`, and `серверная`
- enforce the total parsed target limit for numeric and word-based repeats
- keep staff selection focused on household products and add unit tests for the new parsing/building behavior

## Tests
- `pytest tests/unit/test_bot_auto_search_query.py tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q`
- `python3 -m py_compile services/bot_product_selection_service.py services/product_read_service.py`