### PR TITLE
Support compact quantity syntax in staff bot selection

### DIFF
--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -102,14 +102,32 @@ class BotProductSelectionService:
         max_targets = 6
         targets: list[dict[str, Any]] = []
 
+        def remaining_slots() -> int:
+            return max(max_targets - len(targets), 0)
+
+        def parse_count(value: str | None) -> int:
+            raw = str(value or "").strip()
+            count = cls.COUNT_WORDS.get(raw)
+            if count is None:
+                count = int(raw) if raw.isdigit() else 1
+            return max(1, min(count, max_targets))
+
+        def add_power_targets(code: str, count: int = 1) -> None:
+            for _ in range(min(count, remaining_slots())):
+                targets.append(cls._target_for_power_class(code))
+
         alias_to_code = {
             alias: code
             for code, aliases in cls.POWER_CLASS_ALIASES.items()
             for alias in aliases
         }
         alias_pattern = "|".join(sorted((re.escape(alias) for alias in alias_to_code), key=len, reverse=True))
+        count_value_pattern = rf"[1-6]|{'|'.join(cls.COUNT_WORDS)}"
+        power_code_pattern = "|".join(sorted((re.escape(code) for code in cls.POWER_CLASSES), key=len, reverse=True))
         token_pattern = re.compile(
             rf"(?:(?P<count>\b\d{{1,2}}\b|{'|'.join(cls.COUNT_WORDS)})\s+)?(?P<alias>{alias_pattern})\b"
+            rf"|(?<!\w)(?P<compact_count>{count_value_pattern})\s*(?:x|\*|шт\.?|штук[аи]?)\s*(?P<compact_code>{power_code_pattern})(?!\w)"
+            rf"|(?<!\w)(?P<word_count>{count_value_pattern})\s+(?P<compact_word_code>{power_code_pattern})(?!\w)"
             r"|(?P<number>\b\d{1,3}\b)\s*(?P<unit>м2|м²|кв\.?|квадрат(?:ов|а)?|квадратный метр(?:ов|а)?)?",
             re.IGNORECASE,
         )
@@ -117,13 +135,13 @@ class BotProductSelectionService:
         for match in token_pattern.finditer(normalized):
             alias = match.group("alias")
             if alias:
-                count_raw = match.group("count")
-                count = cls.COUNT_WORDS.get(str(count_raw or "").strip(), None)
-                if count is None:
-                    count = int(count_raw) if str(count_raw or "").isdigit() else 1
-                count = max(1, min(count, 6))
+                count = parse_count(match.group("count"))
                 code = alias_to_code[alias]
-                targets.extend(cls._target_for_power_class(code) for _ in range(count))
+                add_power_targets(code, count)
+            elif match.group("compact_code") or match.group("compact_word_code"):
+                code = cls._normalize_power_code(match.group("compact_code") or match.group("compact_word_code"))
+                if code:
+                    add_power_targets(code, parse_count(match.group("compact_count") or match.group("word_count")))
             else:
                 number_raw = match.group("number")
                 if not number_raw:
@@ -135,7 +153,7 @@ class BotProductSelectionService:
                     if 8 <= value <= 120:
                         targets.append(cls._target_for_area(value))
                 elif power_code:
-                    targets.append(cls._target_for_power_class(power_code))
+                    add_power_targets(power_code)
                 elif 8 <= value <= 120:
                     targets.append(cls._target_for_area(value))
 

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -124,9 +124,11 @@ class BotProductSelectionService:
         alias_pattern = "|".join(sorted((re.escape(alias) for alias in alias_to_code), key=len, reverse=True))
         count_value_pattern = rf"[1-6]|{'|'.join(cls.COUNT_WORDS)}"
         power_code_pattern = "|".join(sorted((re.escape(code) for code in cls.POWER_CLASSES), key=len, reverse=True))
+        compact_separator_pattern = r"x|х|\*"
         token_pattern = re.compile(
             rf"(?:(?P<count>\b\d{{1,2}}\b|{'|'.join(cls.COUNT_WORDS)})\s+)?(?P<alias>{alias_pattern})\b"
-            rf"|(?<!\w)(?P<compact_count>{count_value_pattern})\s*(?:x|\*|шт\.?|штук[аи]?)\s*(?P<compact_code>{power_code_pattern})(?!\w)"
+            rf"|(?<!\w)(?P<compact_count>{count_value_pattern})\s*(?:{compact_separator_pattern}|шт\.?|штук[аи]?)\s*(?P<compact_code>{power_code_pattern})(?!\w)"
+            rf"|(?<!\w)(?P<reverse_code>{power_code_pattern})\s*(?:{compact_separator_pattern})\s*(?P<reverse_count>{count_value_pattern})(?!\w)"
             rf"|(?<!\w)(?P<word_count>{count_value_pattern})\s+(?P<compact_word_code>{power_code_pattern})(?!\w)"
             r"|(?P<number>\b\d{1,3}\b)\s*(?P<unit>м2|м²|кв\.?|квадрат(?:ов|а)?|квадратный метр(?:ов|а)?)?",
             re.IGNORECASE,
@@ -142,6 +144,10 @@ class BotProductSelectionService:
                 code = cls._normalize_power_code(match.group("compact_code") or match.group("compact_word_code"))
                 if code:
                     add_power_targets(code, parse_count(match.group("compact_count") or match.group("word_count")))
+            elif match.group("reverse_code"):
+                code = cls._normalize_power_code(match.group("reverse_code"))
+                if code:
+                    add_power_targets(code, parse_count(match.group("reverse_count")))
             else:
                 number_raw = match.group("number")
                 if not number_raw:

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -7,10 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
+from crud.product import ProductDAO
 from models import StaffUser
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
+from services.product_read_service import ProductReadService
 from services.product_service import ProductService
 from bot_app.utils import format_caption
 
@@ -119,6 +121,33 @@ def test_product_selection_parse_limits_word_repeats():
     assert [target["code"] for target in parsed["targets"]] == ["7", "7", "9", "9", "12", "12"]
 
 
+def test_product_selection_parse_compact_quantity_syntax():
+    cases = {
+        "2x7 и 12": ["7", "7", "12"],
+        "2*7, 3 шт 12": ["7", "7", "12", "12", "12"],
+        "две 7 и один 12": ["7", "7", "12"],
+        "4 штуки 9": ["9", "9", "9", "9"],
+    }
+
+    for query, expected_codes in cases.items():
+        parsed = BotProductSelectionService.parse_selection_request(query)
+
+        assert [target["code"] for target in parsed["targets"]] == expected_codes
+
+
+def test_product_selection_parse_limits_compact_quantity_syntax():
+    parsed = BotProductSelectionService.parse_selection_request("4x7 4x12")
+
+    assert [target["code"] for target in parsed["targets"]] == ["7", "7", "7", "7", "12", "12"]
+
+
+def test_product_selection_parse_does_not_treat_large_area_as_quantity():
+    parsed = BotProductSelectionService.parse_selection_request("20 12")
+
+    assert [target.get("code") for target in parsed["targets"]] == [None, "12"]
+    assert parsed["targets"][0]["label"] == "20 м²"
+
+
 @pytest.mark.asyncio
 async def test_bot_access_context_for_staff_and_non_staff(sqlite_staff_session):
     sqlite_staff_session.add(
@@ -223,6 +252,40 @@ async def test_product_selection_builds_onoff_only_for_server_room(monkeypatch):
     assert [tier["key"] for tier in selection["areas"][0]["tiers"]] == ["onoff"]
     assert calls == [{"is_inverter": False, "area_min": 33, "area_max": 42}]
     assert "Режим: только ON-OFF (серверная)" in formatted
+
+
+@pytest.mark.asyncio
+async def test_product_read_curated_passes_power_range_to_dao(monkeypatch):
+    calls = {}
+
+    async def fake_resolve_slugs(session, tag_slugs):
+        calls["tag_slugs"] = tag_slugs
+        return [[101]]
+
+    async def fake_get_filtered(session, **kwargs):
+        calls["filtered"] = kwargs
+        return []
+
+    monkeypatch.setattr(ProductReadService, "resolve_slugs_to_grouped_ids", fake_resolve_slugs)
+    monkeypatch.setattr(ProductDAO, "get_filtered", fake_get_filtered)
+
+    items = await ProductReadService.get_curated(
+        object(),
+        area=15,
+        area_min=15,
+        area_max=24,
+        is_inverter=False,
+        tag_slugs=["cat-household"],
+        limit=12,
+    )
+
+    assert items == []
+    assert calls["tag_slugs"] == ["cat-household"]
+    assert calls["filtered"]["area_min"] == 15
+    assert calls["filtered"]["area_max"] == 24
+    assert calls["filtered"]["is_inverter"] is False
+    assert calls["filtered"]["faceted_tag_ids"] == [[101]]
+    assert calls["filtered"]["limit"] == 12
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -124,7 +124,9 @@ def test_product_selection_parse_limits_word_repeats():
 def test_product_selection_parse_compact_quantity_syntax():
     cases = {
         "2x7 и 12": ["7", "7", "12"],
+        "2х7 и 12": ["7", "7", "12"],
         "2*7, 3 шт 12": ["7", "7", "12", "12", "12"],
+        "7x2 и 12х3": ["7", "7", "12", "12", "12"],
         "две 7 и один 12": ["7", "7", "12"],
         "4 штуки 9": ["9", "9", "9", "9"],
     }


### PR DESCRIPTION
## Summary
- support manager shorthand like `2x7`, `2х7`, `7x2`, `7х2`, `2*7`, `3 шт 12`, `две 7`, and `один 12`
- keep the total parsed target limit across compact, word, and numeric syntax
- avoid treating large area-like numbers such as `20 12` as quantity syntax
- add service-layer coverage that curated power-class ranges reach `ProductDAO.get_filtered` with household tag filtering

Closes #525.

## Tests
- `pytest tests/unit/test_bot_auto_search_query.py tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q`
- `python3 -m py_compile services/bot_product_selection_service.py services/product_read_service.py`