### PR TITLE
Make staff bot selection rules configurable

### DIFF
--- a/scripts/ensure_global_config_defaults.py
+++ b/scripts/ensure_global_config_defaults.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 from datetime import datetime
 
@@ -10,6 +11,7 @@ sys.path.append(".")
 
 from core.config import settings
 from models.content import GlobalConfig
+from services.bot_product_selection_service import BotProductSelectionService
 
 
 DEFAULT_CONFIGS: list[tuple[str, str, str]] = [
@@ -20,6 +22,11 @@ DEFAULT_CONFIGS: list[tuple[str, str, str]] = [
     ("fx_rate_source", "manual", "Источник курса USD/BYN: manual | nbrb"),
     ("supplier_default_spreadsheet_id", "", "Spreadsheet ID по умолчанию для новых источников"),
     ("fx_supplier_markup_percent", "2.0", "Надбавка к курсу USD/BYN для закупки, %"),
+    (
+        BotProductSelectionService.CONFIG_KEY,
+        json.dumps(BotProductSelectionService.default_rules(), ensure_ascii=False, indent=2),
+        "JSON-правила подбора кондиционеров для staff Telegram-бота",
+    ),
 ]
 
 

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -1,13 +1,17 @@
+import json
 import re
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from core.config import settings
+from models import GlobalConfig
 from services.product_service import ProductService
 
 
 class BotProductSelectionService:
+    CONFIG_KEY = "bot_product_selection_rules"
     TIERS = (
         ("budget", "Бюджетнее", {"is_inverter": False, "sort": "price"}),
         ("optimal", "Оптимально", {"is_inverter": True, "sort": "balanced"}),
@@ -45,6 +49,142 @@ class BotProductSelectionService:
         "четыре": 4,
     }
 
+    @classmethod
+    def _serialize_tiers(cls, tiers) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": key,
+                "label": label,
+                "is_inverter": bool(options.get("is_inverter")),
+                "sort": str(options.get("sort") or "balanced"),
+            }
+            for key, label, options in tiers
+        ]
+
+    @classmethod
+    def default_rules(cls) -> dict[str, Any]:
+        return {
+            "power_classes": {
+                code: {
+                    "kw": float(config["kw"]),
+                    "area_min": int(config["area"][0]),
+                    "area_max": int(config["area"][1]),
+                }
+                for code, config in cls.POWER_CLASSES.items()
+            },
+            "default_tag_slugs": list(cls.DEFAULT_TAG_SLUGS),
+            "tiers": {
+                "mixed": cls._serialize_tiers(cls.TIERS),
+                "inverter_only": cls._serialize_tiers(cls.INVERTER_TIERS),
+                "onoff_only": cls._serialize_tiers(cls.ONOFF_TIERS),
+            },
+        }
+
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "y", "да"}
+        return bool(value)
+
+    @classmethod
+    def _normalize_power_classes(cls, raw: Any) -> dict[str, dict[str, Any]]:
+        normalized = dict(cls.default_rules()["power_classes"])
+        if not isinstance(raw, dict):
+            return normalized
+
+        for raw_code, raw_config in raw.items():
+            code = cls._normalize_power_code(str(raw_code), {"power_classes": normalized})
+            if code is None:
+                code = str(raw_code or "").strip().lstrip("0")
+            if not code or not code.isdigit() or not isinstance(raw_config, dict):
+                continue
+
+            try:
+                kw = float(raw_config["kw"])
+                if "area" in raw_config and isinstance(raw_config["area"], (list, tuple)):
+                    area_min = int(raw_config["area"][0])
+                    area_max = int(raw_config["area"][1])
+                else:
+                    area_min = int(raw_config["area_min"])
+                    area_max = int(raw_config["area_max"])
+            except (KeyError, TypeError, ValueError, IndexError):
+                continue
+
+            if kw <= 0 or area_min < 1 or area_max < area_min or area_max > 200:
+                continue
+            normalized[code] = {"kw": kw, "area_min": area_min, "area_max": area_max}
+        return normalized
+
+    @classmethod
+    def _normalize_tiers(cls, raw: Any) -> dict[str, tuple[tuple[str, str, dict[str, Any]], ...]]:
+        defaults = {
+            "mixed": cls.TIERS,
+            "inverter_only": cls.INVERTER_TIERS,
+            "onoff_only": cls.ONOFF_TIERS,
+        }
+        if not isinstance(raw, dict):
+            return defaults
+
+        normalized = dict(defaults)
+        for mode in defaults:
+            raw_items = raw.get(mode)
+            if not isinstance(raw_items, list):
+                continue
+
+            tier_items: list[tuple[str, str, dict[str, Any]]] = []
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+                key = str(item.get("key") or "").strip()
+                label = str(item.get("label") or "").strip()
+                if not key or not label:
+                    continue
+                tier_items.append(
+                    (
+                        key,
+                        label,
+                        {
+                            "is_inverter": cls._coerce_bool(item.get("is_inverter")),
+                            "sort": str(item.get("sort") or "balanced").strip() or "balanced",
+                        },
+                    )
+                )
+            if tier_items:
+                normalized[mode] = tuple(tier_items)
+        return normalized
+
+    @classmethod
+    def normalize_rules(cls, raw: Any) -> dict[str, Any]:
+        payload = raw if isinstance(raw, dict) else {}
+        tag_slugs = payload.get("default_tag_slugs")
+        if not isinstance(tag_slugs, list):
+            tag_slugs = payload.get("tag_slugs")
+        normalized_tag_slugs = [
+            str(slug).strip()
+            for slug in (tag_slugs if isinstance(tag_slugs, list) else cls.DEFAULT_TAG_SLUGS)
+            if str(slug).strip()
+        ]
+        if not normalized_tag_slugs:
+            normalized_tag_slugs = list(cls.DEFAULT_TAG_SLUGS)
+
+        return {
+            "power_classes": cls._normalize_power_classes(payload.get("power_classes")),
+            "default_tag_slugs": normalized_tag_slugs,
+            "tiers": cls._normalize_tiers(payload.get("tiers")),
+        }
+
+    @classmethod
+    async def get_selection_rules(cls, session: AsyncSession) -> dict[str, Any]:
+        try:
+            result = await session.execute(select(GlobalConfig).where(GlobalConfig.key == cls.CONFIG_KEY))
+            config = result.scalar_one_or_none()
+            raw_value = json.loads(config.value) if config and config.value else {}
+        except Exception:
+            raw_value = {}
+        return cls.normalize_rules(raw_value)
+
     @staticmethod
     def product_url(product: dict[str, Any]) -> str:
         slug = str(product.get("slug") or "").strip()
@@ -65,15 +205,21 @@ class BotProductSelectionService:
         return (text or "").casefold().replace("ё", "е")
 
     @classmethod
-    def _normalize_power_code(cls, value: str) -> str | None:
+    def _normalize_power_code(cls, value: str, rules: dict[str, Any] | None = None) -> str | None:
         normalized = str(value or "").strip().lstrip("0") or "0"
-        return normalized if normalized in cls.POWER_CLASSES else None
+        power_classes = (rules or {}).get("power_classes") if isinstance(rules, dict) else None
+        if not isinstance(power_classes, dict):
+            power_classes = cls.default_rules()["power_classes"]
+        return normalized if normalized in power_classes else None
 
     @classmethod
-    def _target_for_power_class(cls, code: str) -> dict[str, Any]:
-        config = cls.POWER_CLASSES[code]
-        area_min = int(config["area"][0])
-        area_max = int(config["area"][1])
+    def _target_for_power_class(cls, code: str, rules: dict[str, Any] | None = None) -> dict[str, Any]:
+        power_classes = (rules or {}).get("power_classes") if isinstance(rules, dict) else None
+        if not isinstance(power_classes, dict):
+            power_classes = cls.default_rules()["power_classes"]
+        config = power_classes[code]
+        area_min = int(config["area_min"])
+        area_max = int(config["area_max"])
         kw = float(config["kw"])
         kw_text = str(kw).replace(".", ",")
         return {
@@ -97,8 +243,10 @@ class BotProductSelectionService:
         }
 
     @classmethod
-    def parse_selection_request(cls, text: str) -> dict[str, Any]:
+    def parse_selection_request(cls, text: str, rules: dict[str, Any] | None = None) -> dict[str, Any]:
         normalized = cls._normalize_text(text)
+        normalized_rules = cls.normalize_rules(rules)
+        power_classes = normalized_rules["power_classes"]
         max_targets = 6
         targets: list[dict[str, Any]] = []
 
@@ -114,7 +262,7 @@ class BotProductSelectionService:
 
         def add_power_targets(code: str, count: int = 1) -> None:
             for _ in range(min(count, remaining_slots())):
-                targets.append(cls._target_for_power_class(code))
+                targets.append(cls._target_for_power_class(code, normalized_rules))
 
         alias_to_code = {
             alias: code
@@ -123,7 +271,7 @@ class BotProductSelectionService:
         }
         alias_pattern = "|".join(sorted((re.escape(alias) for alias in alias_to_code), key=len, reverse=True))
         count_value_pattern = rf"[1-6]|{'|'.join(cls.COUNT_WORDS)}"
-        power_code_pattern = "|".join(sorted((re.escape(code) for code in cls.POWER_CLASSES), key=len, reverse=True))
+        power_code_pattern = "|".join(sorted((re.escape(code) for code in power_classes), key=len, reverse=True))
         compact_separator_pattern = r"x|х|\*"
         token_pattern = re.compile(
             rf"(?:(?P<count>\b\d{{1,2}}\b|{'|'.join(cls.COUNT_WORDS)})\s+)?(?P<alias>{alias_pattern})\b"
@@ -141,11 +289,11 @@ class BotProductSelectionService:
                 code = alias_to_code[alias]
                 add_power_targets(code, count)
             elif match.group("compact_code") or match.group("compact_word_code"):
-                code = cls._normalize_power_code(match.group("compact_code") or match.group("compact_word_code"))
+                code = cls._normalize_power_code(match.group("compact_code") or match.group("compact_word_code"), normalized_rules)
                 if code:
                     add_power_targets(code, parse_count(match.group("compact_count") or match.group("word_count")))
             elif match.group("reverse_code"):
-                code = cls._normalize_power_code(match.group("reverse_code"))
+                code = cls._normalize_power_code(match.group("reverse_code"), normalized_rules)
                 if code:
                     add_power_targets(code, parse_count(match.group("reverse_count")))
             else:
@@ -154,7 +302,7 @@ class BotProductSelectionService:
                     continue
                 value = int(number_raw)
                 unit = match.group("unit")
-                power_code = cls._normalize_power_code(number_raw)
+                power_code = cls._normalize_power_code(number_raw, normalized_rules)
                 if unit:
                     if 8 <= value <= 120:
                         targets.append(cls._target_for_area(value))
@@ -186,7 +334,13 @@ class BotProductSelectionService:
         }
 
     @classmethod
-    def _tiers_for_mode(cls, compressor_mode: str):
+    def _tiers_for_mode(cls, compressor_mode: str, rules: dict[str, Any] | None = None):
+        if isinstance(rules, dict):
+            tiers = rules.get("tiers")
+            if not isinstance(tiers, dict):
+                tiers = cls.normalize_rules(rules)["tiers"]
+            if compressor_mode in tiers:
+                return tiers[compressor_mode]
         if compressor_mode == "inverter_only":
             return cls.INVERTER_TIERS
         if compressor_mode == "onoff_only":
@@ -209,13 +363,14 @@ class BotProductSelectionService:
         return 3
 
     @staticmethod
-    def _sort_for_tier(products: list[dict[str, Any]], tier_key: str) -> list[dict[str, Any]]:
+    def _sort_for_tier(products: list[dict[str, Any]], tier_key: str, sort: str | None = None) -> list[dict[str, Any]]:
         def price(product: dict[str, Any]) -> int:
             return int(product.get("price") or 0)
 
-        if tier_key in {"budget", "onoff"}:
+        sort_mode = str(sort or tier_key or "").strip().lower()
+        if sort_mode in {"budget", "onoff", "price"}:
             return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), price(item)))
-        if tier_key == "premium":
+        if sort_mode == "premium":
             return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), -price(item)))
         return sorted(products, key=lambda item: (BotProductSelectionService.availability_rank(item), abs(price(item))))
 
@@ -244,7 +399,8 @@ class BotProductSelectionService:
         *,
         limit_per_tier: int = 1,
     ) -> dict[str, Any]:
-        parsed = cls.parse_selection_request(query)
+        rules = await cls.get_selection_rules(session)
+        parsed = cls.parse_selection_request(query, rules)
         targets = parsed["targets"]
         if not targets:
             return {"areas": [], "message": "Не нашел мощность или площадь. Напишите, например: подбор 7,7,12 или 20 и 35 м²."}
@@ -254,7 +410,8 @@ class BotProductSelectionService:
             "compressor_mode": parsed["compressor_mode"],
             "mode_reason": parsed["mode_reason"],
         }
-        tiers = cls._tiers_for_mode(parsed["compressor_mode"])
+        tiers = cls._tiers_for_mode(parsed["compressor_mode"], rules)
+        tag_slugs = rules["default_tag_slugs"]
         for target in targets:
             area_payload = {
                 "area": target["area"],
@@ -271,12 +428,12 @@ class BotProductSelectionService:
                     area_min=target["area_min"],
                     area_max=target["area_max"],
                     is_inverter=bool(options["is_inverter"]),
-                    tag_slugs=cls.DEFAULT_TAG_SLUGS,
+                    tag_slugs=tag_slugs,
                     limit=12,
                 )
                 sorted_products = [
                     product
-                    for product in cls._sort_for_tier(products, tier_key)
+                    for product in cls._sort_for_tier(products, tier_key, str(options.get("sort") or ""))
                     if int(product.get("id") or 0) not in seen_ids
                 ]
                 picked = sorted_products[:limit_per_tier]

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from crud.product import ProductDAO
-from models import StaffUser
+from models import GlobalConfig, StaffUser
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
@@ -150,6 +151,34 @@ def test_product_selection_parse_does_not_treat_large_area_as_quantity():
     assert parsed["targets"][0]["label"] == "20 м²"
 
 
+def test_product_selection_rules_defaults_match_current_mapping():
+    rules = BotProductSelectionService.normalize_rules({})
+
+    assert rules["power_classes"]["7"] == {"kw": 1.9, "area_min": 15, "area_max": 24}
+    assert rules["default_tag_slugs"] == ["cat-household"]
+    assert [tier[0] for tier in rules["tiers"]["mixed"]] == ["budget", "optimal", "premium"]
+
+
+def test_product_selection_parse_uses_configured_power_class_rules():
+    rules = BotProductSelectionService.normalize_rules(
+        {
+            "power_classes": {
+                "7": {"kw": 2.0, "area_min": 18, "area_max": 27},
+                "5": {"kw": 1.5, "area": [10, 16]},
+            }
+        }
+    )
+
+    parsed = BotProductSelectionService.parse_selection_request("2x5 и 7", rules)
+
+    assert [target["code"] for target in parsed["targets"]] == ["5", "5", "7"]
+    assert parsed["targets"][0]["label"] == "5 (1,5 кВт)"
+    assert parsed["targets"][0]["area_min"] == 10
+    assert parsed["targets"][2]["label"] == "7 (2,0 кВт)"
+    assert parsed["targets"][2]["area_min"] == 18
+    assert parsed["targets"][2]["area_max"] == 27
+
+
 @pytest.mark.asyncio
 async def test_bot_access_context_for_staff_and_non_staff(sqlite_staff_session):
     sqlite_staff_session.add(
@@ -227,6 +256,84 @@ async def test_product_selection_builds_power_classes_and_inverter_only(monkeypa
     assert calls[0]["area_min"] == 15
     assert calls[0]["area_max"] == 24
     assert calls[0]["tag_slugs"] == ["cat-household"]
+
+
+@pytest.mark.asyncio
+async def test_product_selection_builds_with_configured_rules(sqlite_staff_session, monkeypatch):
+    calls = []
+    sqlite_staff_session.add(
+        GlobalConfig(
+            key=BotProductSelectionService.CONFIG_KEY,
+            value=json.dumps(
+                {
+                    "power_classes": {
+                        "7": {"kw": 2.0, "area_min": 18, "area_max": 27},
+                    },
+                    "default_tag_slugs": ["cat-wall"],
+                    "tiers": {
+                        "mixed": [
+                            {
+                                "key": "manager_pick",
+                                "label": "Менеджерский выбор",
+                                "is_inverter": True,
+                                "sort": "premium",
+                            }
+                        ]
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            description="Bot selection test rules",
+        )
+    )
+    await sqlite_staff_session.commit()
+
+    async def fake_get_curated(session, area, is_inverter, limit=12, **kwargs):
+        calls.append(
+            {
+                "area": area,
+                "area_min": kwargs.get("area_min"),
+                "area_max": kwargs.get("area_max"),
+                "is_inverter": is_inverter,
+                "tag_slugs": kwargs.get("tag_slugs"),
+            }
+        )
+        return [
+            {
+                "id": 1,
+                "title": "Configured Cheaper",
+                "slug": "configured-cheaper",
+                "price": 2000,
+                "vitebsk_qty": 1,
+                "minsk_qty": 0,
+            },
+            {
+                "id": 2,
+                "title": "Configured Premium",
+                "slug": "configured-premium",
+                "price": 3000,
+                "vitebsk_qty": 1,
+                "minsk_qty": 0,
+            }
+        ]
+
+    monkeypatch.setattr(ProductService, "get_curated", fake_get_curated)
+
+    selection = await BotProductSelectionService.build_selection(sqlite_staff_session, "7")
+
+    assert selection["areas"][0]["label"] == "7 (2,0 кВт)"
+    assert selection["areas"][0]["tiers"][0]["key"] == "manager_pick"
+    assert selection["areas"][0]["tiers"][0]["label"] == "Менеджерский выбор"
+    assert selection["areas"][0]["tiers"][0]["products"][0]["title"] == "Configured Premium"
+    assert calls == [
+        {
+            "area": 18,
+            "area_min": 18,
+            "area_max": 27,
+            "is_inverter": True,
+            "tag_slugs": ["cat-wall"],
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `bot_product_selection_rules` JSON config for staff bot selection via existing `GlobalConfig` / Manager settings
- keep safe fallback defaults when the setting is missing or invalid
- allow overriding power-class mappings (`kw`, `area_min`, `area_max`) and adding new power classes
- allow configuring default tag slugs and tier lists per mode (`mixed`, `inverter_only`, `onoff_only`)
- make tier `sort` active for `price`, `premium`, and balanced selection
- seed the default JSON in `scripts/ensure_global_config_defaults.py`

Closes #526.

## Tests
- `pytest tests/unit/test_bot_auto_search_query.py tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q`
- `python3 -m py_compile services/bot_product_selection_service.py scripts/ensure_global_config_defaults.py`