### PR TITLE
Add client-ready text for bot selections

### DIFF
--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -8,7 +8,11 @@ from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_task_service import BotTaskService
-from ..keyboards import quick_order_confirm_keyboard, task_actions_keyboard
+from ..keyboards import (
+    quick_order_confirm_keyboard,
+    selection_result_keyboard,
+    task_actions_keyboard,
+)
 from ..states import ShopState
 
 router = Router()
@@ -128,8 +132,28 @@ async def selection_process(message: types.Message, state: FSMContext):
     query = (message.text or "").strip()
     async with async_session_maker() as session:
         selection = await BotProductSelectionService.build_selection(session, query)
-    await message.answer(BotProductSelectionService.format_selection(selection), parse_mode="HTML")
-    await state.clear()
+    await state.update_data(selection_client_text=BotProductSelectionService.format_client_selection(selection))
+    await state.set_state(None)
+    await message.answer(
+        BotProductSelectionService.format_selection(selection),
+        parse_mode="HTML",
+        reply_markup=selection_result_keyboard() if selection.get("areas") else None,
+    )
+
+
+@router.callback_query(F.data == "selection_client_text")
+async def selection_client_text(callback: CallbackQuery, state: FSMContext):
+    context = await _access_context(callback.from_user.id)
+    if not context.is_staff or not context.is_manager:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+    data = await state.get_data()
+    text = str(data.get("selection_client_text") or "").strip()
+    if not text:
+        await callback.answer("Подбор не найден", show_alert=True)
+        return
+    await callback.message.answer(text)
+    await callback.answer("Можно переслать клиенту")
 
 
 @router.message(F.text == "📅 Календарь")

--- a/bot_app/keyboards.py
+++ b/bot_app/keyboards.py
@@ -119,6 +119,14 @@ def quick_order_confirm_keyboard() -> InlineKeyboardMarkup:
     )
 
 
+def selection_result_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Текст клиенту", callback_data="selection_client_text")],
+        ]
+    )
+
+
 def task_actions_keyboard(tasks: list[dict]) -> InlineKeyboardMarkup | None:
     rows: list[list[InlineKeyboardButton]] = []
     for task in tasks[:5]:

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -391,6 +391,19 @@ class BotProductSelectionService:
             return "Наличие уточнить"
         return "Нет в наличии"
 
+    @staticmethod
+    def client_availability_text(product: dict[str, Any]) -> str:
+        vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+        minsk_qty = int(product.get("minsk_qty") or 0)
+        availability = str(product.get("availability_status") or "").strip().lower()
+        if vitebsk_qty > 0 or availability == "in_stock_now":
+            return "в наличии"
+        if minsk_qty > 0 or availability == "available_2_3_days":
+            return "доступно 2-3 дня"
+        if availability == "check_availability":
+            return "наличие уточним"
+        return "наличие уточним"
+
     @classmethod
     async def build_selection(
         cls,
@@ -476,4 +489,30 @@ class BotProductSelectionService:
                     f"{reason}\n"
                     f"{cls.product_url(product)}"
                 )
+        return "\n".join(lines)
+
+    @classmethod
+    def format_client_selection(cls, selection: dict[str, Any]) -> str:
+        if not selection.get("areas"):
+            return selection.get("message") or "Пока не получилось подобрать варианты."
+
+        lines = ["Подобрал варианты кондиционеров:"]
+        for area in selection["areas"]:
+            area_label = area.get("label") or f"{area['area']} м²"
+            area_lines = []
+            for tier in area["tiers"]:
+                products = tier.get("products") or []
+                if not products:
+                    continue
+                product = products[0]
+                area_lines.append(
+                    f"{tier['label']}: {product.get('title')} - {product.get('price')} руб.\n"
+                    f"{cls.client_availability_text(product)}\n"
+                    f"{cls.product_url(product)}"
+                )
+            if area_lines:
+                lines.extend(["", area_label, *area_lines])
+
+        if len(lines) == 1:
+            return "Пока не получилось подобрать варианты из наличия."
         return "\n".join(lines)

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -15,6 +15,7 @@ from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
+from bot_app.keyboards import selection_result_keyboard
 from bot_app.utils import format_caption
 
 
@@ -177,6 +178,59 @@ def test_product_selection_parse_uses_configured_power_class_rules():
     assert parsed["targets"][2]["label"] == "7 (2,0 кВт)"
     assert parsed["targets"][2]["area_min"] == 18
     assert parsed["targets"][2]["area_max"] == 27
+
+
+def test_product_selection_formats_client_forward_text(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+    selection = {
+        "areas": [
+            {
+                "label": "7 (1,9 кВт)",
+                "tiers": [
+                    {
+                        "label": "Бюджетнее",
+                        "products": [
+                            {
+                                "title": "Midea 07",
+                                "slug": "midea-07",
+                                "price": 990,
+                                "vitebsk_qty": 1,
+                                "minsk_qty": 0,
+                            }
+                        ],
+                    },
+                    {
+                        "label": "Оптимально",
+                        "products": [],
+                    },
+                ],
+            }
+        ]
+    }
+
+    formatted = BotProductSelectionService.format_client_selection(selection)
+
+    assert formatted == (
+        "Подобрал варианты кондиционеров:\n"
+        "\n"
+        "7 (1,9 кВт)\n"
+        "Бюджетнее: Midea 07 - 990 руб.\n"
+        "в наличии\n"
+        "https://example.test/product/midea-07/"
+    )
+    assert "<b>" not in formatted
+    assert "Витебск" not in formatted
+
+
+def test_selection_result_keyboard_has_client_text_action():
+    keyboard = selection_result_keyboard()
+
+    button = keyboard.inline_keyboard[0][0]
+    assert button.text == "Текст клиенту"
+    assert button.callback_data == "selection_client_text"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a clean client-facing formatter for Telegram bot product selections
- add a "Текст клиенту" inline action after staff selection results
- keep the internal manager selection format with stock details unchanged

## Tests
- pytest tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q
- git diff --check