### PR TITLE
Notify admins about quick bot orders

### DIFF
--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -8,7 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from schemas import ManagerOrderCreatePayload, OrderWorkStageCreatePayload
+from services.notification_service import NotificationService
 from services.order_service import OrderService
+
+logger = logging.getLogger(__name__)
 
 
 class BotQuickOrderService:
@@ -268,6 +272,7 @@ class BotQuickOrderService:
             raise ValueError("Не удалось создать заказ")
 
         service_type = normalized.get("service_type")
+        result = order
         if target_date and service_type != "maintenance":
             stage_payload = OrderWorkStageCreatePayload(
                 name=cls.SERVICE_LABELS.get(service_type, "Рабочая задача"),
@@ -275,6 +280,15 @@ class BotQuickOrderService:
                 manager_comment=normalized["request_text"],
             )
             updated = await OrderService.add_order_stage(session, int(order["id"]), stage_payload)
-            return updated or order
+            result = updated or order
 
-        return order
+        try:
+            await NotificationService.notify_admins_staff_order_created(
+                session,
+                int(order["id"]),
+                source_label="Telegram-бот",
+            )
+        except Exception:
+            logger.exception("BOT_QUICK_ORDER_NOTIFY_FAILED order_id=%s", order.get("id"))
+
+        return result

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -13,6 +13,15 @@ logger = logging.getLogger(__name__)
 
 
 class NotificationService:
+    SERVICE_LABELS = {
+        "turnkey": "Продажа + монтаж",
+        "install_only": "Монтаж",
+        "pre_install": "Закладка трассы",
+        "maintenance": "Обслуживание",
+        "repair": "Ремонт",
+        "dismantling": "Демонтаж",
+    }
+
     @staticmethod
     async def _admin_recipient_ids(session: AsyncSession) -> list[int]:
         return await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
@@ -65,6 +74,62 @@ class NotificationService:
                 await BotService.send_message(admin_id, admin_text)
             except Exception:
                 logger.exception("NOTIFY_NEW_ORDER_SEND_FAILED order_id=%s admin_id=%s", order.id, admin_id)
+
+    @staticmethod
+    async def notify_admins_staff_order_created(
+        session: AsyncSession,
+        order_id: int,
+        *,
+        source_label: str = "рабочий бот",
+    ) -> int:
+        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not admin_ids:
+            return 0
+
+        stmt = (
+            select(Order)
+            .where(Order.id == order_id)
+            .options(selectinload(Order.customer))
+        )
+        result = await session.execute(stmt)
+        order = result.scalar_one_or_none()
+        if not order:
+            logger.warning("NOTIFY_STAFF_ORDER_SKIPPED missing_order_id=%s", order_id)
+            return 0
+
+        customer = getattr(order, "customer", None)
+        customer_name = getattr(customer, "name", None) or "Новый клиент"
+        customer_phone = getattr(customer, "phone", None) or "не указан"
+        meta = order.technical_meta if isinstance(order.technical_meta, dict) else {}
+        service_type = str(meta.get("service_type") or "").strip()
+        service_label = NotificationService.SERVICE_LABELS.get(service_type, service_type or "не указана")
+        order_date = order.installation_date or order.measurement_date
+        date_text = order_date.strftime("%d.%m.%Y %H:%M") if order_date else "не назначена"
+        comment = (order.comment or "").strip()
+        if len(comment) > 320:
+            comment = f"{comment[:317]}..."
+
+        lines = [
+            f"🔔 <b>Новый рабочий заказ #{order.id}</b>",
+            f"Источник: {escape(source_label)}",
+            f"Услуга: {escape(service_label)}",
+            f"Дата: {escape(date_text)}",
+            f"Клиент: {escape(customer_name)}",
+            f"Телефон: {escape(customer_phone)}",
+            f"Адрес: {escape(order.delivery_address or 'не указан')}",
+        ]
+        if comment:
+            lines.extend(["", f"<i>{escape(comment)}</i>"])
+
+        text = "\n".join(lines)
+        sent = 0
+        for admin_id in admin_ids:
+            try:
+                await BotService.send_message(admin_id, text)
+                sent += 1
+            except Exception:
+                logger.exception("NOTIFY_STAFF_ORDER_SEND_FAILED order_id=%s admin_id=%s", order.id, admin_id)
+        return sent
 
     @staticmethod
     async def notify_admins_bank_receipts_imported(

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -464,6 +464,10 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
         calls["stage_payload"] = payload
         return {"id": order_id, "work_stages": [{"name": payload.name}]}
 
+    async def fake_notify(session, order_id, *, source_label):
+        calls["notify"] = {"order_id": order_id, "source_label": source_label}
+        return 1
+
     monkeypatch.setattr(
         "services.bot_quick_order_service.OrderService.create_manager_order",
         fake_create_manager_order,
@@ -471,6 +475,10 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
     monkeypatch.setattr(
         "services.bot_quick_order_service.OrderService.add_order_stage",
         fake_add_order_stage,
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.NotificationService.notify_admins_staff_order_created",
+        fake_notify,
     )
 
     order = await BotQuickOrderService.create_order_from_draft(
@@ -490,3 +498,51 @@ async def test_quick_order_create_uses_order_service_and_stage_for_dated_work(mo
     assert calls["payload"].service_type == "install_only"
     assert calls["stage_order_id"] == 42
     assert calls["stage_payload"].name == "Монтаж"
+    assert calls["notify"] == {"order_id": 42, "source_label": "Telegram-бот"}
+
+
+@pytest.mark.asyncio
+async def test_quick_order_create_notifies_admins_for_maintenance_without_stage(monkeypatch):
+    calls = {}
+
+    async def fake_create_manager_order(session, payload):
+        calls["payload"] = payload
+        return {"id": 43}
+
+    async def fake_add_order_stage(session, order_id, payload):
+        raise AssertionError("maintenance quick orders should use order installation_date, not a work stage")
+
+    async def fake_notify(session, order_id, *, source_label):
+        calls["notify"] = {"order_id": order_id, "source_label": source_label}
+        return 1
+
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.OrderService.create_manager_order",
+        fake_create_manager_order,
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.OrderService.add_order_stage",
+        fake_add_order_stage,
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.NotificationService.notify_admins_staff_order_created",
+        fake_notify,
+    )
+
+    order = await BotQuickOrderService.create_order_from_draft(
+        object(),
+        {
+            "name": "Иван",
+            "phone": "+375291234567",
+            "address": "Победы 15",
+            "service_type": "maintenance",
+            "target_date": "2026-06-15T14:00:00",
+            "request_text": "ТО, Иван, Победы 15",
+        },
+    )
+
+    assert order["id"] == 43
+    assert calls["payload"].source == "bot"
+    assert calls["payload"].service_type == "maintenance"
+    assert calls["payload"].target_date.isoformat() == "2026-06-15T14:00:00"
+    assert calls["notify"] == {"order_id": 43, "source_label": "Telegram-бот"}

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -104,3 +104,36 @@ async def test_notify_admins_new_order_sends_to_admins(monkeypatch):
     assert "НОВЫЙ ЗАКАЗ #77" in sent_text
     assert "Model X x2" in sent_text
     assert "Монтаж: 120 BYN" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_notify_admins_staff_order_created_sends_work_order_summary(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "10,11", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+
+    order = SimpleNamespace(
+        id=88,
+        delivery_address="Победы 15",
+        installation_date=None,
+        measurement_date=None,
+        comment="ТО, Иван, +375 29 123-45-67, Победы 15",
+        technical_meta={"service_type": "maintenance"},
+        customer=SimpleNamespace(name="Иван", phone="+375 29 123-45-67"),
+    )
+    session = _DummySession(order=order)
+    send_mock = AsyncMock()
+    monkeypatch.setattr("services.notification_service.BotService.send_message", send_mock)
+
+    sent = await NotificationService.notify_admins_staff_order_created(
+        session=session,
+        order_id=88,
+        source_label="Telegram-бот",
+    )
+
+    assert sent == 2
+    sent_text = send_mock.await_args_list[0].args[1]
+    assert "Новый рабочий заказ #88" in sent_text
+    assert "Источник: Telegram-бот" in sent_text
+    assert "Услуга: Обслуживание" in sent_text
+    assert "Клиент: Иван" in sent_text
+    assert "Победы 15" in sent_text


### PR DESCRIPTION
## Summary
- add a generic staff-order Telegram admin notification
- send that notification after confirmed quick orders from the staff bot
- keep quick order creation resilient if notification delivery fails
- cover maintenance quick orders so ТО with date stays order/calendar-based and still notifies admins

## Tests
- pytest tests/unit/test_bot_work_services.py tests/unit/test_notification_service.py tests/unit/test_bot_handlers_architecture.py -q
- git diff --check