### PR TITLE
Add Telegram rich message adapter

### DIFF
--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -1,5 +1,8 @@
 import logging
+
+import httpx
 from aiogram import Bot
+
 from core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -17,6 +20,42 @@ class BotService:
                 await bot.send_message(chat_id=user_id, text=text, parse_mode="HTML")
         except Exception as e:
             logger.error(f"Failed to send Telegram message to {user_id}: {e}")
+
+    @staticmethod
+    async def send_rich_message(
+        user_id: int,
+        rich_html: str,
+        *,
+        fallback_text: str | None = None,
+    ) -> bool:
+        """
+        Send a Telegram Bot API 10.1 rich message.
+
+        aiogram may lag behind new Bot API methods, so this uses the HTTP API
+        directly and falls back to the existing HTML message path on failure.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    f"https://api.telegram.org/bot{settings.BOT_TOKEN}/sendRichMessage",
+                    json={
+                        "chat_id": user_id,
+                        "rich_message": {
+                            "html": rich_html,
+                        },
+                    },
+                )
+                response.raise_for_status()
+                payload = response.json()
+                if payload.get("ok"):
+                    return True
+                logger.warning("Telegram sendRichMessage returned non-ok response: %s", payload)
+        except Exception as exc:
+            logger.warning("Failed to send Telegram rich message to %s: %s", user_id, exc)
+
+        if fallback_text:
+            await BotService.send_message(user_id, fallback_text)
+        return False
 
     @staticmethod
     async def notify_installer_new_order(installer_tg_id: int, order_id: int, address: str, date_str: str, role: str):

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -122,10 +122,34 @@ class NotificationService:
             lines.extend(["", f"<i>{escape(comment)}</i>"])
 
         text = "\n".join(lines)
+        rich_html = (
+            f"<h3>Новый рабочий заказ #{order.id}</h3>"
+            "<p>"
+            f"<b>Источник:</b> {escape(source_label)}<br/>"
+            f"<b>Услуга:</b> {escape(service_label)}<br/>"
+            f"<b>Дата:</b> {escape(date_text)}<br/>"
+            f"<b>Клиент:</b> {escape(customer_name)}<br/>"
+            f"<b>Телефон:</b> {escape(customer_phone)}<br/>"
+            f"<b>Адрес:</b> {escape(order.delivery_address or 'не указан')}"
+            "</p>"
+        )
+        if comment:
+            rich_html += f"<blockquote>{escape(comment)}</blockquote>"
+
         sent = 0
         for admin_id in admin_ids:
             try:
-                await BotService.send_message(admin_id, text)
+                delivered = await BotService.send_rich_message(
+                    admin_id,
+                    rich_html,
+                    fallback_text=text,
+                )
+                if not delivered:
+                    logger.info(
+                        "NOTIFY_STAFF_ORDER_RICH_FALLBACK_USED order_id=%s admin_id=%s",
+                        order.id,
+                        admin_id,
+                    )
                 sent += 1
             except Exception:
                 logger.exception("NOTIFY_STAFF_ORDER_SEND_FAILED order_id=%s admin_id=%s", order.id, admin_id)

--- a/tests/unit/test_bot_service.py
+++ b/tests/unit/test_bot_service.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.bot_service import BotService
+
+
+class _FakeResponse:
+    def __init__(self, payload=None, *, raise_error: Exception | None = None):
+        self._payload = payload or {"ok": True}
+        self._raise_error = raise_error
+
+    def raise_for_status(self):
+        if self._raise_error:
+            raise self._raise_error
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    requests = []
+    response = _FakeResponse()
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, *, json):
+        self.__class__.requests.append({"url": url, "json": json})
+        return self.__class__.response
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_calls_telegram_bot_api(monkeypatch):
+    _FakeAsyncClient.requests = []
+    _FakeAsyncClient.response = _FakeResponse({"ok": True, "result": {"message_id": 1}})
+    monkeypatch.setattr("services.bot_service.httpx.AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr("services.bot_service.settings.BOT_TOKEN", "123:test", raising=False)
+    fallback = AsyncMock()
+    monkeypatch.setattr(BotService, "send_message", fallback)
+
+    delivered = await BotService.send_rich_message(777, "<h3>Заказ</h3>", fallback_text="fallback")
+
+    assert delivered is True
+    assert _FakeAsyncClient.requests == [
+        {
+            "url": "https://api.telegram.org/bot123:test/sendRichMessage",
+            "json": {
+                "chat_id": 777,
+                "rich_message": {
+                    "html": "<h3>Заказ</h3>",
+                },
+            },
+        }
+    ]
+    fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_falls_back_to_html_message(monkeypatch):
+    _FakeAsyncClient.requests = []
+    _FakeAsyncClient.response = _FakeResponse({"ok": False})
+    monkeypatch.setattr("services.bot_service.httpx.AsyncClient", _FakeAsyncClient)
+    fallback = AsyncMock()
+    monkeypatch.setattr(BotService, "send_message", fallback)
+
+    delivered = await BotService.send_rich_message(777, "<h3>Заказ</h3>", fallback_text="fallback")
+
+    assert delivered is False
+    fallback.assert_awaited_once_with(777, "fallback")

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -121,8 +121,8 @@ async def test_notify_admins_staff_order_created_sends_work_order_summary(monkey
         customer=SimpleNamespace(name="Иван", phone="+375 29 123-45-67"),
     )
     session = _DummySession(order=order)
-    send_mock = AsyncMock()
-    monkeypatch.setattr("services.notification_service.BotService.send_message", send_mock)
+    send_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("services.notification_service.BotService.send_rich_message", send_mock)
 
     sent = await NotificationService.notify_admins_staff_order_created(
         session=session,
@@ -131,9 +131,11 @@ async def test_notify_admins_staff_order_created_sends_work_order_summary(monkey
     )
 
     assert sent == 2
-    sent_text = send_mock.await_args_list[0].args[1]
-    assert "Новый рабочий заказ #88" in sent_text
-    assert "Источник: Telegram-бот" in sent_text
-    assert "Услуга: Обслуживание" in sent_text
-    assert "Клиент: Иван" in sent_text
-    assert "Победы 15" in sent_text
+    rich_text = send_mock.await_args_list[0].args[1]
+    fallback_text = send_mock.await_args_list[0].kwargs["fallback_text"]
+    assert "<h3>Новый рабочий заказ #88</h3>" in rich_text
+    assert "<b>Источник:</b> Telegram-бот" in rich_text
+    assert "<b>Услуга:</b> Обслуживание" in rich_text
+    assert "<b>Клиент:</b> Иван" in rich_text
+    assert "Победы 15" in rich_text
+    assert "Новый рабочий заказ #88" in fallback_text


### PR DESCRIPTION
## Summary
- add a direct Bot API sendRichMessage adapter with fallback to existing HTML messages
- use rich HTML for staff quick-order admin notifications as the first pilot
- keep aiogram 3.24.0 compatibility while Bot API 10.1 support catches up

## Notes
- Telegram Bot API 10.1 introduced Rich Messages on 2026-06-11
- InputRichMessage accepts html/markdown, so this starts with rich HTML before deeper block-level rendering

## Tests
- pytest tests/unit/test_bot_service.py tests/unit/test_notification_service.py tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q
- git diff --check