### PR TITLE
Use rich messages for bot work cards

### DIFF
--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -7,6 +7,7 @@ from core.database import async_session_maker
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
+from services.bot_service import BotService
 from services.bot_task_service import BotTaskService
 from ..keyboards import (
     quick_order_confirm_keyboard,
@@ -60,11 +61,15 @@ async def quick_order_parse(message: types.Message, state: FSMContext):
         return
     draft = await BotQuickOrderService.parse_text(text)
     await state.update_data(quick_order_draft=draft)
-    await message.answer(
-        BotQuickOrderService.format_draft_preview(draft),
-        parse_mode="HTML",
-        reply_markup=quick_order_confirm_keyboard(),
+    keyboard = quick_order_confirm_keyboard()
+    fallback_text = BotQuickOrderService.format_draft_preview(draft)
+    delivered = await BotService.send_rich_message(
+        message.chat.id,
+        BotQuickOrderService.format_draft_preview_rich_html(draft),
+        reply_markup=keyboard,
     )
+    if not delivered:
+        await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
 
 
 @router.callback_query(F.data == "quick_order_create")
@@ -172,11 +177,15 @@ async def my_tasks(message: types.Message):
         return
     async with async_session_maker() as session:
         tasks = await BotTaskService.list_my_tasks(session, message.from_user.id if message.from_user else None)
-    await message.answer(
-        BotTaskService.format_tasks(tasks),
-        parse_mode="HTML",
-        reply_markup=task_actions_keyboard(tasks),
+    keyboard = task_actions_keyboard(tasks)
+    fallback_text = BotTaskService.format_tasks(tasks)
+    delivered = await BotService.send_rich_message(
+        message.chat.id,
+        BotTaskService.format_tasks_rich_html(tasks),
+        reply_markup=keyboard,
     )
+    if not delivered:
+        await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
 
 
 @router.callback_query(F.data.startswith("task_accept_") | F.data.startswith("task_done_"))

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta
+from html import escape
 from typing import Any, Optional
 
 import httpx
@@ -225,26 +226,50 @@ class BotQuickOrderService:
         return normalized
 
     @classmethod
-    def format_draft_preview(cls, draft: dict[str, Any]) -> str:
+    def _display_target_date(cls, draft: dict[str, Any]) -> str | None:
         target_date = draft.get("target_date")
         if target_date:
             try:
                 dt = datetime.fromisoformat(str(target_date).replace("Z", "+00:00"))
-                target_date = dt.strftime("%d.%m.%Y %H:%M")
+                return dt.strftime("%d.%m.%Y %H:%M")
             except ValueError:
-                pass
+                return str(target_date)
+        return None
+
+    @classmethod
+    def format_draft_preview(cls, draft: dict[str, Any]) -> str:
+        target_date = cls._display_target_date(draft)
         service_type = draft.get("service_type")
         lines = [
             "<b>Черновик заказа</b>",
-            f"Клиент: {draft.get('name') or 'не указан'}",
-            f"Телефон: {draft.get('phone') or 'не указан'}",
-            f"Адрес: {draft.get('address') or 'не указан'}",
-            f"Услуга: {cls.SERVICE_LABELS.get(service_type, 'не указана')}",
-            f"Дата: {target_date or 'не указана'}",
+            f"Клиент: {escape(str(draft.get('name') or 'не указан'))}",
+            f"Телефон: {escape(str(draft.get('phone') or 'не указан'))}",
+            f"Адрес: {escape(str(draft.get('address') or 'не указан'))}",
+            f"Услуга: {escape(cls.SERVICE_LABELS.get(service_type, 'не указана'))}",
+            f"Дата: {escape(target_date or 'не указана')}",
             "",
-            f"<i>{draft.get('request_text') or ''}</i>",
+            f"<i>{escape(str(draft.get('request_text') or ''))}</i>",
         ]
         return "\n".join(lines)
+
+    @classmethod
+    def format_draft_preview_rich_html(cls, draft: dict[str, Any]) -> str:
+        target_date = cls._display_target_date(draft)
+        service_type = draft.get("service_type")
+        request_text = str(draft.get("request_text") or "").strip()
+        rich_html = (
+            "<h3>Черновик заказа</h3>"
+            "<p>"
+            f"<b>Клиент:</b> {escape(str(draft.get('name') or 'не указан'))}<br/>"
+            f"<b>Телефон:</b> {escape(str(draft.get('phone') or 'не указан'))}<br/>"
+            f"<b>Адрес:</b> {escape(str(draft.get('address') or 'не указан'))}<br/>"
+            f"<b>Услуга:</b> {escape(cls.SERVICE_LABELS.get(service_type, 'не указана'))}<br/>"
+            f"<b>Дата:</b> {escape(target_date or 'не указана')}"
+            "</p>"
+        )
+        if request_text:
+            rich_html += f"<blockquote>{escape(request_text)}</blockquote>"
+        return rich_html
 
     @classmethod
     async def create_order_from_draft(

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import httpx
 from aiogram import Bot
@@ -9,7 +10,17 @@ logger = logging.getLogger(__name__)
 
 class BotService:
     @staticmethod
-    async def send_message(user_id: int, text: str):
+    def _serialize_reply_markup(reply_markup: Any) -> dict[str, Any] | None:
+        if reply_markup is None:
+            return None
+        if isinstance(reply_markup, dict):
+            return reply_markup
+        if hasattr(reply_markup, "model_dump"):
+            return reply_markup.model_dump(exclude_none=True)
+        return None
+
+    @staticmethod
+    async def send_message(user_id: int, text: str, *, reply_markup: Any = None):
         """
         Sends a message to a specific Telegram user.
         Uses the shared BOT_TOKEN from settings.
@@ -17,7 +28,12 @@ class BotService:
         try:
             bot = Bot(token=settings.BOT_TOKEN)
             async with bot.context():
-                await bot.send_message(chat_id=user_id, text=text, parse_mode="HTML")
+                await bot.send_message(
+                    chat_id=user_id,
+                    text=text,
+                    parse_mode="HTML",
+                    reply_markup=reply_markup,
+                )
         except Exception as e:
             logger.error(f"Failed to send Telegram message to {user_id}: {e}")
 
@@ -27,6 +43,7 @@ class BotService:
         rich_html: str,
         *,
         fallback_text: str | None = None,
+        reply_markup: Any = None,
     ) -> bool:
         """
         Send a Telegram Bot API 10.1 rich message.
@@ -36,14 +53,19 @@ class BotService:
         """
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
+                body: dict[str, Any] = {
+                    "chat_id": user_id,
+                    "rich_message": {
+                        "html": rich_html,
+                    },
+                }
+                serialized_reply_markup = BotService._serialize_reply_markup(reply_markup)
+                if serialized_reply_markup:
+                    body["reply_markup"] = serialized_reply_markup
+
                 response = await client.post(
                     f"https://api.telegram.org/bot{settings.BOT_TOKEN}/sendRichMessage",
-                    json={
-                        "chat_id": user_id,
-                        "rich_message": {
-                            "html": rich_html,
-                        },
-                    },
+                    json=body,
                 )
                 response.raise_for_status()
                 payload = response.json()
@@ -54,7 +76,7 @@ class BotService:
             logger.warning("Failed to send Telegram rich message to %s: %s", user_id, exc)
 
         if fallback_text:
-            await BotService.send_message(user_id, fallback_text)
+            await BotService.send_message(user_id, fallback_text, reply_markup=reply_markup)
         return False
 
     @staticmethod

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from html import escape
 from typing import Any
 
 from sqlalchemy import or_
@@ -133,16 +134,38 @@ class BotTaskService:
             lines.extend(
                 [
                     "",
-                    f"<b>#{task['order_id']} - {task['title']}</b>",
-                    f"Дата: {date_text}",
-                    f"Клиент: {task.get('customer_name') or 'Клиент'}",
-                    f"Телефон: {task.get('customer_phone') or 'не указан'}",
-                    f"Адрес: {task.get('address') or 'не указан'}",
+                    f"<b>#{task['order_id']} - {escape(str(task['title']))}</b>",
+                    f"Дата: {escape(date_text)}",
+                    f"Клиент: {escape(str(task.get('customer_name') or 'Клиент'))}",
+                    f"Телефон: {escape(str(task.get('customer_phone') or 'не указан'))}",
+                    f"Адрес: {escape(str(task.get('address') or 'не указан'))}",
                 ]
             )
             if task.get("comment"):
-                lines.append(f"Комментарий: {task['comment']}")
+                lines.append(f"Комментарий: {escape(str(task['comment']))}")
         return "\n".join(lines)
+
+    @staticmethod
+    def format_tasks_rich_html(tasks: list[dict[str, Any]]) -> str:
+        if not tasks:
+            return "<h3>Мои ближайшие задачи</h3><p>У вас нет ближайших задач.</p>"
+
+        blocks = ["<h3>Мои ближайшие задачи</h3>"]
+        for task in tasks:
+            dt = task.get("start_time")
+            date_text = dt.strftime("%d.%m.%Y %H:%M") if dt else "время не назначено"
+            blocks.append(
+                "<p>"
+                f"<b>#{task['order_id']} - {escape(str(task['title']))}</b><br/>"
+                f"<b>Дата:</b> {escape(date_text)}<br/>"
+                f"<b>Клиент:</b> {escape(str(task.get('customer_name') or 'Клиент'))}<br/>"
+                f"<b>Телефон:</b> {escape(str(task.get('customer_phone') or 'не указан'))}<br/>"
+                f"<b>Адрес:</b> {escape(str(task.get('address') or 'не указан'))}"
+                "</p>"
+            )
+            if task.get("comment"):
+                blocks.append(f"<blockquote>{escape(str(task['comment']))}</blockquote>")
+        return "".join(blocks)
 
     @staticmethod
     async def update_stage_status(

--- a/tests/unit/test_bot_service.py
+++ b/tests/unit/test_bot_service.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from bot_app.keyboards import quick_order_confirm_keyboard
 from services.bot_service import BotService
 
 
@@ -64,6 +65,25 @@ async def test_send_rich_message_calls_telegram_bot_api(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_rich_message_serializes_reply_markup(monkeypatch):
+    _FakeAsyncClient.requests = []
+    _FakeAsyncClient.response = _FakeResponse({"ok": True, "result": {"message_id": 1}})
+    monkeypatch.setattr("services.bot_service.httpx.AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr("services.bot_service.settings.BOT_TOKEN", "123:test", raising=False)
+
+    delivered = await BotService.send_rich_message(
+        777,
+        "<h3>Черновик</h3>",
+        reply_markup=quick_order_confirm_keyboard(),
+    )
+
+    assert delivered is True
+    payload = _FakeAsyncClient.requests[0]["json"]
+    assert payload["reply_markup"]["inline_keyboard"][0][0]["text"] == "Создать"
+    assert payload["reply_markup"]["inline_keyboard"][0][0]["callback_data"] == "quick_order_create"
+
+
+@pytest.mark.asyncio
 async def test_send_rich_message_falls_back_to_html_message(monkeypatch):
     _FakeAsyncClient.requests = []
     _FakeAsyncClient.response = _FakeResponse({"ok": False})
@@ -74,4 +94,4 @@ async def test_send_rich_message_falls_back_to_html_message(monkeypatch):
     delivered = await BotService.send_rich_message(777, "<h3>Заказ</h3>", fallback_text="fallback")
 
     assert delivered is False
-    fallback.assert_awaited_once_with(777, "fallback")
+    fallback.assert_awaited_once_with(777, "fallback", reply_markup=None)

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -13,6 +13,7 @@ from models import GlobalConfig, StaffUser
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
+from services.bot_task_service import BotTaskService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
 from bot_app.keyboards import selection_result_keyboard
@@ -43,6 +44,54 @@ def test_quick_order_fallback_parses_service_phone_address_and_date():
     assert draft["name"] == "Иван"
     assert draft["address"] == "Победы 15"
     assert draft["target_date"] == "2026-06-15T14:00:00"
+
+
+def test_quick_order_rich_preview_formats_and_escapes_fields():
+    draft = {
+        "name": "Иван <опасно>",
+        "phone": "+375 29 123-45-67",
+        "address": "Победы 15",
+        "service_type": "maintenance",
+        "target_date": "2026-06-15T14:00:00",
+        "request_text": "ТО <script>, Иван, Победы 15",
+    }
+
+    rich = BotQuickOrderService.format_draft_preview_rich_html(draft)
+    fallback = BotQuickOrderService.format_draft_preview(draft)
+
+    assert "<h3>Черновик заказа</h3>" in rich
+    assert "<b>Услуга:</b> Обслуживание" in rich
+    assert "<b>Дата:</b> 15.06.2026 14:00" in rich
+    assert "Иван &lt;опасно&gt;" in rich
+    assert "<script>" not in rich
+    assert "Иван &lt;опасно&gt;" in fallback
+    assert "<script>" not in fallback
+
+
+def test_tasks_rich_html_formats_and_escapes_cards():
+    tasks = [
+        {
+            "kind": "stage",
+            "id": 10,
+            "order_id": 42,
+            "title": "Монтаж <важно>",
+            "start_time": datetime(2026, 6, 15, 14, 0),
+            "customer_name": "Иван",
+            "customer_phone": "+375291234567",
+            "address": "Победы 15",
+            "comment": "Не забыть <лестницу>",
+        }
+    ]
+
+    rich = BotTaskService.format_tasks_rich_html(tasks)
+    fallback = BotTaskService.format_tasks(tasks)
+
+    assert "<h3>Мои ближайшие задачи</h3>" in rich
+    assert "#42 - Монтаж &lt;важно&gt;" in rich
+    assert "<b>Дата:</b> 15.06.2026 14:00" in rich
+    assert "Не забыть &lt;лестницу&gt;" in rich
+    assert "<важно>" not in rich
+    assert "Монтаж &lt;важно&gt;" in fallback
 
 
 def test_product_caption_contains_public_product_link(monkeypatch):


### PR DESCRIPTION
## Summary
- render quick-order drafts as Telegram Rich Messages with inline confirmation buttons
- render installer "Мои задачи" cards as Rich Messages with task action buttons
- extend the Rich Message adapter to serialize reply_markup and keep HTML fallback with markup
- escape user-provided text in quick-order/task HTML fallbacks

## Tests
- pytest tests/unit/test_bot_service.py tests/unit/test_bot_work_services.py tests/unit/test_notification_service.py tests/unit/test_bot_handlers_architecture.py -q
- git diff --check