### PR TITLE
Accept media task reports in bot

### DIFF
--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -212,7 +212,7 @@ async def task_report_start(callback: CallbackQuery, state: FSMContext):
     stage_id = int((callback.data or "").rsplit("_", 1)[-1])
     await state.update_data(task_report_stage_id=stage_id)
     await state.set_state(ShopState.waiting_for_task_report)
-    await callback.message.answer("Пришлите комментарий/отчет по задаче.")
+    await callback.message.answer("Пришлите комментарий/отчет по задаче: текст, фото или документ с подписью.")
     await callback.answer()
 
 
@@ -220,7 +220,15 @@ async def task_report_start(callback: CallbackQuery, state: FSMContext):
 async def task_report_finish(message: types.Message, state: FSMContext):
     data = await state.get_data()
     stage_id = int(data.get("task_report_stage_id") or 0)
-    report = (message.text or "").strip()
+    photo_file_id = message.photo[-1].file_id if message.photo else None
+    document = message.document
+    report = BotTaskService.build_stage_report(
+        text=message.text,
+        caption=message.caption,
+        photo_file_id=photo_file_id,
+        document_file_id=document.file_id if document else None,
+        document_name=document.file_name if document else None,
+    )
     if not stage_id or not report:
         await message.answer("Отчет пустой, попробуйте еще раз.")
         return

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -168,6 +168,34 @@ class BotTaskService:
         return "".join(blocks)
 
     @staticmethod
+    def build_stage_report(
+        *,
+        text: str | None = None,
+        caption: str | None = None,
+        photo_file_id: str | None = None,
+        document_file_id: str | None = None,
+        document_name: str | None = None,
+    ) -> str:
+        body = (text or caption or "").strip()
+        lines: list[str] = [body] if body else []
+        attachments: list[str] = []
+
+        if photo_file_id:
+            attachments.append(f"Фото: {photo_file_id}")
+
+        if document_file_id:
+            safe_name = " ".join((document_name or "файл").split())[:120] or "файл"
+            attachments.append(f"Документ: {safe_name} ({document_file_id})")
+
+        if attachments:
+            if lines:
+                lines.append("")
+            lines.append("Вложения:")
+            lines.extend(f"- {attachment}" for attachment in attachments)
+
+        return "\n".join(lines).strip()
+
+    @staticmethod
     async def update_stage_status(
         session: AsyncSession,
         stage_id: int,

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -94,6 +94,35 @@ def test_tasks_rich_html_formats_and_escapes_cards():
     assert "Монтаж &lt;важно&gt;" in fallback
 
 
+def test_task_report_builder_keeps_text_report_plain():
+    report = BotTaskService.build_stage_report(text="Фреон дозаправлен, трасса проверена")
+
+    assert report == "Фреон дозаправлен, трасса проверена"
+
+
+def test_task_report_builder_accepts_photo_with_caption():
+    report = BotTaskService.build_stage_report(
+        caption="Фото после обслуживания",
+        photo_file_id="AgACAgIAAxkBAAIB_photo",
+    )
+
+    assert report == (
+        "Фото после обслуживания\n"
+        "\n"
+        "Вложения:\n"
+        "- Фото: AgACAgIAAxkBAAIB_photo"
+    )
+
+
+def test_task_report_builder_accepts_document_without_caption():
+    report = BotTaskService.build_stage_report(
+        document_file_id="BQACAgIAAxkBAAIB_doc",
+        document_name="акт выполненных работ.pdf",
+    )
+
+    assert report == "Вложения:\n- Документ: акт выполненных работ.pdf (BQACAgIAAxkBAAIB_doc)"
+
+
 def test_product_caption_contains_public_product_link(monkeypatch):
     monkeypatch.setattr(
         "services.bot_product_selection_service.settings",


### PR DESCRIPTION
## Summary
- allow installer task reports in Telegram bot to include photo or document messages
- store captions/text plus Telegram file IDs in the existing installer report field
- add unit coverage for text, photo, and document report formatting

## Tests
- pytest tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py -q