### PR TITLE
Use rich messages for bot selections

### DIFF
--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -139,11 +139,15 @@ async def selection_process(message: types.Message, state: FSMContext):
         selection = await BotProductSelectionService.build_selection(session, query)
     await state.update_data(selection_client_text=BotProductSelectionService.format_client_selection(selection))
     await state.set_state(None)
-    await message.answer(
-        BotProductSelectionService.format_selection(selection),
-        parse_mode="HTML",
-        reply_markup=selection_result_keyboard() if selection.get("areas") else None,
+    keyboard = selection_result_keyboard() if selection.get("areas") else None
+    fallback_text = BotProductSelectionService.format_selection(selection)
+    delivered = await BotService.send_rich_message(
+        message.chat.id,
+        BotProductSelectionService.format_selection_rich_html(selection),
+        reply_markup=keyboard,
     )
+    if not delivered:
+        await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
 
 
 @router.callback_query(F.data == "selection_client_text")

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -1,5 +1,6 @@
 import json
 import re
+from html import escape
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -465,7 +466,7 @@ class BotProductSelectionService:
     @classmethod
     def format_selection(cls, selection: dict[str, Any]) -> str:
         if not selection.get("areas"):
-            return selection.get("message") or "Ничего не подобрал."
+            return escape(str(selection.get("message") or "Ничего не подобрал."))
 
         lines = ["<b>Подбор кондиционеров для клиента</b>"]
         mode = selection.get("compressor_mode")
@@ -473,23 +474,62 @@ class BotProductSelectionService:
             lines.append("Режим: только инверторы")
         elif mode == "onoff_only":
             reason = f" ({selection.get('mode_reason')})" if selection.get("mode_reason") else ""
-            lines.append(f"Режим: только ON-OFF{reason}")
+            lines.append(f"Режим: только ON-OFF{escape(reason)}")
         for area in selection["areas"]:
             area_label = area.get("label") or f"{area['area']} м²"
-            lines.extend(["", f"<b>{area_label}</b>"])
+            lines.extend(["", f"<b>{escape(str(area_label))}</b>"])
             for tier in area["tiers"]:
                 products = tier.get("products") or []
                 if not products:
-                    lines.append(f"{tier['label']}: нет подходящих моделей")
+                    lines.append(f"{escape(str(tier['label']))}: нет подходящих моделей")
                     continue
                 product = products[0]
                 reason = cls.availability_text(product)
                 lines.append(
-                    f"{tier['label']}: {product.get('title')} - {product.get('price')} руб.\n"
-                    f"{reason}\n"
-                    f"{cls.product_url(product)}"
+                    f"{escape(str(tier['label']))}: {escape(str(product.get('title') or 'Товар'))} - "
+                    f"{escape(str(product.get('price') or 0))} руб.\n"
+                    f"{escape(reason)}\n"
+                    f"{escape(cls.product_url(product))}"
                 )
         return "\n".join(lines)
+
+    @classmethod
+    def format_selection_rich_html(cls, selection: dict[str, Any]) -> str:
+        if not selection.get("areas"):
+            message = escape(str(selection.get("message") or "Ничего не подобрал."))
+            return f"<h3>Подбор кондиционеров</h3><p>{message}</p>"
+
+        blocks = ["<h3>Подбор кондиционеров для клиента</h3>"]
+        mode = selection.get("compressor_mode")
+        if mode == "inverter_only":
+            blocks.append("<p><b>Режим:</b> только инверторы</p>")
+        elif mode == "onoff_only":
+            reason = f" ({selection.get('mode_reason')})" if selection.get("mode_reason") else ""
+            blocks.append(f"<p><b>Режим:</b> только ON-OFF{escape(reason)}</p>")
+
+        for area in selection["areas"]:
+            area_label = area.get("label") or f"{area['area']} м²"
+            blocks.append(f"<h4>{escape(str(area_label))}</h4>")
+            for tier in area["tiers"]:
+                products = tier.get("products") or []
+                tier_label = escape(str(tier.get("label") or "Вариант"))
+                if not products:
+                    blocks.append(f"<p><b>{tier_label}:</b> нет подходящих моделей</p>")
+                    continue
+                product = products[0]
+                title = escape(str(product.get("title") or "Товар"))
+                price = escape(str(product.get("price") or 0))
+                availability = escape(cls.availability_text(product))
+                url = escape(cls.product_url(product))
+                blocks.append(
+                    "<p>"
+                    f"<b>{tier_label}:</b> {title}<br/>"
+                    f"<b>Цена:</b> {price} руб.<br/>"
+                    f"<b>Наличие:</b> {availability}<br/>"
+                    f"<a href=\"{url}\">Открыть товар на сайте</a>"
+                    "</p>"
+                )
+        return "".join(blocks)
 
     @classmethod
     def format_client_selection(cls, selection: dict[str, Any]) -> str:

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -303,6 +303,48 @@ def test_product_selection_formats_client_forward_text(monkeypatch):
     assert "Витебск" not in formatted
 
 
+def test_product_selection_rich_html_formats_cards_and_escapes(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+    selection = {
+        "compressor_mode": "inverter_only",
+        "mode_reason": "инверторы",
+        "areas": [
+            {
+                "label": "7 <1,9 кВт>",
+                "tiers": [
+                    {
+                        "label": "Оптимально",
+                        "products": [
+                            {
+                                "title": "Midea <script>",
+                                "slug": "midea-07",
+                                "price": 1200,
+                                "vitebsk_qty": 2,
+                                "minsk_qty": 0,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    rich = BotProductSelectionService.format_selection_rich_html(selection)
+    fallback = BotProductSelectionService.format_selection(selection)
+
+    assert "<h3>Подбор кондиционеров для клиента</h3>" in rich
+    assert "<b>Режим:</b> только инверторы" in rich
+    assert "7 &lt;1,9 кВт&gt;" in rich
+    assert "Midea &lt;script&gt;" in rich
+    assert '<a href="https://example.test/product/midea-07/">Открыть товар на сайте</a>' in rich
+    assert "<script>" not in rich
+    assert "Midea &lt;script&gt;" in fallback
+    assert "<script>" not in fallback
+
+
 def test_selection_result_keyboard_has_client_text_action():
     keyboard = selection_result_keyboard()
 


### PR DESCRIPTION
## Summary
- send manager product selections through Telegram Rich Messages with HTML fallback
- add a rich selection card formatter with product links and availability
- escape staff selection fallback output before sending with HTML parse mode

## Tests
- pytest tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py tests/unit/test_bot_service.py -q