### PR TITLE
Add client text action for bot product cards

### DIFF
--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -8,6 +8,7 @@ from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
 from services.bot_access_service import BotAccessService
+from services.bot_product_selection_service import BotProductSelectionService
 from services.product_service import ProductService
 from services.staff_user_service import StaffUserService
 from ..keyboards import area_selection_kb, type_selection_kb, winter_selection_kb, wifi_selection_kb
@@ -225,6 +226,24 @@ async def search_details(callback: CallbackQuery):
 
     await send_product_card(callback, product, is_admin)
     await callback.answer()
+
+
+@router.callback_query(F.data.startswith("product_client_text_"))
+async def product_client_text(callback: CallbackQuery):
+    if not await _is_staff_user(callback.from_user.id):
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+    product_id = int((callback.data or "").split("_")[-1])
+    async with async_session_maker() as session:
+        product = await ProductService.get_by_id(session, product_id)
+
+    if not product:
+        await callback.answer("Товар не найден", show_alert=True)
+        return
+
+    await callback.message.answer(BotProductSelectionService.format_client_product(product))
+    await callback.answer("Можно переслать клиенту")
+
 
 @router.message(ShopState.waiting_for_search)
 async def search_process(message: types.Message, state: FSMContext):

--- a/bot_app/keyboards.py
+++ b/bot_app/keyboards.py
@@ -73,6 +73,9 @@ def get_product_keyboard(product_id, is_admin=False, in_favorites=False, product
         buttons = []
         if url:
             buttons.append([InlineKeyboardButton(text="Открыть на сайте", url=url)])
+            buttons.append(
+                [InlineKeyboardButton(text="Текст клиенту", callback_data=f"product_client_text_{product_id}")]
+            )
         buttons.append([InlineKeyboardButton(text="Подробнее", callback_data=f"search_details_{product_id}")])
         if is_admin:
             buttons.append(

--- a/bot_app/utils.py
+++ b/bot_app/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from html import escape
 from pathlib import Path
 from aiogram import types
 from aiogram.types import FSInputFile
@@ -36,17 +37,17 @@ def format_caption(product):
     specs_str = ""
     # Если categories существует (и это список), выводим красиво
     if product.get('categories') and isinstance(product['categories'], list):
-        specs_str += f"📌 {', '.join(product['categories'])}\n"
+        specs_str += f"📌 {escape(', '.join(str(category) for category in product['categories']))}\n"
     
     return (
-        f"❄️ <b>{product['title']}</b>\n"
+        f"❄️ <b>{escape(str(product['title']))}</b>\n"
         f"{_availability_badge(product)}"
         f"{_availability_details(product)}"
-        f"💰 <b>{product['price']} руб.</b>\n"
-        f"🏠 Площадь: {product.get('area', '-')} м²\n"
+        f"💰 <b>{escape(str(product['price']))} руб.</b>\n"
+        f"🏠 Площадь: {escape(str(product.get('area', '-')))} м²\n"
         f"{specs_str}"
-        f"📝 {product.get('description', '')[:200]}\n"
-        f"🔗 {BotProductSelectionService.product_url(product)}"
+        f"📝 {escape(str(product.get('description', ''))[:200])}\n"
+        f"🔗 {escape(BotProductSelectionService.product_url(product))}"
     )
 
 async def send_product_card(message_or_callback, product, is_admin, *, staff_mode=True):

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -556,3 +556,16 @@ class BotProductSelectionService:
         if len(lines) == 1:
             return "Пока не получилось подобрать варианты из наличия."
         return "\n".join(lines)
+
+    @classmethod
+    def format_client_product(cls, product: dict[str, Any]) -> str:
+        title = str(product.get("title") or "Кондиционер").strip()
+        price = product.get("price")
+        price_text = f"{price} руб." if price not in (None, "") else "цену уточним"
+        lines = [
+            f"{title}",
+            f"Цена: {price_text}",
+            cls.client_availability_text(product),
+            cls.product_url(product),
+        ]
+        return "\n".join(line for line in lines if str(line).strip())

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -16,7 +16,7 @@ from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_task_service import BotTaskService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
-from bot_app.keyboards import selection_result_keyboard
+from bot_app.keyboards import get_product_keyboard, selection_result_keyboard
 from bot_app.utils import format_caption
 
 
@@ -141,6 +141,77 @@ def test_product_caption_contains_public_product_link(monkeypatch):
     )
 
     assert "https://example.test/product/midea-12/" in caption
+
+
+def test_product_caption_escapes_html_fields(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+
+    caption = format_caption(
+        {
+            "id": 1,
+            "title": "Midea <script>",
+            "slug": "midea-12",
+            "price": 1200,
+            "area": "35 <bad>",
+            "categories": ["Настенные <x>"],
+            "description": "Описание <b>опасно</b>",
+        }
+    )
+
+    assert "Midea &lt;script&gt;" in caption
+    assert "Настенные &lt;x&gt;" in caption
+    assert "35 &lt;bad&gt;" in caption
+    assert "Описание &lt;b&gt;опасно&lt;/b&gt;" in caption
+    assert "<script>" not in caption
+    assert "<bad>" not in caption
+
+
+def test_staff_product_keyboard_has_client_text_action(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+
+    keyboard = get_product_keyboard(
+        42,
+        is_admin=False,
+        product={"id": 42, "slug": "midea-12"},
+        staff_mode=True,
+    )
+
+    assert keyboard.inline_keyboard[0][0].text == "Открыть на сайте"
+    assert keyboard.inline_keyboard[0][0].url == "https://example.test/product/midea-12/"
+    assert keyboard.inline_keyboard[1][0].text == "Текст клиенту"
+    assert keyboard.inline_keyboard[1][0].callback_data == "product_client_text_42"
+
+
+def test_product_client_text_is_forwardable(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+
+    text = BotProductSelectionService.format_client_product(
+        {
+            "title": "Midea 12",
+            "slug": "midea-12",
+            "price": 1200,
+            "vitebsk_qty": 0,
+            "minsk_qty": 2,
+        }
+    )
+
+    assert text == (
+        "Midea 12\n"
+        "Цена: 1200 руб.\n"
+        "доступно 2-3 дня\n"
+        "https://example.test/product/midea-12/"
+    )
+    assert "Витебск" not in text
+    assert "<b>" not in text
 
 
 def test_product_selection_sorts_by_vitebsk_then_minsk_then_unknown():


### PR DESCRIPTION
## Summary
- add a staff product-card action that returns clean client-forwardable text for one model
- reuse public product URLs and client-safe availability wording
- escape product card HTML fields before sending search cards with parse_mode=HTML

## Tests
- pytest tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py tests/unit/test_bot_auto_search_query.py -q