### PR TITLE
Notify admins about bot task status changes

### DIFF
--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from html import escape
 from typing import Any
@@ -8,7 +9,10 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from models import Order, OrderInstaller, OrderStageStatus, OrderWorkStage, StaffUser
+from services.notification_service import NotificationService
 from services.staff_user_service import StaffUserService
+
+logger = logging.getLogger(__name__)
 
 
 class BotTaskService:
@@ -210,6 +214,10 @@ class BotTaskService:
         stage.status = OrderStageStatus(status)
         session.add(stage)
         await session.commit()
+        try:
+            await NotificationService.notify_admins_work_stage_status_changed(session, stage_id)
+        except Exception:
+            logger.exception("BOT_TASK_STATUS_NOTIFY_FAILED stage_id=%s", stage_id)
         return True
 
     @staticmethod

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models.order import BankReceipt, Order, OrderProductLink
+from models.order import BankReceipt, Order, OrderProductLink, OrderWorkStage
 from services.bot_service import BotService
 from services.staff_user_service import StaffUserService
 
@@ -20,6 +20,12 @@ class NotificationService:
         "maintenance": "Обслуживание",
         "repair": "Ремонт",
         "dismantling": "Демонтаж",
+    }
+    WORK_STAGE_STATUS_LABELS = {
+        "planned": "запланирована",
+        "in_progress": "принята в работу",
+        "completed": "выполнена",
+        "canceled": "отменена",
     }
 
     @staticmethod
@@ -153,6 +159,91 @@ class NotificationService:
                 sent += 1
             except Exception:
                 logger.exception("NOTIFY_STAFF_ORDER_SEND_FAILED order_id=%s admin_id=%s", order.id, admin_id)
+        return sent
+
+    @staticmethod
+    async def notify_admins_work_stage_status_changed(
+        session: AsyncSession,
+        stage_id: int,
+    ) -> int:
+        admin_ids = await NotificationService._admin_recipient_ids(session)
+        if not admin_ids:
+            return 0
+
+        stmt = (
+            select(OrderWorkStage)
+            .where(OrderWorkStage.id == stage_id)
+            .options(
+                selectinload(OrderWorkStage.order).selectinload(Order.customer),
+                selectinload(OrderWorkStage.installer),
+            )
+        )
+        result = await session.execute(stmt)
+        stage = result.scalar_one_or_none()
+        if not stage:
+            logger.warning("NOTIFY_WORK_STAGE_STATUS_SKIPPED missing_stage_id=%s", stage_id)
+            return 0
+
+        order = getattr(stage, "order", None)
+        customer = getattr(order, "customer", None) if order else None
+        installer = getattr(stage, "installer", None)
+        status_value = stage.status.value if hasattr(stage.status, "value") else str(stage.status)
+        status_label = NotificationService.WORK_STAGE_STATUS_LABELS.get(status_value, status_value)
+        date_text = stage.start_time.strftime("%d.%m.%Y %H:%M") if stage.start_time else "не назначена"
+        order_id = getattr(order, "id", None) or stage.order_id
+        title = stage.name or "Рабочая задача"
+        customer_name = getattr(customer, "name", None) or "Клиент"
+        customer_phone = getattr(customer, "phone", None) or "не указан"
+        address = getattr(order, "delivery_address", None) if order else None
+        installer_name = getattr(installer, "name", None) or "исполнитель не указан"
+        comment = (stage.installer_report or stage.manager_comment or "").strip()
+        if len(comment) > 320:
+            comment = f"{comment[:317]}..."
+
+        text_lines = [
+            f"🔧 <b>Задача #{stage.id}: {escape(status_label)}</b>",
+            f"Заказ: #{order_id}",
+            f"Задача: {escape(title)}",
+            f"Исполнитель: {escape(installer_name)}",
+            f"Дата: {escape(date_text)}",
+            f"Клиент: {escape(customer_name)}",
+            f"Телефон: {escape(customer_phone)}",
+            f"Адрес: {escape(address or 'не указан')}",
+        ]
+        if comment:
+            text_lines.extend(["", f"<i>{escape(comment)}</i>"])
+        text = "\n".join(text_lines)
+
+        rich_html = (
+            f"<h3>Задача #{stage.id}: {escape(status_label)}</h3>"
+            "<p>"
+            f"<b>Заказ:</b> #{order_id}<br/>"
+            f"<b>Задача:</b> {escape(title)}<br/>"
+            f"<b>Исполнитель:</b> {escape(installer_name)}<br/>"
+            f"<b>Дата:</b> {escape(date_text)}<br/>"
+            f"<b>Клиент:</b> {escape(customer_name)}<br/>"
+            f"<b>Телефон:</b> {escape(customer_phone)}<br/>"
+            f"<b>Адрес:</b> {escape(address or 'не указан')}"
+            "</p>"
+        )
+        if comment:
+            rich_html += f"<blockquote>{escape(comment)}</blockquote>"
+
+        sent = 0
+        for admin_id in admin_ids:
+            try:
+                await BotService.send_rich_message(
+                    admin_id,
+                    rich_html,
+                    fallback_text=text,
+                )
+                sent += 1
+            except Exception:
+                logger.exception(
+                    "NOTIFY_WORK_STAGE_STATUS_SEND_FAILED stage_id=%s admin_id=%s",
+                    stage.id,
+                    admin_id,
+                )
         return sent
 
     @staticmethod

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -10,6 +10,7 @@ from sqlmodel import SQLModel
 
 from crud.product import ProductDAO
 from models import GlobalConfig, StaffUser
+from models.common import OrderStageStatus
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
@@ -151,6 +152,51 @@ def test_task_report_builder_accepts_document_without_caption():
     )
 
     assert report == "Вложения:\n- Документ: акт выполненных работ.pdf (BQACAgIAAxkBAAIB_doc)"
+
+
+@pytest.mark.asyncio
+async def test_task_status_update_notifies_admins(monkeypatch):
+    calls = {}
+    stage = SimpleNamespace(id=10, installer_id=7, status=OrderStageStatus.PLANNED)
+    staff = SimpleNamespace(legacy_installer_id=7)
+
+    class FakeSession:
+        async def get(self, model, stage_id):
+            calls["get"] = {"model": model, "stage_id": stage_id}
+            return stage
+
+        def add(self, item):
+            calls["add"] = item
+
+        async def commit(self):
+            calls["commit"] = True
+
+    async def fake_staff_by_telegram_id(session, telegram_id):
+        calls["staff_lookup"] = {"session": session, "telegram_id": telegram_id}
+        return staff
+
+    async def fake_notify(session, stage_id):
+        calls["notify"] = {"session": session, "stage_id": stage_id}
+        return 1
+
+    monkeypatch.setattr(BotTaskService, "_staff_by_telegram_id", fake_staff_by_telegram_id)
+    monkeypatch.setattr(
+        "services.bot_task_service.NotificationService.notify_admins_work_stage_status_changed",
+        fake_notify,
+    )
+
+    session = FakeSession()
+    ok = await BotTaskService.update_stage_status(
+        session,
+        10,
+        "completed",
+        telegram_id=777,
+    )
+
+    assert ok
+    assert stage.status == OrderStageStatus.COMPLETED
+    assert calls["commit"] is True
+    assert calls["notify"] == {"session": session, "stage_id": 10}
 
 
 def test_product_caption_contains_public_product_link(monkeypatch):

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -139,3 +140,40 @@ async def test_notify_admins_staff_order_created_sends_work_order_summary(monkey
     assert "<b>Клиент:</b> Иван" in rich_text
     assert "Победы 15" in rich_text
     assert "Новый рабочий заказ #88" in fallback_text
+
+
+@pytest.mark.asyncio
+async def test_notify_admins_work_stage_status_changed_sends_task_summary(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "10,11", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+
+    stage = SimpleNamespace(
+        id=5,
+        order_id=88,
+        name="Монтаж <важно>",
+        status="completed",
+        start_time=datetime(2026, 6, 15, 14, 0),
+        manager_comment="Комментарий менеджера",
+        installer_report="Готово <фото>",
+        installer=SimpleNamespace(name="Петр"),
+        order=SimpleNamespace(
+            id=88,
+            delivery_address="Победы 15",
+            customer=SimpleNamespace(name="Иван", phone="+375 29 123-45-67"),
+        ),
+    )
+    session = _DummySession(order=stage)
+    send_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr("services.notification_service.BotService.send_rich_message", send_mock)
+
+    sent = await NotificationService.notify_admins_work_stage_status_changed(session, stage_id=5)
+
+    assert sent == 2
+    rich_text = send_mock.await_args_list[0].args[1]
+    fallback_text = send_mock.await_args_list[0].kwargs["fallback_text"]
+    assert "<h3>Задача #5: выполнена</h3>" in rich_text
+    assert "<b>Заказ:</b> #88" in rich_text
+    assert "Монтаж &lt;важно&gt;" in rich_text
+    assert "<blockquote>Готово &lt;фото&gt;</blockquote>" in rich_text
+    assert "<важно>" not in rich_text
+    assert "Задача #5: выполнена" in fallback_text


### PR DESCRIPTION
## Summary
- notify owner/manager Telegram recipients when an executor accepts or completes a bot task
- include order, task, executor, date, customer, address, and latest report/comment in a rich message with fallback text
- keep task status updates best-effort if notification delivery fails

## Tests
- pytest tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py tests/unit/test_notification_service.py -q