### PR TITLE
Polish bot selection client wording

### DIFF
--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -10,6 +10,7 @@ from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_service import BotService
 from services.bot_task_service import BotTaskService
 from ..keyboards import (
+    get_staff_main_menu,
     quick_order_confirm_keyboard,
     selection_result_keyboard,
     task_actions_keyboard,
@@ -123,7 +124,8 @@ async def selection_start(message: types.Message, state: FSMContext):
         return
     await state.set_state(ShopState.waiting_for_selection)
     await message.answer(
-        "Напишите запрос: например, 20 м² и 35 м², нужны бюджетный, оптимальный и премиум варианты.",
+        "Напишите запрос: например, 7х2, 7, 12 или 9 инвертора. "
+        "Можно добавить: бюджетнее, премиум, ON-OFF, серверная.",
         reply_markup=ReplyKeyboardRemove(),
     )
 
@@ -148,6 +150,7 @@ async def selection_process(message: types.Message, state: FSMContext):
     )
     if not delivered:
         await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
+    await message.answer("Готово. Можно продолжить работу из меню.", reply_markup=get_staff_main_menu(context))
 
 
 @router.callback_query(F.data == "selection_client_text")

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -400,7 +400,7 @@ class BotProductSelectionService:
         if vitebsk_qty > 0 or availability == "in_stock_now":
             return "в наличии"
         if minsk_qty > 0 or availability == "available_2_3_days":
-            return "доступно 2-3 дня"
+            return "в наличии в Минске, срок поставки 2-4 дня"
         if availability == "check_availability":
             return "наличие уточним"
         return "наличие уточним"

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -283,7 +283,7 @@ def test_product_client_text_is_forwardable(monkeypatch):
     assert text == (
         "Midea 12\n"
         "Цена: 1200 руб.\n"
-        "доступно 2-3 дня\n"
+        "в наличии в Минске, срок поставки 2-4 дня\n"
         "https://example.test/product/midea-12/"
     )
     assert "Витебск" not in text


### PR DESCRIPTION
## Summary
- change client-facing Minsk availability wording to: "в наличии в Минске, срок поставки 2-4 дня"
- update selection prompt examples to internal manager shorthand like 7х2, 7, 12, 9
- restore the staff reply menu after selection results so managers do not need to send /start again

## Tests
- pytest tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py -q