### PR TITLE
Polish Telegram bot work UX

### DIFF
--- a/bot_app/handlers/base.py
+++ b/bot_app/handlers/base.py
@@ -6,7 +6,7 @@ from ..keyboards import get_staff_main_menu
 
 router = Router()
 
-@router.message(Command("start"))
+@router.message(Command("start", "menu", "help"))
 async def cmd_start(message: types.Message):
     async with async_session_maker() as session:
         context = await BotAccessService.get_context(

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -11,7 +11,13 @@ from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.product_service import ProductService
 from services.staff_user_service import StaffUserService
-from ..keyboards import area_selection_kb, type_selection_kb, winter_selection_kb, wifi_selection_kb
+from ..keyboards import (
+    area_selection_kb,
+    get_staff_main_menu,
+    type_selection_kb,
+    winter_selection_kb,
+    wifi_selection_kb,
+)
 from ..utils import send_product_card
 from ..states import ShopState
 
@@ -32,6 +38,12 @@ async def _is_staff_user(user_id: int | None) -> bool:
 async def _is_manager_user(user_id: int | None) -> bool:
     context = await _get_access_context(user_id)
     return context.is_staff and context.is_manager
+
+
+async def _answer_with_staff_menu(message: types.Message, user_id: int | None) -> None:
+    context = await _get_access_context(user_id)
+    if context.is_staff:
+        await message.answer("Можно продолжить работу из меню.", reply_markup=get_staff_main_menu(context))
 
 
 def _is_inline_search_query(text: str) -> bool:
@@ -195,6 +207,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
             await send_product_card(callback, product, is_admin)
             
     await state.clear()
+    await _answer_with_staff_menu(callback.message, callback.from_user.id)
     await callback.answer()
 
 # ==================== ПОИСК ====================
@@ -272,6 +285,7 @@ async def search_process(message: types.Message, state: FSMContext):
     await _render_search_results(message, query, products)
 
     await state.clear()
+    await _answer_with_staff_menu(message, user_id)
 
 
 @router.message(StateFilter(None), F.text)

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -33,6 +33,11 @@ async def _require_staff(message: types.Message):
     return context
 
 
+async def _answer_with_staff_menu(message: types.Message, context, text: str = "Можно продолжить работу из меню.") -> None:
+    if context and context.is_staff:
+        await message.answer(text, reply_markup=get_staff_main_menu(context))
+
+
 @router.message(F.text == "⚡ Быстрый заказ")
 @router.message(Command("quick_order"))
 async def quick_order_start(message: types.Message, state: FSMContext):
@@ -96,6 +101,7 @@ async def quick_order_create(callback: CallbackQuery, state: FSMContext):
         f"✅ Заказ #{order['id']} создан.\n"
         "Он уже доступен в менеджере и календаре, если дата была указана."
     )
+    await _answer_with_staff_menu(callback.message, context)
     await callback.answer()
 
 
@@ -108,8 +114,10 @@ async def quick_order_retry(callback: CallbackQuery, state: FSMContext):
 
 @router.callback_query(F.data == "quick_order_cancel")
 async def quick_order_cancel(callback: CallbackQuery, state: FSMContext):
+    context = await _access_context(callback.from_user.id)
     await state.clear()
     await callback.message.edit_text("Быстрый заказ отменен.")
+    await _answer_with_staff_menu(callback.message, context)
     await callback.answer()
 
 
@@ -173,7 +181,10 @@ async def calendar_hint(message: types.Message):
     context = await _require_staff(message)
     if not context:
         return
-    await message.answer("Календарь ведем в Manager. Быстрые заказы с датой автоматически появляются там.")
+    await message.answer(
+        "Календарь ведем в Manager. Быстрые заказы с датой автоматически появляются там.",
+        reply_markup=get_staff_main_menu(context),
+    )
 
 
 @router.message(F.text == "🧰 Мои задачи")
@@ -193,10 +204,12 @@ async def my_tasks(message: types.Message):
     )
     if not delivered:
         await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
+    await _answer_with_staff_menu(message, context)
 
 
 @router.callback_query(F.data.startswith("task_accept_") | F.data.startswith("task_done_"))
 async def update_task_status(callback: CallbackQuery):
+    context = await _access_context(callback.from_user.id)
     data = callback.data or ""
     status = "in_progress" if data.startswith("task_accept_") else "completed"
     stage_id = int(data.rsplit("_", 1)[-1])
@@ -211,7 +224,7 @@ async def update_task_status(callback: CallbackQuery):
         await callback.answer("Задача не найдена или нет доступа", show_alert=True)
         return
     await callback.answer("Готово")
-    await callback.message.answer("Статус задачи обновлен.")
+    await callback.message.answer("Статус задачи обновлен.", reply_markup=get_staff_main_menu(context))
 
 
 @router.callback_query(F.data.startswith("task_report_"))
@@ -247,4 +260,8 @@ async def task_report_finish(message: types.Message, state: FSMContext):
             telegram_id=message.from_user.id if message.from_user else None,
         )
     await state.clear()
-    await message.answer("Отчет сохранен." if ok else "Задача не найдена или нет доступа.")
+    context = await _access_context(message.from_user.id if message.from_user else None)
+    await message.answer(
+        "Отчет сохранен." if ok else "Задача не найдена или нет доступа.",
+        reply_markup=get_staff_main_menu(context) if context.is_staff else None,
+    )

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 from aiogram import types
+from aiogram.types import BotCommand
 from .config import bot, dp
 from .handlers import admin, base, catalog, work
 from core.config import settings
@@ -7,6 +8,16 @@ from core.logger import setup_logging
 
 # Setup logging with session-specific bot.log (cleared on restart)
 logger = setup_logging(session_log_file="logs/bot.log", clear_session_log=True)
+
+STAFF_BOT_COMMANDS = [
+    BotCommand(command="start", description="Открыть рабочее меню"),
+    BotCommand(command="menu", description="Показать рабочее меню"),
+    BotCommand(command="help", description="Показать рабочее меню и подсказки"),
+    BotCommand(command="quick_order", description="Быстрый заказ из текста звонка"),
+    BotCommand(command="selection", description="Подбор кондиционеров: 7х2, 7, 12"),
+    BotCommand(command="search", description="Поиск товара: Midea 12"),
+    BotCommand(command="tasks", description="Мои задачи и отчеты"),
+]
 
 # Global Error Handler for Bot
 @dp.error()
@@ -17,6 +28,10 @@ async def error_handler(event: types.ErrorEvent):
 async def _idle_when_disabled() -> None:
     while True:
         await asyncio.sleep(3600)
+
+
+async def _setup_bot_commands() -> None:
+    await bot.set_my_commands(STAFF_BOT_COMMANDS)
 
 
 async def main(*, wait_when_disabled: bool = True):
@@ -35,6 +50,7 @@ async def main(*, wait_when_disabled: bool = True):
     dp.include_router(catalog.router)
     dp.include_router(admin.router)
     
+    await _setup_bot_commands()
     await bot.delete_webhook(drop_pending_updates=True)
     await dp.start_polling(bot)
 

--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -494,14 +494,35 @@ class BotProductSelectionService:
     def _format_area_label(area: dict[str, Any]) -> str:
         label = str(area.get("label") or f"{area['area']} м²")
         quantity = int(area.get("quantity") or 1)
-        return f"{label} x{quantity}" if quantity > 1 else label
+        return f"{label}, {quantity} шт." if quantity > 1 else label
 
     @staticmethod
-    def _format_price(product: dict[str, Any], quantity: int = 1) -> str:
-        price = int(product.get("price") or 0)
+    def _product_price(product: dict[str, Any]) -> int | None:
+        price = product.get("price")
+        if price in (None, ""):
+            return None
+        try:
+            return int(price)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _format_price(cls, product: dict[str, Any], quantity: int = 1) -> str:
+        price = cls._product_price(product)
+        if price is None:
+            return "цену уточним"
         if quantity <= 1:
             return f"{price} руб."
         return f"{price} руб. x {quantity} шт. = {price * quantity} руб."
+
+    @classmethod
+    def _product_total_price(cls, product: dict[str, Any], quantity: int = 1) -> int | None:
+        price = cls._product_price(product)
+        return price * max(int(quantity or 1), 1) if price is not None else None
+
+    @staticmethod
+    def _format_total_price(total: int | None) -> str:
+        return f"{total} руб." if total is not None else "цену уточним"
 
     @staticmethod
     def availability_text(product: dict[str, Any]) -> str:
@@ -660,7 +681,7 @@ class BotProductSelectionService:
                 blocks.append(
                     "<p>"
                     f"<b>{tier_label}:</b> {title}<br/>"
-                    f"<b>Цена:</b> {price} руб.<br/>"
+                    f"<b>Цена:</b> {price}<br/>"
                     f"<b>Наличие:</b> {availability}<br/>"
                     f"<a href=\"{url}\">Открыть товар на сайте</a>"
                     "</p>"
@@ -672,8 +693,13 @@ class BotProductSelectionService:
         if not selection.get("areas"):
             return selection.get("message") or "Пока не получилось подобрать варианты."
 
+        areas = selection["areas"]
+        is_kit = len(areas) > 1 or any(int(area.get("quantity") or 1) > 1 for area in areas)
+        if is_kit:
+            return cls._format_client_kit_selection(areas)
+
         lines = ["Подобрал варианты кондиционеров:"]
-        for area in selection["areas"]:
+        for area in areas:
             area_label = cls._format_area_label(area)
             quantity = int(area.get("quantity") or 1)
             area_lines = []
@@ -689,6 +715,53 @@ class BotProductSelectionService:
                 )
             if area_lines:
                 lines.extend(["", area_label, *area_lines])
+
+        if len(lines) == 1:
+            return "Пока не получилось подобрать варианты из наличия."
+        return "\n".join(lines)
+
+    @classmethod
+    def _format_client_kit_selection(cls, areas: list[dict[str, Any]]) -> str:
+        tier_keys = list(
+            dict.fromkeys(
+                str(tier.get("key") or tier.get("label") or "")
+                for area in areas
+                for tier in area.get("tiers", [])
+                if tier.get("products")
+            )
+        )
+        lines = ["Подобрал варианты кондиционеров комплектом:"]
+        for tier_key in tier_keys:
+            tier_label = ""
+            tier_lines: list[str] = []
+            total: int | None = 0
+            for area in areas:
+                tier = next(
+                    (
+                        item
+                        for item in area.get("tiers", [])
+                        if str(item.get("key") or item.get("label") or "") == tier_key
+                    ),
+                    None,
+                )
+                products = (tier or {}).get("products") or []
+                if not products:
+                    continue
+                product = products[0]
+                quantity = int(area.get("quantity") or 1)
+                tier_label = tier_label or str((tier or {}).get("label") or "Вариант")
+                area_label = cls._format_area_label(area)
+                title = str(product.get("title") or "Товар")
+                product_total = cls._product_total_price(product, quantity)
+                total = total + product_total if total is not None and product_total is not None else None
+                tier_lines.append(
+                    f"- {area_label}: {title} - {cls._format_price(product, quantity)}\n"
+                    f"  {cls.client_availability_text(product)}\n"
+                    f"  {cls.product_url(product)}"
+                )
+            if tier_lines:
+                lines.extend(["", f"{tier_label}:", *tier_lines])
+                lines.append(f"Итого по варианту: {cls._format_total_price(total)}")
 
         if len(lines) == 1:
             return "Пока не получилось подобрать варианты из наличия."

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -487,9 +487,45 @@ def test_product_selection_rich_html_formats_cards_and_escapes(monkeypatch):
     assert "7 &lt;1,9 кВт&gt;" in rich
     assert "Midea &lt;script&gt;" in rich
     assert '<a href="https://example.test/product/midea-07/">Открыть товар на сайте</a>' in rich
+    assert "1200 руб. руб." not in rich
     assert "<script>" not in rich
     assert "Midea &lt;script&gt;" in fallback
     assert "<script>" not in fallback
+
+
+def test_product_selection_missing_price_uses_contact_us_text(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+    selection = {
+        "areas": [
+            {
+                "label": "12 (3,5 кВт)",
+                "tiers": [
+                    {
+                        "label": "Оптимально",
+                        "products": [
+                            {
+                                "title": "Midea 12",
+                                "slug": "midea-12",
+                                "price": None,
+                                "vitebsk_qty": 0,
+                                "minsk_qty": 0,
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    formatted = BotProductSelectionService.format_client_selection(selection)
+    rich = BotProductSelectionService.format_selection_rich_html(selection)
+
+    assert "Midea 12 - цену уточним" in formatted
+    assert "0 руб." not in formatted
+    assert "<b>Цена:</b> цену уточним<br/>" in rich
 
 
 def test_selection_result_keyboard_has_client_text_action():
@@ -602,10 +638,12 @@ async def test_product_selection_groups_duplicate_power_classes(monkeypatch):
     assert len(selection["areas"]) == 1
     assert selection["areas"][0]["label"] == "7 (1,9 кВт)"
     assert selection["areas"][0]["quantity"] == 2
-    assert "<b>7 (1,9 кВт) x2</b>" in formatted
+    assert "<b>7 (1,9 кВт), 2 шт.</b>" in formatted
     assert "1200 руб. x 2 шт. = 2400 руб." in formatted
-    assert "7 (1,9 кВт) x2" in client_text
+    assert "Подобрал варианты кондиционеров комплектом:" in client_text
+    assert "7 (1,9 кВт), 2 шт." in client_text
     assert "1200 руб. x 2 шт. = 2400 руб." in client_text
+    assert "Итого по варианту: 2400 руб." in client_text
 
 
 @pytest.mark.asyncio
@@ -660,6 +698,7 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
     monkeypatch.setattr(ProductService, "get_curated", fake_get_curated)
 
     selection = await BotProductSelectionService.build_selection(object(), "7,9 инвертора")
+    client_text = BotProductSelectionService.format_client_selection(selection)
 
     optimal_products = [
         area["tiers"][0]["products"][0]
@@ -668,6 +707,11 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
     assert [area["label"] for area in selection["areas"]] == ["7 (1,9 кВт)", "9 (2,6 кВт)"]
     assert {product["series_id"] for product in optimal_products} == {10}
     assert [product["title"] for product in optimal_products] == ["LG Artcool 7", "LG Artcool 9"]
+    assert "Подобрал варианты кондиционеров комплектом:" in client_text
+    assert "Оптимально:" in client_text
+    assert "- 7 (1,9 кВт): LG Artcool 7 - 1100 руб." in client_text
+    assert "- 9 (2,6 кВт): LG Artcool 9 - 1000 руб." in client_text
+    assert "Итого по варианту: 2100 руб." in client_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -94,6 +94,22 @@ def test_start_scheduler_loop_skips_for_standby(monkeypatch):
     create_task.assert_not_called()
 
 
+def test_bot_main_registers_staff_commands(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+    monkeypatch.setattr(config.settings, "BOT_TOKEN", "123:test", raising=False)
+    bot_main = importlib.import_module("bot_app.main")
+
+    commands = {command.command: command.description for command in bot_main.STAFF_BOT_COMMANDS}
+
+    assert commands["menu"] == "Показать рабочее меню"
+    assert commands["help"] == "Показать рабочее меню и подсказки"
+    assert commands["quick_order"] == "Быстрый заказ из текста звонка"
+    assert commands["selection"] == "Подбор кондиционеров: 7х2, 7, 12"
+    assert commands["search"] == "Поиск товара: Midea 12"
+    assert commands["tasks"] == "Мои задачи и отчеты"
+
+
 @pytest.mark.asyncio
 async def test_bot_main_disabled_does_not_poll(monkeypatch):
     _set_required_env(monkeypatch)


### PR DESCRIPTION
## Summary
- register Telegram command hints for staff bot workflows and add /menu + /help aliases
- return the staff reply menu after terminal work flows: quick orders, calendar/tasks, task reports, manual search, legacy smart selection
- format client-ready kit selections by tier with quantities and option totals
- fix rich selection price formatting so currency is not duplicated and missing prices say цену уточним

## Tests
- Scoped bot/runtime tests: passed, 65 tests
- git diff --check: passed

## Notes
- Full local pytest tests/unit -q could not complete because this machine cannot resolve the configured test DB host db_test:5432; bot scoped tests passed.