### PR TITLE
Clarify storefront price and availability fallbacks

### DIFF
--- a/web/src/components/PriceWithToggle.vue
+++ b/web/src/components/PriceWithToggle.vue
@@ -5,10 +5,15 @@ import { getInstallationRates, getGlobalConfig, getProductById, submitProductAva
 import { addItem } from '../store/cart';
 import { addToast } from '../store/toast';
 import { validateRequiredBelarusPhone } from '../utils/validation';
+import {
+    formatProductPrice,
+    hasKnownProductPrice,
+    resolveProductAvailability,
+} from '../utils/product-display';
 
 const props = defineProps({
-  basePrice: { type: Number, required: true },
-  oldPrice: { type: Number, default: 0 },
+  basePrice: { type: [Number, String], default: 0 },
+  oldPrice: { type: [Number, String], default: 0 },
   installPrice: { type: Number, default: 600 }, // Fallback/Legacy
   currency: { type: String, default: 'р.' },
   showToggle: { type: Boolean, default: true },
@@ -44,10 +49,11 @@ const notifyForm = ref({
 const notifyPhoneInputRef = ref(null);
 let notifyMask = null;
 
-const liveBasePrice = ref(props.basePrice);
-const liveOldPrice = ref(props.oldPrice);
+const liveBasePrice = ref(Number(props.basePrice) || 0);
+const liveOldPrice = ref(Number(props.oldPrice) || 0);
 const liveVitebskQty = ref(Number(props.vitebskQty) || 0);
 const liveMinskQty = ref(Number(props.minskQty) || 0);
+const liveAvailabilityStatus = ref(props.availabilityStatus);
 
 onMounted(async () => {
     try {
@@ -65,10 +71,11 @@ onMounted(async () => {
             discount.value = parseInt(configData.install_discount, 10) || 0;
         }
         if (freshProduct && freshProduct.price !== undefined) {
-            liveBasePrice.value = freshProduct.price;
-            liveOldPrice.value = freshProduct.old_price || 0;
+            liveBasePrice.value = Number(freshProduct.price) || 0;
+            liveOldPrice.value = Number(freshProduct.old_price) || 0;
             liveVitebskQty.value = Number(freshProduct.vitebsk_qty) || 0;
             liveMinskQty.value = Number(freshProduct.minsk_qty) || 0;
+            liveAvailabilityStatus.value = freshProduct.availability_status;
         }
     } finally {
         loading.value = false;
@@ -187,38 +194,63 @@ const finalInstallPrice = computed(() => {
     return Math.max(0, effectiveInstallPrice.value - discount.value);
 });
 
-const isUnavailableInCities = computed(() => {
-    return liveVitebskQty.value <= 0 && liveMinskQty.value <= 0;
+const hasKnownPrice = computed(() => hasKnownProductPrice(liveBasePrice.value));
+
+const availabilityState = computed(() => {
+    return resolveProductAvailability({
+        vitebskQty: liveVitebskQty.value,
+        minskQty: liveMinskQty.value,
+        availabilityStatus: liveAvailabilityStatus.value,
+    });
 });
 
 const availabilityMessage = computed(() => {
-    if (liveVitebskQty.value > 0) return 'В наличии в Витебске';
-    if (liveMinskQty.value > 0) return 'В наличии в Минске';
-    return 'Нет в наличии';
+    return availabilityState.value.message;
 });
 
 const availabilityTone = computed(() => {
-    if (liveVitebskQty.value > 0) return 'vitebsk';
-    if (liveMinskQty.value > 0) return 'minsk';
-    return 'out';
+    return availabilityState.value.tone;
+});
+
+const isExplicitOutOfStock = computed(() => {
+    return availabilityState.value.isExplicitOutOfStock;
+});
+
+const shouldOpenInquiry = computed(() => {
+    return !hasKnownPrice.value || !availabilityState.value.canOrder;
+});
+
+const canAddToCart = computed(() => {
+    return hasKnownPrice.value && availabilityState.value.canOrder;
 });
 
 const shouldShowToggle = computed(() => {
-    if (isUnavailableInCities.value) return false;
+    if (!canAddToCart.value) return false;
     if (!matchedRate.value) return false;
     if (!matchedRate.value.is_fixed) return false;
     return props.showToggle;
 });
 
 // Force ru-RU to match server side rendering
-const format = (num) => num.toLocaleString('ru-RU');
+const format = (num) => Number(num).toLocaleString('ru-RU');
 
 const priceDisplay = computed(() => {
+    if (!hasKnownPrice.value) {
+        return {
+            current: formatProductPrice(liveBasePrice.value),
+            old: null,
+            showCurrency: false,
+            isInquiry: true,
+        };
+    }
+
     // Case 1: No match or non-fixed -> Just Product Price
     if (!matchedRate.value || !matchedRate.value.is_fixed) {
          return {
              current: format(liveBasePrice.value),
-             old: null
+             old: null,
+             showCurrency: true,
+             isInquiry: false,
          };
     }
     
@@ -226,24 +258,28 @@ const priceDisplay = computed(() => {
     if (!isInstalled.value) {
         return {
             current: format(liveBasePrice.value),
-            old: null
+            old: null,
+            showCurrency: true,
+            isInquiry: false,
         };
     }
 
     // Case 3: Fixed rate + Toggled -> Product + Discounted Install
-    const total = liveBasePrice.value + finalInstallPrice.value;
-    const oldTotal = liveBasePrice.value + effectiveInstallPrice.value;
+    const total = Number(liveBasePrice.value) + Number(finalInstallPrice.value);
+    const oldTotal = Number(liveBasePrice.value) + Number(effectiveInstallPrice.value);
 
     return {
         current: format(total),
-        old: discount.value > 0 ? format(oldTotal) : null
+        old: discount.value > 0 ? format(oldTotal) : null,
+        showCurrency: true,
+        isInquiry: false,
     };
 });
 
 const discountPct = computed(() => {
-    if (!liveOldPrice.value || !liveBasePrice.value) return 0;
+    if (!liveOldPrice.value || !hasKnownPrice.value) return 0;
     const diff = liveOldPrice.value - liveBasePrice.value;
-    return Math.round((diff / liveOldPrice.value) * 100);
+    return diff > 0 ? Math.round((diff / liveOldPrice.value) * 100) : 0;
 });
 
 const toggle = (e) => {
@@ -253,13 +289,13 @@ const toggle = (e) => {
 }
 
 const addToCart = () => {
-    if (isUnavailableInCities.value) return;
+    if (!canAddToCart.value) return;
     if (!props.id) return;
     
     addItem({
         id: props.id,
         name: props.title,
-        price: liveBasePrice.value,
+        price: Number(liveBasePrice.value),
         image: props.image,
         productId: props.productId,
         withInstallation: isInstalled.value,
@@ -277,17 +313,46 @@ const addToCart = () => {
 }
 
 const buttonLabel = computed(() => {
-    if (isUnavailableInCities.value) return 'Сообщить о поступлении';
+    if (!hasKnownPrice.value && availabilityState.value.isUnknown) return 'Уточнить цену и наличие';
+    if (!hasKnownPrice.value) return 'Уточнить цену';
+    if (isExplicitOutOfStock.value) return 'Сообщить о поступлении';
+    if (!availabilityState.value.canOrder) return 'Уточнить наличие';
     return buttonState.value === 'success' ? 'Добавлено' : 'В корзину';
 });
 
 const buttonIcon = computed(() => {
-    if (isUnavailableInCities.value) return 'notifications_active';
+    if (isExplicitOutOfStock.value) return 'notifications_active';
+    if (shouldOpenInquiry.value) return 'support_agent';
     return buttonState.value === 'success' ? 'check' : 'shopping_cart';
 });
 
 const buttonVariant = computed(() => {
-    return isUnavailableInCities.value ? 'notify' : 'primary';
+    return shouldOpenInquiry.value ? 'notify' : 'primary';
+});
+
+const inquiryModalTitle = computed(() => {
+    if (!hasKnownPrice.value && availabilityState.value.isUnknown) return 'Уточнить цену и наличие';
+    if (!hasKnownPrice.value) return 'Уточнить цену';
+    if (isExplicitOutOfStock.value) return 'Сообщить о поступлении';
+    return 'Уточнить наличие';
+});
+
+const inquiryModalDescription = computed(() => {
+    if (!hasKnownPrice.value && availabilityState.value.isUnknown) {
+        return 'Оставьте телефон, и мы уточним цену и наличие этой модели.';
+    }
+    if (!hasKnownPrice.value) {
+        return 'Оставьте телефон, и мы уточним актуальную цену этой модели.';
+    }
+    if (isExplicitOutOfStock.value) {
+        return 'Оставьте телефон, и мы сообщим, когда модель появится в наличии.';
+    }
+    return 'Оставьте телефон, и мы уточним наличие и срок поставки этой модели.';
+});
+
+const inquirySuccessText = computed(() => {
+    if (isExplicitOutOfStock.value) return 'Сообщим, когда товар появится в наличии.';
+    return 'Менеджер свяжется с вами и уточнит детали.';
 });
 
 const validateNotifyPhone = () => {
@@ -311,7 +376,7 @@ const closeNotifyModal = () => {
 };
 
 const handlePrimaryAction = () => {
-    if (isUnavailableInCities.value) {
+    if (shouldOpenInquiry.value) {
         openNotifyModal();
         return;
     }
@@ -336,7 +401,7 @@ const submitNotifyLead = async () => {
     }
 
     notifySuccess.value = true;
-    addToast(`Запрос на поступление отправлен: ${props.title}`);
+    addToast(`Запрос отправлен: ${props.title}`);
     setTimeout(() => {
         closeNotifyModal();
     }, 2500);
@@ -348,7 +413,7 @@ const submitNotifyLead = async () => {
     <!-- Price Display -->
     <div class="price-wrapper">
         <!-- Sale Badge -->
-        <div v-if="liveOldPrice" class="discount-badge sale-badge">
+        <div v-if="discountPct > 0" class="discount-badge sale-badge">
           -{{ discountPct }}%
         </div>
         
@@ -356,7 +421,7 @@ const submitNotifyLead = async () => {
             {{ priceDisplay.old }} <span class="price-byn"></span>
         </span>
         <span class="final-price" :class="{ 'pulse-primary': isInstalled }">
-          {{ priceDisplay.current }} <span class="price-byn"></span>
+          {{ priceDisplay.current }} <span v-if="priceDisplay.showCurrency" class="price-byn"></span>
         </span>
     </div>
 
@@ -405,7 +470,7 @@ const submitNotifyLead = async () => {
     <div class="actions-container">
         <button 
             class="btn-action js-track-cart"
-            :class="[buttonVariant, { success: buttonState === 'success' && !isUnavailableInCities }]"
+            :class="[buttonVariant, { success: buttonState === 'success' && canAddToCart }]"
             @click.stop="handlePrimaryAction"
         >
             <span class="material-icons-round">{{ buttonIcon }}</span>
@@ -425,9 +490,9 @@ const submitNotifyLead = async () => {
         </button>
 
         <div v-if="!notifySuccess">
-          <h3 class="modal-title">Сообщить о поступлении</h3>
+          <h3 class="modal-title">{{ inquiryModalTitle }}</h3>
           <p class="modal-desc">
-            Оставьте телефон, и мы сообщим, когда <strong>{{ title }}</strong> появится в наличии.
+            {{ inquiryModalDescription }}
           </p>
 
           <form class="notify-form" @submit.prevent="submitNotifyLead">
@@ -467,7 +532,7 @@ const submitNotifyLead = async () => {
             <span class="material-icons-round">check_circle</span>
           </div>
           <h3>Запрос отправлен</h3>
-          <p>Сообщим, когда товар появится в наличии.</p>
+          <p>{{ inquirySuccessText }}</p>
         </div>
       </div>
     </div>

--- a/web/src/components/ProductCard.astro
+++ b/web/src/components/ProductCard.astro
@@ -1,11 +1,12 @@
 ---
 import PriceWithToggle from "./PriceWithToggle.vue";
 import { resolveImageUrl } from "../utils/api";
+import { formatProductPrice, hasKnownProductPrice } from "../utils/product-display";
 
 interface Props {
   product: {
     title: string;
-    price: number;
+    price: number | null;
     slug: string;
     main_image?: string;
     card_image?: string | null;
@@ -56,7 +57,7 @@ const pricingProps = {
     : {}),
 };
 
-const formatPrice = (price: number) => price.toLocaleString();
+const formatPrice = (price: number | null) => formatProductPrice(price);
 const productCardImage = product.card_image || product.main_image;
 const productDescription = product.description || "Кондиционер из каталога";
 
@@ -294,7 +295,10 @@ const showAreaBadge = !!product.area;
       <div class="m-info">
         <p class="m-title">{product.title}</p>
         <div class="m-footer">
-          <span class="final-price small">{formatPrice(product.price)} <span class="price-byn"></span></span>
+          <span class="final-price small">
+            {formatPrice(product.price)}
+            {hasKnownProductPrice(product.price) && <span class="price-byn"></span>}
+          </span>
           <button class="add-btn micro plain js-track-cart">
             <span class="material-icons-round">arrow_forward</span>
           </button>

--- a/web/src/components/product/StickyBuyBar.vue
+++ b/web/src/components/product/StickyBuyBar.vue
@@ -3,16 +3,16 @@
     <div class="bar-content">
       <div class="price-info">
         <span class="label">Итого:</span>
-        <span class="price-val">{{ formattedPrice }} <span class="price-byn"></span></span>
-        <span v-if="isUnavailableInCities" class="stock-note">Нет в наличии</span>
+        <span class="price-val">{{ formattedPrice }} <span v-if="hasKnownPrice" class="price-byn"></span></span>
+        <span v-if="shouldInquire" class="stock-note">{{ stockNote }}</span>
       </div>
       <button
         class="btn btn-primary btn-sm js-track-cart"
-        :class="{ notify: isUnavailableInCities }"
+        :class="{ notify: shouldInquire }"
         @click="scrollToBuy"
       >
-        <span class="material-icons-round">{{ isUnavailableInCities ? 'notifications_active' : 'shopping_cart' }}</span>
-        {{ isUnavailableInCities ? 'Сообщить о поступлении' : 'В корзину' }}
+        <span class="material-icons-round">{{ actionIcon }}</span>
+        {{ actionLabel }}
       </button>
     </div>
   </div>
@@ -20,22 +20,54 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue';
+import {
+    formatProductPrice,
+    getProductAvailabilityDisplay,
+    hasKnownProductPrice,
+} from '../../utils/product-display';
 
 const props = defineProps({
-  price: { type: Number, required: true },
+  price: { type: [Number, String], default: 0 },
   currency: { type: String, default: 'Br' },
   vitebskQty: { type: Number, default: 0 },
-  minskQty: { type: Number, default: 0 }
+  minskQty: { type: Number, default: 0 },
+  availabilityStatus: { type: String, default: null }
 });
 
 const isVisible = ref(false);
 
 const formattedPrice = computed(() => {
-  return props.price.toLocaleString('ru-RU');
+  return formatProductPrice(props.price);
 });
 
-const isUnavailableInCities = computed(() => {
-  return Number(props.vitebskQty) <= 0 && Number(props.minskQty) <= 0;
+const hasKnownPrice = computed(() => hasKnownProductPrice(props.price));
+
+const availabilityState = computed(() => {
+  return getProductAvailabilityDisplay({
+    vitebskQty: props.vitebskQty,
+    minskQty: props.minskQty,
+    availabilityStatus: props.availabilityStatus,
+  });
+});
+
+const shouldInquire = computed(() => {
+  return !hasKnownPrice.value || !availabilityState.value.canOrder;
+});
+
+const stockNote = computed(() => availabilityState.value.message);
+
+const actionLabel = computed(() => {
+  if (!hasKnownPrice.value && availabilityState.value.isUnknown) return 'Уточнить';
+  if (!hasKnownPrice.value) return 'Уточнить цену';
+  if (availabilityState.value.isExplicitOutOfStock) return 'Сообщить';
+  if (!availabilityState.value.canOrder) return 'Уточнить наличие';
+  return 'В корзину';
+});
+
+const actionIcon = computed(() => {
+  if (availabilityState.value.isExplicitOutOfStock) return 'notifications_active';
+  if (shouldInquire.value) return 'support_agent';
+  return 'shopping_cart';
 });
 
 const handleScroll = () => {

--- a/web/src/pages/product/[slug].astro
+++ b/web/src/pages/product/[slug].astro
@@ -26,6 +26,7 @@ import {
 } from "../../utils/spec-dictionary";
 import { generateBentoCards } from "../../utils/bento-cards";
 import { buildProductMetaDescription } from "../../utils/seo";
+import { formatProductPrice } from "../../utils/product-display";
 
 export const prerender = !isRuntimeFreshnessEnabled();
 
@@ -161,10 +162,8 @@ const publicTags = (product.tags || []).filter((t: any) => t.is_public);
 const seoDescription = buildProductMetaDescription(product);
 const asText = (value: unknown) => String(value || "").trim();
 const formatSeriesPrice = (value: unknown) => {
-    const price = Number(value);
-    return Number.isFinite(price) && price > 0
-        ? `${price.toLocaleString("ru-RU")} Br`
-        : "Цена по запросу";
+    const formatted = formatProductPrice(value as number | string | null);
+    return formatted === "Цену уточняйте" ? formatted : `${formatted} Br`;
 };
 const formatSeriesArea = (item: any) => {
     const rawArea = item?.area ?? item?.specs?.area_m2;
@@ -208,6 +207,7 @@ const seriesSiblings = Array.isArray(product.series_siblings)
         currency="Br"
         vitebskQty={product.vitebsk_qty}
         minskQty={product.minsk_qty}
+        availabilityStatus={product.availability_status}
     />
 
     <div class="container product-page">

--- a/web/src/utils/catalog-seo.ts
+++ b/web/src/utils/catalog-seo.ts
@@ -1,3 +1,5 @@
+import { hasKnownProductPrice } from "./product-display";
+
 type CatalogSeoProduct = {
     id?: number;
     title: string;
@@ -25,7 +27,7 @@ export function getSchemaAvailability(product: CatalogSeoProduct) {
     if (stockQty > 0 || status === "in_stock_now" || status === "available_2_3_days") {
         return "https://schema.org/InStock";
     }
-    return "https://schema.org/OutOfStock";
+    return "https://schema.org/LimitedAvailability";
 }
 
 export function buildCatalogItemListSchema(products: CatalogSeoProduct[], origin: string) {
@@ -43,7 +45,7 @@ export function buildCatalogItemListSchema(products: CatalogSeoProduct[], origin
                 sku: product.id ? String(product.id) : undefined,
                 offers: {
                     "@type": "Offer",
-                    price: Number(product.price || 0),
+                    ...(hasKnownProductPrice(product.price) ? { price: Number(product.price) } : {}),
                     priceCurrency: "BYN",
                     availability: getSchemaAvailability(product),
                     url: absoluteUrl(product.slug ? `/product/${product.slug}/` : undefined, origin),

--- a/web/src/utils/product-display.ts
+++ b/web/src/utils/product-display.ts
@@ -1,0 +1,110 @@
+type AvailabilityInput = {
+    vitebsk_qty?: number | string | null;
+    minsk_qty?: number | string | null;
+    availability_status?: string | null;
+    vitebskQty?: number | string | null;
+    minskQty?: number | string | null;
+    availabilityStatus?: string | null;
+};
+
+export type ProductAvailabilityDisplay = {
+    message: string;
+    tone: "vitebsk" | "minsk" | "available" | "unknown" | "out";
+    isPurchasable: boolean;
+    canOrder: boolean;
+    isUnknown: boolean;
+    isOutOfStock: boolean;
+    isExplicitOutOfStock: boolean;
+};
+
+const toQty = (value: number | string | null | undefined) => Number(value || 0);
+
+export const hasKnownProductPrice = (price: number | string | null | undefined) => {
+    const numeric = Number(price);
+    return Number.isFinite(numeric) && numeric > 0;
+};
+
+export const formatProductPrice = (
+    price: number | string | null | undefined,
+    options: { fallback?: string; locale?: string } = {},
+) => {
+    if (!hasKnownProductPrice(price)) {
+        return options.fallback || "Цену уточняйте";
+    }
+    return Number(price).toLocaleString(options.locale || "ru-RU");
+};
+
+export const getProductAvailabilityDisplay = (
+    product: AvailabilityInput,
+): ProductAvailabilityDisplay => {
+    const vitebskQty = toQty(product.vitebsk_qty ?? product.vitebskQty);
+    const minskQty = toQty(product.minsk_qty ?? product.minskQty);
+    const status = String(product.availability_status ?? product.availabilityStatus ?? "").trim().toLowerCase();
+
+    if (vitebskQty > 0) {
+        return {
+            message: "В наличии в Витебске",
+            tone: "vitebsk",
+            isPurchasable: true,
+            canOrder: true,
+            isUnknown: false,
+            isOutOfStock: false,
+            isExplicitOutOfStock: false,
+        };
+    }
+    if (minskQty > 0) {
+        return {
+            message: "В наличии в Минске",
+            tone: "minsk",
+            isPurchasable: true,
+            canOrder: true,
+            isUnknown: false,
+            isOutOfStock: false,
+            isExplicitOutOfStock: false,
+        };
+    }
+    if (status === "in_stock_now") {
+        return {
+            message: "В наличии",
+            tone: "available",
+            isPurchasable: true,
+            canOrder: true,
+            isUnknown: false,
+            isOutOfStock: false,
+            isExplicitOutOfStock: false,
+        };
+    }
+    if (status === "available_2_3_days") {
+        return {
+            message: "В наличии в Минске, срок поставки 2-4 дня",
+            tone: "minsk",
+            isPurchasable: true,
+            canOrder: true,
+            isUnknown: false,
+            isOutOfStock: false,
+            isExplicitOutOfStock: false,
+        };
+    }
+    if (status === "out_of_stock") {
+        return {
+            message: "Нет в наличии",
+            tone: "out",
+            isPurchasable: false,
+            canOrder: false,
+            isUnknown: false,
+            isOutOfStock: true,
+            isExplicitOutOfStock: true,
+        };
+    }
+    return {
+        message: "Наличие уточняйте",
+        tone: "unknown",
+        isPurchasable: false,
+        canOrder: false,
+        isUnknown: true,
+        isOutOfStock: false,
+        isExplicitOutOfStock: false,
+    };
+};
+
+export const resolveProductAvailability = getProductAvailabilityDisplay;


### PR DESCRIPTION
## Summary
- add shared storefront helpers for product price and availability display
- show Цену уточняйте instead of zero-price output in product price widgets and compact cards
- show Наличие уточняйте for unknown/check availability states instead of treating unknown supply as out of stock
- adapt product inquiry buttons/modals for price and availability clarification
- avoid zero-price Offer data in catalog JSON-LD and use LimitedAvailability for unknown availability

## Verification
- cd web && npm run audit:theme
- cd web && npm run test:seo
- git diff --check
- cd web && npm run build
- Browser smoke: catalog and product page on local preview, no visible zero-currency text, no console errors

## Delegation
- delegated initial web audit/partial implementation to Curie; final integration and verification completed here.