### PR TITLE
Polish bot client selection copy

### DIFF
--- a/services/bot_product_selection_service.py
+++ b/services/bot_product_selection_service.py
@@ -525,6 +525,97 @@ class BotProductSelectionService:
         return f"{total} руб." if total is not None else "цену уточним"
 
     @staticmethod
+    def _parse_spec_number(value: Any, *, nominal_from_range: bool = False) -> float | None:
+        if value in (None, ""):
+            return None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            number = float(value)
+            return number if number > 0 else None
+
+        text = str(value).replace(",", ".")
+        matches = [float(match) for match in re.findall(r"\d+(?:\.\d+)?", text)]
+        if not matches:
+            return None
+        if nominal_from_range and len(matches) >= 3 and "/" in text:
+            return matches[1]
+        return max(matches)
+
+    @staticmethod
+    def _format_decimal(value: float) -> str:
+        rounded = round(value, 2)
+        if rounded.is_integer():
+            return str(int(rounded))
+        text = f"{rounded:.2f}".rstrip("0").rstrip(".")
+        return text.replace(".", ",")
+
+    @classmethod
+    def _product_cooling_power(cls, product: dict[str, Any]) -> float | None:
+        direct = cls._parse_spec_number(product.get("power_cooling"))
+        if direct is not None:
+            return direct
+
+        specs = product.get("specs") if isinstance(product.get("specs"), dict) else {}
+        for key in ("capacity_cooling_kw", "Мощность охлаждения", "Мощность охлаждения, кВт", "Охлаждение, кВт"):
+            number = cls._parse_spec_number(specs.get(key), nominal_from_range=True)
+            if number is not None:
+                return number
+        return None
+
+    @classmethod
+    def _product_area(cls, product: dict[str, Any]) -> float | None:
+        direct = cls._parse_spec_number(product.get("area"))
+        if direct is not None:
+            return direct
+
+        specs = product.get("specs") if isinstance(product.get("specs"), dict) else {}
+        for key in (
+            "area_m2",
+            "Обслуживаемая площадь",
+            "Обслуживаемая площадь до",
+            "Рекомендуемая максимальная площадь помещения",
+        ):
+            number = cls._parse_spec_number(specs.get(key))
+            if number is not None:
+                return number
+        return None
+
+    @classmethod
+    def _client_product_characteristics(cls, product: dict[str, Any]) -> str:
+        parts: list[str] = []
+        power = cls._product_cooling_power(product)
+        area = cls._product_area(product)
+        if power is not None:
+            parts.append(f"мощность {cls._format_decimal(power)} кВт")
+        if area is not None:
+            parts.append(f"на {cls._format_decimal(area)} м²")
+        return f" {', '.join(parts)}" if parts else ""
+
+    @staticmethod
+    def _client_tier_label(label: Any) -> str:
+        normalized = str(label or "").strip().lower()
+        if normalized == "бюджетнее":
+            return "Бюджетный вариант"
+        if normalized == "оптимально":
+            return "Оптимальный вариант"
+        if normalized == "премиум":
+            return "Премиальный вариант"
+        if normalized == "on-off":
+            return "ON-OFF вариант"
+        label_text = str(label or "Вариант").strip()
+        return label_text if label_text.lower().endswith("вариант") else f"{label_text} вариант"
+
+    @classmethod
+    def _format_client_product_line(cls, product: dict[str, Any], quantity: int = 1) -> str:
+        title = str(product.get("title") or "Кондиционер").strip()
+        characteristics = cls._client_product_characteristics(product)
+        return (
+            f"- кондиционер {title}{characteristics}\n"
+            f"  {cls._format_price(product, quantity)}\n"
+            f"  {cls.client_availability_text(product)}\n"
+            f"  {cls.product_url(product)}"
+        )
+
+    @staticmethod
     def availability_text(product: dict[str, Any]) -> str:
         vitebsk_qty = int(product.get("vitebsk_qty") or 0)
         minsk_qty = int(product.get("minsk_qty") or 0)
@@ -551,8 +642,8 @@ class BotProductSelectionService:
         if minsk_qty > 0 or availability == "available_2_3_days":
             return "в наличии в Минске, срок поставки 2-4 дня"
         if availability == "check_availability":
-            return "наличие уточним"
-        return "наличие уточним"
+            return "наличие уточняем"
+        return "наличие уточняем"
 
     @classmethod
     async def build_selection(
@@ -700,7 +791,6 @@ class BotProductSelectionService:
 
         lines = ["Подобрал варианты кондиционеров:"]
         for area in areas:
-            area_label = cls._format_area_label(area)
             quantity = int(area.get("quantity") or 1)
             area_lines = []
             for tier in area["tiers"]:
@@ -709,12 +799,11 @@ class BotProductSelectionService:
                     continue
                 product = products[0]
                 area_lines.append(
-                    f"{tier['label']}: {product.get('title')} - {cls._format_price(product, quantity)}\n"
-                    f"{cls.client_availability_text(product)}\n"
-                    f"{cls.product_url(product)}"
+                    f"{cls._client_tier_label(tier.get('label'))}:\n"
+                    f"{cls._format_client_product_line(product, quantity)}"
                 )
             if area_lines:
-                lines.extend(["", area_label, *area_lines])
+                lines.extend(["", *area_lines])
 
         if len(lines) == 1:
             return "Пока не получилось подобрать варианты из наличия."
@@ -750,17 +839,11 @@ class BotProductSelectionService:
                 product = products[0]
                 quantity = int(area.get("quantity") or 1)
                 tier_label = tier_label or str((tier or {}).get("label") or "Вариант")
-                area_label = cls._format_area_label(area)
-                title = str(product.get("title") or "Товар")
                 product_total = cls._product_total_price(product, quantity)
                 total = total + product_total if total is not None and product_total is not None else None
-                tier_lines.append(
-                    f"- {area_label}: {title} - {cls._format_price(product, quantity)}\n"
-                    f"  {cls.client_availability_text(product)}\n"
-                    f"  {cls.product_url(product)}"
-                )
+                tier_lines.append(cls._format_client_product_line(product, quantity))
             if tier_lines:
-                lines.extend(["", f"{tier_label}:", *tier_lines])
+                lines.extend(["", f"{cls._client_tier_label(tier_label)}:", *tier_lines])
                 lines.append(f"Итого по варианту: {cls._format_total_price(total)}")
 
         if len(lines) == 1:

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -422,6 +422,8 @@ def test_product_selection_formats_client_forward_text(monkeypatch):
                                 "title": "Midea 07",
                                 "slug": "midea-07",
                                 "price": 990,
+                                "power_cooling": 2.05,
+                                "area": 22,
                                 "vitebsk_qty": 1,
                                 "minsk_qty": 0,
                             }
@@ -441,13 +443,15 @@ def test_product_selection_formats_client_forward_text(monkeypatch):
     assert formatted == (
         "Подобрал варианты кондиционеров:\n"
         "\n"
-        "7 (1,9 кВт)\n"
-        "Бюджетнее: Midea 07 - 990 руб.\n"
-        "в наличии\n"
-        "https://example.test/product/midea-07/"
+        "Бюджетный вариант:\n"
+        "- кондиционер Midea 07 мощность 2,05 кВт, на 22 м²\n"
+        "  990 руб.\n"
+        "  в наличии\n"
+        "  https://example.test/product/midea-07/"
     )
     assert "<b>" not in formatted
     assert "Витебск" not in formatted
+    assert "7 (1,9 кВт)" not in formatted
 
 
 def test_product_selection_rich_html_formats_cards_and_escapes(monkeypatch):
@@ -523,9 +527,50 @@ def test_product_selection_missing_price_uses_contact_us_text(monkeypatch):
     formatted = BotProductSelectionService.format_client_selection(selection)
     rich = BotProductSelectionService.format_selection_rich_html(selection)
 
-    assert "Midea 12 - цену уточним" in formatted
+    assert "- кондиционер Midea 12" in formatted
+    assert "  цену уточним" in formatted
+    assert "наличие уточняем" in formatted
     assert "0 руб." not in formatted
     assert "<b>Цена:</b> цену уточним<br/>" in rich
+
+
+def test_product_selection_client_text_uses_product_specs_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "services.bot_product_selection_service.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+    selection = {
+        "areas": [
+            {
+                "label": "7 (1,9 кВт)",
+                "tiers": [
+                    {
+                        "label": "Бюджетнее",
+                        "products": [
+                            {
+                                "title": "Haier Flexis 07",
+                                "slug": "haier-flexis-07",
+                                "price": 1657,
+                                "area": None,
+                                "power_cooling": None,
+                                "specs": {
+                                    "capacity_cooling_kw": "0,7 / 2,1 / 2,4",
+                                    "area_m2": "до 25",
+                                },
+                                "vitebsk_qty": 0,
+                                "minsk_qty": 0,
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    formatted = BotProductSelectionService.format_client_selection(selection)
+
+    assert "- кондиционер Haier Flexis 07 мощность 2,1 кВт, на 25 м²" in formatted
+    assert "1,9 кВт" not in formatted
 
 
 def test_selection_result_keyboard_has_client_text_action():
@@ -624,6 +669,8 @@ async def test_product_selection_groups_duplicate_power_classes(monkeypatch):
                 "title": f"Picked {area}",
                 "slug": f"picked-{area}",
                 "price": 1200,
+                "power_cooling": 2.1,
+                "area": 22,
                 "vitebsk_qty": 1,
                 "minsk_qty": 0,
             }
@@ -641,7 +688,8 @@ async def test_product_selection_groups_duplicate_power_classes(monkeypatch):
     assert "<b>7 (1,9 кВт), 2 шт.</b>" in formatted
     assert "1200 руб. x 2 шт. = 2400 руб." in formatted
     assert "Подобрал варианты кондиционеров комплектом:" in client_text
-    assert "7 (1,9 кВт), 2 шт." in client_text
+    assert "7 (1,9 кВт), 2 шт." not in client_text
+    assert "- кондиционер Picked 15 мощность 2,1 кВт, на 22 м²" in client_text
     assert "1200 руб. x 2 шт. = 2400 руб." in client_text
     assert "Итого по варианту: 2400 руб." in client_text
 
@@ -656,6 +704,8 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
                     "title": "TCL 7",
                     "slug": "tcl-7",
                     "price": 900,
+                    "power_cooling": 2.0,
+                    "area": 20,
                     "series_id": 20,
                     "brand_id": 2,
                     "vitebsk_qty": 1,
@@ -666,6 +716,8 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
                     "title": "LG Artcool 7",
                     "slug": "lg-artcool-7",
                     "price": 1100,
+                    "power_cooling": 2.1,
+                    "area": 22,
                     "series_id": 10,
                     "brand_id": 1,
                     "vitebsk_qty": 1,
@@ -678,6 +730,8 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
                 "title": "LG Artcool 9",
                 "slug": "lg-artcool-9",
                 "price": 1000,
+                "power_cooling": 2.64,
+                "area": 28,
                 "series_id": 10,
                 "brand_id": 1,
                 "vitebsk_qty": 1,
@@ -688,6 +742,8 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
                 "title": "TCL 9",
                 "slug": "tcl-9",
                 "price": 1300,
+                "power_cooling": 2.65,
+                "area": 28,
                 "series_id": 20,
                 "brand_id": 2,
                 "vitebsk_qty": 1,
@@ -708,9 +764,11 @@ async def test_product_selection_prefers_same_series_for_multi_power_kit(monkeyp
     assert {product["series_id"] for product in optimal_products} == {10}
     assert [product["title"] for product in optimal_products] == ["LG Artcool 7", "LG Artcool 9"]
     assert "Подобрал варианты кондиционеров комплектом:" in client_text
-    assert "Оптимально:" in client_text
-    assert "- 7 (1,9 кВт): LG Artcool 7 - 1100 руб." in client_text
-    assert "- 9 (2,6 кВт): LG Artcool 9 - 1000 руб." in client_text
+    assert "Оптимальный вариант:" in client_text
+    assert "- кондиционер LG Artcool 7 мощность 2,1 кВт, на 22 м²" in client_text
+    assert "- кондиционер LG Artcool 9 мощность 2,64 кВт, на 28 м²" in client_text
+    assert "- 7 (1,9 кВт):" not in client_text
+    assert "- 9 (2,6 кВт):" not in client_text
     assert "Итого по варианту: 2100 руб." in client_text
 
 


### PR DESCRIPTION
## Summary
- rewrite Telegram selection client text so forwarded offers do not expose internal power labels like 7 (1,9 кВт)
- show product-derived cooling power and area from product fields, with specs fallback
- clarify unknown availability as "наличие уточняем" in client copy

## Tests
- pytest tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q