### PR TITLE
Ask bot file intent before OCR

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -84,24 +84,31 @@ def _preview_keyboard(data: dict) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
+def _requisites_file_intent_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Извлечь реквизиты", callback_data="req_file_extract")],
+            [InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")],
+        ]
+    )
+
+
 async def _download_telegram_file(file_id: str) -> bytes:
     buffer = BytesIO()
     await bot.download(file_id, destination=buffer)
     return buffer.getvalue()
 
 
-async def _handle_requisites_file(
-    message: types.Message,
+async def _run_requisites_recognition(
+    progress_message: types.Message,
     *,
     file_id: str,
     filename: str,
     mime_type: str,
+    telegram_user_id: int | None,
+    telegram_chat_id: int | None,
+    telegram_message_id: int | None,
 ):
-    if not await _is_admin_user(message.from_user.id if message.from_user else None):
-        await message.answer("Распознавание реквизитов доступно только администраторам.")
-        return
-
-    progress = await message.answer("Распознаю реквизиты…")
     try:
         content = await _download_telegram_file(file_id)
         async with async_session_maker() as session:
@@ -111,24 +118,84 @@ async def _handle_requisites_file(
                 filename=filename,
                 mime_type=mime_type,
                 source="telegram",
-                telegram_user_id=message.from_user.id if message.from_user else None,
-                telegram_chat_id=message.chat.id if message.chat else None,
-                telegram_message_id=message.message_id,
+                telegram_user_id=telegram_user_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
             )
     except Exception as exc:
-        await progress.edit_text(f"❌ Не удалось распознать реквизиты: {escape(str(exc))}")
+        await progress_message.edit_text(f"❌ Не удалось распознать реквизиты: {escape(str(exc))}")
         return
 
-    await progress.edit_text(_preview_text(data), reply_markup=_preview_keyboard(data), parse_mode="HTML")
+    await progress_message.edit_text(_preview_text(data), reply_markup=_preview_keyboard(data), parse_mode="HTML")
+
+
+async def _handle_requisites_file(
+    message: types.Message,
+    *,
+    file_id: str,
+    filename: str,
+    mime_type: str,
+    telegram_user_id: int | None = None,
+    telegram_chat_id: int | None = None,
+    telegram_message_id: int | None = None,
+):
+    user_id = telegram_user_id if telegram_user_id is not None else (message.from_user.id if message.from_user else None)
+    if not await _is_admin_user(user_id):
+        await message.answer("Распознавание реквизитов доступно только администраторам.")
+        return
+
+    progress = await message.answer("Распознаю реквизиты…")
+    await _run_requisites_recognition(
+        progress,
+        file_id=file_id,
+        filename=filename,
+        mime_type=mime_type,
+        telegram_user_id=user_id,
+        telegram_chat_id=telegram_chat_id if telegram_chat_id is not None else (message.chat.id if message.chat else None),
+        telegram_message_id=telegram_message_id if telegram_message_id is not None else message.message_id,
+    )
+
+
+async def _ask_requisites_file_action(
+    message: types.Message,
+    state: FSMContext,
+    *,
+    file_id: str,
+    filename: str,
+    mime_type: str,
+):
+    user_id = message.from_user.id if message.from_user else None
+    if not await _is_admin_user(user_id):
+        await message.answer(
+            "Файл получил. Сейчас распознавание реквизитов доступно только администраторам; "
+            "прикрепление фото к заказу добавим следующим шагом."
+        )
+        return
+
+    await state.update_data(
+        pending_requisites_file={
+            "file_id": file_id,
+            "filename": filename,
+            "mime_type": mime_type,
+            "telegram_message_id": message.message_id,
+            "telegram_chat_id": message.chat.id if message.chat else None,
+        }
+    )
+    await message.answer(
+        "Файл получил. Что сделать?\n\n"
+        "Сейчас могу извлечь реквизиты. Позже добавим действие «прикрепить к заказу».",
+        reply_markup=_requisites_file_intent_keyboard(),
+    )
 
 
 @router.message(F.photo)
-async def recognize_requisites_photo(message: types.Message):
+async def recognize_requisites_photo(message: types.Message, state: FSMContext):
     if not message.photo:
         return
     photo = message.photo[-1]
-    await _handle_requisites_file(
+    await _ask_requisites_file_action(
         message,
+        state,
         file_id=photo.file_id,
         filename=f"telegram-photo-{message.message_id}.jpg",
         mime_type="image/jpeg",
@@ -136,19 +203,53 @@ async def recognize_requisites_photo(message: types.Message):
 
 
 @router.message(F.document)
-async def recognize_requisites_document(message: types.Message):
+async def recognize_requisites_document(message: types.Message, state: FSMContext):
     document = message.document
     if not document:
         return
     mime_type = document.mime_type or ""
     if mime_type not in {"image/jpeg", "image/png", "image/webp", "application/pdf"}:
         return
-    await _handle_requisites_file(
+    await _ask_requisites_file_action(
         message,
+        state,
         file_id=document.file_id,
         filename=document.file_name or f"telegram-document-{message.message_id}",
         mime_type=mime_type,
     )
+
+
+@router.callback_query(F.data == "req_file_extract")
+async def extract_pending_requisites_file(callback: CallbackQuery, state: FSMContext):
+    if not await _is_admin_user(callback.from_user.id):
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Файл не найден. Отправьте его еще раз.", show_alert=True)
+        return
+
+    await state.update_data(pending_requisites_file=None)
+    await callback.answer()
+    await callback.message.edit_text("Распознаю реквизиты…")
+    await _run_requisites_recognition(
+        callback.message,
+        file_id=str(pending.get("file_id")),
+        filename=str(pending.get("filename") or "telegram-file"),
+        mime_type=str(pending.get("mime_type") or "application/octet-stream"),
+        telegram_user_id=callback.from_user.id,
+        telegram_chat_id=pending.get("telegram_chat_id") or (callback.message.chat.id if callback.message and callback.message.chat else None),
+        telegram_message_id=pending.get("telegram_message_id"),
+    )
+
+
+@router.callback_query(F.data == "req_file_cancel")
+async def cancel_pending_requisites_file(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(pending_requisites_file=None)
+    await callback.message.edit_text("Ок, файл оставил без обработки.")
+    await callback.answer()
 
 
 @router.callback_query(F.data.startswith("ocr_create_") | F.data.startswith("ocr_update_") | F.data.startswith("ocr_cancel_"))

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -20,6 +20,7 @@ class _DummyMessage:
         self.chat = SimpleNamespace(id=100)
         self.message_id = 55
         self.answer = AsyncMock()
+        self.edit_text = AsyncMock()
         self.delete = AsyncMock()
 
 
@@ -27,9 +28,14 @@ class _DummyState:
     def __init__(self, data: dict):
         self._data = data
         self.clear = AsyncMock()
+        self.update_data = AsyncMock(side_effect=self._update_data)
+        self.set_state = AsyncMock()
 
     async def get_data(self):
         return self._data
+
+    async def _update_data(self, **kwargs):
+        self._data.update(kwargs)
 
 
 class _DummyCallback:
@@ -205,3 +211,115 @@ async def test_requisites_file_sends_preview_for_admin(monkeypatch):
     args, kwargs = progress.edit_text.await_args
     assert "ООО Тест" in args[0]
     assert kwargs["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
+async def test_requisites_photo_prompts_for_action_without_recognition(monkeypatch):
+    message = _DummyMessage(text="", user_id=5)
+    message.photo = [
+        SimpleNamespace(file_id="small-photo"),
+        SimpleNamespace(file_id="large-photo"),
+    ]
+    state = _DummyState({})
+
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
+    recognize_mock = AsyncMock()
+    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", recognize_mock)
+
+    await admin_handler.recognize_requisites_photo(message, state)
+
+    recognize_mock.assert_not_called()
+    state.update_data.assert_awaited_once()
+    pending = state._data["pending_requisites_file"]
+    assert pending == {
+        "file_id": "large-photo",
+        "filename": "telegram-photo-55.jpg",
+        "mime_type": "image/jpeg",
+        "telegram_message_id": 55,
+        "telegram_chat_id": 100,
+    }
+    message.answer.assert_awaited_once()
+    args, kwargs = message.answer.await_args
+    assert "Что сделать" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_extract"
+
+
+@pytest.mark.asyncio
+async def test_requisites_document_prompts_for_pdf(monkeypatch):
+    message = _DummyMessage(text="", user_id=5)
+    message.document = SimpleNamespace(
+        file_id="pdf-file",
+        file_name="requisites.pdf",
+        mime_type="application/pdf",
+    )
+    state = _DummyState({})
+
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
+    download_mock = AsyncMock(return_value=b"pdf")
+    monkeypatch.setattr(admin_handler, "_download_telegram_file", download_mock)
+
+    await admin_handler.recognize_requisites_document(message, state)
+
+    download_mock.assert_not_called()
+    assert state._data["pending_requisites_file"]["file_id"] == "pdf-file"
+    assert state._data["pending_requisites_file"]["mime_type"] == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_extract_callback_runs_recognition(monkeypatch):
+    callback = _DummyCallback(data="req_file_extract", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "file-1",
+                "filename": "req.png",
+                "mime_type": "image/png",
+                "telegram_message_id": 77,
+                "telegram_chat_id": 200,
+            }
+        }
+    )
+
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
+    monkeypatch.setattr(admin_handler, "_download_telegram_file", AsyncMock(return_value=b"image"))
+
+    async def fake_recognize(session, **kwargs):
+        assert kwargs["content"] == b"image"
+        assert kwargs["filename"] == "req.png"
+        assert kwargs["mime_type"] == "image/png"
+        assert kwargs["telegram_user_id"] == 5
+        assert kwargs["telegram_chat_id"] == 200
+        assert kwargs["telegram_message_id"] == 77
+        return {
+            "id": 12,
+            "status": "recognized",
+            "source": "telegram",
+            "raw_text": "raw",
+            "extracted": {"name": "ООО Тест", "inn": "123456789"},
+            "validation_flags": {"field_errors": {}, "warnings": {}, "is_valid": True},
+            "duplicate_customer": None,
+        }
+
+    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", fake_recognize)
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+
+    await admin_handler.extract_pending_requisites_file(callback, state)
+
+    assert state._data["pending_requisites_file"] is None
+    callback.answer.assert_awaited_once()
+    assert callback.message.edit_text.await_count == 2
+    final_args, final_kwargs = callback.message.edit_text.await_args
+    assert "ООО Тест" in final_args[0]
+    assert final_kwargs["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_cancel_clears_pending(monkeypatch):
+    callback = _DummyCallback(data="req_file_cancel", user_id=5)
+    state = _DummyState({"pending_requisites_file": {"file_id": "file-1"}})
+
+    await admin_handler.cancel_pending_requisites_file(callback, state)
+
+    assert state._data["pending_requisites_file"] is None
+    callback.message.edit_text.assert_awaited_once_with("Ок, файл оставил без обработки.")
+    callback.answer.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ask admins what to do with incoming photos/PDFs before running requisites OCR
- store pending Telegram file metadata in FSM state and run OCR only from the explicit "Извлечь реквизиты" callback
- keep cancel path and non-admin guard ready for the future "attach to order" flow

## Tests
- pytest tests/unit/test_bot_admin_handler.py tests/unit/test_bot_handlers_architecture.py -q
- pytest tests/unit/test_bot_*.py -q