### PR TITLE
Add bot order attachment flow

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -6,9 +6,12 @@ from aiogram import Router, types, F
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
 from services.product_service import ProductService
 from services.staff_user_service import StaffUserService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
+from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.bot_task_service import BotTaskService
 from ..config import bot
 from ..states import ShopState
 
@@ -18,6 +21,16 @@ router = Router()
 async def _is_admin_user(user_id: int | None) -> bool:
     async with async_session_maker() as session:
         return await StaffUserService.is_active_owner_admin_telegram_user(session, user_id)
+
+
+async def _get_bot_access_context(user_id: int | None):
+    async with async_session_maker() as session:
+        return await BotAccessService.get_context(session, user_id)
+
+
+async def _is_staff_user(user_id: int | None) -> bool:
+    context = await _get_bot_access_context(user_id)
+    return context.is_staff
 
 
 def _manager_customer_url(customer_id: int) -> str:
@@ -84,13 +97,71 @@ def _preview_keyboard(data: dict) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
-def _requisites_file_intent_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="Извлечь реквизиты", callback_data="req_file_extract")],
-            [InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")],
-        ]
-    )
+def _requisites_file_intent_keyboard(*, can_extract_requisites: bool = True) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    if can_extract_requisites:
+        rows.append([InlineKeyboardButton(text="Извлечь реквизиты", callback_data="req_file_extract")])
+    rows.append([InlineKeyboardButton(text="Прикрепить к заказу", callback_data="req_file_attach")])
+    rows.append([InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _order_attachment_keyboard(orders: list[dict]) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        if not order_id:
+            continue
+        title = " ".join(str(order.get("title") or order.get("customer_name") or "заказ").split())
+        if len(title) > 36:
+            title = f"{title[:33]}..."
+        rows.append(
+            [InlineKeyboardButton(text=f"#{order_id} - {title}", callback_data=f"req_file_attach_order_{order_id}")]
+        )
+    rows.append([InlineKeyboardButton(text="Ввести номер/id заказа", callback_data="req_file_attach_manual")])
+    rows.append([InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _format_order_attachment_choices(orders: list[dict]) -> str:
+    if not orders:
+        return "Быстрых вариантов не нашел. Введите номер/id заказа сообщением."
+
+    lines = ["К какому заказу прикрепить файл?"]
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        customer = order.get("customer_name") or "клиент не указан"
+        title = order.get("title") or "заказ"
+        address = order.get("address") or "адрес не указан"
+        lines.append(f"#{order_id}: {escape(str(title))}, {escape(str(customer))}, {escape(str(address))}")
+    return "\n".join(lines)
+
+
+def _order_choices_from_tasks(tasks: list[dict]) -> list[dict]:
+    choices: list[dict] = []
+    seen: set[int] = set()
+    for task in tasks:
+        order_id = int(task.get("order_id") or task.get("id") or 0)
+        if not order_id or order_id in seen:
+            continue
+        seen.add(order_id)
+        choices.append(
+            {
+                "id": order_id,
+                "title": task.get("title") or "заказ",
+                "customer_name": task.get("customer_name"),
+                "address": task.get("address"),
+            }
+        )
+    return choices
+
+
+def _parse_order_id(text: str | None) -> int | None:
+    cleaned = str(text or "").strip().lstrip("#").strip()
+    if not cleaned.isdigit():
+        return None
+    order_id = int(cleaned)
+    return order_id if order_id > 0 else None
 
 
 async def _download_telegram_file(file_id: str) -> bytes:
@@ -165,12 +236,12 @@ async def _ask_requisites_file_action(
     mime_type: str,
 ):
     user_id = message.from_user.id if message.from_user else None
-    if not await _is_admin_user(user_id):
+    if not await _is_staff_user(user_id):
         await message.answer(
-            "Файл получил. Сейчас распознавание реквизитов доступно только администраторам; "
-            "прикрепление фото к заказу добавим следующим шагом."
+            "Файл получил, но действия с файлами доступны только сотрудникам."
         )
         return
+    can_extract_requisites = await _is_admin_user(user_id)
 
     await state.update_data(
         pending_requisites_file={
@@ -182,9 +253,8 @@ async def _ask_requisites_file_action(
         }
     )
     await message.answer(
-        "Файл получил. Что сделать?\n\n"
-        "Сейчас могу извлечь реквизиты. Позже добавим действие «прикрепить к заказу».",
-        reply_markup=_requisites_file_intent_keyboard(),
+        "Файл получил. Что сделать?",
+        reply_markup=_requisites_file_intent_keyboard(can_extract_requisites=can_extract_requisites),
     )
 
 
@@ -232,6 +302,7 @@ async def extract_pending_requisites_file(callback: CallbackQuery, state: FSMCon
         return
 
     await state.update_data(pending_requisites_file=None)
+    await state.set_state(None)
     await callback.answer()
     await callback.message.edit_text("Распознаю реквизиты…")
     await _run_requisites_recognition(
@@ -245,9 +316,156 @@ async def extract_pending_requisites_file(callback: CallbackQuery, state: FSMCon
     )
 
 
+@router.callback_query(F.data == "req_file_attach")
+async def choose_order_for_pending_file(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Файл не найден. Отправьте его еще раз.", show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        if context.is_manager:
+            orders = await BotOrderAttachmentService.list_recent_orders(session, limit=5)
+        else:
+            tasks = await BotTaskService.list_my_tasks(session, callback.from_user.id, limit=5)
+            orders = _order_choices_from_tasks(tasks)
+
+    if orders:
+        await callback.message.edit_text(
+            _format_order_attachment_choices(orders),
+            reply_markup=_order_attachment_keyboard(orders),
+            parse_mode="HTML",
+        )
+    else:
+        await state.set_state(ShopState.waiting_for_order_attachment_order_id)
+        await callback.message.edit_text("Быстрых вариантов не нашел. Введите номер/id заказа сообщением.")
+    await callback.answer()
+
+
+@router.callback_query(F.data == "req_file_attach_manual")
+async def enter_order_id_for_pending_file(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Файл не найден. Отправьте его еще раз.", show_alert=True)
+        return
+
+    await state.set_state(ShopState.waiting_for_order_attachment_order_id)
+    await callback.message.edit_text("Введите номер/id заказа сообщением.")
+    await callback.answer()
+
+
+async def _attach_pending_file_to_order(
+    *,
+    order_id: int,
+    telegram_user_id: int | None,
+    can_attach_any: bool,
+    state: FSMContext,
+) -> dict | None:
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        return None
+
+    async with async_session_maker() as session:
+        allowed = await BotOrderAttachmentService.can_attach_to_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+        if not allowed:
+            return {"forbidden": True}
+        return await BotOrderAttachmentService.attach_to_order(
+            session,
+            order_id,
+            file_id=str(pending.get("file_id")),
+            filename=str(pending.get("filename") or "telegram-file"),
+            mime_type=str(pending.get("mime_type") or "application/octet-stream"),
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=pending.get("telegram_chat_id"),
+            telegram_message_id=pending.get("telegram_message_id"),
+        )
+
+
+@router.callback_query(F.data.startswith("req_file_attach_order_"))
+async def attach_pending_file_to_chosen_order(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    order_id = _parse_order_id((callback.data or "").rsplit("_", 1)[-1])
+    if not order_id:
+        await callback.answer("Не понял номер заказа", show_alert=True)
+        return
+
+    result = await _attach_pending_file_to_order(
+        order_id=order_id,
+        telegram_user_id=callback.from_user.id,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+    if not result:
+        await callback.answer("Файл или заказ не найден. Проверьте номер.", show_alert=True)
+        return
+    if result.get("forbidden"):
+        await callback.answer("Этот заказ вам не назначен.", show_alert=True)
+        return
+
+    await state.update_data(pending_requisites_file=None)
+    await state.set_state(None)
+    status = "уже был прикреплен" if result.get("already_attached") else "прикреплен"
+    await callback.message.edit_text(f"✅ Файл {status} к заказу #{result['id']}.")
+    await callback.answer()
+
+
+@router.message(ShopState.waiting_for_order_attachment_order_id)
+async def attach_pending_file_to_typed_order(message: types.Message, state: FSMContext):
+    context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await state.clear()
+        return
+
+    order_id = _parse_order_id(message.text)
+    if not order_id:
+        await message.answer("Введите номер заказа числом, например: 123")
+        return
+
+    result = await _attach_pending_file_to_order(
+        order_id=order_id,
+        telegram_user_id=message.from_user.id if message.from_user else None,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+    if not result:
+        await message.answer("Файл или заказ не найден. Отправьте файл еще раз или проверьте номер заказа.")
+        return
+    if result.get("forbidden"):
+        await message.answer("Этот заказ вам не назначен. Проверьте номер заказа или попросите менеджера прикрепить файл.")
+        return
+
+    await state.update_data(pending_requisites_file=None)
+    await state.set_state(None)
+    status = "уже был прикреплен" if result.get("already_attached") else "прикреплен"
+    await message.answer(f"✅ Файл {status} к заказу #{result['id']}.")
+
+
 @router.callback_query(F.data == "req_file_cancel")
 async def cancel_pending_requisites_file(callback: CallbackQuery, state: FSMContext):
     await state.update_data(pending_requisites_file=None)
+    await state.set_state(None)
     await callback.message.edit_text("Ок, файл оставил без обработки.")
     await callback.answer()
 

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -151,13 +151,12 @@ async def selection_process(message: types.Message, state: FSMContext):
     await state.set_state(None)
     keyboard = selection_result_keyboard() if selection.get("areas") else None
     fallback_text = BotProductSelectionService.format_selection(selection)
-    delivered = await BotService.send_rich_message(
+    await BotService.send_rich_message(
         message.chat.id,
         BotProductSelectionService.format_selection_rich_html(selection),
+        fallback_text=fallback_text,
         reply_markup=keyboard,
     )
-    if not delivered:
-        await message.answer(fallback_text, parse_mode="HTML", reply_markup=keyboard)
     await message.answer("Готово. Можно продолжить работу из меню.", reply_markup=get_staff_main_menu(context))
 
 

--- a/bot_app/states.py
+++ b/bot_app/states.py
@@ -7,6 +7,7 @@ class ShopState(StatesGroup):
     waiting_for_quick_order = State()
     waiting_for_selection = State()
     waiting_for_task_report = State()
+    waiting_for_order_attachment_order_id = State()
     select_area = State()
     select_type = State()
     select_winter = State()  # Выбор зимнего обогрева

--- a/services/bot_order_attachment_service.py
+++ b/services/bot_order_attachment_service.py
@@ -1,0 +1,193 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models import Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from services.staff_user_service import StaffUserService
+
+
+class BotOrderAttachmentService:
+    TELEGRAM_ATTACHMENTS_META_KEY = "telegram_attachments"
+    ACTIVE_STATUSES = {
+        OrderStatus.NEW_LEAD,
+        OrderStatus.NEGOTIATION,
+        OrderStatus.EXECUTION,
+    }
+
+    @staticmethod
+    def _clean_filename(value: Any) -> str:
+        return " ".join(str(value or "telegram-file").split())[:160] or "telegram-file"
+
+    @staticmethod
+    def _file_kind(mime_type: str | None) -> str:
+        if str(mime_type or "").startswith("image/"):
+            return "photo"
+        if str(mime_type or "") == "application/pdf":
+            return "pdf"
+        return "document"
+
+    @classmethod
+    def _build_entry(
+        cls,
+        *,
+        file_id: str,
+        filename: str,
+        mime_type: str | None,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        attached_at: datetime,
+    ) -> dict[str, Any]:
+        return {
+            "source": "telegram_bot",
+            "file_id": file_id,
+            "filename": cls._clean_filename(filename),
+            "mime_type": mime_type or "application/octet-stream",
+            "kind": cls._file_kind(mime_type),
+            "telegram_user_id": telegram_user_id,
+            "telegram_chat_id": telegram_chat_id,
+            "telegram_message_id": telegram_message_id,
+            "attached_at": attached_at.isoformat(timespec="seconds"),
+        }
+
+    @staticmethod
+    def _comment_line(entry: dict[str, Any], attached_at: datetime) -> str:
+        filename = BotOrderAttachmentService._clean_filename(entry.get("filename"))
+        kind = "Фото" if entry.get("kind") == "photo" else "PDF" if entry.get("kind") == "pdf" else "Документ"
+        return (
+            f"[Telegram attachment {attached_at.strftime('%d.%m.%Y %H:%M')}] "
+            f"{kind}: {filename}; file_id={entry.get('file_id')}"
+        )
+
+    @staticmethod
+    def _append_comment(existing: str | None, line: str) -> str:
+        current = (existing or "").strip()
+        if line in current:
+            return current
+        return f"{current}\n\n{line}".strip() if current else line
+
+    @staticmethod
+    def _map_order(order: Order) -> dict[str, Any]:
+        customer = getattr(order, "customer", None)
+        return {
+            "id": int(order.id or 0),
+            "title": order.title,
+            "status": order.status.value if hasattr(order.status, "value") else str(order.status),
+            "customer_name": getattr(customer, "name", None) if customer else None,
+            "customer_phone": getattr(customer, "phone", None) if customer else None,
+            "address": order.delivery_address,
+            "updated_at": order.updated_at,
+            "created_at": order.created_at,
+        }
+
+    @classmethod
+    async def list_recent_orders(cls, session: AsyncSession, *, limit: int = 5) -> list[dict[str, Any]]:
+        stmt = (
+            select(Order)
+            .where(Order.status.in_(list(cls.ACTIVE_STATUSES)))
+            .options(selectinload(Order.customer))
+            .order_by(Order.updated_at.desc(), Order.created_at.desc(), Order.id.desc())
+            .limit(max(1, min(limit, 10)))
+        )
+        result = await session.execute(stmt)
+        return [cls._map_order(order) for order in result.scalars().all()]
+
+    @classmethod
+    async def can_attach_to_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        telegram_user_id: int | str | None,
+        can_attach_any: bool = False,
+    ) -> bool:
+        if can_attach_any:
+            return True
+
+        try:
+            normalized_telegram_id = int(telegram_user_id) if telegram_user_id is not None else 0
+        except (TypeError, ValueError):
+            return False
+        if not normalized_telegram_id:
+            return False
+
+        staff_result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id == normalized_telegram_id)
+            .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .order_by(StaffUser.id.asc())
+        )
+        staff = staff_result.scalars().first()
+        installer_id = getattr(staff, "legacy_installer_id", None)
+        if not installer_id:
+            return False
+
+        stage_result = await session.execute(
+            select(OrderWorkStage.id)
+            .where(OrderWorkStage.order_id == order_id)
+            .where(OrderWorkStage.installer_id == int(installer_id))
+            .limit(1)
+        )
+        if stage_result.first():
+            return True
+
+        legacy_result = await session.execute(
+            select(OrderInstaller.order_id)
+            .where(OrderInstaller.order_id == order_id)
+            .where(OrderInstaller.installer_id == int(installer_id))
+            .limit(1)
+        )
+        return legacy_result.first() is not None
+
+    @classmethod
+    async def attach_to_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        file_id: str,
+        filename: str,
+        mime_type: str | None,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> dict[str, Any] | None:
+        stmt = select(Order).where(Order.id == order_id).options(selectinload(Order.customer))
+        result = await session.execute(stmt)
+        order = result.scalars().first()
+        if not order:
+            return None
+
+        attached_at = datetime.now()
+        entry = cls._build_entry(
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            attached_at=attached_at,
+        )
+
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        raw_attachments = meta.get(cls.TELEGRAM_ATTACHMENTS_META_KEY)
+        attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
+        already_attached = any(isinstance(item, dict) and item.get("file_id") == file_id for item in attachments)
+        if not already_attached:
+            attachments.append(entry)
+            meta[cls.TELEGRAM_ATTACHMENTS_META_KEY] = attachments
+            order.technical_meta = meta
+            order.comment = cls._append_comment(order.comment, cls._comment_line(entry, attached_at))
+            flag_modified(order, "technical_meta")
+            session.add(order)
+            await session.commit()
+            await session.refresh(order)
+
+        data = cls._map_order(order)
+        data["attachment"] = entry
+        data["already_attached"] = already_attached
+        return data

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -222,6 +222,7 @@ async def test_requisites_photo_prompts_for_action_without_recognition(monkeypat
     ]
     state = _DummyState({})
 
+    monkeypatch.setattr(admin_handler, "_is_staff_user", AsyncMock(return_value=True))
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     recognize_mock = AsyncMock()
     monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", recognize_mock)
@@ -242,6 +243,44 @@ async def test_requisites_photo_prompts_for_action_without_recognition(monkeypat
     args, kwargs = message.answer.await_args
     assert "Что сделать" in args[0]
     assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_extract"
+    assert kwargs["reply_markup"].inline_keyboard[1][0].callback_data == "req_file_attach"
+
+
+@pytest.mark.asyncio
+async def test_requisites_photo_for_staff_non_admin_allows_attach_only(monkeypatch):
+    message = _DummyMessage(text="", user_id=5)
+    message.photo = [SimpleNamespace(file_id="large-photo")]
+    state = _DummyState({})
+
+    monkeypatch.setattr(admin_handler, "_is_staff_user", AsyncMock(return_value=True))
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=False))
+
+    await admin_handler.recognize_requisites_photo(message, state)
+
+    message.answer.assert_awaited_once()
+    args, kwargs = message.answer.await_args
+    assert "Что сделать" in args[0]
+    callbacks = [
+        row[0].callback_data
+        for row in kwargs["reply_markup"].inline_keyboard
+    ]
+    assert callbacks == ["req_file_attach", "req_file_cancel"]
+    assert state._data["pending_requisites_file"]["file_id"] == "large-photo"
+
+
+@pytest.mark.asyncio
+async def test_requisites_photo_rejects_non_staff(monkeypatch):
+    message = _DummyMessage(text="", user_id=5)
+    message.photo = [SimpleNamespace(file_id="large-photo")]
+    state = _DummyState({})
+
+    monkeypatch.setattr(admin_handler, "_is_staff_user", AsyncMock(return_value=False))
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=False))
+
+    await admin_handler.recognize_requisites_photo(message, state)
+
+    message.answer.assert_awaited_once_with("Файл получил, но действия с файлами доступны только сотрудникам.")
+    assert "pending_requisites_file" not in state._data
 
 
 @pytest.mark.asyncio
@@ -254,6 +293,7 @@ async def test_requisites_document_prompts_for_pdf(monkeypatch):
     )
     state = _DummyState({})
 
+    monkeypatch.setattr(admin_handler, "_is_staff_user", AsyncMock(return_value=True))
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     download_mock = AsyncMock(return_value=b"pdf")
     monkeypatch.setattr(admin_handler, "_download_telegram_file", download_mock)
@@ -311,6 +351,165 @@ async def test_requisites_file_extract_callback_runs_recognition(monkeypatch):
     final_args, final_kwargs = callback.message.edit_text.await_args
     assert "ООО Тест" in final_args[0]
     assert final_kwargs["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_attach_callback_shows_recent_orders(monkeypatch):
+    callback = _DummyCallback(data="req_file_attach", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "file-1",
+                "filename": "photo.jpg",
+                "mime_type": "image/jpeg",
+            }
+        }
+    )
+
+    async def fake_list_recent(session, *, limit):
+        assert limit == 5
+        return [
+            {
+                "id": 42,
+                "title": "Монтаж",
+                "customer_name": "Иван",
+                "address": "Победы 15",
+            }
+        ]
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "list_recent_orders", fake_list_recent)
+
+    await admin_handler.choose_order_for_pending_file(callback, state)
+
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "К какому заказу" in args[0]
+    assert "#42" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_attach_order_42"
+    assert kwargs["reply_markup"].inline_keyboard[-2][0].callback_data == "req_file_attach_manual"
+    callback.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_attach_callback_shows_executor_tasks(monkeypatch):
+    callback = _DummyCallback(data="req_file_attach", user_id=5)
+    state = _DummyState({"pending_requisites_file": {"file_id": "file-1"}})
+
+    list_recent_mock = AsyncMock()
+
+    async def fake_list_tasks(session, telegram_id, *, limit):
+        assert telegram_id == 5
+        assert limit == 5
+        return [
+            {
+                "id": 7,
+                "order_id": 42,
+                "title": "Монтаж",
+                "customer_name": "Иван",
+                "address": "Победы 15",
+            }
+        ]
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=False)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "list_recent_orders", list_recent_mock)
+    monkeypatch.setattr(admin_handler.BotTaskService, "list_my_tasks", fake_list_tasks)
+
+    await admin_handler.choose_order_for_pending_file(callback, state)
+
+    list_recent_mock.assert_not_called()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "#42" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_attach_order_42"
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_attach_chosen_order_saves_and_clears_pending(monkeypatch):
+    callback = _DummyCallback(data="req_file_attach_order_42", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "file-1",
+                "filename": "photo.jpg",
+                "mime_type": "image/jpeg",
+                "telegram_message_id": 77,
+                "telegram_chat_id": 200,
+            }
+        }
+    )
+
+    async def fake_attach(session, order_id, **kwargs):
+        assert order_id == 42
+        assert kwargs["file_id"] == "file-1"
+        assert kwargs["telegram_user_id"] == 5
+        assert kwargs["telegram_chat_id"] == 200
+        assert kwargs["telegram_message_id"] == 77
+        return {"id": 42, "already_attached": False}
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "can_attach_to_order", AsyncMock(return_value=True))
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "attach_to_order", fake_attach)
+
+    await admin_handler.attach_pending_file_to_chosen_order(callback, state)
+
+    assert state._data["pending_requisites_file"] is None
+    state.set_state.assert_awaited_with(None)
+    callback.message.edit_text.assert_awaited_once_with("✅ Файл прикреплен к заказу #42.")
+    callback.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_attach_chosen_order_blocks_unassigned_executor(monkeypatch):
+    callback = _DummyCallback(data="req_file_attach_order_42", user_id=5)
+    state = _DummyState({"pending_requisites_file": {"file_id": "file-1"}})
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=False)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "can_attach_to_order", AsyncMock(return_value=False))
+    attach_mock = AsyncMock()
+    monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "attach_to_order", attach_mock)
+
+    await admin_handler.attach_pending_file_to_chosen_order(callback, state)
+
+    attach_mock.assert_not_called()
+    callback.answer.assert_awaited_once_with("Этот заказ вам не назначен.", show_alert=True)
+    assert state._data["pending_requisites_file"]["file_id"] == "file-1"
+
+
+@pytest.mark.asyncio
+async def test_requisites_file_attach_typed_order_validates_number(monkeypatch):
+    message = _DummyMessage(text="не номер", user_id=5)
+    state = _DummyState({"pending_requisites_file": {"file_id": "file-1"}})
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+
+    await admin_handler.attach_pending_file_to_typed_order(message, state)
+
+    message.answer.assert_awaited_once_with("Введите номер заказа числом, например: 123")
+    assert state._data["pending_requisites_file"]["file_id"] == "file-1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_order_attachment_service.py
+++ b/tests/unit/test_bot_order_attachment_service.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import Customer, Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from services.bot_order_attachment_service import BotOrderAttachmentService
+
+
+@pytest.fixture
+async def sqlite_order_attachment_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'bot_order_attachment.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_stores_file_id_in_order_meta_and_comment(sqlite_order_attachment_session):
+    customer = Customer(name="Иван", phone="+375291234567")
+    sqlite_order_attachment_session.add(customer)
+    await sqlite_order_attachment_session.flush()
+    order = Order(customer_id=customer.id, title="Монтаж", comment="Исходный комментарий")
+    sqlite_order_attachment_session.add(order)
+    await sqlite_order_attachment_session.commit()
+
+    result = await BotOrderAttachmentService.attach_to_order(
+        sqlite_order_attachment_session,
+        int(order.id),
+        file_id="AgACAgIAAxkBAAIB_photo",
+        filename="объект.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+    )
+
+    assert result is not None
+    assert result["id"] == order.id
+    assert result["already_attached"] is False
+    await sqlite_order_attachment_session.refresh(order)
+    attachments = order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY]
+    assert attachments == [
+        {
+            "source": "telegram_bot",
+            "file_id": "AgACAgIAAxkBAAIB_photo",
+            "filename": "объект.jpg",
+            "mime_type": "image/jpeg",
+            "kind": "photo",
+            "telegram_user_id": 777,
+            "telegram_chat_id": 100,
+            "telegram_message_id": 55,
+            "attached_at": attachments[0]["attached_at"],
+        }
+    ]
+    assert "Исходный комментарий" in order.comment
+    assert "file_id=AgACAgIAAxkBAAIB_photo" in order.comment
+
+
+@pytest.mark.asyncio
+async def test_does_not_duplicate_same_file(sqlite_order_attachment_session):
+    order = Order(title="Монтаж")
+    sqlite_order_attachment_session.add(order)
+    await sqlite_order_attachment_session.commit()
+
+    kwargs = {
+        "file_id": "same-file",
+        "filename": "акт.pdf",
+        "mime_type": "application/pdf",
+        "telegram_user_id": 777,
+        "telegram_chat_id": 100,
+        "telegram_message_id": 55,
+    }
+    first = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs)
+    second = await BotOrderAttachmentService.attach_to_order(sqlite_order_attachment_session, int(order.id), **kwargs)
+
+    assert first["already_attached"] is False
+    assert second["already_attached"] is True
+    await sqlite_order_attachment_session.refresh(order)
+    attachments = order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY]
+    assert len(attachments) == 1
+    assert order.comment.count("file_id=same-file") == 1
+
+
+@pytest.mark.asyncio
+async def test_lists_recent_active_orders(sqlite_order_attachment_session):
+    active = Order(title="Активный", status=OrderStatus.NEGOTIATION)
+    closed = Order(title="Закрытый", status=OrderStatus.CLOSED)
+    sqlite_order_attachment_session.add(active)
+    sqlite_order_attachment_session.add(closed)
+    await sqlite_order_attachment_session.commit()
+
+    orders = await BotOrderAttachmentService.list_recent_orders(sqlite_order_attachment_session)
+
+    assert [item["id"] for item in orders] == [active.id]
+
+
+@pytest.mark.asyncio
+async def test_executor_can_attach_only_assigned_order(sqlite_order_attachment_session):
+    staff = StaffUser(
+        display_name="Монтажник",
+        status="active",
+        primary_role="installer",
+        roles=["installer"],
+        telegram_id=777,
+        legacy_installer_id=10,
+    )
+    assigned = Order(title="Назначенный")
+    other = Order(title="Чужой")
+    sqlite_order_attachment_session.add(staff)
+    sqlite_order_attachment_session.add(assigned)
+    sqlite_order_attachment_session.add(other)
+    await sqlite_order_attachment_session.flush()
+    sqlite_order_attachment_session.add(OrderWorkStage(order_id=assigned.id, installer_id=10, name="Монтаж"))
+    await sqlite_order_attachment_session.commit()
+
+    assert await BotOrderAttachmentService.can_attach_to_order(
+        sqlite_order_attachment_session,
+        int(assigned.id),
+        telegram_user_id=777,
+    )
+    assert not await BotOrderAttachmentService.can_attach_to_order(
+        sqlite_order_attachment_session,
+        int(other.id),
+        telegram_user_id=777,
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_can_attach_legacy_installer_order(sqlite_order_attachment_session):
+    staff = StaffUser(
+        display_name="Монтажник",
+        status="active",
+        primary_role="installer",
+        roles=["installer"],
+        telegram_id=777,
+        legacy_installer_id=10,
+    )
+    order = Order(title="Старый монтаж")
+    sqlite_order_attachment_session.add(staff)
+    sqlite_order_attachment_session.add(order)
+    await sqlite_order_attachment_session.flush()
+    sqlite_order_attachment_session.add(OrderInstaller(order_id=order.id, installer_id=10))
+    await sqlite_order_attachment_session.commit()
+
+    assert await BotOrderAttachmentService.can_attach_to_order(
+        sqlite_order_attachment_session,
+        int(order.id),
+        telegram_user_id=777,
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_can_attach_any_order(sqlite_order_attachment_session):
+    assert await BotOrderAttachmentService.can_attach_to_order(
+        sqlite_order_attachment_session,
+        999,
+        telegram_user_id=None,
+        can_attach_any=True,
+    )

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -17,7 +17,8 @@ from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_task_service import BotTaskService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
-from bot_app.keyboards import get_product_keyboard, selection_result_keyboard
+from bot_app.keyboards import get_product_keyboard, get_staff_main_menu, selection_result_keyboard
+from bot_app.handlers import work as work_handlers
 from bot_app.utils import format_caption
 
 
@@ -579,6 +580,105 @@ def test_selection_result_keyboard_has_client_text_action():
     button = keyboard.inline_keyboard[0][0]
     assert button.text == "Текст клиенту"
     assert button.callback_data == "selection_client_text"
+
+
+@pytest.mark.asyncio
+async def test_selection_process_passes_html_fallback_to_rich_sender(monkeypatch):
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeMessage:
+        text = "7"
+        from_user = SimpleNamespace(id=777)
+        chat = SimpleNamespace(id=555)
+
+        def __init__(self):
+            self.answers = []
+
+        async def answer(self, text, **kwargs):
+            self.answers.append({"text": text, "kwargs": kwargs})
+
+    class FakeState:
+        def __init__(self):
+            self.data = {}
+            self.states = []
+
+        async def update_data(self, **kwargs):
+            self.data.update(kwargs)
+
+        async def set_state(self, state):
+            self.states.append(state)
+
+        async def clear(self):
+            self.states.append("clear")
+
+    context = SimpleNamespace(is_staff=True, is_manager=True, is_executor=False)
+    selection = {
+        "areas": [
+            {
+                "label": "7 (1,9 кВт)",
+                "tiers": [
+                    {
+                        "label": "Бюджетнее",
+                        "products": [
+                            {
+                                "title": "Midea 07",
+                                "slug": "midea-07",
+                                "price": 990,
+                                "vitebsk_qty": 1,
+                                "minsk_qty": 0,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    calls = {}
+
+    async def fake_require_staff(message):
+        return context
+
+    async def fake_build_selection(session, query):
+        calls["build"] = {"session": session, "query": query}
+        return selection
+
+    async def fake_send_rich_message(user_id, rich_html, **kwargs):
+        calls["rich"] = {
+            "user_id": user_id,
+            "rich_html": rich_html,
+            "fallback_text": kwargs.get("fallback_text"),
+            "reply_markup": kwargs.get("reply_markup"),
+        }
+        return False
+
+    monkeypatch.setattr(work_handlers, "_require_staff", fake_require_staff)
+    monkeypatch.setattr(work_handlers, "async_session_maker", lambda: FakeSessionContext())
+    monkeypatch.setattr(work_handlers.BotProductSelectionService, "build_selection", fake_build_selection)
+    monkeypatch.setattr(work_handlers.BotService, "send_rich_message", fake_send_rich_message)
+
+    message = FakeMessage()
+    state = FakeState()
+
+    await work_handlers.selection_process(message, state)
+
+    assert calls["build"]["query"] == "7"
+    assert calls["rich"]["user_id"] == 555
+    assert "<h3>Подбор кондиционеров для клиента</h3>" in calls["rich"]["rich_html"]
+    assert "<b>Подбор кондиционеров для клиента</b>" in calls["rich"]["fallback_text"]
+    assert calls["rich"]["reply_markup"] is not None
+    assert state.data["selection_client_text"].startswith("Подобрал варианты кондиционеров:")
+    assert state.states == [None]
+    assert message.answers == [
+        {
+            "text": "Готово. Можно продолжить работу из меню.",
+            "kwargs": {"reply_markup": get_staff_main_menu(context)},
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add Telegram file action to attach photos/PDFs to CRM orders from the bot
- store Telegram attachment metadata in Order.technical_meta and append a visible comment line for managers
- keep requisites OCR admin-only while allowing active staff to attach files; executors can attach only assigned orders
- pass selection HTML fallback through BotService rich-message path

## Delegation
- Attachment flow implemented by worker Schrodinger, reviewed and tightened for staff/executor access boundaries
- Selection rich fallback implemented by worker Hilbert
- QA/smoke matrix audited by explorer Bohr

## Tests
- pytest tests/unit/test_bot_admin_handler.py tests/unit/test_bot_order_attachment_service.py tests/unit/test_bot_work_services.py tests/unit/test_bot_handlers_architecture.py -q
- pytest tests/unit/test_bot_*.py -q
- python3 -m compileall bot_app/handlers/admin.py bot_app/handlers/work.py bot_app/states.py services/bot_order_attachment_service.py