### PR TITLE
[codex] Polish bot tasks and quick orders

### DIFF
--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -178,6 +178,8 @@ export type { ManagerStaffCreatePayload } from './models/ManagerStaffCreatePaylo
 export type { ManagerStaffListResponse } from './models/ManagerStaffListResponse';
 export type { ManagerStaffResponse } from './models/ManagerStaffResponse';
 export type { ManagerStaffUpdatePayload } from './models/ManagerStaffUpdatePayload';
+export type { ManagerStaleWorkStageItem } from './models/ManagerStaleWorkStageItem';
+export type { ManagerStaleWorkStageListResponse } from './models/ManagerStaleWorkStageListResponse';
 export type { ManagerTagCreatePayload } from './models/ManagerTagCreatePayload';
 export type { ManagerTagGroupCreatePayload } from './models/ManagerTagGroupCreatePayload';
 export type { ManagerTagGroupResponse } from './models/ManagerTagGroupResponse';

--- a/manager_frontend/src/client/models/ManagerStaleWorkStageItem.ts
+++ b/manager_frontend/src/client/models/ManagerStaleWorkStageItem.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerStaleWorkStageItem = {
+    id: number;
+    order_id: number;
+    order_status: string;
+    order_title?: (string | null);
+    name: string;
+    status: string;
+    start_time?: (string | null);
+    end_time?: (string | null);
+    installer_id?: (number | null);
+    installer_name?: (string | null);
+    customer_name?: (string | null);
+    customer_phone?: (string | null);
+    address?: (string | null);
+    manager_comment?: (string | null);
+    installer_report?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerStaleWorkStageListResponse.ts
+++ b/manager_frontend/src/client/models/ManagerStaleWorkStageListResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerStaleWorkStageItem } from './ManagerStaleWorkStageItem';
+export type ManagerStaleWorkStageListResponse = {
+    items: Array<ManagerStaleWorkStageItem>;
+    total: number;
+};
+

--- a/manager_frontend/src/client/services/ManagerOrdersService.ts
+++ b/manager_frontend/src/client/services/ManagerOrdersService.ts
@@ -7,6 +7,8 @@ import type { ManagerOrderDetailResponse } from '../models/ManagerOrderDetailRes
 import type { ManagerOrderDocumentResponse } from '../models/ManagerOrderDocumentResponse';
 import type { ManagerOrderListResponse } from '../models/ManagerOrderListResponse';
 import type { ManagerOrderUpdatePayload } from '../models/ManagerOrderUpdatePayload';
+import type { ManagerStaleWorkStageItem } from '../models/ManagerStaleWorkStageItem';
+import type { ManagerStaleWorkStageListResponse } from '../models/ManagerStaleWorkStageListResponse';
 import type { OrderProposalCreatePayload } from '../models/OrderProposalCreatePayload';
 import type { OrderProposalUpdatePayload } from '../models/OrderProposalUpdatePayload';
 import type { OrderWorkStageCreatePayload } from '../models/OrderWorkStageCreatePayload';
@@ -75,6 +77,32 @@ export class ManagerOrdersService {
         });
     }
     /**
+     * List Manager Stale Order Stages
+     * @param olderThanDays
+     * @param includeUnscheduled
+     * @param limit
+     * @returns ManagerStaleWorkStageListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listManagerStaleOrderStages(
+        olderThanDays: number = 7,
+        includeUnscheduled: boolean = true,
+        limit: number = 100,
+    ): CancelablePromise<ManagerStaleWorkStageListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/orders/work-stages/stale',
+            query: {
+                'older_than_days': olderThanDays,
+                'include_unscheduled': includeUnscheduled,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
      * Get Manager Order Detail
      * @param orderId
      * @returns ManagerOrderDetailResponse Successful Response
@@ -132,6 +160,46 @@ export class ManagerOrdersService {
             url: '/api/manager/orders/{order_id}',
             path: {
                 'order_id': orderId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Cancel Manager Order Stage Direct
+     * @param stageId
+     * @returns ManagerStaleWorkStageItem Successful Response
+     * @throws ApiError
+     */
+    public static cancelManagerOrderStageDirect(
+        stageId: number,
+    ): CancelablePromise<ManagerStaleWorkStageItem> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/manager/orders/work-stages/{stage_id}/cancel',
+            path: {
+                'stage_id': stageId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Manager Order Stage Direct
+     * @param stageId
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteManagerOrderStageDirect(
+        stageId: number,
+    ): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/orders/work-stages/{stage_id}',
+            path: {
+                'stage_id': stageId,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/views/CalendarDashboard.vue
+++ b/manager_frontend/src/views/CalendarDashboard.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import FullCalendar from '@fullcalendar/vue3';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import type { CalendarOptions, EventSourceFunc } from '@fullcalendar/core';
-import { ManagerCalendarService, type CalendarEventResponse, type ManagerOrderDetailResponse, type ManagerOrderUpdatePayload } from '../client';
+import { ManagerCalendarService, ManagerOrdersService, type CalendarEventResponse, type ManagerOrderDetailResponse, type ManagerOrderUpdatePayload, type ManagerStaleWorkStageItem } from '../client';
 import { api } from '../api';
-import { Loader2 } from 'lucide-vue-next';
+import { Loader2, RefreshCw, Trash2, XCircle } from 'lucide-vue-next';
 import OrderEditDrawer from '../components/orders/OrderEditDrawer.vue';
-import { parseApiFieldErrors } from '../utils/api-errors';
+import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 
 const isLoading = ref(false);
 const error = ref<string | null>(null);
@@ -22,6 +22,10 @@ const orderFormError = ref('');
 const saving = ref(false);
 const toast = ref('');
 const calendarRef = ref<any>(null);
+const staleStages = ref<ManagerStaleWorkStageItem[]>([]);
+const staleStagesTotal = ref(0);
+const staleStagesLoading = ref(false);
+const staleStagesError = ref('');
 
 const setToast = (message: string) => {
   toast.value = message;
@@ -87,6 +91,52 @@ const openOrder = async (orderId: number) => {
   }
 };
 
+const loadStaleStages = async () => {
+  staleStagesLoading.value = true;
+  staleStagesError.value = '';
+  try {
+    const response = await ManagerOrdersService.listManagerStaleOrderStages(7, true, 100);
+    staleStages.value = response.items || [];
+    staleStagesTotal.value = response.total || 0;
+  } catch (err) {
+    console.error('Failed to load stale work stages', err);
+    staleStagesError.value = getApiErrorMessage(err);
+  } finally {
+    staleStagesLoading.value = false;
+  }
+};
+
+const refreshCalendar = () => {
+  const calendarApi = calendarRef.value?.getApi();
+  if (calendarApi) {
+    calendarApi.refetchEvents();
+  }
+};
+
+const cancelStaleStage = async (stage: ManagerStaleWorkStageItem) => {
+  if (!window.confirm(`Отменить задачу «${stage.name}» по заказу #${stage.order_id}?`)) return;
+  try {
+    await ManagerOrdersService.cancelManagerOrderStageDirect(stage.id);
+    setToast('Задача отменена');
+    await loadStaleStages();
+    refreshCalendar();
+  } catch (err) {
+    setToast(`Ошибка отмены: ${getApiErrorMessage(err)}`);
+  }
+};
+
+const deleteStaleStage = async (stage: ManagerStaleWorkStageItem) => {
+  if (!window.confirm(`Удалить задачу «${stage.name}» по заказу #${stage.order_id}?`)) return;
+  try {
+    await ManagerOrdersService.deleteManagerOrderStageDirect(stage.id);
+    setToast('Задача удалена');
+    await loadStaleStages();
+    refreshCalendar();
+  } catch (err) {
+    setToast(`Ошибка удаления: ${getApiErrorMessage(err)}`);
+  }
+};
+
 const saveOrder = async (payload: { orderId: number; data: ManagerOrderUpdatePayload }) => {
   if (saving.value) return;
   saving.value = true;
@@ -97,10 +147,7 @@ const saveOrder = async (payload: { orderId: number; data: ManagerOrderUpdatePay
     setToast('Сделка сохранена');
     
     // Refresh events to show updated dates immediately
-    const calendarApi = calendarRef.value?.getApi();
-    if (calendarApi) {
-      calendarApi.refetchEvents();
-    }
+    refreshCalendar();
   } catch (error: any) {
     console.error(error);
     const parsed = parseApiFieldErrors(error, [
@@ -137,11 +184,21 @@ const handleOrderDeleted = (orderId: number) => {
     selectedOrder.value = null;
   }
   setToast('Сделка удалена');
-  const calendarApi = calendarRef.value?.getApi();
-  if (calendarApi) {
-    calendarApi.refetchEvents();
-  }
+  refreshCalendar();
 };
+
+const formatStageDate = (value?: string | null) => {
+  if (!value) return 'дата не задана';
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+onMounted(loadStaleStages);
 
 const fetchEvents: EventSourceFunc = async (fetchInfo, successCallback, failureCallback) => {
   isLoading.value = true;
@@ -221,6 +278,93 @@ const calendarOptions = ref<CalendarOptions>({
     <div v-if="error" class="bg-red-50 text-red-600 p-4 rounded-lg mb-6">
       {{ error }}
     </div>
+
+    <section class="mb-6 rounded-xl border border-amber-200 bg-amber-50/70 p-4 shadow-sm">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-sm font-bold uppercase tracking-wide text-amber-900">Хвосты рабочих задач</h2>
+          <p class="mt-1 text-sm text-amber-800">
+            Незавершенные этапы старше 7 дней или без даты: {{ staleStagesTotal }}
+          </p>
+        </div>
+        <button
+          class="inline-flex items-center justify-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-medium text-amber-900 shadow-sm transition hover:bg-amber-100 disabled:opacity-60"
+          :disabled="staleStagesLoading"
+          @click="loadStaleStages"
+        >
+          <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': staleStagesLoading }" />
+          Обновить
+        </button>
+      </div>
+
+      <div v-if="staleStagesError" class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+        {{ staleStagesError }}
+      </div>
+      <div v-else-if="staleStagesLoading" class="mt-3 flex items-center gap-2 text-sm text-amber-800">
+        <Loader2 class="h-4 w-4 animate-spin" />
+        Проверяем задачи...
+      </div>
+      <div v-else-if="!staleStages.length" class="mt-3 rounded-lg bg-white/70 px-3 py-2 text-sm text-amber-800">
+        Просроченных рабочих задач нет.
+      </div>
+      <div v-else class="mt-4 overflow-x-auto">
+        <table class="min-w-full border-separate border-spacing-y-2 text-sm">
+          <thead class="text-left text-xs uppercase tracking-wide text-amber-900">
+            <tr>
+              <th class="px-3 py-1">Задача</th>
+              <th class="px-3 py-1">Дата</th>
+              <th class="px-3 py-1">Клиент</th>
+              <th class="px-3 py-1">Исполнитель</th>
+              <th class="px-3 py-1 text-right">Действия</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="stage in staleStages" :key="stage.id" class="bg-white shadow-sm">
+              <td class="rounded-l-lg px-3 py-3 align-top">
+                <button class="font-semibold text-teal-700 hover:text-teal-900" @click="openOrder(stage.order_id)">
+                  #{{ stage.order_id }} · {{ stage.name }}
+                </button>
+                <div class="mt-1 text-xs text-slate-500">
+                  {{ stage.order_title || 'Заказ без названия' }} · {{ stage.order_status }}
+                </div>
+                <div v-if="stage.manager_comment" class="mt-2 max-w-xl text-xs text-slate-600">
+                  {{ stage.manager_comment }}
+                </div>
+              </td>
+              <td class="px-3 py-3 align-top text-slate-700">
+                {{ formatStageDate(stage.start_time) }}
+              </td>
+              <td class="px-3 py-3 align-top text-slate-700">
+                <div>{{ stage.customer_name || 'Клиент не указан' }}</div>
+                <div class="text-xs text-slate-500">{{ stage.customer_phone || 'телефон не указан' }}</div>
+                <div class="text-xs text-slate-500">{{ stage.address || 'адрес не указан' }}</div>
+              </td>
+              <td class="px-3 py-3 align-top text-slate-700">
+                {{ stage.installer_name || 'не назначен' }}
+              </td>
+              <td class="rounded-r-lg px-3 py-3 align-top">
+                <div class="flex justify-end gap-2">
+                  <button
+                    class="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
+                    @click="cancelStaleStage(stage)"
+                  >
+                    <XCircle class="h-4 w-4" />
+                    Отменить
+                  </button>
+                  <button
+                    class="inline-flex items-center gap-1 rounded-lg border border-red-200 px-2.5 py-1.5 text-xs font-medium text-red-700 transition hover:bg-red-50"
+                    @click="deleteStaleStage(stage)"
+                  >
+                    <Trash2 class="h-4 w-4" />
+                    Удалить
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 calendar-wrapper">
       <FullCalendar ref="calendarRef" :options="calendarOptions" />

--- a/openapi.json
+++ b/openapi.json
@@ -5739,6 +5739,78 @@
         }
       }
     },
+    "/api/manager/orders/work-stages/stale": {
+      "get": {
+        "tags": [
+          "manager-orders"
+        ],
+        "summary": "List Manager Stale Order Stages",
+        "operationId": "list_manager_stale_order_stages",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "older_than_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 0,
+              "default": 7,
+              "title": "Older Than Days"
+            }
+          },
+          {
+            "name": "include_unscheduled",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Include Unscheduled"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerStaleWorkStageListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/orders/{order_id}": {
       "get": {
         "tags": [
@@ -5871,6 +5943,102 @@
                   "type": "object",
                   "additionalProperties": true,
                   "title": "Response Delete Manager Order"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/orders/work-stages/{stage_id}/cancel": {
+      "patch": {
+        "tags": [
+          "manager-orders"
+        ],
+        "summary": "Cancel Manager Order Stage Direct",
+        "operationId": "cancel_manager_order_stage_direct",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stage_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stage Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerStaleWorkStageItem"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/orders/work-stages/{stage_id}": {
+      "delete": {
+        "tags": [
+          "manager-orders"
+        ],
+        "summary": "Delete Manager Order Stage Direct",
+        "operationId": "delete_manager_order_stage_direct",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stage_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stage Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Manager Order Stage Direct"
                 }
               }
             }
@@ -22824,6 +22992,172 @@
         },
         "type": "object",
         "title": "ManagerStaffUpdatePayload"
+      },
+      "ManagerStaleWorkStageItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "order_id": {
+            "type": "integer",
+            "title": "Order Id"
+          },
+          "order_status": {
+            "type": "string",
+            "title": "Order Status"
+          },
+          "order_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Title"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "installer_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Installer Id"
+          },
+          "installer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Installer Name"
+          },
+          "customer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Name"
+          },
+          "customer_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Phone"
+          },
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "manager_comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manager Comment"
+          },
+          "installer_report": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Installer Report"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "order_id",
+          "order_status",
+          "name",
+          "status"
+        ],
+        "title": "ManagerStaleWorkStageItem"
+      },
+      "ManagerStaleWorkStageListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerStaleWorkStageItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "ManagerStaleWorkStageListResponse"
       },
       "ManagerTagCreatePayload": {
         "properties": {

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -94,6 +94,9 @@ DELETE_MANAGER_ORDER_PAYMENT = "delete_manager_order_payment"
 CREATE_MANAGER_ORDER_STAGE = "create_manager_order_stage"
 UPDATE_MANAGER_ORDER_STAGE = "update_manager_order_stage"
 DELETE_MANAGER_ORDER_STAGE = "delete_manager_order_stage"
+LIST_MANAGER_STALE_ORDER_STAGES = "list_manager_stale_order_stages"
+CANCEL_MANAGER_ORDER_STAGE_DIRECT = "cancel_manager_order_stage_direct"
+DELETE_MANAGER_ORDER_STAGE_DIRECT = "delete_manager_order_stage_direct"
 GET_MANAGER_DOC_DOWNLOAD = "get_manager_doc_download"
 DELETE_MANAGER_DOC = "delete_manager_doc"
 IMPORT_MANAGER_BANK_RECEIPTS = "import_manager_bank_receipts"
@@ -286,6 +289,9 @@ ALL_MANAGER_OPERATION_IDS = (
     CREATE_MANAGER_ORDER_STAGE,
     UPDATE_MANAGER_ORDER_STAGE,
     DELETE_MANAGER_ORDER_STAGE,
+    LIST_MANAGER_STALE_ORDER_STAGES,
+    CANCEL_MANAGER_ORDER_STAGE_DIRECT,
+    DELETE_MANAGER_ORDER_STAGE_DIRECT,
     GET_MANAGER_DOC_DOWNLOAD,
     DELETE_MANAGER_DOC,
     IMPORT_MANAGER_BANK_RECEIPTS,

--- a/routers/manager_orders_read.py
+++ b/routers/manager_orders_read.py
@@ -5,8 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.security import get_current_username
-from routers.manager_operation_ids import GET_MANAGER_ORDER_DETAIL, GET_MANAGER_ORDERS
-from schemas import ManagerOrderDetailResponse, ManagerOrderListResponse
+from routers.manager_operation_ids import GET_MANAGER_ORDER_DETAIL, GET_MANAGER_ORDERS, LIST_MANAGER_STALE_ORDER_STAGES
+from schemas import ManagerOrderDetailResponse, ManagerOrderListResponse, ManagerStaleWorkStageListResponse
 from services.order_service import OrderService
 
 
@@ -38,6 +38,26 @@ async def get_manager_orders(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/work-stages/stale",
+    response_model=ManagerStaleWorkStageListResponse,
+    operation_id=LIST_MANAGER_STALE_ORDER_STAGES,
+)
+async def list_manager_stale_order_stages(
+    older_than_days: int = Query(7, ge=0, le=365),
+    include_unscheduled: bool = Query(True),
+    limit: int = Query(100, ge=1, le=100),
+    _: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
+):
+    return await OrderService.list_stale_order_stages(
+        session,
+        older_than_days=older_than_days,
+        include_unscheduled=include_unscheduled,
+        limit=limit,
+    )
 
 
 @router.get("/{order_id}", response_model=ManagerOrderDetailResponse, operation_id=GET_MANAGER_ORDER_DETAIL)

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -21,6 +21,8 @@ from routers.manager_operation_ids import (
     CREATE_MANAGER_ORDER_STAGE,
     UPDATE_MANAGER_ORDER_STAGE,
     DELETE_MANAGER_ORDER_STAGE,
+    CANCEL_MANAGER_ORDER_STAGE_DIRECT,
+    DELETE_MANAGER_ORDER_STAGE_DIRECT,
 )
 from schemas import (
     ManagerOrderCreatePayload,
@@ -33,6 +35,7 @@ from schemas import (
     PaymentResponse,
     OrderWorkStageCreatePayload,
     OrderWorkStageUpdatePayload,
+    ManagerStaleWorkStageItem,
 )
 from services.document_service import DocumentService
 from services.order_service import OrderService
@@ -57,6 +60,48 @@ async def create_manager_order(
             message=str(exc),
         ) from exc
     return data
+
+
+@router.patch(
+    "/work-stages/{stage_id}/cancel",
+    response_model=ManagerStaleWorkStageItem,
+    operation_id=CANCEL_MANAGER_ORDER_STAGE_DIRECT,
+)
+async def cancel_manager_order_stage_direct(
+    stage_id: int,
+    _: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
+):
+    try:
+        return await OrderService.cancel_order_stage_direct(session, stage_id)
+    except ValueError as exc:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=CANCEL_MANAGER_ORDER_STAGE_DIRECT,
+            error_code=ORDER_NOT_FOUND,
+            message=str(exc),
+        ) from exc
+
+
+@router.delete(
+    "/work-stages/{stage_id}",
+    response_model=dict,
+    operation_id=DELETE_MANAGER_ORDER_STAGE_DIRECT,
+)
+async def delete_manager_order_stage_direct(
+    stage_id: int,
+    _: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
+):
+    try:
+        return await OrderService.delete_order_stage_direct(session, stage_id)
+    except ValueError as exc:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=DELETE_MANAGER_ORDER_STAGE_DIRECT,
+            error_code=ORDER_NOT_FOUND,
+            message=str(exc),
+        ) from exc
 
 
 @router.patch("/{order_id}", response_model=ManagerOrderDetailResponse, operation_id=PATCH_MANAGER_ORDER)

--- a/schemas.py
+++ b/schemas.py
@@ -725,6 +725,29 @@ class OrderWorkStageResponse(BaseModel):
     installer: Optional[ManagerInstallerResponse] = None
 
 
+class ManagerStaleWorkStageItem(BaseModel):
+    id: int
+    order_id: int
+    order_status: str
+    order_title: Optional[str] = None
+    name: str
+    status: str
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    installer_id: Optional[int] = None
+    installer_name: Optional[str] = None
+    customer_name: Optional[str] = None
+    customer_phone: Optional[str] = None
+    address: Optional[str] = None
+    manager_comment: Optional[str] = None
+    installer_report: Optional[str] = None
+
+
+class ManagerStaleWorkStageListResponse(BaseModel):
+    items: List[ManagerStaleWorkStageItem]
+    total: int
+
+
 class OrderProposalResponse(BaseModel):
     id: int
     order_id: int

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -9,7 +9,9 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
+from core.input_validation import normalize_phone_digits
 from schemas import ManagerOrderCreatePayload, OrderWorkStageCreatePayload
+from services.address_suggest_service import AddressSuggestService
 from services.notification_service import NotificationService
 from services.order_service import OrderService
 
@@ -77,6 +79,16 @@ class BotQuickOrderService:
             return None
         phone = re.sub(r"\s+", " ", match.group(1)).strip()
         return phone
+
+    @classmethod
+    def normalize_phone(cls, value: Any) -> Optional[str]:
+        cleaned = cls._clean_optional(value)
+        if not cleaned:
+            return None
+        digits = normalize_phone_digits(cleaned)
+        if len(digits) == 12 and digits.startswith("375"):
+            return f"+{digits}"
+        return cleaned
 
     @staticmethod
     def _infer_service_type(text: str) -> Optional[str]:
@@ -187,14 +199,14 @@ class BotQuickOrderService:
 
     @classmethod
     def parse_text_fallback(cls, text: str, *, now: Optional[datetime] = None) -> dict[str, Any]:
-        phone = cls._extract_phone(text)
+        raw_phone = cls._extract_phone(text)
         service_type = cls._infer_service_type(text)
         target_date = cls._parse_date(text, now=now)
-        name = cls._extract_name(text, phone)
+        name = cls._extract_name(text, raw_phone)
         address = cls._extract_address(text)
         return {
             "name": name,
-            "phone": phone,
+            "phone": cls.normalize_phone(raw_phone),
             "address": address,
             "service_type": service_type,
             "target_date": target_date.isoformat() if target_date else None,
@@ -220,7 +232,7 @@ class BotQuickOrderService:
         fallback = cls.parse_text_fallback(text)
         token = settings.DEEPSEEK_TOKEN.strip()
         if not token:
-            return fallback
+            return await cls.enrich_draft(cls.normalize_draft(fallback))
 
         try:
             async with httpx.AsyncClient(timeout=12.0) as client:
@@ -240,7 +252,7 @@ class BotQuickOrderService:
                 content = response.json()["choices"][0]["message"]["content"]
             parsed = cls._extract_json_object(content)
         except Exception:
-            return fallback
+            return await cls.enrich_draft(cls.normalize_draft(fallback))
 
         merged = dict(fallback)
         for key in ("name", "phone", "address", "service_type", "target_date", "request_text"):
@@ -248,13 +260,13 @@ class BotQuickOrderService:
             if value:
                 merged[key] = value
         merged["parser"] = "ai"
-        return cls.normalize_draft(merged)
+        return await cls.enrich_draft(cls.normalize_draft(merged))
 
     @classmethod
     def normalize_draft(cls, draft: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(draft or {})
         normalized["name"] = cls._clean_optional(normalized.get("name"))
-        normalized["phone"] = cls._clean_optional(normalized.get("phone"))
+        normalized["phone"] = cls.normalize_phone(normalized.get("phone"))
         normalized["address"] = cls._clean_optional(normalized.get("address"))
         normalized["request_text"] = cls._clean_optional(normalized.get("request_text")) or ""
         service_type = cls._clean_optional(normalized.get("service_type"))
@@ -271,6 +283,67 @@ class BotQuickOrderService:
             normalized["target_date"] = None
         return normalized
 
+    @staticmethod
+    def _address_tokens(value: str) -> set[str]:
+        return set(re.findall(r"\d+[а-яa-z]?", value.casefold().replace("ё", "е")))
+
+    @classmethod
+    async def enrich_draft(cls, draft: dict[str, Any]) -> dict[str, Any]:
+        enriched = dict(draft or {})
+        address = cls._clean_optional(enriched.get("address"))
+        if not address:
+            enriched.pop("address_check", None)
+            return enriched
+
+        try:
+            suggestions = await AddressSuggestService.suggest(address)
+        except (RuntimeError, httpx.HTTPError):
+            enriched["address_check"] = {
+                "status": "unchecked",
+                "message": "адрес не проверен, сервис подсказок временно недоступен",
+            }
+            return enriched
+        except Exception:
+            logger.exception("BOT_QUICK_ORDER_ADDRESS_CHECK_FAILED")
+            enriched["address_check"] = {
+                "status": "unchecked",
+                "message": "адрес не проверен",
+            }
+            return enriched
+
+        if not suggestions:
+            enriched["address_check"] = {
+                "status": "not_found",
+                "message": "адрес не найден в подсказках, лучше уточнить у клиента",
+            }
+            return enriched
+
+        suggestion = suggestions[0]
+        suggested_value = cls._clean_optional(suggestion.get("value") or suggestion.get("title"))
+        input_tokens = cls._address_tokens(address)
+        suggested_tokens = cls._address_tokens(suggested_value or "")
+        if input_tokens and not (input_tokens & suggested_tokens):
+            enriched["address_check"] = {
+                "status": "needs_review",
+                "message": "адрес найден, но номер дома стоит сверить",
+                "suggestion": suggested_value,
+            }
+            return enriched
+        if not input_tokens:
+            enriched["address_check"] = {
+                "status": "needs_review",
+                "message": "адрес найден, уточните номер дома",
+                "suggestion": suggested_value,
+            }
+            return enriched
+
+        enriched["address_check"] = {
+            "status": "confirmed",
+            "message": "адрес найден",
+            "suggestion": suggested_value,
+        }
+        return enriched
+
     @classmethod
     def _display_target_date(cls, draft: dict[str, Any]) -> str | None:
         target_date = draft.get("target_date")
@@ -282,10 +355,25 @@ class BotQuickOrderService:
                 return str(target_date)
         return None
 
+    @staticmethod
+    def _address_check_text(draft: dict[str, Any]) -> str | None:
+        check = draft.get("address_check")
+        if not isinstance(check, dict):
+            return None
+        status = check.get("status")
+        message = str(check.get("message") or "").strip()
+        suggestion = str(check.get("suggestion") or "").strip()
+        if status == "confirmed" and suggestion:
+            return f"{message}: {suggestion}"
+        if suggestion:
+            return f"{message}. Вариант: {suggestion}"
+        return message or None
+
     @classmethod
     def format_draft_preview(cls, draft: dict[str, Any]) -> str:
         target_date = cls._display_target_date(draft)
         service_type = draft.get("service_type")
+        address_check_text = cls._address_check_text(draft)
         lines = [
             "<b>Черновик заказа</b>",
             f"Клиент: {escape(str(draft.get('name') or 'не указан'))}",
@@ -296,6 +384,8 @@ class BotQuickOrderService:
             "",
             f"<i>{escape(str(draft.get('request_text') or ''))}</i>",
         ]
+        if address_check_text:
+            lines.insert(4, f"Проверка адреса: {escape(address_check_text)}")
         return "\n".join(lines)
 
     @classmethod
@@ -303,12 +393,14 @@ class BotQuickOrderService:
         target_date = cls._display_target_date(draft)
         service_type = draft.get("service_type")
         request_text = str(draft.get("request_text") or "").strip()
+        address_check_text = cls._address_check_text(draft)
         rich_html = (
             "<h3>Черновик заказа</h3>"
             "<p>"
             f"<b>Клиент:</b> {escape(str(draft.get('name') or 'не указан'))}<br/>"
             f"<b>Телефон:</b> {escape(str(draft.get('phone') or 'не указан'))}<br/>"
             f"<b>Адрес:</b> {escape(str(draft.get('address') or 'не указан'))}<br/>"
+            f"{('<b>Проверка адреса:</b> ' + escape(address_check_text) + '<br/>') if address_check_text else ''}"
             f"<b>Услуга:</b> {escape(cls.SERVICE_LABELS.get(service_type, 'не указана'))}<br/>"
             f"<b>Дата:</b> {escape(target_date or 'не указана')}"
             "</p>"

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -3,12 +3,11 @@ from datetime import datetime, timedelta
 from html import escape
 from typing import Any
 
-from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Order, OrderInstaller, OrderStageStatus, OrderWorkStage, StaffUser
+from models import Order, OrderInstaller, OrderStageStatus, OrderStatus, OrderWorkStage, StaffUser
 from services.notification_service import NotificationService
 from services.staff_user_service import StaffUserService
 
@@ -16,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 class BotTaskService:
+    ACTIVE_ORDER_STATUSES = {
+        OrderStatus.NEW_LEAD,
+        OrderStatus.NEGOTIATION,
+        OrderStatus.EXECUTION,
+    }
+
     @staticmethod
     async def _staff_by_telegram_id(session: AsyncSession, telegram_id: int | str | None) -> StaffUser | None:
         try:
@@ -51,11 +56,10 @@ class BotTaskService:
             select(OrderWorkStage)
             .join(Order, Order.id == OrderWorkStage.order_id)
             .where(OrderWorkStage.installer_id == installer_id)
+            .where(Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)))
+            .where(OrderWorkStage.start_time.is_not(None))
             .where(
-                or_(
-                    OrderWorkStage.start_time.is_(None),
-                    (OrderWorkStage.start_time >= now) & (OrderWorkStage.start_time <= until),
-                )
+                (OrderWorkStage.start_time >= now) & (OrderWorkStage.start_time <= until)
             )
             .where(OrderWorkStage.status != OrderStageStatus.COMPLETED)
             .where(OrderWorkStage.status != OrderStageStatus.CANCELED)
@@ -74,11 +78,10 @@ class BotTaskService:
             select(Order)
             .join(OrderInstaller, OrderInstaller.order_id == Order.id)
             .where(OrderInstaller.installer_id == installer_id)
+            .where(Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)))
+            .where(Order.installation_date.is_not(None))
             .where(
-                or_(
-                    Order.installation_date.is_(None),
-                    (Order.installation_date >= now) & (Order.installation_date <= until),
-                )
+                (Order.installation_date >= now) & (Order.installation_date <= until)
             )
             .options(selectinload(Order.customer), selectinload(Order.installers))
             .order_by(Order.installation_date.asc().nullslast(), Order.id.asc())

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -1,7 +1,7 @@
 import logging
 import json
 from typing import Optional, List, Dict, Any
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 from sqlalchemy import func, or_, and_, not_, cast, String, delete, inspect
@@ -10,7 +10,7 @@ from sqlalchemy.orm.attributes import NO_VALUE, flag_modified
 
 from crud.order import OrderDAO
 from crud.product import ProductDAO
-from models import Order, OrderProductLink, OrderProposal, OrderServiceLink, Customer, CustomerBranch, CustomerContract, CustomerType, OrderStatus, PaymentCurrency, Product, LeadSource, Service, ServiceTariff, OrderInstaller, OrderWorkStage, Payment
+from models import Order, OrderProductLink, OrderProposal, OrderServiceLink, Customer, CustomerBranch, CustomerContract, CustomerType, OrderStageStatus, OrderStatus, PaymentCurrency, Product, LeadSource, Service, ServiceTariff, OrderInstaller, OrderWorkStage, Payment
 from services.customer_contract_service import CustomerContractService
 from services.document_role_service import DocumentRoleService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
@@ -1534,6 +1534,99 @@ class OrderService:
         session.add(stage)
         await session.commit()
         return await OrderService.get_order_detail_for_manager(session, order_id)
+
+    @staticmethod
+    def _map_stale_order_stage(stage: OrderWorkStage) -> Dict[str, Any]:
+        order = getattr(stage, "order", None)
+        customer = getattr(order, "customer", None) if order else None
+        installer = getattr(stage, "installer", None)
+        return {
+            "id": stage.id,
+            "order_id": stage.order_id,
+            "order_status": order.status.value if order and hasattr(order.status, "value") else str(order.status if order else ""),
+            "order_title": OrderService._display_order_title(order) if order else None,
+            "name": stage.name,
+            "status": stage.status.value if hasattr(stage.status, "value") else str(stage.status),
+            "start_time": stage.start_time,
+            "end_time": stage.end_time,
+            "installer_id": stage.installer_id,
+            "installer_name": installer.name if installer else None,
+            "customer_name": customer.name if customer else None,
+            "customer_phone": customer.phone if customer else None,
+            "address": order.delivery_address if order else None,
+            "manager_comment": stage.manager_comment,
+            "installer_report": stage.installer_report,
+        }
+
+    @staticmethod
+    async def list_stale_order_stages(
+        session: AsyncSession,
+        *,
+        older_than_days: int = 7,
+        include_unscheduled: bool = True,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        safe_limit = max(1, min(int(limit or 100), 100))
+        cutoff = datetime.now() - timedelta(days=max(0, int(older_than_days or 0)))
+        stale_conditions = [OrderWorkStage.start_time < cutoff]
+        if include_unscheduled:
+            stale_conditions.append(OrderWorkStage.start_time.is_(None))
+
+        base_filters = [
+            OrderWorkStage.status.notin_([OrderStageStatus.COMPLETED, OrderStageStatus.CANCELED]),
+            or_(*stale_conditions),
+        ]
+        count_result = await session.execute(
+            select(func.count())
+            .select_from(OrderWorkStage)
+            .join(Order, Order.id == OrderWorkStage.order_id)
+            .where(*base_filters)
+        )
+        total = int(count_result.scalar_one() or 0)
+
+        result = await session.execute(
+            select(OrderWorkStage)
+            .join(Order, Order.id == OrderWorkStage.order_id)
+            .where(*base_filters)
+            .options(
+                selectinload(OrderWorkStage.order).selectinload(Order.customer),
+                selectinload(OrderWorkStage.installer),
+            )
+            .order_by(OrderWorkStage.start_time.asc().nullsfirst(), OrderWorkStage.id.asc())
+            .limit(safe_limit)
+        )
+        return {
+            "items": [OrderService._map_stale_order_stage(stage) for stage in result.scalars().all()],
+            "total": total,
+        }
+
+    @staticmethod
+    async def cancel_order_stage_direct(session: AsyncSession, stage_id: int) -> Dict[str, Any]:
+        stage = await session.get(OrderWorkStage, stage_id)
+        if not stage:
+            raise ValueError("Stage not found")
+        stage.status = OrderStageStatus.CANCELED
+        session.add(stage)
+        await session.commit()
+        await session.refresh(stage)
+        result = await session.execute(
+            select(OrderWorkStage)
+            .where(OrderWorkStage.id == stage_id)
+            .options(
+                selectinload(OrderWorkStage.order).selectinload(Order.customer),
+                selectinload(OrderWorkStage.installer),
+            )
+        )
+        return OrderService._map_stale_order_stage(result.scalars().one())
+
+    @staticmethod
+    async def delete_order_stage_direct(session: AsyncSession, stage_id: int) -> Dict[str, Any]:
+        stage = await session.get(OrderWorkStage, stage_id)
+        if not stage:
+            raise ValueError("Stage not found")
+        await session.delete(stage)
+        await session.commit()
+        return {"ok": True, "id": stage_id}
 
     @staticmethod
     async def update_order_stage(session: AsyncSession, order_id: int, stage_id: int, payload: Any):

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from crud.product import ProductDAO
-from models import GlobalConfig, StaffUser
+from models import Customer, GlobalConfig, Installer, Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
 from models.common import OrderStageStatus
 from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
@@ -42,10 +42,17 @@ def test_quick_order_fallback_parses_service_phone_address_and_date():
     )
 
     assert draft["service_type"] == "maintenance"
-    assert draft["phone"] == "+375 29 123-45-67"
+    assert draft["phone"] == "+375291234567"
     assert draft["name"] == "Иван"
     assert draft["address"] == "Победы 15"
     assert draft["target_date"] == "2026-06-15T14:00:00"
+
+
+def test_quick_order_normalizes_belarus_phone_variants():
+    assert BotQuickOrderService.normalize_phone("+375 (29) 123-45-67") == "+375291234567"
+    assert BotQuickOrderService.normalize_phone("80291234567") == "+375291234567"
+    assert BotQuickOrderService.normalize_phone("0291234567") == "+375291234567"
+    assert BotQuickOrderService.normalize_phone("291234567") == "+375291234567"
 
 
 def test_quick_order_fallback_parses_weekday_and_loose_time():
@@ -100,6 +107,40 @@ def test_quick_order_rich_preview_formats_and_escapes_fields():
     assert "<script>" not in fallback
 
 
+@pytest.mark.asyncio
+async def test_quick_order_address_check_adds_preview_warning(monkeypatch):
+    async def fake_suggest(query: str):
+        assert query == "Победы 15"
+        return [{"value": "Беларусь, Витебск, улица Победы, 15"}]
+
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.AddressSuggestService.suggest",
+        fake_suggest,
+    )
+
+    draft = await BotQuickOrderService.enrich_draft({"address": "Победы 15"})
+    preview = BotQuickOrderService.format_draft_preview(draft)
+
+    assert draft["address_check"]["status"] == "confirmed"
+    assert "Проверка адреса: адрес найден: Беларусь, Витебск, улица Победы, 15" in preview
+
+
+@pytest.mark.asyncio
+async def test_quick_order_address_check_does_not_block_when_suggest_unavailable(monkeypatch):
+    async def fake_suggest(query: str):
+        raise RuntimeError("YANDEX_API_KEY not configured")
+
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.AddressSuggestService.suggest",
+        fake_suggest,
+    )
+
+    draft = await BotQuickOrderService.enrich_draft({"address": "Победы 15"})
+
+    assert draft["address"] == "Победы 15"
+    assert draft["address_check"]["status"] == "unchecked"
+
+
 def test_tasks_rich_html_formats_and_escapes_cards():
     tasks = [
         {
@@ -124,6 +165,94 @@ def test_tasks_rich_html_formats_and_escapes_cards():
     assert "Не забыть &lt;лестницу&gt;" in rich
     assert "<важно>" not in rich
     assert "Монтаж &lt;важно&gt;" in fallback
+
+
+@pytest.mark.asyncio
+async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_session):
+    installer = Installer(name="Иван Монтажник")
+    sqlite_staff_session.add(installer)
+    await sqlite_staff_session.commit()
+    await sqlite_staff_session.refresh(installer)
+
+    staff = StaffUser(
+        display_name="Иван",
+        telegram_id=12345,
+        status="active",
+        roles=["installer"],
+        primary_role="installer",
+        legacy_installer_id=installer.id,
+    )
+    customer = Customer(name="Клиент", phone="+375291234567")
+    sqlite_staff_session.add(staff)
+    sqlite_staff_session.add(customer)
+    await sqlite_staff_session.commit()
+    await sqlite_staff_session.refresh(customer)
+
+    active_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        title="Активный заказ",
+        delivery_address="Победы 15",
+    )
+    closed_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.CLOSED,
+        title="Закрытый заказ",
+        delivery_address="Победы 16",
+        installation_date=datetime.now() + timedelta(days=3),
+    )
+    legacy_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        title="Старый монтаж без даты",
+        delivery_address="Победы 17",
+    )
+    sqlite_staff_session.add(active_order)
+    sqlite_staff_session.add(closed_order)
+    sqlite_staff_session.add(legacy_order)
+    await sqlite_staff_session.commit()
+    await sqlite_staff_session.refresh(active_order)
+    await sqlite_staff_session.refresh(closed_order)
+    await sqlite_staff_session.refresh(legacy_order)
+
+    sqlite_staff_session.add_all(
+        [
+            OrderWorkStage(
+                order_id=active_order.id,
+                name="Старый мартовский этап",
+                installer_id=installer.id,
+                start_time=datetime.now() - timedelta(days=90),
+                status=OrderStageStatus.PLANNED,
+            ),
+            OrderWorkStage(
+                order_id=active_order.id,
+                name="Этап без даты",
+                installer_id=installer.id,
+                start_time=None,
+                status=OrderStageStatus.PLANNED,
+            ),
+            OrderWorkStage(
+                order_id=active_order.id,
+                name="Ближайший монтаж",
+                installer_id=installer.id,
+                start_time=datetime.now() + timedelta(days=2),
+                status=OrderStageStatus.PLANNED,
+            ),
+            OrderWorkStage(
+                order_id=closed_order.id,
+                name="Этап закрытого заказа",
+                installer_id=installer.id,
+                start_time=datetime.now() + timedelta(days=2),
+                status=OrderStageStatus.PLANNED,
+            ),
+            OrderInstaller(order_id=legacy_order.id, installer_id=installer.id),
+        ]
+    )
+    await sqlite_staff_session.commit()
+
+    tasks = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345)
+
+    assert [task["title"] for task in tasks] == ["Ближайший монтаж"]
 
 
 def test_task_report_builder_keeps_text_report_plain():

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -10,8 +10,11 @@ from models import (
     BankReceipt,
     Customer,
     CustomerType,
+    Installer,
     Order,
+    OrderWorkStage,
     OrderProposal,
+    OrderStageStatus,
     OrderStatus,
     OutgoingEmail,
     PaymentCurrency,
@@ -42,6 +45,77 @@ def test_service_default_order_title_inference():
     assert OrderService._build_default_order_title(comment="Купить кондиционер") == "Продажа"
     assert OrderService._build_default_order_title(items=[{"product_id": 1, "with_installation": True}]) == "Продажа + монтаж"
     assert OrderService._build_default_order_title(items=[{"product_id": 1}]) == "Продажа"
+
+
+@pytest.mark.asyncio
+async def test_service_lists_cancels_and_deletes_stale_work_stages(sqlite_order_session):
+    installer = Installer(name="Монтажник")
+    customer = Customer(name="Иван", phone="+375291234567")
+    sqlite_order_session.add(installer)
+    sqlite_order_session.add(customer)
+    await sqlite_order_session.commit()
+    await sqlite_order_session.refresh(installer)
+    await sqlite_order_session.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        title="Монтаж",
+        delivery_address="Победы 15",
+    )
+    sqlite_order_session.add(order)
+    await sqlite_order_session.commit()
+    await sqlite_order_session.refresh(order)
+
+    stale_stage = OrderWorkStage(
+        order_id=order.id,
+        name="Старый выезд",
+        installer_id=installer.id,
+        start_time=datetime.now() - timedelta(days=30),
+        status=OrderStageStatus.PLANNED,
+    )
+    unscheduled_stage = OrderWorkStage(
+        order_id=order.id,
+        name="Без даты",
+        installer_id=installer.id,
+        start_time=None,
+        status=OrderStageStatus.PLANNED,
+    )
+    upcoming_stage = OrderWorkStage(
+        order_id=order.id,
+        name="Будущий выезд",
+        installer_id=installer.id,
+        start_time=datetime.now() + timedelta(days=2),
+        status=OrderStageStatus.PLANNED,
+    )
+    completed_stage = OrderWorkStage(
+        order_id=order.id,
+        name="Закрытый выезд",
+        installer_id=installer.id,
+        start_time=datetime.now() - timedelta(days=30),
+        status=OrderStageStatus.COMPLETED,
+    )
+    sqlite_order_session.add_all([stale_stage, unscheduled_stage, upcoming_stage, completed_stage])
+    await sqlite_order_session.commit()
+    for stage in (stale_stage, unscheduled_stage, upcoming_stage, completed_stage):
+        await sqlite_order_session.refresh(stage)
+
+    result = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7)
+    names = {item["name"] for item in result["items"]}
+
+    assert result["total"] == 2
+    assert names == {"Старый выезд", "Без даты"}
+    assert result["items"][0]["customer_name"] == "Иван"
+
+    canceled = await OrderService.cancel_order_stage_direct(sqlite_order_session, stale_stage.id)
+    assert canceled["status"] == "canceled"
+
+    after_cancel = await OrderService.list_stale_order_stages(sqlite_order_session, older_than_days=7)
+    assert {item["name"] for item in after_cancel["items"]} == {"Без даты"}
+
+    deleted = await OrderService.delete_order_stage_direct(sqlite_order_session, unscheduled_stage.id)
+    assert deleted == {"ok": True, "id": unscheduled_stage.id}
+    assert await sqlite_order_session.get(OrderWorkStage, unscheduled_stage.id) is None
 
 
 def test_service_display_order_title_hides_legacy_site_title():


### PR DESCRIPTION
## Summary
- Hide stale or unscheduled installer tasks from the Telegram bot nearest-task list.
- Add quick-order normalization for Belarus phone formats and best-effort Yandex address suggest checks in the draft preview.
- Add Manager calendar cleanup for stale work stages with cancel/delete actions.

## Details
- Bot task list now only shows active-order work planned from yesterday through the next 30 days.
- Quick-order drafts normalize phones to `+375...` when possible and show address verification status without blocking order creation if Yandex is unavailable.
- Manager API now exposes stale work-stage listing plus direct cancel/delete endpoints.
- Calendar view shows a `Хвосты рабочих задач` section for unfinished stages older than 7 days or without a date.

## Validation
- `pytest tests/unit/test_bot_work_services.py -q`
- `pytest tests/unit/test_order_service_manager.py::test_service_lists_cancels_and_deletes_stale_work_stages -q`
- `pytest tests/unit/test_bot_*.py tests/unit/test_bot_handlers_architecture.py -q`
- `pytest tests/unit/test_address_suggest_service.py tests/unit/test_public_address_suggest_api.py -q`
- `python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api`
- `cd manager_frontend && npm run build`

## Notes
- Local browser check reached the Manager login page and showed no console errors; the internal calendar block was not visually inspected because auth requires a real manager session.
- A full `pytest tests/unit/test_bot_work_services.py tests/unit/test_order_service_manager.py -q` run was blocked by local `db_test` DNS for older PostgreSQL-backed tests, unrelated to this change.
