### PR TITLE
Add manager media library

### DIFF
--- a/alembic/versions/c2f8a4d6b901_add_media_asset_library.py
+++ b/alembic/versions/c2f8a4d6b901_add_media_asset_library.py
@@ -1,0 +1,81 @@
+"""add media asset library
+
+Revision ID: c2f8a4d6b901
+Revises: f6a7b8c9d0e2
+Create Date: 2026-06-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "c2f8a4d6b901"
+down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "media_asset",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("parent_asset_id", sa.Integer(), nullable=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("alt_text", sa.String(), nullable=True),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column("variant_type", sa.String(), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("original_url", sa.String(), nullable=True),
+        sa.Column("source_filename", sa.String(), nullable=True),
+        sa.Column("mime_type", sa.String(), nullable=False),
+        sa.Column("storage_provider", sa.String(), nullable=False),
+        sa.Column("processing_status", sa.String(), nullable=False),
+        sa.Column("processing_error", sa.String(), nullable=True),
+        sa.Column("content_hash", sa.String(), nullable=True),
+        sa.Column("width", sa.Integer(), nullable=True),
+        sa.Column("height", sa.Integer(), nullable=True),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("created_by", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["parent_asset_id"], ["media_asset.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    for column in (
+        "parent_asset_id",
+        "title",
+        "kind",
+        "variant_type",
+        "url",
+        "source_filename",
+        "mime_type",
+        "storage_provider",
+        "processing_status",
+        "content_hash",
+        "created_by",
+        "created_at",
+    ):
+        op.create_index(f"ix_media_asset_{column}", "media_asset", [column], unique=False)
+
+
+def downgrade() -> None:
+    for column in (
+        "created_at",
+        "created_by",
+        "content_hash",
+        "processing_status",
+        "storage_provider",
+        "mime_type",
+        "source_filename",
+        "url",
+        "variant_type",
+        "kind",
+        "title",
+        "parent_asset_id",
+    ):
+        op.drop_index(f"ix_media_asset_{column}", table_name="media_asset")
+    op.drop_table("media_asset")

--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -7,6 +7,7 @@ import { getApiErrorMessage } from './utils/api-errors';
 import type { TelegramLoginPayload } from './api';
 
 const ProductsView = defineAsyncComponent(() => import('./views/ProductsView.vue'));
+const MediaLibraryView = defineAsyncComponent(() => import('./views/MediaLibraryView.vue'));
 const ProductMainImageCleanupView = defineAsyncComponent(() => import('./views/ProductMainImageCleanupView.vue'));
 const CustomersView = defineAsyncComponent(() => import('./views/CustomersView.vue'));
 const CustomerProfileView = defineAsyncComponent(() => import('./views/CustomerProfileView.vue'));
@@ -86,6 +87,7 @@ const navSections: NavSection[] = [
       { path: '/manager/supplier-mapping', label: 'Маппинг прайсов', icon: Link2, match: 'prefix' },
       { path: '/manager/brands', label: 'Бренды', icon: Award, match: 'prefix' },
       { path: '/manager/tags', label: 'Теги', icon: Tags, match: 'prefix' },
+      { path: '/manager/media', label: 'Медиатека', icon: ImageIcon, match: 'exact' },
       { path: '/manager/media/main-image-cleanup', label: 'Главные изображения', icon: ImageIcon, match: 'prefix' },
     ],
   },
@@ -187,6 +189,7 @@ const currentView = computed(() => {
   if (path.startsWith('/manager/orders')) return 'orders';
   if (path.startsWith('/manager/calendar')) return 'calendar';
   if (path.startsWith('/manager/media/main-image-cleanup')) return 'main-image-cleanup';
+  if (path === '/manager/media') return 'media-library';
   if (path.startsWith('/manager/customers/profile')) return 'customer-profile';
   if (path.startsWith('/manager/customers')) return 'customers';
   if (path.startsWith('/manager/staff') || path.startsWith('/manager/users') || path.startsWith('/manager/installers')) return 'installers';
@@ -574,6 +577,7 @@ watch(currentPath, () => {
       <OrdersKanbanView v-else-if="currentView === 'orders'" :key="currentLocation" />
       <CalendarDashboard v-else-if="currentView === 'calendar'" :key="currentLocation" />
       <ProductMainImageCleanupView v-else-if="currentView === 'main-image-cleanup'" :key="currentLocation" />
+      <MediaLibraryView v-else-if="currentView === 'media-library'" :key="currentLocation" />
       <CustomerProfileView v-else-if="currentView === 'customer-profile'" :key="currentLocation" />
       <CustomersView v-else-if="currentView === 'customers'" :key="currentLocation" />
       <InstallersView v-else-if="currentView === 'installers'" :key="currentLocation" />

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -13,8 +13,10 @@ import {
     ManagerTariffsService,
     ManagerServiceEstimatesService,
     ManagerBrandsService,
+    ManagerMediaService,
     SystemService,
     ApiService,
+    type Body_upload_media_assets,
     type ProductUpdate,
     type ManagerCustomerBranchCreatePayload,
     type ManagerCustomerBranchUpdatePayload,
@@ -72,6 +74,12 @@ import {
     type ManagerBrandSeriesResponse,
     type ManagerBrandSeriesUpdatePayload,
     type ManagerBrandUpdatePayload,
+    type ManagerMediaAssetCropPayload,
+    type ManagerMediaAssetListResponse,
+    type ManagerMediaAssetResponse,
+    type ManagerMediaAssetUpdatePayload,
+    type ManagerMediaAssetUrlUploadPayload,
+    type ManagerMediaAssetUploadResponse,
     type ProductImageVariantBatchProcessResponse,
     type ProductImageVariantCandidateResponse,
     type ProductImageVariantCandidatesResponse,
@@ -129,6 +137,15 @@ export type {
     ManagerBrandSeriesCreatePayload,
     ManagerBrandSeriesUpdatePayload,
     ManagerBrandUpdatePayload,
+};
+export type {
+    Body_upload_media_assets,
+    ManagerMediaAssetCropPayload,
+    ManagerMediaAssetListResponse,
+    ManagerMediaAssetResponse,
+    ManagerMediaAssetUpdatePayload,
+    ManagerMediaAssetUrlUploadPayload,
+    ManagerMediaAssetUploadResponse,
 };
 export type {
     ProductImageVariantBatchProcessResponse,
@@ -215,6 +232,48 @@ export const api = {
 
     async getDashboardStats() {
         return await ManagerDashboardService.getDashboardStats();
+    },
+
+    async listMediaAssets(params: {
+        page?: number;
+        limit?: number;
+        q?: string | null;
+        kind?: string | null;
+        tag?: string | null;
+        status?: string | null;
+    } = {}): Promise<ManagerMediaAssetListResponse> {
+        return await ManagerMediaService.listMediaAssets(
+            params.page ?? 1,
+            params.limit ?? 40,
+            params.q ?? null,
+            params.kind ?? null,
+            params.tag ?? null,
+            params.status ?? null,
+        );
+    },
+
+    async uploadMediaAssets(formData: Body_upload_media_assets): Promise<ManagerMediaAssetUploadResponse> {
+        return await ManagerMediaService.uploadMediaAssets(formData);
+    },
+
+    async uploadMediaAssetFromUrl(payload: ManagerMediaAssetUrlUploadPayload): Promise<ManagerMediaAssetUploadResponse> {
+        return await ManagerMediaService.uploadMediaAssetFromUrl(payload);
+    },
+
+    async updateMediaAsset(assetId: number, payload: ManagerMediaAssetUpdatePayload): Promise<ManagerMediaAssetResponse> {
+        return await ManagerMediaService.updateMediaAsset(assetId, payload);
+    },
+
+    async cropMediaAsset(assetId: number, payload: ManagerMediaAssetCropPayload): Promise<ManagerMediaAssetResponse> {
+        return await ManagerMediaService.cropMediaAsset(assetId, payload);
+    },
+
+    async removeMediaAssetBackground(assetId: number): Promise<ManagerMediaAssetResponse> {
+        return await ManagerMediaService.removeMediaAssetBackground(assetId);
+    },
+
+    async deleteMediaAsset(assetId: number, force = false) {
+        return await ManagerMediaService.deleteMediaAsset(assetId, force);
     },
 
     async getManagerOrders(params: {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -25,6 +25,7 @@ export type { Body_register_manager_external_contract } from './models/Body_regi
 export type { Body_upload_local_images } from './models/Body_upload_local_images';
 export type { Body_upload_manager_customer_contract } from './models/Body_upload_manager_customer_contract';
 export type { Body_upload_manager_order_document } from './models/Body_upload_manager_order_document';
+export type { Body_upload_media_assets } from './models/Body_upload_media_assets';
 export type { BulkGalleryAddRequest } from './models/BulkGalleryAddRequest';
 export type { BulkGalleryDeleteRequest } from './models/BulkGalleryDeleteRequest';
 export type { BulkProductIdsRequest } from './models/BulkProductIdsRequest';
@@ -134,6 +135,12 @@ export type { ManagerInstallerUpdatePayload } from './models/ManagerInstallerUpd
 export type { ManagerInstallEstimateCalculatePayload } from './models/ManagerInstallEstimateCalculatePayload';
 export type { ManagerInstallEstimateResponse } from './models/ManagerInstallEstimateResponse';
 export type { ManagerInstallEstimateSavePayload } from './models/ManagerInstallEstimateSavePayload';
+export type { ManagerMediaAssetCropPayload } from './models/ManagerMediaAssetCropPayload';
+export type { ManagerMediaAssetListResponse } from './models/ManagerMediaAssetListResponse';
+export type { ManagerMediaAssetResponse } from './models/ManagerMediaAssetResponse';
+export type { ManagerMediaAssetUpdatePayload } from './models/ManagerMediaAssetUpdatePayload';
+export type { ManagerMediaAssetUploadResponse } from './models/ManagerMediaAssetUploadResponse';
+export type { ManagerMediaAssetUrlUploadPayload } from './models/ManagerMediaAssetUrlUploadPayload';
 export type { ManagerMediaBulkAddResponse } from './models/ManagerMediaBulkAddResponse';
 export type { ManagerMediaBulkDeleteResponse } from './models/ManagerMediaBulkDeleteResponse';
 export type { ManagerMediaBulkUploadResponse } from './models/ManagerMediaBulkUploadResponse';
@@ -298,6 +305,7 @@ export { ManagerInstallersService } from './services/ManagerInstallersService';
 export { ManagerLeadsService } from './services/ManagerLeadsService';
 export { ManagerLeadsInboxService } from './services/ManagerLeadsInboxService';
 export { ManagerMailService } from './services/ManagerMailService';
+export { ManagerMediaService } from './services/ManagerMediaService';
 export { ManagerOrdersService } from './services/ManagerOrdersService';
 export { ManagerRepairComplaintsService } from './services/ManagerRepairComplaintsService';
 export { ManagerServiceEstimatesService } from './services/ManagerServiceEstimatesService';

--- a/manager_frontend/src/client/models/Body_upload_media_assets.ts
+++ b/manager_frontend/src/client/models/Body_upload_media_assets.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_upload_media_assets = {
+    files: Array<Blob>;
+    kind?: string;
+    tags_json?: string;
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetCropPayload.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetCropPayload.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerMediaAssetCropPayload = {
+    'x': number;
+    'y': number;
+    width: number;
+    height: number;
+    title?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetListResponse.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetListResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerMediaAssetResponse } from './ManagerMediaAssetResponse';
+import type { Meta } from './Meta';
+export type ManagerMediaAssetListResponse = {
+    items: Array<ManagerMediaAssetResponse>;
+    meta: Meta;
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetResponse.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetResponse.ts
@@ -1,0 +1,30 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerMediaAssetResponse = {
+    id: number;
+    parent_asset_id?: (number | null);
+    title: string;
+    alt_text?: (string | null);
+    description?: (string | null);
+    kind: string;
+    tags?: Array<string>;
+    variant_type: string;
+    url: string;
+    original_url?: (string | null);
+    source_filename?: (string | null);
+    mime_type: string;
+    storage_provider: string;
+    processing_status: string;
+    processing_error?: (string | null);
+    content_hash?: (string | null);
+    width?: (number | null);
+    height?: (number | null);
+    size_bytes?: number;
+    usage_count?: number;
+    created_by?: (string | null);
+    created_at: string;
+    updated_at: string;
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetUpdatePayload.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerMediaAssetUpdatePayload = {
+    title?: (string | null);
+    alt_text?: (string | null);
+    description?: (string | null);
+    kind?: (string | null);
+    tags?: (Array<string> | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetUploadResponse.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetUploadResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerMediaAssetResponse } from './ManagerMediaAssetResponse';
+export type ManagerMediaAssetUploadResponse = {
+    uploaded: number;
+    items: Array<ManagerMediaAssetResponse>;
+};
+

--- a/manager_frontend/src/client/models/ManagerMediaAssetUrlUploadPayload.ts
+++ b/manager_frontend/src/client/models/ManagerMediaAssetUrlUploadPayload.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerMediaAssetUrlUploadPayload = {
+    url: string;
+    kind?: string;
+    tags?: Array<string>;
+};
+

--- a/manager_frontend/src/client/services/ManagerMediaService.ts
+++ b/manager_frontend/src/client/services/ManagerMediaService.ts
@@ -1,0 +1,183 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Body_upload_media_assets } from '../models/Body_upload_media_assets';
+import type { ManagerActionMessageResponse } from '../models/ManagerActionMessageResponse';
+import type { ManagerMediaAssetCropPayload } from '../models/ManagerMediaAssetCropPayload';
+import type { ManagerMediaAssetListResponse } from '../models/ManagerMediaAssetListResponse';
+import type { ManagerMediaAssetResponse } from '../models/ManagerMediaAssetResponse';
+import type { ManagerMediaAssetUpdatePayload } from '../models/ManagerMediaAssetUpdatePayload';
+import type { ManagerMediaAssetUploadResponse } from '../models/ManagerMediaAssetUploadResponse';
+import type { ManagerMediaAssetUrlUploadPayload } from '../models/ManagerMediaAssetUrlUploadPayload';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ManagerMediaService {
+    /**
+     * List Media Assets
+     * @param page
+     * @param limit
+     * @param q
+     * @param kind
+     * @param tag
+     * @param status
+     * @returns ManagerMediaAssetListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listMediaAssets(
+        page: number = 1,
+        limit: number = 40,
+        q?: (string | null),
+        kind?: (string | null),
+        tag?: (string | null),
+        status?: (string | null),
+    ): CancelablePromise<ManagerMediaAssetListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/media/assets',
+            query: {
+                'page': page,
+                'limit': limit,
+                'q': q,
+                'kind': kind,
+                'tag': tag,
+                'status': status,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Upload Media Assets
+     * @param formData
+     * @returns ManagerMediaAssetUploadResponse Successful Response
+     * @throws ApiError
+     */
+    public static uploadMediaAssets(
+        formData: Body_upload_media_assets,
+    ): CancelablePromise<ManagerMediaAssetUploadResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/media/assets',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Upload Media Asset From Url
+     * @param requestBody
+     * @returns ManagerMediaAssetUploadResponse Successful Response
+     * @throws ApiError
+     */
+    public static uploadMediaAssetFromUrl(
+        requestBody: ManagerMediaAssetUrlUploadPayload,
+    ): CancelablePromise<ManagerMediaAssetUploadResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/media/assets/from-url',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Media Asset
+     * @param assetId
+     * @param requestBody
+     * @returns ManagerMediaAssetResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateMediaAsset(
+        assetId: number,
+        requestBody: ManagerMediaAssetUpdatePayload,
+    ): CancelablePromise<ManagerMediaAssetResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/manager/media/assets/{asset_id}',
+            path: {
+                'asset_id': assetId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Media Asset
+     * @param assetId
+     * @param force
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static deleteMediaAsset(
+        assetId: number,
+        force: boolean = false,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/media/assets/{asset_id}',
+            path: {
+                'asset_id': assetId,
+            },
+            query: {
+                'force': force,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Crop Media Asset
+     * @param assetId
+     * @param requestBody
+     * @returns ManagerMediaAssetResponse Successful Response
+     * @throws ApiError
+     */
+    public static cropMediaAsset(
+        assetId: number,
+        requestBody: ManagerMediaAssetCropPayload,
+    ): CancelablePromise<ManagerMediaAssetResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/media/assets/{asset_id}/crop',
+            path: {
+                'asset_id': assetId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Remove Media Asset Background
+     * @param assetId
+     * @returns ManagerMediaAssetResponse Successful Response
+     * @throws ApiError
+     */
+    public static removeMediaAssetBackground(
+        assetId: number,
+    ): CancelablePromise<ManagerMediaAssetResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/media/assets/{asset_id}/remove-background',
+            path: {
+                'asset_id': assetId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -1,0 +1,738 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import {
+  ClipboardPaste,
+  Copy,
+  Image as ImageIcon,
+  Link,
+  Save,
+  Scissors,
+  Search,
+  Trash2,
+  UploadCloud,
+  Wand2,
+  X,
+} from 'lucide-vue-next';
+import { api, type ManagerMediaAssetResponse } from '../api';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+type CropBox = { x: number; y: number; width: number; height: number };
+type MediaKind = { value: string; label: string };
+
+const kindOptions: MediaKind[] = [
+  { value: 'misc', label: 'Разное' },
+  { value: 'product', label: 'Товары' },
+  { value: 'article', label: 'Статьи' },
+  { value: 'service', label: 'Услуги' },
+  { value: 'installation', label: 'Монтажи' },
+  { value: 'strobe', label: 'Штробы' },
+  { value: 'brand', label: 'Бренды' },
+];
+
+const assets = ref<ManagerMediaAssetResponse[]>([]);
+const loading = ref(false);
+const uploading = ref(false);
+const saving = ref(false);
+const deleting = ref(false);
+const processing = ref<'crop' | 'background' | ''>('');
+const page = ref(1);
+const limit = ref(40);
+const total = ref(0);
+const pages = ref(1);
+const query = ref('');
+const kind = ref('');
+const tag = ref('');
+const status = ref('');
+const uploadKind = ref('misc');
+const uploadTags = ref('');
+const uploadUrl = ref('');
+const uploadInput = ref<HTMLInputElement | null>(null);
+const selectedAsset = ref<ManagerMediaAssetResponse | null>(null);
+const toast = ref('');
+const toastType = ref<'success' | 'error'>('success');
+const dragActive = ref(false);
+const cropMode = ref(false);
+const cropBox = ref<CropBox | null>(null);
+const cropStart = ref<{ x: number; y: number } | null>(null);
+const previewImage = ref<HTMLImageElement | null>(null);
+const editForm = ref({
+  title: '',
+  alt_text: '',
+  description: '',
+  kind: 'misc',
+  tagsText: '',
+});
+
+const tagList = computed(() => {
+  const values = new Set<string>();
+  for (const asset of assets.value) {
+    for (const item of asset.tags || []) {
+      if (item) values.add(item);
+    }
+  }
+  return Array.from(values).sort((a, b) => a.localeCompare(b, 'ru'));
+});
+
+const selectedUrl = computed(() => selectedAsset.value ? imageUrl(selectedAsset.value.url) : '');
+
+const setToast = (message: string, type: 'success' | 'error' = 'success') => {
+  toast.value = message;
+  toastType.value = type;
+  window.setTimeout(() => {
+    if (toast.value === message) toast.value = '';
+  }, 3200);
+};
+
+const mediaErrorMessage = (err: unknown, fallback: string) => {
+  const message = getApiErrorMessage(err);
+  if (!message) return fallback;
+  if (/permission|notallowed|denied/i.test(message)) {
+    return 'Браузер не дал прямой доступ к буферу. Нажмите Ctrl+V или Cmd+V на странице.';
+  }
+  if (/fetch/i.test(message)) {
+    return 'API медиатеки недоступен. Проверьте, что backend запущен, и повторите поиск.';
+  }
+  if (/rembg provider is not installed/i.test(message)) {
+    return 'Удаление фона пока не настроено: установите rembg в backend-окружении.';
+  }
+  return message;
+};
+
+const imageUrl = (path?: string | null) => {
+  if (!path) return '';
+  if (path.startsWith('http')) return path;
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
+const bytesLabel = (value?: number | null) => {
+  const size = Number(value || 0);
+  if (size >= 1024 * 1024) return `${(size / 1024 / 1024).toFixed(1)} МБ`;
+  if (size >= 1024) return `${Math.round(size / 1024)} КБ`;
+  return `${size} Б`;
+};
+
+const kindLabel = (value?: string | null) => (
+  kindOptions.find((item) => item.value === value)?.label || 'Разное'
+);
+
+const variantLabel = (value?: string | null) => {
+  if (value === 'background_removed') return 'без фона';
+  if (value === 'crop') return 'crop';
+  return 'original';
+};
+
+const parseTags = (value: string) => value
+  .split(',')
+  .map((item) => item.trim())
+  .filter(Boolean);
+
+const fallbackAltText = (title?: string | null, sourceFilename?: string | null) => (
+  (title || sourceFilename || '').trim()
+);
+
+const appendUploadedAssets = (items: ManagerMediaAssetResponse[], count: number) => {
+  assets.value = [...items, ...assets.value];
+  total.value += count;
+  if (items[0]) selectAsset(items[0]);
+};
+
+const loadAssets = async () => {
+  loading.value = true;
+  try {
+    const response = await api.listMediaAssets({
+      page: page.value,
+      limit: limit.value,
+      q: query.value.trim() || null,
+      kind: kind.value || null,
+      tag: tag.value || null,
+      status: status.value || null,
+    });
+    assets.value = response.items || [];
+    total.value = response.meta.total;
+    pages.value = response.meta.pages;
+    if (selectedAsset.value) {
+      const refreshed = assets.value.find((item) => item.id === selectedAsset.value?.id);
+      if (refreshed) selectedAsset.value = refreshed;
+    }
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось загрузить медиатеку'), 'error');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const uploadFiles = async (files: FileList | File[]) => {
+  const imageFiles = Array.from(files).filter((file) => file.type.startsWith('image/'));
+  if (!imageFiles.length) {
+    setToast('Выберите изображения', 'error');
+    return;
+  }
+  uploading.value = true;
+  try {
+    const response = await api.uploadMediaAssets({
+      files: imageFiles,
+      kind: uploadKind.value,
+      tags_json: JSON.stringify(parseTags(uploadTags.value)),
+    });
+    appendUploadedAssets(response.items, response.uploaded);
+    setToast(`Загружено: ${response.uploaded}`);
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось загрузить файлы'), 'error');
+  } finally {
+    uploading.value = false;
+    dragActive.value = false;
+    if (uploadInput.value) uploadInput.value.value = '';
+  }
+};
+
+const uploadFromUrl = async () => {
+  const url = uploadUrl.value.trim();
+  if (!url) {
+    setToast('Укажите URL изображения', 'error');
+    return;
+  }
+  uploading.value = true;
+  try {
+    const response = await api.uploadMediaAssetFromUrl({
+      url,
+      kind: uploadKind.value,
+      tags: parseTags(uploadTags.value),
+    });
+    appendUploadedAssets(response.items, response.uploaded);
+    uploadUrl.value = '';
+    setToast('Изображение загружено по URL');
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось загрузить изображение по URL'), 'error');
+  } finally {
+    uploading.value = false;
+  }
+};
+
+type ClipboardImageItem = {
+  types: readonly string[];
+  getType: (type: string) => Promise<Blob>;
+};
+
+const extensionFromMime = (mimeType: string) => mimeType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+
+const uploadClipboardFiles = async (files: File[]) => {
+  if (!files.length) {
+    setToast('В буфере нет изображения', 'error');
+    return;
+  }
+  await uploadFiles(files);
+};
+
+const pasteFromClipboard = async () => {
+  const clipboard = navigator.clipboard as Clipboard & { read?: () => Promise<ClipboardImageItem[]> };
+  if (!clipboard?.read) {
+    setToast('Вставьте изображение через Ctrl+V или Cmd+V', 'error');
+    return;
+  }
+  try {
+    const items = await clipboard.read();
+    const files: File[] = [];
+    for (const item of items) {
+      const imageType = item.types.find((type) => type.startsWith('image/'));
+      if (!imageType) continue;
+      const blob = await item.getType(imageType);
+      files.push(new File([blob], `clipboard-${Date.now()}.${extensionFromMime(imageType)}`, { type: imageType }));
+    }
+    await uploadClipboardFiles(files);
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось прочитать изображение из буфера'), 'error');
+  }
+};
+
+const selectAsset = (asset: ManagerMediaAssetResponse) => {
+  const title = asset.title || '';
+  selectedAsset.value = asset;
+  editForm.value = {
+    title,
+    alt_text: asset.alt_text || fallbackAltText(title, asset.source_filename),
+    description: asset.description || '',
+    kind: asset.kind || 'misc',
+    tagsText: (asset.tags || []).join(', '),
+  };
+  cropMode.value = false;
+  cropBox.value = null;
+};
+
+const saveSelected = async () => {
+  if (!selectedAsset.value) return;
+  saving.value = true;
+  try {
+    const updated = await api.updateMediaAsset(selectedAsset.value.id, {
+      title: editForm.value.title,
+      alt_text: editForm.value.alt_text || fallbackAltText(editForm.value.title, selectedAsset.value.source_filename),
+      description: editForm.value.description,
+      kind: editForm.value.kind,
+      tags: parseTags(editForm.value.tagsText),
+    });
+    selectedAsset.value = updated;
+    assets.value = assets.value.map((item) => item.id === updated.id ? updated : item);
+    setToast('Метаданные сохранены');
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось сохранить'), 'error');
+  } finally {
+    saving.value = false;
+  }
+};
+
+const copyUrl = async (asset = selectedAsset.value) => {
+  if (!asset) return;
+  try {
+    await navigator.clipboard.writeText(asset.url);
+    setToast('URL скопирован');
+  } catch {
+    setToast(asset.url);
+  }
+};
+
+const deleteSelected = async () => {
+  if (!selectedAsset.value) return;
+  const used = Number(selectedAsset.value.usage_count || 0) > 0;
+  if (!confirm(used ? 'Файл используется. Удалить metadata принудительно?' : 'Удалить файл из медиатеки?')) return;
+  const assetId = selectedAsset.value.id;
+  deleting.value = true;
+  try {
+    await api.deleteMediaAsset(assetId, used);
+    assets.value = assets.value.filter((item) => item.id !== assetId);
+    selectedAsset.value = null;
+    total.value = Math.max(0, total.value - 1);
+    setToast('Файл удален');
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось удалить'), 'error');
+  } finally {
+    deleting.value = false;
+  }
+};
+
+const relativePoint = (event: PointerEvent) => {
+  const target = event.currentTarget as HTMLElement;
+  const rect = target.getBoundingClientRect();
+  return {
+    x: Math.max(0, Math.min(event.clientX - rect.left, rect.width)),
+    y: Math.max(0, Math.min(event.clientY - rect.top, rect.height)),
+  };
+};
+
+const onCropPointerDown = (event: PointerEvent) => {
+  if (!cropMode.value) return;
+  const point = relativePoint(event);
+  cropStart.value = point;
+  cropBox.value = { x: point.x, y: point.y, width: 1, height: 1 };
+  (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+};
+
+const onCropPointerMove = (event: PointerEvent) => {
+  if (!cropMode.value || !cropStart.value) return;
+  const point = relativePoint(event);
+  const start = cropStart.value;
+  cropBox.value = {
+    x: Math.min(start.x, point.x),
+    y: Math.min(start.y, point.y),
+    width: Math.abs(point.x - start.x),
+    height: Math.abs(point.y - start.y),
+  };
+};
+
+const onCropPointerUp = (event: PointerEvent) => {
+  if (!cropMode.value) return;
+  cropStart.value = null;
+  try {
+    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+  } catch {
+    // Pointer capture may already be released by the browser.
+  }
+};
+
+const applyCrop = async () => {
+  if (!selectedAsset.value || !cropBox.value || !previewImage.value) return;
+  if (cropBox.value.width < 8 || cropBox.value.height < 8) {
+    setToast('Выделите область крупнее', 'error');
+    return;
+  }
+  const image = previewImage.value;
+  const scaleX = image.naturalWidth / image.clientWidth;
+  const scaleY = image.naturalHeight / image.clientHeight;
+  processing.value = 'crop';
+  try {
+    const cropped = await api.cropMediaAsset(selectedAsset.value.id, {
+      x: Math.round(cropBox.value.x * scaleX),
+      y: Math.round(cropBox.value.y * scaleY),
+      width: Math.round(cropBox.value.width * scaleX),
+      height: Math.round(cropBox.value.height * scaleY),
+      title: `${selectedAsset.value.title || 'Image'} crop`,
+    });
+    assets.value = [cropped, ...assets.value];
+    selectAsset(cropped);
+    setToast('Crop сохранен как новая версия');
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось обрезать изображение'), 'error');
+  } finally {
+    processing.value = '';
+  }
+};
+
+const removeBackground = async () => {
+  if (!selectedAsset.value) return;
+  processing.value = 'background';
+  try {
+    const processed = await api.removeMediaAssetBackground(selectedAsset.value.id);
+    assets.value = [processed, ...assets.value];
+    selectAsset(processed);
+    setToast('Версия без фона готова');
+  } catch (err) {
+    setToast(mediaErrorMessage(err, 'Не удалось удалить фон'), 'error');
+  } finally {
+    processing.value = '';
+  }
+};
+
+const onDrop = (event: DragEvent) => {
+  event.preventDefault();
+  if (event.dataTransfer?.files?.length) {
+    void uploadFiles(event.dataTransfer.files);
+  }
+};
+
+const onPaste = (event: ClipboardEvent) => {
+  const files: File[] = [];
+  for (const item of Array.from(event.clipboardData?.items || [])) {
+    if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
+    const file = item.getAsFile();
+    if (file) files.push(file);
+  }
+  if (files.length) {
+    event.preventDefault();
+    void uploadClipboardFiles(files);
+    return;
+  }
+
+  const text = event.clipboardData?.getData('text/plain')?.trim() || '';
+  if (/^https?:\/\//i.test(text)) {
+    uploadUrl.value = text;
+  }
+};
+
+const applyFilters = () => {
+  if (page.value !== 1) {
+    page.value = 1;
+    return;
+  }
+  void loadAssets();
+};
+
+watch(page, () => void loadAssets());
+
+onMounted(() => {
+  document.addEventListener('paste', onPaste);
+  void loadAssets();
+});
+
+onUnmounted(() => {
+  document.removeEventListener('paste', onPaste);
+});
+</script>
+
+<template>
+  <div class="space-y-6 px-4 pb-6 lg:px-0">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div class="min-h-12 pl-16 lg:min-h-0 lg:pl-0">
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">Медиатека</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ total }} файлов · изображения для товаров, статей и сервисных материалов
+        </p>
+      </div>
+      <input
+        ref="uploadInput"
+        type="file"
+        accept="image/*"
+        multiple
+        class="hidden"
+        @change="event => uploadFiles((event.target as HTMLInputElement).files || [])"
+      />
+    </div>
+
+    <div
+      class="rounded-xl border border-dashed p-3 transition dark:border-gray-700 lg:p-4"
+      :class="dragActive ? 'border-teal-500 bg-teal-50 dark:bg-teal-950/30' : 'border-gray-300 bg-white dark:bg-gray-900'"
+      @dragenter.prevent="dragActive = true"
+      @dragover.prevent="dragActive = true"
+      @dragleave.prevent="dragActive = false"
+      @drop="onDrop"
+    >
+      <div class="grid gap-2 lg:grid-cols-[1fr_180px_1fr_auto] lg:items-end lg:gap-3">
+        <label class="block">
+          <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Теги загрузки</span>
+          <input
+            v-model="uploadTags"
+            type="text"
+            placeholder="монтаж, штробы, обслуживание"
+            class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Тип</span>
+          <select
+            v-model="uploadKind"
+            class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+          >
+            <option v-for="item in kindOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+          </select>
+        </label>
+        <div class="hidden min-h-[42px] items-center rounded-lg bg-gray-50 px-3 text-sm text-gray-500 dark:bg-gray-950 dark:text-gray-400 lg:flex">
+          Перетащите изображения сюда
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-60 lg:min-w-[120px]"
+          :disabled="uploading"
+          @click="uploadInput?.click()"
+        >
+          <UploadCloud class="h-4 w-4" />
+          {{ uploading ? 'Загрузка...' : 'Выбрать' }}
+        </button>
+      </div>
+      <div class="mt-2 lg:mt-3">
+        <div class="relative">
+          <Link class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <input
+            v-model="uploadUrl"
+            type="url"
+            placeholder="https://site.by/image.jpg"
+            class="w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-24 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+            @keydown.enter.prevent="uploadFromUrl"
+          />
+          <div class="absolute right-1 top-1/2 flex -translate-y-1/2 gap-1">
+            <button
+              type="button"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-md text-teal-700 transition hover:bg-teal-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-teal-200 dark:hover:bg-teal-950/40"
+              :disabled="uploading"
+              title="Скачать по URL"
+              aria-label="Скачать по URL"
+              @click="uploadFromUrl"
+            >
+              <UploadCloud class="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+              :disabled="uploading"
+              title="Вставить из буфера"
+              aria-label="Вставить из буфера"
+              @click="pasteFromClipboard"
+            >
+              <ClipboardPaste class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-2 rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900 lg:grid-cols-[1fr_180px_180px_160px_120px] lg:gap-3 lg:p-4">
+      <label class="relative col-span-2 block lg:col-span-1">
+        <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          v-model="query"
+          type="search"
+          placeholder="Поиск по названию, alt, файлу"
+          class="w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+          @keydown.enter="applyFilters"
+        />
+      </label>
+      <select v-model="kind" class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white">
+        <option value="">Все типы</option>
+        <option v-for="item in kindOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+      </select>
+      <select v-model="tag" class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white">
+        <option value="">Все теги</option>
+        <option v-for="item in tagList" :key="item" :value="item">{{ item }}</option>
+      </select>
+      <select v-model="status" class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white">
+        <option value="">Все статусы</option>
+        <option value="ready">Готово</option>
+        <option value="processing">В обработке</option>
+        <option value="failed">Ошибка</option>
+      </select>
+      <button
+        type="button"
+        class="inline-flex items-center justify-center gap-2 rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
+        :disabled="loading"
+        @click="applyFilters"
+      >
+        <Search class="h-4 w-4" />
+        {{ loading ? 'Ищу...' : 'Найти' }}
+      </button>
+    </div>
+
+    <div class="grid gap-6 xl:grid-cols-[1fr_420px]">
+      <div class="xl:min-h-[440px]">
+        <div v-if="loading" class="grid grid-cols-2 gap-4 md:grid-cols-3 2xl:grid-cols-4">
+          <div v-for="idx in 8" :key="idx" class="h-60 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800" />
+        </div>
+        <div v-else-if="!assets.length" class="flex min-h-[360px] items-center justify-center rounded-xl border border-gray-200 bg-white text-center dark:border-gray-800 dark:bg-gray-900">
+          <div>
+            <ImageIcon class="mx-auto h-12 w-12 text-gray-300" />
+            <p class="mt-3 text-sm font-medium text-gray-900 dark:text-white">Файлов пока нет</p>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Загрузите первые изображения для медиатеки.</p>
+          </div>
+        </div>
+        <div v-else class="grid grid-cols-2 gap-4 md:grid-cols-3 2xl:grid-cols-4">
+          <button
+            v-for="asset in assets"
+            :key="asset.id"
+            type="button"
+            class="group overflow-hidden rounded-xl border bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:bg-gray-900"
+            :class="selectedAsset?.id === asset.id ? 'border-teal-500 ring-2 ring-teal-500/20' : 'border-gray-200 dark:border-gray-800'"
+            @click="selectAsset(asset)"
+          >
+            <div class="flex aspect-[4/3] items-center justify-center bg-gray-100 dark:bg-gray-950">
+              <img :src="imageUrl(asset.url)" :alt="asset.alt_text || asset.title" class="h-full w-full object-contain" loading="lazy" />
+            </div>
+            <div class="space-y-2 p-3">
+              <div class="flex items-start justify-between gap-2">
+                <p class="line-clamp-2 text-sm font-medium text-gray-900 dark:text-white">{{ asset.title || asset.source_filename || asset.url }}</p>
+                <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-600 dark:bg-gray-800 dark:text-gray-300">{{ variantLabel(asset.variant_type) }}</span>
+              </div>
+              <div class="flex flex-wrap gap-1">
+                <span class="rounded bg-teal-50 px-1.5 py-0.5 text-[11px] font-medium text-teal-700 dark:bg-teal-950 dark:text-teal-200">{{ kindLabel(asset.kind) }}</span>
+                <span v-for="item in (asset.tags || []).slice(0, 2)" :key="item" class="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-600 dark:bg-gray-800 dark:text-gray-300">{{ item }}</span>
+              </div>
+              <p class="text-xs text-gray-500 dark:text-gray-400">{{ asset.width || 0 }}×{{ asset.height || 0 }} · {{ bytesLabel(asset.size_bytes) }}</p>
+            </div>
+          </button>
+        </div>
+
+        <div class="mt-4 flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          <span>Страница {{ page }} из {{ pages }}</span>
+          <div class="flex gap-2">
+            <button class="rounded-lg border border-gray-300 px-3 py-1.5 disabled:opacity-50 dark:border-gray-700" :disabled="page <= 1" @click="page -= 1">Назад</button>
+            <button class="rounded-lg border border-gray-300 px-3 py-1.5 disabled:opacity-50 dark:border-gray-700" :disabled="page >= pages" @click="page += 1">Вперед</button>
+          </div>
+        </div>
+      </div>
+
+      <aside class="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+        <div v-if="!selectedAsset" class="flex min-h-[520px] items-center justify-center p-8 text-center">
+          <div>
+            <ImageIcon class="mx-auto h-10 w-10 text-gray-300" />
+            <p class="mt-3 text-sm font-medium text-gray-900 dark:text-white">Выберите файл</p>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Метаданные и редактор появятся здесь.</p>
+          </div>
+        </div>
+        <div v-else class="flex max-h-[calc(100vh-140px)] flex-col">
+          <div class="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-800">
+            <div>
+              <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ selectedAsset.title || 'Без названия' }}</p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">#{{ selectedAsset.id }} · {{ selectedAsset.width }}×{{ selectedAsset.height }}</p>
+            </div>
+            <button class="rounded-lg p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800" @click="selectedAsset = null">
+              <X class="h-5 w-5" />
+            </button>
+          </div>
+
+          <div class="space-y-5 overflow-y-auto p-4">
+            <div class="rounded-xl bg-gray-100 p-3 dark:bg-gray-950">
+              <div
+                class="relative mx-auto inline-block max-h-[420px] max-w-full select-none"
+                :class="cropMode ? 'cursor-crosshair' : ''"
+                @pointerdown="onCropPointerDown"
+                @pointermove="onCropPointerMove"
+                @pointerup="onCropPointerUp"
+              >
+                <img
+                  ref="previewImage"
+                  :src="selectedUrl"
+                  :alt="selectedAsset.alt_text || selectedAsset.title"
+                  class="block max-h-[420px] max-w-full rounded-lg object-contain"
+                  draggable="false"
+                />
+                <div
+                  v-if="cropMode && cropBox"
+                  class="pointer-events-none absolute border-2 border-teal-400 bg-teal-400/15 shadow-[0_0_0_9999px_rgba(15,23,42,0.35)]"
+                  :style="{ left: `${cropBox.x}px`, top: `${cropBox.y}px`, width: `${cropBox.width}px`, height: `${cropBox.height}px` }"
+                />
+              </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-2">
+              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800" @click="copyUrl()">
+                <Copy class="h-4 w-4" />
+                URL
+              </button>
+              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800" @click="cropMode = !cropMode; cropBox = null">
+                <Scissors class="h-4 w-4" />
+                Crop
+              </button>
+              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800" :disabled="Boolean(processing)" @click="removeBackground">
+                <Wand2 class="h-4 w-4" />
+                {{ processing === 'background' ? 'Фон...' : 'Без фона' }}
+              </button>
+              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-600 transition hover:bg-red-50 disabled:opacity-50 dark:border-red-900/60 dark:hover:bg-red-950/30" :disabled="deleting" @click="deleteSelected">
+                <Trash2 class="h-4 w-4" />
+                Удалить
+              </button>
+            </div>
+
+            <div v-if="cropMode" class="rounded-lg border border-teal-200 bg-teal-50 p-3 dark:border-teal-900 dark:bg-teal-950/30">
+              <div class="flex items-center justify-between gap-3">
+                <p class="text-sm text-teal-900 dark:text-teal-100">Выделите область на изображении.</p>
+                <button class="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-teal-700 disabled:opacity-50" :disabled="!cropBox || processing === 'crop'" @click="applyCrop">
+                  <Scissors class="h-4 w-4" />
+                  {{ processing === 'crop' ? 'Сохраняю...' : 'Сохранить crop' }}
+                </button>
+              </div>
+            </div>
+
+            <div class="space-y-3">
+              <label class="block">
+                <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Название</span>
+                <input v-model="editForm.title" class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white" />
+              </label>
+              <label class="block">
+                <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Alt text</span>
+                <input v-model="editForm.alt_text" class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white" />
+              </label>
+              <div class="grid grid-cols-2 gap-3">
+                <label class="block">
+                  <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Тип</span>
+                  <select v-model="editForm.kind" class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white">
+                    <option v-for="item in kindOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+                  </select>
+                </label>
+                <label class="block">
+                  <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Теги</span>
+                  <input v-model="editForm.tagsText" class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white" />
+                </label>
+              </div>
+              <label class="block">
+                <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Описание</span>
+                <textarea v-model="editForm.description" rows="3" class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-white" />
+              </label>
+              <button class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-950" :disabled="saving" @click="saveSelected">
+                <Save class="h-4 w-4" />
+                {{ saving ? 'Сохраняю...' : 'Сохранить метаданные' }}
+              </button>
+            </div>
+
+            <div class="space-y-1 rounded-lg bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-950 dark:text-gray-400">
+              <p class="break-all"><span class="font-medium">URL:</span> {{ selectedAsset.url }}</p>
+              <p><span class="font-medium">Использований:</span> {{ selectedAsset.usage_count || 0 }}</p>
+              <p><span class="font-medium">Hash:</span> {{ selectedAsset.content_hash?.slice(0, 16) || '—' }}</p>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <div
+      v-if="toast"
+      class="fixed bottom-5 right-5 z-50 rounded-xl px-4 py-3 text-sm font-medium shadow-lg"
+      :class="toastType === 'error' ? 'bg-red-600 text-white' : 'bg-gray-900 text-white dark:bg-white dark:text-gray-950'"
+    >
+      {{ toast }}
+    </div>
+  </div>
+</template>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -19,6 +19,7 @@ from .brand import Brand, ProductSeries
 from .cart import Cart, CartItem
 from .catalog_import import CatalogImportJob
 from .content import Article, GlobalConfig
+from .media import MediaAsset
 from .staff import StaffUser
 from .order import (
     BankReceipt,
@@ -96,6 +97,7 @@ __all__ = [
     "LeadSegmentHint",
     "LeadSource",
     "LeadStatus",
+    "MediaAsset",
     "Order",
     "OrderDocument",
     "OrderInstaller",

--- a/models/media.py
+++ b/models/media.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import Column, String
+from sqlmodel import Field, JSON, SQLModel
+
+
+class MediaAsset(SQLModel, table=True):
+    __tablename__ = "media_asset"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    parent_asset_id: Optional[int] = Field(default=None, foreign_key="media_asset.id", index=True)
+    title: str = Field(default="", index=True)
+    alt_text: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None, sa_column=Column(String))
+    kind: str = Field(default="misc", index=True)
+    tags: List[str] = Field(default=[], sa_column=Column(JSON))
+    variant_type: str = Field(default="original", index=True)
+    url: str = Field(index=True)
+    original_url: Optional[str] = Field(default=None)
+    source_filename: Optional[str] = Field(default=None, index=True)
+    mime_type: str = Field(default="image/webp", index=True)
+    storage_provider: str = Field(default="local", index=True)
+    processing_status: str = Field(default="ready", index=True)
+    processing_error: Optional[str] = Field(default=None, sa_column=Column(String))
+    content_hash: Optional[str] = Field(default=None, index=True)
+    width: Optional[int] = None
+    height: Optional[int] = None
+    size_bytes: int = Field(default=0)
+    created_by: Optional[str] = Field(default=None, index=True)
+    created_at: datetime = Field(default_factory=datetime.now, index=True)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    def __str__(self) -> str:
+        return self.title or self.source_filename or self.url

--- a/openapi.json
+++ b/openapi.json
@@ -4041,6 +4041,437 @@
         }
       }
     },
+    "/api/manager/media/assets": {
+      "get": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "List Media Assets",
+        "operationId": "list_media_assets",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 40,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Kind"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Upload Media Assets",
+        "operationId": "upload_media_assets",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_media_assets"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/media/assets/from-url": {
+      "post": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Upload Media Asset From Url",
+        "operationId": "upload_media_asset_from_url",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerMediaAssetUrlUploadPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/manager/media/assets/{asset_id}": {
+      "patch": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Update Media Asset",
+        "operationId": "update_media_asset",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Asset Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerMediaAssetUpdatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Delete Media Asset",
+        "operationId": "delete_media_asset",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Asset Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Force"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/media/assets/{asset_id}/crop": {
+      "post": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Crop Media Asset",
+        "operationId": "crop_media_asset",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Asset Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerMediaAssetCropPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/media/assets/{asset_id}/remove-background": {
+      "post": {
+        "tags": [
+          "manager media"
+        ],
+        "summary": "Remove Media Asset Background",
+        "operationId": "remove_media_asset_background",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Asset Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaAssetResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/gallery/reuse-search": {
       "get": {
         "tags": [
@@ -12963,6 +13394,33 @@
         ],
         "title": "Body_upload_manager_order_document"
       },
+      "Body_upload_media_assets": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "misc"
+          },
+          "tags_json": {
+            "type": "string",
+            "title": "Tags Json",
+            "default": "[]"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "Body_upload_media_assets"
+      },
       "BulkGalleryAddRequest": {
         "properties": {
           "product_ids": {
@@ -19573,6 +20031,368 @@
         },
         "type": "object",
         "title": "ManagerInstallerUpdatePayload"
+      },
+      "ManagerMediaAssetCropPayload": {
+        "properties": {
+          "x": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "X"
+          },
+          "y": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Y"
+          },
+          "width": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Width"
+          },
+          "height": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Height"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "required": [
+          "x",
+          "y",
+          "width",
+          "height"
+        ],
+        "title": "ManagerMediaAssetCropPayload"
+      },
+      "ManagerMediaAssetListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerMediaAssetResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "meta"
+        ],
+        "title": "ManagerMediaAssetListResponse"
+      },
+      "ManagerMediaAssetResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "parent_asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Asset Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "alt_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt Text"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          },
+          "variant_type": {
+            "type": "string",
+            "title": "Variant Type"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "original_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Url"
+          },
+          "source_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Filename"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "storage_provider": {
+            "type": "string",
+            "title": "Storage Provider"
+          },
+          "processing_status": {
+            "type": "string",
+            "title": "Processing Status"
+          },
+          "processing_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processing Error"
+          },
+          "content_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Hash"
+          },
+          "width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Width"
+          },
+          "height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Height"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes",
+            "default": 0
+          },
+          "usage_count": {
+            "type": "integer",
+            "title": "Usage Count",
+            "default": 0
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "kind",
+          "variant_type",
+          "url",
+          "mime_type",
+          "storage_provider",
+          "processing_status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagerMediaAssetResponse"
+      },
+      "ManagerMediaAssetUpdatePayload": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "alt_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt Text"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "title": "ManagerMediaAssetUpdatePayload"
+      },
+      "ManagerMediaAssetUploadResponse": {
+        "properties": {
+          "uploaded": {
+            "type": "integer",
+            "title": "Uploaded"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerMediaAssetResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "uploaded",
+          "items"
+        ],
+        "title": "ManagerMediaAssetUploadResponse"
+      },
+      "ManagerMediaAssetUrlUploadPayload": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "misc"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "ManagerMediaAssetUrlUploadPayload"
       },
       "ManagerMediaBulkAddResponse": {
         "properties": {

--- a/routers/manager_media.py
+++ b/routers/manager_media.py
@@ -3,9 +3,11 @@ from fastapi import APIRouter
 from routers.manager_media_gallery import router as manager_media_gallery_router
 from routers.manager_media_cleanup import router as manager_media_cleanup_router
 from routers.manager_media_ingest import router as manager_media_ingest_router
+from routers.manager_media_library import router as manager_media_library_router
 
 
 router = APIRouter()
 router.include_router(manager_media_cleanup_router)
 router.include_router(manager_media_ingest_router)
+router.include_router(manager_media_library_router)
 router.include_router(manager_media_gallery_router)

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -1,0 +1,206 @@
+import json
+from typing import List
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
+from core.security import get_current_username
+from routers.manager_operation_ids import (
+    CROP_MEDIA_ASSET,
+    DELETE_MEDIA_ASSET,
+    LIST_MEDIA_ASSETS,
+    REMOVE_MEDIA_ASSET_BACKGROUND,
+    UPDATE_MEDIA_ASSET,
+    UPLOAD_MEDIA_ASSET_FROM_URL,
+    UPLOAD_MEDIA_ASSETS,
+)
+from schemas import (
+    ManagerActionMessageResponse,
+    ManagerMediaAssetCropPayload,
+    ManagerMediaAssetListResponse,
+    ManagerMediaAssetResponse,
+    ManagerMediaAssetUpdatePayload,
+    ManagerMediaAssetUrlUploadPayload,
+    ManagerMediaAssetUploadResponse,
+)
+from services.media_library_service import MediaLibraryService
+
+
+router = APIRouter(prefix="/api/manager/media/assets", tags=["manager media"])
+
+
+@router.get(
+    "",
+    response_model=ManagerMediaAssetListResponse,
+    operation_id=LIST_MEDIA_ASSETS,
+)
+async def list_media_assets(
+    page: int = Query(1, ge=1),
+    limit: int = Query(40, ge=1, le=100),
+    q: str | None = Query(None),
+    kind: str | None = Query(None),
+    tag: str | None = Query(None),
+    status: str | None = Query(None),
+    session: AsyncSession = Depends(get_session),
+    _username: str = Depends(get_current_username),
+):
+    return await MediaLibraryService.list_assets(
+        session=session,
+        page=page,
+        limit=limit,
+        query=q,
+        kind=kind,
+        tag=tag,
+        status=status,
+    )
+
+
+@router.post(
+    "",
+    response_model=ManagerMediaAssetUploadResponse,
+    operation_id=UPLOAD_MEDIA_ASSETS,
+)
+async def upload_media_assets(
+    files: List[UploadFile] = File(...),
+    kind: str = Form("misc"),
+    tags_json: str = Form("[]"),
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    try:
+        tags = json.loads(tags_json or "[]")
+        if not isinstance(tags, list):
+            raise ValueError("tags_json must be a JSON array")
+        file_payloads = [(item.filename, await item.read()) for item in files]
+        return await MediaLibraryService.upload_assets(
+            session=session,
+            files=file_payloads,
+            kind=kind,
+            tags=[str(item) for item in tags],
+            created_by=username,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/from-url",
+    response_model=ManagerMediaAssetUploadResponse,
+    operation_id=UPLOAD_MEDIA_ASSET_FROM_URL,
+)
+async def upload_media_asset_from_url(
+    payload: ManagerMediaAssetUrlUploadPayload,
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    try:
+        return await MediaLibraryService.upload_asset_from_url(
+            session=session,
+            url=payload.url,
+            kind=payload.kind,
+            tags=payload.tags,
+            created_by=username,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.patch(
+    "/{asset_id}",
+    response_model=ManagerMediaAssetResponse,
+    operation_id=UPDATE_MEDIA_ASSET,
+)
+async def update_media_asset(
+    asset_id: int,
+    payload: ManagerMediaAssetUpdatePayload,
+    session: AsyncSession = Depends(get_session),
+    _username: str = Depends(get_current_username),
+):
+    try:
+        return await MediaLibraryService.update_asset(
+            session=session,
+            asset_id=asset_id,
+            title=payload.title,
+            alt_text=payload.alt_text,
+            description=payload.description,
+            kind=payload.kind,
+            tags=payload.tags,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{asset_id}/crop",
+    response_model=ManagerMediaAssetResponse,
+    operation_id=CROP_MEDIA_ASSET,
+)
+async def crop_media_asset(
+    asset_id: int,
+    payload: ManagerMediaAssetCropPayload,
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    try:
+        return await MediaLibraryService.crop_asset(
+            session=session,
+            asset_id=asset_id,
+            x=payload.x,
+            y=payload.y,
+            width=payload.width,
+            height=payload.height,
+            title=payload.title,
+            created_by=username,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{asset_id}/remove-background",
+    response_model=ManagerMediaAssetResponse,
+    operation_id=REMOVE_MEDIA_ASSET_BACKGROUND,
+)
+async def remove_media_asset_background(
+    asset_id: int,
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    try:
+        return await MediaLibraryService.remove_background(
+            session=session,
+            asset_id=asset_id,
+            created_by=username,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/{asset_id}",
+    response_model=ManagerActionMessageResponse,
+    operation_id=DELETE_MEDIA_ASSET,
+)
+async def delete_media_asset(
+    asset_id: int,
+    force: bool = Query(False),
+    session: AsyncSession = Depends(get_session),
+    _username: str = Depends(get_current_username),
+):
+    try:
+        return await MediaLibraryService.delete_asset(session=session, asset_id=asset_id, force=force)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -57,6 +57,13 @@ CLEANUP_MEDIA = "cleanup_media"
 GET_IMAGE_VARIANT_CANDIDATES = "get_image_variant_candidates"
 PROCESS_MISSING_IMAGE_VARIANTS = "process_missing_image_variants"
 REPROCESS_IMAGE_VARIANT = "reprocess_image_variant"
+LIST_MEDIA_ASSETS = "list_media_assets"
+UPLOAD_MEDIA_ASSETS = "upload_media_assets"
+UPLOAD_MEDIA_ASSET_FROM_URL = "upload_media_asset_from_url"
+UPDATE_MEDIA_ASSET = "update_media_asset"
+DELETE_MEDIA_ASSET = "delete_media_asset"
+CROP_MEDIA_ASSET = "crop_media_asset"
+REMOVE_MEDIA_ASSET_BACKGROUND = "remove_media_asset_background"
 CREATE_MAIN_IMAGE_CLEANUP_BATCH = "create_main_image_cleanup_batch"
 LIST_MAIN_IMAGE_CLEANUP_BATCHES = "list_main_image_cleanup_batches"
 LIST_MAIN_IMAGE_CLEANUP_ITEMS = "list_main_image_cleanup_items"
@@ -255,6 +262,13 @@ ALL_MANAGER_OPERATION_IDS = (
     GET_IMAGE_VARIANT_CANDIDATES,
     PROCESS_MISSING_IMAGE_VARIANTS,
     REPROCESS_IMAGE_VARIANT,
+    LIST_MEDIA_ASSETS,
+    UPLOAD_MEDIA_ASSETS,
+    UPLOAD_MEDIA_ASSET_FROM_URL,
+    UPDATE_MEDIA_ASSET,
+    DELETE_MEDIA_ASSET,
+    CROP_MEDIA_ASSET,
+    REMOVE_MEDIA_ASSET_BACKGROUND,
     CREATE_MAIN_IMAGE_CLEANUP_BATCH,
     LIST_MAIN_IMAGE_CLEANUP_BATCHES,
     LIST_MAIN_IMAGE_CLEANUP_ITEMS,

--- a/schemas.py
+++ b/schemas.py
@@ -35,6 +35,64 @@ class Meta(BaseModel):
     limit: int
     pages: int
 
+
+class ManagerMediaAssetResponse(BaseModel):
+    id: int
+    parent_asset_id: Optional[int] = None
+    title: str
+    alt_text: Optional[str] = None
+    description: Optional[str] = None
+    kind: str
+    tags: List[str] = []
+    variant_type: str
+    url: str
+    original_url: Optional[str] = None
+    source_filename: Optional[str] = None
+    mime_type: str
+    storage_provider: str
+    processing_status: str
+    processing_error: Optional[str] = None
+    content_hash: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    size_bytes: int = 0
+    usage_count: int = 0
+    created_by: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ManagerMediaAssetListResponse(BaseModel):
+    items: List[ManagerMediaAssetResponse]
+    meta: Meta
+
+
+class ManagerMediaAssetUpdatePayload(BaseModel):
+    title: Optional[str] = None
+    alt_text: Optional[str] = None
+    description: Optional[str] = None
+    kind: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class ManagerMediaAssetCropPayload(BaseModel):
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    title: Optional[str] = None
+
+
+class ManagerMediaAssetUrlUploadPayload(BaseModel):
+    url: str
+    kind: str = "misc"
+    tags: List[str] = []
+
+
+class ManagerMediaAssetUploadResponse(BaseModel):
+    uploaded: int
+    items: List[ManagerMediaAssetResponse]
+
 # --- CATALOG ---
 
 class ProductBase(BaseModel):

--- a/services/media_library_service.py
+++ b/services/media_library_service.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ipaddress
+import math
+import os
+import socket
+from dataclasses import dataclass
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import unquote, urlparse
+
+import httpx
+from PIL import Image, ImageOps, UnidentifiedImageError, features
+from sqlalchemy import func, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Article, MediaAsset, Product, ProductImage, ProductImageVariant
+from services.product_image_processing_contract import ProductImageVariantType
+from services.product_image_processing_provider import (
+    ProductImageProcessingContext,
+    RembgProductImageProcessor,
+)
+
+
+MEDIA_LIBRARY_BASE_DIR = Path("media/library")
+MEDIA_LIBRARY_PUBLIC_PREFIX = "/media/library"
+MAX_LIBRARY_IMAGE_PIXELS = 50_000_000
+MAX_REMOTE_IMAGE_BYTES = 20 * 1024 * 1024
+REMOTE_IMAGE_TIMEOUT_SECONDS = 12.0
+ALLOWED_KINDS = {
+    "product",
+    "article",
+    "service",
+    "installation",
+    "strobe",
+    "brand",
+    "misc",
+}
+
+
+@dataclass(frozen=True)
+class StoredLibraryImage:
+    url: str
+    path: str
+    content_hash: str
+    width: int
+    height: int
+    size_bytes: int
+    mime_type: str = "image/webp"
+    storage_provider: str = "local"
+
+
+class MediaLibraryService:
+    @staticmethod
+    async def list_assets(
+        session: AsyncSession,
+        *,
+        page: int = 1,
+        limit: int = 40,
+        query: str | None = None,
+        kind: str | None = None,
+        tag: str | None = None,
+        status: str | None = None,
+    ) -> dict:
+        safe_page = max(1, int(page or 1))
+        safe_limit = max(1, min(int(limit or 40), 100))
+
+        stmt = select(MediaAsset)
+        conditions = []
+        q = (query or "").strip()
+        if q:
+            pattern = f"%{q}%"
+            conditions.append(
+                or_(
+                    MediaAsset.title.ilike(pattern),
+                    MediaAsset.alt_text.ilike(pattern),
+                    MediaAsset.description.ilike(pattern),
+                    MediaAsset.source_filename.ilike(pattern),
+                )
+            )
+        if kind:
+            conditions.append(MediaAsset.kind == MediaLibraryService._normalize_kind(kind))
+        if status:
+            conditions.append(MediaAsset.processing_status == status)
+        for condition in conditions:
+            stmt = stmt.where(condition)
+
+        rows = (await session.execute(stmt.order_by(MediaAsset.created_at.desc()))).scalars().all()
+        normalized_tag = MediaLibraryService._normalize_tag(tag) if tag else ""
+        if normalized_tag:
+            rows = [
+                row
+                for row in rows
+                if normalized_tag in {MediaLibraryService._normalize_tag(item) for item in row.tags or []}
+            ]
+
+        total = len(rows)
+        start = (safe_page - 1) * safe_limit
+        page_rows = rows[start : start + safe_limit]
+        items = [await MediaLibraryService.serialize_asset(session, item) for item in page_rows]
+        return {
+            "items": items,
+            "meta": {
+                "total": total,
+                "page": safe_page,
+                "limit": safe_limit,
+                "pages": math.ceil(total / safe_limit) if total else 1,
+            },
+        }
+
+    @staticmethod
+    async def upload_assets(
+        session: AsyncSession,
+        *,
+        files: Iterable[tuple[str | None, bytes]],
+        kind: str,
+        tags: list[str] | None,
+        created_by: str | None,
+    ) -> dict:
+        assets: list[MediaAsset] = []
+        for filename, content in files:
+            if not content:
+                continue
+            stored = await MediaLibraryService._store_image(
+                content,
+                variant_type="original",
+            )
+            asset = MediaAsset(
+                title=MediaLibraryService._title_from_filename(filename) or "Без названия",
+                kind=MediaLibraryService._normalize_kind(kind),
+                tags=MediaLibraryService._normalize_tags(tags),
+                variant_type="original",
+                url=stored.url,
+                original_url=stored.url,
+                source_filename=filename,
+                mime_type=stored.mime_type,
+                storage_provider=stored.storage_provider,
+                processing_status="ready",
+                content_hash=stored.content_hash,
+                width=stored.width,
+                height=stored.height,
+                size_bytes=stored.size_bytes,
+                created_by=created_by,
+            )
+            session.add(asset)
+            assets.append(asset)
+
+        if not assets:
+            raise ValueError("No valid image files uploaded")
+
+        await session.commit()
+        for asset in assets:
+            await session.refresh(asset)
+        return {
+            "uploaded": len(assets),
+            "items": [await MediaLibraryService.serialize_asset(session, asset) for asset in assets],
+        }
+
+    @staticmethod
+    async def upload_asset_from_url(
+        session: AsyncSession,
+        *,
+        url: str,
+        kind: str,
+        tags: list[str] | None,
+        created_by: str | None,
+    ) -> dict:
+        normalized_url = MediaLibraryService._validate_remote_image_url(url)
+        try:
+            content, filename = await MediaLibraryService._download_remote_image(normalized_url)
+        except httpx.HTTPStatusError as exc:
+            raise ValueError(f"Remote image returned HTTP {exc.response.status_code}") from exc
+        except httpx.HTTPError as exc:
+            raise ValueError("Remote image could not be downloaded") from exc
+        return await MediaLibraryService.upload_assets(
+            session=session,
+            files=[(filename, content)],
+            kind=kind,
+            tags=tags,
+            created_by=created_by,
+        )
+
+    @staticmethod
+    async def update_asset(
+        session: AsyncSession,
+        *,
+        asset_id: int,
+        title: str | None = None,
+        alt_text: str | None = None,
+        description: str | None = None,
+        kind: str | None = None,
+        tags: list[str] | None = None,
+    ) -> dict:
+        asset = await session.get(MediaAsset, asset_id)
+        if not asset:
+            raise LookupError("Media asset not found")
+
+        if title is not None:
+            asset.title = title.strip()
+        if alt_text is not None:
+            asset.alt_text = alt_text.strip() or None
+        if description is not None:
+            asset.description = description.strip() or None
+        if kind is not None:
+            asset.kind = MediaLibraryService._normalize_kind(kind)
+        if tags is not None:
+            asset.tags = MediaLibraryService._normalize_tags(tags)
+        asset.updated_at = datetime.now()
+        session.add(asset)
+        await session.commit()
+        await session.refresh(asset)
+        return await MediaLibraryService.serialize_asset(session, asset)
+
+    @staticmethod
+    async def crop_asset(
+        session: AsyncSession,
+        *,
+        asset_id: int,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        title: str | None,
+        created_by: str | None,
+    ) -> dict:
+        source = await MediaLibraryService._get_asset_or_raise(session, asset_id)
+        source_path = MediaLibraryService._local_path_for_url(source.url)
+        if source_path is None or not source_path.exists():
+            raise ValueError("Source file is not available in local media storage")
+
+        def crop() -> bytes:
+            image = MediaLibraryService._open_image(source_path.read_bytes())
+            left = max(0, min(x, image.width - 1))
+            top = max(0, min(y, image.height - 1))
+            right = max(left + 1, min(left + width, image.width))
+            bottom = max(top + 1, min(top + height, image.height))
+            cropped = image.crop((left, top, right, bottom))
+            return MediaLibraryService._export_webp(cropped)
+
+        content = await asyncio.to_thread(crop)
+        stored = await MediaLibraryService._store_processed_webp(content, variant_type="crop")
+        asset = await MediaLibraryService._create_variant_asset(
+            session,
+            source=source,
+            stored=stored,
+            variant_type="crop",
+            title=title or f"{source.title or source.source_filename or 'Image'} crop",
+            created_by=created_by,
+        )
+        return await MediaLibraryService.serialize_asset(session, asset)
+
+    @staticmethod
+    async def remove_background(
+        session: AsyncSession,
+        *,
+        asset_id: int,
+        created_by: str | None,
+    ) -> dict:
+        source = await MediaLibraryService._get_asset_or_raise(session, asset_id)
+        source_path = MediaLibraryService._local_path_for_url(source.url)
+        if source_path is None or not source_path.exists():
+            raise ValueError("Source file is not available in local media storage")
+
+        processor = RembgProductImageProcessor()
+        processed = await processor.process(
+            source_content=source_path.read_bytes(),
+            context=ProductImageProcessingContext(
+                product_image_id=0,
+                source_url=source.url,
+                variant_type=ProductImageVariantType.PROCESSED.value,
+            ),
+        )
+        stored = await MediaLibraryService._store_processed_webp(
+            processed.content,
+            variant_type="background_removed",
+        )
+        asset = await MediaLibraryService._create_variant_asset(
+            session,
+            source=source,
+            stored=stored,
+            variant_type="background_removed",
+            title=f"{source.title or source.source_filename or 'Image'} без фона",
+            created_by=created_by,
+        )
+        return await MediaLibraryService.serialize_asset(session, asset)
+
+    @staticmethod
+    async def delete_asset(session: AsyncSession, *, asset_id: int, force: bool = False) -> dict:
+        asset = await session.get(MediaAsset, asset_id)
+        if not asset:
+            raise LookupError("Media asset not found")
+
+        usage_count = await MediaLibraryService._usage_count(session, asset.url)
+        if usage_count > 0 and not force:
+            raise ValueError("Media asset is used. Pass force=true to delete metadata anyway.")
+
+        url = asset.url
+        children = (
+            await session.execute(select(MediaAsset).where(MediaAsset.parent_asset_id == asset_id))
+        ).scalars().all()
+        for child in children:
+            child.parent_asset_id = None
+            session.add(child)
+        await session.delete(asset)
+        await session.commit()
+        await MediaLibraryService._remove_file_if_unreferenced(session, url)
+        return {"message": "Media asset deleted"}
+
+    @staticmethod
+    async def serialize_asset(session: AsyncSession, asset: MediaAsset) -> dict:
+        return {
+            "id": asset.id,
+            "parent_asset_id": asset.parent_asset_id,
+            "title": asset.title,
+            "alt_text": asset.alt_text,
+            "description": asset.description,
+            "kind": asset.kind,
+            "tags": asset.tags or [],
+            "variant_type": asset.variant_type,
+            "url": asset.url,
+            "original_url": asset.original_url,
+            "source_filename": asset.source_filename,
+            "mime_type": asset.mime_type,
+            "storage_provider": asset.storage_provider,
+            "processing_status": asset.processing_status,
+            "processing_error": asset.processing_error,
+            "content_hash": asset.content_hash,
+            "width": asset.width,
+            "height": asset.height,
+            "size_bytes": asset.size_bytes,
+            "usage_count": await MediaLibraryService._usage_count(session, asset.url),
+            "created_by": asset.created_by,
+            "created_at": asset.created_at,
+            "updated_at": asset.updated_at,
+        }
+
+    @staticmethod
+    async def _create_variant_asset(
+        session: AsyncSession,
+        *,
+        source: MediaAsset,
+        stored: StoredLibraryImage,
+        variant_type: str,
+        title: str,
+        created_by: str | None,
+    ) -> MediaAsset:
+        asset = MediaAsset(
+            parent_asset_id=source.id,
+            title=title,
+            alt_text=source.alt_text,
+            description=source.description,
+            kind=source.kind,
+            tags=list(source.tags or []),
+            variant_type=variant_type,
+            url=stored.url,
+            original_url=source.original_url or source.url,
+            source_filename=source.source_filename,
+            mime_type=stored.mime_type,
+            storage_provider=stored.storage_provider,
+            processing_status="ready",
+            content_hash=stored.content_hash,
+            width=stored.width,
+            height=stored.height,
+            size_bytes=stored.size_bytes,
+            created_by=created_by,
+        )
+        session.add(asset)
+        await session.commit()
+        await session.refresh(asset)
+        return asset
+
+    @staticmethod
+    async def _get_asset_or_raise(session: AsyncSession, asset_id: int) -> MediaAsset:
+        asset = await session.get(MediaAsset, asset_id)
+        if not asset:
+            raise LookupError("Media asset not found")
+        return asset
+
+    @staticmethod
+    async def _store_image(content: bytes, *, variant_type: str) -> StoredLibraryImage:
+        webp_content = await asyncio.to_thread(
+            lambda: MediaLibraryService._export_webp(MediaLibraryService._open_image(content))
+        )
+        return await MediaLibraryService._store_processed_webp(webp_content, variant_type=variant_type)
+
+    @staticmethod
+    async def _download_remote_image(url: str) -> tuple[bytes, str]:
+        current_url = url
+        async with httpx.AsyncClient(timeout=REMOTE_IMAGE_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            for _ in range(4):
+                MediaLibraryService._validate_remote_image_url(current_url)
+                async with client.stream("GET", current_url, headers={"Accept": "image/*"}) as response:
+                    if response.status_code in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ValueError("Remote image redirect has no destination")
+                        current_url = str(response.url.join(location))
+                        continue
+
+                    response.raise_for_status()
+                    content_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                    if content_type and not content_type.startswith("image/"):
+                        raise ValueError("Remote URL does not point to an image")
+
+                    length = response.headers.get("content-length")
+                    if length and int(length) > MAX_REMOTE_IMAGE_BYTES:
+                        raise ValueError("Remote image is too large")
+
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in response.aiter_bytes():
+                        total += len(chunk)
+                        if total > MAX_REMOTE_IMAGE_BYTES:
+                            raise ValueError("Remote image is too large")
+                        chunks.append(chunk)
+
+                    content = b"".join(chunks)
+                    if not content:
+                        raise ValueError("Remote image is empty")
+                    filename = MediaLibraryService._filename_from_url(str(response.url))
+                    return content, filename
+
+        raise ValueError("Remote image has too many redirects")
+
+    @staticmethod
+    def _validate_remote_image_url(url: str) -> str:
+        normalized = str(url or "").strip()
+        parsed = urlparse(normalized)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError("Image URL must use http or https")
+
+        hostname = parsed.hostname.lower()
+        if hostname in {"localhost", "localhost.localdomain"}:
+            raise ValueError("Localhost URLs are not allowed")
+
+        try:
+            addresses = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80))
+        except socket.gaierror as exc:
+            raise ValueError("Image URL host cannot be resolved") from exc
+
+        for address in addresses:
+            ip = ipaddress.ip_address(address[4][0])
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+                or ip.is_unspecified
+            ):
+                raise ValueError("Private network image URLs are not allowed")
+        return normalized
+
+    @staticmethod
+    def _filename_from_url(url: str) -> str:
+        path = unquote(urlparse(url).path or "")
+        filename = Path(path).name.strip()
+        return filename or "remote-image"
+
+    @staticmethod
+    async def _store_processed_webp(content: bytes, *, variant_type: str) -> StoredLibraryImage:
+        if not content:
+            raise ValueError("Cannot store empty media content")
+
+        width, height = await asyncio.to_thread(MediaLibraryService._image_size, content)
+        content_hash = hashlib.sha256(content).hexdigest()
+        safe_variant = MediaLibraryService._safe_path_segment(variant_type)
+        target_dir = MEDIA_LIBRARY_BASE_DIR / safe_variant
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / f"{content_hash}.webp"
+        if not target_path.exists():
+            target_path.write_bytes(content)
+
+        relative_path = str(target_path).replace(os.sep, "/")
+        return StoredLibraryImage(
+            url=f"{MEDIA_LIBRARY_PUBLIC_PREFIX}/{safe_variant}/{target_path.name}",
+            path=relative_path,
+            content_hash=content_hash,
+            width=width,
+            height=height,
+            size_bytes=len(content),
+        )
+
+    @staticmethod
+    def _open_image(content: bytes) -> Image.Image:
+        if not content:
+            raise ValueError("Source image is empty")
+        try:
+            with Image.open(BytesIO(content)) as image:
+                if image.width * image.height > MAX_LIBRARY_IMAGE_PIXELS:
+                    raise ValueError("Source image is too large for safe processing")
+                transposed = ImageOps.exif_transpose(image)
+                mode = "RGBA" if MediaLibraryService._has_alpha(transposed) else "RGB"
+                converted = transposed.convert(mode)
+                converted.load()
+                return converted.copy()
+        except UnidentifiedImageError as exc:
+            raise ValueError("Source image cannot be opened") from exc
+
+    @staticmethod
+    def _export_webp(image: Image.Image) -> bytes:
+        if not features.check("webp"):
+            raise RuntimeError("Pillow WebP support is required for media library")
+        output = BytesIO()
+        image.save(output, format="WEBP", quality=88, method=6, exact=image.mode == "RGBA")
+        return output.getvalue()
+
+    @staticmethod
+    def _image_size(content: bytes) -> tuple[int, int]:
+        image = MediaLibraryService._open_image(content)
+        return image.width, image.height
+
+    @staticmethod
+    def _has_alpha(image: Image.Image) -> bool:
+        return image.mode in {"RGBA", "LA"} or (
+            image.mode == "P" and "transparency" in image.info
+        )
+
+    @staticmethod
+    def _local_path_for_url(url: str) -> Path | None:
+        if not url:
+            return None
+        prefix = MEDIA_LIBRARY_PUBLIC_PREFIX.rstrip("/") + "/"
+        if url.startswith(prefix):
+            relative = url[len(prefix) :]
+            return MEDIA_LIBRARY_BASE_DIR / relative
+        if url.startswith("/media/"):
+            return Path(url.lstrip("/"))
+        if url.startswith("media/"):
+            return Path(url)
+        return None
+
+    @staticmethod
+    async def _usage_count(session: AsyncSession, url: str) -> int:
+        counts = []
+        counts.append(
+            await session.scalar(select(func.count()).select_from(Product).where(Product.main_image == url))
+        )
+        counts.append(
+            await session.scalar(select(func.count()).select_from(ProductImage).where(ProductImage.url == url))
+        )
+        counts.append(
+            await session.scalar(
+                select(func.count()).select_from(ProductImageVariant).where(ProductImageVariant.url == url)
+            )
+        )
+        counts.append(
+            await session.scalar(
+                select(func.count()).select_from(Article).where(
+                    or_(Article.main_image == url, Article.cover_image == url)
+                )
+            )
+        )
+        return sum(int(value or 0) for value in counts)
+
+    @staticmethod
+    async def _remove_file_if_unreferenced(session: AsyncSession, url: str) -> None:
+        media_refs = await session.scalar(
+            select(func.count()).select_from(MediaAsset).where(MediaAsset.url == url)
+        )
+        if int(media_refs or 0) > 0:
+            return
+        if await MediaLibraryService._usage_count(session, url) > 0:
+            return
+        path = MediaLibraryService._local_path_for_url(url)
+        if path and path.exists():
+            path.unlink()
+
+    @staticmethod
+    def _normalize_kind(kind: str | None) -> str:
+        normalized = (kind or "misc").strip().lower().replace(" ", "_")
+        return normalized if normalized in ALLOWED_KINDS else "misc"
+
+    @staticmethod
+    def _normalize_tags(tags: list[str] | None) -> list[str]:
+        result = []
+        seen = set()
+        for tag in tags or []:
+            normalized = MediaLibraryService._normalize_tag(tag)
+            if not normalized or normalized.casefold() in seen:
+                continue
+            seen.add(normalized.casefold())
+            result.append(normalized)
+        return result
+
+    @staticmethod
+    def _normalize_tag(tag: str | None) -> str:
+        return " ".join(str(tag or "").strip().split())
+
+    @staticmethod
+    def _title_from_filename(filename: str | None) -> str:
+        if not filename:
+            return ""
+        return Path(filename).stem.replace("_", " ").replace("-", " ").strip()
+
+    @staticmethod
+    def _safe_path_segment(value: str) -> str:
+        safe = "".join(char if char.isalnum() or char in {"-", "_"} else "_" for char in value)
+        return safe.strip("_") or "misc"

--- a/tests/unit/test_media_library_service.py
+++ b/tests/unit/test_media_library_service.py
@@ -1,0 +1,156 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+import models  # noqa: F401
+from services import media_library_service
+from services.media_library_service import MediaLibraryService
+
+
+def image_bytes(size=(120, 80), color=(20, 180, 160)) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", size, color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path, monkeypatch):
+    monkeypatch.setattr(media_library_service, "MEDIA_LIBRARY_BASE_DIR", tmp_path / "library")
+    monkeypatch.setattr(media_library_service, "MEDIA_LIBRARY_PUBLIC_PREFIX", "/media/library")
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upload_and_list_media_assets(sqlite_session):
+    response = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("install-photo.png", image_bytes())],
+        kind="installation",
+        tags=["монтаж", "штробы"],
+        created_by="admin",
+    )
+
+    assert response["uploaded"] == 1
+    item = response["items"][0]
+    assert item["url"].startswith("/media/library/original/")
+    assert item["kind"] == "installation"
+    assert item["tags"] == ["монтаж", "штробы"]
+    assert item["width"] == 120
+    assert item["height"] == 80
+
+    listing = await MediaLibraryService.list_assets(
+        session=sqlite_session,
+        kind="installation",
+        tag="монтаж",
+    )
+    assert listing["meta"]["total"] == 1
+    assert listing["items"][0]["id"] == item["id"]
+
+
+@pytest.mark.asyncio
+async def test_crop_media_asset_creates_variant(sqlite_session):
+    upload = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("source.png", image_bytes(size=(200, 100)))],
+        kind="article",
+        tags=["обложка"],
+        created_by="admin",
+    )
+    source = upload["items"][0]
+
+    cropped = await MediaLibraryService.crop_asset(
+        session=sqlite_session,
+        asset_id=source["id"],
+        x=20,
+        y=10,
+        width=60,
+        height=40,
+        title="source crop",
+        created_by="admin",
+    )
+
+    assert cropped["parent_asset_id"] == source["id"]
+    assert cropped["variant_type"] == "crop"
+    assert cropped["original_url"] == source["url"]
+    assert cropped["width"] == 60
+    assert cropped["height"] == 40
+    assert cropped["tags"] == ["обложка"]
+
+
+@pytest.mark.asyncio
+async def test_upload_media_asset_from_url_uses_existing_pipeline(sqlite_session, monkeypatch):
+    monkeypatch.setattr(
+        MediaLibraryService,
+        "_validate_remote_image_url",
+        staticmethod(lambda url: url),
+    )
+
+    async def fake_download(_url: str):
+        return image_bytes(size=(90, 60)), "remote-photo.png"
+
+    monkeypatch.setattr(
+        MediaLibraryService,
+        "_download_remote_image",
+        staticmethod(fake_download),
+    )
+
+    response = await MediaLibraryService.upload_asset_from_url(
+        session=sqlite_session,
+        url="https://example.com/remote-photo.png",
+        kind="service",
+        tags=["обслуживание"],
+        created_by="admin",
+    )
+
+    assert response["uploaded"] == 1
+    item = response["items"][0]
+    assert item["source_filename"] == "remote-photo.png"
+    assert item["kind"] == "service"
+    assert item["tags"] == ["обслуживание"]
+    assert item["width"] == 90
+    assert item["height"] == 60
+
+
+@pytest.mark.asyncio
+async def test_delete_parent_media_asset_keeps_variant(sqlite_session):
+    upload = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("source.png", image_bytes(size=(200, 100)))],
+        kind="article",
+        tags=["обложка"],
+        created_by="admin",
+    )
+    source = upload["items"][0]
+    cropped = await MediaLibraryService.crop_asset(
+        session=sqlite_session,
+        asset_id=source["id"],
+        x=20,
+        y=10,
+        width=60,
+        height=40,
+        title="source crop",
+        created_by="admin",
+    )
+
+    result = await MediaLibraryService.delete_asset(
+        session=sqlite_session,
+        asset_id=source["id"],
+    )
+
+    assert result["message"] == "Media asset deleted"
+    listing = await MediaLibraryService.list_assets(session=sqlite_session)
+    assert listing["meta"]["total"] == 1
+    assert listing["items"][0]["id"] == cropped["id"]
+    assert listing["items"][0]["parent_asset_id"] is None


### PR DESCRIPTION
## Summary
- add a manager media library with file upload, drag-and-drop, URL import, clipboard paste handling, filtering, metadata editing, crop, delete, and background-removal action
- add backend media asset model, Alembic migration, service layer, manager API routes, SSRF-aware remote image downloading, WebP optimization, and variant-safe deletion
- regenerate OpenAPI and the manager frontend client

## Deployment notes
- production deploy runs from `main` via `.github/workflows/deploy.yml`; after merge it builds the backend image with the manager frontend and runs `alembic upgrade head`
- background removal endpoint is wired, but the current runtime still needs a `rembg` provider/model setup before that action will work in production

## Checks
- `python3 scripts/legacy/extract_openapi.py`
- `cd manager_frontend && npm run gen:api`
- `pytest tests/unit/test_media_library_service.py -q`
- `cd manager_frontend && npm run build`
- `python3 -m compileall services/media_library_service.py routers/manager_media_library.py schemas.py`
- `git diff --check`
- browser QA on `http://localhost:8000/manager/media` including mobile layout, URL upload, delete, and expected rembg-not-installed handling
