### PR TITLE
[codex] Add reusable media crop manager

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -80,6 +80,7 @@ import {
     type ManagerMediaAssetUpdatePayload,
     type ManagerMediaAssetUrlUploadPayload,
     type ManagerMediaAssetUploadResponse,
+    type ProductImageCropPayload,
     type ProductImageVariantBatchProcessResponse,
     type ProductImageVariantCandidateResponse,
     type ProductImageVariantCandidatesResponse,
@@ -152,6 +153,7 @@ export type {
     ProductImageVariantCandidateResponse,
     ProductImageVariantCandidatesResponse,
     ProductImageVariantResponse,
+    ProductImageCropPayload,
 };
 export type {
     ProductMainImageCleanupBatchCreatePayload,
@@ -537,6 +539,10 @@ export const api = {
 
     async deleteGalleryImage(imageId: number) {
         return await ManagerService.deleteImage(imageId);
+    },
+
+    async cropGalleryImage(imageId: number, payload: ProductImageCropPayload) {
+        return await ManagerService.cropProductImage(imageId, payload);
     },
 
     async reuseSearch(q: string) {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -229,6 +229,7 @@ export type { PaymentResponse } from './models/PaymentResponse';
 export type { ProductAvailabilityLeadPayload } from './models/ProductAvailabilityLeadPayload';
 export type { ProductAvailabilityLeadResponse } from './models/ProductAvailabilityLeadResponse';
 export type { ProductBrandResponse } from './models/ProductBrandResponse';
+export type { ProductImageCropPayload } from './models/ProductImageCropPayload';
 export type { ProductImageResponse } from './models/ProductImageResponse';
 export type { ProductImageVariantBatchProcessResponse } from './models/ProductImageVariantBatchProcessResponse';
 export type { ProductImageVariantCandidateResponse } from './models/ProductImageVariantCandidateResponse';

--- a/manager_frontend/src/client/models/ProductImageCropPayload.ts
+++ b/manager_frontend/src/client/models/ProductImageCropPayload.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductImageCropPayload = {
+    'x': number;
+    'y': number;
+    width: number;
+    height: number;
+    mode?: 'append' | 'replace';
+    set_main?: boolean;
+};
+

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -46,6 +46,7 @@ import type { ManagerMediaSetMainImageResponse } from '../models/ManagerMediaSet
 import type { ManagerMediaUploadLocalImagesResponse } from '../models/ManagerMediaUploadLocalImagesResponse';
 import type { ManagerNormalizeLegacySpecsResponse } from '../models/ManagerNormalizeLegacySpecsResponse';
 import type { ManagerTagGroupResponse } from '../models/ManagerTagGroupResponse';
+import type { ProductImageCropPayload } from '../models/ProductImageCropPayload';
 import type { ProductImageVariantBatchProcessResponse } from '../models/ProductImageVariantBatchProcessResponse';
 import type { ProductImageVariantCandidatesResponse } from '../models/ProductImageVariantCandidatesResponse';
 import type { ProductImageVariantResponse } from '../models/ProductImageVariantResponse';
@@ -1022,6 +1023,31 @@ export class ManagerService {
             path: {
                 'image_id': imageId,
             },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Crop Product Image
+     * Crop a concrete ProductImage and either append or replace the gallery image.
+     * @param imageId
+     * @param requestBody
+     * @returns ManagerMediaImageLinkResponse Successful Response
+     * @throws ApiError
+     */
+    public static cropProductImage(
+        imageId: number,
+        requestBody: ProductImageCropPayload,
+    ): CancelablePromise<ManagerMediaImageLinkResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/gallery/{image_id}/crop',
+            path: {
+                'image_id': imageId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/ImageCropSelector.vue
+++ b/manager_frontend/src/components/ImageCropSelector.vue
@@ -1,0 +1,284 @@
+<script lang="ts">
+export type ImageCropValue = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type ImageCropSourceSize = {
+  width: number;
+  height: number;
+};
+</script>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+type CropHandle = 'nw' | 'ne' | 'sw' | 'se';
+type DragMode = 'draw' | 'move' | CropHandle;
+type CropPoint = { x: number; y: number };
+type DragState = {
+  mode: DragMode;
+  startPoint: CropPoint;
+  startRect: ImageCropValue;
+  anchor?: CropPoint;
+};
+
+const props = withDefaults(defineProps<{
+  src: string;
+  modelValue: ImageCropValue;
+  sourceWidth: number;
+  sourceHeight: number;
+  minSize?: number;
+  imageAlt?: string;
+  disabled?: boolean;
+}>(), {
+  minSize: 1,
+  imageAlt: '',
+  disabled: false,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: ImageCropValue];
+  'source-load': [size: ImageCropSourceSize];
+}>();
+
+const imageEl = ref<HTMLImageElement | null>(null);
+const dragState = ref<DragState | null>(null);
+
+const normalizedMinSize = computed(() => Math.max(1, Math.trunc(props.minSize)));
+
+const hasSourceSize = computed(() => props.sourceWidth > 0 && props.sourceHeight > 0);
+
+const selectionStyle = computed(() => {
+  if (!hasSourceSize.value || !props.modelValue.width || !props.modelValue.height) {
+    return { display: 'none' };
+  }
+
+  return {
+    left: `${Math.max(0, Math.min(100, (props.modelValue.x / props.sourceWidth) * 100))}%`,
+    top: `${Math.max(0, Math.min(100, (props.modelValue.y / props.sourceHeight) * 100))}%`,
+    width: `${Math.max(0, Math.min(100, (props.modelValue.width / props.sourceWidth) * 100))}%`,
+    height: `${Math.max(0, Math.min(100, (props.modelValue.height / props.sourceHeight) * 100))}%`,
+  };
+});
+
+const handleControls: Array<{
+  key: CropHandle;
+  label: string;
+  className: string;
+}> = [
+  {
+    key: 'nw',
+    label: 'Левый верхний угол',
+    className: 'left-0 top-0 -translate-x-1/2 -translate-y-1/2 cursor-nwse-resize',
+  },
+  {
+    key: 'ne',
+    label: 'Правый верхний угол',
+    className: 'right-0 top-0 translate-x-1/2 -translate-y-1/2 cursor-nesw-resize',
+  },
+  {
+    key: 'sw',
+    label: 'Левый нижний угол',
+    className: 'bottom-0 left-0 -translate-x-1/2 translate-y-1/2 cursor-nesw-resize',
+  },
+  {
+    key: 'se',
+    label: 'Правый нижний угол',
+    className: 'bottom-0 right-0 translate-x-1/2 translate-y-1/2 cursor-nwse-resize',
+  },
+];
+
+const clampRect = (rect: ImageCropValue): ImageCropValue => {
+  if (!hasSourceSize.value) return { x: 0, y: 0, width: 0, height: 0 };
+
+  const sourceWidth = props.sourceWidth;
+  const sourceHeight = props.sourceHeight;
+  const minSize = Math.min(normalizedMinSize.value, sourceWidth, sourceHeight);
+  const maxX = Math.max(0, sourceWidth - minSize);
+  const maxY = Math.max(0, sourceHeight - minSize);
+  const x = Math.max(0, Math.min(Math.trunc(rect.x), maxX));
+  const y = Math.max(0, Math.min(Math.trunc(rect.y), maxY));
+  const width = Math.max(minSize, Math.min(Math.trunc(rect.width), sourceWidth - x));
+  const height = Math.max(minSize, Math.min(Math.trunc(rect.height), sourceHeight - y));
+
+  return { x, y, width, height };
+};
+
+const getPointFromEvent = (event: PointerEvent): CropPoint | null => {
+  const image = imageEl.value;
+  if (!image || !hasSourceSize.value) return null;
+
+  const rect = image.getBoundingClientRect();
+  if (!rect.width || !rect.height) return null;
+
+  const relativeX = Math.max(0, Math.min(event.clientX - rect.left, rect.width));
+  const relativeY = Math.max(0, Math.min(event.clientY - rect.top, rect.height));
+
+  return {
+    x: Math.round((relativeX / rect.width) * props.sourceWidth),
+    y: Math.round((relativeY / rect.height) * props.sourceHeight),
+  };
+};
+
+const getAnchorForHandle = (handle: CropHandle, rect: ImageCropValue): CropPoint => {
+  const right = rect.x + rect.width;
+  const bottom = rect.y + rect.height;
+
+  if (handle === 'nw') return { x: right, y: bottom };
+  if (handle === 'ne') return { x: rect.x, y: bottom };
+  if (handle === 'sw') return { x: right, y: rect.y };
+  return { x: rect.x, y: rect.y };
+};
+
+const rectFromCorners = (anchor: CropPoint, point: CropPoint): ImageCropValue => {
+  const minSize = normalizedMinSize.value;
+  let x = Math.min(anchor.x, point.x);
+  let y = Math.min(anchor.y, point.y);
+  let width = Math.abs(point.x - anchor.x);
+  let height = Math.abs(point.y - anchor.y);
+
+  if (width < minSize) {
+    if (point.x < anchor.x) x = anchor.x - minSize;
+    width = minSize;
+  }
+  if (height < minSize) {
+    if (point.y < anchor.y) y = anchor.y - minSize;
+    height = minSize;
+  }
+
+  return clampRect({ x, y, width, height });
+};
+
+const updateCrop = (value: ImageCropValue) => {
+  emit('update:modelValue', clampRect(value));
+};
+
+const getPointerMode = (target: EventTarget | null): DragMode => {
+  if (!(target instanceof HTMLElement)) return 'draw';
+
+  const handle = target.closest<HTMLElement>('[data-crop-handle]');
+  if (handle?.dataset.cropHandle) return handle.dataset.cropHandle as CropHandle;
+
+  const selection = target.closest<HTMLElement>('[data-crop-selection]');
+  return selection ? 'move' : 'draw';
+};
+
+const onPointerDown = (event: PointerEvent) => {
+  if (props.disabled) return;
+  event.preventDefault();
+
+  const point = getPointFromEvent(event);
+  if (!point) return;
+
+  const mode = getPointerMode(event.target);
+  const startRect = clampRect(props.modelValue);
+  const anchor = mode === 'draw'
+    ? point
+    : mode === 'move'
+      ? undefined
+      : getAnchorForHandle(mode, startRect);
+
+  dragState.value = { mode, startPoint: point, startRect, anchor };
+
+  if (mode === 'draw') {
+    updateCrop({ x: point.x, y: point.y, width: normalizedMinSize.value, height: normalizedMinSize.value });
+  }
+
+  try {
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+  } catch {
+    // Pointer capture can fail for synthetic or already-ended events.
+  }
+};
+
+const onPointerMove = (event: PointerEvent) => {
+  if (!dragState.value || props.disabled) return;
+  event.preventDefault();
+
+  const point = getPointFromEvent(event);
+  if (!point) return;
+
+  const state = dragState.value;
+  if (state.mode === 'move') {
+    const deltaX = point.x - state.startPoint.x;
+    const deltaY = point.y - state.startPoint.y;
+    updateCrop({
+      ...state.startRect,
+      x: state.startRect.x + deltaX,
+      y: state.startRect.y + deltaY,
+    });
+    return;
+  }
+
+  const anchor = state.anchor || state.startPoint;
+  updateCrop(rectFromCorners(anchor, point));
+};
+
+const onPointerUp = (event: PointerEvent) => {
+  if (!dragState.value) return;
+  event.preventDefault();
+  dragState.value = null;
+
+  try {
+    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+  } catch {
+    // Pointer capture may already be released by the browser.
+  }
+};
+
+const onImageLoad = (event: Event) => {
+  const image = event.target as HTMLImageElement;
+  emit('source-load', {
+    width: image.naturalWidth,
+    height: image.naturalHeight,
+  });
+};
+</script>
+
+<template>
+  <div
+    class="flex w-full justify-center"
+    :class="{ 'opacity-60': disabled }"
+  >
+    <div
+      class="relative inline-block max-h-[56vh] max-w-full cursor-crosshair touch-none select-none overflow-hidden rounded-md bg-white"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+      @dragstart.prevent
+    >
+      <img
+        ref="imageEl"
+        :src="src"
+        :alt="imageAlt"
+        draggable="false"
+        class="block max-h-[56vh] max-w-full select-none object-contain"
+        @load="onImageLoad"
+      />
+      <div class="pointer-events-none absolute inset-0">
+        <div
+          class="absolute pointer-events-auto cursor-move border-2 border-teal-500 bg-teal-500/10 shadow-[0_0_0_9999px_rgba(15,23,42,0.30)]"
+          :style="selectionStyle"
+          data-crop-selection="true"
+        >
+          <button
+            v-for="handle in handleControls"
+            :key="handle.key"
+            type="button"
+            class="absolute z-10 flex h-8 w-8 items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2"
+            :class="handle.className"
+            :data-crop-handle="handle.key"
+            :aria-label="handle.label"
+            :title="handle.label"
+          >
+            <span class="block h-3.5 w-3.5 rounded-full border-2 border-white bg-teal-500 shadow-md"></span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/manager_frontend/src/components/MediaField.vue
+++ b/manager_frontend/src/components/MediaField.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { api } from '../api';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+const props = withDefaults(defineProps<{
+    modelValue?: string;
+    label: string;
+    kind?: string;
+    tags?: string[];
+    accept?: string;
+    placeholder?: string;
+}>(), {
+    modelValue: '',
+    kind: 'misc',
+    tags: () => [],
+    accept: 'image/*,.svg',
+    placeholder: '/media/library/original/logo.svg',
+});
+
+const emit = defineEmits<{
+    'update:modelValue': [value: string];
+    uploaded: [url: string];
+}>();
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const uploading = ref(false);
+const error = ref('');
+
+const value = computed({
+    get: () => props.modelValue || '',
+    set: (next: string) => emit('update:modelValue', next),
+});
+
+const normalizedUrl = computed(() => value.value.trim());
+
+const chooseFile = () => {
+    fileInput.value?.click();
+};
+
+const uploadFile = async (file: File) => {
+    uploading.value = true;
+    error.value = '';
+    try {
+        const response = await api.uploadMediaAssets({
+            files: [file],
+            kind: props.kind,
+            tags_json: JSON.stringify(props.tags || []),
+        });
+        const uploaded = response.items?.[0];
+        if (!uploaded?.url) {
+            throw new Error('Загрузка завершилась без URL файла');
+        }
+        value.value = uploaded.url;
+        emit('uploaded', uploaded.url);
+    } catch (err) {
+        error.value = getApiErrorMessage(err);
+    } finally {
+        uploading.value = false;
+        if (fileInput.value) fileInput.value.value = '';
+    }
+};
+
+const onFileChange = async (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    await uploadFile(file);
+};
+
+const clearValue = () => {
+    value.value = '';
+    error.value = '';
+};
+</script>
+
+<template>
+    <div class="space-y-2">
+        <div class="flex items-center justify-between gap-3">
+            <span class="text-sm font-medium text-gray-600 dark:text-slate-300">{{ label }}</span>
+            <div class="inline-flex items-center gap-1">
+                <button
+                    type="button"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 hover:text-teal-700 disabled:cursor-wait disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-200"
+                    :disabled="uploading"
+                    title="Загрузить файл"
+                    aria-label="Загрузить файл"
+                    @click="chooseFile"
+                >
+                    <span class="material-icons-round text-[18px]">upload</span>
+                </button>
+                <button
+                    v-if="normalizedUrl"
+                    type="button"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-500 transition-colors hover:bg-gray-50 hover:text-red-600 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800"
+                    title="Очистить"
+                    aria-label="Очистить"
+                    @click="clearValue"
+                >
+                    <span class="material-icons-round text-[18px]">close</span>
+                </button>
+            </div>
+        </div>
+
+        <input
+            ref="fileInput"
+            type="file"
+            class="hidden"
+            :accept="accept"
+            @change="onFileChange"
+        />
+
+        <div class="grid grid-cols-1 gap-3 sm:grid-cols-[96px_1fr]">
+            <div class="flex h-24 w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-slate-700 dark:bg-slate-950 sm:w-24">
+                <img
+                    v-if="normalizedUrl"
+                    :src="normalizedUrl"
+                    :alt="label"
+                    class="max-h-full max-w-full object-contain"
+                />
+                <span v-else class="material-icons-round text-[28px] text-gray-300 dark:text-slate-600">image</span>
+            </div>
+            <label class="min-w-0 text-sm">
+                <input
+                    v-model="value"
+                    type="text"
+                    :placeholder="placeholder"
+                    class="w-full rounded-lg border border-gray-200 bg-slate-100 px-3 py-2 dark:border-slate-700 dark:bg-slate-900"
+                />
+                <span v-if="uploading" class="mt-1 block text-xs font-medium text-teal-700 dark:text-teal-300">
+                    Загрузка...
+                </span>
+                <span v-if="error" class="mt-1 block text-xs font-medium text-red-600 dark:text-red-300">
+                    {{ error }}
+                </span>
+            </label>
+        </div>
+    </div>
+</template>

--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
 import { api, type ManagerBrand, type ManagerBrandSeries } from '../api';
+import MediaField from '../components/MediaField.vue';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 type BrandForm = {
@@ -841,10 +842,14 @@ onMounted(() => {
                             <input v-model="form.slug" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
                         </label>
                     </div>
-                    <label class="text-sm space-y-1 block">
-                        <span class="text-gray-600 dark:text-slate-300 font-medium">Логотип (URL)</span>
-                        <input v-model="form.logo_url" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
-                    </label>
+                    <MediaField
+                        v-model="form.logo_url"
+                        label="Логотип"
+                        kind="brand"
+                        :tags="['logo', 'brand']"
+                        accept="image/svg+xml,image/png,image/jpeg,image/webp,.svg"
+                        placeholder="/media/library/original/logo.svg"
+                    />
                     <label class="text-sm space-y-1 block">
                         <span class="text-gray-600 dark:text-slate-300 font-medium">Описание</span>
                         <textarea v-model="form.description" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
@@ -891,10 +896,14 @@ onMounted(() => {
                             <input v-model="seriesForm.slug" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
                         </label>
                     </div>
-                    <label class="text-sm space-y-1 block">
-                        <span class="text-gray-600 dark:text-slate-300 font-medium">Hero image (URL)</span>
-                        <input v-model="seriesForm.hero_image" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
-                    </label>
+                    <MediaField
+                        v-model="seriesForm.hero_image"
+                        label="Hero image"
+                        kind="brand"
+                        :tags="['series', 'hero']"
+                        accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                        placeholder="/media/library/original/series.webp"
+                    />
                     <label class="text-sm space-y-1 block">
                         <span class="text-gray-600 dark:text-slate-300 font-medium">Описание серии</span>
                         <textarea v-model="seriesForm.description" rows="5" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -15,8 +15,8 @@ import {
 } from 'lucide-vue-next';
 import { api, type ManagerMediaAssetResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
+import ImageCropSelector, { type ImageCropSourceSize, type ImageCropValue } from '../components/ImageCropSelector.vue';
 
-type CropBox = { x: number; y: number; width: number; height: number };
 type MediaKind = { value: string; label: string };
 
 const kindOptions: MediaKind[] = [
@@ -52,9 +52,8 @@ const toast = ref('');
 const toastType = ref<'success' | 'error'>('success');
 const dragActive = ref(false);
 const cropMode = ref(false);
-const cropBox = ref<CropBox | null>(null);
-const cropStart = ref<{ x: number; y: number } | null>(null);
-const previewImage = ref<HTMLImageElement | null>(null);
+const cropBox = ref<ImageCropValue>({ x: 0, y: 0, width: 0, height: 0 });
+const cropSourceSize = ref<ImageCropSourceSize>({ width: 0, height: 0 });
 const editForm = ref({
   title: '',
   alt_text: '',
@@ -255,7 +254,11 @@ const selectAsset = (asset: ManagerMediaAssetResponse) => {
     tagsText: (asset.tags || []).join(', '),
   };
   cropMode.value = false;
-  cropBox.value = null;
+  cropBox.value = { x: 0, y: 0, width: 0, height: 0 };
+  cropSourceSize.value = {
+    width: Number(asset.width || 0),
+    height: Number(asset.height || 0),
+  };
 };
 
 const saveSelected = async () => {
@@ -308,61 +311,41 @@ const deleteSelected = async () => {
   }
 };
 
-const relativePoint = (event: PointerEvent) => {
-  const target = event.currentTarget as HTMLElement;
-  const rect = target.getBoundingClientRect();
-  return {
-    x: Math.max(0, Math.min(event.clientX - rect.left, rect.width)),
-    y: Math.max(0, Math.min(event.clientY - rect.top, rect.height)),
-  };
-};
-
-const onCropPointerDown = (event: PointerEvent) => {
-  if (!cropMode.value) return;
-  const point = relativePoint(event);
-  cropStart.value = point;
-  cropBox.value = { x: point.x, y: point.y, width: 1, height: 1 };
-  (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
-};
-
-const onCropPointerMove = (event: PointerEvent) => {
-  if (!cropMode.value || !cropStart.value) return;
-  const point = relativePoint(event);
-  const start = cropStart.value;
+const resetCropBoxToFullFrame = () => {
+  if (!cropSourceSize.value.width || !cropSourceSize.value.height) return;
   cropBox.value = {
-    x: Math.min(start.x, point.x),
-    y: Math.min(start.y, point.y),
-    width: Math.abs(point.x - start.x),
-    height: Math.abs(point.y - start.y),
+    x: 0,
+    y: 0,
+    width: cropSourceSize.value.width,
+    height: cropSourceSize.value.height,
   };
 };
 
-const onCropPointerUp = (event: PointerEvent) => {
-  if (!cropMode.value) return;
-  cropStart.value = null;
-  try {
-    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
-  } catch {
-    // Pointer capture may already be released by the browser.
+const toggleCropMode = () => {
+  cropMode.value = !cropMode.value;
+  if (cropMode.value) resetCropBoxToFullFrame();
+};
+
+const handleCropSourceLoad = (size: ImageCropSourceSize) => {
+  cropSourceSize.value = size;
+  if (cropMode.value && (!cropBox.value.width || !cropBox.value.height)) {
+    resetCropBoxToFullFrame();
   }
 };
 
 const applyCrop = async () => {
-  if (!selectedAsset.value || !cropBox.value || !previewImage.value) return;
+  if (!selectedAsset.value) return;
   if (cropBox.value.width < 8 || cropBox.value.height < 8) {
     setToast('Выделите область крупнее', 'error');
     return;
   }
-  const image = previewImage.value;
-  const scaleX = image.naturalWidth / image.clientWidth;
-  const scaleY = image.naturalHeight / image.clientHeight;
   processing.value = 'crop';
   try {
     const cropped = await api.cropMediaAsset(selectedAsset.value.id, {
-      x: Math.round(cropBox.value.x * scaleX),
-      y: Math.round(cropBox.value.y * scaleY),
-      width: Math.round(cropBox.value.width * scaleX),
-      height: Math.round(cropBox.value.height * scaleY),
+      x: Math.round(cropBox.value.x),
+      y: Math.round(cropBox.value.y),
+      width: Math.round(cropBox.value.width),
+      height: Math.round(cropBox.value.height),
       title: `${selectedAsset.value.title || 'Image'} crop`,
     });
     assets.value = [cropped, ...assets.value];
@@ -635,24 +618,21 @@ onUnmounted(() => {
 
           <div class="space-y-5 overflow-y-auto p-4">
             <div class="rounded-xl bg-gray-100 p-3 dark:bg-gray-950">
-              <div
-                class="relative mx-auto inline-block max-h-[420px] max-w-full select-none"
-                :class="cropMode ? 'cursor-crosshair' : ''"
-                @pointerdown="onCropPointerDown"
-                @pointermove="onCropPointerMove"
-                @pointerup="onCropPointerUp"
-              >
+              <ImageCropSelector
+                v-if="cropMode"
+                v-model="cropBox"
+                :src="selectedUrl"
+                :source-width="cropSourceSize.width"
+                :source-height="cropSourceSize.height"
+                :image-alt="selectedAsset.alt_text || selectedAsset.title || 'Изображение медиатеки'"
+                @source-load="handleCropSourceLoad"
+              />
+              <div v-else class="mx-auto flex max-h-[420px] max-w-full justify-center">
                 <img
-                  ref="previewImage"
                   :src="selectedUrl"
                   :alt="selectedAsset.alt_text || selectedAsset.title"
                   class="block max-h-[420px] max-w-full rounded-lg object-contain"
                   draggable="false"
-                />
-                <div
-                  v-if="cropMode && cropBox"
-                  class="pointer-events-none absolute border-2 border-teal-400 bg-teal-400/15 shadow-[0_0_0_9999px_rgba(15,23,42,0.35)]"
-                  :style="{ left: `${cropBox.x}px`, top: `${cropBox.y}px`, width: `${cropBox.width}px`, height: `${cropBox.height}px` }"
                 />
               </div>
             </div>
@@ -662,7 +642,7 @@ onUnmounted(() => {
                 <Copy class="h-4 w-4" />
                 URL
               </button>
-              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800" @click="cropMode = !cropMode; cropBox = null">
+              <button class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800" @click="toggleCropMode">
                 <Scissors class="h-4 w-4" />
                 Crop
               </button>
@@ -678,8 +658,8 @@ onUnmounted(() => {
 
             <div v-if="cropMode" class="rounded-lg border border-teal-200 bg-teal-50 p-3 dark:border-teal-900 dark:bg-teal-950/30">
               <div class="flex items-center justify-between gap-3">
-                <p class="text-sm text-teal-900 dark:text-teal-100">Выделите область на изображении.</p>
-                <button class="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-teal-700 disabled:opacity-50" :disabled="!cropBox || processing === 'crop'" @click="applyCrop">
+                <p class="text-sm text-teal-900 dark:text-teal-100">Потяните рамку или углы, чтобы выбрать область.</p>
+                <button class="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-teal-700 disabled:opacity-50" :disabled="!cropBox.width || !cropBox.height || processing === 'crop'" @click="applyCrop">
                   <Scissors class="h-4 w-4" />
                   {{ processing === 'crop' ? 'Сохраняю...' : 'Сохранить crop' }}
                 </button>

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -5,6 +5,7 @@ import {
     api,
     type ManagerBrand,
     type Product,
+    type ProductImageCropPayload,
     type ProductImageVariantBatchProcessResponse,
     type ProductImageVariantCandidateResponse,
     type ProductImageVariantResponse,
@@ -12,12 +13,13 @@ import {
 import {
     Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images,
     Settings, ArrowLeft, LayoutGrid, List, Package, Link2, ExternalLink,
-    Star, SlidersHorizontal, X, Trash2, Download,
+    Star, SlidersHorizontal, X, Trash2, Download, Crop,
 } from 'lucide-vue-next';
 import BulkSpecsModal from '../components/BulkSpecsModal.vue';
 import BulkCompatibilityModal from '../components/BulkCompatibilityModal.vue';
 import ProductEditModal from '../components/ProductEditModal.vue';
 import OnlinerImportModal from '../components/OnlinerImportModal.vue';
+import ImageCropSelector, { type ImageCropSourceSize } from '../components/ImageCropSelector.vue';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 // Product state
@@ -516,6 +518,7 @@ watch(showModal, (val) => {
     document.body.style.overflow = '';
     confirmDeleteUrl.value = null;
     resetVariantState();
+    resetCropEditor();
   }
 });
 
@@ -699,7 +702,6 @@ const openSearchModal = (product: Product) => {
   resetVariantState();
   showModal.value = true;
   handleImageSearch();
-  loadVariantCandidates();
 };
 
 const openEditModal = (product: Product) => {
@@ -740,6 +742,14 @@ const getImageUrl = (path: string) => {
 type GalleryImage = Product['gallery_images'][number];
 type VariantStatus = 'ready' | 'failed' | 'skipped' | 'pending' | 'unknown';
 
+const cropEditorOpen = ref(false);
+const cropEditorImage = ref<GalleryImage | null>(null);
+const cropSaving = ref(false);
+const cropMode = ref<'append' | 'replace'>('append');
+const cropSetMain = ref(false);
+const cropSourceSize = ref({ width: 0, height: 0 });
+const cropForm = ref({ x: 0, y: 0, width: 0, height: 0 });
+
 const boundedVariantLimit = computed(() => {
     const parsed = Number(variantLimit.value);
     if (!Number.isFinite(parsed)) return 50;
@@ -757,6 +767,101 @@ const variantCandidateByImageId = computed(() => {
 const displayedGalleryImages = computed<GalleryImage[]>(() => (
     selectedProduct.value?.gallery_images || []
 ).filter((image) => includeInstallationVariants.value || !image.is_installation_photo));
+
+const cropCanSetMain = computed(() => Boolean(cropEditorImage.value && !cropEditorImage.value.is_installation_photo));
+
+const clampCropForm = () => {
+    const source = cropSourceSize.value;
+    if (!source.width || !source.height) return;
+
+    const maxX = Math.max(0, source.width - 1);
+    const maxY = Math.max(0, source.height - 1);
+    const x = Math.max(0, Math.min(Math.trunc(Number(cropForm.value.x) || 0), maxX));
+    const y = Math.max(0, Math.min(Math.trunc(Number(cropForm.value.y) || 0), maxY));
+    const maxWidth = Math.max(1, source.width - x);
+    const maxHeight = Math.max(1, source.height - y);
+
+    cropForm.value = {
+        x,
+        y,
+        width: Math.max(1, Math.min(Math.trunc(Number(cropForm.value.width) || 1), maxWidth)),
+        height: Math.max(1, Math.min(Math.trunc(Number(cropForm.value.height) || 1), maxHeight)),
+    };
+};
+
+const resetCropToFullFrame = () => {
+    const source = cropSourceSize.value;
+    if (!source.width || !source.height) return;
+    cropForm.value = { x: 0, y: 0, width: source.width, height: source.height };
+};
+
+const setCenteredSquareCrop = () => {
+    const source = cropSourceSize.value;
+    if (!source.width || !source.height) return;
+    const side = Math.min(source.width, source.height);
+    cropForm.value = {
+        x: Math.round((source.width - side) / 2),
+        y: Math.round((source.height - side) / 2),
+        width: side,
+        height: side,
+    };
+};
+
+const openCropEditor = (image: GalleryImage) => {
+    cropEditorImage.value = image;
+    cropMode.value = 'append';
+    cropSetMain.value = false;
+    cropSourceSize.value = { width: 0, height: 0 };
+    cropForm.value = { x: 0, y: 0, width: 0, height: 0 };
+    cropEditorOpen.value = true;
+};
+
+const closeCropEditor = () => {
+    if (cropSaving.value) return;
+    cropEditorOpen.value = false;
+    cropEditorImage.value = null;
+};
+
+const resetCropEditor = () => {
+    cropEditorOpen.value = false;
+    cropEditorImage.value = null;
+    cropSaving.value = false;
+    cropSetMain.value = false;
+};
+
+const handleCropSourceLoad = (size: ImageCropSourceSize) => {
+    cropSourceSize.value = size;
+    resetCropToFullFrame();
+};
+
+const saveCrop = async () => {
+    if (!cropEditorImage.value) return;
+    clampCropForm();
+
+    const payload: ProductImageCropPayload = {
+        x: cropForm.value.x,
+        y: cropForm.value.y,
+        width: cropForm.value.width,
+        height: cropForm.value.height,
+        mode: cropMode.value,
+        set_main: cropCanSetMain.value ? cropSetMain.value : false,
+    };
+
+    cropSaving.value = true;
+    try {
+        await api.cropGalleryImage(cropEditorImage.value.id, payload);
+        await loadProducts();
+        refreshSelectedProduct();
+        setToast(cropMode.value === 'replace' ? 'Фото заменено после кропа' : 'Кроп добавлен в галерею');
+        cropEditorOpen.value = false;
+        cropEditorImage.value = null;
+    } catch (e) {
+        setToast(`Ошибка кропа: ${getApiErrorMessage(e)}`);
+        console.error(e);
+    } finally {
+        cropSaving.value = false;
+    }
+};
 
 const mergeVariantRecords = (variants: ProductImageVariantResponse[] = []) => {
     const next: Record<number, ProductImageVariantResponse[]> = { ...variantRecordsByImageId.value };
@@ -1706,7 +1811,7 @@ watchDebounced(
   
   <!-- Search / Manage Modal -->
   <div v-if="showModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" @click.self="showModal = false">
-      <div class="bg-white rounded-xl w-full max-w-6xl h-[90vh] flex flex-col shadow-2xl">
+      <div class="relative bg-white rounded-xl w-full max-w-6xl h-[90vh] flex flex-col shadow-2xl">
           <!-- Tabs -->
           <div class="flex border-b bg-gray-50 rounded-t-xl">
                <button 
@@ -1818,7 +1923,7 @@ watchDebounced(
           
           <!-- Current Product Gallery Preview (Footer) -->
           <div class="h-60 bg-white border-t p-4 overflow-x-auto flex gap-4 shrink-0">
-              <div class="w-72 shrink-0 border-r pr-4 text-sm">
+              <div v-if="isBulkMode" class="w-72 shrink-0 border-r pr-4 text-sm">
                   <div class="font-semibold text-gray-700">
                       {{ isBulkMode ? 'Общая галерея' : 'Текущая галерея' }}
                   </div>
@@ -1944,6 +2049,13 @@ watchDebounced(
                       <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 p-2 transition-opacity">
                            <button @click="setAsMain(img.id)" class="text-[10px] bg-white text-black px-2 py-1 rounded hover:bg-gray-200 w-full">Сделать главным</button>
                            <button
+                              @click="openCropEditor(img)"
+                              class="inline-flex w-full items-center justify-center gap-1 rounded bg-white px-2 py-1 text-[10px] font-medium text-gray-900 hover:bg-gray-200"
+                           >
+                              <Crop class="h-3 w-3" />
+                              Кроп
+                           </button>
+                           <button
                               @click="reprocessCardVariant(img.id)"
                               :disabled="variantReprocessingImageId === img.id || variantProcessingLoading"
                               class="text-[10px] bg-teal-600 text-white px-2 py-1 rounded hover:bg-teal-700 disabled:opacity-60 w-full"
@@ -1961,6 +2073,108 @@ watchDebounced(
                       </div>
                   </div>
               </template>
+          </div>
+          <div
+              v-if="cropEditorOpen && cropEditorImage"
+              class="absolute inset-0 z-20 flex items-center justify-center bg-slate-950/55 p-3 sm:p-6"
+              @click.self="closeCropEditor"
+          >
+              <div class="flex max-h-full w-full max-w-4xl flex-col overflow-hidden rounded-xl bg-white shadow-2xl">
+                  <div class="flex items-start justify-between gap-4 border-b border-gray-200 px-4 py-3 sm:px-5">
+                      <div class="min-w-0">
+                          <h3 class="truncate text-lg font-semibold text-gray-950">Кроп фото товара</h3>
+                          <p class="mt-0.5 truncate text-sm text-gray-500">
+                              {{ cropSourceSize.width || '...' }}×{{ cropSourceSize.height || '...' }} · #{{ cropEditorImage.id }}
+                          </p>
+                      </div>
+                      <button
+                          type="button"
+                          class="rounded-lg p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+                          @click="closeCropEditor"
+                      >
+                          <X class="h-5 w-5" />
+                      </button>
+                  </div>
+
+                  <div class="grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+                      <div class="flex min-h-[260px] items-center justify-center rounded-lg bg-gray-100 p-3">
+                          <ImageCropSelector
+                              v-model="cropForm"
+                              :src="getImageUrl(cropEditorImage.url)"
+                              :source-width="cropSourceSize.width"
+                              :source-height="cropSourceSize.height"
+                              image-alt="Фото товара для кропа"
+                              @source-load="handleCropSourceLoad"
+                          />
+                      </div>
+
+                      <div class="space-y-4">
+                          <div class="grid grid-cols-2 gap-3">
+                              <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                  X
+                                  <input id="product-crop-x" v-model.number="cropForm.x" name="product-crop-x" type="number" min="0" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" @change="clampCropForm" />
+                              </label>
+                              <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                  Y
+                                  <input id="product-crop-y" v-model.number="cropForm.y" name="product-crop-y" type="number" min="0" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" @change="clampCropForm" />
+                              </label>
+                              <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                  Ширина
+                                  <input id="product-crop-width" v-model.number="cropForm.width" name="product-crop-width" type="number" min="1" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" @change="clampCropForm" />
+                              </label>
+                              <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                  Высота
+                                  <input id="product-crop-height" v-model.number="cropForm.height" name="product-crop-height" type="number" min="1" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500" @change="clampCropForm" />
+                              </label>
+                          </div>
+
+                          <div class="flex flex-wrap gap-2">
+                              <button type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" @click="resetCropToFullFrame">
+                                  Весь кадр
+                              </button>
+                              <button type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" @click="setCenteredSquareCrop">
+                                  Квадрат по центру
+                              </button>
+                          </div>
+
+                          <div class="rounded-lg border border-gray-200 p-2">
+                              <label class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm text-gray-700 hover:bg-gray-50">
+                                  <input v-model="cropMode" name="product-crop-mode" type="radio" value="append" class="text-teal-600 focus:ring-teal-500" />
+                                  Добавить как новое фото
+                              </label>
+                              <label class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-sm text-gray-700 hover:bg-gray-50">
+                                  <input v-model="cropMode" name="product-crop-mode" type="radio" value="replace" class="text-teal-600 focus:ring-teal-500" />
+                                  Заменить это фото
+                              </label>
+                          </div>
+
+                          <label class="flex items-center gap-2 text-sm text-gray-700" :class="{ 'opacity-50': !cropCanSetMain }">
+                              <input id="product-crop-set-main" v-model="cropSetMain" name="product-crop-set-main" type="checkbox" class="rounded border-gray-300 text-teal-600 focus:ring-teal-500" :disabled="!cropCanSetMain" />
+                              Сделать главным
+                          </label>
+                      </div>
+                  </div>
+
+                  <div class="flex flex-col-reverse gap-2 border-t border-gray-200 p-4 sm:flex-row sm:justify-end">
+                      <button
+                          type="button"
+                          class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                          :disabled="cropSaving"
+                          @click="closeCropEditor"
+                      >
+                          Отмена
+                      </button>
+                      <button
+                          type="button"
+                          class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700 disabled:opacity-50"
+                          :disabled="cropSaving || !cropSourceSize.width"
+                          @click="saveCrop"
+                      >
+                          <Crop class="h-4 w-4" />
+                          {{ cropSaving ? 'Сохраняем...' : 'Сохранить кроп' }}
+                      </button>
+                  </div>
+              </div>
           </div>
       </div>
   </div>

--- a/openapi.json
+++ b/openapi.json
@@ -4814,6 +4814,64 @@
         }
       }
     },
+    "/api/manager/gallery/{image_id}/crop": {
+      "post": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Crop Product Image",
+        "description": "Crop a concrete ProductImage and either append or replace the gallery image.",
+        "operationId": "crop_product_image",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Image Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductImageCropPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaImageLinkResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/gallery/reuse-image": {
       "post": {
         "tags": [
@@ -26375,6 +26433,52 @@
           "slug"
         ],
         "title": "ProductBrandResponse"
+      },
+      "ProductImageCropPayload": {
+        "properties": {
+          "x": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "X"
+          },
+          "y": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Y"
+          },
+          "width": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Width"
+          },
+          "height": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Height"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "append",
+              "replace"
+            ],
+            "title": "Mode",
+            "default": "append"
+          },
+          "set_main": {
+            "type": "boolean",
+            "title": "Set Main",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "x",
+          "y",
+          "width",
+          "height"
+        ],
+        "title": "ProductImageCropPayload"
       },
       "ProductImageResponse": {
         "properties": {

--- a/routers/manager_media_gallery_write.py
+++ b/routers/manager_media_gallery_write.py
@@ -11,6 +11,7 @@ from routers.manager_operation_ids import (
     BULK_DELETE_COMMON_GALLERY_IMAGES,
     BULK_UPLOAD_LOCAL_IMAGES,
     CLEANUP_MEDIA,
+    CROP_PRODUCT_IMAGE,
     DELETE_IMAGE,
     LINK_SEARCH_RESULT,
     PROCESS_MISSING_IMAGE_VARIANTS,
@@ -29,6 +30,7 @@ from schemas import (
     ManagerMediaImageLinkResponse,
     ManagerMediaReuseImageResponse,
     ManagerMediaSetMainImageResponse,
+    ProductImageCropPayload,
     ProductImageVariantBatchProcessResponse,
     ProductImageVariantResponse,
 )
@@ -98,6 +100,33 @@ async def delete_gallery_image(
         return await ManagerMediaService.delete_gallery_image(session, image_id)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post(
+    "/gallery/{image_id}/crop",
+    response_model=ManagerMediaImageLinkResponse,
+    operation_id=CROP_PRODUCT_IMAGE,
+)
+async def crop_product_image(
+    image_id: int,
+    payload: ProductImageCropPayload,
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    """Crop a concrete ProductImage and either append or replace the gallery image."""
+    try:
+        return await ManagerMediaService.crop_gallery_image(
+            session=session,
+            image_id=image_id,
+            x=payload.x,
+            y=payload.y,
+            width=payload.width,
+            height=payload.height,
+            mode=payload.mode,
+            set_main=payload.set_main,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -49,6 +49,7 @@ GET_COMMON_GALLERY_IMAGES = "get_common_gallery_images"
 LINK_SEARCH_RESULT = "link_search_result"
 SET_MAIN_IMAGE = "set_main_image"
 DELETE_IMAGE = "delete_image"
+CROP_PRODUCT_IMAGE = "crop_product_image"
 REUSE_IMAGE = "reuse_image"
 BULK_ADD_GALLERY_IMAGES = "bulk_add_gallery_images"
 BULK_UPLOAD_LOCAL_IMAGES = "bulk_upload_local_images"
@@ -254,6 +255,7 @@ ALL_MANAGER_OPERATION_IDS = (
     LINK_SEARCH_RESULT,
     SET_MAIN_IMAGE,
     DELETE_IMAGE,
+    CROP_PRODUCT_IMAGE,
     REUSE_IMAGE,
     BULK_ADD_GALLERY_IMAGES,
     BULK_UPLOAD_LOCAL_IMAGES,

--- a/schemas.py
+++ b/schemas.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, Dict
+from typing import List, Optional, Any, Dict, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, computed_field
 from datetime import datetime
 from enum import Enum
@@ -1824,6 +1824,15 @@ class ManagerMediaReuseSearchItemResponse(BaseModel):
 class ManagerMediaImageLinkResponse(BaseModel):
     id: int
     url: str
+
+
+class ProductImageCropPayload(BaseModel):
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    mode: Literal["append", "replace"] = "append"
+    set_main: bool = False
 
 
 class ProductImageVariantResponse(BaseModel):

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -2,11 +2,14 @@
 
 import asyncio
 import os
+from io import BytesIO
+from pathlib import Path
 from typing import List, Set
 
 import httpx
 from core.logger import logger
 from duckduckgo_search import DDGS
+from PIL import Image, ImageOps, UnidentifiedImageError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import func
 from sqlmodel import select, update
@@ -63,6 +66,88 @@ class ManagerMediaService:
         for variant_url in variant_urls:
             await ManagerMediaService.remove_file_if_unreferenced(session, variant_url)
         return {"message": "Image deleted"}
+
+    @staticmethod
+    async def crop_gallery_image(
+        session: AsyncSession,
+        image_id: int,
+        *,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        mode: str = "append",
+        set_main: bool = False,
+    ) -> dict:
+        image = await session.get(ProductImage, image_id)
+        if not image:
+            raise ValueError("Image not found")
+
+        product = await session.get(Product, image.product_id)
+        if not product:
+            raise ValueError("Product not found")
+
+        try:
+            source_content = await ManagerMediaService.load_image_source_content(image.url)
+            cropped_content = await asyncio.to_thread(
+                ManagerMediaService.crop_image_bytes,
+                source_content,
+                x,
+                y,
+                width,
+                height,
+            )
+        except UnidentifiedImageError as exc:
+            raise ValueError("Source image cannot be opened") from exc
+
+        normalized_mode = mode if mode in {"append", "replace"} else "append"
+        if normalized_mode == "append":
+            return await ManagerMediaService.save_image_from_bytes(
+                image_content=cropped_content,
+                product_id=product.id,
+                session=session,
+                set_main=set_main and not image.is_installation_photo,
+                is_installation=image.is_installation_photo,
+            )
+
+        old_url = image.url
+        was_main = product.main_image == old_url
+        original = await ProductOriginalMediaService.save_shared_original(cropped_content)
+
+        variant_rows = (
+            await session.execute(
+                select(ProductImageVariant).where(ProductImageVariant.product_image_id == image.id)
+            )
+        ).scalars().all()
+        variant_urls = [variant.url for variant in variant_rows if variant.url]
+        for variant in variant_rows:
+            await session.delete(variant)
+
+        image.url = original.url
+        session.add(image)
+        await session.flush()
+        await ProductImageVariantService.ensure_original_variant(
+            session,
+            image,
+            source_content=original.content,
+            extension="webp",
+            width=original.width,
+            height=original.height,
+        )
+
+        if (was_main or set_main) and not image.is_installation_photo:
+            product.main_image = original.url
+            session.add(product)
+
+        await ManagerMediaService.sync_legacy_images(session, product.id)
+        await session.commit()
+        await session.refresh(image)
+
+        await ManagerMediaService.remove_file_if_unreferenced(session, old_url)
+        for variant_url in variant_urls:
+            await ManagerMediaService.remove_file_if_unreferenced(session, variant_url)
+
+        return {"id": image.id, "url": image.url}
 
     @staticmethod
     async def search_reuse_products(session: AsyncSession, query: str, limit: int = 10) -> List[dict]:
@@ -247,6 +332,51 @@ class ManagerMediaService:
                 os.remove(path)
             except Exception as exc:
                 logger.error(f"Failed to delete unreferenced file {url}: {exc}")
+
+    @staticmethod
+    def local_media_path_for_url(url: str) -> Path | None:
+        if not url:
+            return None
+        if url.startswith("/media/"):
+            return Path(url.lstrip("/"))
+        if url.startswith("media/"):
+            return Path(url)
+        return None
+
+    @staticmethod
+    async def load_image_source_content(url: str) -> bytes:
+        source_path = ManagerMediaService.local_media_path_for_url(url)
+        if source_path is not None and source_path.exists():
+            return await asyncio.to_thread(source_path.read_bytes)
+
+        if url.startswith("http://") or url.startswith("https://"):
+            try:
+                async with httpx.AsyncClient(follow_redirects=True) as client:
+                    response = await client.get(url, timeout=15.0)
+                    response.raise_for_status()
+                    return response.content
+            except Exception as exc:
+                logger.error(f"Failed to download source image for crop: {exc}")
+                raise ValueError("Source image is not available") from exc
+
+        raise ValueError("Source image is not available in local media storage")
+
+    @staticmethod
+    def crop_image_bytes(content: bytes, x: int, y: int, width: int, height: int) -> bytes:
+        if not content:
+            raise ValueError("Source image is empty")
+        with Image.open(BytesIO(content)) as source:
+            image = ImageOps.exif_transpose(source)
+            left = max(0, min(int(x), image.width - 1))
+            top = max(0, min(int(y), image.height - 1))
+            right = max(left + 1, min(left + int(width), image.width))
+            bottom = max(top + 1, min(top + int(height), image.height))
+            cropped = image.crop((left, top, right, bottom))
+            if cropped.mode in {"RGBA", "P"}:
+                cropped = cropped.convert("RGB")
+            output = BytesIO()
+            cropped.save(output, format="PNG")
+            return output.getvalue()
 
     @staticmethod
     async def get_common_gallery_urls(

--- a/services/media_library_service.py
+++ b/services/media_library_service.py
@@ -5,7 +5,9 @@ import hashlib
 import ipaddress
 import math
 import os
+import re
 import socket
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
@@ -19,7 +21,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import Article, MediaAsset, Product, ProductImage, ProductImageVariant
+from models import Article, Brand, MediaAsset, Product, ProductImage, ProductImageVariant, ProductSeries
 from services.product_image_processing_contract import ProductImageVariantType
 from services.product_image_processing_provider import (
     ProductImageProcessingContext,
@@ -32,6 +34,8 @@ MEDIA_LIBRARY_PUBLIC_PREFIX = "/media/library"
 MAX_LIBRARY_IMAGE_PIXELS = 50_000_000
 MAX_REMOTE_IMAGE_BYTES = 20 * 1024 * 1024
 REMOTE_IMAGE_TIMEOUT_SECONDS = 12.0
+SVG_MIME_TYPE = "image/svg+xml"
+SVG_FORBIDDEN_TAGS = {"script", "foreignobject", "iframe", "object", "embed"}
 ALLOWED_KINDS = {
     "product",
     "article",
@@ -229,6 +233,8 @@ class MediaLibraryService:
         created_by: str | None,
     ) -> dict:
         source = await MediaLibraryService._get_asset_or_raise(session, asset_id)
+        if source.mime_type == SVG_MIME_TYPE:
+            raise ValueError("SVG assets cannot be cropped")
         source_path = MediaLibraryService._local_path_for_url(source.url)
         if source_path is None or not source_path.exists():
             raise ValueError("Source file is not available in local media storage")
@@ -262,6 +268,8 @@ class MediaLibraryService:
         created_by: str | None,
     ) -> dict:
         source = await MediaLibraryService._get_asset_or_raise(session, asset_id)
+        if source.mime_type == SVG_MIME_TYPE:
+            raise ValueError("SVG assets cannot be processed by background removal")
         source_path = MediaLibraryService._local_path_for_url(source.url)
         if source_path is None or not source_path.exists():
             raise ValueError("Source file is not available in local media storage")
@@ -383,6 +391,9 @@ class MediaLibraryService:
 
     @staticmethod
     async def _store_image(content: bytes, *, variant_type: str) -> StoredLibraryImage:
+        if MediaLibraryService._looks_like_svg(content):
+            return await MediaLibraryService._store_svg(content, variant_type=variant_type)
+
         webp_content = await asyncio.to_thread(
             lambda: MediaLibraryService._export_webp(MediaLibraryService._open_image(content))
         )
@@ -487,6 +498,28 @@ class MediaLibraryService:
         )
 
     @staticmethod
+    async def _store_svg(content: bytes, *, variant_type: str) -> StoredLibraryImage:
+        sanitized, width, height = await asyncio.to_thread(MediaLibraryService._sanitize_svg, content)
+        content_hash = hashlib.sha256(sanitized).hexdigest()
+        safe_variant = MediaLibraryService._safe_path_segment(variant_type)
+        target_dir = MEDIA_LIBRARY_BASE_DIR / safe_variant
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / f"{content_hash}.svg"
+        if not target_path.exists():
+            target_path.write_bytes(sanitized)
+
+        relative_path = str(target_path).replace(os.sep, "/")
+        return StoredLibraryImage(
+            url=f"{MEDIA_LIBRARY_PUBLIC_PREFIX}/{safe_variant}/{target_path.name}",
+            path=relative_path,
+            content_hash=content_hash,
+            width=width,
+            height=height,
+            size_bytes=len(sanitized),
+            mime_type=SVG_MIME_TYPE,
+        )
+
+    @staticmethod
     def _open_image(content: bytes) -> Image.Image:
         if not content:
             raise ValueError("Source image is empty")
@@ -514,6 +547,90 @@ class MediaLibraryService:
     def _image_size(content: bytes) -> tuple[int, int]:
         image = MediaLibraryService._open_image(content)
         return image.width, image.height
+
+    @staticmethod
+    def _looks_like_svg(content: bytes) -> bool:
+        prefix = content[:512].lstrip()
+        lowered = prefix.lower()
+        return lowered.startswith(b"<svg") or lowered.startswith(b"<?xml") and b"<svg" in lowered
+
+    @staticmethod
+    def _sanitize_svg(content: bytes) -> tuple[bytes, int, int]:
+        if not content:
+            raise ValueError("Source SVG is empty")
+        if len(content) > MAX_REMOTE_IMAGE_BYTES:
+            raise ValueError("Source SVG is too large")
+
+        text = content.decode("utf-8-sig").strip()
+        lowered = text.lower()
+        if "<!doctype" in lowered or "<!entity" in lowered:
+            raise ValueError("SVG doctype and entities are not allowed")
+
+        try:
+            root = ET.fromstring(text)
+        except ET.ParseError as exc:
+            raise ValueError("Source SVG cannot be parsed") from exc
+
+        if MediaLibraryService._local_xml_name(root.tag) != "svg":
+            raise ValueError("Source SVG must have an svg root element")
+
+        for element in root.iter():
+            tag_name = MediaLibraryService._local_xml_name(element.tag)
+            if tag_name.lower() in SVG_FORBIDDEN_TAGS:
+                raise ValueError("SVG contains unsupported embedded content")
+            for attr_name, attr_value in element.attrib.items():
+                local_attr = MediaLibraryService._local_xml_name(attr_name).lower()
+                value = str(attr_value or "").strip().lower()
+                if local_attr.startswith("on"):
+                    raise ValueError("SVG event handlers are not allowed")
+                if local_attr in {"href", "src"} and value and not value.startswith("#"):
+                    raise ValueError("SVG external references are not allowed")
+                if local_attr == "style" and ("javascript:" in value or "expression(" in value):
+                    raise ValueError("SVG unsafe inline styles are not allowed")
+                if MediaLibraryService._has_external_svg_url(value):
+                    raise ValueError("SVG external references are not allowed")
+
+        width, height = MediaLibraryService._svg_size(root)
+        return ET.tostring(root, encoding="utf-8", xml_declaration=True), width, height
+
+    @staticmethod
+    def _local_xml_name(name: str) -> str:
+        return name.rsplit("}", 1)[-1] if "}" in name else name
+
+    @staticmethod
+    def _has_external_svg_url(value: str) -> bool:
+        for match in re.finditer(r"url\(([^)]+)\)", value, flags=re.IGNORECASE):
+            target = match.group(1).strip(" \t\r\n'\"")
+            if target and not target.startswith("#"):
+                return True
+        return False
+
+    @staticmethod
+    def _svg_size(root: ET.Element) -> tuple[int, int]:
+        width = MediaLibraryService._svg_dimension(root.attrib.get("width"))
+        height = MediaLibraryService._svg_dimension(root.attrib.get("height"))
+        if width and height:
+            return width, height
+
+        view_box = root.attrib.get("viewBox") or root.attrib.get("viewbox")
+        if view_box:
+            try:
+                parts = [float(part) for part in re.split(r"[\s,]+", view_box.strip()) if part]
+            except ValueError:
+                parts = []
+            if len(parts) == 4 and parts[2] > 0 and parts[3] > 0:
+                return max(1, round(parts[2])), max(1, round(parts[3]))
+
+        return width or 0, height or 0
+
+    @staticmethod
+    def _svg_dimension(value: str | None) -> int:
+        if not value:
+            return 0
+        match = re.match(r"^\s*([0-9]+(?:\.[0-9]+)?)", value)
+        if not match:
+            return 0
+        return max(1, round(float(match.group(1))))
 
     @staticmethod
     def _has_alpha(image: Image.Image) -> bool:
@@ -554,6 +671,14 @@ class MediaLibraryService:
                 select(func.count()).select_from(Article).where(
                     or_(Article.main_image == url, Article.cover_image == url)
                 )
+            )
+        )
+        counts.append(
+            await session.scalar(select(func.count()).select_from(Brand).where(Brand.logo_url == url))
+        )
+        counts.append(
+            await session.scalar(
+                select(func.count()).select_from(ProductSeries).where(ProductSeries.hero_image == url)
             )
         )
         return sum(int(value or 0) for value in counts)

--- a/tests/unit/test_manager_media_service_crop.py
+++ b/tests/unit/test_manager_media_service_crop.py
@@ -1,0 +1,153 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+import models  # noqa: F401
+from models import Product, ProductImage
+from services.manager_media_service import ManagerMediaService
+
+
+def image_bytes(size=(120, 90), color=(30, 120, 210)) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", size, color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source_path = tmp_path / "media" / "products" / "source.png"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_bytes(image_bytes())
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def make_product_with_image(session: AsyncSession) -> tuple[Product, ProductImage]:
+    product = Product(
+        title="Crop Test",
+        slug="crop-test",
+        price=1000,
+        main_image="/media/products/source.png",
+        images=["/media/products/source.png"],
+    )
+    session.add(product)
+    await session.flush()
+
+    image = ProductImage(
+        product_id=product.id,
+        url="/media/products/source.png",
+    )
+    session.add(image)
+    await session.commit()
+    await session.refresh(product)
+    await session.refresh(image)
+    return product, image
+
+
+@pytest.mark.asyncio
+async def test_crop_gallery_image_appends_new_product_image(sqlite_session):
+    product, source_image = await make_product_with_image(sqlite_session)
+
+    result = await ManagerMediaService.crop_gallery_image(
+        sqlite_session,
+        source_image.id,
+        x=10,
+        y=10,
+        width=50,
+        height=40,
+        mode="append",
+    )
+
+    rows = (
+        await sqlite_session.execute(
+            select(ProductImage).where(ProductImage.product_id == product.id)
+        )
+    ).scalars().all()
+    await sqlite_session.refresh(product)
+
+    assert result["id"] != source_image.id
+    assert result["url"].startswith("/media/products/shared/")
+    assert len(rows) == 2
+    assert product.main_image == "/media/products/source.png"
+
+
+@pytest.mark.asyncio
+async def test_crop_gallery_image_replaces_source_and_main_image(sqlite_session):
+    product, source_image = await make_product_with_image(sqlite_session)
+
+    result = await ManagerMediaService.crop_gallery_image(
+        sqlite_session,
+        source_image.id,
+        x=5,
+        y=5,
+        width=60,
+        height=50,
+        mode="replace",
+    )
+
+    await sqlite_session.refresh(product)
+    await sqlite_session.refresh(source_image)
+
+    assert result["id"] == source_image.id
+    assert result["url"].startswith("/media/products/shared/")
+    assert source_image.url == result["url"]
+    assert product.main_image == result["url"]
+    assert product.images == [result["url"]]
+
+
+@pytest.mark.asyncio
+async def test_crop_gallery_image_downloads_remote_source(sqlite_session, monkeypatch):
+    product = Product(
+        title="Remote Crop Test",
+        slug="remote-crop-test",
+        price=1000,
+        main_image="https://example.com/source.png",
+        images=["https://example.com/source.png"],
+    )
+    sqlite_session.add(product)
+    await sqlite_session.flush()
+    source_image = ProductImage(
+        product_id=product.id,
+        url="https://example.com/source.png",
+    )
+    sqlite_session.add(source_image)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(product)
+    await sqlite_session.refresh(source_image)
+
+    async def fake_load_source_content(_url: str) -> bytes:
+        return image_bytes(size=(160, 120))
+
+    monkeypatch.setattr(
+        ManagerMediaService,
+        "load_image_source_content",
+        staticmethod(fake_load_source_content),
+    )
+
+    result = await ManagerMediaService.crop_gallery_image(
+        sqlite_session,
+        source_image.id,
+        x=10,
+        y=10,
+        width=70,
+        height=60,
+        mode="append",
+        set_main=True,
+    )
+
+    await sqlite_session.refresh(product)
+
+    assert result["url"].startswith("/media/products/shared/")
+    assert product.main_image == result["url"]

--- a/tests/unit/test_media_library_service.py
+++ b/tests/unit/test_media_library_service.py
@@ -17,6 +17,13 @@ def image_bytes(size=(120, 80), color=(20, 180, 160)) -> bytes:
     return buffer.getvalue()
 
 
+def svg_bytes() -> bytes:
+    return b"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80">
+        <rect width="240" height="80" fill="#0f766e"/>
+        <text x="24" y="52" fill="#fff">MVN</text>
+    </svg>"""
+
+
 @pytest.fixture
 async def sqlite_session(tmp_path, monkeypatch):
     monkeypatch.setattr(media_library_service, "MEDIA_LIBRARY_BASE_DIR", tmp_path / "library")
@@ -57,6 +64,71 @@ async def test_upload_and_list_media_assets(sqlite_session):
     )
     assert listing["meta"]["total"] == 1
     assert listing["items"][0]["id"] == item["id"]
+
+
+@pytest.mark.asyncio
+async def test_upload_svg_media_asset_keeps_vector_source(sqlite_session):
+    response = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("brand-logo.svg", svg_bytes())],
+        kind="brand",
+        tags=["logo"],
+        created_by="admin",
+    )
+
+    assert response["uploaded"] == 1
+    item = response["items"][0]
+    assert item["url"].startswith("/media/library/original/")
+    assert item["url"].endswith(".svg")
+    assert item["mime_type"] == "image/svg+xml"
+    assert item["kind"] == "brand"
+    assert item["tags"] == ["logo"]
+    assert item["width"] == 240
+    assert item["height"] == 80
+
+    with pytest.raises(ValueError, match="SVG assets cannot be cropped"):
+        await MediaLibraryService.crop_asset(
+            session=sqlite_session,
+            asset_id=item["id"],
+            x=0,
+            y=0,
+            width=20,
+            height=20,
+            title="logo crop",
+            created_by="admin",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_svg_media_asset_rejects_script(sqlite_session):
+    with pytest.raises(ValueError, match="unsupported embedded content"):
+        await MediaLibraryService.upload_assets(
+            session=sqlite_session,
+            files=[("unsafe.svg", b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>')],
+            kind="brand",
+            tags=["logo"],
+            created_by="admin",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_svg_media_asset_allows_internal_style_references(sqlite_session):
+    content = b"""<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+        <defs>
+            <linearGradient id="brand"><stop offset="0" stop-color="#00a991"/></linearGradient>
+        </defs>
+        <rect width="16" height="16" style="fill:url(#brand)"/>
+    </svg>"""
+
+    response = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("gradient-logo.svg", content)],
+        kind="brand",
+        tags=["logo"],
+        created_by="admin",
+    )
+
+    assert response["items"][0]["mime_type"] == "image/svg+xml"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что изменилось

- Добавлен переиспользуемый `ImageCropSelector` для кропа с перетаскиванием области и четырьмя угловыми ручками.
- Интегрирован кроп в медиатеку и в модалку фото товара: можно добавить кроп как новое фото или заменить исходное, с опцией сделать главным.
- Добавлен backend endpoint `POST /api/manager/gallery/{image_id}/crop` и сервисная логика для локальных и удалённых исходников товара.
- Добавлен переиспользуемый `MediaField` и применён в брендах/сериях для логотипа и hero image.
- Расширена медиатека: SVG хранится как векторный исходник, санитайзится, учитывается в used-count для брендов/серий; SVG не отправляется в raster crop/background removal.
- Обновлены OpenAPI и сгенерированный manager client.

## Аудит и проверки

- Код-аудит по зонам риска: backend crop/storage, SVG sanitation, frontend crop coordinates/mobile UX, OpenAPI/client contract.
- Исправлено найденное на аудите: SVG `style="url(#id)"` для внутренних градиентов/масок теперь разрешён, внешние URL и unsafe styles остаются заблокированы.
- `pytest tests/unit/test_media_library_service.py tests/unit/test_manager_media_service_crop.py tests/unit/test_manager_operation_ids_contract.py -q`
- `python3 -m compileall services/manager_media_service.py services/media_library_service.py routers/manager_media_gallery_write.py schemas.py`
- `cd manager_frontend && npm run build`
- Browser QA: проверены product crop и media library crop с угловыми ручками, перемещением области и мобильной компоновкой.

## Деплой

- Миграции БД не требуются.
- Storefront (`web/`) не менялся.
- Ожидаемый путь выкладки: backend deploy workflow, который собирает manager frontend в backend image.
