### PR TITLE
[codex] Add background removal provider layer

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -270,8 +270,8 @@ export const api = {
         return await ManagerMediaService.cropMediaAsset(assetId, payload);
     },
 
-    async removeMediaAssetBackground(assetId: number): Promise<ManagerMediaAssetResponse> {
-        return await ManagerMediaService.removeMediaAssetBackground(assetId);
+    async removeMediaAssetBackground(assetId: number, provider = 'auto'): Promise<ManagerMediaAssetResponse> {
+        return await ManagerMediaService.removeMediaAssetBackground(assetId, provider);
     },
 
     async deleteMediaAsset(assetId: number, force = false) {

--- a/manager_frontend/src/client/services/ManagerMediaService.ts
+++ b/manager_frontend/src/client/services/ManagerMediaService.ts
@@ -163,17 +163,22 @@ export class ManagerMediaService {
     /**
      * Remove Media Asset Background
      * @param assetId
+     * @param provider Processing provider: auto, noop, manual, rembg, birefnet, ben
      * @returns ManagerMediaAssetResponse Successful Response
      * @throws ApiError
      */
     public static removeMediaAssetBackground(
         assetId: number,
+        provider: string = 'auto',
     ): CancelablePromise<ManagerMediaAssetResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/manager/media/assets/{asset_id}/remove-background',
             path: {
                 'asset_id': assetId,
+            },
+            query: {
+                'provider': provider,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -1144,7 +1144,7 @@ export class ManagerService {
      * @param limit
      * @param includeInstallation
      * @param dryRun
-     * @param provider Processing provider: noop, manual, rembg
+     * @param provider Processing provider: auto, noop, manual, rembg, birefnet, ben
      * @returns ProductImageVariantBatchProcessResponse Successful Response
      * @throws ApiError
      */
@@ -1175,7 +1175,7 @@ export class ManagerService {
      * Retry/reprocess a failed or skipped image variant.
      * @param imageId
      * @param variantType Variant to reprocess: processed, card, full
-     * @param provider Processing provider: noop, manual, rembg
+     * @param provider Processing provider: auto, noop, manual, rembg, birefnet, ben
      * @returns ProductImageVariantResponse Successful Response
      * @throws ApiError
      */

--- a/manager_frontend/src/utils/media-processing.ts
+++ b/manager_frontend/src/utils/media-processing.ts
@@ -1,0 +1,13 @@
+export type BackgroundRemovalProvider = 'auto' | 'noop' | 'manual' | 'rembg' | 'birefnet' | 'ben';
+
+export const backgroundRemovalProviderOptions: Array<{
+  value: BackgroundRemovalProvider;
+  label: string;
+}> = [
+  { value: 'auto', label: 'auto' },
+  { value: 'noop', label: 'noop' },
+  { value: 'manual', label: 'manual' },
+  { value: 'rembg', label: 'rembg' },
+  { value: 'birefnet', label: 'BiRefNet' },
+  { value: 'ben', label: 'BEN' },
+];

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -15,6 +15,10 @@ import {
 } from 'lucide-vue-next';
 import { api, type ManagerMediaAssetResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
+import {
+  backgroundRemovalProviderOptions,
+  type BackgroundRemovalProvider,
+} from '../utils/media-processing';
 import ImageCropSelector, { type ImageCropSourceSize, type ImageCropValue } from '../components/ImageCropSelector.vue';
 
 type MediaKind = { value: string; label: string };
@@ -35,6 +39,7 @@ const uploading = ref(false);
 const saving = ref(false);
 const deleting = ref(false);
 const processing = ref<'crop' | 'background' | ''>('');
+const backgroundProvider = ref<BackgroundRemovalProvider>('auto');
 const page = ref(1);
 const limit = ref(40);
 const total = ref(0);
@@ -93,6 +98,9 @@ const mediaErrorMessage = (err: unknown, fallback: string) => {
   }
   if (/rembg provider is not installed/i.test(message)) {
     return 'Удаление фона пока не настроено: установите rembg в backend-окружении.';
+  }
+  if (/provider is not configured|provider is not installed/i.test(message)) {
+    return 'Провайдер удаления фона пока не настроен на backend. Проверьте env-команду или зависимости модели.';
   }
   return message;
 };
@@ -362,7 +370,10 @@ const removeBackground = async () => {
   if (!selectedAsset.value) return;
   processing.value = 'background';
   try {
-    const processed = await api.removeMediaAssetBackground(selectedAsset.value.id);
+    const processed = await api.removeMediaAssetBackground(
+      selectedAsset.value.id,
+      backgroundProvider.value,
+    );
     assets.value = [processed, ...assets.value];
     selectAsset(processed);
     setToast('Версия без фона готова');
@@ -655,6 +666,21 @@ onUnmounted(() => {
                 Удалить
               </button>
             </div>
+            <label class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Провайдер удаления фона
+              <select
+                v-model="backgroundProvider"
+                class="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-teal-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+              >
+                <option
+                  v-for="option in backgroundRemovalProviderOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+            </label>
 
             <div v-if="cropMode" class="rounded-lg border border-teal-200 bg-teal-50 p-3 dark:border-teal-900 dark:bg-teal-950/30">
               <div class="flex items-center justify-between gap-3">

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -21,6 +21,10 @@ import ProductEditModal from '../components/ProductEditModal.vue';
 import OnlinerImportModal from '../components/OnlinerImportModal.vue';
 import ImageCropSelector, { type ImageCropSourceSize } from '../components/ImageCropSelector.vue';
 import { getApiErrorMessage } from '../utils/api-errors';
+import {
+    backgroundRemovalProviderOptions,
+    type BackgroundRemovalProvider,
+} from '../utils/media-processing';
 
 // Product state
 const products = ref<Product[]>([]);
@@ -46,7 +50,7 @@ const showOnlinerImportModal = ref(false);
 const yandexPriceListLoading = ref(false);
 const variantLimit = ref(50);
 const includeInstallationVariants = ref(false);
-const variantProvider = ref<'noop' | 'manual' | 'rembg'>('noop');
+const variantProvider = ref<BackgroundRemovalProvider>('noop');
 const variantCandidatesLoading = ref(false);
 const variantProcessingLoading = ref(false);
 const variantReprocessingImageId = ref<number | null>(null);
@@ -1946,9 +1950,13 @@ watchDebounced(
                           class="h-8 rounded-md border border-gray-300 px-2 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500"
                           title="Провайдер обработки variant card"
                       >
-                          <option value="noop">noop</option>
-                          <option value="manual">manual</option>
-                          <option value="rembg">rembg</option>
+                          <option
+                              v-for="option in backgroundRemovalProviderOptions"
+                              :key="option.value"
+                              :value="option.value"
+                          >
+                              {{ option.label }}
+                          </option>
                       </select>
                       <label class="flex items-center gap-1 text-xs text-gray-600">
                           <input v-model="includeInstallationVariants" type="checkbox" class="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />

--- a/openapi.json
+++ b/openapi.json
@@ -4446,6 +4446,18 @@
               "type": "integer",
               "title": "Asset Id"
             }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben",
+              "default": "auto",
+              "title": "Provider"
+            },
+            "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben"
           }
         ],
         "responses": {
@@ -5134,11 +5146,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "description": "Processing provider: noop, manual, rembg",
+              "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben",
               "default": "noop",
               "title": "Provider"
             },
-            "description": "Processing provider: noop, manual, rembg"
+            "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben"
           }
         ],
         "responses": {
@@ -5206,11 +5218,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "description": "Processing provider: noop, manual, rembg",
+              "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben",
               "default": "noop",
               "title": "Provider"
             },
-            "description": "Processing provider: noop, manual, rembg"
+            "description": "Processing provider: auto, noop, manual, rembg, birefnet, ben"
           }
         ],
         "responses": {

--- a/routers/manager_media_gallery_write.py
+++ b/routers/manager_media_gallery_write.py
@@ -233,7 +233,7 @@ async def process_missing_image_variants(
     limit: int = Query(100, ge=1, le=100),
     include_installation: bool = Query(False),
     dry_run: bool = Query(True),
-    provider: str = Query("noop", description="Processing provider: noop, manual, rembg"),
+    provider: str = Query("noop", description="Processing provider: auto, noop, manual, rembg, birefnet, ben"),
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):
@@ -259,7 +259,7 @@ async def process_missing_image_variants(
 async def reprocess_image_variant(
     image_id: int,
     variant_type: str = Query("card", description="Variant to reprocess: processed, card, full"),
-    provider: str = Query("noop", description="Processing provider: noop, manual, rembg"),
+    provider: str = Query("noop", description="Processing provider: auto, noop, manual, rembg, birefnet, ben"),
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -170,6 +170,7 @@ async def crop_media_asset(
 )
 async def remove_media_asset_background(
     asset_id: int,
+    provider: str = Query("auto", description="Processing provider: auto, noop, manual, rembg, birefnet, ben"),
     session: AsyncSession = Depends(get_session),
     username: str = Depends(get_current_username),
 ):
@@ -178,6 +179,7 @@ async def remove_media_asset_background(
             session=session,
             asset_id=asset_id,
             created_by=username,
+            provider=provider,
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/scripts/process_product_image_variants.py
+++ b/scripts/process_product_image_variants.py
@@ -27,8 +27,12 @@ PROCESSABLE_VARIANTS = (
     ProductImageVariantType.FULL.value,
 )
 CLI_PROVIDERS = (
+    ProductImageProcessingProvider.AUTO.value,
     ProductImageProcessingProvider.NOOP.value,
+    ProductImageProcessingProvider.MANUAL.value,
     ProductImageProcessingProvider.REMBG.value,
+    ProductImageProcessingProvider.BIREFNET.value,
+    ProductImageProcessingProvider.BEN.value,
 )
 
 
@@ -137,7 +141,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--provider",
         choices=CLI_PROVIDERS,
         default=ProductImageProcessingProvider.NOOP.value,
-        help="Processing provider. noop means local Pillow normalization without background removal.",
+        help=(
+            "Processing provider. noop means local Pillow normalization without background "
+            "removal; auto uses BACKGROUND_REMOVAL_PROVIDER."
+        ),
     )
     parser.add_argument(
         "--include-installation",

--- a/services/media_library_service.py
+++ b/services/media_library_service.py
@@ -25,7 +25,7 @@ from models import Article, Brand, MediaAsset, Product, ProductImage, ProductIma
 from services.product_image_processing_contract import ProductImageVariantType
 from services.product_image_processing_provider import (
     ProductImageProcessingContext,
-    RembgProductImageProcessor,
+    get_product_image_processor,
 )
 
 
@@ -266,6 +266,7 @@ class MediaLibraryService:
         *,
         asset_id: int,
         created_by: str | None,
+        provider: str = "auto",
     ) -> dict:
         source = await MediaLibraryService._get_asset_or_raise(session, asset_id)
         if source.mime_type == SVG_MIME_TYPE:
@@ -274,7 +275,7 @@ class MediaLibraryService:
         if source_path is None or not source_path.exists():
             raise ValueError("Source file is not available in local media storage")
 
-        processor = RembgProductImageProcessor()
+        processor = get_product_image_processor(provider)
         processed = await processor.process(
             source_content=source_path.read_bytes(),
             context=ProductImageProcessingContext(

--- a/services/product_image_processing_contract.py
+++ b/services/product_image_processing_contract.py
@@ -43,9 +43,12 @@ class ProductImageManualQualityStatus(str, Enum):
 
 
 class ProductImageProcessingProvider(str, Enum):
+    AUTO = "auto"
     MANUAL = "manual"
     NOOP = "noop"
     REMBG = "rembg"
+    BIREFNET = "birefnet"
+    BEN = "ben"
 
 
 CATALOG_VARIANT_TYPES = {

--- a/services/product_image_processing_provider.py
+++ b/services/product_image_processing_provider.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
+import shlex
+import subprocess
+import tempfile
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Protocol
@@ -22,6 +27,14 @@ CARD_PADDING_RATIO = 0.08
 PROCESSED_MAX_EDGE = 1600
 FULL_MAX_EDGE = 1800
 MAX_SOURCE_PIXELS = 40_000_000
+BACKGROUND_REMOVAL_PROVIDER_ENV = "BACKGROUND_REMOVAL_PROVIDER"
+BACKGROUND_REMOVAL_TIMEOUT_ENV = "BACKGROUND_REMOVAL_TIMEOUT_SECONDS"
+BACKGROUND_REMOVAL_COMMAND_ENVS = {
+    ProductImageProcessingProvider.BIREFNET.value: "BACKGROUND_REMOVAL_BIREFNET_COMMAND",
+    ProductImageProcessingProvider.BEN.value: "BACKGROUND_REMOVAL_BEN_COMMAND",
+}
+DEFAULT_BACKGROUND_REMOVAL_PROVIDER = ProductImageProcessingProvider.REMBG.value
+DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS = 120
 
 
 @dataclass(frozen=True)
@@ -91,14 +104,166 @@ class RembgProductImageProcessor:
         return _process_image_bytes(output, context=context)
 
 
+class CommandProductImageProcessor:
+    """Adapter for model runners wired by env command templates.
+
+    The command receives `{input}` and `{output}` placeholders. This lets ops test
+    BEN, BiRefNet, or any local/remote wrapper without changing the app contract.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider_name: str,
+        command_env: str,
+        timeout_seconds: int | None = None,
+    ):
+        self.provider_name = provider_name
+        self.command_env = command_env
+        self.timeout_seconds = timeout_seconds or _background_removal_timeout_seconds()
+
+    async def process(
+        self,
+        *,
+        source_content: bytes,
+        context: ProductImageProcessingContext,
+    ) -> ProductImageProcessingResult:
+        command_template = os.getenv(self.command_env, "").strip()
+        if not command_template:
+            raise RuntimeError(
+                f"{self.provider_name} provider is not configured: set {self.command_env}"
+            )
+
+        output = await asyncio.to_thread(
+            self._run_command,
+            command_template,
+            source_content,
+        )
+        return _process_image_bytes(output, context=context)
+
+    def _run_command(self, command_template: str, source_content: bytes) -> bytes:
+        with tempfile.TemporaryDirectory(prefix=f"{self.provider_name}-bg-") as tmp_dir:
+            input_path = os.path.join(tmp_dir, "input.png")
+            output_path = os.path.join(tmp_dir, "output.png")
+            with open(input_path, "wb") as input_file:
+                input_file.write(source_content)
+
+            command = command_template.format(
+                input=shlex.quote(input_path),
+                output=shlex.quote(output_path),
+            )
+            completed = subprocess.run(
+                command,
+                shell=True,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+            if completed.returncode != 0:
+                stderr = (completed.stderr or completed.stdout or "").strip()
+                detail = f": {stderr[:500]}" if stderr else ""
+                raise RuntimeError(f"{self.provider_name} provider failed{detail}")
+            if not os.path.exists(output_path):
+                raise RuntimeError(
+                    f"{self.provider_name} provider did not create output image"
+                )
+            with open(output_path, "rb") as output_file:
+                return output_file.read()
+
+
+class BiRefNetProductImageProcessor(CommandProductImageProcessor):
+    def __init__(self):
+        super().__init__(
+            provider_name=ProductImageProcessingProvider.BIREFNET.value,
+            command_env=BACKGROUND_REMOVAL_COMMAND_ENVS[
+                ProductImageProcessingProvider.BIREFNET.value
+            ],
+        )
+
+
+class BenProductImageProcessor(CommandProductImageProcessor):
+    def __init__(self):
+        super().__init__(
+            provider_name=ProductImageProcessingProvider.BEN.value,
+            command_env=BACKGROUND_REMOVAL_COMMAND_ENVS[ProductImageProcessingProvider.BEN.value],
+        )
+
+
 def get_product_image_processor(provider: str) -> ProductImageProcessor:
-    if provider == ProductImageProcessingProvider.NOOP.value:
+    normalized_provider = resolve_background_removal_provider(provider)
+    if normalized_provider == ProductImageProcessingProvider.AUTO.value:
+        normalized_provider = DEFAULT_BACKGROUND_REMOVAL_PROVIDER
+    if normalized_provider == ProductImageProcessingProvider.NOOP.value:
         return NoopProductImageProcessor()
-    if provider == ProductImageProcessingProvider.MANUAL.value:
+    if normalized_provider == ProductImageProcessingProvider.MANUAL.value:
         return ManualProductImageProcessor()
-    if provider == ProductImageProcessingProvider.REMBG.value:
+    if normalized_provider == ProductImageProcessingProvider.REMBG.value:
         return RembgProductImageProcessor()
+    if normalized_provider == ProductImageProcessingProvider.BIREFNET.value:
+        return BiRefNetProductImageProcessor()
+    if normalized_provider == ProductImageProcessingProvider.BEN.value:
+        return BenProductImageProcessor()
     raise ValueError(f"Unsupported image processing provider={provider!r}")
+
+
+def resolve_background_removal_provider(provider: str | None) -> str:
+    requested = (provider or ProductImageProcessingProvider.AUTO.value).strip().lower()
+    if requested != ProductImageProcessingProvider.AUTO.value:
+        return requested
+
+    configured = os.getenv(
+        BACKGROUND_REMOVAL_PROVIDER_ENV,
+        DEFAULT_BACKGROUND_REMOVAL_PROVIDER,
+    ).strip().lower()
+    if not configured or configured == ProductImageProcessingProvider.AUTO.value:
+        return DEFAULT_BACKGROUND_REMOVAL_PROVIDER
+    return configured
+
+
+def background_removal_provider_options() -> list[dict[str, str]]:
+    return [
+        {
+            "value": ProductImageProcessingProvider.AUTO.value,
+            "label": "auto",
+            "description": f"Use {BACKGROUND_REMOVAL_PROVIDER_ENV}, default rembg",
+        },
+        {
+            "value": ProductImageProcessingProvider.NOOP.value,
+            "label": "noop",
+            "description": "Normalize image without background removal",
+        },
+        {
+            "value": ProductImageProcessingProvider.MANUAL.value,
+            "label": "manual",
+            "description": "Manual/operator-approved processing alias",
+        },
+        {
+            "value": ProductImageProcessingProvider.REMBG.value,
+            "label": "rembg",
+            "description": "Python rembg package",
+        },
+        {
+            "value": ProductImageProcessingProvider.BIREFNET.value,
+            "label": "BiRefNet",
+            "description": f"Command adapter via {BACKGROUND_REMOVAL_COMMAND_ENVS['birefnet']}",
+        },
+        {
+            "value": ProductImageProcessingProvider.BEN.value,
+            "label": "BEN",
+            "description": f"Command adapter via {BACKGROUND_REMOVAL_COMMAND_ENVS['ben']}",
+        },
+    ]
+
+
+def _background_removal_timeout_seconds() -> int:
+    raw_value = os.getenv(BACKGROUND_REMOVAL_TIMEOUT_ENV, "").strip()
+    if not raw_value:
+        return DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        return DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS
 
 
 def _process_image_bytes(

--- a/services/product_image_variant_service.py
+++ b/services/product_image_variant_service.py
@@ -261,10 +261,12 @@ class ProductImageVariantService:
             product_image_id=product_image_id,
             variant_type=normalized_type,
         )
+        active_processor = processor or get_product_image_processor(normalized_provider)
+        effective_provider = getattr(active_processor, "provider_name", normalized_provider)
         now = datetime.now()
         variant.processing_status = ProductImageProcessingStatus.PROCESSING.value
         variant.processing_stage = ProductImageProcessingStage.VARIANT_GENERATION.value
-        variant.processing_provider = normalized_provider
+        variant.processing_provider = effective_provider
         variant.processing_error = None
         variant.updated_at = now
         session.add(variant)
@@ -291,7 +293,6 @@ class ProductImageVariantService:
                 await session.commit()
             return ProductImageVariantService.serialize_variant(variant)
 
-        active_processor = processor or get_product_image_processor(normalized_provider)
         active_storage = storage or get_product_media_storage()
         try:
             source_content = source_path.read_bytes()

--- a/tests/unit/test_media_library_service.py
+++ b/tests/unit/test_media_library_service.py
@@ -24,6 +24,19 @@ def svg_bytes() -> bytes:
     </svg>"""
 
 
+class FakeBackgroundProcessor:
+    provider_name = "ben"
+
+    async def process(self, *, source_content: bytes, context):
+        class Result:
+            content = image_bytes(size=(48, 32), color=(200, 20, 80))
+            extension = "webp"
+            width = 48
+            height = 32
+
+        return Result()
+
+
 @pytest.fixture
 async def sqlite_session(tmp_path, monkeypatch):
     monkeypatch.setattr(media_library_service, "MEDIA_LIBRARY_BASE_DIR", tmp_path / "library")
@@ -159,6 +172,38 @@ async def test_crop_media_asset_creates_variant(sqlite_session):
     assert cropped["width"] == 60
     assert cropped["height"] == 40
     assert cropped["tags"] == ["обложка"]
+
+
+@pytest.mark.asyncio
+async def test_remove_background_uses_selected_provider(sqlite_session, monkeypatch):
+    requested_providers = []
+
+    def fake_get_processor(provider: str):
+        requested_providers.append(provider)
+        return FakeBackgroundProcessor()
+
+    monkeypatch.setattr(media_library_service, "get_product_image_processor", fake_get_processor)
+    upload = await MediaLibraryService.upload_assets(
+        session=sqlite_session,
+        files=[("source.png", image_bytes(size=(160, 120)))],
+        kind="product",
+        tags=["товар"],
+        created_by="admin",
+    )
+    source = upload["items"][0]
+
+    processed = await MediaLibraryService.remove_background(
+        session=sqlite_session,
+        asset_id=source["id"],
+        created_by="admin",
+        provider="ben",
+    )
+
+    assert requested_providers == ["ben"]
+    assert processed["parent_asset_id"] == source["id"]
+    assert processed["variant_type"] == "background_removed"
+    assert processed["width"] == 48
+    assert processed["height"] == 32
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_product_image_processing_provider.py
+++ b/tests/unit/test_product_image_processing_provider.py
@@ -1,0 +1,91 @@
+import sys
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from services.product_image_processing_contract import ProductImageProcessingProvider
+from services.product_image_processing_provider import (
+    BenProductImageProcessor,
+    CommandProductImageProcessor,
+    ProductImageProcessingContext,
+    RembgProductImageProcessor,
+    background_removal_provider_options,
+    get_product_image_processor,
+    resolve_background_removal_provider,
+)
+
+
+def image_bytes(size=(120, 80), color=(20, 180, 160)) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", size, color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_auto_provider_uses_default_when_env_is_empty(monkeypatch):
+    monkeypatch.delenv("BACKGROUND_REMOVAL_PROVIDER", raising=False)
+
+    assert resolve_background_removal_provider("auto") == ProductImageProcessingProvider.REMBG.value
+    assert isinstance(get_product_image_processor("auto"), RembgProductImageProcessor)
+
+
+def test_auto_provider_uses_env_override(monkeypatch):
+    monkeypatch.setenv("BACKGROUND_REMOVAL_PROVIDER", "ben")
+
+    processor = get_product_image_processor("auto")
+
+    assert isinstance(processor, BenProductImageProcessor)
+    assert processor.provider_name == "ben"
+
+
+def test_background_provider_options_include_candidate_models():
+    values = {item["value"] for item in background_removal_provider_options()}
+
+    assert {"auto", "rembg", "birefnet", "ben", "noop", "manual"} <= values
+
+
+@pytest.mark.asyncio
+async def test_command_provider_runs_configured_adapter(tmp_path, monkeypatch):
+    script = tmp_path / "copy_image.py"
+    script.write_text(
+        "import shutil, sys\n"
+        "shutil.copyfile(sys.argv[1], sys.argv[2])\n"
+    )
+    processor = CommandProductImageProcessor(
+        provider_name="ben",
+        command_env="TEST_BEN_COMMAND",
+        timeout_seconds=5,
+    )
+
+    monkeypatch.setenv("TEST_BEN_COMMAND", f"{sys.executable} {script} {{input}} {{output}}")
+    result = await processor.process(
+        source_content=image_bytes(size=(40, 30)),
+        context=ProductImageProcessingContext(
+            product_image_id=1,
+            source_url="/media/source.png",
+            variant_type="processed",
+        ),
+    )
+
+    assert result.content
+    assert result.width == 40
+    assert result.height == 30
+
+
+@pytest.mark.asyncio
+async def test_command_provider_requires_command_env():
+    processor = CommandProductImageProcessor(
+        provider_name="birefnet",
+        command_env="TEST_MISSING_BIREFNET_COMMAND",
+        timeout_seconds=5,
+    )
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        await processor.process(
+            source_content=image_bytes(size=(40, 30)),
+            context=ProductImageProcessingContext(
+                product_image_id=1,
+                source_url="/media/source.png",
+                variant_type="processed",
+            ),
+        )


### PR DESCRIPTION
## Что изменилось

- Добавлен pluggable background-removal provider layer для product/media processing.
- Расширены провайдеры: `auto`, `noop`, `manual`, `rembg`, `birefnet`, `ben`.
- `auto` читает `BACKGROUND_REMOVAL_PROVIDER`, по умолчанию остаётся `rembg`.
- `BEN` и `BiRefNet` подключаются как command adapters:
  - `BACKGROUND_REMOVAL_BEN_COMMAND`
  - `BACKGROUND_REMOVAL_BIREFNET_COMMAND`
  - команда получает `{input}` и `{output}` placeholder'ы.
- Добавлен общий timeout `BACKGROUND_REMOVAL_TIMEOUT_SECONDS`.
- Медиатека больше не hardcode'ит `RembgProductImageProcessor`; endpoint `/api/manager/media/assets/{asset_id}/remove-background` принимает `provider` query.
- Product gallery variant endpoints и CLI теперь принимают тот же набор provider values.
- Manager UI получил общий список провайдеров: медиатека показывает provider select для “Без фона”, товары расширяют существующий select для `card` variants.
- Обновлены OpenAPI и сгенерированный manager client.

## Зачем

Нам нужно сравнивать rembg/BiRefNet/BEN и будущие модели на реальных изображениях кондиционеров, не переписывая UI/API под каждую модель. Этот PR создаёт стабильную “розетку”: сервер можно переключать env-переменными или подключать модель через wrapper script.

## Настройка примера

```bash
BACKGROUND_REMOVAL_PROVIDER=ben
BACKGROUND_REMOVAL_BEN_COMMAND="python3 /opt/bg-runners/ben_remove.py {input} {output}"
BACKGROUND_REMOVAL_TIMEOUT_SECONDS=180
```

Для BiRefNet аналогично через `BACKGROUND_REMOVAL_BIREFNET_COMMAND`.

## Аудит и проверки

- Делегирован backend-аудит текущих provider/cleanup/media flows.
- Делегирован frontend-аудит UI-точек удаления фона и мобильных рисков.
- `pytest tests/unit/test_product_image_processing_provider.py tests/unit/test_media_library_service.py tests/unit/test_product_image_variants.py tests/unit/test_manager_operation_ids_contract.py -q`
- `python3 -m compileall services/product_image_processing_contract.py services/product_image_processing_provider.py services/product_image_variant_service.py services/media_library_service.py routers/manager_media_library.py routers/manager_media_gallery_write.py scripts/process_product_image_variants.py`
- `cd manager_frontend && npm run build`
- Browser QA: `/manager/media` показывает provider select после выбора ассета; варианты `auto/noop/manual/rembg/BiRefNet/BEN`; console errors отсутствуют.

## Ограничения

- Реальные BEN/BiRefNet веса и runner scripts не входят в PR.
- Main image cleanup approval-flow пока не переключён на новый provider layer; его лучше подключать отдельным PR, чтобы не смешивать candidate/approve semantics с медиатекой.
