### PR TITLE
[codex] Harden rembg defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,9 @@ PRODUCT_MEDIA_S3_CACHE_CONTROL=public, max-age=31536000, immutable
 # --- Background removal providers ---
 BACKGROUND_REMOVAL_PROVIDER=rembg
 BACKGROUND_REMOVAL_REMBG_MODEL=u2net
-BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS=u2net,isnet-general-use,birefnet-general-lite,birefnet-general,birefnet-massive,bria-rmbg
+# Keep production warmup conservative. Heavy/experimental rembg models can be
+# tested manually by overriding this value, but should not preload by default.
+BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS=u2net
 BACKGROUND_REMOVAL_TIMEOUT_SECONDS=120
 BACKGROUND_REMOVAL_BIREFNET_COMMAND=
 BACKGROUND_REMOVAL_BEN_COMMAND=

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -50,11 +50,6 @@ const backgroundModel = ref('u2net');
 const backgroundModelsLoading = ref(false);
 const backgroundModelOptions = ref<BackgroundRemovalModelOption[]>([
   { value: 'u2net', label: 'U2Net', recommended: true },
-  { value: 'isnet-general-use', label: 'ISNet general', recommended: true },
-  { value: 'birefnet-general-lite', label: 'BiRefNet lite', recommended: true },
-  { value: 'birefnet-general', label: 'BiRefNet general', recommended: true },
-  { value: 'birefnet-massive', label: 'BiRefNet massive' },
-  { value: 'bria-rmbg', label: 'BRIA RMBG' },
 ]);
 const page = ref(1);
 const limit = ref(40);

--- a/scripts/warmup_rembg_models.py
+++ b/scripts/warmup_rembg_models.py
@@ -23,7 +23,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--models",
         default="",
-        help="Comma-separated rembg model names. Defaults to BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS or the popular model list.",
+        help="Comma-separated rembg model names. Defaults to BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS or the safe preload list.",
     )
     parser.add_argument(
         "--fail-fast",

--- a/services/product_image_processing_provider.py
+++ b/services/product_image_processing_provider.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from io import BytesIO
 from typing import Any, Protocol
 
@@ -39,30 +39,32 @@ BACKGROUND_REMOVAL_COMMAND_ENVS = {
 DEFAULT_BACKGROUND_REMOVAL_PROVIDER = ProductImageProcessingProvider.REMBG.value
 DEFAULT_BACKGROUND_REMOVAL_REMBG_MODEL = "u2net"
 DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS = 120
-REMBG_MODEL_OPTIONS = [
+SAFE_REMBG_MODEL_OPTIONS = [
     {
         "value": "u2net",
         "label": "U2Net",
         "description": "Stable baseline model for the first comparison pass.",
         "recommended": True,
     },
+]
+EXPERIMENTAL_REMBG_MODEL_OPTIONS = [
     {
         "value": "isnet-general-use",
         "label": "ISNet general",
         "description": "Often handles complex edges and light products more carefully.",
-        "recommended": True,
+        "recommended": False,
     },
     {
         "value": "birefnet-general-lite",
         "label": "BiRefNet lite",
         "description": "Faster BiRefNet candidate for quality comparison.",
-        "recommended": True,
+        "recommended": False,
     },
     {
         "value": "birefnet-general",
         "label": "BiRefNet general",
         "description": "High-quality general model, usually heavier than lite.",
-        "recommended": True,
+        "recommended": False,
     },
     {
         "value": "birefnet-massive",
@@ -77,7 +79,8 @@ REMBG_MODEL_OPTIONS = [
         "recommended": False,
     },
 ]
-DEFAULT_REMBG_PRELOAD_MODELS = tuple(item["value"] for item in REMBG_MODEL_OPTIONS)
+REMBG_MODEL_OPTIONS = [*SAFE_REMBG_MODEL_OPTIONS, *EXPERIMENTAL_REMBG_MODEL_OPTIONS]
+DEFAULT_REMBG_PRELOAD_MODELS = tuple(item["value"] for item in SAFE_REMBG_MODEL_OPTIONS)
 
 
 @dataclass(frozen=True)
@@ -148,7 +151,16 @@ class RembgProductImageProcessor:
             raise RuntimeError("rembg provider is not installed") from exc
 
         session = _get_rembg_session(self.model_name)
-        output = remove(source_content, session=session)
+        timeout_seconds = _background_removal_timeout_seconds()
+        try:
+            output = await asyncio.wait_for(
+                asyncio.to_thread(partial(remove, source_content, session=session)),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(
+                f"rembg provider timed out after {timeout_seconds}s: {self.model_name}"
+            ) from exc
         return _process_image_bytes(output, context=context)
 
 
@@ -308,8 +320,9 @@ def background_removal_provider_options() -> list[dict[str, str]]:
     ]
 
 
-def rembg_model_options() -> list[dict[str, Any]]:
-    return [dict(item) for item in REMBG_MODEL_OPTIONS]
+def rembg_model_options(*, include_experimental: bool = False) -> list[dict[str, Any]]:
+    options = REMBG_MODEL_OPTIONS if include_experimental else SAFE_REMBG_MODEL_OPTIONS
+    return [dict(item) for item in options]
 
 
 def default_rembg_model_name() -> str:

--- a/tests/unit/test_product_image_processing_provider.py
+++ b/tests/unit/test_product_image_processing_provider.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from io import BytesIO
 
 import pytest
@@ -67,8 +68,14 @@ def test_rembg_processor_records_model_in_provider_name():
     assert processor.provider_name == "rembg:isnet-general-use"
 
 
-def test_rembg_model_options_include_popular_candidates():
-    values = {item["value"] for item in rembg_model_options()}
+def test_rembg_model_options_expose_only_safe_default_candidates():
+    values = [item["value"] for item in rembg_model_options()]
+
+    assert values == ["u2net"]
+
+
+def test_rembg_model_options_keep_experimental_candidates_for_manual_ops():
+    values = {item["value"] for item in rembg_model_options(include_experimental=True)}
 
     assert {
         "u2net",
@@ -82,8 +89,7 @@ def test_rembg_model_options_include_popular_candidates():
 
 def test_rembg_preload_models_use_default_and_env_override(monkeypatch):
     monkeypatch.delenv("BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS", raising=False)
-    assert rembg_preload_model_names()[0] == "u2net"
-    assert "birefnet-general" in rembg_preload_model_names()
+    assert rembg_preload_model_names() == ["u2net"]
 
     monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS", "u2net, birefnet-general, u2net")
     assert rembg_preload_model_names() == ["u2net", "birefnet-general"]
@@ -161,6 +167,38 @@ async def test_rembg_processor_passes_configured_session(monkeypatch):
     assert result.width == 40
     assert sessions == [{"model": "isnet-general-use"}]
     assert removed_sessions == [{"model": "isnet-general-use"}]
+
+
+@pytest.mark.asyncio
+async def test_rembg_processor_times_out_without_blocking_event_loop(monkeypatch):
+    class FakeRembgModule:
+        @staticmethod
+        def new_session(model_name):
+            return {"model": model_name}
+
+        @staticmethod
+        def remove(source_content, *, session):
+            time.sleep(0.05)
+            return source_content
+
+    monkeypatch.setitem(sys.modules, "rembg", FakeRembgModule)
+    monkeypatch.setattr(
+        "services.product_image_processing_provider._background_removal_timeout_seconds",
+        lambda: 0.01,
+    )
+    _get_rembg_session.cache_clear()
+
+    processor = RembgProductImageProcessor(model_name="u2net")
+
+    with pytest.raises(RuntimeError, match="rembg provider timed out"):
+        await processor.process(
+            source_content=image_bytes(size=(40, 30)),
+            context=ProductImageProcessingContext(
+                product_image_id=1,
+                source_url="/media/source.png",
+                variant_type="processed",
+            ),
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose only `u2net` as the normal rembg model option in the media manager
- stop preloading experimental/heavy rembg models by default
- run rembg removal off the async event loop and return a timeout error instead of freezing API requests

## Why
Production testing showed `u2net` behaves acceptably, `isnet` is worse, and heavier candidates such as BiRefNet can hang the server when used directly through rembg. This PR makes the safe path conservative while keeping experimental models available for explicit manual ops/testing.

## Validation
- `pytest tests/unit/test_product_image_processing_provider.py -q`
- `pytest tests/unit/test_media_library_service.py tests/unit/test_manager_operation_ids_contract.py -q`
- `python3 -m compileall services/product_image_processing_provider.py scripts/warmup_rembg_models.py routers/manager_media_library.py`
- `npm run build` in `manager_frontend/`
- `git diff --check`
