### PR TITLE
[codex] Isolate experimental rembg models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,12 @@ BACKGROUND_REMOVAL_REMBG_MODEL=u2net
 # Keep production warmup conservative. Heavy/experimental rembg models can be
 # tested manually by overriding this value, but should not preload by default.
 BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS=u2net
+# rembg subprocess mode: experimental isolates non-safe models; always isolates
+# every rembg model; never keeps all rembg work in the API process.
+BACKGROUND_REMOVAL_REMBG_PROCESS_MODE=experimental
 BACKGROUND_REMOVAL_TIMEOUT_SECONDS=120
+BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB=
+BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS=
 BACKGROUND_REMOVAL_BIREFNET_COMMAND=
 BACKGROUND_REMOVAL_BEN_COMMAND=
 # --- Mail (Yandex app password, not the main account password) ---

--- a/manager_frontend/src/client/models/ManagerBackgroundRemovalConfigResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBackgroundRemovalConfigResponse.ts
@@ -7,6 +7,7 @@ import type { ManagerBackgroundRemovalProviderOption } from './ManagerBackground
 export type ManagerBackgroundRemovalConfigResponse = {
     default_provider: string;
     default_rembg_model: string;
+    rembg_process_mode: string;
     preload_models: Array<string>;
     provider_options: Array<ManagerBackgroundRemovalProviderOption>;
     rembg_models: Array<ManagerBackgroundRemovalModelOption>;

--- a/openapi.json
+++ b/openapi.json
@@ -16678,6 +16678,10 @@
             "type": "string",
             "title": "Default Rembg Model"
           },
+          "rembg_process_mode": {
+            "type": "string",
+            "title": "Rembg Process Mode"
+          },
           "preload_models": {
             "items": {
               "type": "string"
@@ -16704,6 +16708,7 @@
         "required": [
           "default_provider",
           "default_rembg_model",
+          "rembg_process_mode",
           "preload_models",
           "provider_options",
           "rembg_models"

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -31,6 +31,7 @@ from services.product_image_processing_provider import (
     background_removal_provider_options,
     default_rembg_model_name,
     rembg_model_options,
+    rembg_process_mode,
     rembg_preload_model_names,
     resolve_background_removal_provider,
 )
@@ -128,6 +129,7 @@ async def get_media_background_removal_config(
     return {
         "default_provider": resolve_background_removal_provider("auto"),
         "default_rembg_model": default_rembg_model_name(),
+        "rembg_process_mode": rembg_process_mode(),
         "preload_models": rembg_preload_model_names(),
         "provider_options": background_removal_provider_options(),
         "rembg_models": rembg_model_options(),

--- a/schemas.py
+++ b/schemas.py
@@ -110,6 +110,7 @@ class ManagerBackgroundRemovalProviderOption(BaseModel):
 class ManagerBackgroundRemovalConfigResponse(BaseModel):
     default_provider: str
     default_rembg_model: str
+    rembg_process_mode: str
     preload_models: List[str]
     provider_options: List[ManagerBackgroundRemovalProviderOption]
     rembg_models: List[ManagerBackgroundRemovalModelOption]

--- a/scripts/rembg_remove.py
+++ b/scripts/rembg_remove.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run rembg in an isolated process for one image."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def _positive_int_from_env(name: str) -> int | None:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _apply_resource_limits() -> None:
+    try:
+        import resource
+    except ImportError:
+        return
+
+    memory_mb = _positive_int_from_env("BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB")
+    if memory_mb:
+        memory_bytes = memory_mb * 1024 * 1024
+        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+
+    cpu_seconds = _positive_int_from_env("BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS")
+    if cpu_seconds:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    _apply_resource_limits()
+
+    try:
+        from rembg import new_session, remove  # type: ignore
+    except ImportError as exc:
+        print(f"rembg provider is not installed: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        with open(args.input, "rb") as input_file:
+            source_content = input_file.read()
+        session = new_session(args.model)
+        output = remove(source_content, session=session)
+        with open(args.output, "wb") as output_file:
+            output_file.write(output)
+    except Exception as exc:
+        print(f"rembg failed for {args.model}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/product_image_processing_provider.py
+++ b/services/product_image_processing_provider.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import shlex
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from functools import lru_cache, partial
 from io import BytesIO
+from pathlib import Path
 from typing import Any, Protocol
 
 from PIL import Image, ImageOps, UnidentifiedImageError, features
@@ -31,6 +34,7 @@ MAX_SOURCE_PIXELS = 40_000_000
 BACKGROUND_REMOVAL_PROVIDER_ENV = "BACKGROUND_REMOVAL_PROVIDER"
 BACKGROUND_REMOVAL_REMBG_MODEL_ENV = "BACKGROUND_REMOVAL_REMBG_MODEL"
 BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS_ENV = "BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS"
+BACKGROUND_REMOVAL_REMBG_PROCESS_MODE_ENV = "BACKGROUND_REMOVAL_REMBG_PROCESS_MODE"
 BACKGROUND_REMOVAL_TIMEOUT_ENV = "BACKGROUND_REMOVAL_TIMEOUT_SECONDS"
 BACKGROUND_REMOVAL_COMMAND_ENVS = {
     ProductImageProcessingProvider.BIREFNET.value: "BACKGROUND_REMOVAL_BIREFNET_COMMAND",
@@ -38,6 +42,7 @@ BACKGROUND_REMOVAL_COMMAND_ENVS = {
 }
 DEFAULT_BACKGROUND_REMOVAL_PROVIDER = ProductImageProcessingProvider.REMBG.value
 DEFAULT_BACKGROUND_REMOVAL_REMBG_MODEL = "u2net"
+DEFAULT_BACKGROUND_REMOVAL_REMBG_PROCESS_MODE = "experimental"
 DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS = 120
 SAFE_REMBG_MODEL_OPTIONS = [
     {
@@ -145,13 +150,22 @@ class RembgProductImageProcessor:
         source_content: bytes,
         context: ProductImageProcessingContext,
     ) -> ProductImageProcessingResult:
+        timeout_seconds = _background_removal_timeout_seconds()
+        if _should_run_rembg_in_subprocess(self.model_name):
+            output = await asyncio.to_thread(
+                _run_rembg_subprocess,
+                model_name=self.model_name,
+                source_content=source_content,
+                timeout_seconds=timeout_seconds,
+            )
+            return _process_image_bytes(output, context=context)
+
         try:
             from rembg import remove  # type: ignore
         except ImportError as exc:
             raise RuntimeError("rembg provider is not installed") from exc
 
         session = _get_rembg_session(self.model_name)
-        timeout_seconds = _background_removal_timeout_seconds()
         try:
             output = await asyncio.wait_for(
                 asyncio.to_thread(partial(remove, source_content, session=session)),
@@ -212,14 +226,15 @@ class CommandProductImageProcessor:
                 input=shlex.quote(input_path),
                 output=shlex.quote(output_path),
             )
-            completed = subprocess.run(
-                command,
-                shell=True,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout_seconds,
-            )
+            try:
+                completed = _run_shell_command_with_timeout(
+                    command,
+                    timeout=self.timeout_seconds,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise RuntimeError(
+                    f"{self.provider_name} provider timed out after {self.timeout_seconds}s"
+                ) from exc
             if completed.returncode != 0:
                 stderr = (completed.stderr or completed.stdout or "").strip()
                 detail = f": {stderr[:500]}" if stderr else ""
@@ -329,6 +344,10 @@ def default_rembg_model_name() -> str:
     return _background_removal_rembg_model()
 
 
+def rembg_process_mode() -> str:
+    return _background_removal_rembg_process_mode()
+
+
 def rembg_preload_model_names(raw_value: str | None = None) -> list[str]:
     configured = (
         raw_value
@@ -371,9 +390,112 @@ def _background_removal_timeout_seconds() -> int:
         return DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS
 
 
+def _background_removal_rembg_process_mode() -> str:
+    requested = os.getenv(
+        BACKGROUND_REMOVAL_REMBG_PROCESS_MODE_ENV,
+        DEFAULT_BACKGROUND_REMOVAL_REMBG_PROCESS_MODE,
+    ).strip().lower()
+    if requested in {"always", "experimental", "never"}:
+        return requested
+    return DEFAULT_BACKGROUND_REMOVAL_REMBG_PROCESS_MODE
+
+
 def _background_removal_rembg_model(model_name: str | None = None) -> str:
     requested = (model_name or os.getenv(BACKGROUND_REMOVAL_REMBG_MODEL_ENV, "")).strip()
     return requested or DEFAULT_BACKGROUND_REMOVAL_REMBG_MODEL
+
+
+def _should_run_rembg_in_subprocess(model_name: str) -> bool:
+    mode = _background_removal_rembg_process_mode()
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+
+    safe_models = {item["value"] for item in SAFE_REMBG_MODEL_OPTIONS}
+    return model_name not in safe_models
+
+
+def _run_rembg_subprocess(
+    *,
+    model_name: str,
+    source_content: bytes,
+    timeout_seconds: int,
+) -> bytes:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "rembg_remove.py"
+    if not script_path.exists():
+        raise RuntimeError("rembg subprocess runner is not available")
+
+    with tempfile.TemporaryDirectory(prefix="rembg-bg-") as tmp_dir:
+        input_path = os.path.join(tmp_dir, "input.bin")
+        output_path = os.path.join(tmp_dir, "output.png")
+        with open(input_path, "wb") as input_file:
+            input_file.write(source_content)
+
+        command = [
+            sys.executable,
+            str(script_path),
+            "--model",
+            model_name,
+            "--input",
+            input_path,
+            "--output",
+            output_path,
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"rembg subprocess timed out after {timeout_seconds}s: {model_name}"
+            ) from exc
+
+        if completed.returncode != 0:
+            stderr = (completed.stderr or completed.stdout or "").strip()
+            detail = f": {stderr[:500]}" if stderr else ""
+            raise RuntimeError(f"rembg subprocess failed for {model_name}{detail}")
+        if not os.path.exists(output_path):
+            raise RuntimeError(f"rembg subprocess did not create output image: {model_name}")
+        with open(output_path, "rb") as output_file:
+            return output_file.read()
+
+
+def _run_shell_command_with_timeout(
+    command: str,
+    *,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_process(process)
+        stdout, stderr = process.communicate()
+        raise subprocess.TimeoutExpired(command, timeout, output=stdout, stderr=stderr)
+
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> None:
+    try:
+        if os.name != "nt":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except ProcessLookupError:
+        return
 
 
 @lru_cache(maxsize=8)

--- a/tests/unit/test_product_image_processing_provider.py
+++ b/tests/unit/test_product_image_processing_provider.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import time
 from io import BytesIO
@@ -13,9 +14,12 @@ from services.product_image_processing_provider import (
     DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS,
     ProductImageProcessingContext,
     RembgProductImageProcessor,
+    _background_removal_rembg_process_mode,
     _background_removal_rembg_model,
     _background_removal_timeout_seconds,
     _get_rembg_session,
+    _run_rembg_subprocess,
+    _should_run_rembg_in_subprocess,
     background_removal_provider_options,
     get_product_image_processor,
     rembg_model_options,
@@ -134,6 +138,29 @@ def test_background_removal_timeout_uses_safe_default_and_env(monkeypatch):
     assert _background_removal_timeout_seconds() == DEFAULT_BACKGROUND_REMOVAL_TIMEOUT_SECONDS
 
 
+def test_rembg_process_mode_uses_experimental_default_and_env(monkeypatch):
+    monkeypatch.delenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", raising=False)
+    assert _background_removal_rembg_process_mode() == "experimental"
+
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "always")
+    assert _background_removal_rembg_process_mode() == "always"
+
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "invalid")
+    assert _background_removal_rembg_process_mode() == "experimental"
+
+
+def test_rembg_process_mode_isolates_experimental_models(monkeypatch):
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "experimental")
+    assert _should_run_rembg_in_subprocess("u2net") is False
+    assert _should_run_rembg_in_subprocess("birefnet-general") is True
+
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "always")
+    assert _should_run_rembg_in_subprocess("u2net") is True
+
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "never")
+    assert _should_run_rembg_in_subprocess("birefnet-general") is False
+
+
 @pytest.mark.asyncio
 async def test_rembg_processor_passes_configured_session(monkeypatch):
     sessions = []
@@ -152,6 +179,7 @@ async def test_rembg_processor_passes_configured_session(monkeypatch):
             return source_content
 
     monkeypatch.setitem(sys.modules, "rembg", FakeRembgModule)
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "never")
     _get_rembg_session.cache_clear()
 
     processor = RembgProductImageProcessor(model_name="isnet-general-use")
@@ -202,6 +230,36 @@ async def test_rembg_processor_times_out_without_blocking_event_loop(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_rembg_processor_uses_subprocess_for_experimental_model(monkeypatch):
+    calls = []
+
+    def fake_run_rembg_subprocess(*, model_name, source_content, timeout_seconds):
+        calls.append((model_name, source_content, timeout_seconds))
+        return source_content
+
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "experimental")
+    monkeypatch.setenv("BACKGROUND_REMOVAL_TIMEOUT_SECONDS", "7")
+    monkeypatch.setattr(
+        "services.product_image_processing_provider._run_rembg_subprocess",
+        fake_run_rembg_subprocess,
+    )
+
+    processor = RembgProductImageProcessor(model_name="birefnet-general")
+    source_content = image_bytes(size=(40, 30))
+    result = await processor.process(
+        source_content=source_content,
+        context=ProductImageProcessingContext(
+            product_image_id=1,
+            source_url="/media/source.png",
+            variant_type="processed",
+        ),
+    )
+
+    assert result.width == 40
+    assert calls == [("birefnet-general", source_content, 7)]
+
+
+@pytest.mark.asyncio
 async def test_rembg_session_is_cached_per_model(monkeypatch):
     created = []
 
@@ -216,6 +274,7 @@ async def test_rembg_session_is_cached_per_model(monkeypatch):
             return source_content
 
     monkeypatch.setitem(sys.modules, "rembg", FakeRembgModule)
+    monkeypatch.setenv("BACKGROUND_REMOVAL_REMBG_PROCESS_MODE", "never")
     _get_rembg_session.cache_clear()
     processor = RembgProductImageProcessor(model_name="u2netp")
 
@@ -243,6 +302,40 @@ def test_rembg_session_wraps_invalid_model_errors(monkeypatch):
 
     with pytest.raises(RuntimeError, match="rembg model is not configured correctly"):
         _get_rembg_session("bad-model")
+
+
+def test_rembg_subprocess_reads_output(tmp_path, monkeypatch):
+    source_content = image_bytes(size=(40, 30))
+
+    def fake_run(command, *, check, capture_output, text, timeout):
+        output_path = command[command.index("--output") + 1]
+        with open(output_path, "wb") as output_file:
+            output_file.write(source_content)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = _run_rembg_subprocess(
+        model_name="birefnet-general",
+        source_content=source_content,
+        timeout_seconds=5,
+    )
+
+    assert output == source_content
+
+
+def test_rembg_subprocess_wraps_timeout(monkeypatch):
+    def fake_run(command, *, check, capture_output, text, timeout):
+        raise subprocess.TimeoutExpired(command, timeout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="rembg subprocess timed out"):
+        _run_rembg_subprocess(
+            model_name="birefnet-general",
+            source_content=image_bytes(size=(40, 30)),
+            timeout_seconds=5,
+        )
 
 
 @pytest.mark.asyncio
@@ -282,6 +375,29 @@ async def test_command_provider_requires_command_env():
     )
 
     with pytest.raises(RuntimeError, match="not configured"):
+        await processor.process(
+            source_content=image_bytes(size=(40, 30)),
+            context=ProductImageProcessingContext(
+                product_image_id=1,
+                source_url="/media/source.png",
+                variant_type="processed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_provider_wraps_timeout(tmp_path, monkeypatch):
+    script = tmp_path / "slow_image.py"
+    script.write_text("import time\n" "time.sleep(3)\n")
+    processor = CommandProductImageProcessor(
+        provider_name="birefnet",
+        command_env="TEST_SLOW_BIREFNET_COMMAND",
+        timeout_seconds=1,
+    )
+
+    monkeypatch.setenv("TEST_SLOW_BIREFNET_COMMAND", f"{sys.executable} {script}")
+
+    with pytest.raises(RuntimeError, match="provider timed out"):
         await processor.process(
             source_content=image_bytes(size=(40, 30)),
             context=ProductImageProcessingContext(


### PR DESCRIPTION
## Summary
- isolate experimental rembg models in a child process instead of loading/running them inside the API process
- add `BACKGROUND_REMOVAL_REMBG_PROCESS_MODE=experimental|always|never` and optional child-process CPU/memory limits
- harden command-based BEN/BiRefNet adapters so timeout kills the spawned process group
- expose the active rembg process mode in the media background-removal config response and regenerate OpenAPI/client types

## Why
Production model testing showed `u2net` is acceptable, while heavier candidates such as BiRefNet can hang the server when run directly. This keeps the normal `u2net` path fast, but makes experimental rembg models safer to test without freezing the API process.

## Validation
- `pytest tests/unit/test_product_image_processing_provider.py tests/unit/test_media_library_service.py -q`
- `pytest tests/unit/test_product_image_processing_provider.py tests/unit/test_media_library_service.py tests/unit/test_product_image_variants.py tests/unit/test_manager_operation_ids_contract.py -q`
- `python3 -m compileall services/product_image_processing_provider.py routers/manager_media_library.py schemas.py scripts/rembg_remove.py scripts/warmup_rembg_models.py`
- `python3 scripts/legacy/extract_openapi.py && cd manager_frontend && npm run gen:api`
- `npm run build` in `manager_frontend/`
- `git diff --check`

## Local integration note
`pytest tests/integration/test_manager_gallery_bulk.py tests/integration/test_manager_main_image_cleanup_api.py -q` ran `test_manager_main_image_cleanup_api` successfully, but the gallery-bulk tests could not set up locally because `db_test:5432` is not resolvable outside the CI/docker test network.
