### PR TITLE
[codex] Expose experimental background models

### DIFF
--- a/manager_frontend/src/utils/media-processing.ts
+++ b/manager_frontend/src/utils/media-processing.ts
@@ -8,6 +8,6 @@ export const backgroundRemovalProviderOptions: Array<{
   { value: 'noop', label: 'noop' },
   { value: 'manual', label: 'manual' },
   { value: 'rembg', label: 'rembg' },
-  { value: 'birefnet', label: 'BiRefNet' },
-  { value: 'ben', label: 'BEN' },
+  { value: 'birefnet', label: 'BiRefNet exp.' },
+  { value: 'ben', label: 'BEN exp.' },
 ];

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -92,6 +92,14 @@ const selectedUrl = computed(() => selectedAsset.value ? imageUrl(selectedAsset.
 const showRembgModelSelect = computed(() => (
   backgroundProvider.value === 'rembg' || backgroundProvider.value === 'auto'
 ));
+const selectedBackgroundModelOption = computed(() => (
+  backgroundModelOptions.value.find((option) => option.value === backgroundModel.value)
+));
+const showBackgroundExperimentWarning = computed(() => (
+  backgroundProvider.value === 'birefnet'
+  || backgroundProvider.value === 'ben'
+  || (showRembgModelSelect.value && selectedBackgroundModelOption.value?.recommended === false)
+));
 
 const setToast = (message: string, type: 'success' | 'error' = 'success') => {
   toast.value = message;
@@ -730,10 +738,13 @@ onUnmounted(() => {
                     :key="option.value"
                     :value="option.value"
                   >
-                    {{ option.label }}
+                    {{ option.recommended === false ? `${option.label} exp.` : option.label }}
                   </option>
                 </select>
               </label>
+            </div>
+            <div v-if="showBackgroundExperimentWarning" class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-100">
+              Экспериментальный режим: обработка может быть долгой и завершиться по timeout.
             </div>
 
             <div v-if="cropMode" class="rounded-lg border border-teal-200 bg-teal-50 p-3 dark:border-teal-900 dark:bg-teal-950/30">

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -132,7 +132,7 @@ async def get_media_background_removal_config(
         "rembg_process_mode": rembg_process_mode(),
         "preload_models": rembg_preload_model_names(),
         "provider_options": background_removal_provider_options(),
-        "rembg_models": rembg_model_options(),
+        "rembg_models": rembg_model_options(include_experimental=True),
     }
 
 


### PR DESCRIPTION
## Summary
- expose experimental rembg models in the media library background-removal model selector
- add an in-UI warning when an experimental provider/model is selected
- label command-based BiRefNet/BEN providers as experimental in the shared manager label list

## Why
We want to test BiRefNet-class models on production now that PR #553 isolates experimental rembg models in child processes. The warning makes the risk explicit while keeping `u2net` as the safe default.

## Validation
- `pytest tests/unit/test_product_image_processing_provider.py tests/unit/test_media_library_service.py tests/unit/test_manager_operation_ids_contract.py -q`
- `python3 -m compileall routers/manager_media_library.py services/product_image_processing_provider.py`
- `npm run build` in `manager_frontend/`
- `git diff --check`
