### PR TITLE
[codex] Improve media editor access

### DIFF
--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -759,8 +759,8 @@ onUnmounted(() => {
       </button>
     </div>
 
-    <div class="grid gap-6 xl:grid-cols-[1fr_420px]">
-      <div class="xl:min-h-[440px]">
+    <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_380px] 2xl:grid-cols-[minmax(0,1fr)_420px]">
+      <div class="lg:min-h-[440px]">
         <div v-if="loading" class="grid grid-cols-2 gap-4 md:grid-cols-3 2xl:grid-cols-4">
           <div v-for="idx in 8" :key="idx" class="h-60 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800" />
         </div>
@@ -807,11 +807,11 @@ onUnmounted(() => {
       </div>
 
       <aside
-        class="xl:sticky xl:top-4 xl:self-start"
-        :class="selectedAsset ? 'fixed inset-0 z-50 flex items-end bg-gray-950/45 p-3 xl:static xl:z-auto xl:block xl:bg-transparent xl:p-0' : 'hidden xl:block'"
+        class="lg:sticky lg:top-4 lg:self-start"
+        :class="selectedAsset ? 'fixed inset-0 z-50 flex items-end bg-gray-950/45 p-3 lg:static lg:z-auto lg:block lg:bg-transparent lg:p-0' : 'hidden lg:block'"
         @click.self="selectedAsset = null"
       >
-        <div class="w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-800 dark:bg-gray-900 xl:shadow-sm">
+        <div class="w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-800 dark:bg-gray-900 lg:shadow-sm">
         <div v-if="!selectedAsset" class="flex min-h-[520px] items-center justify-center p-8 text-center">
           <div>
             <ImageIcon class="mx-auto h-10 w-10 text-gray-300" />
@@ -819,7 +819,7 @@ onUnmounted(() => {
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Метаданные и редактор появятся здесь.</p>
           </div>
         </div>
-        <div v-else class="flex max-h-[calc(100vh-48px)] flex-col xl:max-h-[calc(100vh-140px)]">
+        <div v-else class="flex max-h-[calc(100vh-48px)] flex-col lg:max-h-[calc(100vh-140px)]">
           <div class="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-800">
             <div>
               <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ selectedAsset.title || 'Без названия' }}</p>

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -806,7 +806,12 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <aside class="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+      <aside
+        class="xl:sticky xl:top-4 xl:self-start"
+        :class="selectedAsset ? 'fixed inset-0 z-50 flex items-end bg-gray-950/45 p-3 xl:static xl:z-auto xl:block xl:bg-transparent xl:p-0' : 'hidden xl:block'"
+        @click.self="selectedAsset = null"
+      >
+        <div class="w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-800 dark:bg-gray-900 xl:shadow-sm">
         <div v-if="!selectedAsset" class="flex min-h-[520px] items-center justify-center p-8 text-center">
           <div>
             <ImageIcon class="mx-auto h-10 w-10 text-gray-300" />
@@ -814,7 +819,7 @@ onUnmounted(() => {
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Метаданные и редактор появятся здесь.</p>
           </div>
         </div>
-        <div v-else class="flex max-h-[calc(100vh-140px)] flex-col">
+        <div v-else class="flex max-h-[calc(100vh-48px)] flex-col xl:max-h-[calc(100vh-140px)]">
           <div class="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-800">
             <div>
               <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ selectedAsset.title || 'Без названия' }}</p>
@@ -990,6 +995,7 @@ onUnmounted(() => {
               <p><span class="font-medium">Hash:</span> {{ selectedAsset.content_hash?.slice(0, 16) || '—' }}</p>
             </div>
           </div>
+        </div>
         </div>
       </aside>
     </div>

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -57,7 +57,6 @@ class ManagerMediaService:
                 select(ProductImageVariant).where(ProductImageVariant.product_image_id == image.id)
             )
         ).scalars().all()
-        variant_urls = [variant.url for variant in variant_rows if variant.url]
         for variant in variant_rows:
             await session.delete(variant)
 
@@ -124,7 +123,6 @@ class ManagerMediaService:
                 select(ProductImageVariant).where(ProductImageVariant.product_image_id == image.id)
             )
         ).scalars().all()
-        variant_urls = [variant.url for variant in variant_rows if variant.url]
         for variant in variant_rows:
             await session.delete(variant)
 
@@ -147,10 +145,6 @@ class ManagerMediaService:
         await ManagerMediaService.sync_legacy_images(session, product.id)
         await session.commit()
         await session.refresh(image)
-
-        await ManagerMediaService.remove_file_if_unreferenced(session, old_url)
-        for variant_url in variant_urls:
-            await ManagerMediaService.remove_file_if_unreferenced(session, variant_url)
 
         return {"id": image.id, "url": image.url}
 
@@ -225,10 +219,6 @@ class ManagerMediaService:
         await ManagerMediaService.sync_legacy_images(session, product.id)
         await session.commit()
         await session.refresh(image)
-
-        await ManagerMediaService.remove_file_if_unreferenced(session, old_url)
-        for variant_url in variant_urls:
-            await ManagerMediaService.remove_file_if_unreferenced(session, variant_url)
 
         return {"id": image.id, "url": image.url}
 

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -57,6 +57,7 @@ class ManagerMediaService:
                 select(ProductImageVariant).where(ProductImageVariant.product_image_id == image.id)
             )
         ).scalars().all()
+        variant_urls = [variant.url for variant in variant_rows if variant.url]
         for variant in variant_rows:
             await session.delete(variant)
 

--- a/tests/unit/test_manager_media_service_crop.py
+++ b/tests/unit/test_manager_media_service_crop.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -113,6 +114,7 @@ async def test_crop_gallery_image_replaces_source_and_main_image(sqlite_session)
     assert source_image.url == result["url"]
     assert product.main_image == result["url"]
     assert product.images == [result["url"]]
+    assert Path("media/products/source.png").exists()
 
 
 @pytest.mark.asyncio
@@ -205,6 +207,7 @@ async def test_remove_background_gallery_image_replaces_source_and_main_image(
     assert product.main_image == result["url"]
     assert product.images == [result["url"]]
     assert len(rows) == 1
+    assert Path("media/products/source.png").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Open the media library editor as a mobile/tablet overlay while keeping a sticky desktop editor panel.
- Keep old product image files on disk after crop/background replace so the current static storefront build does not hit 404s before rebuild.
- Add regression coverage for preserving the old source file after product image replacement.

## Tests
- pytest tests/unit/test_manager_media_service_crop.py -q
- npm run build (manager_frontend)

## Notes
After replacing a main product image, the public static storefront still needs the usual site rebuild/update to point HTML/API snapshots at the new URL. The old file is now preserved until explicit cleanup, so stale static pages should not lose the image during that window.