### PR TITLE
[codex] Serve media WebP files with image MIME type

### DIFF
--- a/core/app_static.py
+++ b/core/app_static.py
@@ -1,3 +1,4 @@
+import mimetypes
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -14,6 +15,11 @@ MANAGER_NO_CACHE_HEADERS = {
     "Pragma": "no-cache",
     "Expires": "0",
 }
+
+
+mimetypes.add_type("image/webp", ".webp")
+mimetypes.add_type("image/avif", ".avif")
+mimetypes.add_type("image/svg+xml", ".svg")
 
 
 def apply_manager_no_cache_headers(response: Response) -> Response:

--- a/tests/unit/test_app_static.py
+++ b/tests/unit/test_app_static.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.app_static import mount_static_and_media
+
+
+def test_media_static_files_serve_webp_with_image_content_type(tmp_path: Path):
+    media_dir = tmp_path / "media"
+    media_dir.mkdir()
+    (media_dir / "sample.webp").write_bytes(b"RIFF\x00\x00\x00\x00WEBP")
+
+    app = FastAPI()
+    mount_static_and_media(app, tmp_path)
+
+    response = TestClient(app).get("/media/sample.webp")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/webp")


### PR DESCRIPTION
## Summary
- Register image MIME types for media/static serving, including WebP
- Add a regression test for /media/*.webp Content-Type

## Verification
- pytest tests/unit/test_app_static.py tests/unit/test_manager_media_service_crop.py tests/unit/test_product_image_variants.py::test_delete_shared_image_keeps_file_until_last_image_and_variant_reference -q