### PR TITLE
Improve product media gallery workflows

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -81,6 +81,7 @@ import {
     type ManagerMediaAssetUpdatePayload,
     type ManagerMediaAssetUrlUploadPayload,
     type ManagerMediaAssetUploadResponse,
+    type ManagerMediaApplySeriesResponse,
     type ManagerMediaBackfillReferencedAssetsResponse,
     type ManagerMediaProcessingJobCreatePayload,
     type ManagerMediaProcessingJobListResponse,
@@ -153,6 +154,7 @@ export type {
     ManagerMediaAssetUpdatePayload,
     ManagerMediaAssetUrlUploadPayload,
     ManagerMediaAssetUploadResponse,
+    ManagerMediaApplySeriesResponse,
     ManagerMediaBackfillReferencedAssetsResponse,
     ManagerMediaProcessingJobCreatePayload,
     ManagerMediaProcessingJobListResponse,
@@ -638,6 +640,14 @@ export const api = {
             urls,
             exclude_installation: excludeInstallation,
         });
+    },
+
+    async applyGalleryToSeries(
+        productId: number,
+        dryRun = false,
+        deleteUnreferenced = false,
+    ): Promise<ManagerMediaApplySeriesResponse> {
+        return await ManagerService.applyGalleryToSeries(productId, dryRun, deleteUnreferenced);
     },
 
     async bulkUploadLocalImages(

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -139,6 +139,7 @@ export type { ManagerInstallerUpdatePayload } from './models/ManagerInstallerUpd
 export type { ManagerInstallEstimateCalculatePayload } from './models/ManagerInstallEstimateCalculatePayload';
 export type { ManagerInstallEstimateResponse } from './models/ManagerInstallEstimateResponse';
 export type { ManagerInstallEstimateSavePayload } from './models/ManagerInstallEstimateSavePayload';
+export type { ManagerMediaApplySeriesResponse } from './models/ManagerMediaApplySeriesResponse';
 export type { ManagerMediaAssetCropPayload } from './models/ManagerMediaAssetCropPayload';
 export type { ManagerMediaAssetListResponse } from './models/ManagerMediaAssetListResponse';
 export type { ManagerMediaAssetResponse } from './models/ManagerMediaAssetResponse';

--- a/manager_frontend/src/client/models/ManagerMediaApplySeriesResponse.ts
+++ b/manager_frontend/src/client/models/ManagerMediaApplySeriesResponse.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerMediaApplySeriesResponse = {
+    message: string;
+    dry_run?: boolean;
+    source_product_id: number;
+    series_id: number;
+    series_title?: (string | null);
+    updated_products: number;
+    images_applied: number;
+    main_image?: (string | null);
+    replaced_links?: number;
+    obsolete_urls?: Array<string>;
+    preserved_installation_links?: number;
+    deleted_files_count?: number;
+};
+

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -33,6 +33,7 @@ import type { ManagerCustomerBranchListResponse } from '../models/ManagerCustome
 import type { ManagerCustomerBranchUpdatePayload } from '../models/ManagerCustomerBranchUpdatePayload';
 import type { ManagerCustomerDocumentListResponse } from '../models/ManagerCustomerDocumentListResponse';
 import type { ManagerCustomerUpdatePayload } from '../models/ManagerCustomerUpdatePayload';
+import type { ManagerMediaApplySeriesResponse } from '../models/ManagerMediaApplySeriesResponse';
 import type { ManagerMediaBulkAddResponse } from '../models/ManagerMediaBulkAddResponse';
 import type { ManagerMediaBulkDeleteResponse } from '../models/ManagerMediaBulkDeleteResponse';
 import type { ManagerMediaBulkUploadResponse } from '../models/ManagerMediaBulkUploadResponse';
@@ -1167,6 +1168,33 @@ export class ManagerService {
             url: '/api/manager/gallery/bulk-delete-common',
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Apply Gallery To Series
+     * Replace sibling products' non-installation galleries with this product's gallery.
+     * @param productId Source product ID
+     * @param dryRun Preview changes without applying them
+     * @param deleteUnreferenced Delete physical files that become unreferenced
+     * @returns ManagerMediaApplySeriesResponse Successful Response
+     * @throws ApiError
+     */
+    public static applyGalleryToSeries(
+        productId: number,
+        dryRun: boolean = false,
+        deleteUnreferenced: boolean = false,
+    ): CancelablePromise<ManagerMediaApplySeriesResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/gallery/apply-to-series',
+            query: {
+                'product_id': productId,
+                'dry_run': dryRun,
+                'delete_unreferenced': deleteUnreferenced,
+            },
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch, computed } from 'vue';
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
 import { watchDebounced } from '@vueuse/core';
 import {
     api,
@@ -13,7 +13,7 @@ import {
 import {
     Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images,
     Settings, ArrowLeft, LayoutGrid, List, Package, Link2, ExternalLink,
-    Star, SlidersHorizontal, X, Trash2, Download, Crop, Wand2,
+    Star, SlidersHorizontal, X, Trash2, Download, Crop, Wand2, MoreHorizontal, ClipboardPaste,
 } from 'lucide-vue-next';
 import BulkSpecsModal from '../components/BulkSpecsModal.vue';
 import BulkCompatibilityModal from '../components/BulkCompatibilityModal.vue';
@@ -44,6 +44,7 @@ const reuseQuery = ref('');
 const reuseResults = ref<any[]>([]);
 const activeTab = ref<'search' | 'reuse' | 'upload'>('search');
 const uploadDragActive = ref(false);
+const uploadUrl = ref('');
 const fileInput = ref<HTMLInputElement | null>(null);
 const toast = ref('');
 const showOnlinerImportModal = ref(false);
@@ -52,6 +53,8 @@ const variantLimit = ref(50);
 const includeInstallationVariants = ref(false);
 const variantProvider = ref<BackgroundRemovalProvider>('noop');
 const productBackgroundProvider = ref<BackgroundRemovalProvider>('rembg');
+const productGallerySettingsOpen = ref(false);
+const applyingSeriesGallery = ref(false);
 const variantCandidatesLoading = ref(false);
 const variantProcessingLoading = ref(false);
 const variantReprocessingImageId = ref<number | null>(null);
@@ -494,7 +497,7 @@ const handleDrop = async (e: DragEvent) => {
     }
 };
 
-const uploadFiles = async (files: FileList) => {
+const uploadFiles = async (files: FileList | File[]) => {
     if (!selectedProduct.value && !isBulkMode.value) return;
     searchLoading.value = true;
     try {
@@ -513,6 +516,98 @@ const uploadFiles = async (files: FileList) => {
         console.error(e);
     } finally {
         searchLoading.value = false;
+        if (fileInput.value) fileInput.value.value = '';
+    }
+};
+
+type ClipboardImageItem = {
+    types: readonly string[];
+    getType: (type: string) => Promise<Blob>;
+};
+
+const extensionFromMime = (mimeType: string) => mimeType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+
+const uploadClipboardFiles = async (files: File[]) => {
+    if (!files.length) {
+        setToast('В буфере нет изображения');
+        return;
+    }
+    await uploadFiles(files);
+};
+
+const pasteFromClipboard = async () => {
+    const clipboard = navigator.clipboard as Clipboard & { read?: () => Promise<ClipboardImageItem[]> };
+    if (!clipboard?.read) {
+        setToast('Вставьте изображение через Ctrl+V или Cmd+V');
+        return;
+    }
+
+    try {
+        const items = await clipboard.read();
+        const files: File[] = [];
+        for (const item of items) {
+            const imageType = item.types.find((type) => type.startsWith('image/'));
+            if (!imageType) continue;
+            const blob = await item.getType(imageType);
+            files.push(new File([blob], `clipboard-${Date.now()}.${extensionFromMime(imageType)}`, { type: imageType }));
+        }
+        await uploadClipboardFiles(files);
+    } catch (e) {
+        setToast(`Не удалось прочитать изображение из буфера: ${getApiErrorMessage(e)}`);
+    }
+};
+
+const uploadFromUrl = async () => {
+    const url = uploadUrl.value.trim();
+    if (!url) {
+        setToast('Укажите URL изображения');
+        return;
+    }
+    if (!/^https?:\/\//i.test(url)) {
+        setToast('URL должен начинаться с http:// или https://');
+        return;
+    }
+    if (!selectedProduct.value && !isBulkMode.value) return;
+
+    uploadingImageId.value = url;
+    searchLoading.value = true;
+    try {
+        if (isBulkMode.value) {
+            await bulkAddFromUrls([url], false);
+            setToast('Изображение добавлено выбранным товарам');
+        } else {
+            await api.linkSearchResult(selectedProduct.value!.id, url);
+            await loadProducts();
+            refreshSelectedProduct();
+            setToast('Изображение загружено по URL');
+        }
+        uploadUrl.value = '';
+    } catch (e) {
+        setToast(`Ошибка загрузки по URL: ${getApiErrorMessage(e)}`);
+    } finally {
+        uploadingImageId.value = null;
+        searchLoading.value = false;
+    }
+};
+
+const onProductImagePaste = (event: ClipboardEvent) => {
+    if (!showModal.value || activeTab.value !== 'upload') return;
+
+    const files: File[] = [];
+    for (const item of Array.from(event.clipboardData?.items || [])) {
+        if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
+        const file = item.getAsFile();
+        if (file) files.push(file);
+    }
+    if (files.length) {
+        event.preventDefault();
+        void uploadClipboardFiles(files);
+        return;
+    }
+
+    const text = event.clipboardData?.getData('text/plain')?.trim() || '';
+    if (/^https?:\/\//i.test(text)) {
+        uploadUrl.value = text;
     }
 };
 
@@ -774,6 +869,14 @@ const displayedGalleryImages = computed<GalleryImage[]>(() => (
     selectedProduct.value?.gallery_images || []
 ).filter((image) => includeInstallationVariants.value || !image.is_installation_photo));
 
+const selectedMainGalleryImage = computed<GalleryImage | null>(() => {
+    const mainUrl = selectedProduct.value?.main_image;
+    if (!mainUrl) return null;
+    return selectedProduct.value?.gallery_images.find((image) => image.url === mainUrl) || null;
+});
+
+const canApplyGalleryToSeries = computed(() => Boolean(selectedProduct.value?.id && selectedProduct.value?.series_id));
+
 const cropCanSetMain = computed(() => Boolean(cropEditorImage.value && !cropEditorImage.value.is_installation_photo));
 
 const clampCropForm = () => {
@@ -963,6 +1066,7 @@ const resetVariantState = () => {
     variantProcessingLoading.value = false;
     variantReprocessingImageId.value = null;
     backgroundRemovingImageId.value = null;
+    productGallerySettingsOpen.value = false;
 };
 
 const loadVariantCandidates = async () => {
@@ -1043,6 +1147,38 @@ const removeGalleryImageBackground = async (image: GalleryImage) => {
         console.error(e);
     } finally {
         backgroundRemovingImageId.value = null;
+    }
+};
+
+const applyGalleryToSeries = async () => {
+    if (!selectedProduct.value?.id || applyingSeriesGallery.value) return;
+    applyingSeriesGallery.value = true;
+    try {
+        const preview = await api.applyGalleryToSeries(selectedProduct.value.id, true, false);
+        const shownUrls = (preview.obsolete_urls || []).slice(0, 8);
+        const hiddenCount = Math.max(0, (preview.obsolete_urls?.length || 0) - shownUrls.length);
+        const obsoleteList = shownUrls.length
+            ? `\n\nБудут сняты из серии:\n${shownUrls.map((url: string) => `- ${url}`).join('\n')}${hiddenCount ? `\n...и еще ${hiddenCount}` : ''}`
+            : '';
+        const proceed = window.confirm(
+            `Применить галерею к товарам серии?\n\nТоваров будет обновлено: ${preview.updated_products}.\nИзображений в новой галерее: ${preview.images_applied}.\nСсылок будет заменено: ${preview.replaced_links}.\nМонтажные фото будут сохранены: ${preview.preserved_installation_links}.${obsoleteList}`,
+        );
+        if (!proceed) return;
+
+        const deleteUnreferenced = (preview.obsolete_urls?.length || 0) > 0
+            ? window.confirm('Удалить физические файлы, которые после отвязки больше нигде не используются?')
+            : false;
+        const result = await api.applyGalleryToSeries(selectedProduct.value.id, false, deleteUnreferenced);
+        await loadProducts();
+        refreshSelectedProduct();
+        productGallerySettingsOpen.value = false;
+        const cleanupText = deleteUnreferenced ? `, файлов удалено: ${result.deleted_files_count}` : '';
+        setToast(`Галерея применена к серии: ${result.updated_products} товаров${cleanupText}`);
+    } catch (e) {
+        setToast(`Ошибка применения к серии: ${getApiErrorMessage(e)}`);
+        console.error(e);
+    } finally {
+        applyingSeriesGallery.value = false;
     }
 };
 
@@ -1207,6 +1343,7 @@ onMounted(() => {
             searchQuery.value = String(pendingEditProductId.value);
         }
     }
+    document.addEventListener('paste', onProductImagePaste);
     loadBrands();
     loadProducts();
 
@@ -1220,6 +1357,10 @@ onMounted(() => {
     watch(sentinel, (el) => {
         if (el) observer.observe(el);
     });
+});
+
+onUnmounted(() => {
+    document.removeEventListener('paste', onProductImagePaste);
 });
 
 const isDeletingProduct = ref<number | null>(null);
@@ -1925,9 +2066,9 @@ watchDebounced(
               </div>
 
               <!-- UPLOAD TAB -->
-              <div v-if="activeTab === 'upload'" class="flex flex-col flex-1 min-h-0 p-8 items-center justify-center bg-gray-50">
+              <div v-if="activeTab === 'upload'" class="flex flex-col flex-1 min-h-0 items-center justify-center gap-4 bg-gray-50 p-4 sm:p-8">
                   <div 
-                      class="w-full max-w-2xl border-4 border-dashed rounded-xl p-12 flex flex-col items-center justify-center transition-colors cursor-pointer"
+                      class="w-full max-w-2xl border-4 border-dashed rounded-xl p-8 sm:p-12 flex flex-col items-center justify-center transition-colors cursor-pointer"
                       :class="uploadDragActive ? 'border-teal-500 bg-teal-50' : 'border-gray-300 hover:border-gray-400 bg-white'"
                       @dragenter.prevent="uploadDragActive = true"
                       @dragleave.prevent="uploadDragActive = false"
@@ -1947,11 +2088,45 @@ watchDebounced(
                           Загрузка...
                       </div>
                   </div>
+                  <div class="w-full max-w-2xl rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+                      <div class="relative">
+                          <Link2 class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                          <input
+                              v-model="uploadUrl"
+                              type="url"
+                              placeholder="https://site.by/image.jpg"
+                              class="w-full rounded-lg border border-gray-300 bg-white py-2.5 pl-9 pr-24 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20"
+                              @keydown.enter.prevent="uploadFromUrl"
+                          />
+                          <div class="absolute right-1 top-1/2 flex -translate-y-1/2 gap-1">
+                              <button
+                                  type="button"
+                                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-teal-700 transition hover:bg-teal-50 disabled:cursor-not-allowed disabled:opacity-50"
+                                  :disabled="searchLoading"
+                                  title="Скачать по URL"
+                                  aria-label="Скачать по URL"
+                                  @click="uploadFromUrl"
+                              >
+                                  <UploadCloud class="h-4 w-4" />
+                              </button>
+                              <button
+                                  type="button"
+                                  class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                                  :disabled="searchLoading"
+                                  title="Вставить из буфера"
+                                  aria-label="Вставить из буфера"
+                                  @click="pasteFromClipboard"
+                              >
+                                  <ClipboardPaste class="h-4 w-4" />
+                              </button>
+                          </div>
+                      </div>
+                  </div>
               </div>
           </div>
           
           <!-- Current Product Gallery Preview (Footer) -->
-          <div class="h-60 bg-white border-t p-4 overflow-x-auto flex gap-4 shrink-0">
+          <div class="relative h-60 bg-white border-t p-4 overflow-x-auto flex gap-4 shrink-0">
               <div v-if="isBulkMode" class="w-72 shrink-0 border-r pr-4 text-sm">
                   <div class="font-semibold text-gray-700">
                       {{ isBulkMode ? 'Общая галерея' : 'Текущая галерея' }}
@@ -2038,30 +2213,84 @@ watchDebounced(
                   </div>
               </template>
               <template v-else>
-                  <div class="w-36 shrink-0 border-r pr-4 text-xs text-gray-600">
-                      <div class="font-semibold text-gray-700">Текущая галерея</div>
-                      <label class="mt-3 block">
-                          <span class="text-[11px] font-medium uppercase tracking-wide text-gray-500">Без фона</span>
-                          <select
-                              v-model="productBackgroundProvider"
-                              class="mt-1 h-8 w-full rounded-md border border-gray-300 px-2 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500"
-                              title="Провайдер удаления фона для текущего фото"
-                          >
-                              <option
-                                  v-for="option in backgroundRemovalProviderOptions"
-                                  :key="option.value"
-                                  :value="option.value"
+                  <div class="absolute right-3 top-3 z-30" @click.stop>
+                      <button
+                          type="button"
+                          class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-600 shadow-sm transition hover:border-teal-300 hover:text-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                          title="Настройки обработки галереи"
+                          @click="productGallerySettingsOpen = !productGallerySettingsOpen"
+                      >
+                          <MoreHorizontal class="h-5 w-5" />
+                      </button>
+                      <div
+                          v-if="productGallerySettingsOpen"
+                          class="absolute right-0 top-11 w-56 rounded-xl border border-gray-200 bg-white p-3 text-xs text-gray-700 shadow-xl"
+                      >
+                          <label class="block">
+                              <span class="font-semibold uppercase tracking-wide text-gray-500">Без фона</span>
+                              <select
+                                  v-model="productBackgroundProvider"
+                                  class="mt-2 h-9 w-full rounded-md border border-gray-300 px-2 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+                                  title="Провайдер удаления фона для текущего фото"
                               >
-                                  {{ option.label }}
-                              </option>
-                          </select>
-                      </label>
+                                  <option
+                                      v-for="option in backgroundRemovalProviderOptions"
+                                      :key="option.value"
+                                      :value="option.value"
+                                  >
+                                      {{ option.label }}
+                                  </option>
+                              </select>
+                          </label>
+                          <button
+                              type="button"
+                              class="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-teal-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-teal-700 disabled:cursor-not-allowed disabled:opacity-50"
+                              :disabled="!canApplyGalleryToSeries || applyingSeriesGallery"
+                              title="Заменить галерею остальных товаров этой серии текущей галереей"
+                              @click="applyGalleryToSeries"
+                          >
+                              <Images class="h-4 w-4" />
+                              {{ applyingSeriesGallery ? 'Применяем...' : 'Ко всей серии' }}
+                          </button>
+                          <p v-if="!canApplyGalleryToSeries" class="mt-2 text-[11px] leading-snug text-gray-500">
+                              Доступно для товаров, привязанных к серии.
+                          </p>
+                      </div>
                   </div>
                   <!-- Main Image -->
                   <div v-if="selectedProduct?.main_image" class="relative group w-36 shrink-0 border-2 border-teal-500 rounded-lg overflow-hidden">
                       <img :src="getImageUrl(selectedProduct.main_image)" class="w-full h-full object-cover" />
                       <span class="absolute top-0 left-0 bg-teal-500 text-white text-[10px] px-1.5 py-0.5 rounded-br-md">Главное</span>
                       <span class="absolute bottom-0 left-0 right-0 bg-black/60 px-1.5 py-1 text-[10px] font-medium text-white">Оригинал URL</span>
+                      <div
+                          v-if="selectedMainGalleryImage"
+                          class="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/50 p-2 opacity-0 transition-opacity group-hover:opacity-100"
+                      >
+                          <button
+                              @click="openCropEditor(selectedMainGalleryImage)"
+                              class="inline-flex w-full items-center justify-center gap-1 rounded bg-white px-2 py-1 text-[10px] font-medium text-gray-900 hover:bg-gray-200"
+                          >
+                              <Crop class="h-3 w-3" />
+                              Кроп
+                          </button>
+                          <button
+                              @click="removeGalleryImageBackground(selectedMainGalleryImage)"
+                              :disabled="backgroundRemovingImageId === selectedMainGalleryImage.id"
+                              class="inline-flex w-full items-center justify-center gap-1 rounded bg-teal-600 px-2 py-1 text-[10px] font-medium text-white hover:bg-teal-700 disabled:opacity-60"
+                              title="Удалить фон и заменить главное фото"
+                          >
+                              <Wand2 class="h-3 w-3" />
+                              {{ backgroundRemovingImageId === selectedMainGalleryImage.id ? 'Обработка...' : 'Без фона' }}
+                          </button>
+                          <button
+                              @click="reprocessCardVariant(selectedMainGalleryImage.id)"
+                              :disabled="variantReprocessingImageId === selectedMainGalleryImage.id || variantProcessingLoading"
+                              class="w-full rounded bg-teal-600 px-2 py-1 text-[10px] text-white hover:bg-teal-700 disabled:opacity-60"
+                              title="Обновить card variant только для главной картинки"
+                          >
+                              {{ variantReprocessingImageId === selectedMainGalleryImage.id ? 'variant...' : 'Обновить card' }}
+                          </button>
+                      </div>
                   </div>
 
                   <!-- Gallery Items -->

--- a/openapi.json
+++ b/openapi.json
@@ -5662,6 +5662,80 @@
         ]
       }
     },
+    "/api/manager/gallery/apply-to-series": {
+      "post": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Apply Gallery To Series",
+        "description": "Replace sibling products' non-installation galleries with this product's gallery.",
+        "operationId": "apply_gallery_to_series",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Source product ID",
+              "title": "Product Id"
+            },
+            "description": "Source product ID"
+          },
+          {
+            "name": "dry_run",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Preview changes without applying them",
+              "default": false,
+              "title": "Dry Run"
+            },
+            "description": "Preview changes without applying them"
+          },
+          {
+            "name": "delete_unreferenced",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Delete physical files that become unreferenced",
+              "default": false,
+              "title": "Delete Unreferenced"
+            },
+            "description": "Delete physical files that become unreferenced"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerMediaApplySeriesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/gallery/variants/process-missing": {
       "post": {
         "tags": [
@@ -20834,6 +20908,88 @@
         },
         "type": "object",
         "title": "ManagerInstallerUpdatePayload"
+      },
+      "ManagerMediaApplySeriesResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          },
+          "source_product_id": {
+            "type": "integer",
+            "title": "Source Product Id"
+          },
+          "series_id": {
+            "type": "integer",
+            "title": "Series Id"
+          },
+          "series_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Title"
+          },
+          "updated_products": {
+            "type": "integer",
+            "title": "Updated Products"
+          },
+          "images_applied": {
+            "type": "integer",
+            "title": "Images Applied"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "replaced_links": {
+            "type": "integer",
+            "title": "Replaced Links",
+            "default": 0
+          },
+          "obsolete_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Obsolete Urls"
+          },
+          "preserved_installation_links": {
+            "type": "integer",
+            "title": "Preserved Installation Links",
+            "default": 0
+          },
+          "deleted_files_count": {
+            "type": "integer",
+            "title": "Deleted Files Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "source_product_id",
+          "series_id",
+          "updated_products",
+          "images_applied"
+        ],
+        "title": "ManagerMediaApplySeriesResponse"
       },
       "ManagerMediaAssetCropPayload": {
         "properties": {

--- a/routers/manager_media_gallery_write.py
+++ b/routers/manager_media_gallery_write.py
@@ -7,6 +7,7 @@ from core.database import get_session
 from core.logger import logger
 from core.security import get_current_username
 from routers.manager_operation_ids import (
+    APPLY_GALLERY_TO_SERIES,
     BULK_ADD_GALLERY_IMAGES,
     BULK_DELETE_COMMON_GALLERY_IMAGES,
     BULK_UPLOAD_LOCAL_IMAGES,
@@ -24,6 +25,7 @@ from schemas import (
     BulkGalleryAddRequest,
     BulkGalleryDeleteRequest,
     ManagerMediaBulkAddResponse,
+    ManagerMediaApplySeriesResponse,
     ManagerMediaBulkDeleteResponse,
     ManagerMediaBulkUploadResponse,
     ManagerMediaCleanupResponse,
@@ -252,6 +254,32 @@ async def bulk_delete_common_gallery_images(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=exc.args[0]) from exc
+
+
+@router.post(
+    "/gallery/apply-to-series",
+    response_model=ManagerMediaApplySeriesResponse,
+    operation_id=APPLY_GALLERY_TO_SERIES,
+)
+async def apply_gallery_to_series(
+    product_id: int = Query(..., description="Source product ID"),
+    dry_run: bool = Query(False, description="Preview changes without applying them"),
+    delete_unreferenced: bool = Query(False, description="Delete physical files that become unreferenced"),
+    session: AsyncSession = Depends(get_session),
+    username: str = Depends(get_current_username),
+):
+    """Replace sibling products' non-installation galleries with this product's gallery."""
+    try:
+        return await ManagerMediaService.apply_gallery_to_series(
+            session,
+            product_id,
+            dry_run=dry_run,
+            delete_unreferenced=delete_unreferenced,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -55,6 +55,7 @@ REUSE_IMAGE = "reuse_image"
 BULK_ADD_GALLERY_IMAGES = "bulk_add_gallery_images"
 BULK_UPLOAD_LOCAL_IMAGES = "bulk_upload_local_images"
 BULK_DELETE_COMMON_GALLERY_IMAGES = "bulk_delete_common_gallery_images"
+APPLY_GALLERY_TO_SERIES = "apply_gallery_to_series"
 CLEANUP_MEDIA = "cleanup_media"
 GET_IMAGE_VARIANT_CANDIDATES = "get_image_variant_candidates"
 PROCESS_MISSING_IMAGE_VARIANTS = "process_missing_image_variants"
@@ -269,6 +270,7 @@ ALL_MANAGER_OPERATION_IDS = (
     BULK_ADD_GALLERY_IMAGES,
     BULK_UPLOAD_LOCAL_IMAGES,
     BULK_DELETE_COMMON_GALLERY_IMAGES,
+    APPLY_GALLERY_TO_SERIES,
     CLEANUP_MEDIA,
     GET_IMAGE_VARIANT_CANDIDATES,
     PROCESS_MISSING_IMAGE_VARIANTS,

--- a/schemas.py
+++ b/schemas.py
@@ -1998,6 +1998,20 @@ class ManagerMediaBulkUploadResponse(ManagerActionMessageResponse):
     uploaded_links: int
 
 
+class ManagerMediaApplySeriesResponse(ManagerActionMessageResponse):
+    dry_run: bool = False
+    source_product_id: int
+    series_id: int
+    series_title: Optional[str] = None
+    updated_products: int
+    images_applied: int
+    main_image: Optional[str] = None
+    replaced_links: int = 0
+    obsolete_urls: List[str] = Field(default_factory=list)
+    preserved_installation_links: int = 0
+    deleted_files_count: int = 0
+
+
 class ManagerMediaUploadLocalImagesResponse(BaseModel):
     uploaded: int
     images: List[ManagerMediaImageLinkResponse]

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import func
 from sqlmodel import select, update
 
-from models import Product, ProductImage, ProductImageVariant
+from models import Product, ProductImage, ProductImageVariant, ProductSeries
 from services.product_image_processing_contract import ProductImageVariantType
 from services.product_image_processing_provider import (
     ProductImageProcessingContext,
@@ -382,7 +382,7 @@ class ManagerMediaService:
         session.add(product)
 
     @staticmethod
-    async def remove_file_if_unreferenced(session: AsyncSession, url: str) -> None:
+    async def remove_file_if_unreferenced(session: AsyncSession, url: str) -> bool:
         """Delete physical file only when no ProductImage/Product.main_image references remain."""
         gallery_ref_stmt = select(func.count()).select_from(ProductImage).where(ProductImage.url == url)
         gallery_refs = (await session.execute(gallery_ref_stmt)).scalar_one()
@@ -396,16 +396,18 @@ class ManagerMediaService:
         variant_refs = (await session.execute(variant_ref_stmt)).scalar_one()
 
         if gallery_refs > 0 or main_refs > 0 or variant_refs > 0:
-            return
+            return False
         if not url.startswith("/media/"):
-            return
+            return False
 
         path = url.lstrip("/")
         if os.path.exists(path):
             try:
                 os.remove(path)
+                return True
             except Exception as exc:
                 logger.error(f"Failed to delete unreferenced file {url}: {exc}")
+        return False
 
     @staticmethod
     def local_media_path_for_url(url: str) -> Path | None:
@@ -604,6 +606,162 @@ class ManagerMediaService:
             "message": "Bulk delete completed",
             "products_count": len(unique_product_ids),
             "deleted_links": deleted_links,
+        }
+
+    @staticmethod
+    async def apply_gallery_to_series(
+        session: AsyncSession,
+        product_id: int,
+        *,
+        dry_run: bool = False,
+        delete_unreferenced: bool = False,
+    ) -> dict:
+        source_product = await session.get(Product, product_id)
+        if not source_product:
+            raise LookupError("Product not found")
+        if not source_product.series_id:
+            raise ValueError("Product is not assigned to a series")
+
+        series = await session.get(ProductSeries, source_product.series_id)
+
+        source_rows = (
+            await session.execute(
+                select(ProductImage)
+                .where(
+                    ProductImage.product_id == source_product.id,
+                    ProductImage.is_installation_photo == False,  # noqa: E712
+                )
+                .order_by(ProductImage.id)
+            )
+        ).scalars().all()
+
+        source_urls: list[str] = []
+        if source_product.main_image:
+            source_urls.append(source_product.main_image)
+        source_urls.extend(image.url for image in source_rows)
+        source_urls = [url for url in dict.fromkeys(source_urls) if url]
+        if not source_urls:
+            raise ValueError("Source product has no non-installation gallery images")
+
+        target_products = (
+            await session.execute(
+                select(Product).where(
+                    Product.series_id == source_product.series_id,
+                    Product.id != source_product.id,
+                )
+            )
+        ).scalars().all()
+
+        updated_products = 0
+        preserved_installation_links = 0
+        replaced_links = 0
+        obsolete_urls: list[str] = []
+        obsolete_variant_urls: list[str] = []
+
+        target_rows_by_product_id: dict[int, list[ProductImage]] = {}
+        for target_product in target_products:
+            target_rows = (
+                await session.execute(
+                    select(ProductImage).where(ProductImage.product_id == target_product.id)
+                )
+            ).scalars().all()
+            target_rows_by_product_id[target_product.id] = list(target_rows)
+            old_gallery_rows = [row for row in target_rows if not row.is_installation_photo]
+            replaced_links += len(old_gallery_rows)
+            obsolete_urls.extend(row.url for row in old_gallery_rows if row.url and row.url not in source_urls)
+            preserved_installation_links += len({row.url for row in target_rows if row.is_installation_photo})
+
+            old_gallery_ids = [row.id for row in old_gallery_rows if row.id is not None]
+            if old_gallery_ids:
+                variant_urls = (
+                    await session.execute(
+                        select(ProductImageVariant.url).where(
+                            ProductImageVariant.product_image_id.in_(old_gallery_ids),
+                            ProductImageVariant.url != None,  # noqa: E711
+                        )
+                    )
+                ).scalars().all()
+                obsolete_variant_urls.extend(url for url in variant_urls if url)
+
+        obsolete_urls = list(dict.fromkeys(obsolete_urls))
+
+        if dry_run:
+            return {
+                "message": "Series gallery preview",
+                "dry_run": True,
+                "source_product_id": source_product.id,
+                "series_id": source_product.series_id,
+                "series_title": series.title if series else None,
+                "updated_products": len(target_products),
+                "images_applied": len(source_urls),
+                "main_image": source_product.main_image,
+                "replaced_links": replaced_links,
+                "obsolete_urls": obsolete_urls,
+                "preserved_installation_links": preserved_installation_links,
+                "deleted_files_count": 0,
+            }
+
+        for target_product in target_products:
+            target_rows = target_rows_by_product_id[target_product.id]
+
+            old_gallery_rows = [row for row in target_rows if not row.is_installation_photo]
+            installation_urls = {row.url for row in target_rows if row.is_installation_photo}
+
+            old_gallery_ids = [row.id for row in old_gallery_rows if row.id is not None]
+            if old_gallery_ids:
+                variant_rows = (
+                    await session.execute(
+                        select(ProductImageVariant).where(
+                            ProductImageVariant.product_image_id.in_(old_gallery_ids)
+                        )
+                    )
+                ).scalars().all()
+                for variant in variant_rows:
+                    await session.delete(variant)
+
+            for row in old_gallery_rows:
+                await session.delete(row)
+            await session.flush()
+
+            for url in source_urls:
+                if url in installation_urls:
+                    continue
+                image = ProductImage(
+                    product_id=target_product.id,
+                    url=url,
+                    is_installation_photo=False,
+                )
+                session.add(image)
+                await session.flush()
+                await ProductImageVariantService.ensure_original_variant(session, image)
+
+            target_product.main_image = source_product.main_image
+            session.add(target_product)
+            await ManagerMediaService.sync_legacy_images(session, target_product.id)
+            updated_products += 1
+
+        await session.commit()
+
+        deleted_files_count = 0
+        if delete_unreferenced:
+            for url in dict.fromkeys([*obsolete_urls, *obsolete_variant_urls]):
+                deleted = await ManagerMediaService.remove_file_if_unreferenced(session, url)
+                if deleted:
+                    deleted_files_count += 1
+
+        return {
+            "message": "Series gallery applied",
+            "dry_run": False,
+            "source_product_id": source_product.id,
+            "series_id": source_product.series_id,
+            "series_title": series.title if series else None,
+            "updated_products": updated_products,
+            "images_applied": len(source_urls),
+            "main_image": source_product.main_image,
+            "replaced_links": replaced_links,
+            "obsolete_urls": obsolete_urls,
+            "preserved_installation_links": preserved_installation_links,
+            "deleted_files_count": deleted_files_count,
         }
 
     @staticmethod

--- a/tests/unit/test_product_image_variants.py
+++ b/tests/unit/test_product_image_variants.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
-from models import Product, ProductImage, ProductImageVariant
+from models import Product, ProductImage, ProductImageVariant, ProductSeries
 from services.manager_media_service import ManagerMediaService
 from services.media_storage_service import LocalProductMediaStorage, StoredMediaObject
 from services.product_image_processing_contract import (
@@ -257,6 +257,145 @@ async def test_delete_shared_image_keeps_file_until_last_image_and_variant_refer
 
     await ManagerMediaService.delete_gallery_image(sqlite_session, second_image.id)
     assert not shared_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_gallery_to_series_preserves_installation_photos_and_replaces_gallery(
+    sqlite_session,
+    monkeypatch,
+):
+    async def _skip_original_variant(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        ProductImageVariantService,
+        "ensure_original_variant",
+        _skip_original_variant,
+    )
+
+    series = ProductSeries(title="MDV Smart", slug="mdv-smart")
+    sqlite_session.add(series)
+    await sqlite_session.flush()
+
+    source = Product(
+        title="Source product",
+        slug="series-source-product",
+        price=1000,
+        area=20,
+        series_id=series.id,
+        main_image="/media/products/shared/source-main.webp",
+        specs={},
+    )
+    target = Product(
+        title="Target product",
+        slug="series-target-product",
+        price=1100,
+        area=25,
+        series_id=series.id,
+        main_image="/media/products/shared/old-main.webp",
+        specs={},
+    )
+    outside = Product(
+        title="Outside product",
+        slug="outside-product",
+        price=1200,
+        area=30,
+        main_image="/media/products/shared/outside.webp",
+        specs={},
+    )
+    sqlite_session.add_all([source, target, outside])
+    await sqlite_session.flush()
+
+    sqlite_session.add_all(
+        [
+            ProductImage(product_id=source.id, url="/media/products/shared/source-main.webp"),
+            ProductImage(product_id=source.id, url="/media/products/shared/source-extra.webp"),
+            ProductImage(
+                product_id=source.id,
+                url="/media/products/shared/source-installation.webp",
+                is_installation_photo=True,
+            ),
+            ProductImage(product_id=target.id, url="/media/products/shared/old-main.webp"),
+            ProductImage(product_id=target.id, url="/media/products/shared/old-extra.webp"),
+            ProductImage(
+                product_id=target.id,
+                url="/media/products/shared/target-installation.webp",
+                is_installation_photo=True,
+            ),
+            ProductImage(product_id=outside.id, url="/media/products/shared/outside.webp"),
+        ]
+    )
+    await sqlite_session.flush()
+
+    old_target_image = (
+        await sqlite_session.execute(
+            select(ProductImage).where(
+                ProductImage.product_id == target.id,
+                ProductImage.url == "/media/products/shared/old-main.webp",
+            )
+        )
+    ).scalar_one()
+    old_target_image_id = old_target_image.id
+    sqlite_session.add(
+        ProductImageVariant(
+            product_image_id=old_target_image_id,
+            variant_type=ProductImageVariantType.CARD.value,
+            url="/media/products/variants/card/old-main.webp",
+            processing_status=ProductImageProcessingStatus.READY.value,
+        )
+    )
+    await sqlite_session.commit()
+
+    preview = await ManagerMediaService.apply_gallery_to_series(
+        sqlite_session,
+        source.id,
+        dry_run=True,
+    )
+
+    assert preview["dry_run"] is True
+    assert preview["updated_products"] == 1
+    assert preview["replaced_links"] == 2
+    assert preview["obsolete_urls"] == [
+        "/media/products/shared/old-main.webp",
+        "/media/products/shared/old-extra.webp",
+    ]
+
+    result = await ManagerMediaService.apply_gallery_to_series(sqlite_session, source.id)
+
+    await sqlite_session.refresh(target)
+    await sqlite_session.refresh(outside)
+    target_images = (
+        await sqlite_session.execute(
+            select(ProductImage).where(ProductImage.product_id == target.id).order_by(ProductImage.id)
+        )
+    ).scalars().all()
+    outside_images = (
+        await sqlite_session.execute(select(ProductImage).where(ProductImage.product_id == outside.id))
+    ).scalars().all()
+    old_variants = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(ProductImageVariant.product_image_id == old_target_image_id)
+        )
+    ).scalars().all()
+
+    assert result["updated_products"] == 1
+    assert result["images_applied"] == 2
+    assert result["replaced_links"] == 2
+    assert result["deleted_files_count"] == 0
+    assert result["preserved_installation_links"] == 1
+    assert target.main_image == source.main_image
+    assert [image.url for image in target_images] == [
+        "/media/products/shared/target-installation.webp",
+        "/media/products/shared/source-main.webp",
+        "/media/products/shared/source-extra.webp",
+    ]
+    assert target.images == [
+        "/media/products/shared/source-main.webp",
+        "/media/products/shared/source-extra.webp",
+    ]
+    assert [image.url for image in outside_images] == ["/media/products/shared/outside.webp"]
+    assert outside.main_image == "/media/products/shared/outside.webp"
+    assert old_variants == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add URL and clipboard upload controls to the product image upload tab
- move product gallery processing settings behind a compact menu and enable actions on the main image card
- add a safe apply-gallery-to-series endpoint with dry-run preview, installation-photo preservation, and optional cleanup of unreferenced files

## Verification
- pytest tests/unit/test_product_image_variants.py tests/unit/test_manager_media_service_crop.py -q
- npm run build (manager_frontend)
- git diff --check

## Notes
- Apply-to-series first previews removed links in the UI, then asks before applying; physical file deletion is optional and still guarded by reference checks.
- Browser rendered smoke loaded /manager/products without console errors, but the local hover-card action did not reliably open via the in-app browser click path, so the modal interaction was not fully exercised visually.