### PR TITLE
[codex] Add bot repair nameplate workflow

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -11,6 +11,7 @@ from services.product_service import ProductService
 from services.staff_user_service import StaffUserService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_task_service import BotTaskService
 from ..config import bot
 from ..states import ShopState
@@ -97,10 +98,16 @@ def _preview_keyboard(data: dict) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
-def _requisites_file_intent_keyboard(*, can_extract_requisites: bool = True) -> InlineKeyboardMarkup:
+def _requisites_file_intent_keyboard(
+    *,
+    can_extract_requisites: bool = True,
+    can_repair_nameplate: bool = False,
+) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     if can_extract_requisites:
         rows.append([InlineKeyboardButton(text="Извлечь реквизиты", callback_data="req_file_extract")])
+    if can_repair_nameplate:
+        rows.append([InlineKeyboardButton(text="Шильдик к ремонту", callback_data="repair_nameplate_start")])
     rows.append([InlineKeyboardButton(text="Прикрепить к заказу", callback_data="req_file_attach")])
     rows.append([InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")])
     return InlineKeyboardMarkup(inline_keyboard=rows)
@@ -123,6 +130,23 @@ def _order_attachment_keyboard(orders: list[dict]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
+def _repair_nameplate_order_keyboard(orders: list[dict]) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        if not order_id:
+            continue
+        title = " ".join(str(order.get("title") or order.get("customer_name") or "ремонт").split())
+        if len(title) > 34:
+            title = f"{title[:31]}..."
+        rows.append(
+            [InlineKeyboardButton(text=f"#{order_id} - {title}", callback_data=f"repair_nameplate_order_{order_id}")]
+        )
+    rows.append([InlineKeyboardButton(text="Ввести номер/id заказа", callback_data="repair_nameplate_manual")])
+    rows.append([InlineKeyboardButton(text="Отмена", callback_data="repair_nameplate_cancel")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
 def _format_order_attachment_choices(orders: list[dict]) -> str:
     if not orders:
         return "Быстрых вариантов не нашел. Введите номер/id заказа сообщением."
@@ -132,6 +156,20 @@ def _format_order_attachment_choices(orders: list[dict]) -> str:
         order_id = int(order.get("id") or 0)
         customer = order.get("customer_name") or "клиент не указан"
         title = order.get("title") or "заказ"
+        address = order.get("address") or "адрес не указан"
+        lines.append(f"#{order_id}: {escape(str(title))}, {escape(str(customer))}, {escape(str(address))}")
+    return "\n".join(lines)
+
+
+def _format_repair_nameplate_order_choices(orders: list[dict]) -> str:
+    if not orders:
+        return "Быстрых ремонтных заказов в исполнении не нашел. Введите номер/id заказа сообщением."
+
+    lines = ["К какому ремонтному заказу добавить данные со шильдика?"]
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        customer = order.get("customer_name") or "клиент не указан"
+        title = order.get("title") or "ремонт"
         address = order.get("address") or "адрес не указан"
         lines.append(f"#{order_id}: {escape(str(title))}, {escape(str(customer))}, {escape(str(address))}")
     return "\n".join(lines)
@@ -162,6 +200,105 @@ def _parse_order_id(text: str | None) -> int | None:
         return None
     order_id = int(cleaned)
     return order_id if order_id > 0 else None
+
+
+def _repair_nameplate_preview_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Записать в ремонт", callback_data="repair_nameplate_confirm")],
+            [InlineKeyboardButton(text="Отмена", callback_data="repair_nameplate_cancel")],
+        ]
+    )
+
+
+def _repair_context_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
+        ]
+    )
+
+
+def _repair_comment_preview_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Записать и продолжить", callback_data="repair_comment_confirm")],
+            [InlineKeyboardButton(text="Не записывать", callback_data="repair_comment_cancel")],
+            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
+        ]
+    )
+
+
+def _repair_nameplate_preview_text(data: dict[str, object]) -> str:
+    extracted = data.get("extracted") if isinstance(data.get("extracted"), dict) else {}
+    validation_flags = data.get("validation_flags") if isinstance(data.get("validation_flags"), dict) else {}
+    merge_preview = data.get("merge_preview") if isinstance(data.get("merge_preview"), dict) else {}
+    applied = merge_preview.get("applied") if isinstance(merge_preview.get("applied"), dict) else {}
+    conflicts = merge_preview.get("conflicts") if isinstance(merge_preview.get("conflicts"), dict) else {}
+    skipped = merge_preview.get("skipped") if isinstance(merge_preview.get("skipped"), dict) else {}
+    warnings = validation_flags.get("warnings") if isinstance(validation_flags.get("warnings"), dict) else {}
+
+    lines = ["<b>Распознал шильдик. Проверьте перед записью:</b>", ""]
+    for field in BotRepairNameplateService.REPAIR_FIELDS:
+        label = BotRepairNameplateService.FIELD_LABELS.get(field, field)
+        value = extracted.get(field)
+        if value:
+            lines.append(f"<b>{escape(label)}:</b> {escape(str(value))}")
+
+    if applied:
+        lines.extend(["", "<b>Будет записано:</b>"])
+        lines.extend(
+            f"• {escape(BotRepairNameplateService.FIELD_LABELS.get(field, field))}: {escape(str(value))}"
+            for field, value in applied.items()
+        )
+    if skipped:
+        lines.extend(["", "<b>Уже было заполнено таким же значением:</b>"])
+        lines.extend(
+            f"• {escape(BotRepairNameplateService.FIELD_LABELS.get(field, field))}: {escape(str(value))}"
+            for field, value in skipped.items()
+        )
+    if conflicts:
+        lines.extend(["", "<b>Конфликты, не перезапишу автоматически:</b>"])
+        for field, values in conflicts.items():
+            label = BotRepairNameplateService.FIELD_LABELS.get(field, field)
+            existing = values.get("existing") if isinstance(values, dict) else ""
+            candidate = values.get("candidate") if isinstance(values, dict) else ""
+            lines.append(f"• {escape(label)}: сейчас {escape(str(existing))}, распознано {escape(str(candidate))}")
+    if warnings:
+        lines.extend(["", "<b>Предупреждения:</b>"])
+        lines.extend(f"• {escape(str(message))}" for message in warnings.values())
+    if not extracted:
+        lines.append("Данных не нашел. Лучше отправить фото ближе и ровнее.")
+    return "\n".join(lines)
+
+
+def _repair_comment_preview_text(data: dict[str, object]) -> str:
+    merge_preview = data.get("merge_preview") if isinstance(data.get("merge_preview"), dict) else {}
+    changes = merge_preview.get("changes") if isinstance(merge_preview.get("changes"), dict) else {}
+    unchanged = merge_preview.get("unchanged") if isinstance(merge_preview.get("unchanged"), dict) else {}
+
+    lines = ["<b>Подготовил поля дефектного акта из комментария:</b>"]
+    if changes:
+        lines.extend(["", "<b>Будет записано/обновлено:</b>"])
+        for field, values in changes.items():
+            label = BotRepairNameplateService.COMMENT_FIELD_LABELS.get(field, field)
+            candidate = values.get("candidate") if isinstance(values, dict) else values
+            existing = values.get("existing") if isinstance(values, dict) else ""
+            if existing:
+                lines.append(f"• <b>{escape(label)}:</b> {escape(str(candidate))}")
+                lines.append(f"  Было: {escape(str(existing))}")
+            else:
+                lines.append(f"• <b>{escape(label)}:</b> {escape(str(candidate))}")
+    if unchanged:
+        lines.extend(["", "<b>Без изменений:</b>"])
+        lines.extend(
+            f"• {escape(BotRepairNameplateService.COMMENT_FIELD_LABELS.get(field, field))}"
+            for field in unchanged.keys()
+        )
+    if not changes and not unchanged:
+        lines.append("")
+        lines.append("AI не вернул полезных полей. Лучше отправить комментарий подробнее.")
+    return "\n".join(lines)
 
 
 async def _download_telegram_file(file_id: str) -> bytes:
@@ -254,7 +391,10 @@ async def _ask_requisites_file_action(
     )
     await message.answer(
         "Файл получил. Что сделать?",
-        reply_markup=_requisites_file_intent_keyboard(can_extract_requisites=can_extract_requisites),
+        reply_markup=_requisites_file_intent_keyboard(
+            can_extract_requisites=can_extract_requisites,
+            can_repair_nameplate=str(mime_type or "").startswith("image/"),
+        ),
     )
 
 
@@ -462,9 +602,352 @@ async def attach_pending_file_to_typed_order(message: types.Message, state: FSMC
     await message.answer(f"✅ Файл {status} к заказу #{result['id']}.")
 
 
+@router.callback_query(F.data == "repair_nameplate_start")
+async def choose_order_for_repair_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+    if not str(pending.get("mime_type") or "").startswith("image/"):
+        await callback.answer("Шильдик распознаем только по фото.", show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        orders = await BotRepairNameplateService.list_repair_orders(
+            session,
+            telegram_user_id=callback.from_user.id,
+            can_attach_any=context.is_manager,
+            limit=5,
+        )
+
+    if orders:
+        await callback.message.edit_text(
+            _format_repair_nameplate_order_choices(orders),
+            reply_markup=_repair_nameplate_order_keyboard(orders),
+            parse_mode="HTML",
+        )
+    else:
+        await state.set_state(ShopState.waiting_for_repair_nameplate_order_id)
+        await callback.message.edit_text(
+            "Быстрых ремонтных заказов в исполнении не нашел. Введите номер/id заказа сообщением."
+        )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_nameplate_manual")
+async def enter_order_id_for_repair_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+
+    await state.set_state(ShopState.waiting_for_repair_nameplate_order_id)
+    await callback.message.edit_text("Введите номер/id ремонтного заказа сообщением.")
+    await callback.answer()
+
+
+async def _run_repair_nameplate_recognition_for_order(
+    progress_message: types.Message,
+    *,
+    order_id: int,
+    telegram_user_id: int | None,
+    can_attach_any: bool,
+    state: FSMContext,
+):
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await progress_message.edit_text("Фото не найдено. Отправьте его еще раз.")
+        return
+
+    async with async_session_maker() as session:
+        allowed = await BotRepairNameplateService.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+    if not allowed:
+        await progress_message.edit_text(
+            "Этот заказ не найден среди ремонтных заказов в исполнении или не назначен вам."
+        )
+        return
+
+    try:
+        content = await _download_telegram_file(str(pending.get("file_id")))
+        recognized = await BotRepairNameplateService.recognize_bytes(
+            content=content,
+            filename=str(pending.get("filename") or "telegram-nameplate.jpg"),
+            mime_type=str(pending.get("mime_type") or "image/jpeg"),
+        )
+        async with async_session_maker() as session:
+            merge_preview = await BotRepairNameplateService.build_merge_preview(
+                session,
+                order_id=order_id,
+                extracted=recognized.get("extracted") or {},
+            )
+    except Exception as exc:
+        await progress_message.edit_text(f"❌ Не удалось распознать шильдик: {escape(str(exc))}")
+        return
+
+    draft = {
+        "order_id": order_id,
+        "file": pending,
+        "raw_text": recognized.get("raw_text") or "",
+        "extracted": recognized.get("extracted") or {},
+        "validation_flags": recognized.get("validation_flags") or {},
+        "merge_preview": merge_preview or {"applied": {}, "conflicts": {}, "skipped": {}},
+    }
+    await state.update_data(pending_repair_nameplate=draft)
+    await state.set_state(None)
+    await progress_message.edit_text(
+        _repair_nameplate_preview_text(draft),
+        reply_markup=_repair_nameplate_preview_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(F.data.startswith("repair_nameplate_order_"))
+async def recognize_repair_nameplate_for_chosen_order(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    order_id = _parse_order_id((callback.data or "").rsplit("_", 1)[-1])
+    if not order_id:
+        await callback.answer("Не понял номер заказа", show_alert=True)
+        return
+
+    await callback.answer()
+    await callback.message.edit_text("Распознаю шильдик…")
+    await _run_repair_nameplate_recognition_for_order(
+        callback.message,
+        order_id=order_id,
+        telegram_user_id=callback.from_user.id,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+
+
+@router.message(ShopState.waiting_for_repair_nameplate_order_id)
+async def recognize_repair_nameplate_for_typed_order(message: types.Message, state: FSMContext):
+    context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await state.clear()
+        return
+
+    order_id = _parse_order_id(message.text)
+    if not order_id:
+        await message.answer("Введите номер ремонтного заказа числом, например: 123")
+        return
+
+    progress = await message.answer("Распознаю шильдик…")
+    await _run_repair_nameplate_recognition_for_order(
+        progress,
+        order_id=order_id,
+        telegram_user_id=message.from_user.id if message.from_user else None,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+
+
+@router.callback_query(F.data == "repair_nameplate_confirm")
+async def confirm_repair_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    draft = data.get("pending_repair_nameplate") or {}
+    if not isinstance(draft, dict) or not draft.get("order_id"):
+        await callback.answer("Черновик не найден. Отправьте фото еще раз.", show_alert=True)
+        return
+    pending_file = draft.get("file") if isinstance(draft.get("file"), dict) else {}
+    if not pending_file or not pending_file.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        result = await BotRepairNameplateService.apply_to_order(
+            session,
+            int(draft["order_id"]),
+            extracted=draft.get("extracted") or {},
+            raw_text=str(draft.get("raw_text") or ""),
+            validation_flags=draft.get("validation_flags") or {},
+            file_id=str(pending_file.get("file_id")),
+            filename=str(pending_file.get("filename") or "telegram-nameplate.jpg"),
+            mime_type=str(pending_file.get("mime_type") or "image/jpeg"),
+            telegram_user_id=callback.from_user.id,
+            telegram_chat_id=pending_file.get("telegram_chat_id"),
+            telegram_message_id=pending_file.get("telegram_message_id"),
+            can_attach_any=context.is_manager,
+        )
+
+    if not result:
+        await callback.answer("Заказ не найден или недоступен.", show_alert=True)
+        return
+
+    await state.update_data(
+        pending_repair_nameplate=None,
+        pending_requisites_file=None,
+        active_repair_order_context={"order_id": int(result["id"])},
+    )
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    applied_count = len(result.get("applied") or {})
+    conflict_count = len(result.get("conflicts") or {})
+    lines = [f"✅ Данные со шильдика записаны в ремонт #{result['id']}."]
+    if applied_count:
+        lines.append(f"Заполнено полей: {applied_count}.")
+    if conflict_count:
+        lines.append(f"Конфликты оставил без перезаписи: {conflict_count}.")
+    lines.append("")
+    lines.append("Теперь можно отправлять комментарии по диагностике текстом или голосом в текст. Я подготовлю поля дефектного акта по этому заказу.")
+    await callback.message.edit_text("\n".join(lines), reply_markup=_repair_context_keyboard())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_nameplate_cancel")
+async def cancel_repair_nameplate(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(pending_repair_nameplate=None, pending_requisites_file=None)
+    await state.set_state(None)
+    await callback.message.edit_text("Ок, шильдик оставил без обработки.")
+    await callback.answer()
+
+
+@router.message(ShopState.waiting_for_repair_context_comment)
+async def handle_repair_context_comment(message: types.Message, state: FSMContext):
+    context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await state.clear()
+        return
+
+    text = str(message.text or "").strip()
+    if not text:
+        await message.answer("Пришлите диагностический комментарий текстом.")
+        return
+    if text.casefold() in {"стоп", "завершить", "готово", "отмена"}:
+        await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
+        await state.set_state(None)
+        await message.answer("Ок, вышел из режима заметок по ремонту.")
+        return
+
+    data = await state.get_data()
+    active_context = data.get("active_repair_order_context") or {}
+    order_id = _parse_order_id(str(active_context.get("order_id") if isinstance(active_context, dict) else ""))
+    if not order_id:
+        await state.set_state(None)
+        await message.answer("Контекст ремонтного заказа потерян. Отправьте шильдик или выберите заказ заново.")
+        return
+
+    progress = await message.answer("Готовлю поля дефектного акта из комментария…")
+    try:
+        async with async_session_maker() as session:
+            draft = await BotRepairNameplateService.build_diagnostic_comment_draft(
+                session,
+                order_id=order_id,
+                comment=text,
+            )
+    except Exception as exc:
+        await progress.edit_text(f"❌ Не удалось обработать комментарий: {escape(str(exc))}")
+        return
+
+    if not draft:
+        await progress.edit_text("Ремонтный заказ не найден. Выйдите из режима и выберите заказ заново.")
+        return
+
+    draft["telegram_message_id"] = message.message_id
+    draft["telegram_chat_id"] = message.chat.id if message.chat else None
+    await state.update_data(pending_repair_comment=draft)
+    await progress.edit_text(
+        _repair_comment_preview_text(draft),
+        reply_markup=_repair_comment_preview_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(F.data == "repair_comment_confirm")
+async def confirm_repair_context_comment(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    active_context = data.get("active_repair_order_context") or {}
+    order_id = _parse_order_id(str(active_context.get("order_id") if isinstance(active_context, dict) else ""))
+    draft = data.get("pending_repair_comment") or {}
+    if not order_id or not isinstance(draft, dict):
+        await callback.answer("Черновик комментария не найден.", show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        result = await BotRepairNameplateService.apply_diagnostic_comment(
+            session,
+            order_id,
+            repair_meta_draft=draft.get("repair_meta") or {},
+            raw_comment=str(draft.get("comment") or ""),
+            telegram_user_id=callback.from_user.id,
+            telegram_chat_id=draft.get("telegram_chat_id"),
+            telegram_message_id=draft.get("telegram_message_id"),
+            can_attach_any=context.is_manager,
+        )
+
+    if not result:
+        await callback.answer("Заказ не найден или недоступен.", show_alert=True)
+        return
+
+    await state.update_data(pending_repair_comment=None)
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    changed_count = len(result.get("changes") or {})
+    await callback.message.edit_text(
+        f"✅ Комментарий записан в ремонт #{result['id']}.\n"
+        f"Обновлено полей: {changed_count}.\n\n"
+        "Можно отправить следующий диагностический комментарий.",
+        reply_markup=_repair_context_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_comment_cancel")
+async def cancel_repair_context_comment(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(pending_repair_comment=None)
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    await callback.message.edit_text(
+        "Ок, комментарий не записал. Можно отправить следующий диагностический комментарий.",
+        reply_markup=_repair_context_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_context_finish")
+async def finish_repair_context(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
+    await state.set_state(None)
+    await callback.message.edit_text("Ок, вышел из режима заметок по ремонту.")
+    await callback.answer()
+
+
 @router.callback_query(F.data == "req_file_cancel")
 async def cancel_pending_requisites_file(callback: CallbackQuery, state: FSMContext):
-    await state.update_data(pending_requisites_file=None)
+    await state.update_data(
+        pending_requisites_file=None,
+        pending_repair_nameplate=None,
+        pending_repair_comment=None,
+    )
     await state.set_state(None)
     await callback.message.edit_text("Ок, файл оставил без обработки.")
     await callback.answer()

--- a/bot_app/states.py
+++ b/bot_app/states.py
@@ -8,6 +8,8 @@ class ShopState(StatesGroup):
     waiting_for_selection = State()
     waiting_for_task_report = State()
     waiting_for_order_attachment_order_id = State()
+    waiting_for_repair_nameplate_order_id = State()
+    waiting_for_repair_context_comment = State()
     select_area = State()
     select_type = State()
     select_winter = State()  # Выбор зимнего обогрева

--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -1,0 +1,680 @@
+import re
+from datetime import datetime
+from typing import Any, Optional
+
+import httpx
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+
+from core.config import settings
+from models import Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
+from services.defect_act_ai_service import DefectActAIService
+from services.order_service import OrderService
+from services.staff_user_service import StaffUserService
+from schemas import ManagerRepairActAiDraftPayload
+
+
+class BotRepairNameplateService:
+    """Recognizes AC nameplates and safely applies passport fields to repair orders."""
+
+    REPAIR_STATUS = OrderStatus.EXECUTION
+    REPAIR_FIELDS = (
+        "equipment_name",
+        "equipment_brand",
+        "equipment_model",
+        "equipment_power",
+        "equipment_serial_number",
+        "equipment_inventory_number",
+        "equipment_commissioning_date",
+        "refrigerant_type",
+        "refrigerant_amount",
+    )
+    FIELD_LABELS = {
+        "equipment_name": "Оборудование",
+        "equipment_brand": "Бренд",
+        "equipment_model": "Модель",
+        "equipment_power": "Мощность",
+        "equipment_serial_number": "Серийный номер",
+        "equipment_inventory_number": "Инвентарный номер",
+        "equipment_commissioning_date": "Дата ввода",
+        "refrigerant_type": "Хладагент",
+        "refrigerant_amount": "Количество хладагента",
+    }
+    HISTORY_META_KEY = "nameplate_recognitions"
+    COMMENT_HISTORY_META_KEY = "bot_diagnostic_comments"
+    COMMENT_FIELDS = (
+        "customer_complaint",
+        "complaint_official",
+        "likely_diagnosis",
+        "technical_condition",
+        "inspection_work_done",
+        "startup_check_result",
+        "compressor_check_result",
+        "measurement_result",
+        "diagnostic_result",
+        "further_use_assessment",
+        "operation_restrictions",
+        "technical_conclusion",
+        "repair_feasibility",
+        "recommended_decision",
+        "repair_recommendation",
+        "repair_possible",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "refrigerant_pricing_mode",
+        "repair_not_viable",
+        "repair_not_viable_reason",
+    )
+    COMMENT_FIELD_LABELS = {
+        "customer_complaint": "Жалоба клиента",
+        "complaint_official": "Жалоба для акта",
+        "likely_diagnosis": "Вероятная причина",
+        "technical_condition": "Техническое состояние",
+        "startup_check_result": "Проверка запуска",
+        "compressor_check_result": "Проверка компрессора",
+        "measurement_result": "Результаты замеров",
+        "diagnostic_result": "Результат диагностики",
+        "further_use_assessment": "Дальнейшая эксплуатация",
+        "operation_restrictions": "Ограничения эксплуатации",
+        "technical_conclusion": "Техническое заключение",
+        "repair_feasibility": "Целесообразность ремонта",
+        "recommended_decision": "Рекомендованное решение",
+        "repair_recommendation": "Рекомендация по ремонту",
+        "repair_possible": "Ремонт возможен",
+        "refrigerant_type": "Хладагент",
+        "refrigerant_amount": "Количество хладагента",
+        "refrigerant_pricing_mode": "Расчет хладагента",
+        "repair_not_viable": "Ремонт нецелесообразен",
+        "repair_not_viable_reason": "Причина нецелесообразности",
+        "inspection_work_done": "Выполненные работы",
+    }
+
+    @staticmethod
+    def _clean_text(value: Any, *, max_length: int = 500) -> Optional[str]:
+        text = str(value or "").strip()
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text[:max_length].strip() or None
+
+    @classmethod
+    def _normalize_refrigerant_type(cls, value: Any) -> Optional[str]:
+        text = cls._clean_text(value, max_length=40)
+        if not text:
+            return None
+        text = text.upper().replace(" ", "")
+        text = text.replace("R-410A", "R410A").replace("R-32", "R32").replace("R-22", "R22")
+        match = re.search(r"\bR\d{2,3}[A-Z]?\b", text)
+        return match.group(0) if match else text
+
+    @classmethod
+    def _normalize_refrigerant_amount(cls, value: Any) -> Optional[str]:
+        text = cls._clean_text(value, max_length=80)
+        if not text:
+            return None
+        text = text.replace("КГ", "кг").replace("KG", "кг").replace("kg", "кг")
+        text = re.sub(r"\s*/\s*", "/", text)
+        match = re.search(r"(\d+(?:[.,]\d+)?)\s*кг", text, flags=re.IGNORECASE)
+        if match:
+            return f"{match.group(1).replace('.', ',')} кг"
+        return text
+
+    @classmethod
+    def _normalize_power(cls, value: Any, raw: dict[str, Any]) -> Optional[str]:
+        text = cls._clean_text(value, max_length=120)
+        if text:
+            return text
+        btu = cls._clean_text(raw.get("capacity_btu") or raw.get("cooling_capacity_btu"), max_length=40)
+        if btu:
+            digits = re.sub(r"\D", "", btu)
+            return f"{digits} BTU/h" if digits else btu
+        kw = cls._clean_text(raw.get("cooling_capacity_kw") or raw.get("capacity_kw"), max_length=40)
+        if kw:
+            return kw if "кВт" in kw else f"{kw} кВт"
+        return None
+
+    @classmethod
+    def _is_repair_execution_order(cls, order: Order | None) -> bool:
+        if not order:
+            return False
+        workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+        return workflow_type == "repair" and order.status == cls.REPAIR_STATUS
+
+    @staticmethod
+    def _map_order(order: Order) -> dict[str, Any]:
+        customer = getattr(order, "customer", None)
+        return {
+            "id": int(order.id or 0),
+            "title": order.title,
+            "status": order.status.value if hasattr(order.status, "value") else str(order.status),
+            "workflow_type": OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)),
+            "customer_name": getattr(customer, "name", None) if customer else None,
+            "customer_phone": getattr(customer, "phone", None) if customer else None,
+            "address": order.delivery_address,
+            "updated_at": order.updated_at,
+            "created_at": order.created_at,
+        }
+
+    @classmethod
+    async def _legacy_installer_id(cls, session: AsyncSession, telegram_user_id: int | str | None) -> Optional[int]:
+        try:
+            normalized_telegram_id = int(telegram_user_id) if telegram_user_id is not None else 0
+        except (TypeError, ValueError):
+            return None
+        if not normalized_telegram_id:
+            return None
+
+        result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id == normalized_telegram_id)
+            .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .order_by(StaffUser.id.asc())
+            .limit(1)
+        )
+        staff = result.scalars().first()
+        installer_id = getattr(staff, "legacy_installer_id", None)
+        return int(installer_id) if installer_id else None
+
+    @classmethod
+    async def list_repair_orders(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_user_id: int | str | None,
+        can_attach_any: bool = False,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        stmt = (
+            select(Order)
+            .where(Order.status == cls.REPAIR_STATUS)
+            .where(Order.workflow_type == "repair")
+            .options(selectinload(Order.customer))
+            .order_by(Order.updated_at.desc(), Order.created_at.desc(), Order.id.desc())
+            .limit(max(1, min(limit, 10)))
+        )
+
+        if not can_attach_any:
+            installer_id = await cls._legacy_installer_id(session, telegram_user_id)
+            if not installer_id:
+                return []
+            stage_exists = (
+                select(OrderWorkStage.id)
+                .where(OrderWorkStage.order_id == Order.id)
+                .where(OrderWorkStage.installer_id == installer_id)
+                .exists()
+            )
+            legacy_exists = (
+                select(OrderInstaller.order_id)
+                .where(OrderInstaller.order_id == Order.id)
+                .where(OrderInstaller.installer_id == installer_id)
+                .exists()
+            )
+            stmt = stmt.where(or_(stage_exists, legacy_exists))
+
+        result = await session.execute(stmt)
+        return [cls._map_order(order) for order in result.scalars().all()]
+
+    @classmethod
+    async def can_use_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        telegram_user_id: int | str | None,
+        can_attach_any: bool = False,
+    ) -> bool:
+        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+        order = result.scalars().first()
+        if not cls._is_repair_execution_order(order):
+            return False
+        if can_attach_any:
+            return True
+        return await BotOrderAttachmentService.can_attach_to_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+        )
+
+    @classmethod
+    def build_extraction_prompt(cls, raw_text: str) -> str:
+        return (
+            "Ты извлекаешь данные с шильдика кондиционера для дефектного акта ремонта.\n"
+            "Верни только JSON-объект без markdown. Не выдумывай данные: если поле не видно, верни null.\n\n"
+            "Ключи JSON:\n"
+            "equipment_name, equipment_brand, equipment_model, equipment_power, equipment_serial_number, "
+            "equipment_inventory_number, equipment_commissioning_date, refrigerant_type, refrigerant_amount, "
+            "unit_type, capacity_btu, cooling_capacity_kw, raw_markings, confidence, warnings.\n\n"
+            "Правила:\n"
+            "- equipment_name: человекочитаемо, например 'Кондиционер, наружный блок' или 'Кондиционер'.\n"
+            "- equipment_model: модель блока ровно как на шильдике.\n"
+            "- equipment_serial_number: серийный номер/SN/Serial No, только если он явно виден.\n"
+            "- equipment_power: полезная холодопроизводительность/мощность, как на шильдике; не путай с потребляемой мощностью.\n"
+            "- refrigerant_type: R32, R410A, R22 и т.п.\n"
+            "- refrigerant_amount: заводская заправка, например '0,60 кг'.\n"
+            "- raw_markings: короткий список важных строк с шильдика.\n"
+            "- confidence: число от 0 до 1.\n"
+            "- warnings: массив коротких предупреждений.\n\n"
+            "OCR-текст:\n"
+            f"{raw_text[:12000]}"
+        )
+
+    @classmethod
+    async def extract_nameplate(cls, raw_text: str) -> dict[str, Any]:
+        token = settings.DEEPSEEK_TOKEN.strip()
+        if not token:
+            raise ValueError("DEEPSEEK_TOKEN is not configured")
+
+        async with httpx.AsyncClient(timeout=45.0) as client:
+            response = await client.post(
+                settings.DEEPSEEK_API_URL,
+                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                json={
+                    "model": settings.DEEPSEEK_MODEL,
+                    "temperature": 0.02,
+                    "response_format": {"type": "json_object"},
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "Ты аккуратно извлекаешь паспортные данные HVAC оборудования и возвращаешь строгий JSON.",
+                        },
+                        {"role": "user", "content": cls.build_extraction_prompt(raw_text)},
+                    ],
+                },
+            )
+            if response.status_code >= 400:
+                raise ValueError(f"DeepSeek вернул ошибку {response.status_code}: {response.text[:300]}")
+            data = response.json()
+
+        try:
+            content = str(data["choices"][0]["message"]["content"])
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ValueError("AI response has unexpected format") from exc
+        return CustomerRequisitesRecognitionService._extract_json_object(content)
+
+    @classmethod
+    def normalize_extracted(cls, raw: dict[str, Any], raw_text: str) -> tuple[dict[str, Any], dict[str, Any]]:
+        data = {
+            "equipment_name": cls._clean_text(raw.get("equipment_name") or raw.get("name"), max_length=160),
+            "equipment_brand": cls._clean_text(raw.get("equipment_brand") or raw.get("brand"), max_length=120),
+            "equipment_model": cls._clean_text(
+                raw.get("equipment_model")
+                or raw.get("model")
+                or raw.get("outdoor_unit_model")
+                or raw.get("indoor_unit_model"),
+                max_length=200,
+            ),
+            "equipment_power": cls._normalize_power(raw.get("equipment_power") or raw.get("power"), raw),
+            "equipment_serial_number": cls._clean_text(
+                raw.get("equipment_serial_number") or raw.get("serial_number") or raw.get("serial"),
+                max_length=160,
+            ),
+            "equipment_inventory_number": cls._clean_text(
+                raw.get("equipment_inventory_number") or raw.get("inventory_number"),
+                max_length=160,
+            ),
+            "equipment_commissioning_date": cls._clean_text(
+                raw.get("equipment_commissioning_date") or raw.get("manufactured_year"),
+                max_length=80,
+            ),
+            "refrigerant_type": cls._normalize_refrigerant_type(raw.get("refrigerant_type") or raw.get("refrigerant")),
+            "refrigerant_amount": cls._normalize_refrigerant_amount(
+                raw.get("refrigerant_amount") or raw.get("refrigerant_charge")
+            ),
+        }
+        data = {key: value for key, value in data.items() if value}
+
+        warnings: dict[str, str] = {}
+        raw_warnings = raw.get("warnings")
+        if isinstance(raw_warnings, list):
+            for index, warning in enumerate(raw_warnings[:5], start=1):
+                cleaned = cls._clean_text(warning, max_length=200)
+                if cleaned:
+                    warnings[f"ai_{index}"] = cleaned
+        elif raw_warnings:
+            cleaned = cls._clean_text(raw_warnings, max_length=300)
+            if cleaned:
+                warnings["ai"] = cleaned
+
+        if not data.get("equipment_model"):
+            warnings["equipment_model"] = "Модель не распознана уверенно"
+        if not data.get("equipment_serial_number"):
+            warnings["equipment_serial_number"] = "Серийный номер не найден на шильдике"
+        if not data.get("refrigerant_type"):
+            warnings["refrigerant_type"] = "Хладагент не распознан"
+
+        confidence = raw.get("confidence")
+        try:
+            confidence_value = float(confidence) if confidence is not None else None
+        except (TypeError, ValueError):
+            confidence_value = None
+        flags = {
+            "warnings": warnings,
+            "confidence": confidence_value,
+            "is_valid": bool(data),
+            "raw_markings": cls._clean_text(raw.get("raw_markings") or raw_text, max_length=2000),
+        }
+        return data, flags
+
+    @classmethod
+    async def recognize_bytes(
+        cls,
+        *,
+        content: bytes,
+        filename: Optional[str],
+        mime_type: Optional[str],
+    ) -> dict[str, Any]:
+        if not content:
+            raise ValueError("Файл пустой")
+        if len(content) > CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES:
+            raise ValueError("Файл слишком большой. Максимальный размер: 10 МБ")
+
+        raw_text = await CustomerRequisitesRecognitionService.extract_ocr_text(
+            content,
+            mime_type=mime_type,
+            filename=filename,
+        )
+        if not raw_text.strip():
+            raise ValueError("Не удалось распознать текст на шильдике")
+        extracted_raw = await cls.extract_nameplate(raw_text)
+        extracted, validation_flags = cls.normalize_extracted(extracted_raw, raw_text)
+        return {
+            "raw_text": raw_text,
+            "extracted": extracted,
+            "validation_flags": validation_flags,
+        }
+
+    @classmethod
+    def preview_merge(cls, current_repair_meta: dict[str, Any], extracted: dict[str, Any]) -> dict[str, Any]:
+        applied: dict[str, Any] = {}
+        conflicts: dict[str, dict[str, Any]] = {}
+        skipped: dict[str, Any] = {}
+        for field in cls.REPAIR_FIELDS:
+            candidate = cls._clean_text(extracted.get(field), max_length=500)
+            if not candidate:
+                continue
+            existing = cls._clean_text(current_repair_meta.get(field), max_length=500)
+            if existing and existing != candidate:
+                conflicts[field] = {"existing": existing, "candidate": candidate}
+                continue
+            if existing == candidate:
+                skipped[field] = candidate
+                continue
+            applied[field] = candidate
+        return {"applied": applied, "conflicts": conflicts, "skipped": skipped}
+
+    @classmethod
+    async def build_merge_preview(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        extracted: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+        order = result.scalars().first()
+        if not order:
+            return None
+        return cls.preview_merge(OrderService._get_repair_meta(order), extracted)
+
+    @classmethod
+    def preview_comment_merge(cls, current_repair_meta: dict[str, Any], draft_meta: dict[str, Any]) -> dict[str, Any]:
+        changes: dict[str, dict[str, str]] = {}
+        unchanged: dict[str, str] = {}
+        for field in cls.COMMENT_FIELDS:
+            candidate = cls._clean_text(draft_meta.get(field), max_length=1200)
+            if not candidate:
+                continue
+            existing = cls._clean_text(current_repair_meta.get(field), max_length=1200)
+            if existing == candidate:
+                unchanged[field] = candidate
+            else:
+                changes[field] = {"existing": existing or "", "candidate": candidate}
+        return {"changes": changes, "unchanged": unchanged}
+
+    @classmethod
+    def _comment_payload(cls, *, repair_meta: dict[str, Any], comment: str) -> ManagerRepairActAiDraftPayload:
+        return ManagerRepairActAiDraftPayload(
+            defect_type="field_diagnostic_note",
+            defect_label="Диагностическая заметка с выезда",
+            allow_assumptions=False,
+            polish_existing=True,
+            equipment_name=cls._clean_text(repair_meta.get("equipment_name"), max_length=200),
+            equipment_brand=cls._clean_text(repair_meta.get("equipment_brand"), max_length=120),
+            equipment_model=cls._clean_text(repair_meta.get("equipment_model"), max_length=200),
+            equipment_power=cls._clean_text(repair_meta.get("equipment_power"), max_length=120),
+            customer_complaint=cls._clean_text(repair_meta.get("customer_complaint"), max_length=500),
+            complaint_official=cls._clean_text(repair_meta.get("complaint_official"), max_length=500),
+            likely_diagnosis=cls._clean_text(repair_meta.get("likely_diagnosis"), max_length=500),
+            extra_context=comment,
+            current_meta=repair_meta,
+        )
+
+    @classmethod
+    async def build_diagnostic_comment_draft(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        comment: str,
+    ) -> dict[str, Any] | None:
+        result = await session.execute(
+            select(Order)
+            .where(Order.id == order_id)
+            .options(selectinload(Order.customer))
+            .limit(1)
+        )
+        order = result.scalars().first()
+        if not order or OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)) != "repair":
+            return None
+
+        raw_comment = cls._clean_text(comment, max_length=4000)
+        if not raw_comment:
+            raise ValueError("Комментарий пустой")
+
+        repair_meta = OrderService._get_repair_meta(order)
+        ai_meta = await DefectActAIService.generate_repair_meta(
+            cls._comment_payload(repair_meta=repair_meta, comment=raw_comment)
+        )
+        merge_preview = cls.preview_comment_merge(repair_meta, ai_meta)
+        return {
+            "order": cls._map_order(order),
+            "comment": raw_comment,
+            "repair_meta": ai_meta,
+            "merge_preview": merge_preview,
+        }
+
+    @classmethod
+    async def apply_diagnostic_comment(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        repair_meta_draft: dict[str, Any],
+        raw_comment: str,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        can_attach_any: bool = False,
+    ) -> dict[str, Any] | None:
+        allowed = await cls.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+        if not allowed:
+            return None
+
+        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+        order = result.scalars().first()
+        if not order:
+            return None
+
+        repair_meta = OrderService._get_repair_meta(order)
+        merge = cls.preview_comment_merge(repair_meta, repair_meta_draft)
+        for field, values in merge["changes"].items():
+            repair_meta[field] = values["candidate"]
+
+        raw_history = repair_meta.get(cls.COMMENT_HISTORY_META_KEY)
+        history = list(raw_history) if isinstance(raw_history, list) else []
+        history.append(
+            {
+                "source": "telegram_bot",
+                "telegram_user_id": telegram_user_id,
+                "telegram_chat_id": telegram_chat_id,
+                "telegram_message_id": telegram_message_id,
+                "comment": cls._clean_text(raw_comment, max_length=4000),
+                "ai_meta": {
+                    key: cls._clean_text(value, max_length=1200)
+                    for key, value in repair_meta_draft.items()
+                    if cls._clean_text(value, max_length=1200)
+                },
+                "applied_fields": list(merge["changes"].keys()),
+                "created_at": datetime.now().isoformat(timespec="seconds"),
+            }
+        )
+        repair_meta[cls.COMMENT_HISTORY_META_KEY] = history[-20:]
+        OrderService._set_repair_meta(
+            order,
+            repair_meta,
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+        flag_modified(order, "technical_meta")
+        session.add(order)
+        await session.commit()
+        await session.refresh(order)
+
+        return {
+            "id": int(order.id or 0),
+            "changes": merge["changes"],
+            "unchanged": merge["unchanged"],
+        }
+
+    @classmethod
+    async def apply_to_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        extracted: dict[str, Any],
+        raw_text: str,
+        validation_flags: dict[str, Any] | None,
+        file_id: str,
+        filename: str,
+        mime_type: str | None,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        can_attach_any: bool = False,
+    ) -> dict[str, Any] | None:
+        allowed = await cls.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+        if not allowed:
+            return None
+
+        result = await session.execute(
+            select(Order)
+            .where(Order.id == order_id)
+            .options(selectinload(Order.customer))
+            .limit(1)
+        )
+        order = result.scalars().first()
+        if not order:
+            return None
+
+        repair_meta = OrderService._get_repair_meta(order)
+        merge = cls.preview_merge(repair_meta, extracted)
+        if merge["applied"]:
+            repair_meta.update(merge["applied"])
+
+        raw_nameplate_history = repair_meta.get(cls.HISTORY_META_KEY)
+        attachments = list(raw_nameplate_history) if isinstance(raw_nameplate_history, list) else []
+        attached_at = datetime.now()
+        entry = BotOrderAttachmentService._build_entry(
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            attached_at=attached_at,
+        )
+        entry["purpose"] = "repair_nameplate"
+        entry["extracted"] = {field: extracted.get(field) for field in cls.REPAIR_FIELDS if extracted.get(field)}
+        entry["validation_flags"] = validation_flags or {}
+        entry["applied_fields"] = list(merge["applied"].keys())
+        entry["conflicts"] = merge["conflicts"]
+        entry["raw_text"] = raw_text[:4000]
+
+        existing_index = next(
+            (
+                index
+                for index, item in enumerate(attachments)
+                if isinstance(item, dict) and item.get("file_id") == file_id
+            ),
+            None,
+        )
+        if existing_index is None:
+            attachments.append(entry)
+        else:
+            attachments[existing_index] = entry
+        repair_meta[cls.HISTORY_META_KEY] = attachments[-10:]
+
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        raw_attachments = meta.get(BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY)
+        telegram_attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
+        already_attached = any(
+            isinstance(item, dict)
+            and item.get("file_id") == file_id
+            and item.get("purpose") == "repair_nameplate"
+            for item in telegram_attachments
+        )
+        if not already_attached:
+            telegram_attachments.append(
+                {
+                    key: value
+                    for key, value in entry.items()
+                    if key
+                    in {
+                        "source",
+                        "file_id",
+                        "filename",
+                        "mime_type",
+                        "kind",
+                        "telegram_user_id",
+                        "telegram_chat_id",
+                        "telegram_message_id",
+                        "attached_at",
+                        "purpose",
+                    }
+                }
+            )
+            meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
+
+        OrderService._set_repair_meta(
+            order,
+            repair_meta,
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+        meta.update(order.technical_meta if isinstance(order.technical_meta, dict) else {})
+        order.technical_meta = meta
+        flag_modified(order, "technical_meta")
+        session.add(order)
+        await session.commit()
+        await session.refresh(order)
+
+        return {
+            "id": int(order.id or 0),
+            "applied": merge["applied"],
+            "conflicts": merge["conflicts"],
+            "skipped": merge["skipped"],
+            "extracted": extracted,
+        }

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -243,7 +243,8 @@ async def test_requisites_photo_prompts_for_action_without_recognition(monkeypat
     args, kwargs = message.answer.await_args
     assert "Что сделать" in args[0]
     assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_extract"
-    assert kwargs["reply_markup"].inline_keyboard[1][0].callback_data == "req_file_attach"
+    assert kwargs["reply_markup"].inline_keyboard[1][0].callback_data == "repair_nameplate_start"
+    assert kwargs["reply_markup"].inline_keyboard[2][0].callback_data == "req_file_attach"
 
 
 @pytest.mark.asyncio
@@ -264,7 +265,7 @@ async def test_requisites_photo_for_staff_non_admin_allows_attach_only(monkeypat
         row[0].callback_data
         for row in kwargs["reply_markup"].inline_keyboard
     ]
-    assert callbacks == ["req_file_attach", "req_file_cancel"]
+    assert callbacks == ["repair_nameplate_start", "req_file_attach", "req_file_cancel"]
     assert state._data["pending_requisites_file"]["file_id"] == "large-photo"
 
 
@@ -303,6 +304,9 @@ async def test_requisites_document_prompts_for_pdf(monkeypatch):
     download_mock.assert_not_called()
     assert state._data["pending_requisites_file"]["file_id"] == "pdf-file"
     assert state._data["pending_requisites_file"]["mime_type"] == "application/pdf"
+    args, kwargs = message.answer.await_args
+    callbacks = [row[0].callback_data for row in kwargs["reply_markup"].inline_keyboard]
+    assert "repair_nameplate_start" not in callbacks
 
 
 @pytest.mark.asyncio
@@ -510,6 +514,245 @@ async def test_requisites_file_attach_typed_order_validates_number(monkeypatch):
 
     message.answer.assert_awaited_once_with("Введите номер заказа числом, например: 123")
     assert state._data["pending_requisites_file"]["file_id"] == "file-1"
+
+
+@pytest.mark.asyncio
+async def test_repair_nameplate_start_shows_repair_orders(monkeypatch):
+    callback = _DummyCallback(data="repair_nameplate_start", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "photo-file",
+                "filename": "nameplate.jpg",
+                "mime_type": "image/jpeg",
+            }
+        }
+    )
+
+    async def fake_list_repair_orders(session, *, telegram_user_id, can_attach_any, limit):
+        assert telegram_user_id == 5
+        assert can_attach_any is True
+        assert limit == 5
+        return [
+            {
+                "id": 42,
+                "title": "Ремонт",
+                "customer_name": "Иван",
+                "address": "Победы 15",
+            }
+        ]
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "list_repair_orders", fake_list_repair_orders)
+
+    await admin_handler.choose_order_for_repair_nameplate(callback, state)
+
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "ремонтному заказу" in args[0]
+    assert "#42" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_nameplate_order_42"
+    callback.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repair_nameplate_chosen_order_runs_recognition_preview(monkeypatch):
+    callback = _DummyCallback(data="repair_nameplate_order_42", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "photo-file",
+                "filename": "nameplate.jpg",
+                "mime_type": "image/jpeg",
+                "telegram_message_id": 77,
+                "telegram_chat_id": 200,
+            }
+        }
+    )
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "can_use_order", AsyncMock(return_value=True))
+    monkeypatch.setattr(admin_handler, "_download_telegram_file", AsyncMock(return_value=b"image"))
+    monkeypatch.setattr(
+        admin_handler.BotRepairNameplateService,
+        "recognize_bytes",
+        AsyncMock(
+            return_value={
+                "raw_text": "MODEL ALASKA AL-12LHJ",
+                "extracted": {
+                    "equipment_model": "ALASKA AL-12LHJ",
+                    "refrigerant_type": "R22",
+                },
+                "validation_flags": {"warnings": {}, "is_valid": True},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        admin_handler.BotRepairNameplateService,
+        "build_merge_preview",
+        AsyncMock(
+            return_value={
+                "applied": {"equipment_model": "ALASKA AL-12LHJ"},
+                "conflicts": {},
+                "skipped": {},
+            }
+        ),
+    )
+
+    await admin_handler.recognize_repair_nameplate_for_chosen_order(callback, state)
+
+    assert callback.message.edit_text.await_count == 2
+    final_args, final_kwargs = callback.message.edit_text.await_args
+    assert "ALASKA AL-12LHJ" in final_args[0]
+    assert final_kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_nameplate_confirm"
+    assert state._data["pending_repair_nameplate"]["order_id"] == 42
+    assert state._data["pending_repair_nameplate"]["extracted"]["refrigerant_type"] == "R22"
+
+
+@pytest.mark.asyncio
+async def test_repair_nameplate_confirm_applies_and_clears_pending(monkeypatch):
+    callback = _DummyCallback(data="repair_nameplate_confirm", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {"file_id": "photo-file"},
+            "pending_repair_nameplate": {
+                "order_id": 42,
+                "file": {
+                    "file_id": "photo-file",
+                    "filename": "nameplate.jpg",
+                    "mime_type": "image/jpeg",
+                    "telegram_message_id": 77,
+                    "telegram_chat_id": 200,
+                },
+                "raw_text": "MODEL ALASKA",
+                "extracted": {"equipment_model": "ALASKA"},
+                "validation_flags": {"warnings": {}, "is_valid": True},
+            },
+        }
+    )
+
+    async def fake_apply(session, order_id, **kwargs):
+        assert order_id == 42
+        assert kwargs["file_id"] == "photo-file"
+        assert kwargs["telegram_user_id"] == 5
+        assert kwargs["can_attach_any"] is True
+        return {"id": 42, "applied": {"equipment_model": "ALASKA"}, "conflicts": {}}
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "apply_to_order", fake_apply)
+
+    await admin_handler.confirm_repair_nameplate(callback, state)
+
+    assert state._data["pending_repair_nameplate"] is None
+    assert state._data["pending_requisites_file"] is None
+    assert state._data["active_repair_order_context"] == {"order_id": 42}
+    state.set_state.assert_awaited_with(admin_handler.ShopState.waiting_for_repair_context_comment)
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "Данные со шильдика записаны" in args[0]
+    assert "можно отправлять комментарии" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_context_finish"
+
+
+@pytest.mark.asyncio
+async def test_repair_context_comment_builds_ai_preview(monkeypatch):
+    message = _DummyMessage(text="фреона нет, утечку нашли, компрессор не качает", user_id=5)
+    state = _DummyState({"active_repair_order_context": {"order_id": 42}})
+    progress = _DummyProgress()
+    message.answer = AsyncMock(return_value=progress)
+
+    async def fake_build(session, *, order_id, comment):
+        assert order_id == 42
+        assert "компрессор" in comment
+        return {
+            "order": {"id": 42},
+            "comment": comment,
+            "repair_meta": {"diagnostic_result": "Компрессор не создает давление."},
+            "merge_preview": {
+                "changes": {
+                    "diagnostic_result": {
+                        "existing": "",
+                        "candidate": "Компрессор не создает давление.",
+                    }
+                },
+                "unchanged": {},
+            },
+        }
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "build_diagnostic_comment_draft", fake_build)
+
+    await admin_handler.handle_repair_context_comment(message, state)
+
+    message.answer.assert_awaited_once_with("Готовлю поля дефектного акта из комментария…")
+    progress.edit_text.assert_awaited_once()
+    args, kwargs = progress.edit_text.await_args
+    assert "Компрессор не создает давление" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_comment_confirm"
+    assert state._data["pending_repair_comment"]["repair_meta"]["diagnostic_result"] == "Компрессор не создает давление."
+
+
+@pytest.mark.asyncio
+async def test_repair_context_comment_confirm_applies_and_keeps_context(monkeypatch):
+    callback = _DummyCallback(data="repair_comment_confirm", user_id=5)
+    state = _DummyState(
+        {
+            "active_repair_order_context": {"order_id": 42},
+            "pending_repair_comment": {
+                "comment": "компрессор не качает",
+                "repair_meta": {"diagnostic_result": "Компрессор не создает давление."},
+                "telegram_message_id": 77,
+                "telegram_chat_id": 200,
+            },
+        }
+    )
+
+    async def fake_apply(session, order_id, **kwargs):
+        assert order_id == 42
+        assert kwargs["telegram_user_id"] == 5
+        assert kwargs["can_attach_any"] is True
+        return {
+            "id": 42,
+            "changes": {"diagnostic_result": {"existing": "", "candidate": "Компрессор не создает давление."}},
+            "unchanged": {},
+        }
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "apply_diagnostic_comment", fake_apply)
+
+    await admin_handler.confirm_repair_context_comment(callback, state)
+
+    assert state._data["pending_repair_comment"] is None
+    state.set_state.assert_awaited_with(admin_handler.ShopState.waiting_for_repair_context_comment)
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "Комментарий записан" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_context_finish"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -1,0 +1,271 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import Customer, Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
+from services.defect_act_ai_service import DefectActAIService
+
+
+@pytest.fixture
+async def sqlite_repair_nameplate_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'bot_repair_nameplate.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+def test_nameplate_normalization_cleans_repair_fields():
+    extracted, flags = BotRepairNameplateService.normalize_extracted(
+        {
+            "brand": " Alaska ",
+            "model": " ALASKA AL-12LHJ ",
+            "serial_number": " SN 001 ",
+            "capacity_btu": "12000 BTU/h",
+            "refrigerant": " R-22 ",
+            "refrigerant_charge": "R22/0.600kg",
+            "confidence": "0.72",
+        },
+        "MODEL ALASKA AL-12LHJ\nRefrigerant/Charge R22/0.600kg",
+    )
+
+    assert extracted["equipment_brand"] == "Alaska"
+    assert extracted["equipment_model"] == "ALASKA AL-12LHJ"
+    assert extracted["equipment_serial_number"] == "SN 001"
+    assert extracted["equipment_power"] == "12000 BTU/h"
+    assert extracted["refrigerant_type"] == "R22"
+    assert extracted["refrigerant_amount"] == "0,600 кг"
+    assert flags["confidence"] == 0.72
+    assert flags["is_valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_nameplate_recognize_rejects_too_large_file_before_ocr(monkeypatch):
+    async def fail_extract(*args, **kwargs):
+        raise AssertionError("OCR should not run for oversized files")
+
+    monkeypatch.setattr(CustomerRequisitesRecognitionService, "extract_ocr_text", fail_extract)
+
+    with pytest.raises(ValueError, match="Файл слишком большой"):
+        await BotRepairNameplateService.recognize_bytes(
+            content=b"x" * (CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES + 1),
+            filename="nameplate.jpg",
+            mime_type="image/jpeg",
+        )
+
+
+@pytest.mark.asyncio
+async def test_lists_only_execution_repair_orders_for_manager(sqlite_repair_nameplate_session):
+    repair_execution = Order(title="Ремонт в работе", status=OrderStatus.EXECUTION, workflow_type="repair")
+    repair_negotiation = Order(title="Ремонт в переговорах", status=OrderStatus.NEGOTIATION, workflow_type="repair")
+    install_execution = Order(title="Монтаж", status=OrderStatus.EXECUTION, workflow_type="sales_installation")
+    sqlite_repair_nameplate_session.add(repair_execution)
+    sqlite_repair_nameplate_session.add(repair_negotiation)
+    sqlite_repair_nameplate_session.add(install_execution)
+    await sqlite_repair_nameplate_session.commit()
+
+    orders = await BotRepairNameplateService.list_repair_orders(
+        sqlite_repair_nameplate_session,
+        telegram_user_id=777,
+        can_attach_any=True,
+    )
+
+    assert [item["id"] for item in orders] == [repair_execution.id]
+
+
+@pytest.mark.asyncio
+async def test_executor_sees_only_assigned_repair_orders(sqlite_repair_nameplate_session):
+    staff = StaffUser(
+        display_name="Монтажник",
+        status="active",
+        primary_role="installer",
+        roles=["installer"],
+        telegram_id=777,
+        legacy_installer_id=10,
+    )
+    assigned = Order(title="Назначенный ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
+    legacy_assigned = Order(title="Старый ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
+    other = Order(title="Чужой ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
+    sqlite_repair_nameplate_session.add(staff)
+    sqlite_repair_nameplate_session.add(assigned)
+    sqlite_repair_nameplate_session.add(legacy_assigned)
+    sqlite_repair_nameplate_session.add(other)
+    await sqlite_repair_nameplate_session.flush()
+    sqlite_repair_nameplate_session.add(OrderWorkStage(order_id=assigned.id, installer_id=10, name="Диагностика"))
+    sqlite_repair_nameplate_session.add(OrderInstaller(order_id=legacy_assigned.id, installer_id=10))
+    await sqlite_repair_nameplate_session.commit()
+
+    orders = await BotRepairNameplateService.list_repair_orders(
+        sqlite_repair_nameplate_session,
+        telegram_user_id=777,
+        can_attach_any=False,
+    )
+
+    assert {item["id"] for item in orders} == {assigned.id, legacy_assigned.id}
+
+
+@pytest.mark.asyncio
+async def test_apply_to_order_merges_without_overwriting_existing_repair_meta(sqlite_repair_nameplate_session):
+    customer = Customer(name="Иван", phone="+375291234567")
+    order = Order(
+        customer=customer,
+        title="Ремонт",
+        status=OrderStatus.EXECUTION,
+        workflow_type="repair",
+        technical_meta={
+            "repair": {
+                "repair_status": "scheduled",
+                "equipment_model": "Введено вручную",
+                "customer_complaint": "Не охлаждает",
+            }
+        },
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotRepairNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        extracted={
+            "equipment_model": "ALASKA AL-12LHJ",
+            "equipment_serial_number": "SN-001",
+            "refrigerant_type": "R22",
+            "refrigerant_amount": "0,600 кг",
+        },
+        raw_text="MODEL ALASKA AL-12LHJ",
+        validation_flags={"warnings": {}, "is_valid": True},
+        file_id="photo-file",
+        filename="nameplate.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        can_attach_any=True,
+    )
+
+    assert result is not None
+    assert result["applied"] == {
+        "equipment_serial_number": "SN-001",
+        "refrigerant_type": "R22",
+        "refrigerant_amount": "0,600 кг",
+    }
+    assert result["conflicts"]["equipment_model"] == {
+        "existing": "Введено вручную",
+        "candidate": "ALASKA AL-12LHJ",
+    }
+
+    await sqlite_repair_nameplate_session.refresh(order)
+    repair_meta = order.technical_meta["repair"]
+    assert repair_meta["equipment_model"] == "Введено вручную"
+    assert repair_meta["equipment_serial_number"] == "SN-001"
+    assert repair_meta["customer_complaint"] == "Не охлаждает"
+    assert repair_meta["repair_status"] == "scheduled"
+    assert repair_meta["nameplate_recognitions"][0]["purpose"] == "repair_nameplate"
+    assert order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY][0]["purpose"] == "repair_nameplate"
+
+
+@pytest.mark.asyncio
+async def test_apply_to_order_rejects_non_repair_order(sqlite_repair_nameplate_session):
+    order = Order(title="Монтаж", status=OrderStatus.EXECUTION, workflow_type="sales_installation")
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotRepairNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        extracted={"equipment_model": "ALASKA"},
+        raw_text="MODEL ALASKA",
+        validation_flags={},
+        file_id="photo-file",
+        filename="nameplate.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        can_attach_any=True,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_build_diagnostic_comment_draft_uses_ai_and_previews_changes(sqlite_repair_nameplate_session, monkeypatch):
+    order = Order(
+        title="Ремонт",
+        status=OrderStatus.EXECUTION,
+        workflow_type="repair",
+        technical_meta={
+            "repair": {
+                "equipment_model": "ALASKA AL-12LHJ",
+                "diagnostic_result": "Старая диагностика",
+            }
+        },
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    async def fake_generate(payload):
+        assert payload.equipment_model == "ALASKA AL-12LHJ"
+        assert "компрессор" in payload.extra_context
+        return {
+            "diagnostic_result": "Компрессор не создает давление в контуре.",
+            "compressor_check_result": "Напряжение 220 В присутствует, рабочий ток компрессора отсутствует.",
+            "repair_recommendation": "Рекомендована замена компрессора или оборудования.",
+        }
+
+    monkeypatch.setattr(DefectActAIService, "generate_repair_meta", fake_generate)
+
+    draft = await BotRepairNameplateService.build_diagnostic_comment_draft(
+        sqlite_repair_nameplate_session,
+        order_id=int(order.id),
+        comment="подключили шланги, утечку устранили, компрессор не качает",
+    )
+
+    assert draft is not None
+    changes = draft["merge_preview"]["changes"]
+    assert changes["diagnostic_result"]["existing"] == "Старая диагностика"
+    assert changes["diagnostic_result"]["candidate"] == "Компрессор не создает давление в контуре."
+    assert changes["compressor_check_result"]["candidate"].startswith("Напряжение 220 В")
+
+
+@pytest.mark.asyncio
+async def test_apply_diagnostic_comment_updates_repair_meta_and_keeps_history(sqlite_repair_nameplate_session):
+    order = Order(title="Ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotRepairNameplateService.apply_diagnostic_comment(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        repair_meta_draft={
+            "diagnostic_result": "Выявлен отказ компрессора.",
+            "repair_recommendation": "Рекомендована замена компрессора.",
+        },
+        raw_comment="компрессор не качает",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        can_attach_any=True,
+    )
+
+    assert result is not None
+    assert set(result["changes"]) == {"diagnostic_result", "repair_recommendation"}
+    await sqlite_repair_nameplate_session.refresh(order)
+    repair_meta = order.technical_meta["repair"]
+    assert repair_meta["diagnostic_result"] == "Выявлен отказ компрессора."
+    assert repair_meta["repair_recommendation"] == "Рекомендована замена компрессора."
+    assert repair_meta["bot_diagnostic_comments"][0]["comment"] == "компрессор не качает"
+    assert repair_meta["bot_diagnostic_comments"][0]["applied_fields"] == [
+        "diagnostic_result",
+        "repair_recommendation",
+    ]


### PR DESCRIPTION
## Summary
- add a Telegram repair-nameplate OCR flow for staff photos
- keep a repair-order context after confirming a nameplate so field comments can be polished into defect-act fields
- protect existing repair metadata from silent overwrites and store nameplate/comment history

## Validation
- pytest tests/unit/test_bot_repair_nameplate_service.py tests/unit/test_bot_admin_handler.py tests/unit/test_bot_order_attachment_service.py tests/unit/test_customer_requisites_recognition_service.py tests/unit/test_document_service_base_documents.py tests/unit/test_defect_act_ai_service.py tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py -q
- result: 103 passed
