### PR TITLE
[codex] add manager product create and duplicate

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -17,6 +17,8 @@ import {
     SystemService,
     ApiService,
     type Body_upload_media_assets,
+    type ProductCreate,
+    type ProductDuplicatePayload,
     type ProductUpdate,
     type ManagerCustomerBranchCreatePayload,
     type ManagerCustomerBranchUpdatePayload,
@@ -108,6 +110,7 @@ OpenAPI.WITH_CREDENTIALS = true;
 export type Segment = 'b2c' | 'b2b';
 export type DashboardView = 'kanban' | 'list';
 export { type Product, type DashboardStatsResponse, type DashboardTouchpoint };
+export type { ProductCreate, ProductDuplicatePayload, ProductUpdate };
 export type { LeadsInboxItemResponse };
 export type { ManagerGoogleAuthStatusResponse, ManagerGoogleAuthUrlResponse };
 export type { ManagerStaffCreatePayload, ManagerStaffResponse, ManagerStaffUpdatePayload, TelegramLoginPayload };
@@ -778,6 +781,14 @@ export const api = {
 
     async updateProduct(id: number, data: ProductUpdate) {
         return await ManagerService.updateProduct(id, data);
+    },
+
+    async createProduct(data: ProductCreate) {
+        return await ManagerService.createManagerProduct(data);
+    },
+
+    async duplicateProduct(id: number, data: ProductDuplicatePayload) {
+        return await ManagerService.duplicateManagerProduct(id, data);
     },
 
     async deleteProduct(id: number) {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -241,6 +241,8 @@ export type { PaymentResponse } from './models/PaymentResponse';
 export type { ProductAvailabilityLeadPayload } from './models/ProductAvailabilityLeadPayload';
 export type { ProductAvailabilityLeadResponse } from './models/ProductAvailabilityLeadResponse';
 export type { ProductBrandResponse } from './models/ProductBrandResponse';
+export type { ProductCreate } from './models/ProductCreate';
+export type { ProductDuplicatePayload } from './models/ProductDuplicatePayload';
 export type { ProductImageCropPayload } from './models/ProductImageCropPayload';
 export type { ProductImageResponse } from './models/ProductImageResponse';
 export type { ProductImageVariantBatchProcessResponse } from './models/ProductImageVariantBatchProcessResponse';

--- a/manager_frontend/src/client/models/ProductCreate.ts
+++ b/manager_frontend/src/client/models/ProductCreate.ts
@@ -3,22 +3,22 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ProductManualPayload } from './ProductManualPayload';
-export type ProductUpdate = {
-    title?: (string | null);
-    price?: (number | null);
+export type ProductCreate = {
+    title: string;
+    price?: number;
     old_price?: (number | null);
     slug?: (string | null);
-    description?: (string | null);
-    area?: (number | null);
-    is_inverter?: (boolean | null);
+    description?: string;
+    area?: number;
+    is_inverter?: boolean;
     power_cooling?: (number | null);
     main_image?: (string | null);
     source_url?: (string | null);
-    specs?: (Record<string, any> | null);
-    is_published?: (boolean | null);
+    specs?: Record<string, any>;
+    is_published?: boolean;
     brand_id?: (number | null);
     series_id?: (number | null);
-    tag_ids?: (Array<number> | null);
+    tag_ids?: Array<number>;
     manuals?: Array<ProductManualPayload>;
 };
 

--- a/manager_frontend/src/client/models/ProductDuplicatePayload.ts
+++ b/manager_frontend/src/client/models/ProductDuplicatePayload.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ProductManualPayload } from './ProductManualPayload';
-export type ProductUpdate = {
+export type ProductDuplicatePayload = {
     title?: (string | null);
     price?: (number | null);
     old_price?: (number | null);
@@ -20,5 +20,9 @@ export type ProductUpdate = {
     series_id?: (number | null);
     tag_ids?: (Array<number> | null);
     manuals?: Array<ProductManualPayload>;
+    copy_gallery?: boolean;
+    copy_manuals?: boolean;
+    copy_tags?: boolean;
+    make_unpublished?: boolean;
 };
 

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -47,6 +47,8 @@ import type { ManagerMediaSetMainImageResponse } from '../models/ManagerMediaSet
 import type { ManagerMediaUploadLocalImagesResponse } from '../models/ManagerMediaUploadLocalImagesResponse';
 import type { ManagerNormalizeLegacySpecsResponse } from '../models/ManagerNormalizeLegacySpecsResponse';
 import type { ManagerTagGroupResponse } from '../models/ManagerTagGroupResponse';
+import type { ProductCreate } from '../models/ProductCreate';
+import type { ProductDuplicatePayload } from '../models/ProductDuplicatePayload';
 import type { ProductImageCropPayload } from '../models/ProductImageCropPayload';
 import type { ProductImageVariantBatchProcessResponse } from '../models/ProductImageVariantBatchProcessResponse';
 import type { ProductImageVariantCandidatesResponse } from '../models/ProductImageVariantCandidatesResponse';
@@ -395,6 +397,51 @@ export class ManagerService {
                 'customer_id': customerId,
                 'branch_id': branchId,
             },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Product
+     * Create a manual product card from the manager UI.
+     * @param requestBody
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static createManagerProduct(
+        requestBody: ProductCreate,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/products',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Duplicate Product
+     * Duplicate a product card, optionally overriding selected fields.
+     * @param productId
+     * @param requestBody
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static duplicateManagerProduct(
+        productId: number,
+        requestBody: ProductDuplicatePayload,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/products/{product_id}/duplicate',
+            path: {
+                'product_id': productId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
-import { api, type Product, type ManagerBrand } from '../api';
+import { api, type Product, type ManagerBrand, type ProductCreate, type ProductDuplicatePayload, type ProductUpdate } from '../api';
 import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import SpecKeyCombobox from './SpecKeyCombobox.vue';
@@ -44,10 +44,15 @@ interface ProductLogisticsComponent {
     kind: LogisticsComponentKind;
 }
 
-const props = defineProps<{
+type ProductEditorMode = 'create' | 'edit' | 'duplicate';
+
+const props = withDefaults(defineProps<{
     modelValue: boolean;
     product: Product | null;
-}>();
+    mode?: ProductEditorMode;
+}>(), {
+    mode: 'edit',
+});
 
 const emit = defineEmits<{
     (e: 'update:modelValue', value: boolean): void;
@@ -58,7 +63,7 @@ const form = ref<any>({
     title: '',
     slug: '',
     price: 0,
-    old_price: 0,
+    old_price: null,
     is_published: true,
 });
 
@@ -105,6 +110,25 @@ const compatibilityInfo = ref('');
 const creatingBrand = ref(false);
 const newBrandTitle = ref('');
 const logisticsComponents = ref<ProductLogisticsComponent[]>([]);
+const isCreateMode = computed(() => props.mode === 'create');
+const isDuplicateMode = computed(() => props.mode === 'duplicate');
+const isPersistedProduct = computed(() => props.mode === 'edit' && Boolean(props.product?.id));
+const modalTitle = computed(() => {
+    if (isCreateMode.value) return 'Создание товара';
+    if (isDuplicateMode.value) return 'Дублирование товара';
+    return 'Редактирование товара';
+});
+const modalSubtitle = computed(() => {
+    if (isCreateMode.value) return 'Новая ручная карточка';
+    if (isDuplicateMode.value) return props.product?.id ? `Донор: #${props.product.id}` : 'Донор не выбран';
+    return props.product?.id ? `ID: ${props.product.id}` : 'Товар не выбран';
+});
+const saveButtonText = computed(() => {
+    if (loading.value) return 'Сохраняем...';
+    if (isCreateMode.value) return 'Создать товар';
+    if (isDuplicateMode.value) return 'Создать дубликат';
+    return 'Сохранить';
+});
 
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
@@ -907,82 +931,107 @@ const isCurrentProductMulti = computed<boolean>(() => {
     );
 });
 
-watch(() => props.modelValue, async (val) => {
-    if (val && props.product) {
-        formMessage.value = '';
-        formServerErrors.value = {};
-        form.value = {
-            title: props.product.title,
-            slug: props.product.slug,
-            price: props.product.price,
-            old_price: props.product.old_price,
-            is_published: props.product.is_published,
-        };
-        
-        // Convert specs object to array
-        const s = props.product.specs || {};
-        compatibilityIndoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_INDOOR_KEY]);
-        compatibilityOutdoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_OUTDOOR_KEY]);
-        logisticsComponents.value = parseLogisticsComponents((s as any)[LOGISTICS_COMPONENTS_KEY]);
-        multiComboRules.value = parseMultiComboRules((s as any)[MULTI_COMBO_RULES_KEY]);
-        multiCompatMode.value = String((s as any)[MULTI_COMPAT_MODE_KEY] || 'free_match') === 'strict'
-            ? 'strict'
-            : 'free_match';
-        capacityCombosInput.value = parseCapacityCombos((s as any)[MULTI_CAPACITY_COMBOS_KEY]).join(', ');
-        specs.value = Object.entries(s)
+const resetEditorState = () => {
+    formMessage.value = '';
+    formServerErrors.value = {};
+    specs.value = [];
+    manuals.value = [];
+    compatibilityIndoorSlugs.value = [];
+    compatibilityOutdoorSlugs.value = [];
+    logisticsComponents.value = [];
+    multiComboRules.value = [];
+    multiCompatMode.value = 'free_match';
+    capacityCombosInput.value = '';
+    compatibilityQuery.value = '';
+    compatibilityResults.value = [];
+    compatibilityInfo.value = '';
+    selectedTagIds.value = new Set();
+    tagSearchQuery.value = '';
+    selectedBrandEntityId.value = null;
+    vitebskQty.value = 0;
+    supplierOffers.value = [];
+};
+
+const getDuplicateSlug = (product: Product | null): string => {
+    const sourceSlug = String(product?.slug || '').trim();
+    if (sourceSlug) return `${sourceSlug}-copy`;
+    return '';
+};
+
+const initializeEditor = async () => {
+    resetEditorState();
+    const source = props.product;
+    form.value = {
+        title: source?.title || '',
+        slug: isDuplicateMode.value ? getDuplicateSlug(source) : (source?.slug || ''),
+        price: Number(source?.price || 0),
+        old_price: source?.old_price ?? null,
+        is_published: source?.is_published ?? true,
+    };
+
+    const s = source?.specs || {};
+    compatibilityIndoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_INDOOR_KEY]);
+    compatibilityOutdoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_OUTDOOR_KEY]);
+    logisticsComponents.value = parseLogisticsComponents((s as any)[LOGISTICS_COMPONENTS_KEY]);
+    multiComboRules.value = parseMultiComboRules((s as any)[MULTI_COMBO_RULES_KEY]);
+    multiCompatMode.value = String((s as any)[MULTI_COMPAT_MODE_KEY] || 'free_match') === 'strict'
+        ? 'strict'
+        : 'free_match';
+    capacityCombosInput.value = parseCapacityCombos((s as any)[MULTI_CAPACITY_COMBOS_KEY]).join(', ');
+    specs.value = Object.entries(s)
         .filter(([key]) => !COMPATIBILITY_KEYS.has(key))
         .map(([key, value]) => {
             let sVal = String(value);
             const config = specsTranslations[key];
             if (config?.type === 'number' && config.unit) {
-                // remove unit, handle case and spaces
                 sVal = sVal.replace(new RegExp(config.unit + '$', 'i'), '').trim();
                 const match = sVal.match(/^-?\d*[.,]?\d*/);
                 sVal = match && match[0] ? match[0].replace(',', '.') : '';
             }
             return { key, value: sVal };
         });
-        manuals.value = (((props.product as any).manuals || []) as Array<any>)
-            .map((item) => ({
-                title: String(item?.title || 'Инструкция').trim() || 'Инструкция',
-                url: String(item?.url || '').trim(),
-            }))
-            .filter((item) => Boolean(item.url));
-        compatibilityQuery.value = '';
-        compatibilityResults.value = [];
-        compatibilityInfo.value = '';
-        
-        // Load tags
-        const productTags = (props.product as any).tags || [];
-        selectedTagIds.value = new Set(productTags.map((t: any) => t.id));
-        tagSearchQuery.value = '';
-        selectedBrandEntityId.value = null;
-        
-        if (knownKeys.value.length === 0) fetchKeys();
-        await Promise.all([fetchTags(), fetchBrands()]);
+    manuals.value = (((source as any)?.manuals || []) as Array<any>)
+        .map((item) => ({
+            title: String(item?.title || 'Инструкция').trim() || 'Инструкция',
+            url: String(item?.url || '').trim(),
+        }))
+        .filter((item) => Boolean(item.url));
 
-        const explicitBrandId = Number((props.product as any)?.brand_id || 0);
-        if (Number.isFinite(explicitBrandId) && explicitBrandId > 0) {
-            selectedBrandEntityId.value = explicitBrandId;
+    const productTags = (source as any)?.tags || [];
+    selectedTagIds.value = new Set(productTags.map((t: any) => t.id));
+
+    if (knownKeys.value.length === 0) fetchKeys();
+    await Promise.all([fetchTags(), fetchBrands()]);
+
+    const explicitBrandId = Number((source as any)?.brand_id || 0);
+    if (Number.isFinite(explicitBrandId) && explicitBrandId > 0) {
+        selectedBrandEntityId.value = explicitBrandId;
+    } else {
+        const byTag = selectedBrandTag.value;
+        if (byTag) {
+            const matched = managerBrands.value.find((brand) => (
+                normalizeText(brand.slug) === normalizeText(byTag.slug)
+                || normalizeText(brand.title) === normalizeText(byTag.title)
+            ));
+            selectedBrandEntityId.value = matched?.id ?? null;
         } else {
-            const byTag = selectedBrandTag.value;
-            if (byTag) {
-                const matched = managerBrands.value.find((brand) => (
-                    normalizeText(brand.slug) === normalizeText(byTag.slug)
-                    || normalizeText(brand.title) === normalizeText(byTag.title)
-                ));
+            const bySpec = getCurrentEditedBrandFromSpecs();
+            if (bySpec) {
+                const matched = managerBrands.value.find((brand) => normalizeText(brand.title) === normalizeText(bySpec));
                 selectedBrandEntityId.value = matched?.id ?? null;
-            } else {
-                const bySpec = getCurrentEditedBrandFromSpecs();
-                if (bySpec) {
-                    const matched = managerBrands.value.find((brand) => normalizeText(brand.title) === normalizeText(bySpec));
-                    selectedBrandEntityId.value = matched?.id ?? null;
-                }
             }
         }
+    }
 
-        vitebskQty.value = Number((props.product as any).vitebsk_qty || 0);
+    if (isPersistedProduct.value) {
+        vitebskQty.value = Number((source as any)?.vitebsk_qty || 0);
         loadSupplierOffers();
+    }
+};
+
+watch(() => [props.modelValue, props.mode, props.product?.id] as const, async ([val]) => {
+    if (val) {
+        await initializeEditor();
     }
 });
 
@@ -1019,7 +1068,7 @@ const saveLocalStock = async () => {
 };
 
 const save = async () => {
-    if (!props.product) return;
+    if ((isDuplicateMode.value || props.mode === 'edit') && !props.product) return;
     
     // Process specs back to object
     const validSpecs: Record<string, any> = {};
@@ -1093,14 +1142,27 @@ const save = async () => {
                 source: 'manager',
             }));
 
-        const updateData = {
+        const updateData: ProductUpdate = {
             ...form.value,
             brand_id: selectedBrandEntityId.value ?? null,
             specs: validSpecs,
             tag_ids: Array.from(selectedTagIds.value),
             manuals: validManuals,
         };
-        await api.updateProduct(props.product.id, updateData);
+        if (isCreateMode.value) {
+            await api.createProduct(updateData as ProductCreate);
+        } else if (isDuplicateMode.value) {
+            const duplicateData: ProductDuplicatePayload = {
+                ...updateData,
+                copy_gallery: true,
+                copy_manuals: true,
+                copy_tags: false,
+                make_unpublished: false,
+            };
+            await api.duplicateProduct(props.product!.id, duplicateData);
+        } else {
+            await api.updateProduct(props.product!.id, updateData);
+        }
         emit('success');
         close();
     } catch (e) {
@@ -1151,8 +1213,8 @@ const unlinkSupplierOffer = async (offer: any) => {
                         <Edit3 class="w-5 h-5" />
                     </div>
                     <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">Редактирование товара</h2>
-                        <p class="text-xs text-gray-500 dark:text-slate-400 font-medium uppercase tracking-wider">ID: {{ product?.id }}</p>
+                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">{{ modalTitle }}</h2>
+                        <p class="text-xs text-gray-500 dark:text-slate-400 font-medium uppercase tracking-wider">{{ modalSubtitle }}</p>
                     </div>
                 </div>
                 <button @click="close" class="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-all">
@@ -1233,7 +1295,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                             </label>
                         </div>
 
-                        <div class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
+                        <div v-if="isPersistedProduct" class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
                             <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Supply</h4>
                             <div class="flex items-end gap-2">
                                 <div class="flex-1">
@@ -1917,7 +1979,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                 >
                     <div v-if="loading" class="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
                     <Save v-else class="w-4 h-4" />
-                    Сохранить
+                    {{ saveButtonText }}
                 </button>
             </footer>
         </div>

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -14,6 +14,7 @@ import {
     Search, RefreshCw, UploadCloud, Edit3, CheckSquare, Square, Images,
     Settings, ArrowLeft, LayoutGrid, List, Package, Link2, ExternalLink,
     Star, SlidersHorizontal, X, Trash2, Download, Crop, Wand2, MoreHorizontal, ClipboardPaste,
+    Plus, Copy,
 } from 'lucide-vue-next';
 import BulkSpecsModal from '../components/BulkSpecsModal.vue';
 import BulkCompatibilityModal from '../components/BulkCompatibilityModal.vue';
@@ -32,6 +33,7 @@ const loading = ref(false);
 const showModal = ref(false);
 const selectedProduct = ref<Product | null>(null);
 const editingProduct = ref<Product | null>(null);
+const productEditorMode = ref<'create' | 'edit' | 'duplicate'>('edit');
 const showEditModal = ref(false);
 const modalMode = ref<'single' | 'bulk'>('single');
 const imageSearchResults = ref<any[]>([]);
@@ -807,6 +809,19 @@ const openSearchModal = (product: Product) => {
 
 const openEditModal = (product: Product) => {
     editingProduct.value = product;
+    productEditorMode.value = 'edit';
+    showEditModal.value = true;
+};
+
+const openCreateProductModal = () => {
+    editingProduct.value = null;
+    productEditorMode.value = 'create';
+    showEditModal.value = true;
+};
+
+const openDuplicateProductModal = (product: Product) => {
+    editingProduct.value = product;
+    productEditorMode.value = 'duplicate';
     showEditModal.value = true;
 };
 
@@ -818,6 +833,11 @@ const navigateBackFromProducts = () => {
 
 const handleEditSuccess = async () => {
     await loadProducts();
+    setToast(productEditorMode.value === 'create'
+        ? 'Товар создан'
+        : productEditorMode.value === 'duplicate'
+            ? 'Дубликат товара создан'
+            : 'Товар обновлен');
 };
 
 const handleImageSearch = async () => {
@@ -1520,8 +1540,16 @@ watchDebounced(
               Выбрать все
           </button>
           <button
-            @click="showOnlinerImportModal = true"
+            @click="openCreateProductModal"
             class="flex items-center gap-1.5 px-3 py-2 bg-teal-600 hover:bg-teal-500 text-white rounded-lg text-sm font-medium transition-colors shadow-sm"
+            title="Создать товар вручную"
+          >
+            <Plus class="w-4 h-4" />
+            Создать
+          </button>
+          <button
+            @click="showOnlinerImportModal = true"
+            class="flex items-center gap-1.5 px-3 py-2 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700 text-gray-700 dark:text-slate-200 rounded-lg text-sm font-medium transition-colors shadow-sm"
             title="Импорт товаров"
           >
             <span class="material-icons-round text-base leading-none">cloud_download</span>
@@ -1788,6 +1816,9 @@ watchDebounced(
                     <button @click="openEditModal(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
                         <Settings class="w-4 h-4 text-teal-600" /> Изменить
                     </button>
+                    <button @click="openDuplicateProductModal(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
+                        <Copy class="w-4 h-4 text-teal-600" /> Дублировать
+                    </button>
                     <button @click="copyPublicProductLink(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
                         <Link2 class="w-4 h-4 text-teal-600" /> Ссылка
                     </button>
@@ -1934,6 +1965,9 @@ watchDebounced(
                   </button>
                   <button @click="openEditModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Изменить">
                     <Settings class="w-4 h-4" />
+                  </button>
+                  <button @click="openDuplicateProductModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Дублировать">
+                    <Copy class="w-4 h-4" />
                   </button>
                   <button @click.stop="deleteProduct(product)" :disabled="isDeletingProduct === product.id" class="p-2 hover:text-red-600 transition-colors" title="Удалить">
                     <span class="material-icons-round text-[18px]">delete</span>
@@ -2523,6 +2557,7 @@ watchDebounced(
     <ProductEditModal 
         v-model="showEditModal"
         :product="editingProduct"
+        :mode="productEditorMode"
         @success="handleEditSuccess"
     />
 

--- a/openapi.json
+++ b/openapi.json
@@ -2780,6 +2780,111 @@
         }
       }
     },
+    "/api/manager/products": {
+      "post": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Create Product",
+        "description": "Create a manual product card from the manager UI.",
+        "operationId": "create_manager_product",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/manager/products/{product_id}/duplicate": {
+      "post": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Duplicate Product",
+        "description": "Duplicate a product card, optionally overriding selected fields.",
+        "operationId": "duplicate_manager_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductDuplicatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/products/{product_id}": {
       "patch": {
         "tags": [
@@ -27737,6 +27842,345 @@
         ],
         "title": "ProductBrandResponse"
       },
+      "ProductCreate": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Title"
+          },
+          "price": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Price",
+            "default": 0
+          },
+          "old_price": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Old Price"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "area": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Area",
+            "default": 0
+          },
+          "is_inverter": {
+            "type": "boolean",
+            "title": "Is Inverter",
+            "default": false
+          },
+          "power_cooling": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power Cooling"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "specs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Specs"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "brand_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Id"
+          },
+          "series_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Id"
+          },
+          "tag_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tag Ids"
+          },
+          "manuals": {
+            "items": {
+              "$ref": "#/components/schemas/ProductManualPayload"
+            },
+            "type": "array",
+            "title": "Manuals"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ProductCreate"
+      },
+      "ProductDuplicatePayload": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "price": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Price"
+          },
+          "old_price": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Old Price"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "area": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Area"
+          },
+          "is_inverter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Inverter"
+          },
+          "power_cooling": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power Cooling"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "specs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specs"
+          },
+          "is_published": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Published"
+          },
+          "brand_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Id"
+          },
+          "series_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Id"
+          },
+          "tag_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag Ids"
+          },
+          "manuals": {
+            "items": {
+              "$ref": "#/components/schemas/ProductManualPayload"
+            },
+            "type": "array",
+            "title": "Manuals"
+          },
+          "copy_gallery": {
+            "type": "boolean",
+            "title": "Copy Gallery",
+            "default": true
+          },
+          "copy_manuals": {
+            "type": "boolean",
+            "title": "Copy Manuals",
+            "default": true
+          },
+          "copy_tags": {
+            "type": "boolean",
+            "title": "Copy Tags",
+            "default": true
+          },
+          "make_unpublished": {
+            "type": "boolean",
+            "title": "Make Unpublished",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ProductDuplicatePayload"
+      },
       "ProductImageCropPayload": {
         "properties": {
           "x": {
@@ -29314,6 +29758,72 @@
               }
             ],
             "title": "Slug"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "area": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Area"
+          },
+          "is_inverter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Inverter"
+          },
+          "power_cooling": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Power Cooling"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           },
           "specs": {
             "anyOf": [

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -27,6 +27,8 @@ from routers.manager_operation_ids import (
     GET_MANAGER_PRODUCTS,
     PATCH_MANAGER_CUSTOMER,
     DELETE_MANAGER_CUSTOMER,
+    CREATE_MANAGER_PRODUCT,
+    DUPLICATE_MANAGER_PRODUCT,
     SMART_SEARCH_PRODUCTS,
     UPDATE_PRODUCT,
     DELETE_MANAGER_PRODUCT,
@@ -59,6 +61,8 @@ from schemas import (
     ManagerTagGroupResponse,
     OnlinerImportPayload,
     OnlinerImportResultResponse,
+    ProductCreate,
+    ProductDuplicatePayload,
     ProductUpdate,
 )
 from services.catalog_import_runtime_service import catalog_import_runtime_service
@@ -431,6 +435,65 @@ async def delete_customer_for_manager(
             error_code=BAD_REQUEST,
             message=str(exc),
         ) from exc
+
+
+@router.post(
+    "/products",
+    response_model=ManagerActionMessageResponse,
+    operation_id=CREATE_MANAGER_PRODUCT,
+)
+async def create_product(
+    data: ProductCreate,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    """Create a manual product card from the manager UI."""
+    try:
+        return await ManagerCatalogService.create_product(
+            session=session,
+            data=data,
+        )
+    except ValueError as exc:
+        raise manager_http_error(
+            status_code=400,
+            endpoint=CREATE_MANAGER_PRODUCT,
+            error_code=BAD_REQUEST,
+            message=str(exc),
+        ) from exc
+
+
+@router.post(
+    "/products/{product_id}/duplicate",
+    response_model=ManagerActionMessageResponse,
+    operation_id=DUPLICATE_MANAGER_PRODUCT,
+)
+async def duplicate_product(
+    product_id: int,
+    data: ProductDuplicatePayload,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    """Duplicate a product card, optionally overriding selected fields."""
+    try:
+        result = await ManagerCatalogService.duplicate_product(
+            session=session,
+            product_id=product_id,
+            data=data,
+        )
+    except ValueError as exc:
+        raise manager_http_error(
+            status_code=400,
+            endpoint=DUPLICATE_MANAGER_PRODUCT,
+            error_code=BAD_REQUEST,
+            message=str(exc),
+        ) from exc
+    if not result:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=DUPLICATE_MANAGER_PRODUCT,
+            error_code=PRODUCT_NOT_FOUND,
+        )
+    return result
 
 
 @router.patch(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -28,6 +28,8 @@ ARCHIVE_MANAGER_CUSTOMER_CONTRACT = "archive_manager_customer_contract"
 DELETE_MANAGER_CUSTOMER_CONTRACT = "delete_manager_customer_contract"
 PATCH_MANAGER_CUSTOMER = "patch_manager_customer"
 DELETE_MANAGER_CUSTOMER = "delete_manager_customer"
+CREATE_MANAGER_PRODUCT = "create_manager_product"
+DUPLICATE_MANAGER_PRODUCT = "duplicate_manager_product"
 UPDATE_PRODUCT = "update_product"
 DELETE_MANAGER_PRODUCT = "delete_manager_product"
 BULK_ROUND_PRICE = "bulk_round_price"
@@ -246,6 +248,8 @@ ALL_MANAGER_OPERATION_IDS = (
     DELETE_MANAGER_CUSTOMER_CONTRACT,
     PATCH_MANAGER_CUSTOMER,
     DELETE_MANAGER_CUSTOMER,
+    CREATE_MANAGER_PRODUCT,
+    DUPLICATE_MANAGER_PRODUCT,
     UPDATE_PRODUCT,
     DELETE_MANAGER_PRODUCT,
     BULK_ROUND_PRICE,

--- a/schemas.py
+++ b/schemas.py
@@ -2132,12 +2132,44 @@ class ProductUpdate(BaseModel):
     price: Optional[int] = None
     old_price: Optional[int] = None
     slug: Optional[str] = None
+    description: Optional[str] = None
+    area: Optional[int] = None
+    is_inverter: Optional[bool] = None
+    power_cooling: Optional[float] = None
+    main_image: Optional[str] = None
+    source_url: Optional[str] = None
     specs: Optional[Dict[str, Any]] = None
     is_published: Optional[bool] = None
     brand_id: Optional[int] = None
     series_id: Optional[int] = None
     tag_ids: Optional[List[int]] = None
     manuals: List[ProductManualPayload] = Field(default_factory=list)
+
+
+class ProductCreate(BaseModel):
+    title: str = Field(min_length=1)
+    price: int = Field(default=0, ge=0)
+    old_price: Optional[int] = None
+    slug: Optional[str] = None
+    description: str = ""
+    area: int = Field(default=0, ge=0)
+    is_inverter: bool = False
+    power_cooling: Optional[float] = None
+    main_image: Optional[str] = None
+    source_url: Optional[str] = None
+    specs: Dict[str, Any] = Field(default_factory=dict)
+    is_published: bool = True
+    brand_id: Optional[int] = None
+    series_id: Optional[int] = None
+    tag_ids: List[int] = Field(default_factory=list)
+    manuals: List[ProductManualPayload] = Field(default_factory=list)
+
+
+class ProductDuplicatePayload(ProductUpdate):
+    copy_gallery: bool = True
+    copy_manuals: bool = True
+    copy_tags: bool = True
+    make_unpublished: bool = False
 
 
 class SupplierResponse(BaseModel):

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -6,6 +6,8 @@ from schemas import (
     ManagerCustomerBranchCreatePayload,
     ManagerCustomerBranchUpdatePayload,
     ManagerCustomerUpdatePayload,
+    ProductCreate,
+    ProductDuplicatePayload,
     ProductUpdate,
 )
 from services.customer_service import CustomerService
@@ -152,6 +154,40 @@ class ManagerCatalogService:
         update_data = data.dict(exclude_unset=True)
         tag_ids = update_data.pop("tag_ids", None)
         return await ProductService.update_product(session, product_id, update_data, tag_ids)
+
+    @staticmethod
+    async def create_product(
+        session: AsyncSession,
+        *,
+        data: ProductCreate,
+    ) -> Dict[str, Any]:
+        payload = data.model_dump(exclude_unset=True)
+        tag_ids = payload.pop("tag_ids", [])
+        return await ProductService.create_product(session, payload, tag_ids)
+
+    @staticmethod
+    async def duplicate_product(
+        session: AsyncSession,
+        *,
+        product_id: int,
+        data: ProductDuplicatePayload,
+    ) -> Optional[Dict[str, Any]]:
+        payload = data.model_dump(exclude_unset=True)
+        tag_ids = payload.pop("tag_ids", None)
+        copy_gallery = bool(payload.pop("copy_gallery", True))
+        copy_manuals = bool(payload.pop("copy_manuals", True))
+        copy_tags = bool(payload.pop("copy_tags", True))
+        make_unpublished = bool(payload.pop("make_unpublished", False))
+        return await ProductService.duplicate_product(
+            session,
+            source_product_id=product_id,
+            overrides=payload,
+            tag_ids=tag_ids,
+            copy_gallery=copy_gallery,
+            copy_manuals=copy_manuals,
+            copy_tags=copy_tags,
+            make_unpublished=make_unpublished,
+        )
 
     @staticmethod
     async def delete_product(

--- a/services/product_write_service.py
+++ b/services/product_write_service.py
@@ -1,10 +1,12 @@
 """Write-oriented product service operations (mutations/updates)."""
 
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
+from slugify import slugify
 
 from crud.product import ProductDAO
 from models import Product, ProductImage, Tag
@@ -16,6 +18,232 @@ from services.product_supply_metrics_service import ProductSupplyMetricsService
 
 
 class ProductWriteService:
+    @staticmethod
+    async def _unique_slug(
+        session: AsyncSession,
+        *,
+        requested_slug: Optional[str],
+        title: str,
+    ) -> str:
+        base = slugify(str(requested_slug or "").strip(), lowercase=True)
+        if not base:
+            base = slugify(str(title or "").strip(), lowercase=True)
+        if not base:
+            raise ValueError("Не удалось сформировать slug товара.")
+
+        candidate = base
+        suffix = 2
+        while True:
+            existing = (
+                await session.execute(select(Product.id).where(Product.slug == candidate))
+            ).scalar_one_or_none()
+            if existing is None:
+                return candidate
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+
+    @staticmethod
+    async def _resolve_tags(session: AsyncSession, tag_ids: Optional[List[int]]) -> List[Tag]:
+        if not tag_ids:
+            return []
+        rows = (
+            await session.execute(
+                select(Tag).where(Tag.id.in_(tag_ids)).options(selectinload(Tag.group))
+            )
+        ).scalars().all()
+        return list(rows)
+
+    @staticmethod
+    def _wifi_tag_slugs(tags: List[Tag]) -> List[str]:
+        return [tag.slug for tag in tags if tag.slug in {"wifi-builtin", "wifi-ready"}]
+
+    @staticmethod
+    async def create_product(
+        session: AsyncSession,
+        create_data: Dict[str, Any],
+        tag_ids: Optional[List[int]] = None,
+    ) -> Dict[str, Any]:
+        payload = dict(create_data)
+        manuals_payload = payload.pop("manuals", [])
+        selected_tags = await ProductWriteService._resolve_tags(session, tag_ids)
+        title = str(payload.get("title") or "").strip()
+        if not title:
+            raise ValueError("Название товара обязательно.")
+
+        slug = await ProductWriteService._unique_slug(
+            session,
+            requested_slug=payload.get("slug"),
+            title=title,
+        )
+        specs = normalize_specs(
+            deepcopy(payload.get("specs") or {}),
+            wifi_tag_slugs=ProductWriteService._wifi_tag_slugs(selected_tags),
+            strict_wifi_from_tags=False,
+            title=title,
+        )
+
+        product = Product(
+            title=title,
+            slug=slug,
+            description=str(payload.get("description") or ""),
+            price=int(payload.get("price") or 0),
+            old_price=payload.get("old_price"),
+            area=int(payload.get("area") or 0),
+            is_inverter=bool(payload.get("is_inverter", False)),
+            power_cooling=payload.get("power_cooling"),
+            main_image=payload.get("main_image"),
+            images=[],
+            tags=selected_tags,
+            specs=specs,
+            is_published=bool(payload.get("is_published", True)),
+            source_url=payload.get("source_url"),
+            brand_id=payload.get("brand_id"),
+            series_id=payload.get("series_id"),
+        )
+        session.add(product)
+        await session.flush()
+
+        await replace_manuals(
+            session,
+            product_id=product.id,
+            manuals=manuals_payload,
+        )
+        await sync_product_brand_series(
+            session,
+            product=product,
+            specs=specs,
+            title=title,
+            tags=selected_tags,
+            explicit_brand_id=payload.get("brand_id"),
+            explicit_brand_override="brand_id" in payload,
+        )
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="product_create",
+            product_ids=[product.id],
+            slugs=[product.slug],
+        )
+        return {"message": "Product created", "id": product.id}
+
+    @staticmethod
+    async def duplicate_product(
+        session: AsyncSession,
+        source_product_id: int,
+        overrides: Dict[str, Any],
+        tag_ids: Optional[List[int]] = None,
+        *,
+        copy_gallery: bool = True,
+        copy_manuals: bool = True,
+        copy_tags: bool = True,
+        make_unpublished: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        source = await ProductDAO.get_by_id(session, source_product_id)
+        if not source:
+            return None
+
+        payload = dict(overrides)
+        manuals_payload = payload.pop("manuals", None)
+        title = str(payload.get("title") or source.title or "").strip()
+        if not title:
+            raise ValueError("Название товара обязательно.")
+
+        if tag_ids is not None:
+            selected_tags = await ProductWriteService._resolve_tags(session, tag_ids)
+        elif copy_tags:
+            selected_tags = list(source.tags or [])
+        else:
+            selected_tags = []
+
+        source_specs = deepcopy(source.specs or {})
+        specs_payload = payload.get("specs", source_specs)
+        specs = normalize_specs(
+            deepcopy(specs_payload or {}),
+            wifi_tag_slugs=ProductWriteService._wifi_tag_slugs(selected_tags),
+            strict_wifi_from_tags=False,
+            title=title,
+        )
+        slug = await ProductWriteService._unique_slug(
+            session,
+            requested_slug=payload.get("slug") or f"{source.slug}-copy",
+            title=title,
+        )
+        is_published = bool(payload.get("is_published", source.is_published))
+        if make_unpublished:
+            is_published = False
+
+        product = Product(
+            title=title,
+            slug=slug,
+            description=str(payload.get("description", source.description or "")),
+            price=int(payload.get("price", source.price) or 0),
+            old_price=payload.get("old_price", source.old_price),
+            area=int(payload.get("area", source.area) or 0),
+            is_inverter=bool(payload.get("is_inverter", source.is_inverter)),
+            power_cooling=payload.get("power_cooling", source.power_cooling),
+            main_image=payload.get("main_image", source.main_image),
+            images=list(source.images or []),
+            tags=selected_tags,
+            specs=specs,
+            is_published=is_published,
+            source_url=payload.get("source_url"),
+            brand_id=payload.get("brand_id", source.brand_id),
+            series_id=payload.get("series_id", source.series_id),
+        )
+        session.add(product)
+        await session.flush()
+
+        if copy_gallery:
+            seen_urls: set[str] = set()
+            for image in source.gallery_images or []:
+                if not image.url or image.url in seen_urls:
+                    continue
+                seen_urls.add(image.url)
+                session.add(
+                    ProductImage(
+                        product_id=product.id,
+                        url=image.url,
+                        is_installation_photo=image.is_installation_photo,
+                    )
+                )
+
+        if manuals_payload is not None:
+            manuals_to_save = manuals_payload
+        elif copy_manuals:
+            manuals_to_save = [
+                {
+                    "kind": item.kind,
+                    "title": item.title,
+                    "url": item.url,
+                    "source": item.source,
+                }
+                for item in (source.attachments or [])
+                if item.kind == "manual"
+            ]
+        else:
+            manuals_to_save = []
+        await replace_manuals(
+            session,
+            product_id=product.id,
+            manuals=manuals_to_save,
+        )
+
+        await sync_product_brand_series(
+            session,
+            product=product,
+            specs=specs,
+            title=title,
+            tags=selected_tags,
+            explicit_brand_id=payload.get("brand_id"),
+            explicit_brand_override="brand_id" in payload,
+        )
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="product_duplicate",
+            product_ids=[product.id],
+            slugs=[product.slug],
+        )
+        return {"message": "Product duplicated", "id": product.id}
+
     @staticmethod
     async def save_main_image(
         session: AsyncSession,


### PR DESCRIPTION
## Summary
- add manager API endpoints to create a manual product and duplicate an existing product
- reuse the product editor modal for create/edit/duplicate modes
- add product list actions for manual creation and duplication
- regenerate OpenAPI and the manager TypeScript client

## Notes
- duplicated products copy gallery image links and manuals without duplicating physical files
- duplicated products do not copy `source_url` by default, so manual cards are not tied to donor import sources
- product slug is uniquified server-side; the UI seeds duplicates with `-copy`

## Validation
- `npm run build` in `manager_frontend/`
- `python3 -m compileall routers/manager_catalog.py services/manager_catalog_service.py services/product_write_service.py schemas.py`
- `POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=127.0.0.1 TEST_DB_PORT=5433 pytest tests/unit -q` (`516 passed`)
- browser smoke: opened `/manager/products`, verified create modal and duplicate modal states
