### PR TITLE
[codex] Support international phones and address suggestions

### DIFF
--- a/core/input_validation.py
+++ b/core/input_validation.py
@@ -1,12 +1,13 @@
 import re
 from typing import Optional
 
-PHONE_ERROR = "Телефон должен быть в формате +375XXXXXXXXX"
+PHONE_ERROR = "Телефон должен быть в международном формате, например +375XXXXXXXXX или +7XXXXXXXXXX"
 UNP_ERROR = "УНП должен содержать 9 цифр"
 IBAN_ERROR = "IBAN должен быть валидным BY-счетом"
 BIC_ERROR = "BIC должен содержать 8-11 латинских символов/цифр"
 
 _EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+_PHONE_PATTERN = re.compile(r"^\+?[\d\s().-]+$")
 _BIC_PATTERN = re.compile(r"^[A-Z0-9]{8,11}$")
 _IBAN_BY_PATTERN = re.compile(r"^BY\d{2}[A-Z0-9]{24}$")
 
@@ -33,22 +34,26 @@ def normalize_phone_digits(value: str) -> str:
     return digits
 
 
+def is_valid_phone(value: str) -> bool:
+    cleaned = clean_optional(value)
+    if not cleaned or not _PHONE_PATTERN.match(cleaned):
+        return False
+    normalized = normalize_phone_digits(cleaned)
+    return 7 <= len(normalized) <= 15
+
+
 def validate_optional_phone(value: Optional[str]) -> Optional[str]:
     cleaned = clean_optional(value)
     if not cleaned:
         return None
-    normalized = normalize_phone_digits(cleaned)
-    if len(normalized) != 12 or not normalized.startswith("375"):
+    if not is_valid_phone(cleaned):
         raise ValueError(PHONE_ERROR)
     return cleaned
 
 
 def validate_required_phone(value: str) -> str:
     cleaned = clean_optional(value)
-    if not cleaned:
-        raise ValueError(PHONE_ERROR)
-    normalized = normalize_phone_digits(cleaned)
-    if len(normalized) != 12 or not normalized.startswith("375"):
+    if not cleaned or not is_valid_phone(cleaned):
         raise ValueError(PHONE_ERROR)
     return cleaned
 

--- a/manager_frontend/src/client/services/ManagerSettingsService.ts
+++ b/manager_frontend/src/client/services/ManagerSettingsService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AddressSuggestResponse } from '../models/AddressSuggestResponse';
 import type { FxRateResponse } from '../models/FxRateResponse';
 import type { ManagerSettingCreatePayload } from '../models/ManagerSettingCreatePayload';
 import type { ManagerSettingListResponse } from '../models/ManagerSettingListResponse';
@@ -55,12 +56,12 @@ export class ManagerSettingsService {
     /**
      * Suggest Address
      * @param q
-     * @returns any Successful Response
+     * @returns AddressSuggestResponse Successful Response
      * @throws ApiError
      */
     public static suggestAddress(
         q: string,
-    ): CancelablePromise<any> {
+    ): CancelablePromise<AddressSuggestResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/manager/settings/address-suggest',

--- a/manager_frontend/src/components/InstallerEditModal.vue
+++ b/manager_frontend/src/components/InstallerEditModal.vue
@@ -153,7 +153,7 @@ const submit = async () => {
 
                                 <label class="block">
                                     <span class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1">Телефон</span>
-                                    <input v-model="formData.phone" type="text" class="field-input" placeholder="+375..." :disabled="loading" />
+                                    <input v-model="formData.phone" type="text" class="field-input" placeholder="+375... или +7..." :disabled="loading" />
                                 </label>
 
                                 <label class="block">

--- a/manager_frontend/src/components/leads/LeadsDashboard.vue
+++ b/manager_frontend/src/components/leads/LeadsDashboard.vue
@@ -1623,7 +1623,7 @@ const onQualifyIbanBlur = async () => {
               :class="createPhoneError ? 'border-red-500 focus:outline-red-400' : ''"
               type="tel"
               inputmode="tel"
-              placeholder="+375 (XX) XXX-XX-XX"
+              placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
               @blur="onCreatePhoneBlur"
             />
             <span v-if="createPhoneError" class="text-xs text-red-300">{{ createPhoneError }}</span>
@@ -1839,7 +1839,7 @@ const onQualifyIbanBlur = async () => {
               :class="qualifyPhoneError ? 'border-red-500 focus:outline-red-400' : ''"
               type="tel"
               inputmode="tel"
-              placeholder="+375 (XX) XXX-XX-XX"
+              placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
               @blur="validateQualifyPhoneOnBlur"
             />
             <span v-if="qualifyPhoneError" class="text-xs text-red-300">{{ qualifyPhoneError }}</span>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -1573,7 +1573,7 @@ const fetchAddressSuggestions = async (query: string) => {
   addressLookupLoading.value = true;
   try {
     const res = await ManagerSettingsService.suggestAddress(query);
-    addressSuggestions.value = res.results || [];
+    addressSuggestions.value = res.items || [];
   } catch (err) {
     console.warn('Failed to fetch address suggestions', err);
   } finally {
@@ -1589,8 +1589,7 @@ const onAddressInput = () => {
 };
 
 const selectAddressSuggestion = (item: any) => {
-  customerDeliveryAddress.value = item.title?.text || '';
-  if (item.subtitle?.text) customerDeliveryAddress.value += `, ${item.subtitle.text}`;
+  customerDeliveryAddress.value = item.value || item.title || '';
   addressSuggestActive.value = false;
   addressSuggestions.value = [];
 };
@@ -2626,8 +2625,8 @@ watch(
                 class="flex cursor-pointer flex-col px-3 py-2 text-sm hover:bg-gray-50 rounded-lg transition-colors border-b border-gray-50 last:border-0"
                 @mousedown.prevent="selectAddressSuggestion(item)"
               >
-                <div class="font-medium text-gray-900">{{ item.title?.text }}</div>
-                <div v-if="item.subtitle?.text" class="text-xs text-gray-500 mt-0.5 truncate">{{ item.subtitle?.text }}</div>
+                <div class="font-medium text-gray-900">{{ item.title || item.value }}</div>
+                <div v-if="item.subtitle" class="text-xs text-gray-500 mt-0.5 truncate">{{ item.subtitle }}</div>
               </li>
             </ul>
           </label>

--- a/manager_frontend/src/composables/useBelarusPhoneMask.ts
+++ b/manager_frontend/src/composables/useBelarusPhoneMask.ts
@@ -1,100 +1,65 @@
-import { onBeforeUnmount, ref, watch, type Ref } from 'vue';
-import IMask, { type InputMask } from 'imask';
+import { computed, onBeforeUnmount, ref, watch, type Ref } from 'vue';
+import { formatPhoneForDisplay, isInternationalPhoneComplete, normalizePhoneForApi } from '../utils/phone';
 
 type PhoneModelRef = Ref<string>;
 
 export function useBelarusPhoneMask(
   inputRef: Ref<HTMLInputElement | null>,
   modelRef: PhoneModelRef,
-  options?: { lazy?: boolean; placeholderChar?: string },
+  options?: { lazy?: boolean; placeholderChar?: string; defaultPrefix?: string },
 ) {
-  const isComplete = ref(false);
+  const defaultPrefix = options?.defaultPrefix ?? '+375 ';
+  const isComplete = computed(() => isInternationalPhoneComplete(modelRef.value || ''));
   const unmaskedValue = ref('');
-
-  let mask: InputMask<any> | null = null;
+  let currentInput: HTMLInputElement | null = null;
 
   const syncState = () => {
-    if (!mask) {
-      isComplete.value = false;
-      unmaskedValue.value = '';
-      return;
-    }
-    isComplete.value = Boolean(mask.masked.isComplete);
-    unmaskedValue.value = mask.unmaskedValue || '';
+    unmaskedValue.value = normalizePhoneForApi(modelRef.value || '');
   };
 
-  const destroyMask = () => {
-    if (mask) {
-      mask.destroy();
-      mask = null;
+  const applyDefaultPrefix = () => {
+    if (!(modelRef.value || '').trim()) {
+      modelRef.value = defaultPrefix;
     }
     syncState();
   };
 
-  // Helper: raw phone from DB looks like '375XXXXXXXXX' (12 digits)
-  // IMask `unmaskedValue` only needs digits after the fixed '+375 ' prefix (9 digits)
-  const applyValueToMask = (value: string) => {
-    if (!mask) return;
-    if (/^375\d{9}$/.test(value)) {
-      // Raw format: strip the 375 country code
-      mask.unmaskedValue = value.slice(3);
-    } else {
-      // Already formatted or partial
-      mask.value = value;
+  const formatCurrentValue = () => {
+    const formatted = formatPhoneForDisplay(modelRef.value || '');
+    if (formatted !== modelRef.value) {
+      modelRef.value = formatted;
     }
-    mask.updateValue();
+    syncState();
   };
 
-  const initMask = (input: HTMLInputElement | null) => {
-    destroyMask();
-    if (!input) return;
-
-    mask = IMask(input, {
-      mask: '+{375} (00) 000-00-00',
-      lazy: options?.lazy ?? false,
-      placeholderChar: options?.placeholderChar ?? '_',
-    });
-
-    if (modelRef.value) {
-      applyValueToMask(modelRef.value);
-      syncState();
-      // Sync model to what the mask actually shows
-      if (modelRef.value !== mask.value) {
-        modelRef.value = mask.value;
-      }
+  const detachInput = () => {
+    if (currentInput) {
+      currentInput.removeEventListener('focus', applyDefaultPrefix);
+      currentInput.removeEventListener('blur', formatCurrentValue);
+      currentInput = null;
     }
+  };
 
-    mask.on('accept', () => {
-      if (!mask) return;
-      if (modelRef.value !== mask.value) {
-        modelRef.value = mask.value;
-      }
-      syncState();
-    });
-
+  const attachInput = (input: HTMLInputElement | null) => {
+    detachInput();
+    currentInput = input;
+    currentInput?.addEventListener('focus', applyDefaultPrefix);
+    currentInput?.addEventListener('blur', formatCurrentValue);
     syncState();
   };
 
   watch(inputRef, (input) => {
-    initMask(input);
-  });
+    attachInput(input);
+  }, { immediate: true });
 
   watch(
     modelRef,
-    (value) => {
-      if (!mask) return;
-      if (value !== mask.value) {
-        mask.value = value || '';
-        // Keep IMask internals aligned when model changes programmatically.
-        mask.updateValue();
-        syncState();
-      }
-    },
+    () => syncState(),
     { flush: 'post' },
   );
 
   onBeforeUnmount(() => {
-    destroyMask();
+    detachInput();
   });
 
   return {

--- a/manager_frontend/src/utils/phone.ts
+++ b/manager_frontend/src/utils/phone.ts
@@ -13,9 +13,34 @@ export function normalizePhoneDigits(value: string): string {
   return extractNormalizedDigits(value);
 }
 
-export function isBelarusPhoneComplete(masked: string): boolean {
-  const normalized = extractNormalizedDigits(masked);
-  return normalized.length === 12 && normalized.startsWith('375');
+export function isInternationalPhoneComplete(value: string): boolean {
+  const raw = (value || '').trim();
+  if (!raw || !/^\+?[\d\s().-]+$/.test(raw)) return false;
+  const normalized = extractNormalizedDigits(raw);
+  return normalized.length >= 7 && normalized.length <= 15;
+}
+
+export function formatPhoneForDisplay(value: string): string {
+  const trimmed = value.trim();
+  const normalized = extractNormalizedDigits(trimmed);
+  if (normalized.length === 12 && normalized.startsWith('375')) {
+    const operator = normalized.slice(3, 5);
+    const p1 = normalized.slice(5, 8);
+    const p2 = normalized.slice(8, 10);
+    const p3 = normalized.slice(10, 12);
+    return `+375 (${operator}) ${p1}-${p2}-${p3}`;
+  }
+
+  if (normalized.length === 11 && (normalized.startsWith('7') || normalized.startsWith('8'))) {
+    const national = normalized.startsWith('8') ? `7${normalized.slice(1)}` : normalized;
+    const operator = national.slice(1, 4);
+    const p1 = national.slice(4, 7);
+    const p2 = national.slice(7, 9);
+    const p3 = national.slice(9, 11);
+    return `+7 (${operator}) ${p1}-${p2}-${p3}`;
+  }
+
+  return trimmed;
 }
 
 export function normalizePhoneForApi(masked: string): string {
@@ -23,13 +48,6 @@ export function normalizePhoneForApi(masked: string): string {
   if (!trimmed) return '';
 
   const normalized = extractNormalizedDigits(trimmed);
-  if (!(normalized.length === 12 && normalized.startsWith('375'))) {
-    return trimmed;
-  }
-
-  const operator = normalized.slice(3, 5);
-  const p1 = normalized.slice(5, 8);
-  const p2 = normalized.slice(8, 10);
-  const p3 = normalized.slice(10, 12);
-  return `+375 (${operator}) ${p1}-${p2}-${p3}`;
+  if (normalized.length < 7) return '';
+  return formatPhoneForDisplay(trimmed);
 }

--- a/manager_frontend/src/utils/validation.ts
+++ b/manager_frontend/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import { normalizeIban, normalizeUnp } from './legal-requisites';
-import { isBelarusPhoneComplete } from './phone';
+import { isInternationalPhoneComplete, normalizePhoneDigits } from './phone';
 
 export function normalizeEmail(value: string): string {
   return (value || '').trim().toLowerCase();
@@ -37,8 +37,10 @@ export function validateOptionalByIban(value: string): string {
 export function validateOptionalBelarusPhone(masked: string, isMaskComplete: boolean): string {
   const raw = (masked || '').trim();
   if (!raw) return '';
-  if (!isMaskComplete || !isBelarusPhoneComplete(raw)) {
-    return 'Введите телефон полностью в формате +375 (XX) XXX-XX-XX';
+  const digits = normalizePhoneDigits(raw);
+  if (digits === '375') return '';
+  if (!isMaskComplete || !isInternationalPhoneComplete(raw)) {
+    return 'Введите телефон в международном формате, например +375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX';
   }
   return '';
 }

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core';
 import { computed, onMounted, ref, watch } from 'vue';
 import { ArrowLeft, Building2, Mail, Phone, Plus, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
 import CreateOrderModal from '../components/CreateOrderModal.vue';
@@ -7,7 +8,9 @@ import {
   ManagerContractsService,
   ManagerDocsService,
   ManagerEquipmentService,
+  ManagerSettingsService,
   ManagerService,
+  type AddressSuggestionItem,
   type DocumentTemplateItem,
   type EquipmentServiceEventType,
   type ManagerCatalogCustomerItemResponse,
@@ -136,6 +139,11 @@ const emailError = ref('');
 const innError = ref('');
 const ibanError = ref('');
 const phoneInputRef = ref<HTMLInputElement | null>(null);
+type CustomerAddressField = 'legal_address' | 'actual_address';
+const customerAddressSuggestions = ref<AddressSuggestionItem[]>([]);
+const activeCustomerAddressField = ref<CustomerAddressField | null>(null);
+const customerAddressLookupLoading = ref(false);
+let customerAddressRequestId = 0;
 
 const form = ref<CustomerForm>({
   name: '',
@@ -381,6 +389,46 @@ const fieldClass = (key: keyof CustomerForm) => ({
     (key === 'inn' && Boolean(innError.value)) ||
     (key === 'iban' && Boolean(ibanError.value)),
 });
+
+const fetchCustomerAddressSuggestions = async (field: CustomerAddressField, query: string) => {
+  const requestId = ++customerAddressRequestId;
+  if (!query || query.length < 3) {
+    customerAddressSuggestions.value = [];
+    return;
+  }
+  customerAddressLookupLoading.value = true;
+  try {
+    const res = await ManagerSettingsService.suggestAddress(query);
+    if (requestId === customerAddressRequestId && activeCustomerAddressField.value === field) {
+      customerAddressSuggestions.value = res.items || [];
+    }
+  } catch (err) {
+    console.warn('Failed to fetch address suggestions', err);
+  } finally {
+    if (requestId === customerAddressRequestId) {
+      customerAddressLookupLoading.value = false;
+    }
+  }
+};
+
+const debouncedFetchCustomerAddressSuggestions = useDebounceFn(fetchCustomerAddressSuggestions, 400);
+
+const onCustomerAddressInput = (field: CustomerAddressField) => {
+  activeCustomerAddressField.value = field;
+  debouncedFetchCustomerAddressSuggestions(field, form.value[field]);
+};
+
+const selectCustomerAddressSuggestion = (field: CustomerAddressField, item: AddressSuggestionItem) => {
+  form.value[field] = item.value || item.title || '';
+  activeCustomerAddressField.value = null;
+  customerAddressSuggestions.value = [];
+};
+
+const hideCustomerAddressSuggestions = () => {
+  window.setTimeout(() => {
+    activeCustomerAddressField.value = null;
+  }, 200);
+};
 
 const clearFieldErrors = () => {
   serverErrors.value = {};
@@ -998,6 +1046,7 @@ onMounted(() => {
                 <p class="detail"><UserRound class="h-4 w-4" /> <span>{{ customer.name || '—' }}</span></p>
                 <p class="detail"><Phone class="h-4 w-4" /> <span>{{ customer.phone || '—' }}</span></p>
                 <p class="detail"><Mail class="h-4 w-4" /> <span>{{ customer.email || '—' }}</span></p>
+                <p v-if="customer.type !== 'company'" class="detail"><Building2 class="h-4 w-4" /> <span>Адрес: {{ customer.actual_address || customer.last_delivery_address || '—' }}</span></p>
                 <p class="detail"><Building2 class="h-4 w-4" /> <span>УНП: {{ customer.inn || '—' }}</span></p>
                 <p class="detail"><Building2 class="h-4 w-4" /> <span>КПП: {{ customer.kpp || '—' }}</span></p>
                 <p class="detail"><ReceiptText class="h-4 w-4" /> <span>Заказов: {{ customer.order_count }}</span></p>
@@ -1011,8 +1060,35 @@ onMounted(() => {
                   <option value="individual">Физ. лицо</option>
                   <option value="company">Юр. лицо</option>
                 </select>
-                <input v-model="form.name" type="text" placeholder="Имя/Компания" :class="fieldClass('name')" />
-                <input ref="phoneInputRef" v-model="form.phone" type="tel" placeholder="+375 (XX) XXX-XX-XX" :class="fieldClass('phone')" />
+                <input v-model="form.name" type="text" :placeholder="isCompany ? 'Компания' : 'Имя клиента'" :class="fieldClass('name')" />
+                <div v-if="!isCompany" class="relative">
+                  <input
+                    v-model="form.actual_address"
+                    type="text"
+                    placeholder="Адрес объекта / доставки"
+                    autocomplete="off"
+                    :class="fieldClass('actual_address')"
+                    @input="onCustomerAddressInput('actual_address')"
+                    @focus="activeCustomerAddressField = 'actual_address'"
+                    @blur="hideCustomerAddressSuggestions"
+                  />
+                  <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'actual_address'" class="absolute right-3 top-2">
+                    <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
+                  </div>
+                  <div v-if="activeCustomerAddressField === 'actual_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
+                    <button
+                      v-for="(item, index) in customerAddressSuggestions"
+                      :key="index"
+                      type="button"
+                      class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
+                      @mousedown.prevent="selectCustomerAddressSuggestion('actual_address', item)"
+                    >
+                      <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
+                      <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
+                    </button>
+                  </div>
+                </div>
+                <input ref="phoneInputRef" v-model="form.phone" type="tel" placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX" :class="fieldClass('phone')" />
                 <span v-if="phoneError" class="field-error">{{ phoneError }}</span>
                 <input v-model="form.email" type="email" placeholder="Email" :class="fieldClass('email')" />
                 <span v-if="emailError" class="field-error">{{ emailError }}</span>
@@ -1050,8 +1126,60 @@ onMounted(() => {
               <div class="space-y-3 text-sm">
                 <div v-if="isCompany" class="space-y-3">
                   <input v-model="form.full_legal_name" type="text" placeholder="Полное наименование" :class="fieldClass('full_legal_name')" />
-                  <input v-model="form.legal_address" type="text" placeholder="Юр. адрес" :class="fieldClass('legal_address')" />
-                  <input v-model="form.actual_address" type="text" placeholder="Факт. адрес" :class="fieldClass('actual_address')" />
+                  <div class="relative">
+                    <input
+                      v-model="form.legal_address"
+                      type="text"
+                      placeholder="Юр. адрес"
+                      autocomplete="off"
+                      :class="fieldClass('legal_address')"
+                      @input="onCustomerAddressInput('legal_address')"
+                      @focus="activeCustomerAddressField = 'legal_address'"
+                      @blur="hideCustomerAddressSuggestions"
+                    />
+                    <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'legal_address'" class="absolute right-3 top-2">
+                      <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
+                    </div>
+                    <div v-if="activeCustomerAddressField === 'legal_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
+                      <button
+                        v-for="(item, index) in customerAddressSuggestions"
+                        :key="index"
+                        type="button"
+                        class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
+                        @mousedown.prevent="selectCustomerAddressSuggestion('legal_address', item)"
+                      >
+                        <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
+                        <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="relative">
+                    <input
+                      v-model="form.actual_address"
+                      type="text"
+                      placeholder="Факт. адрес"
+                      autocomplete="off"
+                      :class="fieldClass('actual_address')"
+                      @input="onCustomerAddressInput('actual_address')"
+                      @focus="activeCustomerAddressField = 'actual_address'"
+                      @blur="hideCustomerAddressSuggestions"
+                    />
+                    <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'actual_address'" class="absolute right-3 top-2">
+                      <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
+                    </div>
+                    <div v-if="activeCustomerAddressField === 'actual_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
+                      <button
+                        v-for="(item, index) in customerAddressSuggestions"
+                        :key="index"
+                        type="button"
+                        class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
+                        @mousedown.prevent="selectCustomerAddressSuggestion('actual_address', item)"
+                      >
+                        <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
+                        <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
+                      </button>
+                    </div>
+                  </div>
                   <input v-model="form.bank_name" type="text" placeholder="Название банка" :class="fieldClass('bank_name')" />
                   <input v-model="form.bic" type="text" placeholder="BIC" :class="fieldClass('bic')" />
                   <div class="relative">

--- a/manager_frontend/src/views/LeadInbox.vue
+++ b/manager_frontend/src/views/LeadInbox.vue
@@ -203,7 +203,7 @@ const fetchAddressSuggestions = async (query: string) => {
   addressLookupLoading.value = true;
   try {
     const res = await ManagerSettingsService.suggestAddress(query);
-    addressSuggestions.value = res.results || [];
+    addressSuggestions.value = res.items || [];
   } catch (err) {
     console.warn('Failed to fetch address suggestions', err);
   } finally {
@@ -219,8 +219,7 @@ const onAddressInput = () => {
 };
 
 const selectAddressSuggestion = (item: any) => {
-  createForm.value.address = item.title?.text || '';
-  if (item.subtitle?.text) createForm.value.address += `, ${item.subtitle.text}`;
+  createForm.value.address = item.value || item.title || '';
   addressSuggestActive.value = false;
   addressSuggestions.value = [];
 };
@@ -629,7 +628,7 @@ const scopeOptions: { value: Scope; label: string }[] = [
               v-model="phoneModelRef"
               @input="onSearchInput"
               type="text"
-              placeholder="+375 (29) 000-00-00"
+              placeholder="+375 (29) 000-00-00 или +7 916 000-00-00"
               class="w-full rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-800 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500"
             />
 
@@ -707,8 +706,8 @@ const scopeOptions: { value: Scope; label: string }[] = [
                     @click.prevent="selectAddressSuggestion(sug)"
                     class="w-full text-left px-4 py-2 hover:bg-slate-50 dark:hover:bg-slate-700 border-b border-slate-100 dark:border-slate-700 last:border-0"
                   >
-                    <div class="text-sm font-semibold text-slate-800 dark:text-white">{{ sug.title?.text || sug.value }}</div>
-                    <div v-if="sug.subtitle?.text" class="text-xs text-slate-500 dark:text-slate-400">{{ sug.subtitle.text }}</div>
+                    <div class="text-sm font-semibold text-slate-800 dark:text-white">{{ sug.title || sug.value }}</div>
+                    <div v-if="sug.subtitle" class="text-xs text-slate-500 dark:text-slate-400">{{ sug.subtitle }}</div>
                   </button>
                 </div>
               </div>

--- a/openapi.json
+++ b/openapi.json
@@ -11402,7 +11402,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/AddressSuggestResponse"
+                }
               }
             }
           },

--- a/routers/manager_settings.py
+++ b/routers/manager_settings.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database import get_session
 from core.security import get_current_username
 from routers.manager_operation_ids import CREATE_MANAGER_SETTING, GET_FX_RATE, LIST_MANAGER_SETTINGS, SUGGEST_ADDRESS, UPDATE_MANAGER_SETTING
-from schemas import ManagerSettingCreatePayload, ManagerSettingListResponse, ManagerSettingResponse, ManagerSettingUpdatePayload, FxRateResponse
+from schemas import AddressSuggestResponse, ManagerSettingCreatePayload, ManagerSettingListResponse, ManagerSettingResponse, ManagerSettingUpdatePayload, FxRateResponse
 from services.address_suggest_service import AddressSuggestService
 from services.settings_service import SettingsService
 from services.fx_rate_service import FxRateService
@@ -35,10 +35,10 @@ async def get_fx_rate(session: AsyncSession = Depends(get_session)):
         source=source
     )
 
-@router.get("/address-suggest", operation_id=SUGGEST_ADDRESS)
+@router.get("/address-suggest", response_model=AddressSuggestResponse, operation_id=SUGGEST_ADDRESS)
 async def suggest_address(q: str = Query(..., min_length=2)):
     try:
-        return await AddressSuggestService.fetch_raw(q)
+        return AddressSuggestResponse(items=await AddressSuggestService.suggest(q))
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except httpx.HTTPError:

--- a/services/address_suggest_service.py
+++ b/services/address_suggest_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 import httpx
@@ -86,7 +87,7 @@ class AddressSuggestService:
 
             title = cls._extract_text(result.get("title")) or cls._extract_text(result.get("displayName"))
             subtitle = cls._extract_text(result.get("subtitle"))
-            value = cls._compose_value(title, subtitle)
+            value = cls._compose_value(result, title, subtitle)
             if not value or value in seen_values:
                 continue
 
@@ -103,6 +104,301 @@ class AddressSuggestService:
 
         return items
 
+    @classmethod
+    def _compose_value(cls, result: dict[str, Any], title: str | None, subtitle: str | None) -> str | None:
+        structured = cls._compose_structured_value(result, title=title, subtitle=subtitle)
+        if structured:
+            return structured
+        return cls._compose_fallback_value(title, subtitle)
+
+    @classmethod
+    def _compose_structured_value(cls, result: dict[str, Any], *, title: str | None, subtitle: str | None) -> str | None:
+        components = cls._extract_address_components(result)
+        if not components:
+            components = cls._parse_title_subtitle(title, subtitle)
+
+        object_name = components.get("object")
+        district = components.get("district")
+        council = components.get("council")
+        city = components.get("city")
+        street = components.get("street")
+        house = components.get("house")
+
+        parts = cls._dedupe_parts(
+            [
+                object_name,
+                district,
+                council,
+                city,
+                street,
+                f"д. {house}" if house else None,
+            ]
+        )
+        if city and (street or house):
+            return ", ".join(parts)
+        return None
+
+    @classmethod
+    def _extract_address_components(cls, result: dict[str, Any]) -> dict[str, str]:
+        components = cls._find_component_list(result)
+        if not components:
+            return {}
+
+        parsed: dict[str, str] = {}
+        city_type_names = {
+            "locality",
+            "settlement",
+        }
+        street_type_names = {"street"}
+        house_type_names = {"house", "house_number", "premise"}
+
+        for component in components:
+            if not isinstance(component, dict):
+                continue
+            name = cls._component_name(component)
+            if not name:
+                continue
+            kinds = cls._component_kinds(component)
+            lowered_name = name.lower()
+            if not parsed.get("district") and "район" in lowered_name:
+                parsed["district"] = name
+            elif not parsed.get("council") and "сельсовет" in lowered_name:
+                parsed["council"] = name
+            elif not parsed.get("city") and kinds & city_type_names:
+                parsed["city"] = name
+            elif not parsed.get("street") and kinds & street_type_names:
+                parsed["street"] = name
+            elif not parsed.get("house") and kinds & house_type_names:
+                parsed["house"] = cls._normalize_house(name)
+
+        title = cls._extract_text(result.get("title")) or ""
+        if parsed.get("city") and parsed.get("street") and parsed.get("house"):
+            title_without_address = cls._strip_address_from_title(title, parsed)
+            if title_without_address:
+                parsed["object"] = title_without_address
+
+        return parsed
+
+    @classmethod
+    def _find_component_list(cls, value: Any) -> list[Any]:
+        if isinstance(value, list):
+            if any(isinstance(item, dict) and cls._component_name(item) for item in value):
+                return value
+            for item in value:
+                nested = cls._find_component_list(item)
+                if nested:
+                    return nested
+        if isinstance(value, dict):
+            for key in ("components", "Components", "address_components", "AddressComponents"):
+                nested = value.get(key)
+                if isinstance(nested, list):
+                    return nested
+            for nested in value.values():
+                found = cls._find_component_list(nested)
+                if found:
+                    return found
+        return []
+
+    @classmethod
+    def _parse_title_subtitle(cls, title: str | None, subtitle: str | None) -> dict[str, str]:
+        title_parts = cls._split_parts(title)
+        subtitle_parts = cls._split_parts(subtitle)
+        if not title_parts and not subtitle_parts:
+            return {}
+
+        house = cls._extract_house(title_parts)
+        street = cls._extract_street(title_parts)
+        city = cls._extract_city(subtitle_parts) or cls._extract_city(title_parts)
+
+        object_name = cls._extract_object_name(
+            title_parts=title_parts,
+            subtitle_parts=subtitle_parts,
+            address_values=[city, street, house, *cls._extract_admin_parts(subtitle_parts)],
+            street=street,
+        )
+        result: dict[str, str] = {}
+        if object_name:
+            result["object"] = object_name
+        for part in cls._extract_admin_parts(subtitle_parts):
+            if "район" in part.lower() and not result.get("district"):
+                result["district"] = part
+            elif "сельсовет" in part.lower() and not result.get("council"):
+                result["council"] = part
+        if city:
+            result["city"] = city
+        if street:
+            result["street"] = street
+        if house:
+            result["house"] = house
+        return result
+
+    @staticmethod
+    def _split_parts(value: str | None) -> list[str]:
+        return [part.strip() for part in (value or "").split(",") if part.strip()]
+
+    @classmethod
+    def _extract_house(cls, parts: list[str]) -> str | None:
+        for part in parts:
+            normalized = cls._normalize_house(part)
+            if normalized and cls._looks_like_house(part):
+                return normalized
+        return None
+
+    @staticmethod
+    def _extract_street(parts: list[str]) -> str | None:
+        street_markers = (
+            "улица",
+            "ул.",
+            "проспект",
+            "пр-т",
+            "переулок",
+            "пер.",
+            "проезд",
+            "тракт",
+            "шоссе",
+            "бульвар",
+            "площадь",
+            "набережная",
+        )
+        for part in parts:
+            lowered = part.lower()
+            if any(marker in lowered for marker in street_markers):
+                return part
+        return None
+
+    @staticmethod
+    def _extract_city(parts: list[str]) -> str | None:
+        skip_markers = (
+            "район",
+            "область",
+            "сельсовет",
+            "вобласць",
+            "беларусь",
+            "республика",
+            "улица",
+            "ул.",
+            "проспект",
+            "пр-т",
+            "переулок",
+            "пер.",
+            "проезд",
+            "тракт",
+            "шоссе",
+            "бульвар",
+            "площадь",
+            "набережная",
+        )
+        for part in parts:
+            lowered = part.lower()
+            if any(marker in lowered for marker in skip_markers):
+                continue
+            if AddressSuggestService._looks_like_house(part):
+                continue
+            if re.match(r"^(г\.|город)\s+", lowered):
+                return re.sub(r"^(г\.|город)\s+", "", part, flags=re.IGNORECASE).strip()
+            return part
+        return None
+
+    @staticmethod
+    def _extract_admin_parts(parts: list[str]) -> list[str]:
+        result: list[str] = []
+        for part in parts:
+            lowered = part.lower()
+            if "район" in lowered or "сельсовет" in lowered:
+                result.append(part)
+        return result
+
+    @classmethod
+    def _extract_object_name(
+        cls,
+        *,
+        title_parts: list[str],
+        subtitle_parts: list[str],
+        address_values: list[str | None],
+        street: str | None,
+    ) -> str | None:
+        address_value_set = {value for value in address_values if value}
+        for part in title_parts + subtitle_parts:
+            normalized_house = cls._normalize_house(part)
+            if part in address_value_set or normalized_house in address_value_set:
+                continue
+            if street and part == street:
+                continue
+            lowered = part.lower()
+            if any(marker in lowered for marker in ("улица", "ул.", "район", "область", "сельсовет", "беларусь")):
+                continue
+            if cls._looks_like_house(part):
+                continue
+            return part
+        return None
+
+    @staticmethod
+    def _component_name(component: dict[str, Any]) -> str | None:
+        for key in ("name", "Name", "text", "Text", "value", "Value"):
+            value = component.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _component_kinds(component: dict[str, Any]) -> set[str]:
+        raw_values: list[Any] = []
+        for key in ("kind", "Kind", "type", "Type", "kinds", "Kinds", "types", "Types"):
+            value = component.get(key)
+            if value is not None:
+                raw_values.append(value)
+        kinds: set[str] = set()
+        for raw in raw_values:
+            if isinstance(raw, str):
+                kinds.add(raw.strip().lower())
+            elif isinstance(raw, list):
+                kinds.update(str(item).strip().lower() for item in raw if str(item).strip())
+        return kinds
+
+    @staticmethod
+    def _looks_like_house(value: str) -> bool:
+        return bool(re.match(r"^(д\.?\s*)?\d+[а-яa-z0-9/-]*$", value.strip(), re.IGNORECASE))
+
+    @staticmethod
+    def _normalize_house(value: str) -> str | None:
+        text = value.strip()
+        match = re.match(r"^(?:д\.?\s*)?(.+)$", text, flags=re.IGNORECASE)
+        if not match:
+            return None
+        house = match.group(1).strip()
+        return house if re.match(r"^\d+[а-яa-z0-9/-]*$", house, re.IGNORECASE) else None
+
+    @classmethod
+    def _strip_address_from_title(cls, title: str, parsed: dict[str, str]) -> str | None:
+        parts = cls._split_parts(title)
+        if not parts:
+            return None
+        address_values = {value for value in (parsed.get("city"), parsed.get("street"), parsed.get("house")) if value}
+        for part in parts:
+            normalized_house = cls._normalize_house(part)
+            if part in address_values or normalized_house in address_values:
+                continue
+            if parsed.get("street") and part == parsed["street"]:
+                continue
+            if cls._looks_like_house(part):
+                continue
+            return part
+        return None
+
+    @staticmethod
+    def _dedupe_parts(parts: list[str | None]) -> list[str]:
+        result: list[str] = []
+        seen: set[str] = set()
+        for part in parts:
+            if not part:
+                continue
+            key = part.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(part)
+        return result
+
     @staticmethod
     def _extract_text(value: Any) -> str | None:
         if isinstance(value, str):
@@ -116,7 +412,7 @@ class AddressSuggestService:
         return None
 
     @staticmethod
-    def _compose_value(title: str | None, subtitle: str | None) -> str | None:
+    def _compose_fallback_value(title: str | None, subtitle: str | None) -> str | None:
         parts: list[str] = []
         for part in (title, subtitle):
             if not part:

--- a/tests/unit/test_address_suggest_service.py
+++ b/tests/unit/test_address_suggest_service.py
@@ -43,8 +43,8 @@ async def test_suggest_prefers_vitebsk_region_then_falls_back(monkeypatch):
         AddressSuggestService.BELARUS_BBOX,
     ]
     assert [item["value"] for item in items] == [
-        "улица Ленина, 1, Витебск",
-        "улица Ленина, 1, Минск",
+        "Витебск, улица Ленина, д. 1",
+        "Минск, улица Ленина, д. 1",
     ]
 
 
@@ -70,6 +70,98 @@ def test_normalize_results_deduplicates_and_skips_invalid_entries():
         {
             "title": "улица Ленина, 1",
             "subtitle": "Витебск",
-            "value": "улица Ленина, 1, Витебск",
+            "value": "Витебск, улица Ленина, д. 1",
         }
     ]
+
+
+def test_normalize_results_orders_city_street_house_from_yandex_title_subtitle():
+    payload = {
+        "results": [
+            {
+                "title": {"text": "6, 3-я Коллективная улица"},
+                "subtitle": {"text": "Витебск"},
+            }
+        ]
+    }
+
+    items = AddressSuggestService.normalize_results(payload)
+
+    assert items[0]["value"] == "Витебск, 3-я Коллективная улица, д. 6"
+
+
+def test_normalize_results_keeps_object_name_before_address():
+    payload = {
+        "results": [
+            {
+                "title": {"text": "Банк, 6, 3-я Коллективная улица"},
+                "subtitle": {"text": "Витебск"},
+            }
+        ]
+    }
+
+    items = AddressSuggestService.normalize_results(payload)
+
+    assert items[0]["value"] == "Банк, Витебск, 3-я Коллективная улица, д. 6"
+
+
+def test_normalize_results_uses_settlement_before_street_and_house():
+    payload = {
+        "results": [
+            {
+                "title": {"text": "Витебская улица, 14"},
+                "subtitle": {"text": "агрогородок Новка, Новкинский сельсовет, Витебский район"},
+            }
+        ]
+    }
+
+    items = AddressSuggestService.normalize_results(payload)
+
+    assert items[0]["value"] == "Витебский район, Новкинский сельсовет, агрогородок Новка, Витебская улица, д. 14"
+
+
+def test_normalize_results_prefers_locality_over_region_for_objects():
+    payload = {
+        "results": [
+            {
+                "title": {"text": "Белагропромбанк"},
+                "subtitle": {"text": "Витебская область, проспект Франциска Скорины, д. 8А"},
+                "address": {
+                    "components": [
+                        {"name": "Беларусь", "kind": "country"},
+                        {"name": "Витебская область", "kind": "province"},
+                        {"name": "Полоцк", "kind": "locality"},
+                        {"name": "проспект Франциска Скорины", "kind": "street"},
+                        {"name": "8А", "kind": "house"},
+                    ]
+                },
+            }
+        ]
+    }
+
+    items = AddressSuggestService.normalize_results(payload)
+
+    assert items[0]["value"] == "Белагропромбанк, Полоцк, проспект Франциска Скорины, д. 8А"
+
+
+def test_normalize_results_keeps_locality_for_object_when_subtitle_starts_with_region():
+    payload = {
+        "results": [
+            {
+                "title": {"text": "Мясная Лавка"},
+                "subtitle": {"text": "Витебская область, Борисовский тракт, д. 91"},
+                "address": {
+                    "components": [
+                        {"name": "Витебская область", "kind": "province"},
+                        {"name": "Лепель", "kind": "locality"},
+                        {"name": "Борисовский тракт", "kind": "street"},
+                        {"name": "91", "kind": "house"},
+                    ]
+                },
+            }
+        ]
+    }
+
+    items = AddressSuggestService.normalize_results(payload)
+
+    assert items[0]["value"] == "Мясная Лавка, Лепель, Борисовский тракт, д. 91"

--- a/tests/unit/test_input_validation.py
+++ b/tests/unit/test_input_validation.py
@@ -15,9 +15,17 @@ def test_validate_required_phone_accepts_belarus_formats():
     assert validate_required_phone("+375 (29) 111-22-33") == "+375 (29) 111-22-33"
 
 
+def test_validate_required_phone_accepts_international_formats():
+    assert validate_required_phone("+7 (916) 111-22-33") == "+7 (916) 111-22-33"
+    assert validate_required_phone("+77 12 345 67 89") == "+77 12 345 67 89"
+    assert validate_required_phone("89161112233") == "89161112233"
+
+
 def test_validate_required_phone_rejects_invalid():
     with pytest.raises(ValueError):
-        validate_required_phone("+371291112233")
+        validate_required_phone("+12")
+    with pytest.raises(ValueError):
+        validate_required_phone("+7 test")
 
 
 def test_validate_optional_email_normalizes_and_rejects():

--- a/web/src/components/ContactForm.vue
+++ b/web/src/components/ContactForm.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 import { submitContactForm } from '../utils/api';
-import IMask from 'imask';
-import { validateRequiredBelarusPhone } from '../utils/validation';
+import { formatPhoneForDisplay, validateRequiredBelarusPhone } from '../utils/validation';
 
 const props = defineProps({
   title: {
@@ -30,27 +29,22 @@ const form = ref({
 });
 
 const phoneInput = ref(null);
-let mask = null;
 const isSubmitting = ref(false);
 const isSuccess = ref(false);
 
 onMounted(() => {
-    if (phoneInput.value) {
-        mask = IMask(phoneInput.value, {
-            mask: '+{375} (00) 000-00-00',
-            lazy: false,
-            placeholderChar: '_'
-        });
-        
-        // Initial sync
-        mask.on('accept', () => {
-            form.value.phone = mask.value;
-        });
-    }
+    if (!phoneInput.value) return;
+    phoneInput.value.onfocus = () => {
+        if (!form.value.phone.trim()) form.value.phone = '+375 ';
+    };
+    phoneInput.value.onblur = () => {
+        form.value.phone = formatPhoneForDisplay(form.value.phone);
+    };
 });
 
 const submitForm = async () => {
-  const phoneError = validateRequiredBelarusPhone(form.value.phone, Boolean(mask && mask.masked.isComplete));
+  form.value.phone = formatPhoneForDisplay(form.value.phone);
+  const phoneError = validateRequiredBelarusPhone(form.value.phone, true);
   if (phoneError) {
       alert(phoneError);
       return;
@@ -75,7 +69,6 @@ const submitForm = async () => {
     setTimeout(() => {
         isSuccess.value = false;
         form.value = { name: '', phone: '', message: '' };
-        if (mask) mask.value = ''; // Reset mask value
     }, 5000);
   } else {
     alert('Ошибка отправки. Попробуйте позже.');
@@ -115,7 +108,7 @@ const submitForm = async () => {
           id="phone" 
           ref="phoneInput"
           v-model="form.phone" 
-          placeholder="+375 (XX) XXX-XX-XX"
+          placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
           required
         >
       </div>

--- a/web/src/components/InstallationCalculator.vue
+++ b/web/src/components/InstallationCalculator.vue
@@ -1,10 +1,9 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { getInstallationRates, getGlobalConfig, createOrder } from '../utils/api';
 import { installationOptions, fetchInstallationOptions } from '../store/installation';
-import IMask from 'imask';
-import { validateRequiredBelarusPhone } from '../utils/validation';
+import { formatPhoneForDisplay, validateRequiredBelarusPhone } from '../utils/validation';
 
 const rates = ref([]);
 const loading = ref(true);
@@ -51,14 +50,12 @@ const RANGE_MAP = {
 
 onMounted(async () => {
   if (phoneInputRef.value) {
-    phoneMask = IMask(phoneInputRef.value, {
-      mask: '+{375} (00) 000-00-00',
-      lazy: false,
-      placeholderChar: '_'
-    });
-    phoneMask.on('accept', () => {
-      form.value.phone = phoneMask.value;
-    });
+    phoneInputRef.value.onfocus = () => {
+      if (!form.value.phone.trim()) form.value.phone = '+375 ';
+    };
+    phoneInputRef.value.onblur = () => {
+      form.value.phone = formatPhoneForDisplay(form.value.phone);
+    };
   }
 
   try {
@@ -88,13 +85,6 @@ onMounted(async () => {
     error.value = err.message;
   } finally {
     loading.value = false;
-  }
-});
-
-onBeforeUnmount(() => {
-  if (phoneMask) {
-    phoneMask.destroy();
-    phoneMask = null;
   }
 });
 
@@ -188,7 +178,6 @@ const submitting = ref(false);
 const success = ref(false);
 const phoneError = ref('');
 const phoneInputRef = ref(null);
-let phoneMask = null;
 const form = ref({
     name: '',
     phone: ''
@@ -201,7 +190,8 @@ const openOrderModal = () => {
 };
 
 const validatePhoneField = () => {
-    phoneError.value = validateRequiredBelarusPhone(form.value.phone, Boolean(phoneMask && phoneMask.masked.isComplete));
+    form.value.phone = formatPhoneForDisplay(form.value.phone);
+    phoneError.value = validateRequiredBelarusPhone(form.value.phone, true);
 };
 
 const submitOrder = async () => {
@@ -240,7 +230,6 @@ const submitOrder = async () => {
     if (res) {
         success.value = true;
         form.value = { name: '', phone: '' };
-        if (phoneMask) phoneMask.value = '';
         setTimeout(() => {
             showModal.value = false;
         }, 3000);
@@ -425,7 +414,7 @@ const submitOrder = async () => {
                           type="tel"
                           v-model="form.phone"
                           required
-                          placeholder="+375 (XX) XXX-XX-XX"
+                          placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
                           class="form-input"
                           :class="{ invalid: phoneError }"
                           @blur="validatePhoneField"

--- a/web/src/components/PriceWithToggle.vue
+++ b/web/src/components/PriceWithToggle.vue
@@ -1,10 +1,9 @@
 <script setup>
-import { ref, computed, onMounted, watch, nextTick, onBeforeUnmount } from 'vue';
-import IMask from 'imask';
+import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import { getInstallationRates, getGlobalConfig, getProductById, submitProductAvailabilityLead } from '../utils/api';
 import { addItem } from '../store/cart';
 import { addToast } from '../store/toast';
-import { validateRequiredBelarusPhone } from '../utils/validation';
+import { formatPhoneForDisplay, validateRequiredBelarusPhone } from '../utils/validation';
 import {
     formatProductPrice,
     hasKnownProductPrice,
@@ -47,7 +46,6 @@ const notifyForm = ref({
     phone: '',
 });
 const notifyPhoneInputRef = ref(null);
-let notifyMask = null;
 
 const liveBasePrice = ref(Number(props.basePrice) || 0);
 const liveOldPrice = ref(Number(props.oldPrice) || 0);
@@ -85,32 +83,16 @@ onMounted(async () => {
 watch(showNotifyModal, async (isOpen) => {
     if (isOpen) {
         await nextTick();
-        if (notifyPhoneInputRef.value && !notifyMask) {
-            notifyMask = IMask(notifyPhoneInputRef.value, {
-                mask: '+{375} (00) 000-00-00',
-                lazy: false,
-                placeholderChar: '_',
-            });
-            notifyMask.on('accept', () => {
-                notifyForm.value.phone = notifyMask.value;
+        if (notifyPhoneInputRef.value) {
+            notifyPhoneInputRef.value.onfocus = () => {
+                if (!notifyForm.value.phone.trim()) notifyForm.value.phone = '+375 ';
                 notifyPhoneError.value = '';
-            });
+            };
         }
         return;
     }
 
     notifyPhoneError.value = '';
-    if (notifyMask) {
-        notifyMask.destroy();
-        notifyMask = null;
-    }
-});
-
-onBeforeUnmount(() => {
-    if (notifyMask) {
-        notifyMask.destroy();
-        notifyMask = null;
-    }
 });
 
 // Helper to normalize strings for comparison
@@ -356,9 +338,10 @@ const inquirySuccessText = computed(() => {
 });
 
 const validateNotifyPhone = () => {
+    notifyForm.value.phone = formatPhoneForDisplay(notifyForm.value.phone);
     notifyPhoneError.value = validateRequiredBelarusPhone(
         notifyForm.value.phone,
-        Boolean(notifyMask && notifyMask.masked.isComplete),
+        true,
     );
     return !notifyPhoneError.value;
 };
@@ -514,7 +497,7 @@ const submitNotifyLead = async () => {
                 type="tel"
                 class="form-input"
                 :class="{ invalid: notifyPhoneError }"
-                placeholder="+375 (XX) XXX-XX-XX"
+                placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
                 @blur="validateNotifyPhone"
               />
               <span v-if="notifyPhoneError" class="err-msg">{{ notifyPhoneError }}</span>

--- a/web/src/components/checkout/CheckoutForm.vue
+++ b/web/src/components/checkout/CheckoutForm.vue
@@ -3,8 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { useStore } from '@nanostores/vue';
 import { cartItems, cartTotal, clearCart, refreshPrices } from '../../store/cart';
 import { createOrder, getProductBySlug, getCompanyByUnp, getBankBySearch, getAddressSuggestions } from '../../utils/api';
-import IMask from 'imask';
-import { validateOptionalByIban, validateOptionalByUnp, validateRequiredBelarusPhone } from '../../utils/validation';
+import { formatPhoneForDisplay, validateOptionalByIban, validateOptionalByUnp, validateRequiredBelarusPhone } from '../../utils/validation';
 
 // State
 const form = ref({
@@ -22,7 +21,6 @@ const form = ref({
 });
 const isLegalEntity = ref(false);
 const phoneInput = ref(null);
-let mask = null;
 const errors = ref({});
 const isSubmitting = ref(false);
 const isLoadingData = ref(false);
@@ -89,7 +87,8 @@ const validate = () => {
     errors.value = {};
     if (!form.value.name) errors.value.name = 'Введите имя';
 
-    const phoneError = validateRequiredBelarusPhone(form.value.phone, Boolean(mask && mask.masked.isComplete));
+    form.value.phone = formatPhoneForDisplay(form.value.phone);
+    const phoneError = validateRequiredBelarusPhone(form.value.phone, true);
     if (phoneError) errors.value.phone = phoneError;
 
     if (isLegalEntity.value) {
@@ -116,16 +115,13 @@ onMounted(() => {
 // Init phone mask when the input element appears in DOM
 // (The form is behind v-if on cart items, so phoneInput may be null at mount time)
 watch(phoneInput, (el) => {
-    if (el && !mask) {
-        mask = IMask(el, {
-            mask: '+{375} (00) 000-00-00',
-            lazy: false,
-            placeholderChar: '_'
-        });
-        
-        mask.on('accept', () => {
-            form.value.phone = mask.value;
-        });
+    if (el) {
+        el.onfocus = () => {
+            if (!form.value.phone.trim()) form.value.phone = '+375 ';
+        };
+        el.onblur = () => {
+            form.value.phone = formatPhoneForDisplay(form.value.phone);
+        };
     }
 });
 
@@ -326,8 +322,9 @@ const submitOrderHandler = async () => {
                         type="tel" 
                         id="phone" 
                         ref="phoneInput"
+                        v-model="form.phone"
                         :class="{ invalid: errors.phone }"
-                        placeholder="+375 (XX) XXX-XX-XX"
+                        placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
                     />
                     <span v-if="errors.phone" class="err-msg">{{ errors.phone }}</span>
                 </div>

--- a/web/src/utils/validation.ts
+++ b/web/src/utils/validation.ts
@@ -8,9 +8,24 @@ function normalizePhoneDigits(value: string): string {
   return digits;
 }
 
-function isBelarusPhoneComplete(masked: string): boolean {
-  const normalized = normalizePhoneDigits(masked);
-  return normalized.length === 12 && normalized.startsWith('375');
+function isInternationalPhoneComplete(value: string): boolean {
+  const raw = (value || '').trim();
+  if (!raw || !/^\+?[\d\s().-]+$/.test(raw)) return false;
+  const normalized = normalizePhoneDigits(raw);
+  return normalized.length >= 7 && normalized.length <= 15;
+}
+
+export function formatPhoneForDisplay(value: string): string {
+  const trimmed = (value || '').trim();
+  const normalized = normalizePhoneDigits(trimmed);
+  if (normalized.length === 12 && normalized.startsWith('375')) {
+    return `+375 (${normalized.slice(3, 5)}) ${normalized.slice(5, 8)}-${normalized.slice(8, 10)}-${normalized.slice(10, 12)}`;
+  }
+  if (normalized.length === 11 && (normalized.startsWith('7') || normalized.startsWith('8'))) {
+    const national = normalized.startsWith('8') ? `7${normalized.slice(1)}` : normalized;
+    return `+7 (${national.slice(1, 4)}) ${national.slice(4, 7)}-${national.slice(7, 9)}-${national.slice(9, 11)}`;
+  }
+  return trimmed;
 }
 
 function normalizeIban(value: string): string {
@@ -48,14 +63,14 @@ export function validateOptionalByIban(value: string): string {
   return ibanChecksumValid(iban) ? '' : 'Введите корректный IBAN BY';
 }
 
-export function validateRequiredBelarusPhone(masked: string, isMaskComplete: boolean): string {
+export function validateRequiredBelarusPhone(masked: string, _isMaskComplete: boolean): string {
   const raw = (masked || '').trim();
   if (!raw) return 'Введите номер телефона';
-  if (!isMaskComplete || !isBelarusPhoneComplete(raw)) {
-    return 'Введите телефон полностью в формате +375 (XX) XXX-XX-XX';
+  if (!isInternationalPhoneComplete(raw)) {
+    return 'Введите телефон в международном формате, например +375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX';
   }
   const digits = normalizePhoneDigits(raw);
-  return digits.length === 12 && digits.startsWith('375')
+  return digits.length >= 7 && digits.length <= 15
     ? ''
-    : 'Введите телефон полностью в формате +375 (XX) XXX-XX-XX';
+    : 'Введите телефон в международном формате, например +375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX';
 }


### PR DESCRIPTION
## Summary

- allow international phone numbers in manager and public site forms while keeping `+375` as the convenient default prefix
- add soft phone formatting for Belarus and +7 numbers without locking the input mask to one country
- normalize Yandex address suggestions into a consistent order for cities, rural settlements, districts, village councils, streets and houses
- expose normalized address suggestions through the manager API contract and reuse them in orders, leads and customer profiles
- add customer-profile address suggest support for both company requisites and individual customer delivery/object addresses

## Why

The previous phone mask hardcoded Belarus numbers and blocked Russian/Kazakh/etc. phone codes. Address suggest also returned provider-formatted strings where object results could lose the city or put administrative pieces in an inconvenient order.

## Validation

- `pytest tests/unit/test_input_validation.py tests/unit/test_address_suggest_service.py tests/unit/test_public_address_suggest_api.py tests/unit/test_order_currency_guards.py -q`
- `python3 -m py_compile services/address_suggest_service.py routers/manager_settings.py core/input_validation.py`
- `bash scripts/audit_theme_hardcodes.sh`
- `git diff --check`
- `npm run build` in `manager_frontend/`
- `npm run build` in `web/`
