### PR TITLE
[codex] Add bot warranty nameplate flow

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -12,6 +12,7 @@ from services.staff_user_service import StaffUserService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.bot_task_service import BotTaskService
 from ..config import bot
 from ..states import ShopState
@@ -102,12 +103,15 @@ def _requisites_file_intent_keyboard(
     *,
     can_extract_requisites: bool = True,
     can_repair_nameplate: bool = False,
+    can_warranty_nameplate: bool = False,
 ) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     if can_extract_requisites:
         rows.append([InlineKeyboardButton(text="Извлечь реквизиты", callback_data="req_file_extract")])
     if can_repair_nameplate:
         rows.append([InlineKeyboardButton(text="Шильдик к ремонту", callback_data="repair_nameplate_start")])
+    if can_warranty_nameplate:
+        rows.append([InlineKeyboardButton(text="Шильдик для гарантии", callback_data="warranty_nameplate_start")])
     rows.append([InlineKeyboardButton(text="Прикрепить к заказу", callback_data="req_file_attach")])
     rows.append([InlineKeyboardButton(text="Отмена", callback_data="req_file_cancel")])
     return InlineKeyboardMarkup(inline_keyboard=rows)
@@ -147,6 +151,33 @@ def _repair_nameplate_order_keyboard(orders: list[dict]) -> InlineKeyboardMarkup
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
+def _warranty_unit_type_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Внутренний блок", callback_data="warranty_nameplate_unit_indoor_unit")],
+            [InlineKeyboardButton(text="Наружный блок", callback_data="warranty_nameplate_unit_outdoor_unit")],
+            [InlineKeyboardButton(text="Отмена", callback_data="warranty_nameplate_cancel")],
+        ]
+    )
+
+
+def _warranty_nameplate_order_keyboard(orders: list[dict]) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        if not order_id:
+            continue
+        title = " ".join(str(order.get("title") or order.get("customer_name") or "монтаж").split())
+        if len(title) > 34:
+            title = f"{title[:31]}..."
+        rows.append(
+            [InlineKeyboardButton(text=f"#{order_id} - {title}", callback_data=f"warranty_nameplate_order_{order_id}")]
+        )
+    rows.append([InlineKeyboardButton(text="Ввести номер/id заказа", callback_data="warranty_nameplate_manual")])
+    rows.append([InlineKeyboardButton(text="Отмена", callback_data="warranty_nameplate_cancel")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
 def _format_order_attachment_choices(orders: list[dict]) -> str:
     if not orders:
         return "Быстрых вариантов не нашел. Введите номер/id заказа сообщением."
@@ -172,6 +203,29 @@ def _format_repair_nameplate_order_choices(orders: list[dict]) -> str:
         title = order.get("title") or "ремонт"
         address = order.get("address") or "адрес не указан"
         lines.append(f"#{order_id}: {escape(str(title))}, {escape(str(customer))}, {escape(str(address))}")
+    return "\n".join(lines)
+
+
+def _format_warranty_nameplate_order_choices(orders: list[dict], *, scope: str, unit_type: str) -> str:
+    unit_label = BotWarrantyNameplateService.UNIT_LABELS.get(unit_type, "блок")
+    if not orders:
+        return f"Подходящих заказов в монтаже не нашел. Введите номер/id заказа для {escape(unit_label)} сообщением."
+
+    heading = (
+        f"К какому сегодняшнему монтажу привязать {unit_label}?"
+        if scope == "today"
+        else f"Сегодняшних монтажей не нашел. Выберите заказ в состоянии монтаж для {unit_label}:"
+    )
+    lines = [heading]
+    for order in orders[:5]:
+        order_id = int(order.get("id") or 0)
+        customer = order.get("customer_name") or "клиент не указан"
+        title = order.get("title") or "монтаж"
+        address = order.get("address") or "адрес не указан"
+        date = order.get("installation_date")
+        date_text = date.strftime("%d.%m %H:%M") if hasattr(date, "strftime") else ""
+        suffix = f", {escape(date_text)}" if date_text else ""
+        lines.append(f"#{order_id}: {escape(str(title))}, {escape(str(customer))}, {escape(str(address))}{suffix}")
     return "\n".join(lines)
 
 
@@ -207,6 +261,15 @@ def _repair_nameplate_preview_keyboard() -> InlineKeyboardMarkup:
         inline_keyboard=[
             [InlineKeyboardButton(text="Записать в ремонт", callback_data="repair_nameplate_confirm")],
             [InlineKeyboardButton(text="Отмена", callback_data="repair_nameplate_cancel")],
+        ]
+    )
+
+
+def _warranty_nameplate_preview_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Записать в гарантию", callback_data="warranty_nameplate_confirm")],
+            [InlineKeyboardButton(text="Отмена", callback_data="warranty_nameplate_cancel")],
         ]
     )
 
@@ -269,6 +332,60 @@ def _repair_nameplate_preview_text(data: dict[str, object]) -> str:
         lines.extend(f"• {escape(str(message))}" for message in warnings.values())
     if not extracted:
         lines.append("Данных не нашел. Лучше отправить фото ближе и ровнее.")
+    return "\n".join(lines)
+
+
+def _warranty_nameplate_preview_text(data: dict[str, object]) -> str:
+    extracted = data.get("extracted") if isinstance(data.get("extracted"), dict) else {}
+    validation_flags = data.get("validation_flags") if isinstance(data.get("validation_flags"), dict) else {}
+    merge_preview = data.get("merge_preview") if isinstance(data.get("merge_preview"), dict) else {}
+    component = merge_preview.get("component") if isinstance(merge_preview.get("component"), dict) else {}
+    equipment = merge_preview.get("equipment") if isinstance(merge_preview.get("equipment"), dict) else {}
+    warnings = validation_flags.get("warnings") if isinstance(validation_flags.get("warnings"), dict) else {}
+    unit_label = merge_preview.get("unit_label") or BotWarrantyNameplateService.UNIT_LABELS.get(str(data.get("unit_type")), "блок")
+
+    lines = [f"<b>Распознал шильдик для гарантии: {escape(str(unit_label))}.</b>", ""]
+    fields = {
+        "brand": extracted.get("equipment_brand"),
+        "model": extracted.get("equipment_model"),
+        "serial": extracted.get("equipment_serial_number"),
+        "refrigerant_type": extracted.get("refrigerant_type"),
+    }
+    for field, value in fields.items():
+        if value:
+            lines.append(f"<b>{escape(BotWarrantyNameplateService.FIELD_LABELS.get(field, field))}:</b> {escape(str(value))}")
+
+    if merge_preview.get("will_create_equipment"):
+        lines.extend(["", "Создам карточку оборудования из заказа, если ее еще нет."])
+    if merge_preview.get("will_create_component"):
+        lines.append("Создам компонент выбранного блока.")
+
+    applied = component.get("applied") if isinstance(component.get("applied"), dict) else {}
+    conflicts = component.get("conflicts") if isinstance(component.get("conflicts"), dict) else {}
+    skipped = component.get("skipped") if isinstance(component.get("skipped"), dict) else {}
+    equipment_applied = equipment.get("applied") if isinstance(equipment.get("applied"), dict) else {}
+    if applied or equipment_applied:
+        lines.extend(["", "<b>Будет записано:</b>"])
+        for field, value in applied.items():
+            lines.append(f"• {escape(BotWarrantyNameplateService.FIELD_LABELS.get(field, field))}: {escape(str(value))}")
+        for field, value in equipment_applied.items():
+            lines.append(f"• карточка: {escape(BotWarrantyNameplateService.FIELD_LABELS.get(field, field))}: {escape(str(value))}")
+    if skipped:
+        lines.extend(["", "<b>Уже заполнено таким же значением:</b>"])
+        for field in skipped.keys():
+            lines.append(f"• {escape(BotWarrantyNameplateService.FIELD_LABELS.get(field, field))}")
+    if conflicts:
+        lines.extend(["", "<b>Конфликты, не перезапишу автоматически:</b>"])
+        for field, values in conflicts.items():
+            existing = values.get("existing") if isinstance(values, dict) else ""
+            candidate = values.get("candidate") if isinstance(values, dict) else ""
+            lines.append(
+                f"• {escape(BotWarrantyNameplateService.FIELD_LABELS.get(field, field))}: "
+                f"сейчас {escape(str(existing))}, распознано {escape(str(candidate))}"
+            )
+    if warnings:
+        lines.extend(["", "<b>Предупреждения:</b>"])
+        lines.extend(f"• {escape(str(message))}" for message in warnings.values())
     return "\n".join(lines)
 
 
@@ -394,6 +511,7 @@ async def _ask_requisites_file_action(
         reply_markup=_requisites_file_intent_keyboard(
             can_extract_requisites=can_extract_requisites,
             can_repair_nameplate=str(mime_type or "").startswith("image/"),
+            can_warranty_nameplate=str(mime_type or "").startswith("image/"),
         ),
     )
 
@@ -828,6 +946,267 @@ async def cancel_repair_nameplate(callback: CallbackQuery, state: FSMContext):
     await callback.answer()
 
 
+@router.callback_query(F.data == "warranty_nameplate_start")
+async def choose_warranty_nameplate_unit(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+    if not str(pending.get("mime_type") or "").startswith("image/"):
+        await callback.answer("Шильдик для гарантии распознаем только по фото.", show_alert=True)
+        return
+
+    await callback.message.edit_text(
+        "Что фотографируем для гарантийного талона?",
+        reply_markup=_warranty_unit_type_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("warranty_nameplate_unit_"))
+async def choose_order_for_warranty_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    unit_type = str(callback.data or "").removeprefix("warranty_nameplate_unit_")
+    if unit_type not in BotWarrantyNameplateService.UNIT_TYPES:
+        await callback.answer("Не понял тип блока", show_alert=True)
+        return
+
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+
+    await state.update_data(pending_warranty_nameplate={"unit_type": unit_type})
+    async with async_session_maker() as session:
+        result = await BotWarrantyNameplateService.list_installation_orders(
+            session,
+            telegram_user_id=callback.from_user.id,
+            can_attach_any=context.is_manager,
+            limit=5,
+        )
+
+    orders = result.get("items") or []
+    if orders:
+        await callback.message.edit_text(
+            _format_warranty_nameplate_order_choices(orders, scope=str(result.get("scope") or ""), unit_type=unit_type),
+            reply_markup=_warranty_nameplate_order_keyboard(orders),
+            parse_mode="HTML",
+        )
+    else:
+        await state.set_state(ShopState.waiting_for_warranty_nameplate_order_id)
+        unit_label = BotWarrantyNameplateService.UNIT_LABELS.get(unit_type, "блок")
+        await callback.message.edit_text(
+            f"Подходящих заказов в монтаже не нашел. Введите номер/id заказа для {unit_label} сообщением."
+        )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "warranty_nameplate_manual")
+async def enter_order_id_for_warranty_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    draft = data.get("pending_warranty_nameplate") or {}
+    if not isinstance(draft, dict) or draft.get("unit_type") not in BotWarrantyNameplateService.UNIT_TYPES:
+        await callback.answer("Тип блока не выбран. Отправьте фото еще раз.", show_alert=True)
+        return
+
+    await state.set_state(ShopState.waiting_for_warranty_nameplate_order_id)
+    await callback.message.edit_text("Введите номер/id заказа в монтаже сообщением.")
+    await callback.answer()
+
+
+async def _run_warranty_nameplate_recognition_for_order(
+    progress_message: types.Message,
+    *,
+    order_id: int,
+    telegram_user_id: int | None,
+    can_attach_any: bool,
+    state: FSMContext,
+):
+    data = await state.get_data()
+    pending = data.get("pending_requisites_file") or {}
+    draft = data.get("pending_warranty_nameplate") or {}
+    unit_type = draft.get("unit_type") if isinstance(draft, dict) else None
+    if unit_type not in BotWarrantyNameplateService.UNIT_TYPES:
+        await progress_message.edit_text("Тип блока не выбран. Отправьте фото еще раз.")
+        return
+    if not isinstance(pending, dict) or not pending.get("file_id"):
+        await progress_message.edit_text("Фото не найдено. Отправьте его еще раз.")
+        return
+
+    async with async_session_maker() as session:
+        allowed = await BotWarrantyNameplateService.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+    if not allowed:
+        await progress_message.edit_text(
+            "Этот заказ не найден среди монтажей или не назначен вам."
+        )
+        return
+
+    try:
+        content = await _download_telegram_file(str(pending.get("file_id")))
+        recognized = await BotRepairNameplateService.recognize_bytes(
+            content=content,
+            filename=str(pending.get("filename") or "telegram-warranty-nameplate.jpg"),
+            mime_type=str(pending.get("mime_type") or "image/jpeg"),
+        )
+        async with async_session_maker() as session:
+            merge_preview = await BotWarrantyNameplateService.build_merge_preview(
+                session,
+                order_id=order_id,
+                unit_type=str(unit_type),
+                extracted=recognized.get("extracted") or {},
+            )
+    except Exception as exc:
+        await progress_message.edit_text(f"❌ Не удалось распознать шильдик для гарантии: {escape(str(exc))}")
+        return
+
+    draft = {
+        "order_id": order_id,
+        "unit_type": unit_type,
+        "file": pending,
+        "raw_text": recognized.get("raw_text") or "",
+        "extracted": recognized.get("extracted") or {},
+        "validation_flags": recognized.get("validation_flags") or {},
+        "merge_preview": merge_preview or {"component": {"applied": {}, "conflicts": {}, "skipped": {}}},
+    }
+    await state.update_data(pending_warranty_nameplate=draft)
+    await state.set_state(None)
+    await progress_message.edit_text(
+        _warranty_nameplate_preview_text(draft),
+        reply_markup=_warranty_nameplate_preview_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(F.data.startswith("warranty_nameplate_order_"))
+async def recognize_warranty_nameplate_for_chosen_order(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    order_id = _parse_order_id((callback.data or "").rsplit("_", 1)[-1])
+    if not order_id:
+        await callback.answer("Не понял номер заказа", show_alert=True)
+        return
+
+    await callback.answer()
+    await callback.message.edit_text("Распознаю шильдик для гарантии…")
+    await _run_warranty_nameplate_recognition_for_order(
+        callback.message,
+        order_id=order_id,
+        telegram_user_id=callback.from_user.id,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+
+
+@router.message(ShopState.waiting_for_warranty_nameplate_order_id)
+async def recognize_warranty_nameplate_for_typed_order(message: types.Message, state: FSMContext):
+    context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await state.clear()
+        return
+
+    order_id = _parse_order_id(message.text)
+    if not order_id:
+        await message.answer("Введите номер заказа числом, например: 123")
+        return
+
+    progress = await message.answer("Распознаю шильдик для гарантии…")
+    await _run_warranty_nameplate_recognition_for_order(
+        progress,
+        order_id=order_id,
+        telegram_user_id=message.from_user.id if message.from_user else None,
+        can_attach_any=context.is_manager,
+        state=state,
+    )
+
+
+@router.callback_query(F.data == "warranty_nameplate_confirm")
+async def confirm_warranty_nameplate(callback: CallbackQuery, state: FSMContext):
+    context = await _get_bot_access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    draft = data.get("pending_warranty_nameplate") or {}
+    if not isinstance(draft, dict) or not draft.get("order_id"):
+        await callback.answer("Черновик не найден. Отправьте фото еще раз.", show_alert=True)
+        return
+    pending_file = draft.get("file") if isinstance(draft.get("file"), dict) else {}
+    if not pending_file or not pending_file.get("file_id"):
+        await callback.answer("Фото не найдено. Отправьте его еще раз.", show_alert=True)
+        return
+
+    try:
+        async with async_session_maker() as session:
+            result = await BotWarrantyNameplateService.apply_to_order(
+                session,
+                int(draft["order_id"]),
+                unit_type=str(draft.get("unit_type") or ""),
+                extracted=draft.get("extracted") or {},
+                raw_text=str(draft.get("raw_text") or ""),
+                validation_flags=draft.get("validation_flags") or {},
+                file_id=str(pending_file.get("file_id")),
+                filename=str(pending_file.get("filename") or "telegram-warranty-nameplate.jpg"),
+                mime_type=str(pending_file.get("mime_type") or "image/jpeg"),
+                telegram_user_id=callback.from_user.id,
+                telegram_chat_id=pending_file.get("telegram_chat_id"),
+                telegram_message_id=pending_file.get("telegram_message_id"),
+                can_attach_any=context.is_manager,
+            )
+    except Exception as exc:
+        await callback.answer(str(exc), show_alert=True)
+        return
+
+    if not result:
+        await callback.answer("Заказ не найден или недоступен.", show_alert=True)
+        return
+
+    await state.update_data(pending_warranty_nameplate=None, pending_requisites_file=None)
+    await state.set_state(None)
+    component_changes = len((result.get("component") or {}).get("applied") or {})
+    equipment_changes = len((result.get("equipment") or {}).get("applied") or {})
+    unit_label = BotWarrantyNameplateService.UNIT_LABELS.get(str(result.get("unit_type")), "блок")
+    await callback.message.edit_text(
+        f"✅ Шильдик для гарантии записан в заказ #{result['id']}.\n"
+        f"Блок: {unit_label}.\n"
+        f"Оборудование #{result['equipment_id']}, компонент #{result['component_id']}.\n"
+        f"Заполнено полей: {component_changes + equipment_changes}."
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "warranty_nameplate_cancel")
+async def cancel_warranty_nameplate(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(pending_warranty_nameplate=None, pending_requisites_file=None)
+    await state.set_state(None)
+    await callback.message.edit_text("Ок, гарантийный шильдик оставил без обработки.")
+    await callback.answer()
+
+
 @router.message(ShopState.waiting_for_repair_context_comment)
 async def handle_repair_context_comment(message: types.Message, state: FSMContext):
     context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
@@ -947,6 +1326,7 @@ async def cancel_pending_requisites_file(callback: CallbackQuery, state: FSMCont
         pending_requisites_file=None,
         pending_repair_nameplate=None,
         pending_repair_comment=None,
+        pending_warranty_nameplate=None,
     )
     await state.set_state(None)
     await callback.message.edit_text("Ок, файл оставил без обработки.")

--- a/bot_app/states.py
+++ b/bot_app/states.py
@@ -10,6 +10,7 @@ class ShopState(StatesGroup):
     waiting_for_order_attachment_order_id = State()
     waiting_for_repair_nameplate_order_id = State()
     waiting_for_repair_context_comment = State()
+    waiting_for_warranty_nameplate_order_id = State()
     select_area = State()
     select_type = State()
     select_winter = State()  # Выбор зимнего обогрева

--- a/services/bot_warranty_nameplate_service.py
+++ b/services/bot_warranty_nameplate_service.py
@@ -1,0 +1,498 @@
+from datetime import datetime, time
+from typing import Any, Optional
+
+from sqlalchemy import or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+
+from models import (
+    CustomerEquipment,
+    EquipmentComponent,
+    Order,
+    OrderInstaller,
+    OrderProductLink,
+    OrderStatus,
+    OrderWorkStage,
+    Product,
+    StaffUser,
+)
+from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.equipment_service import EquipmentService
+from services.order_service import OrderService
+from services.staff_user_service import StaffUserService
+
+
+class BotWarrantyNameplateService:
+    UNIT_TYPES = {"indoor_unit", "outdoor_unit"}
+    ORDER_WORKFLOWS = {"sales_installation", "service_work"}
+    HISTORY_META_KEY = "warranty_nameplate_recognitions"
+    WARRANTY_MONTHS_DEFAULT = 24
+
+    FIELD_LABELS = {
+        "brand": "Бренд",
+        "model": "Модель блока",
+        "serial": "Серийный номер",
+        "refrigerant_type": "Хладагент",
+    }
+    UNIT_LABELS = {
+        "indoor_unit": "внутренний блок",
+        "outdoor_unit": "наружный блок",
+    }
+
+    @staticmethod
+    def _clean_text(value: Any, *, max_length: int = 500) -> Optional[str]:
+        return BotRepairNameplateService._clean_text(value, max_length=max_length)
+
+    @staticmethod
+    def _today_bounds(now: Optional[datetime] = None) -> tuple[datetime, datetime]:
+        current = now or datetime.now()
+        start = datetime.combine(current.date(), time.min)
+        end = datetime.combine(current.date(), time.max)
+        return start, end
+
+    @classmethod
+    def _is_installation_order(cls, order: Order | None) -> bool:
+        if not order or order.status != OrderStatus.EXECUTION:
+            return False
+        workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+        return workflow_type in cls.ORDER_WORKFLOWS
+
+    @classmethod
+    def _map_order(cls, order: Order) -> dict[str, Any]:
+        customer = getattr(order, "customer", None)
+        return {
+            "id": int(order.id or 0),
+            "title": order.title,
+            "status": order.status.value if hasattr(order.status, "value") else str(order.status),
+            "workflow_type": OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)),
+            "customer_name": getattr(customer, "name", None) if customer else None,
+            "customer_phone": getattr(customer, "phone", None) if customer else None,
+            "address": order.delivery_address,
+            "installation_date": order.installation_date,
+            "updated_at": order.updated_at,
+            "created_at": order.created_at,
+        }
+
+    @classmethod
+    async def _legacy_installer_id(cls, session: AsyncSession, telegram_user_id: int | str | None) -> Optional[int]:
+        try:
+            normalized_telegram_id = int(telegram_user_id) if telegram_user_id is not None else 0
+        except (TypeError, ValueError):
+            return None
+        if not normalized_telegram_id:
+            return None
+
+        result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id == normalized_telegram_id)
+            .where(StaffUser.status == StaffUserService.STATUS_ACTIVE)
+            .order_by(StaffUser.id.asc())
+            .limit(1)
+        )
+        staff = result.scalars().first()
+        installer_id = getattr(staff, "legacy_installer_id", None)
+        return int(installer_id) if installer_id else None
+
+    @classmethod
+    def _permission_filters(cls, installer_id: int):
+        stage_exists = (
+            select(OrderWorkStage.id)
+            .where(OrderWorkStage.order_id == Order.id)
+            .where(OrderWorkStage.installer_id == installer_id)
+            .exists()
+        )
+        legacy_exists = (
+            select(OrderInstaller.order_id)
+            .where(OrderInstaller.order_id == Order.id)
+            .where(OrderInstaller.installer_id == installer_id)
+            .exists()
+        )
+        return or_(stage_exists, legacy_exists)
+
+    @classmethod
+    async def list_installation_orders(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_user_id: int | str | None,
+        can_attach_any: bool = False,
+        limit: int = 5,
+        now: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        base_filters = [
+            Order.status == OrderStatus.EXECUTION,
+            Order.workflow_type.in_(sorted(cls.ORDER_WORKFLOWS)),
+        ]
+        if not can_attach_any:
+            installer_id = await cls._legacy_installer_id(session, telegram_user_id)
+            if not installer_id:
+                return {"items": [], "scope": "today"}
+            base_filters.append(cls._permission_filters(installer_id))
+
+        capped_limit = max(1, min(limit, 10))
+        start, end = cls._today_bounds(now)
+        today_stmt = (
+            select(Order)
+            .where(*base_filters)
+            .where(Order.installation_date >= start)
+            .where(Order.installation_date <= end)
+            .options(selectinload(Order.customer))
+            .order_by(Order.installation_date.asc(), Order.updated_at.desc(), Order.id.desc())
+            .limit(capped_limit)
+        )
+        today_result = await session.execute(today_stmt)
+        today_orders = today_result.scalars().all()
+        if today_orders:
+            return {"items": [cls._map_order(order) for order in today_orders], "scope": "today"}
+
+        fallback_stmt = (
+            select(Order)
+            .where(*base_filters)
+            .options(selectinload(Order.customer))
+            .order_by(Order.installation_date.desc().nullslast(), Order.updated_at.desc(), Order.id.desc())
+            .limit(capped_limit)
+        )
+        fallback_result = await session.execute(fallback_stmt)
+        return {"items": [cls._map_order(order) for order in fallback_result.scalars().all()], "scope": "execution"}
+
+    @classmethod
+    async def can_use_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        telegram_user_id: int | str | None,
+        can_attach_any: bool = False,
+    ) -> bool:
+        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+        order = result.scalars().first()
+        if not cls._is_installation_order(order):
+            return False
+        if can_attach_any:
+            return True
+        return await BotOrderAttachmentService.can_attach_to_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+        )
+
+    @classmethod
+    def _component_payload_from_extracted(cls, extracted: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "brand": cls._clean_text(extracted.get("equipment_brand"), max_length=120),
+            "model": cls._clean_text(extracted.get("equipment_model"), max_length=200),
+            "serial": cls._clean_text(extracted.get("equipment_serial_number"), max_length=160),
+            "refrigerant_type": cls._clean_text(extracted.get("refrigerant_type"), max_length=80),
+        }
+
+    @classmethod
+    def _preview_component_merge(cls, component: EquipmentComponent | None, payload: dict[str, Any]) -> dict[str, Any]:
+        applied: dict[str, Any] = {}
+        conflicts: dict[str, dict[str, str]] = {}
+        skipped: dict[str, Any] = {}
+        for field in ("brand", "model", "serial"):
+            candidate = cls._clean_text(payload.get(field), max_length=500)
+            if not candidate:
+                continue
+            existing = cls._clean_text(getattr(component, field, None), max_length=500) if component else None
+            if existing and existing != candidate:
+                conflicts[field] = {"existing": existing, "candidate": candidate}
+            elif existing == candidate:
+                skipped[field] = candidate
+            else:
+                applied[field] = candidate
+        return {"applied": applied, "conflicts": conflicts, "skipped": skipped}
+
+    @classmethod
+    def _preview_equipment_merge(cls, equipment: CustomerEquipment | None, payload: dict[str, Any]) -> dict[str, Any]:
+        applied: dict[str, Any] = {}
+        conflicts: dict[str, dict[str, str]] = {}
+        skipped: dict[str, Any] = {}
+        for field in ("brand", "refrigerant_type"):
+            candidate = cls._clean_text(payload.get(field), max_length=500)
+            if not candidate:
+                continue
+            existing = cls._clean_text(getattr(equipment, field, None), max_length=500) if equipment else None
+            if existing and existing != candidate:
+                conflicts[field] = {"existing": existing, "candidate": candidate}
+            elif existing == candidate:
+                skipped[field] = candidate
+            else:
+                applied[field] = candidate
+        return {"applied": applied, "conflicts": conflicts, "skipped": skipped}
+
+    @classmethod
+    async def _load_order(cls, session: AsyncSession, order_id: int) -> Optional[Order]:
+        result = await session.execute(
+            select(Order)
+            .where(Order.id == order_id)
+            .options(
+                selectinload(Order.customer),
+                selectinload(Order.customer_branch),
+                selectinload(Order.proposals),
+                selectinload(Order.product_links).selectinload(OrderProductLink.product).selectinload(Product.brand),
+            )
+            .limit(1)
+        )
+        return result.scalars().first()
+
+    @classmethod
+    async def _existing_equipment_for_order(cls, session: AsyncSession, order_id: int) -> list[CustomerEquipment]:
+        result = await session.execute(
+            select(CustomerEquipment)
+            .where(CustomerEquipment.source_order_id == order_id)
+            .where(CustomerEquipment.is_archived == False)
+            .order_by(CustomerEquipment.id.asc())
+        )
+        return list(result.scalars().all())
+
+    @classmethod
+    async def _components_for_equipment(cls, session: AsyncSession, equipment_ids: list[int]) -> list[EquipmentComponent]:
+        if not equipment_ids:
+            return []
+        result = await session.execute(
+            select(EquipmentComponent)
+            .where(EquipmentComponent.equipment_id.in_(equipment_ids))
+            .where(EquipmentComponent.is_archived == False)
+            .order_by(EquipmentComponent.equipment_id.asc(), EquipmentComponent.id.asc())
+        )
+        return list(result.scalars().all())
+
+    @classmethod
+    async def _ensure_equipment_for_order(cls, session: AsyncSession, order: Order) -> list[CustomerEquipment]:
+        order_id = int(order.id or 0)
+        equipment = await cls._existing_equipment_for_order(session, order_id)
+        if equipment:
+            return equipment
+
+        try:
+            await EquipmentService.create_equipment_from_order(
+                session,
+                order_id=order_id,
+                payload={
+                    "warranty_months": cls.WARRANTY_MONTHS_DEFAULT,
+                    "warranty_start_date": order.installation_date,
+                    "include_component_placeholders": True,
+                },
+            )
+        except ValueError:
+            if order.customer_id is None:
+                raise
+            start = EquipmentService._order_warranty_start(order, {"warranty_start_date": order.installation_date})
+            expires = EquipmentService._add_months(start, cls.WARRANTY_MONTHS_DEFAULT)
+            fallback_equipment = CustomerEquipment(
+                customer_id=int(order.customer_id),
+                customer_branch_id=order.customer_branch_id,
+                source_order_id=order_id,
+                equipment_type="hvac",
+                equipment_source="installed_by_us",
+                display_name=cls._clean_text(order.title, max_length=200) or f"Оборудование из заказа #{order_id}",
+                location_hint=cls._clean_text(
+                    order.delivery_address or (order.customer_branch.delivery_address if order.customer_branch else None),
+                    max_length=300,
+                ),
+                installed_at=EquipmentService._normalize_naive_datetime(order.installation_date),
+                commissioned_at=start,
+                warranty_started_at=start,
+                warranty_expires_at=expires,
+                warranty_terms="Гарантия действует при соблюдении условий эксплуатации и сервисного обслуживания.",
+                notes=f"Создано ботом из заказа #{order_id} для заполнения гарантийного талона.",
+            )
+            session.add(fallback_equipment)
+            await session.commit()
+        return await cls._existing_equipment_for_order(session, order_id)
+
+    @classmethod
+    def _select_equipment_component(
+        cls,
+        equipment: list[CustomerEquipment],
+        components: list[EquipmentComponent],
+        *,
+        unit_type: str,
+        payload: dict[str, Any],
+    ) -> tuple[CustomerEquipment | None, EquipmentComponent | None]:
+        by_equipment_id = {int(item.id or 0): item for item in equipment}
+        unit_components = [item for item in components if item.component_type == unit_type]
+        serial = cls._clean_text(payload.get("serial"), max_length=160)
+        model = cls._clean_text(payload.get("model"), max_length=200)
+        for component in unit_components:
+            if serial and cls._clean_text(component.serial, max_length=160) == serial:
+                return by_equipment_id.get(int(component.equipment_id)), component
+        for component in unit_components:
+            if model and cls._clean_text(component.model, max_length=200) == model:
+                return by_equipment_id.get(int(component.equipment_id)), component
+        for component in unit_components:
+            if not cls._clean_text(component.serial, max_length=160):
+                return by_equipment_id.get(int(component.equipment_id)), component
+        if unit_components:
+            component = unit_components[0]
+            return by_equipment_id.get(int(component.equipment_id)), component
+        return (equipment[0] if equipment else None), None
+
+    @classmethod
+    async def build_merge_preview(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        unit_type: str,
+        extracted: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if unit_type not in cls.UNIT_TYPES:
+            raise ValueError("Неизвестный тип блока")
+        order = await cls._load_order(session, order_id)
+        if not cls._is_installation_order(order):
+            return None
+        equipment = await cls._existing_equipment_for_order(session, order_id)
+        components = await cls._components_for_equipment(session, [int(item.id or 0) for item in equipment])
+        payload = cls._component_payload_from_extracted(extracted)
+        selected_equipment, selected_component = cls._select_equipment_component(
+            equipment,
+            components,
+            unit_type=unit_type,
+            payload=payload,
+        )
+        return {
+            "unit_type": unit_type,
+            "unit_label": cls.UNIT_LABELS[unit_type],
+            "will_create_equipment": not bool(equipment),
+            "will_create_component": selected_component is None,
+            "equipment_id": int(selected_equipment.id) if selected_equipment and selected_equipment.id else None,
+            "component_id": int(selected_component.id) if selected_component and selected_component.id else None,
+            "component": cls._preview_component_merge(selected_component, payload),
+            "equipment": cls._preview_equipment_merge(selected_equipment, payload),
+        }
+
+    @classmethod
+    async def apply_to_order(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        unit_type: str,
+        extracted: dict[str, Any],
+        raw_text: str,
+        validation_flags: dict[str, Any] | None,
+        file_id: str,
+        filename: str,
+        mime_type: str | None,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        can_attach_any: bool = False,
+    ) -> dict[str, Any] | None:
+        if unit_type not in cls.UNIT_TYPES:
+            raise ValueError("Неизвестный тип блока")
+        allowed = await cls.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+        if not allowed:
+            return None
+        order = await cls._load_order(session, order_id)
+        if not order:
+            return None
+
+        equipment = await cls._ensure_equipment_for_order(session, order)
+        if not equipment:
+            raise ValueError("Не удалось создать карточку оборудования для заказа")
+        components = await cls._components_for_equipment(session, [int(item.id or 0) for item in equipment])
+        payload = cls._component_payload_from_extracted(extracted)
+        selected_equipment, selected_component = cls._select_equipment_component(
+            equipment,
+            components,
+            unit_type=unit_type,
+            payload=payload,
+        )
+        if not selected_equipment:
+            raise ValueError("Не удалось выбрать карточку оборудования")
+
+        equipment_merge = cls._preview_equipment_merge(selected_equipment, payload)
+        for field, value in equipment_merge["applied"].items():
+            setattr(selected_equipment, field, value)
+        if selected_equipment.warranty_started_at is None:
+            selected_equipment.warranty_started_at = EquipmentService._order_warranty_start(
+                order,
+                {"warranty_start_date": order.installation_date},
+            )
+        if selected_equipment.warranty_expires_at is None and selected_equipment.warranty_started_at:
+            selected_equipment.warranty_expires_at = EquipmentService._add_months(
+                selected_equipment.warranty_started_at,
+                cls.WARRANTY_MONTHS_DEFAULT,
+            )
+        if selected_equipment.installed_at is None:
+            selected_equipment.installed_at = EquipmentService._normalize_naive_datetime(order.installation_date)
+        if selected_equipment.commissioned_at is None:
+            selected_equipment.commissioned_at = selected_equipment.warranty_started_at
+        selected_equipment.updated_at = datetime.now()
+        session.add(selected_equipment)
+
+        created_component = False
+        if selected_component is None:
+            selected_component = EquipmentComponent(
+                equipment_id=int(selected_equipment.id or 0),
+                catalog_product_id=selected_equipment.catalog_product_id,
+                component_type=unit_type,
+                title=cls.UNIT_LABELS[unit_type].capitalize(),
+            )
+            session.add(selected_component)
+            await session.flush()
+            created_component = True
+
+        component_merge = cls._preview_component_merge(selected_component, payload)
+        for field, value in component_merge["applied"].items():
+            setattr(selected_component, field, value)
+        selected_component.updated_at = datetime.now()
+        session.add(selected_component)
+
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        history = list(meta.get(cls.HISTORY_META_KEY)) if isinstance(meta.get(cls.HISTORY_META_KEY), list) else []
+        attached_at = datetime.now()
+        entry = BotOrderAttachmentService._build_entry(
+            file_id=file_id,
+            filename=filename,
+            mime_type=mime_type,
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            attached_at=attached_at,
+        )
+        entry.update(
+            {
+                "purpose": "warranty_nameplate",
+                "unit_type": unit_type,
+                "equipment_id": int(selected_equipment.id or 0),
+                "component_id": int(selected_component.id or 0),
+                "extracted": {key: value for key, value in payload.items() if value},
+                "validation_flags": validation_flags or {},
+                "component_applied_fields": list(component_merge["applied"].keys()),
+                "component_conflicts": component_merge["conflicts"],
+                "equipment_applied_fields": list(equipment_merge["applied"].keys()),
+                "equipment_conflicts": equipment_merge["conflicts"],
+                "raw_text": raw_text[:4000],
+            }
+        )
+        history.append(entry)
+        meta[cls.HISTORY_META_KEY] = history[-20:]
+        order.technical_meta = meta
+        flag_modified(order, "technical_meta")
+        session.add(order)
+        await session.commit()
+        await session.refresh(selected_component)
+        await session.refresh(selected_equipment)
+
+        return {
+            "id": int(order.id or 0),
+            "equipment_id": int(selected_equipment.id or 0),
+            "component_id": int(selected_component.id or 0),
+            "unit_type": unit_type,
+            "created_component": created_component,
+            "component": component_merge,
+            "equipment": equipment_merge,
+            "extracted": payload,
+        }

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -244,7 +244,8 @@ async def test_requisites_photo_prompts_for_action_without_recognition(monkeypat
     assert "Что сделать" in args[0]
     assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_extract"
     assert kwargs["reply_markup"].inline_keyboard[1][0].callback_data == "repair_nameplate_start"
-    assert kwargs["reply_markup"].inline_keyboard[2][0].callback_data == "req_file_attach"
+    assert kwargs["reply_markup"].inline_keyboard[2][0].callback_data == "warranty_nameplate_start"
+    assert kwargs["reply_markup"].inline_keyboard[3][0].callback_data == "req_file_attach"
 
 
 @pytest.mark.asyncio
@@ -265,7 +266,7 @@ async def test_requisites_photo_for_staff_non_admin_allows_attach_only(monkeypat
         row[0].callback_data
         for row in kwargs["reply_markup"].inline_keyboard
     ]
-    assert callbacks == ["repair_nameplate_start", "req_file_attach", "req_file_cancel"]
+    assert callbacks == ["repair_nameplate_start", "warranty_nameplate_start", "req_file_attach", "req_file_cancel"]
     assert state._data["pending_requisites_file"]["file_id"] == "large-photo"
 
 
@@ -307,6 +308,7 @@ async def test_requisites_document_prompts_for_pdf(monkeypatch):
     args, kwargs = message.answer.await_args
     callbacks = [row[0].callback_data for row in kwargs["reply_markup"].inline_keyboard]
     assert "repair_nameplate_start" not in callbacks
+    assert "warranty_nameplate_start" not in callbacks
 
 
 @pytest.mark.asyncio
@@ -667,6 +669,141 @@ async def test_repair_nameplate_confirm_applies_and_clears_pending(monkeypatch):
     assert "Данные со шильдика записаны" in args[0]
     assert "можно отправлять комментарии" in args[0]
     assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_context_finish"
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_start_asks_unit_type(monkeypatch):
+    callback = _DummyCallback(data="warranty_nameplate_start", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "photo-file",
+                "filename": "nameplate.jpg",
+                "mime_type": "image/jpeg",
+            }
+        }
+    )
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+
+    await admin_handler.choose_warranty_nameplate_unit(callback, state)
+
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "Что фотографируем" in args[0]
+    callbacks = [row[0].callback_data for row in kwargs["reply_markup"].inline_keyboard]
+    assert callbacks[:2] == ["warranty_nameplate_unit_indoor_unit", "warranty_nameplate_unit_outdoor_unit"]
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_unit_shows_installation_orders(monkeypatch):
+    callback = _DummyCallback(data="warranty_nameplate_unit_indoor_unit", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "photo-file",
+                "filename": "nameplate.jpg",
+                "mime_type": "image/jpeg",
+            }
+        }
+    )
+
+    async def fake_list_installation_orders(session, *, telegram_user_id, can_attach_any, limit):
+        assert telegram_user_id == 5
+        assert can_attach_any is True
+        assert limit == 5
+        return {
+            "scope": "today",
+            "items": [
+                {
+                    "id": 42,
+                    "title": "Монтаж",
+                    "customer_name": "Иван",
+                    "address": "Победы 15",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotWarrantyNameplateService, "list_installation_orders", fake_list_installation_orders)
+
+    await admin_handler.choose_order_for_warranty_nameplate(callback, state)
+
+    assert state._data["pending_warranty_nameplate"] == {"unit_type": "indoor_unit"}
+    args, kwargs = callback.message.edit_text.await_args
+    assert "сегодняшнему монтажу" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "warranty_nameplate_order_42"
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_chosen_order_runs_recognition_preview(monkeypatch):
+    callback = _DummyCallback(data="warranty_nameplate_order_42", user_id=5)
+    state = _DummyState(
+        {
+            "pending_requisites_file": {
+                "file_id": "photo-file",
+                "filename": "nameplate.jpg",
+                "mime_type": "image/jpeg",
+                "telegram_message_id": 77,
+                "telegram_chat_id": 200,
+            },
+            "pending_warranty_nameplate": {"unit_type": "outdoor_unit"},
+        }
+    )
+
+    monkeypatch.setattr(
+        admin_handler,
+        "_get_bot_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(admin_handler.BotWarrantyNameplateService, "can_use_order", AsyncMock(return_value=True))
+    monkeypatch.setattr(admin_handler, "_download_telegram_file", AsyncMock(return_value=b"image"))
+    monkeypatch.setattr(
+        admin_handler.BotRepairNameplateService,
+        "recognize_bytes",
+        AsyncMock(
+            return_value={
+                "raw_text": "MODEL 1U25S2SM1FA",
+                "extracted": {
+                    "equipment_model": "1U25S2SM1FA",
+                    "equipment_serial_number": "SN-OUT-001",
+                },
+                "validation_flags": {"warnings": {}, "is_valid": True},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        admin_handler.BotWarrantyNameplateService,
+        "build_merge_preview",
+        AsyncMock(
+            return_value={
+                "unit_type": "outdoor_unit",
+                "unit_label": "наружный блок",
+                "will_create_equipment": False,
+                "will_create_component": False,
+                "component": {"applied": {"serial": "SN-OUT-001"}, "conflicts": {}, "skipped": {}},
+                "equipment": {"applied": {}, "conflicts": {}, "skipped": {}},
+            }
+        ),
+    )
+
+    await admin_handler.recognize_warranty_nameplate_for_chosen_order(callback, state)
+
+    final_args, final_kwargs = callback.message.edit_text.await_args
+    assert "наружный блок" in final_args[0]
+    assert "SN-OUT-001" in final_args[0]
+    assert final_kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "warranty_nameplate_confirm"
+    assert state._data["pending_warranty_nameplate"]["order_id"] == 42
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -1,13 +1,26 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
-from models import Customer, Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
+from models import (
+    Customer,
+    CustomerEquipment,
+    EquipmentComponent,
+    Order,
+    OrderInstaller,
+    OrderProductLink,
+    OrderStatus,
+    OrderWorkStage,
+    Product,
+    StaffUser,
+)
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.defect_act_ai_service import DefectActAIService
 
@@ -269,3 +282,122 @@ async def test_apply_diagnostic_comment_updates_repair_meta_and_keeps_history(sq
         "diagnostic_result",
         "repair_recommendation",
     ]
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_lists_today_installations_first(sqlite_repair_nameplate_session):
+    today_order = Order(
+        title="Сегодняшний монтаж",
+        status=OrderStatus.EXECUTION,
+        workflow_type="sales_installation",
+        installation_date=datetime(2026, 6, 18, 14, 0, 0),
+    )
+    other_execution = Order(
+        title="Другой монтаж",
+        status=OrderStatus.EXECUTION,
+        workflow_type="sales_installation",
+        installation_date=datetime(2026, 6, 17, 14, 0, 0),
+    )
+    repair = Order(title="Ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
+    sqlite_repair_nameplate_session.add(today_order)
+    sqlite_repair_nameplate_session.add(other_execution)
+    sqlite_repair_nameplate_session.add(repair)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotWarrantyNameplateService.list_installation_orders(
+        sqlite_repair_nameplate_session,
+        telegram_user_id=777,
+        can_attach_any=True,
+        now=datetime(2026, 6, 18, 10, 0, 0),
+    )
+
+    assert result["scope"] == "today"
+    assert [item["id"] for item in result["items"]] == [today_order.id]
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_falls_back_to_execution_installations(sqlite_repair_nameplate_session):
+    order = Order(
+        title="Монтаж без даты сегодня",
+        status=OrderStatus.EXECUTION,
+        workflow_type="service_work",
+        installation_date=datetime(2026, 6, 17, 14, 0, 0),
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotWarrantyNameplateService.list_installation_orders(
+        sqlite_repair_nameplate_session,
+        telegram_user_id=777,
+        can_attach_any=True,
+        now=datetime(2026, 6, 18, 10, 0, 0),
+    )
+
+    assert result["scope"] == "execution"
+    assert [item["id"] for item in result["items"]] == [order.id]
+
+
+@pytest.mark.asyncio
+async def test_warranty_nameplate_creates_order_equipment_and_updates_selected_component(sqlite_repair_nameplate_session):
+    customer = Customer(name="Иван", phone="+375291234567")
+    product = Product(
+        title="Haier Flexis 12",
+        slug="haier-flexis-12",
+        price=2000,
+        specs={
+            "indoor_model": "AS25S2SF1FA",
+            "outdoor_model": "1U25S2SM1FA",
+            "refrigerant": "R32",
+        },
+    )
+    sqlite_repair_nameplate_session.add(customer)
+    sqlite_repair_nameplate_session.add(product)
+    await sqlite_repair_nameplate_session.flush()
+    order = Order(
+        customer_id=customer.id,
+        title="Продажа и монтаж",
+        status=OrderStatus.EXECUTION,
+        workflow_type="sales_installation",
+        installation_date=datetime(2026, 6, 18, 14, 0, 0),
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.flush()
+    sqlite_repair_nameplate_session.add(OrderProductLink(order_id=order.id, product_id=product.id, quantity=1))
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotWarrantyNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        unit_type="indoor_unit",
+        extracted={
+            "equipment_brand": "Haier",
+            "equipment_model": "AS25S2SF1FA",
+            "equipment_serial_number": "SN-IN-001",
+            "refrigerant_type": "R32",
+        },
+        raw_text="MODEL AS25S2SF1FA SERIAL SN-IN-001",
+        validation_flags={"warnings": {}, "is_valid": True},
+        file_id="photo-file",
+        filename="nameplate.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        can_attach_any=True,
+    )
+
+    assert result is not None
+    assert result["component"]["applied"]["serial"] == "SN-IN-001"
+    equipment = await sqlite_repair_nameplate_session.get(CustomerEquipment, result["equipment_id"])
+    component = await sqlite_repair_nameplate_session.get(EquipmentComponent, result["component_id"])
+    await sqlite_repair_nameplate_session.refresh(order)
+
+    assert equipment is not None
+    assert equipment.source_order_id == order.id
+    assert equipment.warranty_started_at == datetime(2026, 6, 18, 14, 0, 0)
+    assert equipment.warranty_expires_at.year == 2028
+    assert component is not None
+    assert component.component_type == "indoor_unit"
+    assert component.model == "AS25S2SF1FA"
+    assert component.serial == "SN-IN-001"
+    assert order.technical_meta["warranty_nameplate_recognitions"][0]["purpose"] == "warranty_nameplate"


### PR DESCRIPTION
## Summary
- add a Telegram photo branch for warranty nameplates
- ask whether staff photographed the indoor or outdoor unit before linking the nameplate
- prioritize today's installation orders, then fall back to active installation/execution orders
- create/order-link customer equipment when needed and fill the selected unit component with recognized model/serial data

## Validation
- pytest tests/unit/test_bot_repair_nameplate_service.py tests/unit/test_bot_admin_handler.py tests/unit/test_bot_order_attachment_service.py tests/unit/test_customer_requisites_recognition_service.py tests/unit/test_equipment_service.py tests/unit/test_bot_handlers_architecture.py tests/unit/test_bot_work_services.py -q
- result: 110 passed
