### PR TITLE
[codex] Proxy storefront media through main domain

### DIFF
--- a/deployment/nginx/mvn-media-proxy-location.conf
+++ b/deployment/nginx/mvn-media-proxy-location.conf
@@ -1,0 +1,25 @@
+# Include inside both `server_name mvn.by www.mvn.by` server blocks before
+# the generic static asset regex location.
+#
+# Purpose: expose backend-managed public media under the storefront origin:
+#   https://mvn.by/media/...
+#
+# The API origin is used directly to avoid an extra Cloudflare-to-Cloudflare hop.
+# Keep the IP in sync with the API VPS documented in docs/deployment.md.
+location ^~ /media/ {
+    proxy_pass https://185.250.45.54;
+    proxy_ssl_server_name on;
+    proxy_ssl_name api.mvn.by;
+
+    proxy_set_header Host api.mvn.by;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout 60s;
+
+    access_log off;
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Expires;
+    add_header Cache-Control "public, max-age=2592000" always;
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -246,6 +246,43 @@ Post-cutover verification:
 5. Roll back by restoring DNS and/or GitHub secrets to the legacy `mvn-web`
    values and running the manual rebuild workflow.
 
+### Storefront Media Proxy
+
+Backend-managed public media lives on the API host under `/media/...`, but
+storefront content should prefer same-origin references such as
+`/media/library/crop/example.webp`. The web VPS proxies those paths to the API
+origin with the nginx snippet in
+`deployment/nginx/mvn-media-proxy-location.conf`.
+
+Install or refresh the snippet on the web VPS:
+
+```bash
+scp deployment/nginx/mvn-media-proxy-location.conf mvn:/etc/nginx/snippets/mvn-media-proxy-location.conf
+ssh mvn
+cp /etc/nginx/sites-available/mvn.by /etc/nginx/sites-available/mvn.by.bak-media-$(date +%Y%m%d%H%M%S)
+# Include the snippet inside both mvn.by server blocks before the generic
+# static asset regex location.
+nginx -t
+systemctl reload nginx
+```
+
+Origin smoke, bypassing Cloudflare:
+
+```bash
+curl -I -H 'Host: mvn.by' http://153.80.244.78/media/library/crop/<file>.webp
+curl -I --resolve mvn.by:443:153.80.244.78 https://mvn.by/media/library/crop/<file>.webp
+```
+
+After enabling a new `/media/...` URL that previously returned 404 through
+Cloudflare, purge that URL from Cloudflare cache or wait for the cached 404 to
+expire. The Cloudflare token used for certbot DNS challenges may not have cache
+purge permissions, so use a token with `Zone.Cache Purge` when clearing this
+manually. Public smoke:
+
+```bash
+curl -I https://mvn.by/media/library/crop/<file>.webp
+```
+
 ### Web SSH Reliability
 
 `deploy-frontend` and the manual `rebuild-web.yml` workflow use bounded SSH port/login preflight checks before rsync. They retry 5 times with backoff and write a summary with separate `ssh_port_failures`, `ssh_login_failures`, `rsync_failures`, and `failure_kind` fields.

--- a/web/src/content/blog/filtry-v-kondicionere-kakie-byvayut.mdx
+++ b/web/src/content/blog/filtry-v-kondicionere-kakie-byvayut.mdx
@@ -30,7 +30,7 @@ import AdditionalFilterOptions from '../../components/mdx/AdditionalFilterOption
 
 <figure>
   <img
-    src="https://api.mvn.by/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp"
+    src="/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp"
     alt="Сетчатый фильтр грубой очистки во внутреннем блоке кондиционера"
     loading="lazy"
   />


### PR DESCRIPTION
## What changed

- Added an nginx snippet that proxies public `/media/...` requests from the storefront domain to the API media origin.
- Documented install, smoke-check, and Cloudflare cache notes for the storefront media proxy.
- Switched the filters article image from `https://api.mvn.by/...` to same-origin `/media/...`.

## Why

Blog and storefront content can now use `https://mvn.by/media/...` instead of exposing `api.mvn.by` image URLs. This keeps media URLs on the main domain while the API server remains the source of uploaded files.

Production note: the snippet has already been installed on the web VPS, `nginx -t` passed, and nginx was reloaded. The prior site config backup is `/etc/nginx/sites-available/mvn.by.bak-media-20260621123854`.

## Validation

- `curl -I -H 'Host: mvn.by' http://153.80.244.78/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp` -> `200 OK`
- `curl -I --resolve mvn.by:443:153.80.244.78 https://mvn.by/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp` -> `200 OK`
- `curl -I https://mvn.by/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp` -> `200 OK`
- `git diff --check`
- `npm run audit:theme`
- `npm run build`

## Follow-up note

The Cloudflare certbot token on the VPS can read the zone but does not have cache purge permissions. Public media is already returning `200 OK`; for future forced purges use a Cloudflare token with `Zone.Cache Purge`.
