### PR TITLE
[codex] Support partial service quantities in scoped acts

### DIFF
--- a/manager_frontend/src/client/services/ManagerOrdersService.ts
+++ b/manager_frontend/src/client/services/ManagerOrdersService.ts
@@ -406,6 +406,7 @@ export class ManagerOrdersService {
      * @param scopeTitle Human-readable object title for scoped closing document
      * @param scopeAddress Object address override for scoped closing document
      * @param scopeServiceLineIds Order service line IDs included in scoped closing document
+     * @param scopeServiceLineQuantities JSON map/list of service line quantities included in scoped closing document
      * @param scopeProductLineIds Order product line IDs included in scoped closing document
      * @returns ManagerOrderDocumentResponse Successful Response
      * @throws ApiError
@@ -422,6 +423,7 @@ export class ManagerOrdersService {
         scopeTitle?: (string | null),
         scopeAddress?: (string | null),
         scopeServiceLineIds?: (Array<number> | null),
+        scopeServiceLineQuantities?: (string | null),
         scopeProductLineIds?: (Array<number> | null),
     ): CancelablePromise<ManagerOrderDocumentResponse> {
         return __request(OpenAPI, {
@@ -441,6 +443,7 @@ export class ManagerOrdersService {
                 'scope_title': scopeTitle,
                 'scope_address': scopeAddress,
                 'scope_service_line_ids': scopeServiceLineIds,
+                'scope_service_line_quantities': scopeServiceLineQuantities,
                 'scope_product_line_ids': scopeProductLineIds,
             },
             errors: {

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -118,6 +118,7 @@ const selectedActBranchId = ref<number | null>(props.order.customer_branch?.id ?
 const actScopeTitle = ref(props.order.customer_branch?.name || '');
 const actScopeAddress = ref(props.order.delivery_address || props.order.customer_branch?.delivery_address || '');
 const selectedActServiceLineIds = ref<number[]>([]);
+const selectedActServiceLineQuantities = ref<Record<number, number>>({});
 const newActBranchName = ref('');
 const newActBranchAddress = ref('');
 const creatingActBranch = ref(false);
@@ -502,8 +503,24 @@ const fallbackActAddress = () => (
   || ''
 );
 
+const maxActServiceQuantity = (line: OrderServiceLineResponse) => Math.max(0, Math.trunc(Number(line.quantity) || 0));
+
+const actServiceQuantity = (lineId: number) => Math.max(0, Math.trunc(Number(selectedActServiceLineQuantities.value[lineId]) || 0));
+
+const syncActServiceIdsFromQuantities = () => {
+  selectedActServiceLineIds.value = activeActServiceLines.value
+    .filter((line) => actServiceQuantity(line.id) > 0)
+    .map((line) => line.id);
+};
+
 const syncActServiceSelection = () => {
-  selectedActServiceLineIds.value = activeActServiceLines.value.map((line) => line.id);
+  const nextQuantities: Record<number, number> = {};
+  activeActServiceLines.value.forEach((line) => {
+    const maxQuantity = maxActServiceQuantity(line);
+    if (maxQuantity > 0) nextQuantities[line.id] = maxQuantity;
+  });
+  selectedActServiceLineQuantities.value = nextQuantities;
+  syncActServiceIdsFromQuantities();
 };
 
 const syncActScopeDefaults = () => {
@@ -760,13 +777,25 @@ const onActBranchChange = () => {
   actScopeAddress.value = branch.delivery_address;
 };
 
+const setActServiceLineQuantity = (line: OrderServiceLineResponse, rawValue: number | string) => {
+  const maxQuantity = maxActServiceQuantity(line);
+  const nextQuantity = Math.max(0, Math.min(maxQuantity, Math.trunc(Number(rawValue) || 0)));
+  selectedActServiceLineQuantities.value = {
+    ...selectedActServiceLineQuantities.value,
+    [line.id]: nextQuantity,
+  };
+  if (nextQuantity <= 0) {
+    const rest = { ...selectedActServiceLineQuantities.value };
+    delete rest[line.id];
+    selectedActServiceLineQuantities.value = rest;
+  }
+  syncActServiceIdsFromQuantities();
+};
+
 const toggleActServiceLine = (lineId: number, checked: boolean) => {
-  const current = new Set(selectedActServiceLineIds.value);
-  if (checked) current.add(lineId);
-  else current.delete(lineId);
-  selectedActServiceLineIds.value = activeActServiceLines.value
-    .map((line) => line.id)
-    .filter((lineId) => current.has(lineId));
+  const line = activeActServiceLines.value.find((item) => item.id === lineId);
+  if (!line) return;
+  setActServiceLineQuantity(line, checked ? maxActServiceQuantity(line) : 0);
 };
 
 const onActServiceCheckboxChange = (lineId: number, event: Event) => {
@@ -874,6 +903,12 @@ const generateDocument = async (type: string) => {
     const scopeServiceLineIds = type === 'act' && selectedActServiceLineIds.value.length
       ? selectedActServiceLineIds.value
       : undefined;
+    const scopeServiceLineQuantities = type === 'act' && selectedActServiceLineIds.value.length
+      ? JSON.stringify(selectedActServiceLineIds.value.map((lineId) => ({
+        service_line_id: lineId,
+        quantity: actServiceQuantity(lineId),
+      })).filter((item) => item.quantity > 0))
+      : undefined;
     const res = await ManagerOrdersService.generateManagerOrderDocument(
       props.order.id,
       type,
@@ -886,6 +921,7 @@ const generateDocument = async (type: string) => {
       scopeTitle,
       scopeAddress,
       scopeServiceLineIds,
+      scopeServiceLineQuantities,
       undefined,
     );
     window.open(res.edit_url, '_blank');
@@ -1395,13 +1431,27 @@ const registerExternalContract = async () => {
                   <input
                     type="checkbox"
                     class="mt-1 h-4 w-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
-                    :checked="selectedActServiceLineIds.includes(line.id)"
+                    :checked="actServiceQuantity(line.id) > 0"
                     @change="onActServiceCheckboxChange(line.id, $event)"
                   />
                   <span class="min-w-0 flex-1">
                     <span class="block font-medium text-slate-800 dark:text-slate-100">{{ line.service_title }}</span>
-                    <span class="text-xs text-slate-500 dark:text-slate-400">
-                      {{ line.quantity }} шт. · {{ formatMoney(line.line_total) }}
+                    <span class="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <span>{{ line.quantity }} шт. · {{ formatMoney(line.line_total) }}</span>
+                      <span class="inline-flex items-center gap-1 rounded-md bg-white px-2 py-1 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-700">
+                        <span>В акт</span>
+                        <input
+                          type="number"
+                          min="0"
+                          :max="maxActServiceQuantity(line)"
+                          step="1"
+                          inputmode="numeric"
+                          class="h-7 w-14 rounded border border-slate-200 bg-white px-2 text-center text-sm font-semibold text-slate-800 outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:ring-teal-900/40"
+                          :value="actServiceQuantity(line.id)"
+                          @input="setActServiceLineQuantity(line, ($event.target as HTMLInputElement).value)"
+                        />
+                        <span>из {{ maxActServiceQuantity(line) }}</span>
+                      </span>
                     </span>
                   </span>
                 </label>

--- a/openapi.json
+++ b/openapi.json
@@ -7988,6 +7988,24 @@
             "description": "Order service line IDs included in scoped closing document"
           },
           {
+            "name": "scope_service_line_quantities",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON map/list of service line quantities included in scoped closing document",
+              "title": "Scope Service Line Quantities"
+            },
+            "description": "JSON map/list of service line quantities included in scoped closing document"
+          },
+          {
             "name": "scope_product_line_ids",
             "in": "query",
             "required": false,

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -292,6 +292,7 @@ async def generate_manager_order_document(
     scope_title: Optional[str] = Query(None, description="Human-readable object title for scoped closing document"),
     scope_address: Optional[str] = Query(None, description="Object address override for scoped closing document"),
     scope_service_line_ids: Optional[List[int]] = Query(None, description="Order service line IDs included in scoped closing document"),
+    scope_service_line_quantities: Optional[str] = Query(None, description="JSON map/list of service line quantities included in scoped closing document"),
     scope_product_line_ids: Optional[List[int]] = Query(None, description="Order product line IDs included in scoped closing document"),
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
@@ -314,6 +315,7 @@ async def generate_manager_order_document(
             scope_title=scope_title,
             scope_address=scope_address,
             scope_service_line_ids=scope_service_line_ids,
+            scope_service_line_quantities=scope_service_line_quantities,
             scope_product_line_ids=scope_product_line_ids,
         )
     except ValueError as exc:

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
-from models import CustomerBranch, CustomerContract, CustomerType, DocumentTemplate, OrderDocument, Order, GlobalConfig
+from models import CustomerBranch, CustomerContract, CustomerType, DocumentTemplate, GlobalConfig, Order, OrderDocument, OrderServiceLink
 from services.google_service import get_google_service
 from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
@@ -157,6 +157,7 @@ class DocumentService:
         scope_title: Optional[str] = None,
         scope_address: Optional[str] = None,
         scope_service_line_ids: Optional[List[int]] = None,
+        scope_service_line_quantities: Any = None,
         scope_product_line_ids: Optional[List[int]] = None,
     ) -> OrderDocument:
         """
@@ -185,6 +186,7 @@ class DocumentService:
                 scope_title=scope_title,
                 scope_address=scope_address,
                 scope_service_line_ids=scope_service_line_ids,
+                scope_service_line_quantities=scope_service_line_quantities,
                 scope_product_line_ids=scope_product_line_ids,
             )
 
@@ -214,6 +216,7 @@ class DocumentService:
             scope_title=scope_title,
             scope_address=scope_address,
             scope_service_line_ids=scope_service_line_ids,
+            scope_service_line_quantities=scope_service_line_quantities,
             scope_product_line_ids=scope_product_line_ids,
         )
 
@@ -231,6 +234,7 @@ class DocumentService:
         scope_title: Optional[str] = None,
         scope_address: Optional[str] = None,
         scope_service_line_ids: Optional[List[int]] = None,
+        scope_service_line_quantities: Any = None,
         scope_product_line_ids: Optional[List[int]] = None,
     ) -> dict:
         if doc_type not in DocumentService.ALLOWED_DOC_TYPES:
@@ -249,6 +253,7 @@ class DocumentService:
             scope_title=scope_title,
             scope_address=scope_address,
             scope_service_line_ids=scope_service_line_ids,
+            scope_service_line_quantities=scope_service_line_quantities,
             scope_product_line_ids=scope_product_line_ids,
         )
         return {
@@ -667,6 +672,56 @@ class DocumentService:
         return normalized
 
     @staticmethod
+    def _normalize_quantity_map(value: Any) -> dict[int, int]:
+        if not value:
+            return {}
+        raw_items: Any = value
+        if isinstance(value, str):
+            try:
+                raw_items = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError("Некорректный формат количества услуг в акте") from exc
+
+        normalized: dict[int, int] = {}
+        if isinstance(raw_items, dict):
+            iterable = raw_items.items()
+        elif isinstance(raw_items, list):
+            iterable = []
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+                line_id = item.get("service_line_id") or item.get("line_id") or item.get("id")
+                quantity = item.get("quantity")
+                iterable.append((line_id, quantity))
+        else:
+            return {}
+
+        for raw_line_id, raw_quantity in iterable:
+            try:
+                line_id = int(raw_line_id)
+                quantity = int(raw_quantity)
+            except (TypeError, ValueError):
+                continue
+            if line_id > 0 and quantity > 0:
+                normalized[line_id] = quantity
+        return normalized
+
+    @staticmethod
+    def _clone_service_link_for_scope(link: OrderServiceLink, quantity: int) -> OrderServiceLink:
+        scoped_link = OrderServiceLink(
+            id=link.id,
+            order_id=link.order_id,
+            proposal_id=link.proposal_id,
+            service_id=link.service_id,
+            title=link.title,
+            quantity=quantity,
+            price=link.price,
+            cost=link.cost,
+        )
+        set_committed_value(scoped_link, "service", link.service)
+        return scoped_link
+
+    @staticmethod
     async def _build_document_scope(
         session: AsyncSession,
         order: Optional[Order],
@@ -675,6 +730,7 @@ class DocumentService:
         scope_title: Optional[str],
         scope_address: Optional[str],
         scope_service_line_ids: Optional[List[int]],
+        scope_service_line_quantities: Any,
         scope_product_line_ids: Optional[List[int]],
     ) -> dict[str, Any]:
         if not order:
@@ -683,7 +739,14 @@ class DocumentService:
         cleaned_title = str(scope_title or "").strip()
         cleaned_address = str(scope_address or "").strip()
         service_line_ids = DocumentService._normalize_id_list(scope_service_line_ids)
+        service_line_quantities = DocumentService._normalize_quantity_map(scope_service_line_quantities)
         product_line_ids = DocumentService._normalize_id_list(scope_product_line_ids)
+        if service_line_quantities:
+            quantity_line_ids = list(service_line_quantities.keys())
+            service_line_ids = service_line_ids or quantity_line_ids
+            for line_id in quantity_line_ids:
+                if line_id not in service_line_ids:
+                    service_line_ids.append(line_id)
 
         branch = None
         if scope_customer_branch_id:
@@ -702,6 +765,8 @@ class DocumentService:
             scope["address"] = cleaned_address
         if service_line_ids:
             scope["service_line_ids"] = service_line_ids
+        if service_line_quantities:
+            scope["service_line_quantities"] = {str(line_id): quantity for line_id, quantity in service_line_quantities.items()}
         if product_line_ids:
             scope["product_line_ids"] = product_line_ids
         return scope
@@ -715,10 +780,22 @@ class DocumentService:
             set_committed_value(order, "delivery_address", str(scope["address"]))
 
         service_ids = set(DocumentService._normalize_id_list(scope.get("service_line_ids")))
+        service_quantities = DocumentService._normalize_quantity_map(scope.get("service_line_quantities"))
         product_ids = set(DocumentService._normalize_id_list(scope.get("product_line_ids")))
 
         if service_ids:
-            scoped_services = [link for link in order.service_links if link.id in service_ids]
+            scoped_services = []
+            for link in order.service_links:
+                if link.id not in service_ids:
+                    continue
+                scoped_quantity = service_quantities.get(int(link.id)) if link.id is not None else None
+                if scoped_quantity is None:
+                    scoped_services.append(link)
+                    continue
+                max_quantity = int(link.quantity or 0)
+                if scoped_quantity > max_quantity:
+                    raise ValueError("Количество услуги в акте не может быть больше количества в заказе")
+                scoped_services.append(DocumentService._clone_service_link_for_scope(link, scoped_quantity))
             if len(scoped_services) != len(service_ids):
                 raise ValueError("В акте выбрана услуга не из этого заказа или предложения")
             set_committed_value(order, "service_links", scoped_services)
@@ -755,6 +832,7 @@ class DocumentService:
         scope_title: Optional[str] = None,
         scope_address: Optional[str] = None,
         scope_service_line_ids: Optional[List[int]] = None,
+        scope_service_line_quantities: Any = None,
         scope_product_line_ids: Optional[List[int]] = None,
     ) -> OrderDocument:
         """Создает новый документ в Google Drive и сохраняет в БД"""
@@ -819,6 +897,7 @@ class DocumentService:
             scope_title=scope_title,
             scope_address=scope_address,
             scope_service_line_ids=scope_service_line_ids,
+            scope_service_line_quantities=scope_service_line_quantities,
             scope_product_line_ids=scope_product_line_ids,
         )
         if doc_type == "act":

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -654,7 +654,7 @@ async def test_manager_order_act_generation_can_be_scoped_to_object_and_service_
     await db.refresh(service_b)
 
     service_link_a = OrderServiceLink(order_id=order.id, service_id=service_a.id, quantity=1, price=300, cost=100)
-    service_link_b = OrderServiceLink(order_id=order.id, service_id=service_b.id, quantity=1, price=150, cost=50)
+    service_link_b = OrderServiceLink(order_id=order.id, service_id=service_b.id, quantity=2, price=150, cost=50)
     db.add_all([service_link_a, service_link_b])
     await db.commit()
     await db.refresh(service_link_a)
@@ -692,6 +692,7 @@ async def test_manager_order_act_generation_can_be_scoped_to_object_and_service_
             ("base_document_id", "0"),
             ("scope_customer_branch_id", str(branch.id)),
             ("scope_service_line_ids", str(service_link_b.id)),
+            ("scope_service_line_quantities", json.dumps([{"service_line_id": service_link_b.id, "quantity": 1}])),
         ],
     )
     assert response.status_code == 200, response.text
@@ -705,12 +706,14 @@ async def test_manager_order_act_generation_can_be_scoped_to_object_and_service_
     assert generated_replacements["{{object_address}}"] == "Полоцк, Скорины 8А"
     assert generated_replacements["{{total_amount}}"] == "150.00"
     assert table_captures[-1][0][1] == "Демонтаж кондиционера"
+    assert table_captures[-1][0][3] == "1"
     assert table_captures[-1][-1][-1] == "150.00"
 
     doc = await db.get(OrderDocument, payload["doc_id"])
     assert doc is not None
     assert doc.scope_customer_branch_id == branch.id
     assert doc.scope_meta["service_line_ids"] == [service_link_b.id]
+    assert doc.scope_meta["service_line_quantities"] == {str(service_link_b.id): 1}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_document_service_base_documents.py
+++ b/tests/unit/test_document_service_base_documents.py
@@ -280,7 +280,7 @@ async def test_act_scope_filters_services_and_overrides_object(sqlite_session):
         order_id=order.id,
         proposal_id=proposal.id,
         service_id=service_b.id,
-        quantity=1,
+        quantity=2,
         price=150,
         cost=50,
     )
@@ -298,6 +298,7 @@ async def test_act_scope_filters_services_and_overrides_object(sqlite_session):
         scope_title=None,
         scope_address=None,
         scope_service_line_ids=[link_b.id],
+        scope_service_line_quantities=[{"service_line_id": link_b.id, "quantity": 1}],
         scope_product_line_ids=None,
     )
     DocumentService._apply_document_scope(strategy.order, scope)
@@ -312,6 +313,7 @@ async def test_act_scope_filters_services_and_overrides_object(sqlite_session):
     assert replacements["{{object_address}}"] == "Полоцк, Скорины 8А"
     assert replacements["{{total_amount}}"] == "150.00"
     assert table_rows[0][1] == "Демонтаж"
+    assert table_rows[0][3] == "1"
     assert table_rows[-1][-1] == "150.00"
 
 
@@ -342,6 +344,7 @@ async def test_act_scope_rejects_service_line_from_another_order(sqlite_session)
         scope_title=None,
         scope_address=None,
         scope_service_line_ids=[foreign_link.id],
+        scope_service_line_quantities=None,
         scope_product_line_ids=None,
     )
 


### PR DESCRIPTION
## Что изменилось
- В scoped-актах можно выбрать не только строку услуги, но и количество из этой строки.
- Количество акта хранится в `scope_meta.service_line_quantities` и не меняет исходный заказ.
- Генерация документа временно подставляет выбранные количества в строки акта и пересчитывает сумму.
- В UI панели документов добавлен компактный счетчик `В акт N из M` рядом с услугой.
- Обновлены OpenAPI и manager client.

## Проверки
- `python3 -m py_compile services/document_service.py routers/manager_orders_write.py`
- `pytest tests/unit/test_document_service_base_documents.py -q`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -q`
- `cd manager_frontend && npm run build`
- `git diff --check`

## Примечание
Локальный запуск integration через `source .env` по-прежнему печатает шум от двух строк `.env`, но тесты проходят.