### PR TITLE
[codex] Improve scoped act addresses and numbering

### DIFF
--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { ManagerContractsService, ManagerDocsService, ManagerOrdersService, ManagerService } from '../../client';
+import { useDebounceFn } from '@vueuse/core';
+import { ManagerContractsService, ManagerDocsService, ManagerOrdersService, ManagerService, ManagerSettingsService } from '../../client';
 import { downloadManagerDocBlob } from '../../api';
 import type {
+  AddressSuggestionItem,
   DocumentTemplateItem,
   ManagerCustomerBranchItemResponse,
   ManagerCustomerContractItemResponse,
@@ -119,6 +121,9 @@ const actScopeTitle = ref(props.order.customer_branch?.name || '');
 const actScopeAddress = ref(props.order.delivery_address || props.order.customer_branch?.delivery_address || '');
 const selectedActServiceLineIds = ref<number[]>([]);
 const selectedActServiceLineQuantities = ref<Record<number, number>>({});
+const actAddressSuggestions = ref<AddressSuggestionItem[]>([]);
+const actAddressSuggestActive = ref(false);
+const actAddressLookupLoading = ref(false);
 const newActBranchName = ref('');
 const newActBranchAddress = ref('');
 const creatingActBranch = ref(false);
@@ -775,6 +780,45 @@ const onActBranchChange = () => {
   if (!branch) return;
   actScopeTitle.value = branch.name || '';
   actScopeAddress.value = branch.delivery_address;
+  actAddressSuggestActive.value = false;
+  actAddressSuggestions.value = [];
+};
+
+const fetchActAddressSuggestions = async (query: string) => {
+  const cleaned = query.trim();
+  if (cleaned.length < 3) {
+    actAddressSuggestions.value = [];
+    return;
+  }
+  actAddressLookupLoading.value = true;
+  try {
+    const res = await ManagerSettingsService.suggestAddress(cleaned);
+    actAddressSuggestions.value = res.items || [];
+  } catch (error) {
+    console.warn('Failed to fetch act address suggestions', error);
+  } finally {
+    actAddressLookupLoading.value = false;
+  }
+};
+
+const debouncedFetchActAddressSuggestions = useDebounceFn(fetchActAddressSuggestions, 400);
+
+const onActAddressInput = () => {
+  actAddressSuggestActive.value = true;
+  selectedActBranchId.value = null;
+  debouncedFetchActAddressSuggestions(actScopeAddress.value);
+};
+
+const selectActAddressSuggestion = (item: AddressSuggestionItem) => {
+  actScopeAddress.value = item.value || item.title || '';
+  actAddressSuggestActive.value = false;
+  actAddressSuggestions.value = [];
+};
+
+const hideActAddressSuggestions = () => {
+  setTimeout(() => {
+    actAddressSuggestActive.value = false;
+  }, 200);
 };
 
 const setActServiceLineQuantity = (line: OrderServiceLineResponse, rawValue: number | string) => {
@@ -1381,11 +1425,32 @@ const registerExternalContract = async () => {
                 class="field-input text-sm"
                 placeholder="Название объекта, если нужно"
               />
-              <input
-                v-model="actScopeAddress"
-                class="field-input text-sm"
-                placeholder="Адрес объекта"
-              />
+              <label class="relative">
+                <input
+                  v-model="actScopeAddress"
+                  class="field-input text-sm"
+                  placeholder="Адрес объекта"
+                  autocomplete="off"
+                  @input="onActAddressInput"
+                  @focus="actAddressSuggestActive = true"
+                  @blur="hideActAddressSuggestions"
+                />
+                <span v-if="actAddressLookupLoading" class="material-icons-round absolute right-3 top-2.5 animate-spin text-[18px] text-slate-400">refresh</span>
+                <ul
+                  v-if="actAddressSuggestActive && actAddressSuggestions.length > 0"
+                  class="absolute left-0 top-full z-50 mt-1 max-h-56 w-full overflow-auto rounded-xl border border-slate-200 bg-white p-1 shadow-2xl ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900"
+                >
+                  <li
+                    v-for="(item, index) in actAddressSuggestions"
+                    :key="`act-address-suggestion-${index}`"
+                    class="flex cursor-pointer flex-col rounded-lg border-b border-slate-100 px-3 py-2 text-sm transition-colors last:border-0 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800"
+                    @mousedown.prevent="selectActAddressSuggestion(item)"
+                  >
+                    <span class="font-medium text-slate-900 dark:text-slate-100">{{ item.title || item.value }}</span>
+                    <span v-if="item.subtitle" class="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">{{ item.subtitle }}</span>
+                  </li>
+                </ul>
+              </label>
             </div>
 
             <div class="mt-3 grid gap-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/70 p-3 dark:border-slate-700 dark:bg-slate-800/40 md:grid-cols-[1fr_1.4fr_auto]">

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from typing import Any, Optional, List
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 from sqlalchemy.orm import selectinload
@@ -915,7 +915,12 @@ class DocumentService:
             base_customer_contract=base_customer_contract,
         )
         if doc_type == "act":
-            act_number = await DocumentService._get_act_number_for_order_contract(session, strategy.order)
+            act_number = await DocumentService._get_act_number_for_document_basis(
+                session,
+                strategy.order,
+                base_document=base_document,
+                base_customer_contract=base_customer_contract,
+            )
             replacements["{{act_number}}"] = str(act_number)
             replacements["{{act_sequence_number}}"] = str(act_number)
             object_title = str(document_scope.get("title") or "").strip()
@@ -1093,18 +1098,54 @@ class DocumentService:
         return f"{prefix}-{current_year}-{next_num:03d}"
 
     @staticmethod
-    async def _get_act_number_for_order_contract(session: AsyncSession, order: Optional[Order]) -> int:
-        if not order or not order.customer_contract_id:
-            return 1
-
-        query = (
-            select(func.count(OrderDocument.id))
-            .join(Order, OrderDocument.order_id == Order.id)
-            .where(
+    async def _get_act_number_for_document_basis(
+        session: AsyncSession,
+        order: Optional[Order],
+        *,
+        base_document: Optional[OrderDocument] = None,
+        base_customer_contract: Optional[CustomerContract] = None,
+    ) -> int:
+        if base_document and base_document.id is not None:
+            query = select(func.count(OrderDocument.id)).where(
                 OrderDocument.doc_type == "act",
-                Order.customer_contract_id == order.customer_contract_id,
+                OrderDocument.base_document_id == base_document.id,
             )
-        )
+        elif base_customer_contract and base_customer_contract.id is not None:
+            query = (
+                select(func.count(OrderDocument.id))
+                .join(Order, OrderDocument.order_id == Order.id)
+                .where(
+                    OrderDocument.doc_type == "act",
+                    or_(
+                        OrderDocument.base_customer_contract_id == base_customer_contract.id,
+                        and_(
+                            OrderDocument.base_customer_contract_id.is_(None),
+                            OrderDocument.base_document_id.is_(None),
+                            Order.customer_contract_id == base_customer_contract.id,
+                        ),
+                    ),
+                )
+            )
+        elif order and order.customer_contract_id:
+            query = (
+                select(func.count(OrderDocument.id))
+                .join(Order, OrderDocument.order_id == Order.id)
+                .where(
+                    OrderDocument.doc_type == "act",
+                    OrderDocument.base_customer_contract_id.is_(None),
+                    OrderDocument.base_document_id.is_(None),
+                    Order.customer_contract_id == order.customer_contract_id,
+                )
+            )
+        elif order and order.id is not None:
+            query = select(func.count(OrderDocument.id)).where(
+                OrderDocument.doc_type == "act",
+                OrderDocument.base_customer_contract_id.is_(None),
+                OrderDocument.base_document_id.is_(None),
+                OrderDocument.order_id == order.id,
+            )
+        else:
+            return 1
         result = await session.execute(query)
         existing_count = int(result.scalar_one() or 0)
         return existing_count + 1

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -619,12 +619,24 @@ async def test_manager_order_contract_selection_and_act_guard(async_client, db, 
         params={"base_document_id": one_time_contract_id},
     )
     assert one_time_contract_act.status_code == 200
+    assert captured_replacements[-1]["{{act_number}}"] == "1"
+    assert captured_replacements[-1]["{{act_sequence_number}}"] == "1"
     assert one_time_contract_act.json()["base_document_id"] == one_time_contract_id
     assert one_time_contract_act.json()["base_customer_contract_id"] is None
     one_time_contract_act_doc = await db.get(OrderDocument, one_time_contract_act.json()["doc_id"])
     assert one_time_contract_act_doc is not None
     assert one_time_contract_act_doc.base_document_id == one_time_contract_id
     assert one_time_contract_act_doc.base_customer_contract_id is None
+
+    second_one_time_contract_act = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/act",
+        headers=headers,
+        params={"base_document_id": one_time_contract_id},
+    )
+    assert second_one_time_contract_act.status_code == 200
+    assert captured_replacements[-1]["{{act_number}}"] == "2"
+    assert captured_replacements[-1]["{{act_sequence_number}}"] == "2"
+    assert second_one_time_contract_act.json()["base_document_id"] == one_time_contract_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что изменилось
- В шаге 3 создания акта поле адреса объекта получило Яндекс-подсказки через существующий `ManagerSettingsService.suggestAddress`.
- Номер `{{act_number}}` теперь считается по фактически выбранному основанию: `base_document_id` или `base_customer_contract_id`.
- Два акта к одному и тому же договору/основанию получают последовательные номера 1, 2, ...
- Добавлен integration-тест на два акта к одному разовому договору-документу.

## Проверки
- `python3 -m py_compile services/document_service.py`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -q`
- `cd manager_frontend && npm run build`
- `git diff --check`

## Примечание
Локальный запуск integration через `source .env` по-прежнему печатает шум от двух строк `.env`, но тесты проходят.