### PR TITLE
[codex] Backfill product logistics template from order lines

### DIFF
--- a/services/order_service.py
+++ b/services/order_service.py
@@ -149,6 +149,55 @@ class OrderService:
         return out or None
 
     @staticmethod
+    def _order_logistics_to_product_template(raw_components: Any) -> List[Dict[str, Any]]:
+        components = OrderService._serialize_order_logistics_components(raw_components)
+        if not components:
+            return []
+
+        out: List[Dict[str, Any]] = []
+        for item in components:
+            quantity_per_parent = int(item.get("quantity_per_parent") or 1)
+            try:
+                price_weight = float(item.get("unit_price") or 0) * quantity_per_parent
+            except (TypeError, ValueError):
+                price_weight = 0.0
+            out.append(
+                {
+                    "title": item["title"],
+                    "country": item.get("country"),
+                    "unit": item.get("unit") or "шт.",
+                    "quantity_per_parent": quantity_per_parent,
+                    "price_weight": price_weight if price_weight > 0 else 1.0,
+                    "kind": item.get("kind"),
+                }
+            )
+        return out
+
+    @staticmethod
+    async def _backfill_product_logistics_template(
+        session: AsyncSession,
+        product_id: Optional[int],
+        raw_components: Any,
+    ) -> None:
+        if not product_id or not raw_components:
+            return
+        template_components = OrderService._order_logistics_to_product_template(raw_components)
+        if not template_components:
+            return
+
+        product = await session.get(Product, product_id)
+        if not product:
+            return
+        if OrderService._serialize_product_logistics_components(product):
+            return
+
+        specs = dict(product.specs or {})
+        specs["logistics_components"] = template_components
+        product.specs = specs
+        flag_modified(product, "specs")
+        session.add(product)
+
+    @staticmethod
     def _clean_order_title(raw: Any) -> Optional[str]:
         title = " ".join(str(raw or "").split())
         return title or None
@@ -1274,15 +1323,21 @@ class OrderService:
         
         # 2. Добавляем товары
         for p in items_data.get("products", []):
+            logistics_components = OrderService._serialize_order_logistics_components(
+                p.get("logistics_components")
+            )
+            await OrderService._backfill_product_logistics_template(
+                session,
+                p.get("product_id"),
+                logistics_components,
+            )
             link = OrderProductLink(
                 order_id=order_id,
                 proposal_id=proposal.id,
                 product_id=p["product_id"],
                 quantity=p["quantity"],
                 price=p["price"], # Цена должна приходить актуальная
-                logistics_components=OrderService._serialize_order_logistics_components(
-                    p.get("logistics_components")
-                ),
+                logistics_components=logistics_components,
             )
             session.add(link)
         
@@ -1435,15 +1490,21 @@ class OrderService:
         
         # 2. Add products
         for prod in items_data.get("products", []):
+            logistics_components = OrderService._serialize_order_logistics_components(
+                prod.get("logistics_components")
+            )
+            await OrderService._backfill_product_logistics_template(
+                session,
+                int(prod["product_id"]),
+                logistics_components,
+            )
             link = OrderProductLink(
                 order_id=order_id,
                 proposal_id=proposal.id,
                 product_id=int(prod["product_id"]),
                 quantity=int(prod["quantity"]),
                 price=int(prod["price"]),
-                logistics_components=OrderService._serialize_order_logistics_components(
-                    prod.get("logistics_components")
-                ),
+                logistics_components=logistics_components,
             )
             session.add(link)
         
@@ -2529,6 +2590,14 @@ class OrderService:
                         session=session,
                         product_id=product_line.product_id,
                     )
+                    logistics_components = OrderService._serialize_order_logistics_components(
+                        product_line.logistics_components
+                    )
+                    await OrderService._backfill_product_logistics_template(
+                        session,
+                        product_line.product_id,
+                        logistics_components,
+                    )
                     new_product_link = OrderProductLink(
                         order_id=order_id,
                         proposal_id=target_proposal_id,
@@ -2536,9 +2605,7 @@ class OrderService:
                         quantity=product_line.quantity,
                         price=product_line.price,
                         cost=product_line.cost if product_line.cost is not None else defaults["cost"],
-                        logistics_components=OrderService._serialize_order_logistics_components(
-                            product_line.logistics_components
-                        ),
+                        logistics_components=logistics_components,
                     )
                     session.add(new_product_link)
 

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -943,6 +943,89 @@ async def test_manager_order_patch_lines_persists_logistics_components(async_cli
     product_lines = response.json()["product_lines"]
     assert product_lines[0]["logistics_components"] == payload["products"][0]["logistics_components"]
 
+    await db.refresh(product)
+    assert product.specs["logistics_components"] == [
+        {
+            "title": "Внутренний блок TEST-IN",
+            "country": "Китай",
+            "unit": "шт.",
+            "quantity_per_parent": 1,
+            "price_weight": 600.0,
+            "kind": "indoor",
+        },
+        {
+            "title": "Наружный блок TEST-OUT",
+            "country": "Китай",
+            "unit": "шт.",
+            "quantity_per_parent": 1,
+            "price_weight": 1203.0,
+            "kind": "outdoor",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manager_order_patch_lines_does_not_overwrite_product_logistics_template(async_client, db):
+    customer = Customer(name="Logistics Existing", phone="+375296666665", type=CustomerType.individual)
+    existing_template = [
+        {
+            "title": "Заводской внутренний блок",
+            "country": "Китай",
+            "unit": "шт.",
+            "quantity_per_parent": 1,
+            "price_weight": 1.0,
+            "kind": "indoor",
+        }
+    ]
+    product = Product(
+        title="Split Logistics Existing",
+        slug="split-logistics-existing",
+        price=2000,
+        area=30,
+        specs={"logistics_components": existing_template},
+    )
+    db.add(customer)
+    db.add(product)
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(product)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={
+            "products": [
+                {
+                    "product_id": product.id,
+                    "quantity": 1,
+                    "price": 2000,
+                    "cost": 1200,
+                    "logistics_components": [
+                        {
+                            "title": "Ручной блок из заказа",
+                            "country": "Китай",
+                            "unit": "шт.",
+                            "quantity_per_parent": 1,
+                            "unit_price": 2000,
+                            "kind": "outdoor",
+                        }
+                    ],
+                }
+            ],
+            "services": [],
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+    await db.refresh(product)
+    assert product.specs["logistics_components"] == existing_template
+
 
 @pytest.mark.asyncio
 async def test_manager_order_proposals_can_duplicate_edit_and_select(async_client, db):


### PR DESCRIPTION
## Что изменилось
- Если в заказе вручную задан состав товара для накладной, а в карточке товара `specs.logistics_components` пустой, backend сохраняет этот состав в товар как шаблон.
- В товар не сохраняются конкретные цены из заказа: `unit_price` превращается в `price_weight` по формуле `unit_price * quantity_per_parent`.
- Если у товара уже есть состав для накладной, он не перезаписывается.
- Backfill подключен к путям пересохранения товарных строк заказа.

## Проверки
- `python3 -m py_compile services/order_service.py`
- `TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -q`
- `git diff --check`

## Примечание
Локальный запуск integration через `source .env` по-прежнему печатает шум от двух строк `.env`, но тесты проходят.