### PR TITLE
Show grouped order debt totals

### DIFF
--- a/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
@@ -106,6 +106,12 @@ const onGroupClick = () => {
         <div class="mt-2 flex flex-wrap gap-1.5 text-[11px] text-slate-500 dark:text-slate-400">
           <span>Сумма: <strong class="text-slate-800 dark:text-slate-200">{{ formatMoney(group.totalAmount) }}</strong></span>
           <span>Маржа: <strong class="text-teal-700 dark:text-teal-300">{{ formatMoney(group.margin) }}</strong></span>
+          <span>
+            Долг:
+            <strong :class="group.balanceDue > 0 ? 'text-red-600 dark:text-red-300' : 'text-emerald-700 dark:text-emerald-300'">
+              {{ formatMoney(group.balanceDue) }}
+            </strong>
+          </span>
           <span v-if="group.needsAttention" class="font-semibold text-red-600 dark:text-red-300">Нужно внимание</span>
         </div>
       </div>

--- a/manager_frontend/src/components/orders/OrderListRow.vue
+++ b/manager_frontend/src/components/orders/OrderListRow.vue
@@ -81,6 +81,12 @@ const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerNa
     <td class="px-3 py-3">{{ formatDate(order.next_followup_date) }}</td>
     <td class="px-3 py-3">{{ formatMoney(order.total_amount) }}</td>
     <td class="px-3 py-3 font-semibold text-teal-700">{{ formatMoney(order.margin) }}</td>
+    <td
+      class="px-3 py-3 font-semibold"
+      :class="(order.balance_due || 0) > 0 ? 'text-red-600' : 'text-emerald-700'"
+    >
+      {{ formatMoney(order.balance_due || 0) }}
+    </td>
     <td class="px-3 py-3">
       <div class="flex flex-wrap gap-2">
         <button

--- a/manager_frontend/src/components/orders/OrdersListTable.vue
+++ b/manager_frontend/src/components/orders/OrdersListTable.vue
@@ -51,7 +51,7 @@ const isGroupSelected = (item: OrderRenderItem) => {
 
 <template>
   <div class="overflow-x-auto rounded-[2rem] border border-gray-200 bg-white p-3">
-    <table class="w-full min-w-[1020px] text-sm text-gray-700">
+    <table class="w-full min-w-[1120px] text-sm text-gray-700">
       <thead>
         <tr class="text-left text-xs uppercase text-slate-500">
           <th class="w-10 px-3 py-2"></th>
@@ -72,6 +72,7 @@ const isGroupSelected = (item: OrderRenderItem) => {
             Маржа
             <span class="inline-block ml-1 opacity-50 text-teal-600 transition-opacity" :class="sort === 'margin_desc' ? 'opacity-100 font-bold' : 'opacity-0 group-hover:opacity-50'">↓</span>
           </th>
+          <th class="px-3 py-2">Долг</th>
           <th class="px-3 py-2">Действия</th>
         </tr>
       </thead>
@@ -109,6 +110,12 @@ const isGroupSelected = (item: OrderRenderItem) => {
               <td class="px-3 py-3 text-xs text-gray-500">Группа клиента</td>
               <td class="px-3 py-3">{{ formatMoney(item.group.totalAmount) }}</td>
               <td class="px-3 py-3 font-semibold text-teal-700">{{ formatMoney(item.group.margin) }}</td>
+              <td
+                class="px-3 py-3 font-semibold"
+                :class="item.group.balanceDue > 0 ? 'text-red-600' : 'text-emerald-700'"
+              >
+                {{ formatMoney(item.group.balanceDue) }}
+              </td>
               <td class="px-3 py-3">
                 <button class="btn-mini-outline" type="button" @click="toggleGroup(item.group.id)">
                   {{ expandedGroupIds.includes(item.group.id) ? 'Скрыть' : 'Показать' }}
@@ -142,7 +149,7 @@ const isGroupSelected = (item: OrderRenderItem) => {
           />
         </template>
         <tr v-if="!totalOrderCount">
-          <td colspan="8" class="px-3 py-8 text-center text-sm text-gray-500">Заказы не найдены</td>
+          <td colspan="9" class="px-3 py-8 text-center text-sm text-gray-500">Заказы не найдены</td>
         </tr>
       </tbody>
     </table>

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -53,6 +53,7 @@ export type CustomerOrderGroup = {
     orders: ManagerOrderListItemResponse[];
     totalAmount: number;
     margin: number;
+    balanceDue: number;
     statusCounts: Array<{ status: string; count: number }>;
     addresses: string[];
     hiddenAddressCount: number;
@@ -158,6 +159,7 @@ function createCustomerOrderGroup(
         orders,
         totalAmount: orders.reduce((sum, order) => sum + order.total_amount, 0),
         margin: orders.reduce((sum, order) => sum + order.margin, 0),
+        balanceDue: orders.reduce((sum, order) => sum + Number(order.balance_due || 0), 0),
         statusCounts: Array.from(statusCounter.entries()).map(([status, count]) => ({ status, count })),
         addresses: addresses.slice(0, 3),
         hiddenAddressCount: Math.max(addresses.length - 3, 0),


### PR DESCRIPTION
## Summary
- aggregate balance_due for grouped order cards
- show group debt in kanban group headers
- add a debt column to the orders list for groups and single rows

## Checks
- cd manager_frontend && npm run build
- git diff --check

## Next phase
- reconciliation acts can build on the same customer-level debt/payments aggregation, with period selection and generated document output.