### PR TITLE
Improve order kanban workflow actions

### DIFF
--- a/alembic/versions/0abf9e6d4c12_add_bot_fsm_state_table.py
+++ b/alembic/versions/0abf9e6d4c12_add_bot_fsm_state_table.py
@@ -17,33 +17,44 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _table_exists(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _index_names(table_name: str) -> set[str]:
+    if not _table_exists(table_name):
+        return set()
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+
+
+def _create_index_if_missing(index_name: str, table_name: str, columns: list[str]) -> None:
+    if index_name not in _index_names(table_name):
+        op.create_index(index_name, table_name, columns, unique=False)
+
+
 def upgrade() -> None:
-    op.create_table(
-        "bot_fsm_state",
-        sa.Column("storage_key", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("bot_id", sa.Integer(), nullable=False),
-        sa.Column("chat_id", sa.Integer(), nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
-        sa.Column("thread_id", sa.Integer(), nullable=True),
-        sa.Column("business_connection_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column("destiny", sa.String(), nullable=False),
-        sa.Column("state", sa.String(), nullable=True),
-        sa.Column("data", sa.JSON(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), nullable=False),
-        sa.PrimaryKeyConstraint("storage_key"),
-    )
-    op.create_index(op.f("ix_bot_fsm_state_bot_id"), "bot_fsm_state", ["bot_id"], unique=False)
-    op.create_index(op.f("ix_bot_fsm_state_chat_id"), "bot_fsm_state", ["chat_id"], unique=False)
-    op.create_index(op.f("ix_bot_fsm_state_user_id"), "bot_fsm_state", ["user_id"], unique=False)
-    op.create_index(op.f("ix_bot_fsm_state_thread_id"), "bot_fsm_state", ["thread_id"], unique=False)
-    op.create_index(
-        op.f("ix_bot_fsm_state_business_connection_id"),
-        "bot_fsm_state",
-        ["business_connection_id"],
-        unique=False,
-    )
-    op.create_index(op.f("ix_bot_fsm_state_destiny"), "bot_fsm_state", ["destiny"], unique=False)
-    op.create_index(op.f("ix_bot_fsm_state_updated_at"), "bot_fsm_state", ["updated_at"], unique=False)
+    if not _table_exists("bot_fsm_state"):
+        op.create_table(
+            "bot_fsm_state",
+            sa.Column("storage_key", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column("bot_id", sa.Integer(), nullable=False),
+            sa.Column("chat_id", sa.Integer(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("thread_id", sa.Integer(), nullable=True),
+            sa.Column("business_connection_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+            sa.Column("destiny", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=True),
+            sa.Column("data", sa.JSON(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=False),
+            sa.PrimaryKeyConstraint("storage_key"),
+        )
+    _create_index_if_missing(op.f("ix_bot_fsm_state_bot_id"), "bot_fsm_state", ["bot_id"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_chat_id"), "bot_fsm_state", ["chat_id"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_user_id"), "bot_fsm_state", ["user_id"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_thread_id"), "bot_fsm_state", ["thread_id"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_business_connection_id"), "bot_fsm_state", ["business_connection_id"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_destiny"), "bot_fsm_state", ["destiny"])
+    _create_index_if_missing(op.f("ix_bot_fsm_state_updated_at"), "bot_fsm_state", ["updated_at"])
 
 
 def downgrade() -> None:

--- a/alembic/versions/9f2c8d7e6a51_add_order_negotiation_workflow_fields.py
+++ b/alembic/versions/9f2c8d7e6a51_add_order_negotiation_workflow_fields.py
@@ -1,0 +1,80 @@
+"""add_order_negotiation_workflow_fields
+
+Revision ID: 9f2c8d7e6a51
+Revises: 0abf9e6d4c12
+Create Date: 2026-06-25 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "9f2c8d7e6a51"
+down_revision: Union[str, Sequence[str], None] = "0abf9e6d4c12"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    columns = _column_names("order")
+    index_names = {idx["name"] for idx in sa.inspect(op.get_bind()).get_indexes("order")}
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "negotiation_status" not in columns:
+            batch_op.add_column(sa.Column("negotiation_status", sa.String(), nullable=False, server_default="awaiting_offer"))
+        if "negotiation_status_changed_at" not in columns:
+            batch_op.add_column(sa.Column("negotiation_status_changed_at", sa.DateTime(), nullable=True))
+        if "execution_without_payment" not in columns:
+            batch_op.add_column(sa.Column("execution_without_payment", sa.Boolean(), nullable=False, server_default=sa.false()))
+        if "execution_without_payment_reason" not in columns:
+            batch_op.add_column(sa.Column("execution_without_payment_reason", sa.String(), nullable=True))
+        if "status_changed_at" not in columns:
+            batch_op.add_column(sa.Column("status_changed_at", sa.DateTime(), nullable=True))
+
+    columns = _column_names("order")
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "negotiation_status" in columns and "ix_order_negotiation_status" not in index_names:
+            batch_op.create_index("ix_order_negotiation_status", ["negotiation_status"])
+        if "execution_without_payment" in columns and "ix_order_execution_without_payment" not in index_names:
+            batch_op.create_index("ix_order_execution_without_payment", ["execution_without_payment"])
+
+    op.execute(
+        """
+        UPDATE "order"
+        SET
+            status_changed_at = COALESCE(status_changed_at, updated_at, created_at),
+            negotiation_status_changed_at = COALESCE(negotiation_status_changed_at, updated_at, created_at),
+            negotiation_status = CASE
+                WHEN proposal_status = 'sent' THEN 'proposal_sent'
+                WHEN proposal_status = 'approved' AND COALESCE(is_paid, false) = false THEN 'awaiting_payment'
+                WHEN COALESCE(measurement_required, false) = true THEN 'awaiting_visit'
+                ELSE COALESCE(NULLIF(negotiation_status, ''), 'awaiting_offer')
+            END
+        """
+    )
+
+
+def downgrade() -> None:
+    columns = _column_names("order")
+    index_names = {idx["name"] for idx in sa.inspect(op.get_bind()).get_indexes("order")}
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "ix_order_execution_without_payment" in index_names:
+            batch_op.drop_index("ix_order_execution_without_payment")
+        if "ix_order_negotiation_status" in index_names:
+            batch_op.drop_index("ix_order_negotiation_status")
+        if "status_changed_at" in columns:
+            batch_op.drop_column("status_changed_at")
+        if "execution_without_payment_reason" in columns:
+            batch_op.drop_column("execution_without_payment_reason")
+        if "execution_without_payment" in columns:
+            batch_op.drop_column("execution_without_payment")
+        if "negotiation_status_changed_at" in columns:
+            batch_op.drop_column("negotiation_status_changed_at")
+        if "negotiation_status" in columns:
+            batch_op.drop_column("negotiation_status")

--- a/alembic/versions/a0b1c2d3e4f5_add_order_auto_execution_on_payment.py
+++ b/alembic/versions/a0b1c2d3e4f5_add_order_auto_execution_on_payment.py
@@ -1,0 +1,49 @@
+"""add_order_auto_execution_on_payment
+
+Revision ID: a0b1c2d3e4f5
+Revises: 9f2c8d7e6a51
+Create Date: 2026-06-26 14:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a0b1c2d3e4f5"
+down_revision: Union[str, Sequence[str], None] = "9f2c8d7e6a51"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    columns = _column_names("order")
+    index_names = _index_names("order")
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "auto_execution_on_payment" not in columns:
+            batch_op.add_column(
+                sa.Column("auto_execution_on_payment", sa.Boolean(), nullable=False, server_default=sa.false())
+            )
+        if "ix_order_auto_execution_on_payment" not in index_names:
+            batch_op.create_index("ix_order_auto_execution_on_payment", ["auto_execution_on_payment"])
+
+
+def downgrade() -> None:
+    columns = _column_names("order")
+    index_names = _index_names("order")
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "ix_order_auto_execution_on_payment" in index_names:
+            batch_op.drop_index("ix_order_auto_execution_on_payment")
+        if "auto_execution_on_payment" in columns:
+            batch_op.drop_column("auto_execution_on_payment")

--- a/alembic/versions/e4f5a6b7c8d9_extend_customer_equipment_warranty.py
+++ b/alembic/versions/e4f5a6b7c8d9_extend_customer_equipment_warranty.py
@@ -18,72 +18,120 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _table_exists(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    if not _table_exists(table_name):
+        return set()
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    if not _table_exists(table_name):
+        return set()
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+
+
+def _foreign_key_names(table_name: str) -> set[str]:
+    if not _table_exists(table_name):
+        return set()
+    return {fk["name"] for fk in sa.inspect(op.get_bind()).get_foreign_keys(table_name) if fk.get("name")}
+
+
+def _create_index_if_missing(index_name: str, table_name: str, columns: list[str]) -> None:
+    if index_name not in _index_names(table_name):
+        op.create_index(index_name, table_name, columns, unique=False)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
+    equipment_columns = _column_names("customer_equipment")
+    equipment_indexes = _index_names("customer_equipment")
+    equipment_fks = _foreign_key_names("customer_equipment")
     with op.batch_alter_table("customer_equipment", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("catalog_product_id", sa.Integer(), nullable=True))
-        batch_op.add_column(sa.Column("source_order_id", sa.Integer(), nullable=True))
-        batch_op.add_column(sa.Column("equipment_source", sa.String(), nullable=False, server_default="unknown"))
-        batch_op.add_column(sa.Column("installed_at", sa.DateTime(), nullable=True))
-        batch_op.add_column(sa.Column("commissioned_at", sa.DateTime(), nullable=True))
-        batch_op.add_column(sa.Column("warranty_started_at", sa.DateTime(), nullable=True))
-        batch_op.add_column(sa.Column("warranty_expires_at", sa.DateTime(), nullable=True))
-        batch_op.add_column(sa.Column("warranty_terms", sa.Text(), nullable=True))
-        batch_op.create_foreign_key(
-            "fk_customer_equipment_catalog_product_id_product",
-            "product",
-            ["catalog_product_id"],
-            ["id"],
-        )
-        batch_op.create_foreign_key(
-            "fk_customer_equipment_source_order_id_order",
-            "order",
-            ["source_order_id"],
-            ["id"],
-        )
-        batch_op.create_index(batch_op.f("ix_customer_equipment_catalog_product_id"), ["catalog_product_id"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_source_order_id"), ["source_order_id"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_equipment_source"), ["equipment_source"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_installed_at"), ["installed_at"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_commissioned_at"), ["commissioned_at"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_warranty_started_at"), ["warranty_started_at"], unique=False)
-        batch_op.create_index(batch_op.f("ix_customer_equipment_warranty_expires_at"), ["warranty_expires_at"], unique=False)
+        if "catalog_product_id" not in equipment_columns:
+            batch_op.add_column(sa.Column("catalog_product_id", sa.Integer(), nullable=True))
+        if "source_order_id" not in equipment_columns:
+            batch_op.add_column(sa.Column("source_order_id", sa.Integer(), nullable=True))
+        if "equipment_source" not in equipment_columns:
+            batch_op.add_column(sa.Column("equipment_source", sa.String(), nullable=False, server_default="unknown"))
+        if "installed_at" not in equipment_columns:
+            batch_op.add_column(sa.Column("installed_at", sa.DateTime(), nullable=True))
+        if "commissioned_at" not in equipment_columns:
+            batch_op.add_column(sa.Column("commissioned_at", sa.DateTime(), nullable=True))
+        if "warranty_started_at" not in equipment_columns:
+            batch_op.add_column(sa.Column("warranty_started_at", sa.DateTime(), nullable=True))
+        if "warranty_expires_at" not in equipment_columns:
+            batch_op.add_column(sa.Column("warranty_expires_at", sa.DateTime(), nullable=True))
+        if "warranty_terms" not in equipment_columns:
+            batch_op.add_column(sa.Column("warranty_terms", sa.Text(), nullable=True))
+        if "fk_customer_equipment_catalog_product_id_product" not in equipment_fks:
+            batch_op.create_foreign_key(
+                "fk_customer_equipment_catalog_product_id_product",
+                "product",
+                ["catalog_product_id"],
+                ["id"],
+            )
+        if "fk_customer_equipment_source_order_id_order" not in equipment_fks:
+            batch_op.create_foreign_key(
+                "fk_customer_equipment_source_order_id_order",
+                "order",
+                ["source_order_id"],
+                ["id"],
+            )
+        if "ix_customer_equipment_catalog_product_id" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_catalog_product_id"), ["catalog_product_id"], unique=False)
+        if "ix_customer_equipment_source_order_id" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_source_order_id"), ["source_order_id"], unique=False)
+        if "ix_customer_equipment_equipment_source" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_equipment_source"), ["equipment_source"], unique=False)
+        if "ix_customer_equipment_installed_at" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_installed_at"), ["installed_at"], unique=False)
+        if "ix_customer_equipment_commissioned_at" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_commissioned_at"), ["commissioned_at"], unique=False)
+        if "ix_customer_equipment_warranty_started_at" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_warranty_started_at"), ["warranty_started_at"], unique=False)
+        if "ix_customer_equipment_warranty_expires_at" not in equipment_indexes:
+            batch_op.create_index(batch_op.f("ix_customer_equipment_warranty_expires_at"), ["warranty_expires_at"], unique=False)
 
-    op.create_table(
-        "equipment_component",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("equipment_id", sa.Integer(), nullable=False),
-        sa.Column("catalog_product_id", sa.Integer(), nullable=True),
-        sa.Column("supplier_id", sa.Integer(), nullable=True),
-        sa.Column("component_type", sa.String(), nullable=False),
-        sa.Column("title", sa.String(), nullable=True),
-        sa.Column("brand", sa.String(), nullable=True),
-        sa.Column("model", sa.String(), nullable=True),
-        sa.Column("serial", sa.String(), nullable=True),
-        sa.Column("inventory_number", sa.String(), nullable=True),
-        sa.Column("supplier_invoice_number", sa.String(), nullable=True),
-        sa.Column("supplier_invoice_date", sa.DateTime(), nullable=True),
-        sa.Column("notes", sa.Text(), nullable=True),
-        sa.Column("is_archived", sa.Boolean(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(["catalog_product_id"], ["product.id"]),
-        sa.ForeignKeyConstraint(["equipment_id"], ["customer_equipment.id"]),
-        sa.ForeignKeyConstraint(["supplier_id"], ["supplier.id"]),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(op.f("ix_equipment_component_catalog_product_id"), "equipment_component", ["catalog_product_id"], unique=False)
-    op.create_index(op.f("ix_equipment_component_component_type"), "equipment_component", ["component_type"], unique=False)
-    op.create_index(op.f("ix_equipment_component_equipment_id"), "equipment_component", ["equipment_id"], unique=False)
-    op.create_index(op.f("ix_equipment_component_inventory_number"), "equipment_component", ["inventory_number"], unique=False)
-    op.create_index(op.f("ix_equipment_component_is_archived"), "equipment_component", ["is_archived"], unique=False)
-    op.create_index(op.f("ix_equipment_component_model"), "equipment_component", ["model"], unique=False)
-    op.create_index(op.f("ix_equipment_component_serial"), "equipment_component", ["serial"], unique=False)
-    op.create_index(op.f("ix_equipment_component_supplier_id"), "equipment_component", ["supplier_id"], unique=False)
-    op.create_index(op.f("ix_equipment_component_supplier_invoice_date"), "equipment_component", ["supplier_invoice_date"], unique=False)
-    op.create_index(op.f("ix_equipment_component_supplier_invoice_number"), "equipment_component", ["supplier_invoice_number"], unique=False)
-    op.create_index(op.f("ix_equipment_component_title"), "equipment_component", ["title"], unique=False)
-    op.create_index(op.f("ix_equipment_component_brand"), "equipment_component", ["brand"], unique=False)
+    if not _table_exists("equipment_component"):
+        op.create_table(
+            "equipment_component",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("equipment_id", sa.Integer(), nullable=False),
+            sa.Column("catalog_product_id", sa.Integer(), nullable=True),
+            sa.Column("supplier_id", sa.Integer(), nullable=True),
+            sa.Column("component_type", sa.String(), nullable=False),
+            sa.Column("title", sa.String(), nullable=True),
+            sa.Column("brand", sa.String(), nullable=True),
+            sa.Column("model", sa.String(), nullable=True),
+            sa.Column("serial", sa.String(), nullable=True),
+            sa.Column("inventory_number", sa.String(), nullable=True),
+            sa.Column("supplier_invoice_number", sa.String(), nullable=True),
+            sa.Column("supplier_invoice_date", sa.DateTime(), nullable=True),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("is_archived", sa.Boolean(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["catalog_product_id"], ["product.id"]),
+            sa.ForeignKeyConstraint(["equipment_id"], ["customer_equipment.id"]),
+            sa.ForeignKeyConstraint(["supplier_id"], ["supplier.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_if_missing(op.f("ix_equipment_component_catalog_product_id"), "equipment_component", ["catalog_product_id"])
+    _create_index_if_missing(op.f("ix_equipment_component_component_type"), "equipment_component", ["component_type"])
+    _create_index_if_missing(op.f("ix_equipment_component_equipment_id"), "equipment_component", ["equipment_id"])
+    _create_index_if_missing(op.f("ix_equipment_component_inventory_number"), "equipment_component", ["inventory_number"])
+    _create_index_if_missing(op.f("ix_equipment_component_is_archived"), "equipment_component", ["is_archived"])
+    _create_index_if_missing(op.f("ix_equipment_component_model"), "equipment_component", ["model"])
+    _create_index_if_missing(op.f("ix_equipment_component_serial"), "equipment_component", ["serial"])
+    _create_index_if_missing(op.f("ix_equipment_component_supplier_id"), "equipment_component", ["supplier_id"])
+    _create_index_if_missing(op.f("ix_equipment_component_supplier_invoice_date"), "equipment_component", ["supplier_invoice_date"])
+    _create_index_if_missing(op.f("ix_equipment_component_supplier_invoice_number"), "equipment_component", ["supplier_invoice_number"])
+    _create_index_if_missing(op.f("ix_equipment_component_title"), "equipment_component", ["title"])
+    _create_index_if_missing(op.f("ix_equipment_component_brand"), "equipment_component", ["brand"])
 
 
 def downgrade() -> None:

--- a/alembic/versions/f5a6b7c8d9e0_add_order_document_scope.py
+++ b/alembic/versions/f5a6b7c8d9e0_add_order_document_scope.py
@@ -17,23 +17,43 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _column_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+
+
+def _foreign_key_names(table_name: str) -> set[str]:
+    return {fk["name"] for fk in sa.inspect(op.get_bind()).get_foreign_keys(table_name) if fk.get("name")}
+
+
 def upgrade() -> None:
-    op.add_column("order_document", sa.Column("scope_customer_branch_id", sa.Integer(), nullable=True))
-    op.add_column("order_document", sa.Column("scope_title", sa.String(), nullable=True))
-    op.add_column("order_document", sa.Column("scope_address", sa.String(), nullable=True))
-    op.add_column("order_document", sa.Column("scope_meta", sa.JSON(), nullable=True))
-    op.create_index(
-        "ix_order_document_scope_customer_branch_id",
-        "order_document",
-        ["scope_customer_branch_id"],
-    )
-    op.create_foreign_key(
-        "fk_order_document_scope_customer_branch_id",
-        "order_document",
-        "customer_branches",
-        ["scope_customer_branch_id"],
-        ["id"],
-    )
+    columns = _column_names("order_document")
+    if "scope_customer_branch_id" not in columns:
+        op.add_column("order_document", sa.Column("scope_customer_branch_id", sa.Integer(), nullable=True))
+    if "scope_title" not in columns:
+        op.add_column("order_document", sa.Column("scope_title", sa.String(), nullable=True))
+    if "scope_address" not in columns:
+        op.add_column("order_document", sa.Column("scope_address", sa.String(), nullable=True))
+    if "scope_meta" not in columns:
+        op.add_column("order_document", sa.Column("scope_meta", sa.JSON(), nullable=True))
+    if "ix_order_document_scope_customer_branch_id" not in _index_names("order_document"):
+        op.create_index(
+            "ix_order_document_scope_customer_branch_id",
+            "order_document",
+            ["scope_customer_branch_id"],
+        )
+    if "fk_order_document_scope_customer_branch_id" not in _foreign_key_names("order_document"):
+        op.create_foreign_key(
+            "fk_order_document_scope_customer_branch_id",
+            "order_document",
+            "customer_branches",
+            ["scope_customer_branch_id"],
+            ["id"],
+        )
 
 
 def downgrade() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - .env
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db/${POSTGRES_DB:-air_conditioners}
+      SCHEDULER_ENABLED: "false"
     ports:
       - "8000:8000"
     volumes:
@@ -75,4 +76,3 @@ services:
 volumes:
   postgres_data:
   postgres_data_test:
-

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -101,7 +101,7 @@ import type { LeadsInboxItemResponse } from './client/models/LeadsInboxItemRespo
 
 OpenAPI.WITH_CREDENTIALS = true;
 
-export type Segment = 'b2c' | 'b2b';
+export type Segment = 'all' | 'b2c' | 'b2b';
 export type DashboardView = 'kanban' | 'list';
 export { type Product, type DashboardStatsResponse, type DashboardTouchpoint };
 export type { ProductCreate, ProductDuplicatePayload, ProductUpdate };

--- a/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
@@ -23,6 +23,7 @@ export type ManagerOrderDetailResponse = {
     manager_labels?: Array<string>;
     created_at: string;
     updated_at?: (string | null);
+    status_changed_at?: (string | null);
     next_followup_date?: (string | null);
     measurement_date?: (string | null);
     installation_date?: (string | null);
@@ -55,6 +56,11 @@ export type ManagerOrderDetailResponse = {
     measurement_result?: (string | null);
     proposal_status?: string;
     proposal_sent_at?: (string | null);
+    negotiation_status?: string;
+    negotiation_status_changed_at?: (string | null);
+    execution_without_payment?: boolean;
+    execution_without_payment_reason?: (string | null);
+    auto_execution_on_payment?: boolean;
     total_payments?: number;
     balance_due?: number;
     product_lines?: Array<OrderProductLineResponse>;

--- a/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
@@ -17,6 +17,7 @@ export type ManagerOrderListItemResponse = {
     manager_labels?: Array<string>;
     created_at: string;
     updated_at?: (string | null);
+    status_changed_at?: (string | null);
     next_followup_date?: (string | null);
     measurement_date?: (string | null);
     installation_date?: (string | null);
@@ -49,6 +50,11 @@ export type ManagerOrderListItemResponse = {
     measurement_result?: (string | null);
     proposal_status?: string;
     proposal_sent_at?: (string | null);
+    negotiation_status?: string;
+    negotiation_status_changed_at?: (string | null);
+    execution_without_payment?: boolean;
+    execution_without_payment_reason?: (string | null);
+    auto_execution_on_payment?: boolean;
     total_payments?: number;
     balance_due?: number;
     readonly needs_attention: boolean;

--- a/manager_frontend/src/client/models/ManagerOrderTransferOrder_Input.ts
+++ b/manager_frontend/src/client/models/ManagerOrderTransferOrder_Input.ts
@@ -32,6 +32,11 @@ export type ManagerOrderTransferOrder_Input = {
     measurement_result?: (string | null);
     proposal_status?: string;
     proposal_sent_at?: (string | null);
+    negotiation_status?: string;
+    negotiation_status_changed_at?: (string | null);
+    execution_without_payment?: boolean;
+    execution_without_payment_reason?: (string | null);
+    auto_execution_on_payment?: boolean;
     equipment_status?: string;
     standard_install_kit_issued?: boolean;
     target_currency?: (PaymentCurrency | null);

--- a/manager_frontend/src/client/models/ManagerOrderTransferOrder_Output.ts
+++ b/manager_frontend/src/client/models/ManagerOrderTransferOrder_Output.ts
@@ -32,6 +32,11 @@ export type ManagerOrderTransferOrder_Output = {
     measurement_result?: (string | null);
     proposal_status?: string;
     proposal_sent_at?: (string | null);
+    negotiation_status?: string;
+    negotiation_status_changed_at?: (string | null);
+    execution_without_payment?: boolean;
+    execution_without_payment_reason?: (string | null);
+    auto_execution_on_payment?: boolean;
     equipment_status?: string;
     standard_install_kit_issued?: boolean;
     target_currency?: (PaymentCurrency | null);

--- a/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
@@ -22,6 +22,10 @@ export type ManagerOrderUpdatePayload = {
     additional_conditions?: (string | null);
     proposal_status?: (string | null);
     proposal_sent_at?: (string | null);
+    negotiation_status?: (string | null);
+    execution_without_payment?: (boolean | null);
+    execution_without_payment_reason?: (string | null);
+    auto_execution_on_payment?: (boolean | null);
     is_paid?: (boolean | null);
     closing_result?: (string | null);
     reject_reason?: (string | null);

--- a/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
+++ b/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { MoreVertical, XCircle } from 'lucide-vue-next';
+import type { ManagerOrderListItemResponse } from '../../client';
+import {
+  NEGOTIATION_STATUS_OPTIONS,
+  formatMoney,
+  getOrderBoardColumn,
+  getOrderNegotiationStatus,
+} from './order-utils';
+
+const props = defineProps<{
+  order: ManagerOrderListItemResponse;
+  allowCloseDebt?: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancelOrder: [payload: { orderId: number }];
+  quickStatus: [payload: { orderId: number; status: string }];
+  closeDebt: [payload: { orderId: number }];
+}>();
+
+const menuOpen = ref(false);
+const balanceDue = computed(() => Number(props.order.balance_due || 0));
+const activeBoardColumn = computed(() => getOrderBoardColumn(props.order));
+const activeNegotiationStatus = computed(() => getOrderNegotiationStatus(props.order));
+
+const boardActions = computed(() => [
+  activeBoardColumn.value !== 'negotiation'
+    ? { value: 'negotiation', label: 'Вернуть в переговоры', icon: 'forum' }
+    : null,
+  activeBoardColumn.value !== 'execution'
+    ? { value: 'execution', label: 'Перенести в работы', icon: 'construction' }
+    : null,
+  activeBoardColumn.value !== 'closed_won'
+    ? { value: 'closed_won', label: 'Завершить успешно', icon: 'check_circle' }
+    : null,
+].filter(Boolean) as Array<{ value: string; label: string; icon: string }>);
+
+const selectStatus = (status: string) => {
+  menuOpen.value = false;
+  emit('quickStatus', { orderId: props.order.id, status });
+};
+
+const cancelOrder = () => {
+  menuOpen.value = false;
+  emit('cancelOrder', { orderId: props.order.id });
+};
+
+const closeDebt = () => {
+  menuOpen.value = false;
+  emit('closeDebt', { orderId: props.order.id });
+};
+</script>
+
+<template>
+  <div class="relative">
+    <button
+      type="button"
+      class="rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
+      aria-label="Действия с заказом"
+      @click.stop="menuOpen = !menuOpen"
+    >
+      <MoreVertical class="h-4 w-4" />
+    </button>
+
+    <div
+      v-if="menuOpen"
+      class="absolute right-0 top-7 z-30 w-64 rounded-xl border border-gray-200 bg-white p-1.5 text-xs shadow-xl dark:border-slate-700 dark:bg-slate-800"
+      @click.stop
+    >
+      <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">Быстрая смена</div>
+      <button
+        v-for="action in boardActions"
+        :key="action.value"
+        type="button"
+        class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
+        @click="selectStatus(action.value)"
+      >
+        <span class="material-icons-round text-[16px]">{{ action.icon }}</span>
+        {{ action.label }}
+      </button>
+
+      <div class="my-1 border-t border-slate-100 dark:border-slate-700" />
+      <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">Переговоры</div>
+      <button
+        v-for="option in NEGOTIATION_STATUS_OPTIONS"
+        :key="option.value"
+        type="button"
+        class="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
+        :class="activeNegotiationStatus === option.value && activeBoardColumn === 'negotiation' ? 'bg-slate-50 dark:bg-slate-700' : ''"
+        @click="selectStatus(option.value)"
+      >
+        <span class="inline-flex min-w-0 items-center gap-2">
+          <span class="material-icons-round text-[16px]">{{ option.icon }}</span>
+          <span class="truncate">{{ option.label }}</span>
+        </span>
+        <span v-if="activeNegotiationStatus === option.value && activeBoardColumn === 'negotiation'" class="material-icons-round text-[15px] text-teal-600">check</span>
+      </button>
+
+      <template v-if="allowCloseDebt && balanceDue > 0">
+        <div class="my-1 border-t border-slate-100 dark:border-slate-700" />
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left font-semibold text-emerald-700 hover:bg-emerald-50 dark:text-emerald-300 dark:hover:bg-emerald-500/10"
+          @click="closeDebt"
+        >
+          <span class="material-icons-round text-[16px]">payments</span>
+          Закрыть долг {{ formatMoney(balanceDue) }}
+        </button>
+      </template>
+
+      <div class="my-1 border-t border-slate-100 dark:border-slate-700" />
+      <button
+        type="button"
+        class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left font-semibold text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-500/10"
+        @click="cancelOrder"
+      >
+        <XCircle class="h-4 w-4" />
+        Пометить отказом
+      </button>
+    </div>
+  </div>
+</template>

--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -2,7 +2,8 @@
 import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
-import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
+import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
+import OrderCardActionsMenu from './OrderCardActionsMenu.vue';
 import OrderTitleEditor from './OrderTitleEditor.vue';
 
 const props = defineProps<{
@@ -14,6 +15,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
+  cancelOrder: [payload: { orderId: number }];
+  quickStatus: [payload: { orderId: number; status: string }];
+  closeDebt: [payload: { orderId: number }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   toggleExpanded: [orderId: number];
   renameOrder: [payload: { orderId: number; title: string | null }];
@@ -23,7 +27,7 @@ const isDragging = ref(false);
 
 const onDragStart = () => {
   isDragging.value = true;
-  emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
+  emit('dragStart', { orderId: props.order.id, oldStatus: getOrderBoardColumn(props.order) });
 };
 
 const onDragEnd = () => {
@@ -47,6 +51,24 @@ const objectLine = computed(() => {
 });
 const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
 const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
+const boardColumn = computed(() => getOrderBoardColumn(props.order));
+const badgeColumn = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationStatus(props.order) : boardColumn.value));
+const boardLabel = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationLabel(props.order) : getOrderBoardLabel(props.order)));
+const fallbackBoardTone = {
+  column: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800',
+  badge: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
+  text: 'text-slate-700 dark:text-slate-200',
+};
+const boardTone = computed(() => BOARD_COLUMN_TONE_CLASSES[badgeColumn.value] ?? fallbackBoardTone);
+const boardBadgeClass = computed(() => boardTone.value.badge);
+const boardTextClass = computed(() => boardTone.value.text);
+const cardAccentClass = computed(() => BOARD_CARD_ACCENT_CLASSES[badgeColumn.value] || BOARD_CARD_ACCENT_CLASSES.negotiation);
+const statusAge = computed(() => {
+  const sourceDate = props.order.status === 'negotiation'
+    ? props.order.negotiation_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
+    : props.order.status_changed_at || props.order.updated_at || props.order.created_at;
+  return formatRelativeAge(sourceDate);
+});
 const dateSummary = computed(() => {
   if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
   if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
@@ -57,8 +79,8 @@ const dateSummary = computed(() => {
 const statusFlags = computed(() => [
   props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
   props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
-  props.order.client_thinking ? { label: 'Думают', className: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300' } : null,
-  props.order.ready_for_execution ? { label: 'Согласовано', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
+  props.order.auto_execution_on_payment ? { label: 'Авто после оплаты', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' } : null,
+  props.order.execution_without_payment ? { label: 'Без оплаты', className: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300' } : null,
 ].filter(Boolean) as { label: string; className: string }[]);
 const hasComment = computed(() => Boolean(props.order.comment?.trim()));
 const paymentSummary = computed(() => {
@@ -75,9 +97,9 @@ const paymentSummary = computed(() => {
 
 <template>
   <article
-    class="group cursor-pointer rounded-2xl border bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:bg-slate-800"
+    class="group cursor-pointer rounded-2xl border p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
     :class="[
-      expanded ? 'border-teal-300 ring-2 ring-teal-500/20 dark:border-teal-500' : 'border-gray-200 dark:border-slate-700',
+      expanded ? 'border-teal-300 bg-white ring-2 ring-teal-500/20 dark:border-teal-500 dark:bg-slate-800' : cardAccentClass,
       isOverdue(order) ? 'ring-2 ring-red-500/60' : '',
     ]"
     :draggable="!draggableDisabled"
@@ -96,19 +118,26 @@ const paymentSummary = computed(() => {
             text-class="text-sm"
             @rename="(payload) => emit('renameOrder', payload)"
           />
-          <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+          <span class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="boardBadgeClass">{{ boardLabel }}</span>
         </div>
         <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>
       </div>
-      <button
-        type="button"
-        class="shrink-0 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
-        :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
-        @click.stop="emit('toggleExpanded', order.id)"
-      >
-        <ChevronUp v-if="expanded" class="h-4 w-4" />
-        <ChevronDown v-else class="h-4 w-4" />
-      </button>
+      <div class="relative flex shrink-0 items-center gap-1">
+        <OrderCardActionsMenu
+          :order="order"
+          @cancel-order="(payload) => emit('cancelOrder', payload)"
+          @quick-status="(payload) => emit('quickStatus', payload)"
+        />
+        <button
+          type="button"
+          class="rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
+          :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
+          @click.stop="emit('toggleExpanded', order.id)"
+        >
+          <ChevronUp v-if="expanded" class="h-4 w-4" />
+          <ChevronDown v-else class="h-4 w-4" />
+        </button>
+      </div>
     </header>
 
     <div v-if="compactLabels.length || hiddenLabelsCount" class="mt-2 flex flex-wrap gap-1">
@@ -131,6 +160,7 @@ const paymentSummary = computed(() => {
       >
         {{ flag.label }}
       </span>
+      <span class="text-[11px] font-medium" :class="boardTextClass">В статусе: {{ statusAge }}</span>
       <span v-if="dateSummary" class="text-[11px] font-medium" :class="dateSummary.className">{{ dateSummary.label }}: {{ dateSummary.value }}</span>
       <span class="text-[11px] font-semibold" :class="paymentSummary.className">{{ paymentSummary.label }}</span>
     </div>

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -2,7 +2,8 @@
 import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
-import { STATUS_LABELS, formatDate, formatMoney, formatPhone, isOverdue } from './order-utils';
+import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
+import OrderCardActionsMenu from './OrderCardActionsMenu.vue';
 import OrderTitleEditor from './OrderTitleEditor.vue';
 
 const props = defineProps<{
@@ -14,6 +15,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
+  cancelOrder: [payload: { orderId: number }];
+  quickStatus: [payload: { orderId: number; status: string }];
+  closeDebt: [payload: { orderId: number }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   toggleExpanded: [orderId: number];
   renameOrder: [payload: { orderId: number; title: string | null }];
@@ -23,7 +27,7 @@ const isDragging = ref(false);
 
 const onDragStart = () => {
   isDragging.value = true;
-  emit('dragStart', { orderId: props.order.id, oldStatus: props.order.status });
+  emit('dragStart', { orderId: props.order.id, oldStatus: getOrderBoardColumn(props.order) });
 };
 
 const onDragEnd = () => {
@@ -47,6 +51,24 @@ const objectLine = computed(() => {
 });
 const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
 const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
+const boardColumn = computed(() => getOrderBoardColumn(props.order));
+const badgeColumn = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationStatus(props.order) : boardColumn.value));
+const boardLabel = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationLabel(props.order) : getOrderBoardLabel(props.order)));
+const fallbackBoardTone = {
+  column: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800',
+  badge: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
+  text: 'text-slate-700 dark:text-slate-200',
+};
+const boardTone = computed(() => BOARD_COLUMN_TONE_CLASSES[badgeColumn.value] ?? fallbackBoardTone);
+const boardBadgeClass = computed(() => boardTone.value.badge);
+const boardTextClass = computed(() => boardTone.value.text);
+const cardAccentClass = computed(() => BOARD_CARD_ACCENT_CLASSES[badgeColumn.value] || BOARD_CARD_ACCENT_CLASSES.negotiation);
+const statusAge = computed(() => {
+  const sourceDate = props.order.status === 'negotiation'
+    ? props.order.negotiation_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
+    : props.order.status_changed_at || props.order.updated_at || props.order.created_at;
+  return formatRelativeAge(sourceDate);
+});
 const dateSummary = computed(() => {
   if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
   if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
@@ -57,8 +79,8 @@ const dateSummary = computed(() => {
 const statusFlags = computed(() => [
   props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
   props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
-  props.order.client_thinking ? { label: 'Думают', className: 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300' } : null,
-  props.order.ready_for_execution ? { label: 'Согласовано', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
+  props.order.auto_execution_on_payment ? { label: 'Авто после оплаты', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' } : null,
+  props.order.execution_without_payment ? { label: 'Без оплаты', className: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300' } : null,
 ].filter(Boolean) as { label: string; className: string }[]);
 const hasComment = computed(() => Boolean(props.order.comment?.trim()));
 const paymentSummary = computed(() => {
@@ -75,9 +97,9 @@ const paymentSummary = computed(() => {
 
 <template>
   <article
-    class="group cursor-pointer rounded-2xl border bg-white p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:bg-slate-800"
+    class="group cursor-pointer rounded-2xl border p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
     :class="[
-      expanded ? 'border-teal-300 ring-2 ring-teal-500/20 dark:border-teal-500' : 'border-gray-200 dark:border-slate-700',
+      expanded ? 'border-teal-300 bg-white ring-2 ring-teal-500/20 dark:border-teal-500 dark:bg-slate-800' : cardAccentClass,
       isOverdue(order) ? 'ring-2 ring-red-500/60' : '',
     ]"
     :draggable="!draggableDisabled"
@@ -96,19 +118,28 @@ const paymentSummary = computed(() => {
             text-class="text-sm"
             @rename="(payload) => emit('renameOrder', payload)"
           />
-          <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700 dark:bg-slate-700 dark:text-slate-300">{{ STATUS_LABELS[order.status] || order.status }}</span>
+          <span class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold" :class="boardBadgeClass">{{ boardLabel }}</span>
         </div>
         <p v-if="objectLine" class="mt-1 truncate text-xs text-gray-500 dark:text-slate-400">{{ objectLine }}</p>
       </div>
-      <button
-        type="button"
-        class="shrink-0 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
-        :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
-        @click.stop="emit('toggleExpanded', order.id)"
-      >
-        <ChevronUp v-if="expanded" class="h-4 w-4" />
-        <ChevronDown v-else class="h-4 w-4" />
-      </button>
+      <div class="relative flex shrink-0 items-center gap-1">
+        <OrderCardActionsMenu
+          :order="order"
+          allow-close-debt
+          @cancel-order="(payload) => emit('cancelOrder', payload)"
+          @quick-status="(payload) => emit('quickStatus', payload)"
+          @close-debt="(payload) => emit('closeDebt', payload)"
+        />
+        <button
+          type="button"
+          class="rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-slate-700 dark:hover:text-white"
+          :aria-label="expanded ? 'Свернуть заказ' : 'Раскрыть заказ'"
+          @click.stop="emit('toggleExpanded', order.id)"
+        >
+          <ChevronUp v-if="expanded" class="h-4 w-4" />
+          <ChevronDown v-else class="h-4 w-4" />
+        </button>
+      </div>
     </header>
 
     <div v-if="compactLabels.length || hiddenLabelsCount" class="mt-2 flex flex-wrap gap-1">
@@ -131,6 +162,7 @@ const paymentSummary = computed(() => {
       >
         {{ flag.label }}
       </span>
+      <span class="text-[11px] font-medium" :class="boardTextClass">В статусе: {{ statusAge }}</span>
       <span v-if="dateSummary" class="text-[11px] font-medium" :class="dateSummary.className">{{ dateSummary.label }}: {{ dateSummary.value }}</span>
       <span class="text-[11px] font-semibold" :class="paymentSummary.className">{{ paymentSummary.label }}</span>
     </div>

--- a/manager_frontend/src/components/orders/OrderColumn.vue
+++ b/manager_frontend/src/components/orders/OrderColumn.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Check, ChevronDown } from 'lucide-vue-next';
 import type { Segment } from '../../api';
+import type { ManagerOrderListItemResponse } from '../../client';
 import type { OrderRenderItem } from './order-utils';
 import OrderCardB2B from './OrderCardB2B.vue';
 import OrderCardB2C from './OrderCardB2C.vue';
 import OrderCustomerGroupCard from './OrderCustomerGroupCard.vue';
+import { BOARD_COLUMN_TONE_CLASSES, createCustomerOrderGroup, getOrderNegotiationStatus, getOrderSegment } from './order-utils';
 
 const props = defineProps<{
   status: string;
   label: string;
+  icon?: string;
+  filterKind?: 'negotiation';
+  filterOptions?: ReadonlyArray<{ value: string; label: string; icon?: string }>;
   items: OrderRenderItem[];
   segment: Segment;
   movingOrderIds: number[];
@@ -18,6 +25,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
+  cancelOrder: [payload: { orderId: number }];
+  quickStatus: [payload: { orderId: number; status: string }];
+  closeDebt: [payload: { orderId: number }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   dropTo: [status: string];
   toggleExpanded: [orderId: number];
@@ -26,27 +36,137 @@ const emit = defineEmits<{
   renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
 
-const orderCount = () => props.items.reduce((total, item) => total + (item.type === 'group' ? item.group.orders.length : 1), 0);
+const activeFilter = ref('');
+const filterOpen = ref(false);
+
+const getFilterValue = (order: ManagerOrderListItemResponse) => {
+  if (props.filterKind === 'negotiation') return getOrderNegotiationStatus(order);
+  return '';
+};
+
+const allOrderCount = computed(() => props.items.reduce((total, item) => total + (item.type === 'group' ? item.group.orders.length : 1), 0));
+
+const filterCounts = computed(() => {
+  const counts: Record<string, number> = {};
+  for (const option of props.filterOptions || []) counts[option.value] = 0;
+  for (const item of props.items) {
+    const orders = item.type === 'group' ? item.group.orders : [item.order];
+    for (const order of orders) {
+      const value = getFilterValue(order);
+      if (value) counts[value] = (counts[value] || 0) + 1;
+    }
+  }
+  return counts;
+});
+
+const visibleItems = computed<OrderRenderItem[]>(() => {
+  if (!activeFilter.value || !props.filterKind) return props.items;
+  const nextItems: OrderRenderItem[] = [];
+  for (const item of props.items) {
+    if (item.type === 'order') {
+      if (getFilterValue(item.order) === activeFilter.value) nextItems.push(item);
+      continue;
+    }
+    const filteredOrders = item.group.orders.filter((order) => getFilterValue(order) === activeFilter.value);
+    if (filteredOrders.length) {
+      const alias = item.group.customerName !== item.group.originalCustomerName ? item.group.customerName : undefined;
+      nextItems.push({
+        type: 'group',
+        group: createCustomerOrderGroup(item.group.customerId, filteredOrders, props.segment, alias),
+      });
+    }
+  }
+  return nextItems;
+});
+
+const visibleOrderCount = computed(() => visibleItems.value.reduce((total, item) => total + (item.type === 'group' ? item.group.orders.length : 1), 0));
+const activeFilterLabel = computed(() => props.filterOptions?.find((option) => option.value === activeFilter.value)?.label || 'Все');
+
+const setFilter = (value: string) => {
+  activeFilter.value = value;
+  filterOpen.value = false;
+};
 
 const onDrop = (event: DragEvent, status: string) => {
   event.preventDefault();
   emit('dropTo', status);
 };
+
+const cardComponentForOrder = (order: ManagerOrderListItemResponse) => (
+  getOrderSegment(order) === 'b2b' ? OrderCardB2B : OrderCardB2C
+);
 </script>
 
 <template>
   <section
-    class="min-h-[220px] w-[calc(100vw-2rem)] max-w-[320px] shrink-0 rounded-2xl border border-gray-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800 sm:w-[320px] md:w-[350px] md:max-w-[350px] lg:w-[380px] lg:max-w-[380px]"
+    class="min-h-[220px] w-[calc(100vw-2rem)] max-w-[320px] shrink-0 rounded-2xl border border-gray-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800 sm:w-[340px] sm:max-w-[340px] md:w-[420px] md:max-w-[420px] xl:w-[460px] xl:max-w-[460px]"
+    :class="BOARD_COLUMN_TONE_CLASSES[status]?.column"
     @dragover.prevent
     @drop="(event) => onDrop(event, status)"
   >
-    <header class="mb-3 flex items-center justify-between">
-      <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-slate-400">{{ label }}</h3>
-      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-0.5 text-xs text-gray-700 dark:text-slate-300">{{ orderCount() }}</span>
+    <header class="relative mb-3 flex items-center justify-between gap-2">
+      <button
+        v-if="filterOptions?.length"
+        type="button"
+        class="inline-flex min-w-0 items-center gap-1.5 rounded-xl px-1.5 py-1 text-left text-sm font-semibold uppercase tracking-wide transition hover:bg-white/70 dark:hover:bg-slate-700/70"
+        :class="BOARD_COLUMN_TONE_CLASSES[status]?.text || 'text-gray-600 dark:text-slate-400'"
+        :aria-expanded="filterOpen"
+        :title="`Фильтр: ${activeFilterLabel}`"
+        @click="filterOpen = !filterOpen"
+      >
+        <span v-if="icon" class="material-icons-round text-[17px]">{{ icon }}</span>
+        <span class="truncate">{{ label }}</span>
+        <span v-if="activeFilter" class="hidden rounded-full bg-white/70 px-1.5 py-0.5 text-[10px] normal-case tracking-normal text-current shadow-sm sm:inline">
+          {{ activeFilterLabel }}
+        </span>
+        <ChevronDown class="h-3.5 w-3.5 shrink-0 transition" :class="filterOpen ? 'rotate-180' : ''" />
+      </button>
+      <h3 v-else class="inline-flex min-w-0 items-center gap-1.5 text-sm font-semibold uppercase tracking-wide" :class="BOARD_COLUMN_TONE_CLASSES[status]?.text || 'text-gray-600 dark:text-slate-400'">
+        <span v-if="icon" class="material-icons-round text-[17px]">{{ icon }}</span>
+        <span class="truncate">{{ label }}</span>
+      </h3>
+      <span class="rounded-full bg-gray-100 dark:bg-slate-700 px-2 py-0.5 text-xs text-gray-700 dark:text-slate-300">
+        {{ activeFilter ? `${visibleOrderCount}/${allOrderCount}` : allOrderCount }}
+      </span>
+      <div
+        v-if="filterOptions?.length && filterOpen"
+        class="absolute left-0 top-9 z-20 w-72 rounded-2xl border border-gray-200 bg-white p-2 text-sm shadow-xl dark:border-slate-700 dark:bg-slate-800"
+      >
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
+          @click="setFilter('')"
+        >
+          <span class="inline-flex items-center gap-2">
+            <span class="material-icons-round text-[16px]">{{ icon || 'filter_list' }}</span>
+            Все
+          </span>
+          <span class="inline-flex items-center gap-2 text-xs text-slate-500">
+            {{ allOrderCount }}
+            <Check v-if="!activeFilter" class="h-4 w-4 text-teal-600" />
+          </span>
+        </button>
+        <button
+          v-for="option in filterOptions"
+          :key="option.value"
+          type="button"
+          class="flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
+          @click="setFilter(option.value)"
+        >
+          <span class="inline-flex min-w-0 items-center gap-2">
+            <span v-if="option.icon" class="material-icons-round text-[16px]">{{ option.icon }}</span>
+            <span class="truncate">{{ option.label }}</span>
+          </span>
+          <span class="inline-flex items-center gap-2 text-xs text-slate-500">
+            {{ filterCounts[option.value] || 0 }}
+            <Check v-if="activeFilter === option.value" class="h-4 w-4 text-teal-600" />
+          </span>
+        </button>
+      </div>
     </header>
 
     <div class="space-y-3">
-      <template v-for="item in items" :key="item.type === 'group' ? item.group.id : item.order.id">
+      <template v-for="item in visibleItems" :key="item.type === 'group' ? item.group.id : item.order.id">
         <OrderCustomerGroupCard
           v-if="item.type === 'group'"
           :group="item.group"
@@ -56,6 +176,9 @@ const onDrop = (event: DragEvent, status: string) => {
           :expanded-order-id="expandedOrderId"
           @open="(orderId) => emit('open', orderId)"
           @generate="(payload) => emit('generate', payload)"
+          @cancel-order="(payload) => emit('cancelOrder', payload)"
+          @quick-status="(payload) => emit('quickStatus', payload)"
+          @close-debt="(payload) => emit('closeDebt', payload)"
           @drag-start="(payload) => emit('dragStart', payload)"
           @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
           @toggle-group="(groupId) => emit('toggleGroup', groupId)"
@@ -63,18 +186,24 @@ const onDrop = (event: DragEvent, status: string) => {
           @rename-order="(payload) => emit('renameOrder', payload)"
         />
         <component
-          :is="segment === 'b2b' ? OrderCardB2B : OrderCardB2C"
+          :is="cardComponentForOrder(item.order)"
           v-else
           :order="item.order"
           :expanded="expandedOrderId === item.order.id"
           :draggable-disabled="movingOrderIds.includes(item.order.id)"
           @open="(orderId) => emit('open', orderId)"
           @generate="(payload) => emit('generate', payload)"
+          @cancel-order="(payload) => emit('cancelOrder', payload)"
+          @quick-status="(payload) => emit('quickStatus', payload)"
+          @close-debt="(payload) => emit('closeDebt', payload)"
           @drag-start="(payload) => emit('dragStart', payload)"
           @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
           @rename-order="(payload) => emit('renameOrder', payload)"
         />
       </template>
+      <div v-if="!visibleItems.length" class="rounded-xl border border-dashed border-gray-200 bg-white/70 px-3 py-6 text-center text-sm text-gray-500 dark:border-slate-700 dark:bg-slate-900/30 dark:text-slate-400">
+        В этой колонке нет заказов под выбранный фильтр.
+      </div>
     </div>
   </section>
 </template>

--- a/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerGroupCard.vue
@@ -2,8 +2,9 @@
 import { ref, watch } from 'vue';
 import { Check, ChevronDown, ChevronUp, X } from 'lucide-vue-next';
 import type { Segment } from '../../api';
+import type { ManagerOrderListItemResponse } from '../../client';
 import type { CustomerOrderGroup } from './order-utils';
-import { formatMoney, formatOrderCount } from './order-utils';
+import { formatMoney, formatOrderCount, getOrderSegment } from './order-utils';
 import OrderCardB2B from './OrderCardB2B.vue';
 import OrderCardB2C from './OrderCardB2C.vue';
 
@@ -18,6 +19,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
+  cancelOrder: [payload: { orderId: number }];
+  quickStatus: [payload: { orderId: number; status: string }];
+  closeDebt: [payload: { orderId: number }];
   dragStart: [payload: { orderId: number; oldStatus: string }];
   toggleExpanded: [orderId: number];
   toggleGroup: [groupId: string];
@@ -53,6 +57,11 @@ const cancelEditing = () => {
 
 const onGroupClick = () => {
   if (!editing.value) emit('toggleGroup', props.group.id);
+};
+
+const cardComponentForOrder = (order: ManagerOrderListItemResponse) => {
+  const segment = props.segment === 'all' ? getOrderSegment(order) : props.segment;
+  return segment === 'b2b' ? OrderCardB2B : OrderCardB2C;
 };
 </script>
 
@@ -124,7 +133,7 @@ const onGroupClick = () => {
     <Transition name="fade">
       <div v-if="expanded" class="mt-3 space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700">
         <component
-          :is="segment === 'b2b' ? OrderCardB2B : OrderCardB2C"
+          :is="cardComponentForOrder(order)"
           v-for="order in group.orders"
           :key="order.id"
           :order="order"
@@ -132,6 +141,9 @@ const onGroupClick = () => {
           :draggable-disabled="movingOrderIds.includes(order.id)"
           @open="(orderId) => emit('open', orderId)"
           @generate="(payload) => emit('generate', payload)"
+          @cancel-order="(payload) => emit('cancelOrder', payload)"
+          @quick-status="(payload) => emit('quickStatus', payload)"
+          @close-debt="(payload) => emit('closeDebt', payload)"
           @drag-start="(payload) => emit('dragStart', payload)"
           @toggle-expanded="(orderId) => emit('toggleExpanded', orderId)"
           @rename-order="(payload) => emit('renameOrder', payload)"

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -28,7 +28,7 @@ import type {
   ManagerEquipmentHistoryFromRepairOrderPayload,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
-import { formatMoney } from './order-utils';
+import { NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
@@ -437,8 +437,21 @@ const measurerId = ref<number | null>(null);
 const measurementResult = ref('');
 const additionalConditions = ref('');
 const proposalStatus = ref<'draft' | 'sent' | 'approved' | 'rejected'>('draft');
+const negotiationStatus = ref('awaiting_offer');
+const executionWithoutPayment = ref(false);
+const executionWithoutPaymentReason = ref('');
+const autoExecutionOnPayment = ref(false);
 const activeProposalId = ref<number | null>(null);
 const proposalActionLoading = ref(false);
+const negotiationStatusLabel = computed(() => (
+  NEGOTIATION_STATUS_OPTIONS.find((option) => option.value === negotiationStatus.value)?.label || 'Ждет предложение'
+));
+
+const setNegotiationStatus = (value: string) => {
+  negotiationStatus.value = value;
+  if (value === 'proposal_sent') proposalStatus.value = 'sent';
+  if (value === 'awaiting_payment') proposalStatus.value = 'approved';
+};
 
 const installersList = ref<ManagerInstallerResponse[]>([]);
 
@@ -1574,6 +1587,10 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   measurementResult.value = order.measurement_result ?? '';
   additionalConditions.value = order.additional_conditions ?? '';
   proposalStatus.value = (order.proposal_status as any) || 'draft';
+  negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
+  executionWithoutPayment.value = Boolean(order.execution_without_payment);
+  executionWithoutPaymentReason.value = order.execution_without_payment_reason || '';
+  autoExecutionOnPayment.value = Boolean(order.auto_execution_on_payment);
   targetCurrency.value = order.target_currency || null;
   targetCurrencyAmount.value = order.target_currency_amount || null;
   targetCurrencyPayments.value = order.target_currency_payments || 0;
@@ -2364,7 +2381,11 @@ const handleSave = () => {
     measurer_id: measurerId.value,
     measurement_result: measurementResult.value,
     additional_conditions: additionalConditions.value,
+    negotiation_status: status.value === 'negotiation' ? negotiationStatus.value : undefined,
     proposal_status: status.value === 'execution' ? 'approved' : proposalStatus.value,
+    execution_without_payment: status.value === 'execution' ? executionWithoutPayment.value : false,
+    execution_without_payment_reason: status.value === 'execution' && executionWithoutPayment.value ? executionWithoutPaymentReason.value : null,
+    auto_execution_on_payment: autoExecutionOnPayment.value,
     target_currency: enableCurrency.value ? (targetCurrency.value || null) : null,
     target_currency_amount: enableCurrency.value && targetCurrencyAmount.value ? Number(String(targetCurrencyAmount.value).replace(',', '.')) : null,
   };
@@ -2859,6 +2880,37 @@ watch(
           <label v-else class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-blue-900 ring-1 ring-blue-100">
             <input type="checkbox" v-model="measurementRequired" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
             {{ isRepairWorkflow ? 'Диагностика нужна' : 'Замер нужен' }}
+          </label>
+        </div>
+
+        <div class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm">
+          <div class="flex items-center justify-between gap-3">
+            <p class="text-xs font-semibold uppercase tracking-[0.12em] text-blue-900/70">Состояние переговоров</p>
+            <span class="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold text-blue-800">
+              {{ negotiationStatusLabel }}
+            </span>
+          </div>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button
+              v-for="option in NEGOTIATION_STATUS_OPTIONS"
+              :key="option.value"
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-semibold transition"
+              :class="negotiationStatus === option.value
+                ? 'border-blue-200 bg-blue-100 text-blue-900 shadow-sm'
+                : 'border-gray-200 bg-white text-gray-600 hover:border-blue-200 hover:bg-blue-50 hover:text-blue-800'"
+              @click="setNegotiationStatus(option.value)"
+            >
+              <span class="material-icons-round text-[15px]">{{ option.icon }}</span>
+              {{ option.label }}
+            </button>
+          </div>
+          <label class="mt-3 flex items-start gap-2 rounded-xl border border-emerald-100 bg-emerald-50/70 px-3 py-2 text-xs text-emerald-900">
+            <input v-model="autoExecutionOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+            <span>
+              <span class="block font-semibold">Перевести в работу после полной оплаты</span>
+              <span class="mt-0.5 block text-emerald-700/80">Сработает автоматически, когда долг по заказу станет нулевым.</span>
+            </span>
           </label>
         </div>
 
@@ -3720,6 +3772,23 @@ watch(
         />
       </OrderDrawerSection>
 
+
+      <section v-if="status === 'execution'" class="mt-4 rounded-2xl border border-teal-100 bg-teal-50/50 p-3">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 class="text-sm font-semibold text-teal-900">Установка / работы</h3>
+            <p class="mt-0.5 text-xs text-teal-700/75">Фиксируем исключения перед выполнением работ.</p>
+          </div>
+          <label class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-teal-900 ring-1 ring-teal-100">
+            <input v-model="executionWithoutPayment" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+            Перенос без оплаты
+          </label>
+        </div>
+        <label v-if="executionWithoutPayment" class="field-label mt-3">
+          Причина переноса без оплаты
+          <textarea v-model="executionWithoutPaymentReason" class="field-input min-h-[60px]" placeholder="Например: постоянный клиент, оплата по факту..." />
+        </label>
+      </section>
 
       <DealExecutionTab
         v-if="status === 'execution' && order"

--- a/manager_frontend/src/components/orders/OrderKanbanBoard.vue
+++ b/manager_frontend/src/components/orders/OrderKanbanBoard.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import type { Segment } from '../../api';
 import type { OrderRenderItem } from './order-utils';
 import OrderColumn from './OrderColumn.vue';
-import { STATUS_LABELS, STATUS_ORDER } from './order-utils';
+import { BOARD_COLUMNS, BOARD_COLUMN_LABELS, NEGOTIATION_STATUS_OPTIONS } from './order-utils';
 
 defineProps<{
   groupedItems: Record<string, OrderRenderItem[]>;
@@ -15,6 +15,8 @@ const emit = defineEmits<{
   open: [orderId: number];
   generate: [payload: { orderId: number; docType: string }];
   move: [payload: { orderId: number; oldStatus: string; newStatus: string }];
+  cancelOrder: [payload: { orderId: number }];
+  closeDebt: [payload: { orderId: number }];
   renameCustomer: [payload: { customerId: number; alias: string | null }];
   renameOrder: [payload: { orderId: number; title: string | null }];
 }>();
@@ -55,17 +57,23 @@ const onToggleGroup = (groupId: string) => {
 <template>
   <div class="flex gap-4 overflow-x-auto pb-4">
     <OrderColumn
-      v-for="status in STATUS_ORDER"
-      :key="status"
-      :status="status"
-      :label="STATUS_LABELS[status] || status"
-      :items="groupedItems[status] || []"
+      v-for="column in BOARD_COLUMNS"
+      :key="column.value"
+      :status="column.value"
+      :label="BOARD_COLUMN_LABELS[column.value] || column.label"
+      :icon="column.icon"
+      :filter-kind="column.value === 'negotiation' ? 'negotiation' : undefined"
+      :filter-options="column.value === 'negotiation' ? NEGOTIATION_STATUS_OPTIONS : undefined"
+      :items="groupedItems[column.value] || []"
       :segment="segment"
       :moving-order-ids="movingOrderIds"
       :expanded-order-id="expandedOrderId"
       :expanded-group-ids="expandedGroupIds"
       @open="(orderId) => emit('open', orderId)"
       @generate="(payload) => emit('generate', payload)"
+      @cancel-order="(payload) => emit('cancelOrder', payload)"
+      @quick-status="(payload) => emit('move', { orderId: payload.orderId, oldStatus: '', newStatus: payload.status })"
+      @close-debt="(payload) => emit('closeDebt', payload)"
       @drag-start="(payload) => onDragStart(payload)"
       @drop-to="(dropStatus) => onDropTo(dropStatus)"
       @toggle-expanded="onToggleExpanded"

--- a/manager_frontend/src/components/orders/OrderListRow.vue
+++ b/manager_frontend/src/components/orders/OrderListRow.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { ManagerOrderListItemResponse } from '../../client';
 import type { Segment } from '../../api';
-import { STATUS_LABELS, formatDate, formatMoney, formatPhone, getOrderCustomerName, isOverdue } from './order-utils';
+import { STATUS_LABELS, formatDate, formatMoney, formatPhone, getOrderCustomerName, getOrderSegment, isOverdue } from './order-utils';
 import OrderTitleEditor from './OrderTitleEditor.vue';
 
 const props = defineProps<{
@@ -19,7 +20,8 @@ const emit = defineEmits<{
   toggleSelect: [payload: { orderId: number; selected: boolean }];
 }>();
 
-const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerName(order, props.segment);
+const rowSegment = computed(() => (props.segment === 'all' ? getOrderSegment(props.order) : props.segment));
+const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerName(order, rowSegment.value);
 </script>
 
 <template>
@@ -60,7 +62,7 @@ const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerNa
       </div>
     </td>
     <td class="px-3 py-3">
-      <template v-if="segment === 'b2b'">
+      <template v-if="rowSegment === 'b2b'">
         <p>{{ customerName(order) }}</p>
         <p class="text-xs text-gray-500">УНП: {{ order.customer?.inn || '—' }}</p>
       </template>
@@ -90,28 +92,28 @@ const customerName = (order: ManagerOrderListItemResponse) => getOrderCustomerNa
     <td class="px-3 py-3">
       <div class="flex flex-wrap gap-2">
         <button
-          v-if="segment === 'b2b'"
+          v-if="rowSegment === 'b2b'"
           class="btn-mini"
           @click="emit('generate', { orderId: order.id, docType: 'invoice' })"
         >
           Счет
         </button>
         <button
-          v-if="segment === 'b2b'"
+          v-if="rowSegment === 'b2b'"
           class="btn-mini"
           @click="emit('generate', { orderId: order.id, docType: 'contract' })"
         >
           Договор
         </button>
         <button
-          v-if="segment === 'b2c'"
+          v-if="rowSegment === 'b2c'"
           class="btn-mini"
           @click="emit('generate', { orderId: order.id, docType: 'work_order' })"
         >
           Наряд
         </button>
         <button
-          v-if="segment === 'b2c'"
+          v-if="rowSegment === 'b2c'"
           class="btn-mini"
           @click="emit('generate', { orderId: order.id, docType: 'act' })"
         >

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -16,7 +16,14 @@ import OrdersViewToggle from './OrdersViewToggle.vue';
 import OrderKanbanBoard from './OrderKanbanBoard.vue';
 import OrdersListTable from './OrdersListTable.vue';
 import OrderEditDrawer from './OrderEditDrawer.vue';
-import { STATUS_LABELS, STATUS_ORDER, buildCustomerOrderRenderItems } from './order-utils';
+import {
+  BOARD_COLUMNS,
+  STATUS_LABELS,
+  STATUS_ORDER,
+  buildCustomerOrderRenderItems,
+  formatMoney,
+  getOrderBoardColumn,
+} from './order-utils';
 import { getApiErrorMessage, parseApiFieldErrors } from '../../utils/api-errors';
 
 const ORDERS_SEGMENT_STORAGE_KEY = 'manager_orders_segment';
@@ -62,17 +69,18 @@ const importPreview = ref<ManagerOrderImportPreviewResponse | null>(null);
 const importFileName = ref('');
 const importModalOpen = ref(false);
 
-const visibleOrders = computed(() => (
-  hideOnHold.value ? orders.value.filter((order) => !order.is_on_hold) : orders.value
-));
+const visibleOrders = computed(() => orders.value.filter((order) => {
+  if (hideOnHold.value && order.is_on_hold) return false;
+  return true;
+}));
 const normalizedSearch = computed(() => search.value.trim());
 const hasActiveOrderFilters = computed(() => Boolean(normalizedSearch.value || statusFilter.value || overdueOnly.value));
 
 const groupedOrders = computed(() => {
   const groups: Record<string, ManagerOrderListItemResponse[]> = {};
-  for (const statusKey of STATUS_ORDER) groups[statusKey] = [];
+  for (const column of BOARD_COLUMNS) groups[column.value] = [];
   for (const order of visibleOrders.value) {
-    const key = order.status;
+    const key = getOrderBoardColumn(order);
     if (!groups[key]) groups[key] = [];
     groups[key].push(order);
   }
@@ -82,8 +90,8 @@ const groupedOrders = computed(() => {
 const groupedOrderItems = computed(() => {
   const groups = groupedOrders.value;
   const items: Record<string, ReturnType<typeof buildCustomerOrderRenderItems>> = {};
-  for (const statusKey of STATUS_ORDER) {
-    items[statusKey] = buildCustomerOrderRenderItems(groups[statusKey] || [], segment.value, groupByCustomer.value, customerAliases.value);
+  for (const column of BOARD_COLUMNS) {
+    items[column.value] = buildCustomerOrderRenderItems(groups[column.value] || [], segment.value, groupByCustomer.value, customerAliases.value);
   }
   return items;
 });
@@ -236,7 +244,7 @@ const restoreSegmentAndView = () => {
   const resolvedSegment = segmentFromUrl || segmentFromStorage;
   const resolvedView = viewFromUrl || viewFromStorage;
 
-  if (resolvedSegment === 'b2b' || resolvedSegment === 'b2c') {
+  if (resolvedSegment === 'all' || resolvedSegment === 'b2b' || resolvedSegment === 'b2c') {
     segment.value = resolvedSegment;
   }
   if (resolvedView === 'kanban' || resolvedView === 'list') {
@@ -388,23 +396,133 @@ const clearOrderFilters = async () => {
   await loadOrders();
 };
 
-const applyStatusLocally = (orderId: number, status: string) => {
+const buildBoardTransitionPayload = (order: ManagerOrderListItemResponse, column: string): ManagerOrderUpdatePayload | null => {
+  if (column === 'closed_lost') return null;
+  if (column === 'closed_won') {
+    return { status: 'closed', closing_result: 'won', reject_reason: null };
+  }
+  if (column === 'execution') {
+    const balanceDue = Number(order.balance_due || 0);
+    const payload: ManagerOrderUpdatePayload = {
+      status: 'execution',
+      closing_result: null,
+      reject_reason: null,
+    };
+    if (balanceDue > 0 && !order.execution_without_payment) {
+      const approved = window.confirm('По заказу есть долг. Перенести в работу без оплаты?');
+      if (!approved) return null;
+      payload.execution_without_payment = true;
+      payload.execution_without_payment_reason = window.prompt('Причина переноса без оплаты', 'Доверенный клиент') || 'Без предоплаты';
+    }
+    return payload;
+  }
+  if (column === 'negotiation') {
+    return {
+      status: 'negotiation',
+      closing_result: null,
+      reject_reason: null,
+      execution_without_payment: false,
+      execution_without_payment_reason: null,
+    };
+  }
+  return {
+    status: 'negotiation',
+    negotiation_status: column,
+    closing_result: null,
+    reject_reason: null,
+    execution_without_payment: false,
+    execution_without_payment_reason: null,
+    measurement_required: column === 'awaiting_visit' ? true : undefined,
+    proposal_status: column === 'proposal_sent' ? 'sent' : column === 'awaiting_payment' ? 'approved' : undefined,
+  };
+};
+
+const applyStatusLocally = (orderId: number, payload: ManagerOrderUpdatePayload) => {
   const item = orders.value.find((order) => order.id === orderId);
-  if (item) item.status = status;
+  if (!item) return;
+  if (payload.status !== undefined && payload.status !== null) item.status = payload.status;
+  if (payload.negotiation_status !== undefined && payload.negotiation_status !== null) item.negotiation_status = payload.negotiation_status;
+  if (payload.closing_result !== undefined) item.closing_result = payload.closing_result;
+  if (payload.reject_reason !== undefined) item.reject_reason = payload.reject_reason;
+  if (payload.proposal_status !== undefined && payload.proposal_status !== null) item.proposal_status = payload.proposal_status;
+  if (payload.measurement_required !== undefined && payload.measurement_required !== null) item.measurement_required = payload.measurement_required;
+  if (payload.execution_without_payment !== undefined && payload.execution_without_payment !== null) item.execution_without_payment = payload.execution_without_payment;
+  if (payload.execution_without_payment_reason !== undefined) item.execution_without_payment_reason = payload.execution_without_payment_reason;
+  const now = new Date().toISOString();
+  item.status_changed_at = now;
+  if (payload.negotiation_status) item.negotiation_status_changed_at = now;
 };
 
 const onMoveOrder = async (payload: { orderId: number; oldStatus: string; newStatus: string }) => {
   if (movingOrderIds.value.includes(payload.orderId)) return;
+  const item = orders.value.find((order) => order.id === payload.orderId);
+  if (!item) return;
+  const updatePayload = buildBoardTransitionPayload(item, payload.newStatus);
+  if (!updatePayload) return;
   const snapshot = orders.value.map((item) => ({ ...item }));
   movingOrderIds.value.push(payload.orderId);
-  applyStatusLocally(payload.orderId, payload.newStatus);
+  applyStatusLocally(payload.orderId, updatePayload);
   try {
-    await api.moveOrderStatus(payload.orderId, payload.newStatus);
+    await api.patchManagerOrder(payload.orderId, updatePayload);
     setToast('Статус обновлен');
   } catch (error) {
     console.error(error);
     orders.value = snapshot;
-    setToast('Ошибка обновления статуса');
+    setToast(`Ошибка обновления статуса: ${getApiErrorMessage(error)}`);
+  } finally {
+    movingOrderIds.value = movingOrderIds.value.filter((id) => id !== payload.orderId);
+  }
+};
+
+const onCancelOrder = async (payload: { orderId: number }) => {
+  const reason = window.prompt('Причина отказа / неуспешного завершения');
+  if (reason === null) return;
+  const trimmedReason = reason.trim() || 'Без пояснения';
+  const snapshot = orders.value.map((item) => ({ ...item }));
+  const updatePayload: ManagerOrderUpdatePayload = {
+    status: 'closed',
+    closing_result: 'lost',
+    reject_reason: trimmedReason,
+  };
+  movingOrderIds.value.push(payload.orderId);
+  applyStatusLocally(payload.orderId, updatePayload);
+  try {
+    await api.patchManagerOrder(payload.orderId, updatePayload);
+    setToast('Заказ помечен отказом');
+  } catch (error) {
+    console.error(error);
+    orders.value = snapshot;
+    setToast(`Не удалось закрыть отказ: ${getApiErrorMessage(error)}`);
+  } finally {
+    movingOrderIds.value = movingOrderIds.value.filter((id) => id !== payload.orderId);
+  }
+};
+
+const onCloseDebt = async (payload: { orderId: number }) => {
+  if (movingOrderIds.value.includes(payload.orderId)) return;
+  const item = orders.value.find((order) => order.id === payload.orderId);
+  if (!item) return;
+  const amount = Number(item.balance_due || 0);
+  if (amount <= 0) {
+    setToast('Долг уже закрыт');
+    return;
+  }
+  const confirmed = window.confirm(`Добавить оплату ${formatMoney(amount)} и закрыть долг по заказу #${payload.orderId}?`);
+  if (!confirmed) return;
+
+  movingOrderIds.value.push(payload.orderId);
+  try {
+    await ManagerOrdersService.addManagerOrderPayment(payload.orderId, {
+      amount,
+      currency: 'BYN',
+      type: 'postpayment',
+      comment: 'Закрытие долга из канбан-карточки',
+    });
+    setToast('Долг закрыт');
+    await loadOrders();
+  } catch (error) {
+    console.error(error);
+    setToast(`Не удалось закрыть долг: ${getApiErrorMessage(error)}`);
   } finally {
     movingOrderIds.value = movingOrderIds.value.filter((id) => id !== payload.orderId);
   }
@@ -572,7 +690,7 @@ watch(drawerOpen, (isOpen) => {
           <div class="ml-auto flex shrink-0 items-center justify-end gap-1 sm:gap-2">
             <button
               type="button"
-              class="inline-flex h-8 items-center justify-center gap-1 rounded-xl border border-gray-200 bg-gray-50 px-2 text-xs font-semibold text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:h-9 sm:px-3"
+              class="hidden h-8 items-center justify-center gap-1 rounded-xl border border-gray-200 bg-gray-50 px-2 text-xs font-semibold text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:inline-flex sm:h-9 sm:px-3"
               :disabled="transferLoading || !selectedOrderIds.length"
               title="Экспорт выбранных заказов"
               @click="exportSelectedOrders"
@@ -583,7 +701,7 @@ watch(drawerOpen, (isOpen) => {
             </button>
             <button
               type="button"
-              class="inline-flex h-8 items-center justify-center gap-1 rounded-xl border border-gray-200 bg-gray-50 px-2 text-xs font-semibold text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:h-9 sm:px-3"
+              class="hidden h-8 items-center justify-center gap-1 rounded-xl border border-gray-200 bg-gray-50 px-2 text-xs font-semibold text-gray-700 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 sm:inline-flex sm:h-9 sm:px-3"
               :disabled="transferLoading"
               title="Импорт заказов из JSON"
               @click="openImportPicker"
@@ -662,6 +780,8 @@ watch(drawerOpen, (isOpen) => {
         @open="openOrder"
         @generate="onGenerateDoc"
         @move="onMoveOrder"
+        @cancel-order="onCancelOrder"
+        @close-debt="onCloseDebt"
         @rename-customer="renameCustomerGroup"
         @rename-order="renameOrderTitle"
       />

--- a/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
+++ b/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
@@ -1,27 +1,29 @@
 <script setup lang="ts">
+import { Building2, Layers3, UserRound } from 'lucide-vue-next';
 import type { Segment } from '../../api';
 
 defineProps<{ modelValue: Segment }>();
 const emit = defineEmits<{ 'update:modelValue': [value: Segment] }>();
+
+const tabs: Array<{ value: Segment; label: string; title: string; icon: typeof Layers3 }> = [
+  { value: 'all', label: 'Все', title: 'Все заказы', icon: Layers3 },
+  { value: 'b2c', label: 'B2C', title: 'Частные клиенты', icon: UserRound },
+  { value: 'b2b', label: 'B2B', title: 'Юридические лица', icon: Building2 },
+];
 </script>
 
 <template>
   <div class="inline-flex shrink-0 rounded-xl border border-gray-200 bg-gray-100 p-0.5">
     <button
-      class="rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
-      :class="modelValue === 'b2c' ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
-      title="Частные клиенты"
-      @click="emit('update:modelValue', 'b2c')"
+      v-for="tab in tabs"
+      :key="tab.value"
+      class="inline-flex items-center gap-1.5 rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
+      :class="modelValue === tab.value ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
+      :title="tab.title"
+      @click="emit('update:modelValue', tab.value)"
     >
-      B2C
-    </button>
-    <button
-      class="rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
-      :class="modelValue === 'b2b' ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
-      title="Юридические лица"
-      @click="emit('update:modelValue', 'b2b')"
-    >
-      B2B
+      <component :is="tab.icon" class="h-3.5 w-3.5" />
+      <span>{{ tab.label }}</span>
     </button>
   </div>
 </template>

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -7,12 +7,126 @@ export const STATUS_ORDER = [
     'closed',
 ] as const;
 
+export const NEGOTIATION_STATUS_OPTIONS = [
+    { value: 'awaiting_offer', label: 'Ждет предложение', icon: 'rate_review', tone: 'sky' },
+    { value: 'awaiting_visit', label: 'Ждет выезд', icon: 'location_on', tone: 'violet' },
+    { value: 'proposal_sent', label: 'Ожидаем ответ', icon: 'send', tone: 'amber' },
+    { value: 'awaiting_payment', label: 'Ожидаем оплату', icon: 'payments', tone: 'emerald' },
+    { value: 'follow_up', label: 'Уточнить', icon: 'contact_phone', tone: 'slate' },
+] as const;
+
+export const BOARD_COLUMNS = [
+    { value: 'negotiation', label: 'Переговоры', icon: 'forum', tone: 'sky' },
+    { value: 'execution', label: 'Установка / работы', icon: 'construction', tone: 'teal' },
+    { value: 'closed_won', label: 'Завершено', icon: 'check_circle', tone: 'green' },
+    { value: 'closed_lost', label: 'Отказники', icon: 'cancel', tone: 'rose' },
+] as const;
+
 export const STATUS_LABELS: Record<string, string> = {
     new_lead: 'Новый лид',
     negotiation: 'Переговоры',
     execution: 'Монтаж',
     closed: 'Закрыто',
 };
+
+export const NEGOTIATION_STATUS_LABELS: Record<string, string> = Object.fromEntries(
+    NEGOTIATION_STATUS_OPTIONS.map((item) => [item.value, item.label]),
+);
+
+export const BOARD_COLUMN_LABELS: Record<string, string> = Object.fromEntries(
+    BOARD_COLUMNS.map((item) => [item.value, item.label]),
+);
+
+export const BOARD_COLUMN_TONE_CLASSES: Record<string, { column: string; badge: string; text: string }> = {
+    negotiation: {
+        column: 'border-sky-100 bg-sky-50/60 dark:border-sky-500/20 dark:bg-sky-500/10',
+        badge: 'bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200',
+        text: 'text-sky-800 dark:text-sky-200',
+    },
+    awaiting_offer: {
+        column: 'border-sky-100 bg-sky-50/60 dark:border-sky-500/20 dark:bg-sky-500/10',
+        badge: 'bg-sky-100 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200',
+        text: 'text-sky-800 dark:text-sky-200',
+    },
+    awaiting_visit: {
+        column: 'border-violet-100 bg-violet-50/60 dark:border-violet-500/20 dark:bg-violet-500/10',
+        badge: 'bg-violet-100 text-violet-700 dark:bg-violet-500/20 dark:text-violet-200',
+        text: 'text-violet-800 dark:text-violet-200',
+    },
+    proposal_sent: {
+        column: 'border-amber-100 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/10',
+        badge: 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+        text: 'text-amber-800 dark:text-amber-200',
+    },
+    awaiting_payment: {
+        column: 'border-emerald-100 bg-emerald-50/60 dark:border-emerald-500/20 dark:bg-emerald-500/10',
+        badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200',
+        text: 'text-emerald-800 dark:text-emerald-200',
+    },
+    follow_up: {
+        column: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800',
+        badge: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
+        text: 'text-slate-700 dark:text-slate-200',
+    },
+    execution: {
+        column: 'border-teal-100 bg-teal-50/60 dark:border-teal-500/20 dark:bg-teal-500/10',
+        badge: 'bg-teal-100 text-teal-700 dark:bg-teal-500/20 dark:text-teal-200',
+        text: 'text-teal-800 dark:text-teal-200',
+    },
+    closed_won: {
+        column: 'border-green-100 bg-green-50/60 dark:border-green-500/20 dark:bg-green-500/10',
+        badge: 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-200',
+        text: 'text-green-800 dark:text-green-200',
+    },
+    closed_lost: {
+        column: 'border-rose-100 bg-rose-50/60 dark:border-rose-500/20 dark:bg-rose-500/10',
+        badge: 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200',
+        text: 'text-rose-800 dark:text-rose-200',
+    },
+};
+
+export const BOARD_CARD_ACCENT_CLASSES: Record<string, string> = {
+    negotiation: 'border-sky-200 bg-sky-50/50 shadow-sky-100/80 hover:shadow-sky-200/80 dark:border-sky-500/30 dark:bg-sky-500/10 dark:shadow-none',
+    awaiting_offer: 'border-sky-200 bg-sky-50/50 shadow-sky-100/80 hover:shadow-sky-200/80 dark:border-sky-500/30 dark:bg-sky-500/10 dark:shadow-none',
+    awaiting_visit: 'border-violet-200 bg-violet-50/55 shadow-violet-100/80 hover:shadow-violet-200/80 dark:border-violet-500/30 dark:bg-violet-500/10 dark:shadow-none',
+    proposal_sent: 'border-amber-200 bg-amber-50/60 shadow-amber-100/80 hover:shadow-amber-200/80 dark:border-amber-500/30 dark:bg-amber-500/10 dark:shadow-none',
+    awaiting_payment: 'border-emerald-200 bg-emerald-50/55 shadow-emerald-100/80 hover:shadow-emerald-200/80 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:shadow-none',
+    follow_up: 'border-slate-300 bg-slate-50 shadow-slate-100/80 hover:shadow-slate-200/80 dark:border-slate-600 dark:bg-slate-700/40 dark:shadow-none',
+    execution: 'border-teal-200 bg-teal-50/55 shadow-teal-100/80 hover:shadow-teal-200/80 dark:border-teal-500/30 dark:bg-teal-500/10 dark:shadow-none',
+    closed_won: 'border-green-200 bg-green-50/55 shadow-green-100/80 hover:shadow-green-200/80 dark:border-green-500/30 dark:bg-green-500/10 dark:shadow-none',
+    closed_lost: 'border-rose-200 bg-rose-50/55 shadow-rose-100/80 hover:shadow-rose-200/80 dark:border-rose-500/30 dark:bg-rose-500/10 dark:shadow-none',
+};
+
+export type ConcreteSegment = 'b2c' | 'b2b';
+
+export function getOrderSegment(order: ManagerOrderListItemResponse): ConcreteSegment {
+    const customer = order.customer;
+    const inn = String(customer?.inn || '').trim();
+    const customerType = String(customer?.type || '').trim();
+    return customerType === 'company' || Boolean(inn) ? 'b2b' : 'b2c';
+}
+
+export function getOrderBoardColumn(order: ManagerOrderListItemResponse): string {
+    if (order.status === 'closed') {
+        return order.closing_result === 'lost' ? 'closed_lost' : 'closed_won';
+    }
+    if (order.status === 'execution') return 'execution';
+    if (order.status === 'negotiation') return 'negotiation';
+    return order.status || 'awaiting_offer';
+}
+
+export function getOrderBoardLabel(order: ManagerOrderListItemResponse): string {
+    return BOARD_COLUMN_LABELS[getOrderBoardColumn(order)] || STATUS_LABELS[order.status] || order.status;
+}
+
+export function getOrderNegotiationStatus(order: ManagerOrderListItemResponse): string {
+    const value = order.negotiation_status || '';
+    return NEGOTIATION_STATUS_LABELS[value] ? value : 'awaiting_offer';
+}
+
+export function getOrderNegotiationLabel(order: ManagerOrderListItemResponse): string {
+    return NEGOTIATION_STATUS_LABELS[getOrderNegotiationStatus(order)] || 'Ждет предложение';
+}
 
 export function formatMoney(value: number): string {
     return `${Math.round(value).toLocaleString('ru-RU')} BYN`;
@@ -23,6 +137,19 @@ export function formatDate(value?: string | null): string {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return '—';
     return date.toLocaleDateString('ru-RU');
+}
+
+export function formatRelativeAge(value?: string | null): string {
+    if (!value) return 'давно';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'давно';
+    const diffMs = Math.max(0, Date.now() - date.getTime());
+    const minutes = Math.floor(diffMs / 60000);
+    if (minutes < 60) return `${Math.max(1, minutes)} мин`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} ч`;
+    const days = Math.floor(hours / 24);
+    return `${days} дн`;
 }
 
 export function formatPhone(phone?: string | null): string {
@@ -69,7 +196,7 @@ export function getOrderCustomerName(order: ManagerOrderListItemResponse, segmen
     const customer = order.customer;
     if (!customer) return `Заказ #${order.id}`;
 
-    if (segment === 'b2b') {
+    if ((segment === 'all' ? getOrderSegment(order) : segment) === 'b2b') {
         return customer.full_legal_name
             || customer.name
             || customer.phone
@@ -136,7 +263,7 @@ export function buildCustomerOrderRenderItems(
     return items;
 }
 
-function createCustomerOrderGroup(
+export function createCustomerOrderGroup(
     customerId: number,
     orders: ManagerOrderListItemResponse[],
     segment: Segment,

--- a/models/order.py
+++ b/models/order.py
@@ -372,8 +372,13 @@ class Order(SQLModel, table=True):
     measurer_id: Optional[int] = Field(default=None, index=True)
     measurement_result: Optional[str] = Field(default=None)
     additional_conditions: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    negotiation_status: str = Field(default="awaiting_offer", sa_column=Column(String, default="awaiting_offer", index=True))
+    negotiation_status_changed_at: Optional[datetime] = None
     proposal_status: str = Field(default="draft", sa_column=Column(String, default="draft", index=True))
     proposal_sent_at: Optional[datetime] = None
+    execution_without_payment: bool = Field(default=False, index=True)
+    execution_without_payment_reason: Optional[str] = Field(default=None)
+    auto_execution_on_payment: bool = Field(default=False, index=True)
 
     # --- Internal: Execution stage ---
     works_plan: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
@@ -387,6 +392,7 @@ class Order(SQLModel, table=True):
     updated_at: Optional[datetime] = Field(default_factory=datetime.now, sa_column_kwargs={"onupdate": datetime.now})
     installation_date: Optional[datetime] = None
     next_followup_date: Optional[datetime] = Field(default=None, description="Дата следующего касания")
+    status_changed_at: Optional[datetime] = None
     closed_at: Optional[datetime] = None
 
     contract_date: Optional[datetime] = Field(default_factory=datetime.now, description="Дата заключения договора")

--- a/openapi.json
+++ b/openapi.json
@@ -7048,7 +7048,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "pattern": "^(b2c|b2b)$",
+              "pattern": "^(all|b2c|b2b)$",
               "default": "b2c",
               "title": "Segment"
             }
@@ -24127,6 +24127,18 @@
             ],
             "title": "Updated At"
           },
+          "status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Changed At"
+          },
           "next_followup_date": {
             "anyOf": [
               {
@@ -24413,6 +24425,44 @@
               }
             ],
             "title": "Proposal Sent At"
+          },
+          "negotiation_status": {
+            "type": "string",
+            "title": "Negotiation Status",
+            "default": "awaiting_offer"
+          },
+          "negotiation_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Negotiation Status Changed At"
+          },
+          "execution_without_payment": {
+            "type": "boolean",
+            "title": "Execution Without Payment",
+            "default": false
+          },
+          "execution_without_payment_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment Reason"
+          },
+          "auto_execution_on_payment": {
+            "type": "boolean",
+            "title": "Auto Execution On Payment",
+            "default": false
           },
           "total_payments": {
             "type": "number",
@@ -25133,6 +25183,18 @@
             ],
             "title": "Updated At"
           },
+          "status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Changed At"
+          },
           "next_followup_date": {
             "anyOf": [
               {
@@ -25419,6 +25481,44 @@
               }
             ],
             "title": "Proposal Sent At"
+          },
+          "negotiation_status": {
+            "type": "string",
+            "title": "Negotiation Status",
+            "default": "awaiting_offer"
+          },
+          "negotiation_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Negotiation Status Changed At"
+          },
+          "execution_without_payment": {
+            "type": "boolean",
+            "title": "Execution Without Payment",
+            "default": false
+          },
+          "execution_without_payment_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment Reason"
+          },
+          "auto_execution_on_payment": {
+            "type": "boolean",
+            "title": "Auto Execution On Payment",
+            "default": false
           },
           "total_payments": {
             "type": "number",
@@ -26029,6 +26129,44 @@
             ],
             "title": "Proposal Sent At"
           },
+          "negotiation_status": {
+            "type": "string",
+            "title": "Negotiation Status",
+            "default": "awaiting_offer"
+          },
+          "negotiation_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Negotiation Status Changed At"
+          },
+          "execution_without_payment": {
+            "type": "boolean",
+            "title": "Execution Without Payment",
+            "default": false
+          },
+          "execution_without_payment_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment Reason"
+          },
+          "auto_execution_on_payment": {
+            "type": "boolean",
+            "title": "Auto Execution On Payment",
+            "default": false
+          },
           "equipment_status": {
             "type": "string",
             "title": "Equipment Status",
@@ -26325,6 +26463,44 @@
               }
             ],
             "title": "Proposal Sent At"
+          },
+          "negotiation_status": {
+            "type": "string",
+            "title": "Negotiation Status",
+            "default": "awaiting_offer"
+          },
+          "negotiation_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Negotiation Status Changed At"
+          },
+          "execution_without_payment": {
+            "type": "boolean",
+            "title": "Execution Without Payment",
+            "default": false
+          },
+          "execution_without_payment_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment Reason"
+          },
+          "auto_execution_on_payment": {
+            "type": "boolean",
+            "title": "Auto Execution On Payment",
+            "default": false
           },
           "equipment_status": {
             "type": "string",
@@ -27101,6 +27277,50 @@
               }
             ],
             "title": "Proposal Sent At"
+          },
+          "negotiation_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Negotiation Status"
+          },
+          "execution_without_payment": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment"
+          },
+          "execution_without_payment_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Without Payment Reason"
+          },
+          "auto_execution_on_payment": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Execution On Payment"
           },
           "is_paid": {
             "anyOf": [

--- a/routers/manager_orders_read.py
+++ b/routers/manager_orders_read.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/api/manager/orders", tags=["manager-orders"])
 
 @router.get("", response_model=ManagerOrderListResponse, operation_id=GET_MANAGER_ORDERS)
 async def get_manager_orders(
-    segment: str = Query("b2c", pattern="^(b2c|b2b)$"),
+    segment: str = Query("b2c", pattern="^(all|b2c|b2b)$"),
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
     status: Optional[str] = Query(None),

--- a/schemas.py
+++ b/schemas.py
@@ -700,6 +700,7 @@ class ManagerOrderListItemResponse(BaseModel):
     manager_labels: List[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: Optional[datetime] = None
+    status_changed_at: Optional[datetime] = None
     next_followup_date: Optional[datetime] = None
     measurement_date: Optional[datetime] = None
     installation_date: Optional[datetime] = None
@@ -736,6 +737,11 @@ class ManagerOrderListItemResponse(BaseModel):
     measurement_result: Optional[str] = None
     proposal_status: str = "draft"
     proposal_sent_at: Optional[datetime] = None
+    negotiation_status: str = "awaiting_offer"
+    negotiation_status_changed_at: Optional[datetime] = None
+    execution_without_payment: bool = False
+    execution_without_payment_reason: Optional[str] = None
+    auto_execution_on_payment: bool = False
 
     @computed_field
     @property
@@ -1046,6 +1052,10 @@ class ManagerOrderUpdatePayload(BaseModel):
     additional_conditions: Optional[str] = None
     proposal_status: Optional[str] = None
     proposal_sent_at: Optional[datetime] = None
+    negotiation_status: Optional[str] = None
+    execution_without_payment: Optional[bool] = None
+    execution_without_payment_reason: Optional[str] = None
+    auto_execution_on_payment: Optional[bool] = None
 
     is_paid: Optional[bool] = None
     # Closing
@@ -1225,6 +1235,11 @@ class ManagerOrderTransferOrder(BaseModel):
     measurement_result: Optional[str] = None
     proposal_status: str = "draft"
     proposal_sent_at: Optional[datetime] = None
+    negotiation_status: str = "awaiting_offer"
+    negotiation_status_changed_at: Optional[datetime] = None
+    execution_without_payment: bool = False
+    execution_without_payment_reason: Optional[str] = None
+    auto_execution_on_payment: bool = False
     equipment_status: str = "pending"
     standard_install_kit_issued: bool = False
     target_currency: Optional[PaymentCurrency] = None

--- a/services/lead_service.py
+++ b/services/lead_service.py
@@ -472,6 +472,7 @@ class LeadService:
             comment=order_comment,
             title=f"Лид #{lead.id}" if not title_suffix else f"Лид #{lead.id}: {title_suffix[:96]}",
             delivery_address=order_delivery_address,
+            status_changed_at=datetime.now(),
         )
         session.add(order)
         await session.flush()

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -52,6 +52,49 @@ class OrderService:
     }
     LOGISTICS_COMPONENT_KINDS = {"indoor", "outdoor", "accessory", "other"}
     DEFAULT_LOGISTICS_COUNTRY = "Китай"
+    NEGOTIATION_STATUSES = {
+        "awaiting_offer",
+        "awaiting_visit",
+        "proposal_sent",
+        "awaiting_payment",
+        "follow_up",
+    }
+    DEFAULT_NEGOTIATION_STATUS = "awaiting_offer"
+    PAYMENT_COMPLETE_TOLERANCE = 0.01
+
+    @staticmethod
+    def _normalize_negotiation_status(value: Any, fallback: str = DEFAULT_NEGOTIATION_STATUS) -> str:
+        cleaned = str(value or "").strip()
+        if cleaned in OrderService.NEGOTIATION_STATUSES:
+            return cleaned
+        return fallback if fallback in OrderService.NEGOTIATION_STATUSES else OrderService.DEFAULT_NEGOTIATION_STATUS
+
+    @staticmethod
+    def _infer_negotiation_status(order: Order) -> str:
+        raw_status = getattr(order, "negotiation_status", None)
+        if raw_status is not None:
+            current = str(raw_status or "").strip()
+            if current in OrderService.NEGOTIATION_STATUSES:
+                return current
+        if order.status != OrderStatus.NEGOTIATION:
+            return OrderService.DEFAULT_NEGOTIATION_STATUS
+        if order.proposal_status == "sent":
+            return "proposal_sent"
+        if order.proposal_status == "approved" and not order.is_paid:
+            return "awaiting_payment"
+        if order.measurement_required:
+            return "awaiting_visit"
+        return OrderService.DEFAULT_NEGOTIATION_STATUS
+
+    @staticmethod
+    def _set_negotiation_status(order: Order, value: Any, *, changed_at: Optional[datetime] = None) -> None:
+        next_status = str(value or "").strip()
+        if next_status not in OrderService.NEGOTIATION_STATUSES:
+            raise ValueError(f"Invalid negotiation_status: {value}")
+        previous = OrderService._normalize_negotiation_status(getattr(order, "negotiation_status", None))
+        order.negotiation_status = next_status
+        if previous != next_status or not getattr(order, "negotiation_status_changed_at", None):
+            order.negotiation_status_changed_at = changed_at or datetime.now()
 
     @staticmethod
     def _clean_optional_text(value: Any) -> Optional[str]:
@@ -544,6 +587,22 @@ class OrderService:
     async def _refresh_order_financials(session: AsyncSession, order: Order) -> None:
         await session.refresh(order, attribute_names=["payments", "proposals", "product_links", "service_links", "installers"])
         order.calculate_totals()
+        OrderService._apply_payment_state(order)
+
+    @staticmethod
+    def _apply_payment_state(order: Order) -> None:
+        if float(order.total_amount or 0) <= 0:
+            return
+        is_fully_paid = float(order.balance_due or 0) <= OrderService.PAYMENT_COMPLETE_TOLERANCE
+        order.is_paid = is_fully_paid
+        if (
+            is_fully_paid
+            and bool(getattr(order, "auto_execution_on_payment", False))
+            and order.status == OrderStatus.NEGOTIATION
+        ):
+            order.status = OrderStatus.EXECUTION
+            order.status_changed_at = datetime.now()
+            order.proposal_status = "approved"
 
     @staticmethod
     def _clean_proposal_name(raw: Any, fallback: str = "Основное") -> str:
@@ -943,7 +1002,8 @@ class OrderService:
             lead_source=lead_source,
             comment=comment,
             title=default_title,
-            created_at=datetime.now()
+            created_at=datetime.now(),
+            status_changed_at=datetime.now(),
         )
         session.add(order)
         await session.flush()
@@ -1826,6 +1886,7 @@ class OrderService:
             "manager_labels": OrderService._get_manager_labels(order),
             "created_at": order.created_at,
             "updated_at": order.updated_at,
+            "status_changed_at": getattr(order, "status_changed_at", None),
             "next_followup_date": order.next_followup_date,
             "measurement_date": order.measurement_date,
             "installation_date": order.installation_date,
@@ -1850,8 +1911,13 @@ class OrderService:
             "measurement_required": bool(order.measurement_required),
             "measurer_id": order.measurer_id,
             "measurement_result": order.measurement_result,
+            "negotiation_status": OrderService._infer_negotiation_status(order),
+            "negotiation_status_changed_at": getattr(order, "negotiation_status_changed_at", None),
             "proposal_status": order.proposal_status or "draft",
             "proposal_sent_at": order.proposal_sent_at,
+            "execution_without_payment": bool(getattr(order, "execution_without_payment", False)),
+            "execution_without_payment_reason": getattr(order, "execution_without_payment_reason", None),
+            "auto_execution_on_payment": bool(getattr(order, "auto_execution_on_payment", False)),
             "equipment_status": getattr(order.equipment_status, "value", str(order.equipment_status)) if order.equipment_status else "pending",
             "standard_install_kit_issued": bool(order.standard_install_kit_issued),
             "target_currency": order.target_currency,
@@ -1940,14 +2006,18 @@ class OrderService:
         from schemas import Meta
 
         segment = customer_segment.lower()
-        if segment not in {"b2c", "b2b"}:
+        if segment not in {"all", "b2c", "b2b"}:
             raise ValueError(f"Invalid segment: {customer_segment}")
 
         # B2B = explicit company OR customer has non-empty INN.
         # B2C = everything else (including legacy orders without linked customer).
         has_inn = and_(Customer.inn.is_not(None), func.length(func.trim(Customer.inn)) > 0)
         is_b2b = or_(Customer.type == CustomerType.company, has_inn)
-        segment_clause = is_b2b if segment == "b2b" else or_(Customer.id.is_(None), not_(is_b2b))
+        base_filters = [Order.status != OrderStatus.NEW_LEAD]
+        if segment == "b2b":
+            base_filters.append(is_b2b)
+        elif segment == "b2c":
+            base_filters.append(or_(Customer.id.is_(None), not_(is_b2b)))
 
         base_stmt = (
             select(Order)
@@ -1961,13 +2031,13 @@ class OrderService:
                 selectinload(Order.service_links).selectinload(OrderServiceLink.service),
                 selectinload(Order.installers).selectinload(OrderInstaller.installer),
             )
-            .where(segment_clause, Order.status != OrderStatus.NEW_LEAD)
+            .where(*base_filters)
         )
 
         count_stmt = (
             select(func.count(Order.id))
             .outerjoin(Customer, Order.customer_id == Customer.id)
-            .where(segment_clause, Order.status != OrderStatus.NEW_LEAD)
+            .where(*base_filters)
         )
 
         if status:
@@ -2336,12 +2406,24 @@ class OrderService:
             fields_set = getattr(payload, "__fields_set__", set())
 
         previous_workflow_type = OrderService._normalize_workflow_type(getattr(order, "workflow_type", None))
+        previous_status = order.status
+        previous_negotiation_status = OrderService._normalize_negotiation_status(
+            getattr(order, "negotiation_status", None),
+        )
 
         if "status" in fields_set and payload.status is not None:
             try:
                 order.status = OrderStatus(payload.status)
             except ValueError as exc:
                 raise ValueError(f"Invalid status: {payload.status}") from exc
+            if order.status != previous_status or not getattr(order, "status_changed_at", None):
+                order.status_changed_at = datetime.now()
+            if order.status == OrderStatus.CLOSED and not order.closing_result:
+                order.closing_result = ClosingResult.WON.value
+            if order.status != OrderStatus.CLOSED:
+                order.closing_result = None
+                order.reject_reason = None
+                order.closed_at = None
         if "title" in fields_set:
             order.title = OrderService._clean_order_title(payload.title)
         if "workflow_type" in fields_set and payload.workflow_type is not None:
@@ -2397,12 +2479,43 @@ class OrderService:
         if "additional_conditions" in fields_set:
             value = (payload.additional_conditions or "").strip()
             order.additional_conditions = value or None
+        if "negotiation_status" in fields_set and payload.negotiation_status is not None:
+            OrderService._set_negotiation_status(order, payload.negotiation_status)
         if "proposal_status" in fields_set and payload.proposal_status is not None:
             order.proposal_status = payload.proposal_status
+            if payload.proposal_status == "sent" and not order.proposal_sent_at:
+                order.proposal_sent_at = datetime.now()
         if "proposal_sent_at" in fields_set:
             order.proposal_sent_at = OrderService._normalize_naive_datetime(payload.proposal_sent_at)
+        if "execution_without_payment" in fields_set and payload.execution_without_payment is not None:
+            order.execution_without_payment = bool(payload.execution_without_payment)
+        if "execution_without_payment_reason" in fields_set:
+            order.execution_without_payment_reason = OrderService._clean_optional_text(payload.execution_without_payment_reason)
+        if "auto_execution_on_payment" in fields_set and payload.auto_execution_on_payment is not None:
+            order.auto_execution_on_payment = bool(payload.auto_execution_on_payment)
         if order.status == OrderStatus.EXECUTION and order.proposal_status != "approved":
             order.proposal_status = "approved"
+        if order.status == OrderStatus.EXECUTION:
+            if not order.installation_date:
+                order.installation_date = datetime.now()
+        elif order.status != OrderStatus.EXECUTION:
+            order.execution_without_payment = False
+            order.execution_without_payment_reason = None
+
+        if order.status == OrderStatus.NEGOTIATION and "negotiation_status" not in fields_set:
+            if "measurement_required" in fields_set and order.measurement_required:
+                OrderService._set_negotiation_status(order, "awaiting_visit")
+            elif "proposal_status" in fields_set and order.proposal_status == "sent":
+                OrderService._set_negotiation_status(order, "proposal_sent")
+            elif "proposal_status" in fields_set and order.proposal_status == "approved":
+                OrderService._set_negotiation_status(order, "awaiting_payment")
+        if order.status == OrderStatus.NEGOTIATION and not getattr(order, "negotiation_status_changed_at", None):
+            order.negotiation_status_changed_at = datetime.now()
+        if (
+            order.status == OrderStatus.NEGOTIATION
+            and OrderService._normalize_negotiation_status(getattr(order, "negotiation_status", None)) != previous_negotiation_status
+        ):
+            order.negotiation_status_changed_at = datetime.now()
         
         # Equipment & Installation
         if "equipment_status" in fields_set and payload.equipment_status is not None:
@@ -2712,6 +2825,8 @@ class OrderService:
         elif currency_fields_changed:
             await session.flush()
             await OrderService._refresh_order_financials(session, order)
+        else:
+            OrderService._apply_payment_state(order)
 
         transitioned_to_repair = previous_workflow_type != "repair" and current_workflow_type == "repair"
         if transitioned_to_repair and "services" not in fields_set:

--- a/services/order_transfer_service.py
+++ b/services/order_transfer_service.py
@@ -240,8 +240,13 @@ class OrderTransferService:
             on_hold_reason=order.on_hold_reason,
             measurement_required=bool(order.measurement_required),
             measurement_result=order.measurement_result,
+            negotiation_status=OrderService._infer_negotiation_status(order),
+            negotiation_status_changed_at=getattr(order, "negotiation_status_changed_at", None),
             proposal_status=order.proposal_status or "draft",
             proposal_sent_at=order.proposal_sent_at,
+            execution_without_payment=bool(getattr(order, "execution_without_payment", False)),
+            execution_without_payment_reason=getattr(order, "execution_without_payment_reason", None),
+            auto_execution_on_payment=bool(getattr(order, "auto_execution_on_payment", False)),
             equipment_status=OrderTransferService._enum_value(order.equipment_status) or EquipmentStatus.PENDING.value,
             standard_install_kit_issued=bool(order.standard_install_kit_issued),
             target_currency=order.target_currency,
@@ -555,8 +560,13 @@ class OrderTransferService:
                 measurement_date=order_data.measurement_date,
                 measurement_result=order_data.measurement_result,
                 additional_conditions=order_data.additional_conditions,
+                negotiation_status=OrderService._normalize_negotiation_status(order_data.negotiation_status),
+                negotiation_status_changed_at=order_data.negotiation_status_changed_at,
                 proposal_status=order_data.proposal_status or "draft",
                 proposal_sent_at=order_data.proposal_sent_at,
+                execution_without_payment=bool(order_data.execution_without_payment),
+                execution_without_payment_reason=order_data.execution_without_payment_reason,
+                auto_execution_on_payment=bool(order_data.auto_execution_on_payment),
                 equipment_status=OrderTransferService._parse_enum(
                     EquipmentStatus,
                     order_data.equipment_status,
@@ -566,6 +576,7 @@ class OrderTransferService:
                 created_at=order_data.created_at or datetime.now(),
                 installation_date=order_data.installation_date,
                 next_followup_date=order_data.next_followup_date,
+                status_changed_at=order_data.created_at or datetime.now(),
             )
             session.add(order)
             await session.flush()

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -70,6 +70,12 @@ async def test_manager_orders_list_segment_filter(async_client, db):
     assert len(b2b_items) == 1
     assert b2b_items[0]["customer"]["inn"] == "123456789"
 
+    r_all = await async_client.get("/api/manager/orders?segment=all", headers=headers)
+    assert r_all.status_code == 200
+    all_items = r_all.json()["items"]
+    assert len(all_items) == 3
+    assert any(item["customer"] is None for item in all_items)
+
 
 @pytest.mark.asyncio
 async def test_manager_orders_list_excludes_leads_before_pagination(async_client, db):
@@ -197,6 +203,7 @@ async def test_manager_order_patch_scalar_fields(async_client, db):
     headers = await _auth_headers(async_client)
     payload = {
         "status": "negotiation",
+        "negotiation_status": "awaiting_visit",
         "comment": "updated from manager",
         "is_paid": True,
     }
@@ -204,8 +211,76 @@ async def test_manager_order_patch_scalar_fields(async_client, db):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "negotiation"
+    assert data["negotiation_status"] == "awaiting_visit"
+    assert data["negotiation_status_changed_at"] is not None
+    assert data["status_changed_at"] is not None
     assert data["comment"] == "updated from manager"
     assert data["is_paid"] is True
+
+
+@pytest.mark.asyncio
+async def test_manager_order_patch_closes_lost_without_deleting_order(async_client, db):
+    customer = Customer(name="Lost Customer", phone="+375295555556", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEGOTIATION, total_amount=500, balance_due=500)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"status": "closed", "closing_result": "lost", "reject_reason": "Не сошлись по цене"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "closed"
+    assert data["closing_result"] == "lost"
+    assert data["reject_reason"] == "Не сошлись по цене"
+
+    detail_response = await async_client.get(f"/api/manager/orders/{order.id}", headers=headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["id"] == order.id
+
+
+@pytest.mark.asyncio
+async def test_manager_order_patch_moves_to_execution_without_payment_flag(async_client, db):
+    customer = Customer(name="Trusted Customer", phone="+375295555557", type=CustomerType.individual)
+    product = Product(title="Trusted AC", slug="trusted-ac", price=1000, area=20)
+    db.add(customer)
+    db.add(product)
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(product)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEGOTIATION, total_amount=0, balance_due=0)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={
+            "status": "execution",
+            "execution_without_payment": True,
+            "execution_without_payment_reason": "Постоянный клиент",
+            "products": [{"product_id": product.id, "quantity": 1, "price": 1000, "cost": 700}],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "execution"
+    assert data["proposal_status"] == "approved"
+    assert data["execution_without_payment"] is True
+    assert data["execution_without_payment_reason"] == "Постоянный клиент"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -12,6 +12,7 @@ from models import (
     CustomerType,
     Installer,
     Order,
+    OrderServiceLink,
     OrderWorkStage,
     OrderProposal,
     OrderStageStatus,
@@ -22,7 +23,7 @@ from models import (
     Service,
     ServiceTariff,
 )
-from schemas import ManagerOrderUpdatePayload, OrderWorkStageCreatePayload, OrderWorkStageUpdatePayload
+from schemas import ManagerOrderUpdatePayload, OrderWorkStageCreatePayload, OrderWorkStageUpdatePayload, PaymentCreatePayload
 from services.order_service import OrderService
 
 
@@ -297,6 +298,9 @@ async def test_service_get_orders_for_manager_segment_and_search(db):
     assert len(b2b["items"]) == 1
     assert b2b["items"][0]["customer"]["name"] == "Acme LLC"
 
+    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20)
+    assert {item["customer"]["name"] for item in all_orders["items"]} == {"Alice", "Acme LLC"}
+
 
 @pytest.mark.asyncio
 async def test_service_get_orders_for_manager_title_and_labels(db):
@@ -335,6 +339,42 @@ async def test_service_get_orders_for_manager_b2c_includes_legacy_without_custom
 
     b2b = await OrderService.get_orders_for_manager(db, "b2b", page=1, limit=20)
     assert len(b2b["items"]) == 0
+
+    all_orders = await OrderService.get_orders_for_manager(db, "all", page=1, limit=20)
+    assert len(all_orders["items"]) == 1
+    assert all_orders["items"][0]["customer"] is None
+
+
+@pytest.mark.asyncio
+async def test_service_auto_execution_on_payment_moves_order_to_work(db):
+    customer = Customer(name="Auto Pay", phone="+375291111113", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEGOTIATION,
+        negotiation_status="awaiting_payment",
+        auto_execution_on_payment=True,
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    db.add(OrderServiceLink(order_id=order.id, title="Монтаж", quantity=1, price=500, cost=0))
+    await db.commit()
+
+    await OrderService.add_payment(
+        db,
+        int(order.id),
+        PaymentCreatePayload(amount=500, type="postpayment"),
+    )
+    await db.refresh(order)
+
+    assert order.status == OrderStatus.EXECUTION
+    assert order.is_paid is True
+    assert order.balance_due == 0
 
 
 @pytest.mark.asyncio
@@ -465,6 +505,13 @@ async def test_service_update_order_for_manager_validation(db):
     with pytest.raises(ValueError):
         await OrderService.update_order_for_manager(db, order.id, ManagerOrderUpdatePayload(status="bad_status"))
 
+    with pytest.raises(ValueError, match="Invalid negotiation_status"):
+        await OrderService.update_order_for_manager(
+            db,
+            order.id,
+            ManagerOrderUpdatePayload(negotiation_status="waiting_for_magic"),
+        )
+
     with pytest.raises(ValueError):
         await OrderService.update_order_for_manager(
             db,
@@ -533,6 +580,17 @@ async def test_service_update_order_lost_archives_customer_in_same_flow(db):
     refreshed_customer = await db.get(Customer, customer.id)
     assert refreshed_customer is not None
     assert refreshed_customer.is_archived is True
+
+
+def test_service_explicit_negotiation_status_wins_over_proposal_status():
+    order = Order(
+        status=OrderStatus.NEGOTIATION,
+        negotiation_status="follow_up",
+        proposal_status="approved",
+        is_paid=False,
+    )
+
+    assert OrderService._infer_negotiation_status(order) == "follow_up"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reworked manager orders Kanban into workflow columns with substatus filtering, card color accents, and all/B2C/B2B segment switching.
- Added quick card actions for status changes, refusal, B2C debt closing, and auto move to work after full payment.
- Added backend/schema/migration support for negotiation workflow fields, `segment=all`, and `auto_execution_on_payment`.

## Checks
- `docker compose exec -T app pytest tests/unit/test_order_service_manager.py tests/integration/test_manager_orders_api.py -q`
- `npm run build` in `manager_frontend`
- `git diff --check`