### PR TITLE
Add execution workflow statuses

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_add_order_execution_workflow_status.py
+++ b/alembic/versions/b1c2d3e4f5a6_add_order_execution_workflow_status.py
@@ -1,0 +1,78 @@
+"""add_order_execution_workflow_status
+
+Revision ID: b1c2d3e4f5a6
+Revises: a0b1c2d3e4f5
+Create Date: 2026-06-26 17:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, Sequence[str], None] = "a0b1c2d3e4f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_names(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    columns = _column_names("order")
+    index_names = _index_names("order")
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "execution_status" not in columns:
+            batch_op.add_column(
+                sa.Column("execution_status", sa.String(), nullable=False, server_default="needs_schedule")
+            )
+        if "execution_status_changed_at" not in columns:
+            batch_op.add_column(sa.Column("execution_status_changed_at", sa.DateTime(), nullable=True))
+        if "auto_close_on_payment" not in columns:
+            batch_op.add_column(sa.Column("auto_close_on_payment", sa.Boolean(), nullable=False, server_default=sa.false()))
+        if "ix_order_execution_status" not in index_names:
+            batch_op.create_index("ix_order_execution_status", ["execution_status"])
+        if "ix_order_auto_close_on_payment" not in index_names:
+            batch_op.create_index("ix_order_auto_close_on_payment", ["auto_close_on_payment"])
+
+    op.execute(
+        """
+        UPDATE "order"
+        SET
+            execution_status = CASE
+                WHEN status = 'execution' AND installation_date IS NOT NULL THEN 'scheduled'
+                WHEN status = 'execution' THEN COALESCE(NULLIF(execution_status, ''), 'needs_schedule')
+                ELSE COALESCE(NULLIF(execution_status, ''), 'needs_schedule')
+            END,
+            execution_status_changed_at = CASE
+                WHEN status = 'execution'
+                THEN COALESCE(execution_status_changed_at, status_changed_at, updated_at, created_at)
+                ELSE execution_status_changed_at
+            END
+        """
+    )
+
+
+def downgrade() -> None:
+    columns = _column_names("order")
+    index_names = _index_names("order")
+    with op.batch_alter_table("order", schema=None) as batch_op:
+        if "ix_order_execution_status" in index_names:
+            batch_op.drop_index("ix_order_execution_status")
+        if "ix_order_auto_close_on_payment" in index_names:
+            batch_op.drop_index("ix_order_auto_close_on_payment")
+        if "auto_close_on_payment" in columns:
+            batch_op.drop_column("auto_close_on_payment")
+        if "execution_status_changed_at" in columns:
+            batch_op.drop_column("execution_status_changed_at")
+        if "execution_status" in columns:
+            batch_op.drop_column("execution_status")

--- a/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderDetailResponse.ts
@@ -61,6 +61,9 @@ export type ManagerOrderDetailResponse = {
     execution_without_payment?: boolean;
     execution_without_payment_reason?: (string | null);
     auto_execution_on_payment?: boolean;
+    auto_close_on_payment?: boolean;
+    execution_status?: string;
+    execution_status_changed_at?: (string | null);
     total_payments?: number;
     balance_due?: number;
     product_lines?: Array<OrderProductLineResponse>;

--- a/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerOrderListItemResponse.ts
@@ -55,6 +55,9 @@ export type ManagerOrderListItemResponse = {
     execution_without_payment?: boolean;
     execution_without_payment_reason?: (string | null);
     auto_execution_on_payment?: boolean;
+    auto_close_on_payment?: boolean;
+    execution_status?: string;
+    execution_status_changed_at?: (string | null);
     total_payments?: number;
     balance_due?: number;
     readonly needs_attention: boolean;

--- a/manager_frontend/src/client/models/ManagerOrderTransferOrder_Input.ts
+++ b/manager_frontend/src/client/models/ManagerOrderTransferOrder_Input.ts
@@ -37,6 +37,9 @@ export type ManagerOrderTransferOrder_Input = {
     execution_without_payment?: boolean;
     execution_without_payment_reason?: (string | null);
     auto_execution_on_payment?: boolean;
+    auto_close_on_payment?: boolean;
+    execution_status?: string;
+    execution_status_changed_at?: (string | null);
     equipment_status?: string;
     standard_install_kit_issued?: boolean;
     target_currency?: (PaymentCurrency | null);

--- a/manager_frontend/src/client/models/ManagerOrderTransferOrder_Output.ts
+++ b/manager_frontend/src/client/models/ManagerOrderTransferOrder_Output.ts
@@ -37,6 +37,9 @@ export type ManagerOrderTransferOrder_Output = {
     execution_without_payment?: boolean;
     execution_without_payment_reason?: (string | null);
     auto_execution_on_payment?: boolean;
+    auto_close_on_payment?: boolean;
+    execution_status?: string;
+    execution_status_changed_at?: (string | null);
     equipment_status?: string;
     standard_install_kit_issued?: boolean;
     target_currency?: (PaymentCurrency | null);

--- a/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerOrderUpdatePayload.ts
@@ -26,6 +26,8 @@ export type ManagerOrderUpdatePayload = {
     execution_without_payment?: (boolean | null);
     execution_without_payment_reason?: (string | null);
     auto_execution_on_payment?: (boolean | null);
+    auto_close_on_payment?: (boolean | null);
+    execution_status?: (string | null);
     is_paid?: (boolean | null);
     closing_result?: (string | null);
     reject_reason?: (string | null);

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -27,6 +27,7 @@ const setToast = (msg: string, type: 'success' | 'error' = 'success') => {
 };
 
 const showAddStage = ref(false);
+const showLegacyPickingList = false;
 const newStageName = ref('');
 const newStageStart = ref('');
 const newStageInstaller = ref<number | null>(null);
@@ -240,7 +241,7 @@ watch(() => props.order.id, () => {
   </div>
 
   <!-- ZONE 1: Timeline -->
-  <section class="rounded-2xl bg-white border border-slate-200 p-5 shadow-sm">
+  <section v-if="showLegacyPickingList" class="rounded-2xl bg-white border border-slate-200 p-5 shadow-sm">
     <div class="flex items-center justify-between mb-4 border-b border-slate-100 pb-3">
         <h3 class="text-lg font-bold text-slate-800 font-['Space_Grotesk']">Хронология выездов</h3>
         <button v-if="!showAddStage" class="btn-mini" @click="showAddStage = true">+ Добавить выезд</button>

--- a/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
+++ b/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
@@ -3,9 +3,11 @@ import { computed, ref } from 'vue';
 import { MoreVertical, XCircle } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
 import {
+  EXECUTION_STATUS_OPTIONS,
   NEGOTIATION_STATUS_OPTIONS,
   formatMoney,
   getOrderBoardColumn,
+  getOrderExecutionStatus,
   getOrderNegotiationStatus,
 } from './order-utils';
 
@@ -24,6 +26,17 @@ const menuOpen = ref(false);
 const balanceDue = computed(() => Number(props.order.balance_due || 0));
 const activeBoardColumn = computed(() => getOrderBoardColumn(props.order));
 const activeNegotiationStatus = computed(() => getOrderNegotiationStatus(props.order));
+const activeExecutionStatus = computed(() => getOrderExecutionStatus(props.order));
+const stageTitle = computed(() => {
+  if (activeBoardColumn.value === 'execution') return 'Работы';
+  if (activeBoardColumn.value === 'negotiation') return 'Переговоры';
+  return '';
+});
+const stageOptions = computed(() => {
+  if (activeBoardColumn.value === 'execution') return EXECUTION_STATUS_OPTIONS;
+  if (activeBoardColumn.value === 'negotiation') return NEGOTIATION_STATUS_OPTIONS;
+  return [];
+});
 
 const boardActions = computed(() => [
   activeBoardColumn.value !== 'negotiation'
@@ -40,6 +53,14 @@ const boardActions = computed(() => [
 const selectStatus = (status: string) => {
   menuOpen.value = false;
   emit('quickStatus', { orderId: props.order.id, status });
+};
+
+const selectStageStatus = (status: string) => {
+  if (activeBoardColumn.value === 'execution') {
+    selectStatus(`execution:${status}`);
+    return;
+  }
+  selectStatus(status);
 };
 
 const cancelOrder = () => {
@@ -81,21 +102,23 @@ const closeDebt = () => {
         {{ action.label }}
       </button>
 
-      <div class="my-1 border-t border-slate-100 dark:border-slate-700" />
-      <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">Переговоры</div>
+      <template v-if="stageOptions.length">
+        <div class="my-1 border-t border-slate-100 dark:border-slate-700" />
+        <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">{{ stageTitle }}</div>
+      </template>
       <button
-        v-for="option in NEGOTIATION_STATUS_OPTIONS"
+        v-for="option in stageOptions"
         :key="option.value"
         type="button"
         class="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
-        :class="activeNegotiationStatus === option.value && activeBoardColumn === 'negotiation' ? 'bg-slate-50 dark:bg-slate-700' : ''"
-        @click="selectStatus(option.value)"
+        :class="(activeBoardColumn === 'execution' ? activeExecutionStatus : activeNegotiationStatus) === option.value ? 'bg-slate-50 dark:bg-slate-700' : ''"
+        @click="selectStageStatus(option.value)"
       >
         <span class="inline-flex min-w-0 items-center gap-2">
           <span class="material-icons-round text-[16px]">{{ option.icon }}</span>
           <span class="truncate">{{ option.label }}</span>
         </span>
-        <span v-if="activeNegotiationStatus === option.value && activeBoardColumn === 'negotiation'" class="material-icons-round text-[15px] text-teal-600">check</span>
+        <span v-if="(activeBoardColumn === 'execution' ? activeExecutionStatus : activeNegotiationStatus) === option.value" class="material-icons-round text-[15px] text-teal-600">check</span>
       </button>
 
       <template v-if="allowCloseDebt && balanceDue > 0">

--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
-import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
+import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderExecutionLabel, getOrderExecutionStatus, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
 import OrderCardActionsMenu from './OrderCardActionsMenu.vue';
 import OrderTitleEditor from './OrderTitleEditor.vue';
 
@@ -52,8 +52,16 @@ const objectLine = computed(() => {
 const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
 const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
 const boardColumn = computed(() => getOrderBoardColumn(props.order));
-const badgeColumn = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationStatus(props.order) : boardColumn.value));
-const boardLabel = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationLabel(props.order) : getOrderBoardLabel(props.order)));
+const badgeColumn = computed(() => {
+  if (props.order.status === 'negotiation') return getOrderNegotiationStatus(props.order);
+  if (props.order.status === 'execution') return getOrderExecutionStatus(props.order);
+  return boardColumn.value;
+});
+const boardLabel = computed(() => {
+  if (props.order.status === 'negotiation') return getOrderNegotiationLabel(props.order);
+  if (props.order.status === 'execution') return getOrderExecutionLabel(props.order);
+  return getOrderBoardLabel(props.order);
+});
 const fallbackBoardTone = {
   column: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800',
   badge: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
@@ -66,6 +74,8 @@ const cardAccentClass = computed(() => BOARD_CARD_ACCENT_CLASSES[badgeColumn.val
 const statusAge = computed(() => {
   const sourceDate = props.order.status === 'negotiation'
     ? props.order.negotiation_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
+    : props.order.status === 'execution'
+      ? props.order.execution_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
     : props.order.status_changed_at || props.order.updated_at || props.order.created_at;
   return formatRelativeAge(sourceDate);
 });
@@ -80,6 +90,7 @@ const statusFlags = computed(() => [
   props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
   props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
   props.order.auto_execution_on_payment ? { label: 'Авто после оплаты', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' } : null,
+  props.order.auto_close_on_payment ? { label: 'Авто закрытие', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
   props.order.execution_without_payment ? { label: 'Без оплаты', className: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300' } : null,
 ].filter(Boolean) as { label: string; className: string }[]);
 const hasComment = computed(() => Boolean(props.order.comment?.trim()));

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 import { ChevronDown, ChevronUp, ExternalLink } from 'lucide-vue-next';
 import type { ManagerOrderListItemResponse } from '../../client';
-import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
+import { BOARD_CARD_ACCENT_CLASSES, BOARD_COLUMN_TONE_CLASSES, formatDate, formatMoney, formatPhone, formatRelativeAge, getOrderBoardColumn, getOrderBoardLabel, getOrderExecutionLabel, getOrderExecutionStatus, getOrderNegotiationLabel, getOrderNegotiationStatus, isOverdue } from './order-utils';
 import OrderCardActionsMenu from './OrderCardActionsMenu.vue';
 import OrderTitleEditor from './OrderTitleEditor.vue';
 
@@ -52,8 +52,16 @@ const objectLine = computed(() => {
 const compactLabels = computed(() => props.order.manager_labels?.slice(0, 2) ?? []);
 const hiddenLabelsCount = computed(() => Math.max((props.order.manager_labels?.length ?? 0) - compactLabels.value.length, 0));
 const boardColumn = computed(() => getOrderBoardColumn(props.order));
-const badgeColumn = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationStatus(props.order) : boardColumn.value));
-const boardLabel = computed(() => (props.order.status === 'negotiation' ? getOrderNegotiationLabel(props.order) : getOrderBoardLabel(props.order)));
+const badgeColumn = computed(() => {
+  if (props.order.status === 'negotiation') return getOrderNegotiationStatus(props.order);
+  if (props.order.status === 'execution') return getOrderExecutionStatus(props.order);
+  return boardColumn.value;
+});
+const boardLabel = computed(() => {
+  if (props.order.status === 'negotiation') return getOrderNegotiationLabel(props.order);
+  if (props.order.status === 'execution') return getOrderExecutionLabel(props.order);
+  return getOrderBoardLabel(props.order);
+});
 const fallbackBoardTone = {
   column: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800',
   badge: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200',
@@ -66,6 +74,8 @@ const cardAccentClass = computed(() => BOARD_CARD_ACCENT_CLASSES[badgeColumn.val
 const statusAge = computed(() => {
   const sourceDate = props.order.status === 'negotiation'
     ? props.order.negotiation_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
+    : props.order.status === 'execution'
+      ? props.order.execution_status_changed_at || props.order.status_changed_at || props.order.updated_at || props.order.created_at
     : props.order.status_changed_at || props.order.updated_at || props.order.created_at;
   return formatRelativeAge(sourceDate);
 });
@@ -80,6 +90,7 @@ const statusFlags = computed(() => [
   props.order.needs_attention ? { label: 'Внимание', className: 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300' } : null,
   props.order.awaiting_measurement ? { label: 'Замер', className: 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300' } : null,
   props.order.auto_execution_on_payment ? { label: 'Авто после оплаты', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' } : null,
+  props.order.auto_close_on_payment ? { label: 'Авто закрытие', className: 'bg-green-100 text-green-700 dark:bg-green-500/15 dark:text-green-300' } : null,
   props.order.execution_without_payment ? { label: 'Без оплаты', className: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-300' } : null,
 ].filter(Boolean) as { label: string; className: string }[]);
 const hasComment = computed(() => Boolean(props.order.comment?.trim()));

--- a/manager_frontend/src/components/orders/OrderColumn.vue
+++ b/manager_frontend/src/components/orders/OrderColumn.vue
@@ -7,13 +7,13 @@ import type { OrderRenderItem } from './order-utils';
 import OrderCardB2B from './OrderCardB2B.vue';
 import OrderCardB2C from './OrderCardB2C.vue';
 import OrderCustomerGroupCard from './OrderCustomerGroupCard.vue';
-import { BOARD_COLUMN_TONE_CLASSES, createCustomerOrderGroup, getOrderNegotiationStatus, getOrderSegment } from './order-utils';
+import { BOARD_COLUMN_TONE_CLASSES, createCustomerOrderGroup, getOrderExecutionStatus, getOrderNegotiationStatus, getOrderSegment } from './order-utils';
 
 const props = defineProps<{
   status: string;
   label: string;
   icon?: string;
-  filterKind?: 'negotiation';
+  filterKind?: 'negotiation' | 'execution';
   filterOptions?: ReadonlyArray<{ value: string; label: string; icon?: string }>;
   items: OrderRenderItem[];
   segment: Segment;
@@ -41,6 +41,7 @@ const filterOpen = ref(false);
 
 const getFilterValue = (order: ManagerOrderListItemResponse) => {
   if (props.filterKind === 'negotiation') return getOrderNegotiationStatus(order);
+  if (props.filterKind === 'execution') return getOrderExecutionStatus(order);
   return '';
 };
 

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -28,7 +28,7 @@ import type {
   ManagerEquipmentHistoryFromRepairOrderPayload,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
-import { NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
+import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
@@ -438,19 +438,28 @@ const measurementResult = ref('');
 const additionalConditions = ref('');
 const proposalStatus = ref<'draft' | 'sent' | 'approved' | 'rejected'>('draft');
 const negotiationStatus = ref('awaiting_offer');
+const executionStatus = ref('needs_schedule');
 const executionWithoutPayment = ref(false);
 const executionWithoutPaymentReason = ref('');
 const autoExecutionOnPayment = ref(false);
+const autoCloseOnPayment = ref(false);
 const activeProposalId = ref<number | null>(null);
 const proposalActionLoading = ref(false);
 const negotiationStatusLabel = computed(() => (
   NEGOTIATION_STATUS_OPTIONS.find((option) => option.value === negotiationStatus.value)?.label || 'Ждет предложение'
+));
+const executionStatusLabel = computed(() => (
+  EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить монтаж'
 ));
 
 const setNegotiationStatus = (value: string) => {
   negotiationStatus.value = value;
   if (value === 'proposal_sent') proposalStatus.value = 'sent';
   if (value === 'awaiting_payment') proposalStatus.value = 'approved';
+};
+
+const setExecutionStatus = (value: string) => {
+  executionStatus.value = value;
 };
 
 const installersList = ref<ManagerInstallerResponse[]>([]);
@@ -1588,9 +1597,11 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   additionalConditions.value = order.additional_conditions ?? '';
   proposalStatus.value = (order.proposal_status as any) || 'draft';
   negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
+  executionStatus.value = order.execution_status || 'needs_schedule';
   executionWithoutPayment.value = Boolean(order.execution_without_payment);
   executionWithoutPaymentReason.value = order.execution_without_payment_reason || '';
   autoExecutionOnPayment.value = Boolean(order.auto_execution_on_payment);
+  autoCloseOnPayment.value = Boolean(order.auto_close_on_payment);
   targetCurrency.value = order.target_currency || null;
   targetCurrencyAmount.value = order.target_currency_amount || null;
   targetCurrencyPayments.value = order.target_currency_payments || 0;
@@ -2383,9 +2394,11 @@ const handleSave = () => {
     additional_conditions: additionalConditions.value,
     negotiation_status: status.value === 'negotiation' ? negotiationStatus.value : undefined,
     proposal_status: status.value === 'execution' ? 'approved' : proposalStatus.value,
+    execution_status: status.value === 'execution' ? executionStatus.value : undefined,
     execution_without_payment: status.value === 'execution' ? executionWithoutPayment.value : false,
     execution_without_payment_reason: status.value === 'execution' && executionWithoutPayment.value ? executionWithoutPaymentReason.value : null,
     auto_execution_on_payment: autoExecutionOnPayment.value,
+    auto_close_on_payment: status.value === 'execution' ? autoCloseOnPayment.value : false,
     target_currency: enableCurrency.value ? (targetCurrency.value || null) : null,
     target_currency_amount: enableCurrency.value && targetCurrencyAmount.value ? Number(String(targetCurrencyAmount.value).replace(',', '.')) : null,
   };
@@ -3777,11 +3790,32 @@ watch(
         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h3 class="text-sm font-semibold text-teal-900">Установка / работы</h3>
-            <p class="mt-0.5 text-xs text-teal-700/75">Фиксируем исключения перед выполнением работ.</p>
+            <p class="mt-0.5 text-xs text-teal-700/75">Текущий этап: {{ executionStatusLabel }}</p>
           </div>
+        </div>
+        <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+          <button
+            v-for="option in EXECUTION_STATUS_OPTIONS"
+            :key="option.value"
+            type="button"
+            class="inline-flex min-h-10 items-center justify-center gap-1.5 rounded-xl border px-2 py-2 text-xs font-semibold transition"
+            :class="executionStatus === option.value
+              ? 'border-teal-500 bg-white text-teal-800 shadow-sm'
+              : 'border-teal-100 bg-white/70 text-slate-600 hover:border-teal-300 hover:text-teal-800'"
+            @click="setExecutionStatus(option.value)"
+          >
+            <span class="material-icons-round text-[15px]">{{ option.icon }}</span>
+            <span class="truncate">{{ option.label }}</span>
+          </button>
+        </div>
+        <div class="mt-3 grid gap-2 sm:grid-cols-2">
           <label class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-teal-900 ring-1 ring-teal-100">
             <input v-model="executionWithoutPayment" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
             Перенос без оплаты
+          </label>
+          <label class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-teal-900 ring-1 ring-teal-100">
+            <input v-model="autoCloseOnPayment" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+            Закрыть после оплаты
           </label>
         </div>
         <label v-if="executionWithoutPayment" class="field-label mt-3">

--- a/manager_frontend/src/components/orders/OrderKanbanBoard.vue
+++ b/manager_frontend/src/components/orders/OrderKanbanBoard.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import type { Segment } from '../../api';
 import type { OrderRenderItem } from './order-utils';
 import OrderColumn from './OrderColumn.vue';
-import { BOARD_COLUMNS, BOARD_COLUMN_LABELS, NEGOTIATION_STATUS_OPTIONS } from './order-utils';
+import { BOARD_COLUMNS, BOARD_COLUMN_LABELS, EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS } from './order-utils';
 
 defineProps<{
   groupedItems: Record<string, OrderRenderItem[]>;
@@ -62,8 +62,8 @@ const onToggleGroup = (groupId: string) => {
       :status="column.value"
       :label="BOARD_COLUMN_LABELS[column.value] || column.label"
       :icon="column.icon"
-      :filter-kind="column.value === 'negotiation' ? 'negotiation' : undefined"
-      :filter-options="column.value === 'negotiation' ? NEGOTIATION_STATUS_OPTIONS : undefined"
+      :filter-kind="column.value === 'negotiation' ? 'negotiation' : column.value === 'execution' ? 'execution' : undefined"
+      :filter-options="column.value === 'negotiation' ? NEGOTIATION_STATUS_OPTIONS : column.value === 'execution' ? EXECUTION_STATUS_OPTIONS : undefined"
       :items="groupedItems[column.value] || []"
       :segment="segment"
       :moving-order-ids="movingOrderIds"

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -18,6 +18,7 @@ import OrdersListTable from './OrdersListTable.vue';
 import OrderEditDrawer from './OrderEditDrawer.vue';
 import {
   BOARD_COLUMNS,
+  EXECUTION_STATUS_LABELS,
   STATUS_LABELS,
   STATUS_ORDER,
   buildCustomerOrderRenderItems,
@@ -397,6 +398,24 @@ const clearOrderFilters = async () => {
 };
 
 const buildBoardTransitionPayload = (order: ManagerOrderListItemResponse, column: string): ManagerOrderUpdatePayload | null => {
+  if (column.startsWith('execution:')) {
+    const executionStatus = column.slice('execution:'.length);
+    if (!EXECUTION_STATUS_LABELS[executionStatus]) return null;
+    const balanceDue = Number(order.balance_due || 0);
+    const payload: ManagerOrderUpdatePayload = {
+      status: 'execution',
+      execution_status: executionStatus,
+      closing_result: null,
+      reject_reason: null,
+    };
+    if (balanceDue > 0 && !order.execution_without_payment && executionStatus !== 'awaiting_payment') {
+      const approved = window.confirm('По заказу есть долг. Перенести в работу без оплаты?');
+      if (!approved) return null;
+      payload.execution_without_payment = true;
+      payload.execution_without_payment_reason = window.prompt('Причина переноса без оплаты', 'Доверенный клиент') || 'Без предоплаты';
+    }
+    return payload;
+  }
   if (column === 'closed_lost') return null;
   if (column === 'closed_won') {
     return { status: 'closed', closing_result: 'won', reject_reason: null };
@@ -442,6 +461,7 @@ const applyStatusLocally = (orderId: number, payload: ManagerOrderUpdatePayload)
   if (!item) return;
   if (payload.status !== undefined && payload.status !== null) item.status = payload.status;
   if (payload.negotiation_status !== undefined && payload.negotiation_status !== null) item.negotiation_status = payload.negotiation_status;
+  if (payload.execution_status !== undefined && payload.execution_status !== null) item.execution_status = payload.execution_status;
   if (payload.closing_result !== undefined) item.closing_result = payload.closing_result;
   if (payload.reject_reason !== undefined) item.reject_reason = payload.reject_reason;
   if (payload.proposal_status !== undefined && payload.proposal_status !== null) item.proposal_status = payload.proposal_status;
@@ -451,6 +471,7 @@ const applyStatusLocally = (orderId: number, payload: ManagerOrderUpdatePayload)
   const now = new Date().toISOString();
   item.status_changed_at = now;
   if (payload.negotiation_status) item.negotiation_status_changed_at = now;
+  if (payload.execution_status) item.execution_status_changed_at = now;
 };
 
 const onMoveOrder = async (payload: { orderId: number; oldStatus: string; newStatus: string }) => {

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -15,6 +15,16 @@ export const NEGOTIATION_STATUS_OPTIONS = [
     { value: 'follow_up', label: 'Уточнить', icon: 'contact_phone', tone: 'slate' },
 ] as const;
 
+export const EXECUTION_STATUS_OPTIONS = [
+    { value: 'order_equipment', label: 'Заказать товар', icon: 'add_shopping_cart', tone: 'rose' },
+    { value: 'awaiting_equipment', label: 'Ждем оборудование', icon: 'local_shipping', tone: 'amber' },
+    { value: 'needs_schedule', label: 'Назначить монтаж', icon: 'event_available', tone: 'teal' },
+    { value: 'scheduled', label: 'Монтаж назначен', icon: 'event', tone: 'cyan' },
+    { value: 'work_done', label: 'Монтаж выполнен', icon: 'task_alt', tone: 'green' },
+    { value: 'awaiting_documents', label: 'Закрыть документы', icon: 'fact_check', tone: 'indigo' },
+    { value: 'awaiting_payment', label: 'Ждет оплату', icon: 'payments', tone: 'emerald' },
+] as const;
+
 export const BOARD_COLUMNS = [
     { value: 'negotiation', label: 'Переговоры', icon: 'forum', tone: 'sky' },
     { value: 'execution', label: 'Установка / работы', icon: 'construction', tone: 'teal' },
@@ -31,6 +41,10 @@ export const STATUS_LABELS: Record<string, string> = {
 
 export const NEGOTIATION_STATUS_LABELS: Record<string, string> = Object.fromEntries(
     NEGOTIATION_STATUS_OPTIONS.map((item) => [item.value, item.label]),
+);
+
+export const EXECUTION_STATUS_LABELS: Record<string, string> = Object.fromEntries(
+    EXECUTION_STATUS_OPTIONS.map((item) => [item.value, item.label]),
 );
 
 export const BOARD_COLUMN_LABELS: Record<string, string> = Object.fromEntries(
@@ -73,6 +87,36 @@ export const BOARD_COLUMN_TONE_CLASSES: Record<string, { column: string; badge: 
         badge: 'bg-teal-100 text-teal-700 dark:bg-teal-500/20 dark:text-teal-200',
         text: 'text-teal-800 dark:text-teal-200',
     },
+    order_equipment: {
+        column: 'border-rose-100 bg-rose-50/60 dark:border-rose-500/20 dark:bg-rose-500/10',
+        badge: 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200',
+        text: 'text-rose-800 dark:text-rose-200',
+    },
+    awaiting_equipment: {
+        column: 'border-amber-100 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/10',
+        badge: 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+        text: 'text-amber-800 dark:text-amber-200',
+    },
+    needs_schedule: {
+        column: 'border-teal-100 bg-teal-50/60 dark:border-teal-500/20 dark:bg-teal-500/10',
+        badge: 'bg-teal-100 text-teal-700 dark:bg-teal-500/20 dark:text-teal-200',
+        text: 'text-teal-800 dark:text-teal-200',
+    },
+    scheduled: {
+        column: 'border-cyan-100 bg-cyan-50/60 dark:border-cyan-500/20 dark:bg-cyan-500/10',
+        badge: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-500/20 dark:text-cyan-200',
+        text: 'text-cyan-800 dark:text-cyan-200',
+    },
+    awaiting_documents: {
+        column: 'border-indigo-100 bg-indigo-50/60 dark:border-indigo-500/20 dark:bg-indigo-500/10',
+        badge: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200',
+        text: 'text-indigo-800 dark:text-indigo-200',
+    },
+    work_done: {
+        column: 'border-green-100 bg-green-50/60 dark:border-green-500/20 dark:bg-green-500/10',
+        badge: 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-200',
+        text: 'text-green-800 dark:text-green-200',
+    },
     closed_won: {
         column: 'border-green-100 bg-green-50/60 dark:border-green-500/20 dark:bg-green-500/10',
         badge: 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-200',
@@ -93,6 +137,12 @@ export const BOARD_CARD_ACCENT_CLASSES: Record<string, string> = {
     awaiting_payment: 'border-emerald-200 bg-emerald-50/55 shadow-emerald-100/80 hover:shadow-emerald-200/80 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:shadow-none',
     follow_up: 'border-slate-300 bg-slate-50 shadow-slate-100/80 hover:shadow-slate-200/80 dark:border-slate-600 dark:bg-slate-700/40 dark:shadow-none',
     execution: 'border-teal-200 bg-teal-50/55 shadow-teal-100/80 hover:shadow-teal-200/80 dark:border-teal-500/30 dark:bg-teal-500/10 dark:shadow-none',
+    order_equipment: 'border-rose-200 bg-rose-50/55 shadow-rose-100/80 hover:shadow-rose-200/80 dark:border-rose-500/30 dark:bg-rose-500/10 dark:shadow-none',
+    awaiting_equipment: 'border-amber-200 bg-amber-50/60 shadow-amber-100/80 hover:shadow-amber-200/80 dark:border-amber-500/30 dark:bg-amber-500/10 dark:shadow-none',
+    needs_schedule: 'border-teal-200 bg-teal-50/55 shadow-teal-100/80 hover:shadow-teal-200/80 dark:border-teal-500/30 dark:bg-teal-500/10 dark:shadow-none',
+    scheduled: 'border-cyan-200 bg-cyan-50/55 shadow-cyan-100/80 hover:shadow-cyan-200/80 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:shadow-none',
+    awaiting_documents: 'border-indigo-200 bg-indigo-50/55 shadow-indigo-100/80 hover:shadow-indigo-200/80 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:shadow-none',
+    work_done: 'border-green-200 bg-green-50/55 shadow-green-100/80 hover:shadow-green-200/80 dark:border-green-500/30 dark:bg-green-500/10 dark:shadow-none',
     closed_won: 'border-green-200 bg-green-50/55 shadow-green-100/80 hover:shadow-green-200/80 dark:border-green-500/30 dark:bg-green-500/10 dark:shadow-none',
     closed_lost: 'border-rose-200 bg-rose-50/55 shadow-rose-100/80 hover:shadow-rose-200/80 dark:border-rose-500/30 dark:bg-rose-500/10 dark:shadow-none',
 };
@@ -126,6 +176,15 @@ export function getOrderNegotiationStatus(order: ManagerOrderListItemResponse): 
 
 export function getOrderNegotiationLabel(order: ManagerOrderListItemResponse): string {
     return NEGOTIATION_STATUS_LABELS[getOrderNegotiationStatus(order)] || 'Ждет предложение';
+}
+
+export function getOrderExecutionStatus(order: ManagerOrderListItemResponse): string {
+    const value = order.execution_status || '';
+    return EXECUTION_STATUS_LABELS[value] ? value : 'needs_schedule';
+}
+
+export function getOrderExecutionLabel(order: ManagerOrderListItemResponse): string {
+    return EXECUTION_STATUS_LABELS[getOrderExecutionStatus(order)] || 'Назначить монтаж';
 }
 
 export function formatMoney(value: number): string {

--- a/models/order.py
+++ b/models/order.py
@@ -379,8 +379,11 @@ class Order(SQLModel, table=True):
     execution_without_payment: bool = Field(default=False, index=True)
     execution_without_payment_reason: Optional[str] = Field(default=None)
     auto_execution_on_payment: bool = Field(default=False, index=True)
+    auto_close_on_payment: bool = Field(default=False, index=True)
 
     # --- Internal: Execution stage ---
+    execution_status: str = Field(default="needs_schedule", sa_column=Column(String, default="needs_schedule", index=True))
+    execution_status_changed_at: Optional[datetime] = None
     works_plan: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
 
     # Store equipment state

--- a/openapi.json
+++ b/openapi.json
@@ -24464,6 +24464,28 @@
             "title": "Auto Execution On Payment",
             "default": false
           },
+          "auto_close_on_payment": {
+            "type": "boolean",
+            "title": "Auto Close On Payment",
+            "default": false
+          },
+          "execution_status": {
+            "type": "string",
+            "title": "Execution Status",
+            "default": "needs_schedule"
+          },
+          "execution_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Status Changed At"
+          },
           "total_payments": {
             "type": "number",
             "title": "Total Payments",
@@ -25520,6 +25542,28 @@
             "title": "Auto Execution On Payment",
             "default": false
           },
+          "auto_close_on_payment": {
+            "type": "boolean",
+            "title": "Auto Close On Payment",
+            "default": false
+          },
+          "execution_status": {
+            "type": "string",
+            "title": "Execution Status",
+            "default": "needs_schedule"
+          },
+          "execution_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Status Changed At"
+          },
           "total_payments": {
             "type": "number",
             "title": "Total Payments",
@@ -26167,6 +26211,28 @@
             "title": "Auto Execution On Payment",
             "default": false
           },
+          "auto_close_on_payment": {
+            "type": "boolean",
+            "title": "Auto Close On Payment",
+            "default": false
+          },
+          "execution_status": {
+            "type": "string",
+            "title": "Execution Status",
+            "default": "needs_schedule"
+          },
+          "execution_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Status Changed At"
+          },
           "equipment_status": {
             "type": "string",
             "title": "Equipment Status",
@@ -26501,6 +26567,28 @@
             "type": "boolean",
             "title": "Auto Execution On Payment",
             "default": false
+          },
+          "auto_close_on_payment": {
+            "type": "boolean",
+            "title": "Auto Close On Payment",
+            "default": false
+          },
+          "execution_status": {
+            "type": "string",
+            "title": "Execution Status",
+            "default": "needs_schedule"
+          },
+          "execution_status_changed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Status Changed At"
           },
           "equipment_status": {
             "type": "string",
@@ -27321,6 +27409,28 @@
               }
             ],
             "title": "Auto Execution On Payment"
+          },
+          "auto_close_on_payment": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Close On Payment"
+          },
+          "execution_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Status"
           },
           "is_paid": {
             "anyOf": [

--- a/schemas.py
+++ b/schemas.py
@@ -742,6 +742,9 @@ class ManagerOrderListItemResponse(BaseModel):
     execution_without_payment: bool = False
     execution_without_payment_reason: Optional[str] = None
     auto_execution_on_payment: bool = False
+    auto_close_on_payment: bool = False
+    execution_status: str = "needs_schedule"
+    execution_status_changed_at: Optional[datetime] = None
 
     @computed_field
     @property
@@ -1056,6 +1059,8 @@ class ManagerOrderUpdatePayload(BaseModel):
     execution_without_payment: Optional[bool] = None
     execution_without_payment_reason: Optional[str] = None
     auto_execution_on_payment: Optional[bool] = None
+    auto_close_on_payment: Optional[bool] = None
+    execution_status: Optional[str] = None
 
     is_paid: Optional[bool] = None
     # Closing
@@ -1240,6 +1245,9 @@ class ManagerOrderTransferOrder(BaseModel):
     execution_without_payment: bool = False
     execution_without_payment_reason: Optional[str] = None
     auto_execution_on_payment: bool = False
+    auto_close_on_payment: bool = False
+    execution_status: str = "needs_schedule"
+    execution_status_changed_at: Optional[datetime] = None
     equipment_status: str = "pending"
     standard_install_kit_issued: bool = False
     target_currency: Optional[PaymentCurrency] = None

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -60,6 +60,16 @@ class OrderService:
         "follow_up",
     }
     DEFAULT_NEGOTIATION_STATUS = "awaiting_offer"
+    EXECUTION_STATUSES = {
+        "order_equipment",
+        "awaiting_equipment",
+        "needs_schedule",
+        "scheduled",
+        "work_done",
+        "awaiting_documents",
+        "awaiting_payment",
+    }
+    DEFAULT_EXECUTION_STATUS = "needs_schedule"
     PAYMENT_COMPLETE_TOLERANCE = 0.01
 
     @staticmethod
@@ -68,6 +78,36 @@ class OrderService:
         if cleaned in OrderService.NEGOTIATION_STATUSES:
             return cleaned
         return fallback if fallback in OrderService.NEGOTIATION_STATUSES else OrderService.DEFAULT_NEGOTIATION_STATUS
+
+    @staticmethod
+    def _normalize_execution_status(value: Any, fallback: str = DEFAULT_EXECUTION_STATUS) -> str:
+        cleaned = str(value or "").strip()
+        if cleaned in OrderService.EXECUTION_STATUSES:
+            return cleaned
+        return fallback if fallback in OrderService.EXECUTION_STATUSES else OrderService.DEFAULT_EXECUTION_STATUS
+
+    @staticmethod
+    def _infer_execution_status(order: Order) -> str:
+        raw_status = getattr(order, "execution_status", None)
+        if raw_status is not None:
+            current = str(raw_status or "").strip()
+            if current in OrderService.EXECUTION_STATUSES:
+                return current
+        if order.status != OrderStatus.EXECUTION:
+            return OrderService.DEFAULT_EXECUTION_STATUS
+        if order.installation_date:
+            return "scheduled"
+        return OrderService.DEFAULT_EXECUTION_STATUS
+
+    @staticmethod
+    def _set_execution_status(order: Order, value: Any, *, changed_at: Optional[datetime] = None) -> None:
+        next_status = str(value or "").strip()
+        if next_status not in OrderService.EXECUTION_STATUSES:
+            raise ValueError(f"Invalid execution_status: {value}")
+        previous = OrderService._normalize_execution_status(getattr(order, "execution_status", None))
+        order.execution_status = next_status
+        if previous != next_status or not getattr(order, "execution_status_changed_at", None):
+            order.execution_status_changed_at = changed_at or datetime.now()
 
     @staticmethod
     def _infer_negotiation_status(order: Order) -> str:
@@ -603,6 +643,18 @@ class OrderService:
             order.status = OrderStatus.EXECUTION
             order.status_changed_at = datetime.now()
             order.proposal_status = "approved"
+        if (
+            is_fully_paid
+            and bool(getattr(order, "auto_close_on_payment", False))
+            and order.status == OrderStatus.EXECUTION
+        ):
+            order.status = OrderStatus.CLOSED
+            order.closing_result = ClosingResult.WON.value
+            order.reject_reason = None
+            order.closed_at = datetime.now()
+            order.status_changed_at = datetime.now()
+            if getattr(order, "execution_status", None) in OrderService.EXECUTION_STATUSES:
+                OrderService._set_execution_status(order, "awaiting_payment")
 
     @staticmethod
     def _clean_proposal_name(raw: Any, fallback: str = "Основное") -> str:
@@ -1918,6 +1970,9 @@ class OrderService:
             "execution_without_payment": bool(getattr(order, "execution_without_payment", False)),
             "execution_without_payment_reason": getattr(order, "execution_without_payment_reason", None),
             "auto_execution_on_payment": bool(getattr(order, "auto_execution_on_payment", False)),
+            "auto_close_on_payment": bool(getattr(order, "auto_close_on_payment", False)),
+            "execution_status": OrderService._infer_execution_status(order),
+            "execution_status_changed_at": getattr(order, "execution_status_changed_at", None),
             "equipment_status": getattr(order.equipment_status, "value", str(order.equipment_status)) if order.equipment_status else "pending",
             "standard_install_kit_issued": bool(order.standard_install_kit_issued),
             "target_currency": order.target_currency,
@@ -2410,6 +2465,9 @@ class OrderService:
         previous_negotiation_status = OrderService._normalize_negotiation_status(
             getattr(order, "negotiation_status", None),
         )
+        previous_execution_status = OrderService._normalize_execution_status(
+            getattr(order, "execution_status", None),
+        )
 
         if "status" in fields_set and payload.status is not None:
             try:
@@ -2481,6 +2539,8 @@ class OrderService:
             order.additional_conditions = value or None
         if "negotiation_status" in fields_set and payload.negotiation_status is not None:
             OrderService._set_negotiation_status(order, payload.negotiation_status)
+        if "execution_status" in fields_set and payload.execution_status is not None:
+            OrderService._set_execution_status(order, payload.execution_status)
         if "proposal_status" in fields_set and payload.proposal_status is not None:
             order.proposal_status = payload.proposal_status
             if payload.proposal_status == "sent" and not order.proposal_sent_at:
@@ -2493,11 +2553,16 @@ class OrderService:
             order.execution_without_payment_reason = OrderService._clean_optional_text(payload.execution_without_payment_reason)
         if "auto_execution_on_payment" in fields_set and payload.auto_execution_on_payment is not None:
             order.auto_execution_on_payment = bool(payload.auto_execution_on_payment)
+        if "auto_close_on_payment" in fields_set and payload.auto_close_on_payment is not None:
+            order.auto_close_on_payment = bool(payload.auto_close_on_payment)
         if order.status == OrderStatus.EXECUTION and order.proposal_status != "approved":
             order.proposal_status = "approved"
         if order.status == OrderStatus.EXECUTION:
-            if not order.installation_date:
-                order.installation_date = datetime.now()
+            if "execution_status" not in fields_set:
+                if "installation_date" in fields_set and order.installation_date:
+                    OrderService._set_execution_status(order, "scheduled")
+                elif not getattr(order, "execution_status_changed_at", None):
+                    OrderService._set_execution_status(order, OrderService._infer_execution_status(order))
         elif order.status != OrderStatus.EXECUTION:
             order.execution_without_payment = False
             order.execution_without_payment_reason = None
@@ -2516,6 +2581,13 @@ class OrderService:
             and OrderService._normalize_negotiation_status(getattr(order, "negotiation_status", None)) != previous_negotiation_status
         ):
             order.negotiation_status_changed_at = datetime.now()
+        if order.status == OrderStatus.EXECUTION and not getattr(order, "execution_status_changed_at", None):
+            order.execution_status_changed_at = datetime.now()
+        if (
+            order.status == OrderStatus.EXECUTION
+            and OrderService._normalize_execution_status(getattr(order, "execution_status", None)) != previous_execution_status
+        ):
+            order.execution_status_changed_at = datetime.now()
         
         # Equipment & Installation
         if "equipment_status" in fields_set and payload.equipment_status is not None:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -268,6 +268,7 @@ async def test_manager_order_patch_moves_to_execution_without_payment_flag(async
         f"/api/manager/orders/{order.id}",
         json={
             "status": "execution",
+            "execution_status": "order_equipment",
             "execution_without_payment": True,
             "execution_without_payment_reason": "Постоянный клиент",
             "products": [{"product_id": product.id, "quantity": 1, "price": 1000, "cost": 700}],
@@ -279,6 +280,8 @@ async def test_manager_order_patch_moves_to_execution_without_payment_flag(async
     data = response.json()
     assert data["status"] == "execution"
     assert data["proposal_status"] == "approved"
+    assert data["execution_status"] == "order_equipment"
+    assert data["execution_status_changed_at"] is not None
     assert data["execution_without_payment"] is True
     assert data["execution_without_payment_reason"] == "Постоянный клиент"
 

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -378,6 +378,39 @@ async def test_service_auto_execution_on_payment_moves_order_to_work(db):
 
 
 @pytest.mark.asyncio
+async def test_service_auto_close_on_payment_closes_execution_order(db):
+    customer = Customer(name="Auto Close", phone="+375291111114", type=CustomerType.company)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        execution_status="awaiting_payment",
+        auto_close_on_payment=True,
+    )
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    db.add(OrderServiceLink(order_id=order.id, title="Монтаж", quantity=1, price=420, cost=0))
+    await db.commit()
+
+    await OrderService.add_payment(
+        db,
+        int(order.id),
+        PaymentCreatePayload(amount=420, type="postpayment"),
+    )
+    await db.refresh(order)
+
+    assert order.status == OrderStatus.CLOSED
+    assert order.closing_result == "won"
+    assert order.is_paid is True
+    assert order.balance_due == 0
+
+
+@pytest.mark.asyncio
 async def test_service_get_orders_for_manager_overdue_filter(db):
     customer = Customer(name="Over", phone="+375293333333", type=CustomerType.individual)
     db.add(customer)


### PR DESCRIPTION
## Summary
- Added execution-stage workflow statuses for ordering equipment, waiting for equipment, scheduling installation, completed work, documents, and payment follow-up.
- Added Kanban filtering/card accents/quick actions for execution statuses while keeping the card menu contextual to the current stage.
- Added `auto_close_on_payment` so execution orders can close successfully after the remaining debt is paid.
- Hid the legacy picking/material issue block from the execution UI without removing backend fields.

## Checks
- `docker compose exec -T app pytest tests/unit/test_order_service_manager.py tests/integration/test_manager_orders_api.py -q`
- `npm run build` in `manager_frontend`
- `git diff --check`
- local `/api/health`