### PR TITLE
Fix mobile order segment tabs

### DIFF
--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -711,8 +711,8 @@ watch(drawerOpen, (isOpen) => {
     <div class="mx-auto max-w-[1400px] px-4 py-6 md:px-8">
       <header class="mb-4 rounded-2xl border border-gray-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-800">
         <div class="flex items-center gap-1 pl-9 sm:gap-2 md:pl-0">
-          <div class="flex min-w-0 shrink items-center gap-1 sm:gap-2">
-            <h1 class="shrink-0 text-lg font-bold dark:text-white md:text-xl">Заказы</h1>
+          <div class="flex min-w-0 flex-1 items-center gap-1 sm:gap-2">
+            <h1 class="hidden shrink-0 text-lg font-bold dark:text-white sm:block md:text-xl">Заказы</h1>
             <OrdersTabSwitcher v-model="segment" />
           </div>
           <div class="ml-auto flex shrink-0 items-center justify-end gap-1 sm:gap-2">

--- a/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
+++ b/manager_frontend/src/components/orders/OrdersTabSwitcher.vue
@@ -17,7 +17,7 @@ const tabs: Array<{ value: Segment; label: string; title: string; icon: typeof L
     <button
       v-for="tab in tabs"
       :key="tab.value"
-      class="inline-flex items-center gap-1.5 rounded-[10px] px-2 py-1.5 text-xs font-semibold transition sm:px-3 sm:text-sm"
+      class="inline-flex items-center gap-1 rounded-[10px] px-1.5 py-1.5 text-xs font-semibold transition sm:gap-1.5 sm:px-3 sm:text-sm"
       :class="modelValue === tab.value ? 'bg-[#007f80] text-white shadow-sm' : 'text-gray-600 hover:text-gray-900'"
       :title="tab.title"
       @click="emit('update:modelValue', tab.value)"


### PR DESCRIPTION
## Summary
- hide the Orders title on narrow screens so the segment switcher has room
- slightly reduce mobile tab padding while keeping labels visible

## Tests
- npm run build (manager_frontend)
- git diff --check
- Browser check at 384x824: All/B2C/B2B visible, B2B click updates segment URL