### PR TITLE
Polish order works kanban labels

### DIFF
--- a/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
+++ b/manager_frontend/src/components/orders/OrderCardActionsMenu.vue
@@ -38,6 +38,17 @@ const stageOptions = computed(() => {
   if (activeBoardColumn.value === 'negotiation') return NEGOTIATION_STATUS_OPTIONS;
   return [];
 });
+const boardActions = computed(() => [
+  activeBoardColumn.value !== 'negotiation'
+    ? { value: 'negotiation', label: 'Вернуть в переговоры', icon: 'forum' }
+    : null,
+  activeBoardColumn.value !== 'execution'
+    ? { value: 'execution', label: 'Перенести в работы', icon: 'construction' }
+    : null,
+  activeBoardColumn.value !== 'closed_won'
+    ? { value: 'closed_won', label: 'Завершить успешно', icon: 'check_circle' }
+    : null,
+].filter(Boolean) as Array<{ value: string; label: string; icon: string }>);
 
 const selectStatus = (status: string) => {
   menuOpen.value = false;
@@ -100,7 +111,21 @@ onBeforeUnmount(() => {
       class="absolute right-0 top-7 z-30 w-64 rounded-xl border border-gray-200 bg-white p-1.5 text-xs shadow-xl dark:border-slate-700 dark:bg-slate-800"
       @click.stop
     >
+      <template v-if="boardActions.length">
+        <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">Быстрая смена</div>
+        <button
+          v-for="action in boardActions"
+          :key="action.value"
+          type="button"
+          class="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left font-semibold text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-700"
+          @click="selectStatus(action.value)"
+        >
+          <span class="material-icons-round text-[16px]">{{ action.icon }}</span>
+          {{ action.label }}
+        </button>
+      </template>
       <template v-if="stageOptions.length">
+        <div v-if="boardActions.length" class="my-1 border-t border-slate-100 dark:border-slate-700" />
         <div class="px-2 pb-1 pt-1 text-[10px] font-bold uppercase tracking-wide text-slate-400">{{ stageTitle }}</div>
       </template>
       <button

--- a/manager_frontend/src/components/orders/OrderCardB2B.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2B.vue
@@ -83,7 +83,7 @@ const dateSummary = computed(() => {
   if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
   if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
   if (props.order.measurement_date) return { label: 'Замер', value: formatDate(props.order.measurement_date), className: 'text-gray-600 dark:text-slate-300' };
-  if (props.order.installation_date) return { label: 'Монтаж', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.installation_date) return { label: 'Работы', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
   return null;
 });
 const statusFlags = computed(() => [
@@ -188,10 +188,9 @@ const paymentSummary = computed(() => {
         <div class="mt-3 grid grid-cols-2 gap-2 text-xs">
           <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Сумма: <span class="font-semibold">{{ formatMoney(order.total_amount) }}</span></p>
           <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Маржа: <span class="font-semibold">{{ formatMoney(order.margin) }}</span></p>
-          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Счет: <span :class="order.is_paid ? 'text-emerald-600 dark:text-emerald-300' : 'text-amber-600 dark:text-amber-300'">{{ order.is_paid ? 'Оплачен' : 'Ожидает' }}</span></p>
           <p v-if="order.next_followup_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Касание: <span class="font-semibold">{{ formatDate(order.next_followup_date) }}</span></p>
           <p v-if="order.measurement_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Замер: <span class="font-semibold">{{ formatDate(order.measurement_date) }}</span></p>
-          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Монтаж: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
+          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Работы: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
         </div>
 
         <div v-if="order.manager_labels?.length" class="mt-3 flex flex-wrap gap-1">
@@ -205,8 +204,6 @@ const paymentSummary = computed(() => {
         </div>
 
         <footer class="mt-3 flex flex-wrap gap-2">
-          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'invoice' })">Счет</button>
-          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'contract' })">Договор</button>
           <button type="button" class="btn-mini-outline inline-flex items-center gap-1" @click.stop="emit('open', order.id)">
             <ExternalLink class="h-3.5 w-3.5" />
             Открыть заказ

--- a/manager_frontend/src/components/orders/OrderCardB2C.vue
+++ b/manager_frontend/src/components/orders/OrderCardB2C.vue
@@ -83,7 +83,7 @@ const dateSummary = computed(() => {
   if (isOverdue(props.order)) return { label: 'Касание', value: 'просрочено', className: 'text-red-600 dark:text-red-300' };
   if (props.order.next_followup_date) return { label: 'Касание', value: formatDate(props.order.next_followup_date), className: 'text-gray-600 dark:text-slate-300' };
   if (props.order.measurement_date) return { label: 'Замер', value: formatDate(props.order.measurement_date), className: 'text-gray-600 dark:text-slate-300' };
-  if (props.order.installation_date) return { label: 'Монтаж', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
+  if (props.order.installation_date) return { label: 'Работы', value: formatDate(props.order.installation_date), className: 'text-gray-600 dark:text-slate-300' };
   return null;
 });
 const statusFlags = computed(() => [
@@ -189,10 +189,9 @@ const paymentSummary = computed(() => {
         <div class="mt-3 grid grid-cols-2 gap-2 text-xs">
           <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Сумма: <span class="font-semibold">{{ formatMoney(order.total_amount) }}</span></p>
           <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Маржа: <span class="font-semibold">{{ formatMoney(order.margin) }}</span></p>
-          <p class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Оплата: <span :class="order.is_paid ? 'text-emerald-600 dark:text-emerald-300' : 'text-amber-600 dark:text-amber-300'">{{ order.is_paid ? 'Оплачено' : 'Ожидает' }}</span></p>
           <p v-if="order.next_followup_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Касание: <span class="font-semibold">{{ formatDate(order.next_followup_date) }}</span></p>
           <p v-if="order.measurement_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Замер: <span class="font-semibold">{{ formatDate(order.measurement_date) }}</span></p>
-          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Монтаж: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
+          <p v-if="order.installation_date" class="rounded-xl bg-gray-50 px-2 py-1.5 text-gray-700 dark:bg-slate-900/40 dark:text-slate-300">Работы: <span class="font-semibold">{{ formatDate(order.installation_date) }}</span></p>
         </div>
 
         <div v-if="order.manager_labels?.length" class="mt-3 flex flex-wrap gap-1">
@@ -206,8 +205,6 @@ const paymentSummary = computed(() => {
         </div>
 
         <footer class="mt-3 flex flex-wrap gap-2">
-          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'work_order' })">Наряд</button>
-          <button type="button" class="btn-mini" @click.stop="emit('generate', { orderId: order.id, docType: 'act' })">Акт</button>
           <button type="button" class="btn-mini-outline inline-flex items-center gap-1" @click.stop="emit('open', order.id)">
             <ExternalLink class="h-3.5 w-3.5" />
             Открыть заказ

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -449,7 +449,7 @@ const negotiationStatusLabel = computed(() => (
   NEGOTIATION_STATUS_OPTIONS.find((option) => option.value === negotiationStatus.value)?.label || 'Ждет предложение'
 ));
 const executionStatusLabel = computed(() => (
-  EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить монтаж'
+  EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить работы'
 ));
 
 const setNegotiationStatus = (value: string) => {
@@ -3789,7 +3789,7 @@ watch(
       <section v-if="status === 'execution'" class="mt-4 rounded-2xl border border-teal-100 bg-teal-50/50 p-3">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h3 class="text-sm font-semibold text-teal-900">Установка / работы</h3>
+            <h3 class="text-sm font-semibold text-teal-900">Работы</h3>
             <p class="mt-0.5 text-xs text-teal-700/75">Текущий этап: {{ executionStatusLabel }}</p>
           </div>
         </div>

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -18,16 +18,16 @@ export const NEGOTIATION_STATUS_OPTIONS = [
 export const EXECUTION_STATUS_OPTIONS = [
     { value: 'order_equipment', label: 'Заказать товар', icon: 'add_shopping_cart', tone: 'rose' },
     { value: 'awaiting_equipment', label: 'Ждем оборудование', icon: 'local_shipping', tone: 'amber' },
-    { value: 'needs_schedule', label: 'Назначить монтаж', icon: 'event_available', tone: 'teal' },
-    { value: 'scheduled', label: 'Монтаж назначен', icon: 'event', tone: 'cyan' },
-    { value: 'work_done', label: 'Монтаж выполнен', icon: 'task_alt', tone: 'green' },
+    { value: 'needs_schedule', label: 'Назначить работы', icon: 'event_available', tone: 'teal' },
+    { value: 'scheduled', label: 'Работы назначены', icon: 'event', tone: 'cyan' },
+    { value: 'work_done', label: 'Работы выполнены', icon: 'task_alt', tone: 'green' },
     { value: 'awaiting_documents', label: 'Закрыть документы', icon: 'fact_check', tone: 'indigo' },
     { value: 'awaiting_payment', label: 'Ждет оплату', icon: 'payments', tone: 'emerald' },
 ] as const;
 
 export const BOARD_COLUMNS = [
     { value: 'negotiation', label: 'Переговоры', icon: 'forum', tone: 'sky' },
-    { value: 'execution', label: 'Установка / работы', icon: 'construction', tone: 'teal' },
+    { value: 'execution', label: 'Работы', icon: 'construction', tone: 'teal' },
     { value: 'closed_won', label: 'Завершено', icon: 'check_circle', tone: 'green' },
     { value: 'closed_lost', label: 'Отказники', icon: 'cancel', tone: 'rose' },
 ] as const;
@@ -35,7 +35,7 @@ export const BOARD_COLUMNS = [
 export const STATUS_LABELS: Record<string, string> = {
     new_lead: 'Новый лид',
     negotiation: 'Переговоры',
-    execution: 'Монтаж',
+    execution: 'Работы',
     closed: 'Закрыто',
 };
 
@@ -184,7 +184,7 @@ export function getOrderExecutionStatus(order: ManagerOrderListItemResponse): st
 }
 
 export function getOrderExecutionLabel(order: ManagerOrderListItemResponse): string {
-    return EXECUTION_STATUS_LABELS[getOrderExecutionStatus(order)] || 'Назначить монтаж';
+    return EXECUTION_STATUS_LABELS[getOrderExecutionStatus(order)] || 'Назначить работы';
 }
 
 export function formatMoney(value: number): string {


### PR DESCRIPTION
## Summary
- rename execution kanban language from installation/montage to works
- restore quick menu actions for moving between negotiation/works and closing successfully
- simplify expanded kanban cards by removing document/payment legacy chips

## Tests
- npm run build (manager_frontend)
- git diff --check
- Browser check: works column/menu labels updated, quick actions visible