### PR TITLE
[codex] Add typed spec normalization registry

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -138,6 +138,22 @@ class ProductDAO:
         return func.lower(func.jsonb_extract_path_text(cast(Product.specs, JSONB), key))
 
     @staticmethod
+    def _json_path_int_expr(session: AsyncSession, *path: str):
+        dialect = session.bind.dialect.name if session.bind is not None else ""
+        if dialect == "sqlite":
+            json_path = "$." + ".".join(path)
+            return cast(func.json_extract(Product.specs, json_path), Integer)
+        return cast(func.jsonb_extract_path_text(cast(Product.specs, JSONB), *path), Integer)
+
+    @staticmethod
+    def _json_path_text_expr(session: AsyncSession, *path: str):
+        dialect = session.bind.dialect.name if session.bind is not None else ""
+        if dialect == "sqlite":
+            json_path = "$." + ".".join(path)
+            return func.lower(cast(func.json_extract(Product.specs, json_path), String))
+        return func.lower(func.jsonb_extract_path_text(cast(Product.specs, JSONB), *path))
+
+    @staticmethod
     def _apply_common_filters(
         session: AsyncSession,
         stmt,
@@ -171,10 +187,23 @@ class ProductDAO:
             stmt = stmt.where(Product.is_inverter == is_inverter)
 
         if heating_min is not None:
-            stmt = stmt.where(ProductDAO._json_int_expr(session, "__filter_min_heat") <= heating_min)
+            typed_heat_min_expr = ProductDAO._json_path_int_expr(
+                session,
+                "__typed_specs",
+                "temp_range_heat",
+                "min",
+            )
+            legacy_heat_min_expr = ProductDAO._json_int_expr(session, "__filter_min_heat")
+            stmt = stmt.where(func.coalesce(typed_heat_min_expr, legacy_heat_min_expr) <= heating_min)
 
         if has_wifi is not None:
             wifi_expr = ProductDAO._json_bool_expr(session, "__filter_wifi")
+            wifi_state_expr = ProductDAO._json_path_text_expr(
+                session,
+                "__typed_specs",
+                "wifi_state",
+                "value",
+            )
             legacy_wifi_tag_subq = (
                 select(ProductTagLink.product_id)
                 .join(Tag, ProductTagLink.tag_id == Tag.id)
@@ -184,14 +213,18 @@ class ProductDAO:
                 if has_wifi:
                     stmt = stmt.where(
                         or_(
-                            wifi_expr == 1,
+                            wifi_state_expr.in_(("builtin", "ready")),
+                            and_(wifi_state_expr.is_(None), wifi_expr == 1),
                             Product.id.in_(legacy_wifi_tag_subq),
                         )
                     )
                 else:
                     stmt = stmt.where(
                         and_(
-                            wifi_expr == 0,
+                            or_(
+                                wifi_state_expr == "none",
+                                and_(wifi_state_expr.is_(None), wifi_expr == 0),
+                            ),
                             ~Product.id.in_(legacy_wifi_tag_subq),
                         )
                     )
@@ -199,14 +232,18 @@ class ProductDAO:
                 if has_wifi:
                     stmt = stmt.where(
                         or_(
-                            wifi_expr == True,
+                            wifi_state_expr.in_(("builtin", "ready")),
+                            and_(wifi_state_expr.is_(None), wifi_expr == True),
                             Product.id.in_(legacy_wifi_tag_subq),
                         )
                     )
                 else:
                     stmt = stmt.where(
                         and_(
-                            wifi_expr == False,
+                            or_(
+                                wifi_state_expr == "none",
+                                and_(wifi_state_expr.is_(None), wifi_expr == False),
+                            ),
                             ~Product.id.in_(legacy_wifi_tag_subq),
                         )
                     )
@@ -231,7 +268,14 @@ class ProductDAO:
                 if value and str(value).strip().lower() in ALLOWED_INDOOR_TYPE_FILTERS
             ]
             if normalized_types:
-                stmt = stmt.where(ProductDAO._json_text_expr(session, "__filter_indoor_type").in_(normalized_types))
+                typed_indoor_type_expr = ProductDAO._json_path_text_expr(
+                    session,
+                    "__typed_specs",
+                    "indoor_type",
+                    "value",
+                )
+                legacy_indoor_type_expr = ProductDAO._json_text_expr(session, "__filter_indoor_type")
+                stmt = stmt.where(func.coalesce(typed_indoor_type_expr, legacy_indoor_type_expr).in_(normalized_types))
 
         if tag_slugs:
             normalized_slugs = [slug.strip().lower() for slug in tag_slugs if slug and slug.strip()]

--- a/docs/process.md
+++ b/docs/process.md
@@ -82,15 +82,27 @@ CI enforces this sync and fails if generated artifacts differ from committed fil
    docker compose exec app python3 scripts/analyze_spec_keys.py
    ```
 
-2. **Обновить карту ключей**
+2. **Обновить реестр характеристик**
    
-   Если скрипт нашел важные ключи (например, `Минимальная мощность` или `Страна`), добавьте их в файл:
+   Если скрипт нашел важные ключи (например, `Минимальная мощность` или `Страна`), добавьте их в единый реестр:
    
-   📄 `services/spec_normalizer.py` -> `KEY_MAP`
+   📄 `services/spec_registry.py` -> `SPEC_DEFINITIONS` + `REGISTRY_LEGACY_ALIASES_BY_KEY`
 
 3. **Применить изменения**
    
-   Чтобы "починить" уже загруженные товары, запустите скрипт нормализации. Он пройдет по всей базе и перепишет `specs` с учетом новых правил.
+   Чтобы безопасно добавить только внутренний typed/filter слой к уже загруженным товарам, сначала запустите dry-run:
+
+   ```bash
+   docker compose exec app python3 scripts/backfill_typed_specs.py --limit 500
+   ```
+
+   Если отчет корректный, выполните ограниченную запись:
+
+   ```bash
+   docker compose exec app python3 scripts/backfill_typed_specs.py --execute --limit 500
+   ```
+
+   Полная нормализация переписывает публичные flat-ключи `specs`, а также может обновить теги/brand-series. Используйте ее только когда нужно именно привести старые поля к новой canonical-структуре:
 
    ```bash
    docker compose exec app python3 scripts/normalize_legacy.py

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -94,6 +94,7 @@ import {
     type ProductMainImageCleanupDecisionResponse,
     type ProductMainImageCleanupItemListResponse,
     type ProductMainImageCleanupItemResponse,
+    type SpecRegistryResponse,
 } from './client';
 import { ManagerTagsService } from './client/services/ManagerTagsService';
 import { ManagerLeadsInboxService } from './client/services/ManagerLeadsInboxService';
@@ -105,6 +106,7 @@ export type Segment = 'all' | 'b2c' | 'b2b';
 export type DashboardView = 'kanban' | 'list';
 export { type Product, type DashboardStatsResponse, type DashboardTouchpoint };
 export type { ProductCreate, ProductDuplicatePayload, ProductUpdate };
+export type { SpecRegistryResponse };
 export type { LeadsInboxItemResponse };
 export type { ManagerGoogleAuthStatusResponse, ManagerGoogleAuthUrlResponse };
 export type { ManagerStaffCreatePayload, ManagerStaffResponse, ManagerStaffUpdatePayload, TelegramLoginPayload };
@@ -892,6 +894,10 @@ export const api = {
 
     async getPublicSpecKeys() {
         return await ApiService.getPublicSpecKeys();
+    },
+
+    async getPublicSpecRegistry() {
+        return await ApiService.getPublicSpecRegistry();
     },
 
     async bulkUpdateSpecs(productIds: number[], specs: Record<string, unknown>, operation: 'merge' | 'replace' | 'delete_keys' = 'merge') {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -306,6 +306,8 @@ export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';
 export type { PublicBrandResponse } from './models/PublicBrandResponse';
 export type { ServiceResponse } from './models/ServiceResponse';
+export type { SpecRegistryItemResponse } from './models/SpecRegistryItemResponse';
+export type { SpecRegistryResponse } from './models/SpecRegistryResponse';
 export type { SpecsKeysResponse } from './models/SpecsKeysResponse';
 export type { SupplierCreatePayload } from './models/SupplierCreatePayload';
 export type { SupplierListResponse } from './models/SupplierListResponse';

--- a/manager_frontend/src/client/models/SpecRegistryItemResponse.ts
+++ b/manager_frontend/src/client/models/SpecRegistryItemResponse.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SpecRegistryItemResponse = {
+    key: string;
+    label: string;
+    value_type: string;
+    quantity_kind?: (string | null);
+    canonical_unit?: (string | null);
+    aliases?: Array<string>;
+    enum_values?: Array<string>;
+    description?: (string | null);
+    manager_note?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/SpecRegistryResponse.ts
+++ b/manager_frontend/src/client/models/SpecRegistryResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { SpecRegistryItemResponse } from './SpecRegistryItemResponse';
+export type SpecRegistryResponse = {
+    items: Array<SpecRegistryItemResponse>;
+    total: number;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -15,6 +15,7 @@ import type { ProductResponse } from '../models/ProductResponse';
 import type { ProductSeriesNavigationResponse } from '../models/ProductSeriesNavigationResponse';
 import type { PublicBrandResponse } from '../models/PublicBrandResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
+import type { SpecRegistryResponse } from '../models/SpecRegistryResponse';
 import type { SpecsKeysResponse } from '../models/SpecsKeysResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -294,6 +295,17 @@ export class ApiService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/specs/keys',
+        });
+    }
+    /**
+     * Get Public Spec Registry
+     * @returns SpecRegistryResponse Successful Response
+     * @throws ApiError
+     */
+    public static getPublicSpecRegistry(): CancelablePromise<SpecRegistryResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/specs/registry',
         });
     }
     /**

--- a/manager_frontend/src/components/BulkSpecsModal.vue
+++ b/manager_frontend/src/components/BulkSpecsModal.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { api } from '../api';
-import { X, Plus, Trash2, Save, AlertTriangle } from 'lucide-vue-next';
+import { X, Plus, Trash2, Save, AlertTriangle, CircleHelp } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import SpecKeyCombobox from './SpecKeyCombobox.vue';
-import { specsTranslations } from '../utils/specsTranslations';
+import { useSpecRegistry } from '../composables/useSpecRegistry';
 
 const props = defineProps<{
     modelValue: boolean; // isOpen
@@ -21,44 +21,26 @@ const operation = ref<'merge' | 'replace' | 'delete_keys'>('merge');
 const loading = ref(false);
 const formMessage = ref('');
 const formServerErrors = ref<Record<string, string>>({});
-const knownKeys = ref<string[]>([]);
-const keysLoading = ref(false);
-const hiddenWifiAliasKeys = new Set([
-    'wifi_module',
-    'wi_fi',
-    'wifi',
-    'wifi-builtin',
-    'wifi-ready',
-    '__filter_wifi',
-    '__filter_wifi_builtin',
-]);
-const getSelectOptions = (key: string, value: unknown): string[] => {
-    const base = [...(specsTranslations[key]?.options || [])];
-    const current = String(value ?? '').trim();
-    if (current && !base.includes(current)) return [current, ...base];
-    return base;
-};
+const {
+    formatSelectOptionLabel,
+    getSelectOptions,
+    getSpecConfig,
+    getSpecHelpText,
+    knownSpecKeys,
+    loadSpecRegistry,
+    serializeSpecValue,
+} = useSpecRegistry();
 
-// Fetch known keys for autocomplete
-const fetchKeys = async () => {
-    keysLoading.value = true;
-    try {
-        const res = await api.getPublicSpecKeys();
-        // Merge API keys with basic keys from translations to ensure they are always present
-        const combined = new Set([...Object.keys(specsTranslations), ...res.keys]);
-        knownKeys.value = Array.from(combined).filter((key) => !hiddenWifiAliasKeys.has(key));
-    } catch (e) {
-        console.error('Failed to fetch spec keys', e);
-    } finally {
-        keysLoading.value = false;
-    }
+const showSpecHelp = (key: string) => {
+    const text = getSpecHelpText(key);
+    if (text) window.alert(text);
 };
 
 watch(() => props.modelValue, (val) => {
     if (val) {
         formMessage.value = '';
         formServerErrors.value = {};
-        if (knownKeys.value.length === 0) fetchKeys();
+        loadSpecRegistry();
         // Reset form
         specs.value = [{ key: '', value: '' }];
         operation.value = 'merge';
@@ -86,16 +68,7 @@ const save = async () => {
     const validSpecs: Record<string, string> = {};
     for (const row of specs.value) {
         if (row.key.trim()) {
-            let finalValue = row.value;
-            const config = specsTranslations[row.key.trim()];
-            if (config?.type === 'number' && config.unit && finalValue.toString().trim() !== '') {
-                finalValue = `${finalValue} ${config.unit}`.trim();
-            } else if (config?.type === 'boolean') {
-                // Keep boolean strings or convert properly based on existing convention (e.g. "true"/"false")
-                // Standardizing to string "true"/"false" as the modal values are tracked as strings initially
-                finalValue = (row.value === 'true') ? 'true' : 'false';
-            }
-            validSpecs[row.key.trim()] = finalValue.toString().trim();
+            validSpecs[row.key.trim()] = serializeSpecValue(row.key.trim(), row.value);
         }
     }
     
@@ -192,13 +165,22 @@ const save = async () => {
                         <div class="relative flex-1">
                             <SpecKeyCombobox 
                                 v-model="row.key" 
-                                :known-keys="knownKeys" 
+                                :known-keys="knownSpecKeys"
                             />
                         </div>
+                        <button
+                            v-if="getSpecHelpText(row.key)"
+                            type="button"
+                            class="mt-2 shrink-0 rounded-full p-1 text-slate-400 transition hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-700 dark:hover:text-teal-300"
+                            :title="getSpecHelpText(row.key)"
+                            @click="showSpecHelp(row.key)"
+                        >
+                            <CircleHelp class="h-4 w-4" />
+                        </button>
                         
                         <!-- Value Input (Disabled if deleting keys) -->
                         <div class="flex-1">
-                            <template v-if="specsTranslations[row.key]?.type === 'boolean'">
+                            <template v-if="getSpecConfig(row.key)?.type === 'boolean'">
                                 <div class="flex items-center h-[38px]">
                                     <button 
                                         type="button"
@@ -222,7 +204,7 @@ const save = async () => {
                                 </div>
                             </template>
                             
-                            <template v-else-if="specsTranslations[row.key]?.type === 'select'">
+                            <template v-else-if="getSpecConfig(row.key)?.type === 'select'">
                                 <select 
                                     v-model="row.value"
                                     :disabled="operation === 'delete_keys'"
@@ -230,16 +212,12 @@ const save = async () => {
                                 >
                                     <option value="" disabled>{{ operation === 'delete_keys' ? 'Пропускается' : 'Выберите значение' }}</option>
                                     <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
-                                        {{
-                                            row.key === 'wifi_ready'
-                                                ? (opt === 'true' ? 'Да (встроен)' : (opt === 'ready' ? 'Ready (модуль отдельно)' : 'Нет'))
-                                                : opt
-                                        }}
+                                        {{ formatSelectOptionLabel(row.key, opt) }}
                                     </option>
                                 </select>
                             </template>
                             
-                            <template v-else-if="specsTranslations[row.key]?.type === 'number'">
+                            <template v-else-if="getSpecConfig(row.key)?.type === 'number'">
                                 <div class="flex h-[38px] rounded shadow-sm">
                                     <input 
                                         type="number"
@@ -248,8 +226,8 @@ const save = async () => {
                                         :placeholder="operation === 'delete_keys' ? 'Пропускается' : 'Значение'" 
                                         class="flex-1 min-w-0 block w-full border dark:border-slate-700 bg-white dark:bg-slate-900 dark:text-slate-200 rounded-none rounded-l px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500"
                                     />
-                                    <span v-if="specsTranslations[row.key]?.unit" class="inline-flex items-center px-3 rounded-r border border-l-0 border-gray-300 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-sm">
-                                        {{ specsTranslations[row.key]?.unit }}
+                                    <span v-if="getSpecConfig(row.key)?.unit" class="inline-flex items-center px-3 rounded-r border border-l-0 border-gray-300 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-sm">
+                                        {{ getSpecConfig(row.key)?.unit }}
                                     </span>
                                 </div>
                             </template>

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
 import { api, type Product, type ManagerBrand, type ProductCreate, type ProductDuplicatePayload, type ProductUpdate } from '../api';
-import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag } from 'lucide-vue-next';
+import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag, CircleHelp } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import SpecKeyCombobox from './SpecKeyCombobox.vue';
-import { specsTranslations } from '../utils/specsTranslations';
+import { useSpecRegistry } from '../composables/useSpecRegistry';
 
 interface TagItem {
     id: number;
@@ -73,7 +73,6 @@ const selectedTagIds = ref<Set<number>>(new Set());
 const loading = ref(false);
 const formMessage = ref('');
 const formServerErrors = ref<Record<string, string>>({});
-const knownKeys = ref<string[]>([]);
 const tagGroups = ref<TagGroupItem[]>([]);
 const tagsLoading = ref(false);
 const brandsLoading = ref(false);
@@ -132,11 +131,20 @@ const saveButtonText = computed(() => {
 
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
-const getSelectOptions = (key: string, value: unknown): string[] => {
-    const base = [...(specsTranslations[key]?.options || [])];
-    const current = String(value ?? '').trim();
-    if (current && !base.includes(current)) return [current, ...base];
-    return base;
+const {
+    formatSelectOptionLabel,
+    getSelectOptions,
+    getSpecConfig,
+    getSpecHelpText,
+    isHiddenSpecKey,
+    knownSpecKeys,
+    loadSpecRegistry,
+    normalizeValueForEdit,
+    serializeSpecValue,
+} = useSpecRegistry();
+const showSpecHelp = (key: string) => {
+    const text = getSpecHelpText(key);
+    if (text) window.alert(text);
 };
 const INVALID_BRAND_TOKENS = new Set([
     'мультисплитсистема',
@@ -818,14 +826,6 @@ const autoFillCompatibilityByBrand = async () => {
     }
 };
 
-const fetchKeys = async () => {
-    try {
-        const res = await api.getPublicSpecKeys();
-        const combined = new Set([...Object.keys(specsTranslations), ...res.keys]);
-        knownKeys.value = Array.from(combined);
-    } catch (e) { console.error(e); }
-};
-
 const fetchTags = async (force = false) => {
     if (!force && tagGroups.value.length > 0) return;
     tagsLoading.value = true;
@@ -968,6 +968,7 @@ const initializeEditor = async () => {
         old_price: source?.old_price ?? null,
         is_published: source?.is_published ?? true,
     };
+    await loadSpecRegistry();
 
     const s = source?.specs || {};
     compatibilityIndoorSlugs.value = parseSlugList((s as any)[COMPATIBLE_INDOOR_KEY]);
@@ -979,17 +980,8 @@ const initializeEditor = async () => {
         : 'free_match';
     capacityCombosInput.value = parseCapacityCombos((s as any)[MULTI_CAPACITY_COMBOS_KEY]).join(', ');
     specs.value = Object.entries(s)
-        .filter(([key]) => !COMPATIBILITY_KEYS.has(key))
-        .map(([key, value]) => {
-            let sVal = String(value);
-            const config = specsTranslations[key];
-            if (config?.type === 'number' && config.unit) {
-                sVal = sVal.replace(new RegExp(config.unit + '$', 'i'), '').trim();
-                const match = sVal.match(/^-?\d*[.,]?\d*/);
-                sVal = match && match[0] ? match[0].replace(',', '.') : '';
-            }
-            return { key, value: sVal };
-        });
+        .filter(([key]) => !COMPATIBILITY_KEYS.has(key) && !isHiddenSpecKey(key))
+        .map(([key, value]) => ({ key, value: normalizeValueForEdit(key, value) }));
     manuals.value = (((source as any)?.manuals || []) as Array<any>)
         .map((item) => ({
             title: String(item?.title || 'Инструкция').trim() || 'Инструкция',
@@ -1000,7 +992,6 @@ const initializeEditor = async () => {
     const productTags = (source as any)?.tags || [];
     selectedTagIds.value = new Set(productTags.map((t: any) => t.id));
 
-    if (knownKeys.value.length === 0) fetchKeys();
     await Promise.all([fetchTags(), fetchBrands()]);
 
     const explicitBrandId = Number((source as any)?.brand_id || 0);
@@ -1074,14 +1065,7 @@ const save = async () => {
     const validSpecs: Record<string, any> = {};
     for (const row of specs.value) {
         if (row.key.trim()) {
-            let finalValue = row.value;
-            const config = specsTranslations[row.key.trim()];
-            if (config?.type === 'number' && config.unit && finalValue.toString().trim() !== '') {
-                finalValue = `${finalValue} ${config.unit}`.trim();
-            } else if (config?.type === 'boolean') {
-                finalValue = (row.value === 'true') ? 'true' : 'false';
-            }
-            validSpecs[row.key.trim()] = finalValue.toString().trim();
+            validSpecs[row.key.trim()] = serializeSpecValue(row.key.trim(), row.value);
         }
     }
 
@@ -1850,12 +1834,21 @@ const unlinkSupplierOffer = async (offer: any) => {
                                 <div class="relative flex-1">
                                     <SpecKeyCombobox 
                                         v-model="row.key" 
-                                        :known-keys="knownKeys" 
+                                        :known-keys="knownSpecKeys"
                                     />
                                 </div>
+                                <button
+                                    v-if="getSpecHelpText(row.key)"
+                                    type="button"
+                                    class="mt-2 shrink-0 rounded-full p-1 text-slate-400 transition hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-700 dark:hover:text-teal-300"
+                                    :title="getSpecHelpText(row.key)"
+                                    @click="showSpecHelp(row.key)"
+                                >
+                                    <CircleHelp class="h-4 w-4" />
+                                </button>
                                 
                                 <div class="flex-1">
-                                    <template v-if="specsTranslations[row.key]?.type === 'boolean'">
+                                    <template v-if="getSpecConfig(row.key)?.type === 'boolean'">
                                         <div class="flex items-center h-[38px]">
                                             <button 
                                                 type="button"
@@ -1878,23 +1871,19 @@ const unlinkSupplierOffer = async (offer: any) => {
                                         </div>
                                     </template>
                                     
-                                    <template v-else-if="specsTranslations[row.key]?.type === 'select'">
+                                    <template v-else-if="getSpecConfig(row.key)?.type === 'select'">
                                         <select 
                                             v-model="row.value"
                                             class="w-full h-[38px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all text-gray-900 dark:text-slate-200 shadow-inner"
                                         >
                                             <option value="" disabled>Выберите значение</option>
                                             <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
-                                                {{
-                                                    row.key === 'wifi_ready'
-                                                        ? (opt === 'true' ? 'Да (встроен)' : (opt === 'ready' ? 'Ready (модуль отдельно)' : 'Нет'))
-                                                        : opt
-                                                }}
+                                                {{ formatSelectOptionLabel(row.key, opt) }}
                                             </option>
                                         </select>
                                     </template>
                                     
-                                    <template v-else-if="specsTranslations[row.key]?.type === 'number'">
+                                    <template v-else-if="getSpecConfig(row.key)?.type === 'number'">
                                         <div class="flex h-[38px] rounded-lg shadow-inner">
                                             <input 
                                                 type="number"
@@ -1902,8 +1891,8 @@ const unlinkSupplierOffer = async (offer: any) => {
                                                 placeholder="Значение" 
                                                 class="flex-1 min-w-0 block w-full border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 text-gray-900 dark:text-slate-200 rounded-none rounded-l-lg px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all"
                                             />
-                                            <span v-if="specsTranslations[row.key]?.unit" class="inline-flex items-center px-2.5 rounded-r-lg border border-l-0 border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-xs">
-                                                {{ specsTranslations[row.key]?.unit }}
+                                            <span v-if="getSpecConfig(row.key)?.unit" class="inline-flex items-center px-2.5 rounded-r-lg border border-l-0 border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-xs">
+                                                {{ getSpecConfig(row.key)?.unit }}
                                             </span>
                                         </div>
                                     </template>

--- a/manager_frontend/src/composables/useSpecRegistry.ts
+++ b/manager_frontend/src/composables/useSpecRegistry.ts
@@ -1,0 +1,158 @@
+import { computed, ref } from 'vue';
+import { api, type SpecRegistryResponse } from '../api';
+import { hiddenSpecKeys, specsTranslations, type SpecConfig } from '../utils/specsTranslations';
+
+type RegistryItem = SpecRegistryResponse['items'][number];
+
+const registryConfigs = ref<Record<string, SpecConfig>>({ ...specsTranslations });
+const knownSpecKeys = ref<string[]>(Object.keys(specsTranslations).filter((key) => !hiddenSpecKeys.has(key)));
+const registryLoading = ref(false);
+const registryLoaded = ref(false);
+
+const unitLabels: Record<string, string> = {
+    A: 'А',
+    C: '°C',
+    dB: 'дБ',
+    g: 'г',
+    'g/m': 'г/м',
+    kg: 'кг',
+    kW: 'кВт',
+    'kWh/year': 'кВт·ч/год',
+    'l/h': 'л/ч',
+    m: 'м',
+    m2: 'м²',
+    'm3/h': 'м³/ч',
+    mm: 'мм',
+    month: 'мес.',
+};
+
+const registryTypeToControl = (item: RegistryItem): SpecConfig['type'] => {
+    if (item.value_type === 'boolean') return 'boolean';
+    if (item.value_type === 'enum' || item.value_type === 'state') return 'select';
+    if (item.value_type === 'quantity') return 'number';
+    return 'text';
+};
+
+const mapRegistryItem = (item: RegistryItem): SpecConfig => {
+    const options = [...(item.enum_values || [])].filter(Boolean);
+    return {
+        label: item.label,
+        type: registryTypeToControl(item),
+        options: options.length ? options : undefined,
+        unit: item.canonical_unit ? (unitLabels[item.canonical_unit] || item.canonical_unit) : undefined,
+        description: item.description || undefined,
+        managerNote: item.manager_note || undefined,
+        source: 'registry',
+    };
+};
+
+const mergeKnownKeys = (...groups: Array<Iterable<string> | undefined>) => {
+    const combined = new Set<string>();
+    for (const group of groups) {
+        if (!group) continue;
+        for (const key of group) {
+            const normalized = String(key || '').trim();
+            if (!normalized || hiddenSpecKeys.has(normalized)) continue;
+            combined.add(normalized);
+        }
+    }
+    knownSpecKeys.value = Array.from(combined).sort((a, b) => a.localeCompare(b, 'ru'));
+};
+
+export const useSpecRegistry = () => {
+    const loadSpecRegistry = async () => {
+        if (registryLoaded.value || registryLoading.value) return;
+        registryLoading.value = true;
+        try {
+            const [registry, keys] = await Promise.all([
+                api.getPublicSpecRegistry(),
+                api.getPublicSpecKeys().catch(() => ({ keys: [] as string[] })),
+            ]);
+            const nextConfigs: Record<string, SpecConfig> = { ...specsTranslations };
+            for (const item of registry.items || []) {
+                nextConfigs[item.key] = {
+                    ...nextConfigs[item.key],
+                    ...mapRegistryItem(item),
+                };
+            }
+            registryConfigs.value = nextConfigs;
+            mergeKnownKeys(Object.keys(nextConfigs), keys.keys || []);
+            registryLoaded.value = true;
+        } catch (error) {
+            console.error('Failed to fetch spec registry', error);
+            try {
+                const keys = await api.getPublicSpecKeys();
+                mergeKnownKeys(Object.keys(specsTranslations), keys.keys || []);
+            } catch (keysError) {
+                console.error('Failed to fetch spec keys', keysError);
+                mergeKnownKeys(Object.keys(specsTranslations));
+            }
+        } finally {
+            registryLoading.value = false;
+        }
+    };
+
+    const getSpecConfig = (key: string): SpecConfig | undefined => registryConfigs.value[key];
+
+    const getSelectOptions = (key: string, value: unknown): string[] => {
+        const base = [...(getSpecConfig(key)?.options || [])];
+        const current = String(value ?? '').trim();
+        if (current && !base.includes(current)) return [current, ...base];
+        return base;
+    };
+
+    const formatSelectOptionLabel = (key: string, option: string): string => {
+        if (key === 'wifi_ready') {
+            if (option === 'true') return 'Да (встроен)';
+            if (option === 'ready') return 'Ready (модуль отдельно)';
+            if (option === 'false') return 'Нет';
+        }
+        if (key === 'wifi_state') {
+            if (option === 'builtin') return 'Встроенный';
+            if (option === 'ready') return 'Ready (модуль отдельно)';
+            if (option === 'none') return 'Нет';
+        }
+        return option;
+    };
+
+    const getSpecHelpText = (key: string): string => {
+        const config = getSpecConfig(key);
+        return [config?.description, config?.managerNote].filter(Boolean).join('\n\n');
+    };
+
+    const normalizeValueForEdit = (key: string, value: unknown): string => {
+        const config = getSpecConfig(key);
+        let result = String(value ?? '');
+        if (config?.type === 'number' && config.unit) {
+            result = result.replace(new RegExp(`${config.unit}$`, 'i'), '').trim();
+            const match = result.match(/^-?\d*[.,]?\d*/);
+            result = match && match[0] ? match[0].replace(',', '.') : '';
+        }
+        return result;
+    };
+
+    const serializeSpecValue = (key: string, value: unknown): string => {
+        let finalValue = String(value ?? '');
+        const config = getSpecConfig(key);
+        if (config?.type === 'number' && config.unit && finalValue.trim() !== '') {
+            finalValue = `${finalValue} ${config.unit}`.trim();
+        } else if (config?.type === 'boolean') {
+            finalValue = finalValue === 'true' ? 'true' : 'false';
+        }
+        return finalValue.trim();
+    };
+
+    return {
+        getSelectOptions,
+        getSpecConfig,
+        getSpecHelpText,
+        formatSelectOptionLabel,
+        isHiddenSpecKey: (key: string) => hiddenSpecKeys.has(key),
+        knownSpecKeys: computed(() => knownSpecKeys.value),
+        loadSpecRegistry,
+        normalizeValueForEdit,
+        registryConfigs: computed(() => registryConfigs.value),
+        registryLoading: computed(() => registryLoading.value),
+        serializeSpecValue,
+    };
+};

--- a/manager_frontend/src/utils/specsTranslations.ts
+++ b/manager_frontend/src/utils/specsTranslations.ts
@@ -3,6 +3,9 @@ export interface SpecConfig {
     type: 'boolean' | 'select' | 'number' | 'text';
     options?: string[];
     unit?: string;
+    description?: string;
+    managerNote?: string;
+    source?: 'registry' | 'fallback';
 }
 
 export const specsTranslations: Record<string, SpecConfig> = {
@@ -10,6 +13,8 @@ export const specsTranslations: Record<string, SpecConfig> = {
     series: { label: 'Серия (Линейка)', type: 'text' },
     is_inverter: { label: 'Инвертор', type: 'boolean' },
     wifi_module: { label: 'Wi-Fi', type: 'boolean' },
+    wifi_builtin: { label: 'Wi-Fi встроенный', type: 'boolean' },
+    wifi_state: { label: 'Состояние Wi-Fi', type: 'select', options: ['builtin', 'ready', 'none'] },
     compressor_brand: { label: 'Марка компрессора', type: 'select', options: ['GMCC', 'Toshiba', 'Highly', 'Panasonic', 'Gree', 'Mitsubishi'] },
     pipe_liquid: { label: 'Труба жидкостная', type: 'select', options: ['1/4"', '3/8"', '1/2"'] },
     pipe_gas: { label: 'Труба газовая', type: 'select', options: ['3/8"', '1/2"', '5/8"', '3/4"'] },
@@ -64,3 +69,18 @@ export const specsTranslations: Record<string, SpecConfig> = {
     remote_control: { label: 'Пульт ДУ', type: 'boolean' },
     timer: { label: 'Таймер', type: 'boolean' },
 };
+
+export const hiddenSpecKeys = new Set([
+    'wifi_module',
+    'wi_fi',
+    'wifi',
+    'wifi-builtin',
+    'wifi-ready',
+    '__filter_wifi',
+    '__filter_wifi_builtin',
+    '__filter_min_heat',
+    '__filter_noise_min',
+    '__filter_indoor_type',
+    '__typed_specs',
+    'compressor_type_norm',
+]);

--- a/openapi.json
+++ b/openapi.json
@@ -680,6 +680,28 @@
         }
       }
     },
+    "/api/v1/specs/registry": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Get Public Spec Registry",
+        "operationId": "get_public_spec_registry",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpecRegistryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/filters/config": {
       "get": {
         "tags": [
@@ -33848,6 +33870,108 @@
           "base_price"
         ],
         "title": "ServiceResponse"
+      },
+      "SpecRegistryItemResponse": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "value_type": {
+            "type": "string",
+            "title": "Value Type"
+          },
+          "quantity_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quantity Kind"
+          },
+          "canonical_unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canonical Unit"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases"
+          },
+          "enum_values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Enum Values"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "manager_note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manager Note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key",
+          "label",
+          "value_type"
+        ],
+        "title": "SpecRegistryItemResponse"
+      },
+      "SpecRegistryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SpecRegistryItemResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "SpecRegistryResponse"
       },
       "SpecsKeysResponse": {
         "properties": {

--- a/routers/api_products.py
+++ b/routers/api_products.py
@@ -14,6 +14,7 @@ from schemas import (
     ProductSeriesNavigationResponse,
     ProductResponse,
     SpecsKeysResponse,
+    SpecRegistryResponse,
 )
 from services.description_generator import DescriptionGeneratorService
 from services.catalog import CatalogService
@@ -27,6 +28,12 @@ router = APIRouter(tags=["api"])
 async def get_public_spec_keys(session: AsyncSession = Depends(get_session)):
     payload = await ProductService.get_public_spec_keys(session)
     return SpecsKeysResponse(**payload)
+
+
+@router.get("/v1/specs/registry", response_model=SpecRegistryResponse, operation_id="get_public_spec_registry")
+async def get_public_spec_registry():
+    payload = ProductService.get_specs_registry()
+    return SpecRegistryResponse(**payload)
 
 
 @router.get("/v1/filters/config", response_model=FiltersConfigResponse, operation_id="get_filters_config")

--- a/schemas.py
+++ b/schemas.py
@@ -332,6 +332,23 @@ class SpecsKeysResponse(BaseModel):
     total_products_using: Dict[str, int] # Статистика: ключ -> кол-во товаров
 
 
+class SpecRegistryItemResponse(BaseModel):
+    key: str
+    label: str
+    value_type: str
+    quantity_kind: Optional[str] = None
+    canonical_unit: Optional[str] = None
+    aliases: List[str] = Field(default_factory=list)
+    enum_values: List[str] = Field(default_factory=list)
+    description: Optional[str] = None
+    manager_note: Optional[str] = None
+
+
+class SpecRegistryResponse(BaseModel):
+    items: List[SpecRegistryItemResponse]
+    total: int
+
+
 class FilterRange(BaseModel):
     min: Optional[int] = None
     max: Optional[int] = None

--- a/scripts/analyze_spec_keys.py
+++ b/scripts/analyze_spec_keys.py
@@ -9,10 +9,18 @@ from sqlalchemy.orm import sessionmaker
 sys.path.append('.')
 from core.config import settings
 from models import Product
-from services.spec_normalizer import KEY_MAP
+from services.spec_normalizer import KEY_MAP, _DIMENSIONS_MAP
 
 # Define system keys (target keys)
-SYSTEM_KEYS = set(KEY_MAP.values())
+SYSTEM_KEYS = set(KEY_MAP.values()) | {key for keys in _DIMENSIONS_MAP.values() for key in keys}
+INTERNAL_SPEC_KEYS = {
+    "compatible_indoor_slugs",
+    "compatible_outdoor_slugs",
+    "compressor_type_norm",
+    "logistics_components",
+    "multi_capacity_combos",
+}
+INTERNAL_SPEC_PREFIXES = ("__filter_", "__smoke_")
 
 async def analyze_keys():
     engine = create_async_engine(settings.DATABASE_URL)
@@ -35,6 +43,10 @@ async def analyze_keys():
             products_with_specs += 1
             
             for key, val in p.specs.items():
+                if str(key).startswith(INTERNAL_SPEC_PREFIXES) or key in INTERNAL_SPEC_KEYS:
+                    continue
+                if key in _DIMENSIONS_MAP:
+                    continue
                 # 1. Check if it's already a known system key
                 if key in SYSTEM_KEYS:
                     continue

--- a/scripts/backfill_typed_specs.py
+++ b/scripts/backfill_typed_specs.py
@@ -1,0 +1,160 @@
+"""Refresh internal typed/filter specs for existing products.
+
+Default mode is dry-run. Use --execute for bounded writes only.
+The command intentionally preserves public flat spec fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import flag_modified
+
+sys.path.append(".")
+
+from core.database import async_session_maker  # noqa: E402
+from models import Product, Tag  # noqa: E402
+from services.spec_typed_backfill_service import (  # noqa: E402
+    INTERNAL_SPEC_KEYS,
+    build_specs_with_typed_internal_layer,
+)
+
+
+def _changed_internal_keys(old_specs: dict[str, Any], new_specs: dict[str, Any]) -> list[str]:
+    return [key for key in INTERNAL_SPEC_KEYS if old_specs.get(key) != new_specs.get(key)]
+
+
+async def run(
+    *,
+    execute: bool,
+    limit: int,
+    product_id: int | None,
+    strict_wifi_from_tags: bool,
+) -> dict[str, Any]:
+    query = select(Product).options(selectinload(Product.tags).selectinload(Tag.group)).order_by(Product.id)
+    if product_id is not None:
+        query = query.where(Product.id == product_id)
+    if limit:
+        query = query.limit(limit)
+
+    async with async_session_maker() as session:
+        products = (await session.execute(query)).scalars().all()
+        changed = 0
+        samples: list[dict[str, Any]] = []
+
+        for product in products:
+            old_specs = dict(product.specs or {})
+            wifi_tag_slugs = [
+                tag.slug
+                for tag in (product.tags or [])
+                if tag.slug in {"wifi-builtin", "wifi-ready"}
+            ]
+            new_specs = build_specs_with_typed_internal_layer(
+                old_specs,
+                wifi_tag_slugs=wifi_tag_slugs,
+                strict_wifi_from_tags=strict_wifi_from_tags,
+                title=product.title or "",
+            )
+            if new_specs == old_specs:
+                continue
+
+            changed += 1
+            changed_keys = _changed_internal_keys(old_specs, new_specs)
+            typed_specs = new_specs.get("__typed_specs") or {}
+            if len(samples) < 20:
+                samples.append(
+                    {
+                        "id": product.id,
+                        "slug": product.slug,
+                        "title": product.title,
+                        "changed_internal_keys": changed_keys,
+                        "typed_keys_count": len(typed_specs) if isinstance(typed_specs, dict) else 0,
+                        "typed_keys_sample": list(typed_specs.keys())[:12] if isinstance(typed_specs, dict) else [],
+                    }
+                )
+
+            if execute:
+                product.specs = new_specs
+                flag_modified(product, "specs")
+                session.add(product)
+
+        if execute:
+            await session.commit()
+        else:
+            await session.rollback()
+
+    return {
+        "mode": "execute" if execute else "dry_run",
+        "processed": len(products),
+        "changed": changed,
+        "limit": limit,
+        "product_id": product_id,
+        "strict_wifi_from_tags": strict_wifi_from_tags,
+        "samples": samples,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill only internal typed/filter catalog spec keys for existing products. "
+            "Public flat specs are preserved."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist specs updates. Without this flag the command only prints a plan.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Force dry-run mode. This is already the default.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Maximum products to inspect in this run (1-5000, default: 500).",
+    )
+    parser.add_argument("--product-id", type=int, default=None, help="Inspect/update one product only.")
+    parser.add_argument(
+        "--strict-wifi-from-tags",
+        action="store_true",
+        help="Treat Wi-Fi tags as authoritative when rebuilding internal Wi-Fi filters.",
+    )
+    return parser
+
+
+def _validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if args.execute and args.dry_run:
+        parser.error("--execute and --dry-run cannot be used together")
+    if args.limit < 1 or args.limit > 5000:
+        parser.error("--limit must be between 1 and 5000")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    _validate_args(args, parser)
+
+    result = asyncio.run(
+        run(
+            execute=args.execute and not args.dry_run,
+            limit=args.limit,
+            product_id=args.product_id,
+            strict_wifi_from_tags=args.strict_wifi_from_tags,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/services/product_read_service.py
+++ b/services/product_read_service.py
@@ -11,6 +11,7 @@ from services.product_dict_mapper import map_product_to_dict
 from services.product_filter_service import ProductFilterService
 from services.product_series_service import ProductSeriesService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
+from services.spec_registry import get_specs_registry_payload
 
 
 class ProductReadService(ProductFilterService, ProductSeriesService):
@@ -47,6 +48,10 @@ class ProductReadService(ProductFilterService, ProductSeriesService):
                 stats[key] = stats.get(key, 0) + 1
 
         return {"keys": sorted(stats.keys()), "total_products_using": stats}
+
+    @staticmethod
+    def get_specs_registry() -> Dict[str, Any]:
+        return get_specs_registry_payload()
 
     @staticmethod
     async def get_catalog_page(

--- a/services/spec_normalizer.py
+++ b/services/spec_normalizer.py
@@ -1,300 +1,28 @@
 import re
 from typing import Any, Dict, List, Optional, Sequence
 
+from services.spec_registry import (
+    REGISTRY_DIMENSIONS_MAP,
+    REGISTRY_KEY_MAP,
+    REGISTRY_UNORDERED_DIMENSION_KEYS,
+    build_typed_specs,
+    normalize_registered_value,
+)
 from services.tag_logic import extract_brand_name, extract_brand_slug, is_invalid_brand_name
 
-# 1. Маппинг (Русский -> Системный)
-KEY_MAP = {
-    # --- ОСНОВНОЕ ---
-    "Тип": "type",
-    "Тип кондиционера": "type",
-    "Тип системы": "inverter",
-    "Тип внутреннего блока": "indoor_type",
-    "Режим работы": "modes",
-    "Режимы работы": "modes",
-    "Артикул": "sku",
-    "Артикул товара": "sku",
-    "Обслуживаемая площадь": "area_m2",
-    "Обслуживаемая площадь, кв.м": "area_m2",
-    "Площадь охлаждения": "area_m2",
-    "Площадь помещения": "area_m2",
-    "Цвет": "color",
-    "Цвет корпуса": "color",
-    "Страна производства": "country",
-    "Хладагент (фреон)": "freon_type",
-    "Хладагент": "freon_type",
-    "Тип хладагента": "freon_type",
-    "Инверторная технология": "inverter",
-    "Инверторный": "inverter",
-    "Инверторное управление": "inverter",
-    "Инверторное управление мощностью": "inverter",
-    "Инверторный компрессор": "inverter",
-    "Тип управления компрессором": "inverter_type",
-    "Бренд": "brand",
-    "Марка": "brand",
-    "Производитель": "brand",
-    "Наличие": "availability",
-    "Серия": "series",
-    "Линейка": "series",
-    "Модельный ряд": "series",
-    
-    # --- УПРАВЛЕНИЕ ---
-    "Wi-Fi": "wifi_ready",
-    "Wi-Fi модуль": "wifi_ready",
-    "Wi-Fi module": "wifi_ready",
-    "Wi-Fi Ready": "wifi_ready",
-    "Вайфай": "wifi_ready",
-    "Пульт дистанционного управления": "remote_control",
-    "Пульт ДУ": "remote_control",
-    "Пульт": "remote_control",
-    "Пульт управления": "remote_control",
-    "Пульт управления в комплекте": "remote_control",
-    "Внутренний блок: Пульт управления": "remote_control",
-    "Зимний комплект": "winter_kit",
-    "Таймер включения/выключения": "timer",
-    "Таймер": "timer",
-    "Регулировка направления воздушного потока": "airflow_direction",
-    "Регулировка скорости вращения вентилятора": "fan_speed",
-    "Регулятор скорости вращения вентилятора": "fan_speed",
-    "Авторестарт после пропадания питания": "autorestart",
-    "Авторестарт": "autorestart",
-    "Турбо-режим": "turbo_mode",
-    "Турбо режим": "turbo_mode",
-    "Режим «Сон»": "sleep_mode",
-    "Ночной режим": "sleep_mode",
-    "Осушение воздуха": "dehumidification",
-    "Осушение": "dehumidification_l_h",
-    "Режим осушения воздуха": "dehumidification",
-
-    # --- МОЩНОСТЬ ---
-    "Мощность охлаждения": "capacity_cooling_kw",
-    "Мощность охлаждения, кВт": "capacity_cooling_kw",
-    "Мощность охлаждения (Мин/Ном/Макс), кВт": "capacity_cooling_kw",
-    "Мощность в режиме охлаждения": "capacity_cooling_kw",
-    "Мощность в режиме охлаждения, кВт": "capacity_cooling_kw",
-    "Холодопроизводительность": "capacity_cooling_kw",
-    "Охлаждение, кВт": "capacity_cooling_kw",
-    "Охлаждение минимум, кВт": "capacity_cooling_min_kw",
-    "Охлаждение максимум, кВт": "capacity_cooling_max_kw",
-    "Мощность обогрева": "capacity_heating_kw",
-    "Мощность обогрева, кВт": "capacity_heating_kw",
-    "Мощность нагрева (Мин/Ном/Макс), кВт": "capacity_heating_kw",
-    "Мощность в режиме обогрева": "capacity_heating_kw",
-    "Мощность в режиме обогрева, кВт": "capacity_heating_kw",
-    "Теплопроизводительность": "capacity_heating_kw",
-    "Нагрев, кВт": "capacity_heating_kw",
-    "Нагрев минимум, кВт": "capacity_heating_min_kw",
-    "Нагрев максимум, кВт": "capacity_heating_max_kw",
-    "Потребляемая мощность при охлаждении": "power_cons_cooling_kw",
-    "Потребляемая мощность при охлаждении, кВт": "power_cons_cooling_kw",
-    "Потребляемая мощность, охлаждение": "power_cons_cooling_kw",
-    "Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт": "power_cons_cooling_kw",
-    "Номинальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_kw",
-    "Минимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_min_kw",
-    "Максимальная потребляемая мощность (охлаждение), кВт": "power_cons_cooling_max_kw",
-    "Потребляемая мощность при обогреве": "power_cons_heating_kw",
-    "Потребляемая мощность при обогреве, кВт": "power_cons_heating_kw",
-    "Потребляемая мощность, обогрев": "power_cons_heating_kw",
-    "Потребление электроэнергии в режиме нагрева (Мин / Ном / Макс), кВт": "power_cons_heating_kw",
-    "Номинальная потребляемая мощность (нагрев), кВт": "power_cons_heating_kw",
-    "Минимальная потребляемая мощность (нагрев), кВт": "power_cons_heating_min_kw",
-    "Максимальная потребляемая мощность (нагрев), кВт": "power_cons_heating_max_kw",
-    
-    # --- ЭФФЕКТИВНОСТЬ ---
-    "Энергоэффективность при охлаждении (EER)": "eer",
-    "EER": "eer",
-    "EER/COP": "eer",
-    "Энергоэффективность при обогреве (COP)": "cop",
-    "COP": "cop",
-    "Класс энергоэффективности": "energy_class",
-    "Класс энергоэффективности при охлаждении": "energy_class_cooling",
-    "Класс энергоэффективности при обогреве": "energy_class_heating",
-    
-    # --- ШУМ ---
-    "Шум внутреннего блока": "noise_indoor",
-    "Шум внутреннего блока, дБ": "noise_indoor",
-    "Уровень шума внутреннего блока": "noise_indoor",
-    "Уровень шума (макс), дБ": "noise_indoor",
-    "Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх": "noise_indoor",
-    "Уровень шума в режиме ОХЛАЖДЕНИЯ (Тих / Низ / Ср /Макс), дБ": "noise_indoor",
-    "Уровень шума в режиме НАГРЕВА (Низ / Ср / Макс), дБ": "noise_indoor",
-    "Шум наружного блока": "noise_outdoor",
-    "Шум наружного блока, дБ": "noise_outdoor",
-    "Шум внешнего блока": "noise_outdoor",
-    "Шум внешнего блока, дБ": "noise_outdoor",
-    "Уровень шума наружного блока": "noise_outdoor",
-    "Уровень шума наружного блока, дБ": "noise_outdoor",
-    "Уровень звукового давления, дБ, А": "noise_outdoor",
-    "Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
-    "Наружный блок: Уровень звукового давления (высокая скорость), дБ, А": "noise_outdoor",
-    "Внутренний блок: Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх": "noise_indoor",
-    "Уровень звукового давления внутреннего блока": "noise_indoor",
-    "Уровень звукового давления наружного блока": "noise_outdoor",
-    
-    # --- ГАБАРИТЫ ВНУТРЕННИЙ ---
-    "Ширина внутреннего блока": "width_indoor",
-    "Высота внутреннего блока": "height_indoor",
-    "Глубина внутреннего блока": "depth_indoor",
-    "Вес внутреннего блока": "weight_indoor",
-    "Вес внутреннего блока, кг": "weight_indoor",
-    "Чистый вес / Вес в упаковке, кг": "weight_indoor",
-    "Внутренний блок: Чистый вес / Вес в упаковке, кг": "weight_indoor",
-    "Внутренний блок без упаковки, кг": "weight_indoor",
-    "Вес внутреннего блока без упаковки": "weight_indoor",
-    
-    # --- ГАБАРИТЫ НАРУЖНЫЙ ---
-    "Ширина наружного блока": "width_outdoor",
-    "Высота наружного блока": "height_outdoor",
-    "Глубина наружного блока": "depth_outdoor",
-    "Вес наружного блока": "weight_outdoor",
-    "Вес наружного блока, кг": "weight_outdoor",
-    "Вес внешнего блока": "weight_outdoor",
-    "Вес внешнего блока, кг": "weight_outdoor",
-    "Чистый вес / вес в упаковке, кг": "weight_outdoor",
-    "Наружный блок: Чистый вес / вес в упаковке, кг": "weight_outdoor",
-    "Наружный блок: Чистый вес / Вес в упаковке, кг": "weight_outdoor",
-    "Наружный блок без упаковки, кг": "weight_outdoor",
-    "Вес наружного блока без упаковки": "weight_outdoor",
-    
-    # --- МОНТАЖ ---
-    "Максимальная длина магистрали": "pipe_max_length",
-    "Максимальная длина коммуникаций": "pipe_max_length",
-    "Максимальная длина коммуникаций, м": "pipe_max_length",
-    "Максимальная длина фреонопровода": "pipe_max_length",
-    "Макс. длина трассы": "pipe_max_length",
-    "Макс. длина трубопроводов без дополнительной заправки, м": "pipe_max_length",
-    "Перепад высот": "pipe_max_height",
-    "Перепад высот, м": "pipe_max_height",
-    "Максимальная длина/перепад высот, м": "pipe_max_length",
-    "Максимальная длина/перепад высот, при использовании только в режиме охлаждения, м": "pipe_max_length",
-    "Максимальный перепад высот": "pipe_max_height",
-    "Максимальное количество внутренних блоков": "multi_max_indoor_units",
-    "Максимальная суммарная длина магистрали": "multi_max_total_pipe_length",
-    "Диаметр жидкостной трубы": "pipe_liquid",
-    "Диаметр жидкостной линии, мм": "pipe_liquid",
-    "Диаметр труб жидкого хладагента, мм": "pipe_liquid",
-    "Диаметр газовой трубы": "pipe_gas",
-    "Диаметр газовой линии, мм": "pipe_gas",
-    "Диаметр труб газообразного хладагента, мм": "pipe_gas",
-    
-    # --- ТЕМПЕРАТУРЫ ---
-    "Рабочая температура при охлаждении": "temp_range_cool",
-    "Рабочий диапазон температур при охлаждении": "temp_range_cool",
-    "Рабочий диапазон температур при охлаждении,°C": "temp_range_cool",
-    "Рабочий диапазон температур при охлаждении, °C": "temp_range_cool",
-    "Гарантированный диапазон рабочих t° наружного воздуха, охлаждение": "temp_range_cool",
-    "Охлаждение, °С": "temp_range_cool",
-    "Рабочая температура при обогреве": "temp_range_heat",
-    "Рабочий диапазон температур при обогреве": "temp_range_heat",
-    "Рабочий диапазон температур при обогреве,°C": "temp_range_heat",
-    "Рабочий диапазон температур при обогреве, °C": "temp_range_heat",
-    "Гарантированный диапазон рабочих t° наружного воздуха, обогрев": "temp_range_heat",
-    "Нагрев, °С": "temp_range_heat",
-    "Минимальная температура наружного воздуха": "temp_range_heat",
-    "Мин. температура (обогрев)": "temp_range_heat",
-    
-    # --- ПЛОЩАДЬ (с единицами) ---
-    "Обслуживаемая площадь до": "area_m2",
-    "Обслуживаемая площадь до, м2": "area_m2",
-    "Рекомендуемая максимальная площадь помещения": "area_m2",
-    "Рекомендованная площадь, м 2": "area_m2",
-    
-    # --- ЭНЕРГОЭФФЕКТИВНОСТЬ (без скобок) ---
-    "Энергоэффективность при охлаждении": "energy_class_cooling",
-    "Энергоэффективность при обогреве": "energy_class_heating",
-    "Класс эффективности": "energy_class",
-    "Класс энергоэффективности (Холод / Тепло)": "energy_class",
-    "Коэффициент энергоэффективности (EER / COP)": "eer",
-    "EER/COP": "eer",
-    "Энергоэффективность SEER/EER": "eer",
-    "Энергоэффективность SCOP/COP": "cop",
-    "SEER (коэффициент/класс)": "seer",
-    "EER (коэффициент / класс)": "eer",
-    "COP (коэффициент / класс)": "cop",
-    
-    "Максимальный расход воздуха внутреннего блока": "airflow_max",
-    "Расход воздуха (высокая скорость), м 3 /ч": "airflow_max",
-    "Расход воздуха внутреннего блока": "airflow_max",
-    "Расход воздуха наружного блока": "airflow_outdoor",
-
-    # --- ФИЛЬТРЫ И ДОП. ФУНКЦИИ ---
-    "Приток свежего воздуха": "fresh_air",
-    'Интеграция в "умный дом"': "smart_home_integration",
-    "Голосовое управление": "voice_control",
-    "Биофильтр": "bio_filter",
-    "Плазменный фильтр": "plasma_filter",
-    "Ионизатор": "ionizer",
-    "Ионизация": "ionizer",
-    "Угольный фильтр": "carbon_filter",
-    "Фотокаталитический фильтр": "photocatalytic_filter",
-    "Электростатический фильтр": "electrostatic_filter",
-    "Обеззараживание ультрафиолетом": "uv_sterilization",
-    "Самоочистка": "self_cleaning",
-    "Автоочистка теплообменника": "self_cleaning",
-    "Wi-Fi управление": "wifi_ready",
-    "Марка используемого хладагента": "freon_type",
-    "Производитель компрессора": "compressor_brand",
-    "Компрессор: Производитель компрессора": "compressor_brand",
-    "Неинверторный компрессор": "inverter",
-    "Компрессор: Неинверторный компрессор": "inverter",
-    "Номинальный уровень рабочего тока (охлаждение), А": "current_cooling_nominal_a",
-    "Номинальный уровень рабочего тока (нагрев), А": "current_heating_nominal_a",
-    "Максимальный рабочий ток, охлаждение": "current_cooling_max_a",
-    "Максимальный рабочий ток, обогрев": "current_heating_max_a",
-    "Дополнительная заправка (г/м)": "refrigerant_additional_g_m",
-    "Дополнительная заправка хладагента": "refrigerant_additional_g_m",
-    "Заводская заправка хладагента": "refrigerant_charge_g",
-    "Вес заправляемого хладагента, г": "refrigerant_charge_g",
-    "Артикулы товара": "sku_list",
-    "Подача питания": "power_supply_location",
-    "Подключение питания": "power_supply_location",
-    "Сторона подключения": "power_supply_location",
-    "Электропитание": "power_supply",
-    "Электропитание, Ф/В/Гц": "power_supply",
-    "Электропитание (Ø / В / Гц)": "power_supply",
-    "Параметры питающей сети": "power_supply_voltage",
-    "Диаметр дренажной трубы: мм (дюйм)": "drain_pipe_diameter",
-    "Модель": "model",
-    "Модель внутреннего блока": "model_indoor",
-    "Модель наружного блока": "model_outdoor",
-    "Гарантия": "warranty_months",
-    "Установка": "installation_orientation",
-    "Внутренний блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_indoor_package_mm",
-    "Наружный блок: Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
-    "Размеры внутреннего блока в упаковке (Ш х В х Г)": "dimensions_indoor_package_mm",
-    "Размеры наружного блока в упаковке (Ш х В х Г)": "dimensions_outdoor_package_mm",
-    "Вес внутреннего блока в упаковке": "weight_indoor_package",
-    "Вес наружного блока в упаковке": "weight_outdoor_package",
-    "Габаритные размеры в упаковке (Ш/Г/В), мм": "dimensions_outdoor_package_mm",
+_TRIPLET_SPEC_KEYS = {
+    "capacity_cooling_kw": ("capacity_cooling_min_kw", "capacity_cooling_max_kw"),
+    "capacity_heating_kw": ("capacity_heating_min_kw", "capacity_heating_max_kw"),
+    "power_cons_cooling_kw": ("power_cons_cooling_min_kw", "power_cons_cooling_max_kw"),
+    "power_cons_heating_kw": ("power_cons_heating_min_kw", "power_cons_heating_max_kw"),
 }
 
-# Composite dimension keys: "940×1250×340" → split into width/height/depth
-# Maps raw key patterns → (width_key, height_key, depth_key)
-_DIMENSIONS_MAP = {
-    "Габариты внутреннего блока (ШхВхГ)": ("width_indoor", "height_indoor", "depth_indoor"),
-    "Габариты внутреннего блока (ШхВхГ), мм": ("width_indoor", "height_indoor", "depth_indoor"),
-    "Габариты наружного блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Габариты наружного блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Габариты внешнего блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Габариты мм": ("width_indoor", "height_indoor", "depth_indoor"),
-    # Haierproff uses width/depth/height order (Ш/Г/В).
-    "Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_indoor", "depth_indoor", "height_indoor"),
-    "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
-    "Внутренний блок без упаковки (Ш × В × Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
-    "Наружный блок без упаковки (Ш × В × Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Размеры внутреннего блока без упаковки (Ш х В х Г)": ("width_indoor", "height_indoor", "depth_indoor"),
-    "Размеры наружного блока без упаковки (Ш х В х Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-    "Размеры внутреннего блока без упаковки (Ш x В x Г)": ("width_indoor", "height_indoor", "depth_indoor"),
-    "Размеры наружного блока без упаковки (Ш x В x Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
-}
+# Registry-backed alias projection. Keep the public KEY_MAP name for scripts/tests.
+KEY_MAP: Dict[str, str] = dict(REGISTRY_KEY_MAP)
 
-_UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS = {
-    "Размеры внутреннего блока без упаковки (Ш х В х Г)",
-    "Размеры наружного блока без упаковки (Ш х В х Г)",
-    "Размеры внутреннего блока без упаковки (Ш x В x Г)",
-    "Размеры наружного блока без упаковки (Ш x В x Г)",
-}
+# Composite dimension keys: "940×1250×340" → split into width/height/depth.
+_DIMENSIONS_MAP = dict(REGISTRY_DIMENSIONS_MAP)
+_UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS = set(REGISTRY_UNORDERED_DIMENSION_KEYS)
 
 _PREFERRED_NUMERIC_KEYS = {
     "capacity_cooling_kw",
@@ -369,11 +97,15 @@ def _split_dimensions(specs: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
+def clean_value(key: str, val: Any, keep_units: bool = True, source_key: str | None = None) -> Any:
     if not isinstance(val, str):
         return val
         
     val_lower = val.lower().strip()
+
+    registered_value = normalize_registered_value(key, val, source_key=source_key)
+    if registered_value is not None:
+        return registered_value
 
     if key in {"pipe_liquid", "pipe_gas"}:
         # Convert common metric diameters to canonical inch fractions for UI/filter selects.
@@ -429,7 +161,8 @@ def clean_value(key: str, val: Any, keep_units: bool = True) -> Any:
         "smart_home_integration", "voice_control",
         "bio_filter", "plasma_filter", "ionizer", "carbon_filter",
         "photocatalytic_filter", "electrostatic_filter", "uv_sterilization",
-        "fresh_air"
+        "fresh_air", "humidification", "presence_sensor", "self_diagnosis",
+        "includes_indoor_unit", "includes_outdoor_unit",
     ]
     
     if key == "wifi_ready":
@@ -692,6 +425,7 @@ def _classify_wifi_value(value: Any) -> str | None:
         "встро",
         "built-in",
         "built in",
+        "builtin",
         "check",
         "галоч",
         "true",
@@ -737,15 +471,30 @@ def _apply_wifi_state(
     enriched = dict(specs)
     wifi_candidates = (
         enriched.get("wifi_ready"),
+        enriched.get("wifi_builtin"),
+        enriched.get("wifi_state"),
         enriched.get("wifi_module"),
         enriched.get("wi_fi"),
         enriched.get("wifi"),
     )
     wifi_kinds = [_classify_wifi_value(value) for value in wifi_candidates]
     wifi_kinds = [kind for kind in wifi_kinds if kind is not None]
+    explicit_builtin_flag = _parse_bool(enriched.get("wifi_builtin"))
+    explicit_ready_flag = _parse_bool(enriched.get("wifi_ready"))
+    if explicit_builtin_flag is False and explicit_ready_flag is True:
+        wifi_kinds = [kind for kind in wifi_kinds if kind != "builtin"]
+        wifi_kinds.append("ready")
 
     # Drop stale keys and rebuild consistently.
-    for key in ("wifi_ready", "wifi-builtin", "wifi-ready", "__filter_wifi", "__filter_wifi_builtin"):
+    for key in (
+        "wifi_ready",
+        "wifi_builtin",
+        "wifi_state",
+        "wifi-builtin",
+        "wifi-ready",
+        "__filter_wifi",
+        "__filter_wifi_builtin",
+    ):
         if key in enriched:
             del enriched[key]
 
@@ -755,18 +504,24 @@ def _apply_wifi_state(
 
     if has_builtin_tag:
         enriched["wifi_ready"] = True
+        enriched["wifi_builtin"] = True
+        enriched["wifi_state"] = "builtin"
         enriched["__filter_wifi"] = True
         enriched["__filter_wifi_builtin"] = True
         return enriched
 
     if has_ready_tag:
         enriched["wifi_ready"] = "ready"
+        enriched["wifi_builtin"] = False
+        enriched["wifi_state"] = "ready"
         enriched["__filter_wifi"] = True
         enriched["__filter_wifi_builtin"] = False
         return enriched
 
     if strict_wifi_from_tags:
         enriched["wifi_ready"] = False
+        enriched["wifi_builtin"] = False
+        enriched["wifi_state"] = "none"
         enriched["__filter_wifi"] = False
         enriched["__filter_wifi_builtin"] = False
         return enriched
@@ -781,14 +536,20 @@ def _apply_wifi_state(
 
     if wifi_kind == "builtin":
         enriched["wifi_ready"] = True
+        enriched["wifi_builtin"] = True
+        enriched["wifi_state"] = "builtin"
         enriched["__filter_wifi"] = True
         enriched["__filter_wifi_builtin"] = True
     elif wifi_kind == "ready":
         enriched["wifi_ready"] = "ready"
+        enriched["wifi_builtin"] = False
+        enriched["wifi_state"] = "ready"
         enriched["__filter_wifi"] = True
         enriched["__filter_wifi_builtin"] = False
     else:
         enriched["wifi_ready"] = False
+        enriched["wifi_builtin"] = False
+        enriched["wifi_state"] = "none"
         enriched["__filter_wifi"] = False
         enriched["__filter_wifi_builtin"] = False
 
@@ -882,7 +643,7 @@ def normalize_specs(
                     new_specs["eer"] = numbers[0].replace(",", ".")
                     if len(numbers) > 1:
                         new_specs["cop"] = numbers[1].replace(",", ".")
-                if rus_key in new_specs:
+                if rus_key != sys_key and rus_key in new_specs:
                     del new_specs[rus_key]
                 continue
             if "seer/eer" in rus_key_l:
@@ -891,7 +652,7 @@ def normalize_specs(
                     new_specs["seer"] = numbers[0].replace(",", ".")
                     if len(numbers) > 1:
                         new_specs["eer"] = numbers[1].replace(",", ".")
-                if rus_key in new_specs:
+                if rus_key != sys_key and rus_key in new_specs:
                     del new_specs[rus_key]
                 continue
             if "scop/cop" in rus_key_l:
@@ -900,7 +661,7 @@ def normalize_specs(
                     new_specs["scop"] = numbers[0].replace(",", ".")
                     if len(numbers) > 1:
                         new_specs["cop"] = numbers[1].replace(",", ".")
-                if rus_key in new_specs:
+                if rus_key != sys_key and rus_key in new_specs:
                     del new_specs[rus_key]
                 continue
 
@@ -920,7 +681,23 @@ def normalize_specs(
                         new_specs["energy_class_cooling"] = energy_class
                     else:
                         new_specs["energy_class_heating"] = energy_class
-                if rus_key in new_specs:
+                if rus_key != sys_key and rus_key in new_specs:
+                    del new_specs[rus_key]
+                continue
+
+            if sys_key == "energy_class" and "/" in str(raw_val) and (
+                "охлаждение" in rus_key_l or "холод" in rus_key_l
+            ):
+                classes = [
+                    item.strip().replace("А", "A").replace("а", "A")
+                    for item in re.split(r"\s*/\s*", str(raw_val))
+                    if item.strip()
+                ]
+                if classes:
+                    new_specs["energy_class_cooling"] = classes[0]
+                    if len(classes) > 1:
+                        new_specs["energy_class_heating"] = classes[1]
+                if rus_key != sys_key and rus_key in new_specs:
                     del new_specs[rus_key]
                 continue
 
@@ -933,18 +710,34 @@ def normalize_specs(
                     new_specs[sys_key] = True
                 else:
                     new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units)
-                if rus_key in new_specs:
+                if rus_key != sys_key and rus_key in new_specs:
                     del new_specs[rus_key]
                 continue
 
             # Чистим / Конвертируем
-            clean_val = clean_value(sys_key, raw_val, keep_units=keep_units)
+            triplet_target = _TRIPLET_SPEC_KEYS.get(sys_key)
+            triplet_numbers = re.findall(r"[-+]?\d+(?:[.,]\d+)?", str(raw_val))
+            if triplet_target and len(triplet_numbers) >= 3 and "/" in str(raw_val):
+                min_key, max_key = triplet_target
+                new_specs[min_key] = clean_value(
+                    min_key,
+                    triplet_numbers[0].replace(",", "."),
+                    keep_units=keep_units,
+                    source_key=rus_key,
+                )
+                new_specs[max_key] = clean_value(
+                    max_key,
+                    triplet_numbers[2].replace(",", "."),
+                    keep_units=keep_units,
+                    source_key=rus_key,
+                )
+            clean_val = clean_value(sys_key, raw_val, keep_units=keep_units, source_key=rus_key)
 
             # Записываем новый ключ
             new_specs[sys_key] = clean_val
 
             # Удаляем старый (чтобы не было дублей)
-            if rus_key in new_specs:
+            if rus_key != sys_key and rus_key in new_specs:
                 del new_specs[rus_key]
                 
     # Also attempt to clean values for keys that are ALREADY system keys
@@ -959,7 +752,7 @@ def normalize_specs(
         sys_key = _resolve_dynamic_system_key(raw_key)
         if not sys_key or sys_key in new_specs:
             continue
-        new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units)
+        new_specs[sys_key] = clean_value(sys_key, raw_val, keep_units=keep_units, source_key=raw_key)
 
     # Source price/rate are import internals; never persist in product specs.
     for dropped_key in _DROPPED_SPEC_KEYS:
@@ -984,8 +777,12 @@ def normalize_specs(
     if auto_tag_slugs is not None and brand_slug and brand_slug not in auto_tag_slugs:
         auto_tag_slugs.append(brand_slug)
             
-    return enrich_filter_keys(
+    enriched_specs = enrich_filter_keys(
         new_specs,
         wifi_tag_slugs=wifi_tag_slugs,
         strict_wifi_from_tags=strict_wifi_from_tags,
     )
+    typed_specs = build_typed_specs(enriched_specs)
+    if typed_specs:
+        enriched_specs["__typed_specs"] = typed_specs
+    return enriched_specs

--- a/services/spec_registry.py
+++ b/services/spec_registry.py
@@ -1,0 +1,1746 @@
+"""Typed registry for catalog specifications.
+
+The registry is intentionally independent from database models: parsers,
+normalizers, manager UI and public catalog code can all use the same metadata.
+The first rollout keeps the old flat specs JSON compatible while giving the
+normalizer canonical aliases, units and value types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+import re
+from typing import Any, Iterable, Mapping
+
+
+class SpecValueType(str, Enum):
+    TEXT = "text"
+    BOOLEAN = "boolean"
+    ENUM = "enum"
+    QUANTITY = "quantity"
+    RANGE = "range"
+    NUMBER_LIST = "number_list"
+    STATE = "state"
+    DIMENSIONS = "dimensions"
+
+
+class QuantityKind(str, Enum):
+    POWER = "power"
+    LENGTH = "length"
+    WEIGHT = "weight"
+    TEMPERATURE = "temperature"
+    AIRFLOW = "airflow"
+    NOISE = "noise"
+    CURRENT = "current"
+    AREA = "area"
+    VOLUME_RATE = "volume_rate"
+    ENERGY = "energy"
+    REFRIGERANT_MASS = "refrigerant_mass"
+    COUNT = "count"
+
+
+@dataclass(frozen=True)
+class SpecDefinition:
+    key: str
+    label: str
+    value_type: SpecValueType
+    quantity_kind: QuantityKind | None = None
+    canonical_unit: str | None = None
+    aliases: tuple[str, ...] = ()
+    enum_values: tuple[str, ...] = ()
+    description: str | None = None
+    manager_note: str | None = None
+
+
+def _spec(
+    key: str,
+    label: str,
+    value_type: SpecValueType,
+    *,
+    quantity_kind: QuantityKind | None = None,
+    canonical_unit: str | None = None,
+    aliases: Iterable[str] = (),
+    enum_values: Iterable[str] = (),
+    description: str | None = None,
+    manager_note: str | None = None,
+) -> SpecDefinition:
+    return SpecDefinition(
+        key=key,
+        label=label,
+        value_type=value_type,
+        quantity_kind=quantity_kind,
+        canonical_unit=canonical_unit,
+        aliases=tuple(aliases),
+        enum_values=tuple(enum_values),
+        description=description,
+        manager_note=manager_note,
+    )
+
+
+SPEC_DEFINITIONS: Mapping[str, SpecDefinition] = {
+    "type": _spec(
+        "type",
+        "Тип кондиционера",
+        SpecValueType.ENUM,
+        enum_values=(
+            "сплит-система",
+            "мульти-сплит-система",
+            "внутренний блок",
+            "наружный блок",
+            "полупромышленный кондиционер",
+        ),
+    ),
+    "indoor_type": _spec(
+        "indoor_type",
+        "Тип внутреннего блока",
+        SpecValueType.ENUM,
+        enum_values=("настенный", "кассетный", "канальный", "напольно-потолочный", "колонный"),
+    ),
+    "brand": _spec("brand", "Бренд", SpecValueType.TEXT),
+    "series": _spec("series", "Серия", SpecValueType.TEXT),
+    "model": _spec("model", "Модель", SpecValueType.TEXT),
+    "model_indoor": _spec("model_indoor", "Модель внутреннего блока", SpecValueType.TEXT),
+    "model_outdoor": _spec("model_outdoor", "Модель наружного блока", SpecValueType.TEXT),
+    "sku": _spec("sku", "Артикул", SpecValueType.TEXT),
+    "release_year": _spec("release_year", "Дата выхода на рынок", SpecValueType.TEXT, aliases=("Дата выхода на рынок",)),
+    "inverter": _spec(
+        "inverter",
+        "Инвертор",
+        SpecValueType.BOOLEAN,
+        aliases=("Компрессор: Инверторный компрессор",),
+    ),
+    "wifi_state": _spec(
+        "wifi_state",
+        "Состояние Wi-Fi",
+        SpecValueType.STATE,
+        enum_values=("builtin", "ready", "none"),
+        description=(
+            "Единое состояние Wi-Fi: встроенный модуль, подготовка под отдельный модуль "
+            "или отсутствие поддержки."
+        ),
+    ),
+    "wifi_ready": _spec(
+        "wifi_ready",
+        "Wi-Fi Ready",
+        SpecValueType.STATE,
+        enum_values=("true", "ready", "false"),
+        description="Совместимое поле Wi-Fi: true означает встроенный модуль, ready — модуль приобретается отдельно.",
+    ),
+    "wifi_builtin": _spec("wifi_builtin", "Wi-Fi встроенный", SpecValueType.BOOLEAN),
+    "capacity_cooling_kw": _spec(
+        "capacity_cooling_kw",
+        "Мощность охлаждения",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        description=(
+            "Номинальная холодопроизводительность. У инверторных моделей фактическая "
+            "мощность может изменяться в диапазоне от минимальной до максимальной."
+        ),
+    ),
+    "capacity_cooling_min_kw": _spec(
+        "capacity_cooling_min_kw",
+        "Минимальная мощность охлаждения",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=("Охлаждение минимум, Вт",),
+    ),
+    "capacity_cooling_max_kw": _spec(
+        "capacity_cooling_max_kw",
+        "Максимальная мощность охлаждения",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=("Охлаждение максимум, Вт",),
+    ),
+    "capacity_heating_kw": _spec(
+        "capacity_heating_kw",
+        "Мощность обогрева",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+    ),
+    "capacity_heating_min_kw": _spec(
+        "capacity_heating_min_kw",
+        "Минимальная мощность обогрева",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=("Нагрев минимум, Вт",),
+    ),
+    "capacity_heating_max_kw": _spec(
+        "capacity_heating_max_kw",
+        "Максимальная мощность обогрева",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=("Нагрев максимум, Вт",),
+    ),
+    "power_cons_cooling_kw": _spec(
+        "power_cons_cooling_kw",
+        "Потребляемая мощность при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=(
+            "Номинальная потребляемая мощность (охлаждение), Вт",
+            "Потребляемая мощность, номинальная (Охлаждение) кВт",
+        ),
+    ),
+    "power_cons_heating_kw": _spec(
+        "power_cons_heating_kw",
+        "Потребляемая мощность при обогреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+        aliases=(
+            "Номинальная потребляемая мощность (нагрев), Вт",
+            "Потребляемая мощность, номинальная (Нагрев) кВт",
+        ),
+    ),
+    "area_m2": _spec("area_m2", "Площадь", SpecValueType.QUANTITY, quantity_kind=QuantityKind.AREA, canonical_unit="m2"),
+    "temp_range_cool": _spec(
+        "temp_range_cool",
+        "Рабочий диапазон температур при охлаждении",
+        SpecValueType.RANGE,
+        quantity_kind=QuantityKind.TEMPERATURE,
+        canonical_unit="C",
+        aliases=(
+            "min_temp_cool",
+            "Гарантированный диапазон рабочих температур (С) Охлаждение",
+            "Температура наружного воздуха при охлаждении",
+        ),
+    ),
+    "temp_range_heat": _spec(
+        "temp_range_heat",
+        "Рабочий диапазон температур при обогреве",
+        SpecValueType.RANGE,
+        quantity_kind=QuantityKind.TEMPERATURE,
+        canonical_unit="C",
+        aliases=(
+            "min_temp_heat",
+            "Температура наружного воздуха при обогреве",
+        ),
+    ),
+    "airflow_max": _spec(
+        "airflow_max",
+        "Расход воздуха внутреннего блока",
+        SpecValueType.NUMBER_LIST,
+        quantity_kind=QuantityKind.AIRFLOW,
+        canonical_unit="m3/h",
+        aliases=(
+            "Внутренний блок: Расход воздуха (высокая скорость), м 3 /ч",
+            "Внутренний блок: Расход воздуха, м 3 /ч",
+            "Расход воздуха, м 3 /ч",
+        ),
+    ),
+    "noise_indoor": _spec(
+        "noise_indoor",
+        "Шум внутреннего блока",
+        SpecValueType.NUMBER_LIST,
+        quantity_kind=QuantityKind.NOISE,
+        canonical_unit="dB",
+    ),
+    "noise_outdoor": _spec(
+        "noise_outdoor",
+        "Шум наружного блока",
+        SpecValueType.NUMBER_LIST,
+        quantity_kind=QuantityKind.NOISE,
+        canonical_unit="dB",
+        aliases=("Наружный блок: Уровень звукового давления, дБ, А",),
+    ),
+    "refrigerant_charge_g": _spec(
+        "refrigerant_charge_g",
+        "Заводская заправка хладагента",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.REFRIGERANT_MASS,
+        canonical_unit="g",
+        aliases=(
+            "Заправка хладагента, кг",
+            "Заводская заправка хладагента, кг",
+            "Заводская заправка хладагента R410a (до 5 м)",
+        ),
+    ),
+    "dehumidification_l_h": _spec(
+        "dehumidification_l_h",
+        "Удаление влаги",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.VOLUME_RATE,
+        canonical_unit="l/h",
+        aliases=("Удаление влаги, л/ч",),
+    ),
+    "energy_class": _spec(
+        "energy_class",
+        "Класс энергоэффективности",
+        SpecValueType.TEXT,
+        aliases=("Класс энергоэффективности (охлаждение/нагрев)",),
+    ),
+    "eer": _spec(
+        "eer",
+        "EER",
+        SpecValueType.QUANTITY,
+        aliases=("Энергоэффективность EER/COP",),
+    ),
+    "multi_max_indoor_units": _spec(
+        "multi_max_indoor_units",
+        "Максимальное количество внутренних блоков",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.COUNT,
+        aliases=(
+            "Максимальное количество подключаемых внутренних блоков",
+            "Макс. количество внутренних блоков, шт",
+        ),
+    ),
+    "pipe_max_height": _spec(
+        "pipe_max_height",
+        "Максимальный перепад высот",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="m",
+        aliases=("multi_max_height_diff",),
+    ),
+    "current_cooling_max_a": _spec(
+        "current_cooling_max_a",
+        "Максимальный рабочий ток при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.CURRENT,
+        canonical_unit="A",
+        aliases=("Максимальный уровень рабочего тока (охлаждение), А",),
+    ),
+    "multi_compat_mode": _spec(
+        "multi_compat_mode",
+        "Режим совместимости мульти-сплита",
+        SpecValueType.ENUM,
+        aliases=("multi_compat_mode",),
+    ),
+    "power_supply_voltage": _spec(
+        "power_supply_voltage",
+        "Напряжение питания",
+        SpecValueType.TEXT,
+        aliases=("Напряжение, В",),
+    ),
+    "power_supply_indoor": _spec(
+        "power_supply_indoor",
+        "Электропитание внутреннего блока",
+        SpecValueType.TEXT,
+        aliases=("Внутренний блок: Электропитание, Ф/В/Гц",),
+    ),
+    "power_supply_outdoor": _spec(
+        "power_supply_outdoor",
+        "Электропитание наружного блока",
+        SpecValueType.TEXT,
+        aliases=("Наружный блок: Электропитание, Ф/В/Гц",),
+    ),
+    "scop": _spec("scop", "SCOP", SpecValueType.QUANTITY, aliases=("SCOP", "scop")),
+    "humidification": _spec("humidification", "Увлажнение воздуха", SpecValueType.BOOLEAN, aliases=("Увлажнение воздуха",)),
+    "presence_sensor": _spec("presence_sensor", "Датчик присутствия", SpecValueType.BOOLEAN, aliases=("Датчик присутствия",)),
+    "self_diagnosis": _spec("self_diagnosis", "Самодиагностика", SpecValueType.BOOLEAN, aliases=("Самодиагностика",)),
+    "compressor_type": _spec("compressor_type", "Тип компрессора", SpecValueType.ENUM, aliases=("compressor_type",)),
+    "cable_power": _spec("cable_power", "Кабель питания", SpecValueType.TEXT, aliases=("cable_power",)),
+    "cable_interconnect": _spec("cable_interconnect", "Межблочный кабель", SpecValueType.TEXT, aliases=("cable_interconnect",)),
+    "indoor_units_count": _spec(
+        "indoor_units_count",
+        "Количество внутренних блоков",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.COUNT,
+        aliases=("Количество внутренних блоков",),
+    ),
+    "includes_indoor_unit": _spec("includes_indoor_unit", "Внутренний блок в комплекте", SpecValueType.BOOLEAN, aliases=("Внутренний блок",)),
+    "includes_outdoor_unit": _spec("includes_outdoor_unit", "Наружный блок в комплекте", SpecValueType.BOOLEAN, aliases=("Наружный блок",)),
+    "annual_energy_cooling_kwh": _spec(
+        "annual_energy_cooling_kwh",
+        "Годовое потребление энергии при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.ENERGY,
+        canonical_unit="kWh/year",
+        aliases=("Годовое потребление энергии (охлаждение), кВт/г.",),
+    ),
+    "annual_energy_heating_kwh": _spec(
+        "annual_energy_heating_kwh",
+        "Годовое потребление энергии при нагреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.ENERGY,
+        canonical_unit="kWh/year",
+        aliases=("Годовое потребление энергии (нагрев), кВт/г.",),
+    ),
+}
+
+
+SPEC_DEFINITIONS = {
+    **SPEC_DEFINITIONS,
+    "airflow_direction": _spec("airflow_direction", "Регулировка направления потока", SpecValueType.BOOLEAN),
+    "airflow_outdoor": _spec(
+        "airflow_outdoor",
+        "Расход воздуха наружного блока",
+        SpecValueType.NUMBER_LIST,
+        quantity_kind=QuantityKind.AIRFLOW,
+        canonical_unit="m3/h",
+    ),
+    "autorestart": _spec("autorestart", "Авторестарт", SpecValueType.BOOLEAN),
+    "availability": _spec("availability", "Наличие", SpecValueType.TEXT),
+    "bio_filter": _spec("bio_filter", "Биофильтр", SpecValueType.BOOLEAN),
+    "carbon_filter": _spec("carbon_filter", "Угольный фильтр", SpecValueType.BOOLEAN),
+    "color": _spec("color", "Цвет", SpecValueType.TEXT),
+    "compressor_brand": _spec(
+        "compressor_brand",
+        "Производитель компрессора",
+        SpecValueType.ENUM,
+        enum_values=("GMCC", "Toshiba", "Highly", "Panasonic", "Gree", "Mitsubishi"),
+    ),
+    "cop": _spec("cop", "COP", SpecValueType.QUANTITY),
+    "country": _spec("country", "Страна производства", SpecValueType.TEXT),
+    "current_cooling_nominal_a": _spec(
+        "current_cooling_nominal_a",
+        "Номинальный рабочий ток при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.CURRENT,
+        canonical_unit="A",
+    ),
+    "current_heating_max_a": _spec(
+        "current_heating_max_a",
+        "Максимальный рабочий ток при обогреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.CURRENT,
+        canonical_unit="A",
+    ),
+    "current_heating_nominal_a": _spec(
+        "current_heating_nominal_a",
+        "Номинальный рабочий ток при обогреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.CURRENT,
+        canonical_unit="A",
+    ),
+    "dehumidification": _spec("dehumidification", "Режим осушения", SpecValueType.BOOLEAN),
+    "depth_indoor": _spec(
+        "depth_indoor",
+        "Глубина внутреннего блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "depth_outdoor": _spec(
+        "depth_outdoor",
+        "Глубина наружного блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "dimensions_indoor_package_mm": _spec(
+        "dimensions_indoor_package_mm",
+        "Габариты внутреннего блока в упаковке",
+        SpecValueType.TEXT,
+        canonical_unit="mm",
+    ),
+    "dimensions_outdoor_package_mm": _spec(
+        "dimensions_outdoor_package_mm",
+        "Габариты наружного блока в упаковке",
+        SpecValueType.TEXT,
+        canonical_unit="mm",
+    ),
+    "drain_pipe_diameter": _spec(
+        "drain_pipe_diameter",
+        "Диаметр дренажной трубы",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "electrostatic_filter": _spec("electrostatic_filter", "Электростатический фильтр", SpecValueType.BOOLEAN),
+    "energy_class_cooling": _spec(
+        "energy_class_cooling",
+        "Класс энергоэффективности при охлаждении",
+        SpecValueType.ENUM,
+        enum_values=("A+++", "A++", "A+", "A", "B", "C", "D", "E"),
+    ),
+    "energy_class_heating": _spec(
+        "energy_class_heating",
+        "Класс энергоэффективности при обогреве",
+        SpecValueType.ENUM,
+        enum_values=("A+++", "A++", "A+", "A", "B", "C", "D", "E"),
+    ),
+    "fan_speed": _spec("fan_speed", "Регулировка скорости вентилятора", SpecValueType.BOOLEAN),
+    "freon_type": _spec(
+        "freon_type",
+        "Хладагент",
+        SpecValueType.ENUM,
+        enum_values=("R32", "R410A", "R290", "R407C", "R134A"),
+    ),
+    "fresh_air": _spec("fresh_air", "Приток свежего воздуха", SpecValueType.BOOLEAN),
+    "height_indoor": _spec(
+        "height_indoor",
+        "Высота внутреннего блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "height_outdoor": _spec(
+        "height_outdoor",
+        "Высота наружного блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "installation_orientation": _spec(
+        "installation_orientation",
+        "Ориентация установки",
+        SpecValueType.ENUM,
+        enum_values=("wall", "floor", "ceiling", "floor_ceiling", "cassette", "duct"),
+    ),
+    "inverter_type": _spec(
+        "inverter_type",
+        "Тип управления компрессором",
+        SpecValueType.ENUM,
+        enum_values=("inverter", "on_off", "full_dc"),
+    ),
+    "ionizer": _spec("ionizer", "Ионизатор", SpecValueType.BOOLEAN),
+    "modes": _spec("modes", "Режимы работы", SpecValueType.TEXT),
+    "multi_max_total_pipe_length": _spec(
+        "multi_max_total_pipe_length",
+        "Максимальная суммарная длина магистрали",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="m",
+    ),
+    "photocatalytic_filter": _spec("photocatalytic_filter", "Фотокаталитический фильтр", SpecValueType.BOOLEAN),
+    "pipe_gas": _spec(
+        "pipe_gas",
+        "Диаметр газовой трубы",
+        SpecValueType.ENUM,
+        enum_values=('1/4"', '3/8"', '1/2"', '5/8"', '3/4"'),
+    ),
+    "pipe_liquid": _spec(
+        "pipe_liquid",
+        "Диаметр жидкостной трубы",
+        SpecValueType.ENUM,
+        enum_values=('1/4"', '3/8"', '1/2"', '5/8"', '3/4"'),
+    ),
+    "pipe_max_length": _spec(
+        "pipe_max_length",
+        "Максимальная длина магистрали",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="m",
+    ),
+    "plasma_filter": _spec("plasma_filter", "Плазменный фильтр", SpecValueType.BOOLEAN),
+    "power_cons_cooling_max_kw": _spec(
+        "power_cons_cooling_max_kw",
+        "Максимальная потребляемая мощность при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+    ),
+    "power_cons_cooling_min_kw": _spec(
+        "power_cons_cooling_min_kw",
+        "Минимальная потребляемая мощность при охлаждении",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+    ),
+    "power_cons_heating_max_kw": _spec(
+        "power_cons_heating_max_kw",
+        "Максимальная потребляемая мощность при обогреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+    ),
+    "power_cons_heating_min_kw": _spec(
+        "power_cons_heating_min_kw",
+        "Минимальная потребляемая мощность при обогреве",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.POWER,
+        canonical_unit="kW",
+    ),
+    "power_supply": _spec("power_supply", "Электропитание", SpecValueType.TEXT),
+    "power_supply_location": _spec(
+        "power_supply_location",
+        "Подключение питания",
+        SpecValueType.ENUM,
+        enum_values=("indoor", "outdoor", "left", "right", "any"),
+    ),
+    "refrigerant_additional_g_m": _spec(
+        "refrigerant_additional_g_m",
+        "Дополнительная заправка хладагента",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.REFRIGERANT_MASS,
+        canonical_unit="g/m",
+    ),
+    "remote_control": _spec("remote_control", "Пульт ДУ", SpecValueType.BOOLEAN),
+    "seer": _spec("seer", "SEER", SpecValueType.QUANTITY),
+    "self_cleaning": _spec("self_cleaning", "Самоочистка", SpecValueType.BOOLEAN),
+    "sku_list": _spec("sku_list", "Артикулы товара", SpecValueType.TEXT),
+    "sleep_mode": _spec("sleep_mode", "Ночной режим", SpecValueType.BOOLEAN),
+    "smart_home_integration": _spec("smart_home_integration", "Интеграция в умный дом", SpecValueType.BOOLEAN),
+    "timer": _spec("timer", "Таймер", SpecValueType.BOOLEAN),
+    "turbo_mode": _spec("turbo_mode", "Турбо-режим", SpecValueType.BOOLEAN),
+    "uv_sterilization": _spec("uv_sterilization", "Ультрафиолетовое обеззараживание", SpecValueType.BOOLEAN),
+    "voice_control": _spec("voice_control", "Голосовое управление", SpecValueType.BOOLEAN),
+    "warranty_months": _spec(
+        "warranty_months",
+        "Гарантия",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.COUNT,
+        canonical_unit="month",
+    ),
+    "weight_indoor": _spec(
+        "weight_indoor",
+        "Вес внутреннего блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.WEIGHT,
+        canonical_unit="kg",
+    ),
+    "weight_indoor_package": _spec(
+        "weight_indoor_package",
+        "Вес внутреннего блока в упаковке",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.WEIGHT,
+        canonical_unit="kg",
+    ),
+    "weight_outdoor": _spec(
+        "weight_outdoor",
+        "Вес наружного блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.WEIGHT,
+        canonical_unit="kg",
+    ),
+    "weight_outdoor_package": _spec(
+        "weight_outdoor_package",
+        "Вес наружного блока в упаковке",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.WEIGHT,
+        canonical_unit="kg",
+    ),
+    "width_indoor": _spec(
+        "width_indoor",
+        "Ширина внутреннего блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "width_outdoor": _spec(
+        "width_outdoor",
+        "Ширина наружного блока",
+        SpecValueType.QUANTITY,
+        quantity_kind=QuantityKind.LENGTH,
+        canonical_unit="mm",
+    ),
+    "winter_kit": _spec("winter_kit", "Зимний комплект", SpecValueType.TEXT),
+}
+
+
+REGISTRY_HELP_TEXTS: Mapping[str, tuple[str | None, str | None]] = {
+    "type": ("Общий тип системы: бытовая сплит-система, мульти-сплит или отдельный блок.", None),
+    "indoor_type": (
+        "Форм-фактор внутреннего блока. Используется для фильтров полупромышленных и мульти-сплит систем.",
+        None,
+    ),
+    "inverter": (
+        "Инверторный компрессор плавно меняет производительность и обычно точнее держит температуру.",
+        "Не путать с маркетинговыми режимами энергосбережения: здесь фиксируется именно тип управления компрессором.",
+    ),
+    "wifi_ready": (
+        "Совместимое поле Wi-Fi: встроенный модуль, подготовка под модуль или отсутствие поддержки.",
+        "Для новой логики предпочтительнее смотреть wifi_state и wifi_builtin.",
+    ),
+    "capacity_cooling_kw": (
+        "Номинальная холодопроизводительность. У инверторных моделей фактическая мощность может плавать в диапазоне min/max.",
+        None,
+    ),
+    "capacity_heating_kw": (
+        "Номинальная теплопроизводительность. При низкой наружной температуре реальная мощность может снижаться.",
+        None,
+    ),
+    "capacity_cooling_min_kw": ("Минимальная холодопроизводительность инвертора в устойчивом режиме.", None),
+    "capacity_cooling_max_kw": ("Максимальная холодопроизводительность, которую модель может кратковременно или штатно выдать.", None),
+    "capacity_heating_min_kw": ("Минимальная теплопроизводительность инвертора в устойчивом режиме.", None),
+    "capacity_heating_max_kw": ("Максимальная теплопроизводительность, обычно важна при подборе на холодный период.", None),
+    "power_cons_cooling_kw": (
+        "Номинальная электрическая мощность потребления в режиме охлаждения, не путать с холодопроизводительностью.",
+        None,
+    ),
+    "power_cons_heating_kw": (
+        "Номинальная электрическая мощность потребления в режиме обогрева, не равна теплопроизводительности.",
+        None,
+    ),
+    "area_m2": (
+        "Рекомендованная площадь помещения. Это ориентир для подбора, а не замена теплотехнического расчета.",
+        None,
+    ),
+    "temp_range_cool": ("Допустимый диапазон наружной температуры для работы в режиме охлаждения.", None),
+    "temp_range_heat": ("Допустимый диапазон наружной температуры для работы в режиме обогрева.", None),
+    "airflow_max": (
+        "Расход воздуха внутреннего блока. Может быть одним числом или списком по скоростям вентилятора.",
+        None,
+    ),
+    "noise_indoor": (
+        "Уровень шума внутреннего блока. Часто поставщики дают список значений по скоростям вентилятора.",
+        None,
+    ),
+    "noise_outdoor": ("Уровень шума наружного блока, обычно важен для плотной городской застройки.", None),
+    "energy_class": ("Класс энергоэффективности, если источник не разделяет охлаждение и обогрев.", None),
+    "energy_class_cooling": ("Класс энергоэффективности в режиме охлаждения.", None),
+    "energy_class_heating": ("Класс энергоэффективности в режиме обогрева.", None),
+    "eer": (
+        "Коэффициент эффективности охлаждения: отношение холодопроизводительности к потребляемой мощности.",
+        None,
+    ),
+    "cop": (
+        "Коэффициент эффективности обогрева: отношение теплопроизводительности к потребляемой мощности.",
+        None,
+    ),
+    "seer": ("Сезонный коэффициент эффективности охлаждения по методике производителя/стандарта.", None),
+    "scop": ("Сезонный коэффициент эффективности обогрева по методике производителя/стандарта.", None),
+    "pipe_max_length": ("Максимально допустимая длина трассы между блоками.", None),
+    "pipe_max_height": ("Максимально допустимый перепад высот между внутренним и наружным блоком.", None),
+    "multi_max_total_pipe_length": ("Максимальная суммарная длина трасс для мульти-сплит системы.", None),
+    "pipe_liquid": ("Диаметр жидкостной фреоновой трубы, обычно указывается в дюймах.", None),
+    "pipe_gas": ("Диаметр газовой фреоновой трубы, обычно указывается в дюймах.", None),
+    "freon_type": ("Тип хладагента: например R32, R410A или другой.", None),
+    "refrigerant_charge_g": (
+        "Заводская заправка хладагента. Используется для оценки монтажа и дозаправки трассы.",
+        None,
+    ),
+    "refrigerant_additional_g_m": (
+        "Норма дополнительной заправки хладагента на каждый метр сверх базовой длины трассы.",
+        None,
+    ),
+    "dehumidification_l_h": ("Производительность осушения воздуха в литрах в час.", None),
+    "width_indoor": ("Ширина внутреннего блока без упаковки.", None),
+    "height_indoor": ("Высота внутреннего блока без упаковки.", None),
+    "depth_indoor": ("Глубина внутреннего блока без упаковки.", None),
+    "width_outdoor": ("Ширина наружного блока без упаковки.", None),
+    "height_outdoor": ("Высота наружного блока без упаковки.", None),
+    "depth_outdoor": ("Глубина наружного блока без упаковки.", None),
+    "weight_indoor": ("Вес внутреннего блока без упаковки.", None),
+    "weight_outdoor": ("Вес наружного блока без упаковки.", None),
+    "current_cooling_max_a": ("Максимальный рабочий ток в режиме охлаждения.", None),
+    "current_heating_max_a": ("Максимальный рабочий ток в режиме обогрева.", None),
+    "power_supply": ("Общее описание электропитания: фаза, напряжение и частота.", None),
+    "power_supply_location": ("Где подключается питание: к внутреннему или наружному блоку, либо сторона подключения.", None),
+    "warranty_months": ("Гарантийный срок в месяцах.", None),
+    "airflow_direction": ("Наличие регулировки направления воздушного потока.", None),
+    "airflow_outdoor": ("Расход воздуха наружного блока, если поставщик указывает его отдельно.", None),
+    "annual_energy_cooling_kwh": ("Расчетное годовое потребление электроэнергии в режиме охлаждения.", None),
+    "annual_energy_heating_kwh": ("Расчетное годовое потребление электроэнергии в режиме обогрева.", None),
+    "autorestart": ("Автоматический перезапуск после пропадания и восстановления питания.", None),
+    "availability": ("Текстовый статус наличия из источника или менеджера.", None),
+    "bio_filter": ("Наличие биофильтра или аналогичного фильтрующего элемента.", None),
+    "brand": ("Производитель или бренд товара.", None),
+    "cable_interconnect": ("Рекомендуемый или требуемый межблочный кабель.", None),
+    "cable_power": ("Рекомендуемый или требуемый кабель питания.", None),
+    "carbon_filter": ("Наличие угольного фильтра.", None),
+    "color": ("Основной цвет корпуса или блока.", None),
+    "compressor_brand": ("Производитель компрессора, если источник указывает его отдельно.", None),
+    "compressor_type": ("Тип компрессора или схема управления компрессором.", None),
+    "country": ("Страна производства или сборки по данным источника.", None),
+    "current_cooling_nominal_a": ("Номинальный рабочий ток в режиме охлаждения.", None),
+    "current_heating_nominal_a": ("Номинальный рабочий ток в режиме обогрева.", None),
+    "dehumidification": ("Наличие режима осушения воздуха.", None),
+    "dimensions_indoor_package_mm": ("Габариты внутреннего блока в упаковке.", None),
+    "dimensions_outdoor_package_mm": ("Габариты наружного блока в упаковке.", None),
+    "drain_pipe_diameter": ("Диаметр дренажной трубы или патрубка.", None),
+    "electrostatic_filter": ("Наличие электростатического фильтра.", None),
+    "fan_speed": ("Наличие регулировки скорости вентилятора.", None),
+    "fresh_air": ("Наличие функции или канала притока свежего воздуха.", None),
+    "humidification": ("Наличие функции увлажнения воздуха.", None),
+    "includes_indoor_unit": ("Признак, что внутренний блок входит в комплект поставки.", None),
+    "includes_outdoor_unit": ("Признак, что наружный блок входит в комплект поставки.", None),
+    "indoor_units_count": ("Количество внутренних блоков в комплекте или системе.", None),
+    "installation_orientation": ("Допустимая ориентация установки блока.", None),
+    "inverter_type": ("Уточнение типа инверторного или неинверторного управления компрессором.", None),
+    "ionizer": ("Наличие ионизатора воздуха.", None),
+    "model": ("Модель товара в каталоге или источнике.", None),
+    "model_indoor": ("Модель внутреннего блока.", None),
+    "model_outdoor": ("Модель наружного блока.", None),
+    "modes": ("Перечень режимов работы: охлаждение, обогрев, осушение, вентиляция и другие.", None),
+    "multi_compat_mode": ("Режим или правило совместимости для мульти-сплит системы.", None),
+    "multi_max_indoor_units": ("Максимальное количество внутренних блоков, подключаемых к наружному блоку.", None),
+    "photocatalytic_filter": ("Наличие фотокаталитического фильтра.", None),
+    "plasma_filter": ("Наличие плазменного фильтра или плазменной очистки.", None),
+    "power_cons_cooling_max_kw": ("Максимальная электрическая мощность потребления при охлаждении.", None),
+    "power_cons_cooling_min_kw": ("Минимальная электрическая мощность потребления при охлаждении.", None),
+    "power_cons_heating_max_kw": ("Максимальная электрическая мощность потребления при обогреве.", None),
+    "power_cons_heating_min_kw": ("Минимальная электрическая мощность потребления при обогреве.", None),
+    "power_supply_indoor": ("Электропитание внутреннего блока, если оно указано отдельно.", None),
+    "power_supply_outdoor": ("Электропитание наружного блока, если оно указано отдельно.", None),
+    "power_supply_voltage": ("Напряжение или параметры питающей сети.", None),
+    "presence_sensor": ("Наличие датчика присутствия или движения.", None),
+    "release_year": ("Дата выхода модели на рынок по данным источника.", None),
+    "remote_control": ("Наличие пульта дистанционного управления в комплекте.", None),
+    "self_cleaning": ("Наличие функции самоочистки внутреннего блока или теплообменника.", None),
+    "self_diagnosis": ("Наличие функции самодиагностики ошибок.", None),
+    "series": ("Серия или линейка модели.", None),
+    "sku": ("Артикул товара.", None),
+    "sku_list": ("Список артикулов, если комплект или источник содержит несколько позиций.", None),
+    "sleep_mode": ("Наличие ночного режима или режима сна.", None),
+    "smart_home_integration": ("Наличие интеграции с умным домом или внешними системами управления.", None),
+    "timer": ("Наличие таймера включения или выключения.", None),
+    "turbo_mode": ("Наличие турбо-режима для быстрого охлаждения или обогрева.", None),
+    "uv_sterilization": ("Наличие ультрафиолетового обеззараживания.", None),
+    "voice_control": ("Наличие голосового управления.", None),
+    "weight_indoor_package": ("Вес внутреннего блока в упаковке.", None),
+    "weight_outdoor_package": ("Вес наружного блока в упаковке.", None),
+    "wifi_builtin": ("Признак встроенного Wi-Fi модуля.", None),
+    "winter_kit": ("Сведения о зимнем комплекте или низкотемпературном исполнении.", None),
+}
+
+SPEC_DEFINITIONS = {
+    key: replace(
+        spec,
+        description=REGISTRY_HELP_TEXTS.get(key, (None, None))[0] or spec.description,
+        manager_note=REGISTRY_HELP_TEXTS.get(key, (None, None))[1] or spec.manager_note,
+    )
+    for key, spec in SPEC_DEFINITIONS.items()
+}
+
+
+REGISTRY_LEGACY_ALIASES_BY_KEY: Mapping[str, tuple[str, ...]] = {
+    'airflow_direction': (
+        'Регулировка направления воздушного потока',
+    ),
+    'airflow_max': (
+        'Максимальный расход воздуха внутреннего блока',
+        'Расход воздуха (высокая скорость), м 3 /ч',
+        'Расход воздуха внутреннего блока',
+        'Внутренний блок: Расход воздуха (высокая скорость), м 3 /ч',
+        'Внутренний блок: Расход воздуха, м 3 /ч',
+        'Расход воздуха, м 3 /ч',
+    ),
+    'airflow_outdoor': (
+        'Расход воздуха наружного блока',
+    ),
+    'annual_energy_cooling_kwh': (
+        'Годовое потребление энергии (охлаждение), кВт/г.',
+    ),
+    'annual_energy_heating_kwh': (
+        'Годовое потребление энергии (нагрев), кВт/г.',
+    ),
+    'area_m2': (
+        'Обслуживаемая площадь',
+        'Обслуживаемая площадь, кв.м',
+        'Площадь охлаждения',
+        'Площадь помещения',
+        'Обслуживаемая площадь до',
+        'Обслуживаемая площадь до, м2',
+        'Рекомендуемая максимальная площадь помещения',
+        'Рекомендованная площадь, м 2',
+    ),
+    'autorestart': (
+        'Авторестарт после пропадания питания',
+        'Авторестарт',
+    ),
+    'availability': (
+        'Наличие',
+    ),
+    'bio_filter': (
+        'Биофильтр',
+    ),
+    'brand': (
+        'Бренд',
+        'Марка',
+        'Производитель',
+    ),
+    'cable_interconnect': (
+        'cable_interconnect',
+    ),
+    'cable_power': (
+        'cable_power',
+    ),
+    'capacity_cooling_kw': (
+        'Мощность охлаждения',
+        'Мощность охлаждения, кВт',
+        'Мощность охлаждения (Мин/Ном/Макс), кВт',
+        'Мощность в режиме охлаждения',
+        'Мощность в режиме охлаждения, кВт',
+        'Холодопроизводительность',
+        'Охлаждение, кВт',
+    ),
+    'capacity_cooling_max_kw': (
+        'Охлаждение максимум, кВт',
+        'Охлаждение максимум, Вт',
+    ),
+    'capacity_cooling_min_kw': (
+        'Охлаждение минимум, кВт',
+        'Охлаждение минимум, Вт',
+    ),
+    'capacity_heating_kw': (
+        'Мощность обогрева',
+        'Мощность обогрева, кВт',
+        'Мощность нагрева (Мин/Ном/Макс), кВт',
+        'Мощность в режиме обогрева',
+        'Мощность в режиме обогрева, кВт',
+        'Теплопроизводительность',
+        'Нагрев, кВт',
+    ),
+    'capacity_heating_max_kw': (
+        'Нагрев максимум, кВт',
+        'Нагрев максимум, Вт',
+    ),
+    'capacity_heating_min_kw': (
+        'Нагрев минимум, кВт',
+        'Нагрев минимум, Вт',
+    ),
+    'carbon_filter': (
+        'Угольный фильтр',
+    ),
+    'color': (
+        'Цвет',
+        'Цвет корпуса',
+    ),
+    'compressor_brand': (
+        'Производитель компрессора',
+        'Компрессор: Производитель компрессора',
+    ),
+    'compressor_type': (
+        'compressor_type',
+    ),
+    'cop': (
+        'Энергоэффективность при обогреве (COP)',
+        'COP',
+        'Энергоэффективность SCOP/COP',
+        'COP (коэффициент / класс)',
+    ),
+    'country': (
+        'Страна производства',
+    ),
+    'current_cooling_max_a': (
+        'Максимальный рабочий ток, охлаждение',
+        'Максимальный уровень рабочего тока (охлаждение), А',
+    ),
+    'current_cooling_nominal_a': (
+        'Номинальный уровень рабочего тока (охлаждение), А',
+    ),
+    'current_heating_max_a': (
+        'Максимальный рабочий ток, обогрев',
+    ),
+    'current_heating_nominal_a': (
+        'Номинальный уровень рабочего тока (нагрев), А',
+    ),
+    'dehumidification': (
+        'Осушение воздуха',
+        'Режим осушения воздуха',
+    ),
+    'dehumidification_l_h': (
+        'Осушение',
+        'Удаление влаги, л/ч',
+    ),
+    'depth_indoor': (
+        'Глубина внутреннего блока',
+    ),
+    'depth_outdoor': (
+        'Глубина наружного блока',
+    ),
+    'dimensions_indoor_package_mm': (
+        'Внутренний блок: Габаритные размеры в упаковке (Ш/Г/В), мм',
+        'Размеры внутреннего блока в упаковке (Ш х В х Г)',
+    ),
+    'dimensions_outdoor_package_mm': (
+        'Наружный блок: Габаритные размеры в упаковке (Ш/Г/В), мм',
+        'Размеры наружного блока в упаковке (Ш х В х Г)',
+        'Габаритные размеры в упаковке (Ш/Г/В), мм',
+    ),
+    'drain_pipe_diameter': (
+        'Диаметр дренажной трубы: мм (дюйм)',
+    ),
+    'eer': (
+        'Энергоэффективность при охлаждении (EER)',
+        'EER',
+        'EER/COP',
+        'Коэффициент энергоэффективности (EER / COP)',
+        'Энергоэффективность SEER/EER',
+        'EER (коэффициент / класс)',
+        'Энергоэффективность EER/COP',
+    ),
+    'electrostatic_filter': (
+        'Электростатический фильтр',
+    ),
+    'energy_class': (
+        'Класс энергоэффективности',
+        'Класс эффективности',
+        'Класс энергоэффективности (Холод / Тепло)',
+        'Класс энергоэффективности (охлаждение/нагрев)',
+    ),
+    'energy_class_cooling': (
+        'Класс энергоэффективности при охлаждении',
+        'Энергоэффективность при охлаждении',
+    ),
+    'energy_class_heating': (
+        'Класс энергоэффективности при обогреве',
+        'Энергоэффективность при обогреве',
+    ),
+    'fan_speed': (
+        'Регулировка скорости вращения вентилятора',
+        'Регулятор скорости вращения вентилятора',
+    ),
+    'freon_type': (
+        'Хладагент (фреон)',
+        'Хладагент',
+        'Тип хладагента',
+        'Марка используемого хладагента',
+    ),
+    'fresh_air': (
+        'Приток свежего воздуха',
+    ),
+    'height_indoor': (
+        'Высота внутреннего блока',
+    ),
+    'height_outdoor': (
+        'Высота наружного блока',
+    ),
+    'humidification': (
+        'Увлажнение воздуха',
+    ),
+    'includes_indoor_unit': (
+        'Внутренний блок',
+    ),
+    'includes_outdoor_unit': (
+        'Наружный блок',
+    ),
+    'indoor_type': (
+        'Тип внутреннего блока',
+    ),
+    'indoor_units_count': (
+        'Количество внутренних блоков',
+    ),
+    'installation_orientation': (
+        'Установка',
+    ),
+    'inverter': (
+        'Тип системы',
+        'Инверторная технология',
+        'Инверторный',
+        'Инверторное управление',
+        'Инверторное управление мощностью',
+        'Инверторный компрессор',
+        'Неинверторный компрессор',
+        'Компрессор: Неинверторный компрессор',
+        'Компрессор: Инверторный компрессор',
+    ),
+    'inverter_type': (
+        'Тип управления компрессором',
+    ),
+    'ionizer': (
+        'Ионизатор',
+        'Ионизация',
+    ),
+    'model': (
+        'Модель',
+    ),
+    'model_indoor': (
+        'Модель внутреннего блока',
+    ),
+    'model_outdoor': (
+        'Модель наружного блока',
+    ),
+    'modes': (
+        'Режим работы',
+        'Режимы работы',
+    ),
+    'multi_compat_mode': (
+        'multi_compat_mode',
+    ),
+    'multi_max_indoor_units': (
+        'Максимальное количество внутренних блоков',
+        'Максимальное количество подключаемых внутренних блоков',
+        'Макс. количество внутренних блоков, шт',
+    ),
+    'multi_max_total_pipe_length': (
+        'Максимальная суммарная длина магистрали',
+    ),
+    'noise_indoor': (
+        'Шум внутреннего блока',
+        'Шум внутреннего блока, дБ',
+        'Уровень шума внутреннего блока',
+        'Уровень шума (макс), дБ',
+        'Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх',
+        'Уровень шума в режиме ОХЛАЖДЕНИЯ (Тих / Низ / Ср /Макс), дБ',
+        'Уровень шума в режиме НАГРЕВА (Низ / Ср / Макс), дБ',
+        'Внутренний блок: Уровень звукового давления [дБ(А)], Выс/Ср/Низ/Сверх',
+        'Уровень звукового давления внутреннего блока',
+    ),
+    'noise_outdoor': (
+        'Шум наружного блока',
+        'Шум наружного блока, дБ',
+        'Шум внешнего блока',
+        'Шум внешнего блока, дБ',
+        'Уровень шума наружного блока',
+        'Уровень шума наружного блока, дБ',
+        'Уровень звукового давления, дБ, А',
+        'Уровень звукового давления (высокая скорость), дБ, А',
+        'Наружный блок: Уровень звукового давления (высокая скорость), дБ, А',
+        'Уровень звукового давления наружного блока',
+        'Наружный блок: Уровень звукового давления, дБ, А',
+    ),
+    'photocatalytic_filter': (
+        'Фотокаталитический фильтр',
+    ),
+    'pipe_gas': (
+        'Диаметр газовой трубы',
+        'Диаметр газовой линии, мм',
+        'Диаметр труб газообразного хладагента, мм',
+    ),
+    'pipe_liquid': (
+        'Диаметр жидкостной трубы',
+        'Диаметр жидкостной линии, мм',
+        'Диаметр труб жидкого хладагента, мм',
+    ),
+    'pipe_max_height': (
+        'Перепад высот',
+        'Перепад высот, м',
+        'Максимальный перепад высот',
+        'multi_max_height_diff',
+    ),
+    'pipe_max_length': (
+        'Максимальная длина магистрали',
+        'Максимальная длина коммуникаций',
+        'Максимальная длина коммуникаций, м',
+        'Максимальная длина фреонопровода',
+        'Макс. длина трассы',
+        'Макс. длина трубопроводов без дополнительной заправки, м',
+        'Максимальная длина/перепад высот, м',
+        'Максимальная длина/перепад высот, при использовании только в режиме охлаждения, м',
+    ),
+    'plasma_filter': (
+        'Плазменный фильтр',
+    ),
+    'power_cons_cooling_kw': (
+        'Потребляемая мощность при охлаждении',
+        'Потребляемая мощность при охлаждении, кВт',
+        'Потребляемая мощность, охлаждение',
+        'Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт',
+        'Номинальная потребляемая мощность (охлаждение), кВт',
+        'Номинальная потребляемая мощность (охлаждение), Вт',
+        'Потребляемая мощность, номинальная (Охлаждение) кВт',
+    ),
+    'power_cons_cooling_max_kw': (
+        'Максимальная потребляемая мощность (охлаждение), кВт',
+    ),
+    'power_cons_cooling_min_kw': (
+        'Минимальная потребляемая мощность (охлаждение), кВт',
+    ),
+    'power_cons_heating_kw': (
+        'Потребляемая мощность при обогреве',
+        'Потребляемая мощность при обогреве, кВт',
+        'Потребляемая мощность, обогрев',
+        'Потребление электроэнергии в режиме нагрева (Мин / Ном / Макс), кВт',
+        'Номинальная потребляемая мощность (нагрев), кВт',
+        'Номинальная потребляемая мощность (нагрев), Вт',
+        'Потребляемая мощность, номинальная (Нагрев) кВт',
+    ),
+    'power_cons_heating_max_kw': (
+        'Максимальная потребляемая мощность (нагрев), кВт',
+    ),
+    'power_cons_heating_min_kw': (
+        'Минимальная потребляемая мощность (нагрев), кВт',
+    ),
+    'power_supply': (
+        'Электропитание',
+        'Электропитание, Ф/В/Гц',
+        'Электропитание (Ø / В / Гц)',
+    ),
+    'power_supply_indoor': (
+        'Внутренний блок: Электропитание, Ф/В/Гц',
+    ),
+    'power_supply_location': (
+        'Подача питания',
+        'Подключение питания',
+        'Сторона подключения',
+    ),
+    'power_supply_outdoor': (
+        'Наружный блок: Электропитание, Ф/В/Гц',
+    ),
+    'power_supply_voltage': (
+        'Параметры питающей сети',
+        'Напряжение, В',
+    ),
+    'presence_sensor': (
+        'Датчик присутствия',
+    ),
+    'refrigerant_additional_g_m': (
+        'Дополнительная заправка (г/м)',
+        'Дополнительная заправка хладагента',
+    ),
+    'refrigerant_charge_g': (
+        'Заводская заправка хладагента',
+        'Вес заправляемого хладагента, г',
+        'Заправка хладагента, кг',
+        'Заводская заправка хладагента, кг',
+        'Заводская заправка хладагента R410a (до 5 м)',
+    ),
+    'release_year': (
+        'Дата выхода на рынок',
+    ),
+    'remote_control': (
+        'Пульт дистанционного управления',
+        'Пульт ДУ',
+        'Пульт',
+        'Пульт управления',
+        'Пульт управления в комплекте',
+        'Внутренний блок: Пульт управления',
+    ),
+    'scop': (
+        'SCOP',
+        'scop',
+    ),
+    'seer': (
+        'SEER (коэффициент/класс)',
+    ),
+    'self_cleaning': (
+        'Самоочистка',
+        'Автоочистка теплообменника',
+    ),
+    'self_diagnosis': (
+        'Самодиагностика',
+    ),
+    'series': (
+        'Серия',
+        'Линейка',
+        'Модельный ряд',
+    ),
+    'sku': (
+        'Артикул',
+        'Артикул товара',
+    ),
+    'sku_list': (
+        'Артикулы товара',
+    ),
+    'sleep_mode': (
+        'Режим «Сон»',
+        'Ночной режим',
+    ),
+    'smart_home_integration': (
+        'Интеграция в "умный дом"',
+    ),
+    'temp_range_cool': (
+        'Рабочая температура при охлаждении',
+        'Рабочий диапазон температур при охлаждении',
+        'Рабочий диапазон температур при охлаждении,°C',
+        'Рабочий диапазон температур при охлаждении, °C',
+        'Гарантированный диапазон рабочих t° наружного воздуха, охлаждение',
+        'Охлаждение, °С',
+        'min_temp_cool',
+        'Гарантированный диапазон рабочих температур (С) Охлаждение',
+        'Температура наружного воздуха при охлаждении',
+    ),
+    'temp_range_heat': (
+        'Рабочая температура при обогреве',
+        'Рабочий диапазон температур при обогреве',
+        'Рабочий диапазон температур при обогреве,°C',
+        'Рабочий диапазон температур при обогреве, °C',
+        'Гарантированный диапазон рабочих t° наружного воздуха, обогрев',
+        'Нагрев, °С',
+        'Минимальная температура наружного воздуха',
+        'Мин. температура (обогрев)',
+        'min_temp_heat',
+        'Температура наружного воздуха при обогреве',
+    ),
+    'timer': (
+        'Таймер включения/выключения',
+        'Таймер',
+    ),
+    'turbo_mode': (
+        'Турбо-режим',
+        'Турбо режим',
+    ),
+    'type': (
+        'Тип',
+        'Тип кондиционера',
+    ),
+    'uv_sterilization': (
+        'Обеззараживание ультрафиолетом',
+    ),
+    'voice_control': (
+        'Голосовое управление',
+    ),
+    'warranty_months': (
+        'Гарантия',
+    ),
+    'weight_indoor': (
+        'Вес внутреннего блока',
+        'Вес внутреннего блока, кг',
+        'Чистый вес / Вес в упаковке, кг',
+        'Внутренний блок: Чистый вес / Вес в упаковке, кг',
+        'Внутренний блок без упаковки, кг',
+        'Вес внутреннего блока без упаковки',
+    ),
+    'weight_indoor_package': (
+        'Вес внутреннего блока в упаковке',
+    ),
+    'weight_outdoor': (
+        'Вес наружного блока',
+        'Вес наружного блока, кг',
+        'Вес внешнего блока',
+        'Вес внешнего блока, кг',
+        'Чистый вес / вес в упаковке, кг',
+        'Наружный блок: Чистый вес / вес в упаковке, кг',
+        'Наружный блок: Чистый вес / Вес в упаковке, кг',
+        'Наружный блок без упаковки, кг',
+        'Вес наружного блока без упаковки',
+    ),
+    'weight_outdoor_package': (
+        'Вес наружного блока в упаковке',
+    ),
+    'width_indoor': (
+        'Ширина внутреннего блока',
+    ),
+    'width_outdoor': (
+        'Ширина наружного блока',
+    ),
+    'wifi_ready': (
+        'Wi-Fi',
+        'Wi-Fi модуль',
+        'Wi-Fi module',
+        'Wi-Fi Ready',
+        'Вайфай',
+        'Wi-Fi управление',
+    ),
+    'winter_kit': (
+        'Зимний комплект',
+    ),
+}
+
+
+def _flatten_aliases(aliases_by_key: Mapping[str, Iterable[str]]) -> dict[str, str]:
+    flattened: dict[str, str] = {}
+    for key, aliases in aliases_by_key.items():
+        if key not in SPEC_DEFINITIONS:
+            raise RuntimeError(f"Spec alias group points to unknown spec key: {key}")
+        for alias in aliases:
+            current = flattened.get(alias)
+            if current is not None and current != key:
+                raise RuntimeError(f"Spec alias conflict for {alias!r}: {current!r} vs {key!r}")
+            flattened[alias] = key
+    return flattened
+
+
+_SPEC_ALIASES_BY_KEY: dict[str, tuple[str, ...]] = {
+    spec.key: spec.aliases for spec in SPEC_DEFINITIONS.values() if spec.aliases
+}
+
+REGISTRY_KEY_MAP: dict[str, str] = _flatten_aliases({
+    **REGISTRY_LEGACY_ALIASES_BY_KEY,
+    **{
+        key: tuple(dict.fromkeys((*REGISTRY_LEGACY_ALIASES_BY_KEY.get(key, ()), *aliases)))
+        for key, aliases in _SPEC_ALIASES_BY_KEY.items()
+    },
+})
+
+
+def _aliases_for_key(key: str) -> list[str]:
+    aliases = REGISTRY_LEGACY_ALIASES_BY_KEY.get(key, ())
+    spec_aliases = SPEC_DEFINITIONS[key].aliases if key in SPEC_DEFINITIONS else ()
+    return list(dict.fromkeys((*aliases, *spec_aliases)))
+
+REGISTRY_DIMENSIONS_MAP: dict[str, tuple[str, str, str]] = {
+    "Габариты внутреннего блока (ШхВхГ)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Габариты внутреннего блока (ШхВхГ), мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Габариты наружного блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты наружного блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты внешнего блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_indoor", "depth_indoor", "height_indoor"),
+    "Внутренний блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_indoor", "depth_indoor", "height_indoor"),
+    "Наружный блок: Габаритные размеры без упаковки (Ш/Г/В), мм": ("width_outdoor", "depth_outdoor", "height_outdoor"),
+    "Внутренний блок без упаковки (Ш × В × Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Наружный блок без упаковки (Ш × В × Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Размеры внутреннего блока без упаковки (Ш х В х Г)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Размеры наружного блока без упаковки (Ш х В х Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Размеры внутреннего блока без упаковки (Ш x В x Г)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Размеры наружного блока без упаковки (Ш x В x Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+}
+
+REGISTRY_UNORDERED_DIMENSION_KEYS: frozenset[str] = frozenset(
+    {
+        "Размеры внутреннего блока без упаковки (Ш х В х Г)",
+        "Размеры наружного блока без упаковки (Ш х В х Г)",
+        "Размеры внутреннего блока без упаковки (Ш x В x Г)",
+        "Размеры наружного блока без упаковки (Ш x В x Г)",
+    }
+)
+
+
+_NOMINAL_FROM_TRIPLET_KEYS = {
+    "capacity_cooling_kw",
+    "capacity_heating_kw",
+    "power_cons_cooling_kw",
+    "power_cons_heating_kw",
+}
+
+_TRIPLET_COMPANION_KEYS = {
+    "capacity_cooling_kw": ("capacity_cooling_min_kw", "capacity_cooling_max_kw"),
+    "capacity_heating_kw": ("capacity_heating_min_kw", "capacity_heating_max_kw"),
+    "power_cons_cooling_kw": ("power_cons_cooling_min_kw", "power_cons_cooling_max_kw"),
+    "power_cons_heating_kw": ("power_cons_heating_min_kw", "power_cons_heating_max_kw"),
+}
+
+
+def get_spec_definition(key: str) -> SpecDefinition | None:
+    return SPEC_DEFINITIONS.get(key)
+
+
+def get_specs_registry_payload() -> dict[str, Any]:
+    items = []
+    for spec in sorted(SPEC_DEFINITIONS.values(), key=lambda item: item.key):
+        items.append(
+            {
+                "key": spec.key,
+                "label": spec.label,
+                "value_type": spec.value_type.value,
+                "quantity_kind": spec.quantity_kind.value if spec.quantity_kind else None,
+                "canonical_unit": spec.canonical_unit,
+                "aliases": _aliases_for_key(spec.key),
+                "enum_values": list(spec.enum_values),
+                "description": spec.description,
+                "manager_note": spec.manager_note,
+            }
+        )
+    return {"items": items, "total": len(items)}
+
+
+def _normalize_decimal(value: Decimal) -> str:
+    normalized = value.normalize()
+    if normalized == normalized.to_integral():
+        return str(normalized.quantize(Decimal("1")))
+    return format(normalized, "f").rstrip("0").rstrip(".")
+
+
+def _to_json_number(value: Decimal) -> int | float:
+    text = _normalize_decimal(value)
+    if "." not in text:
+        return int(text)
+    return float(text)
+
+
+def _to_decimal(raw: str) -> Decimal | None:
+    try:
+        return Decimal(raw.replace(",", "."))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _extract_numbers(value: Any) -> list[Decimal]:
+    if value is None:
+        return []
+    if isinstance(value, bool):
+        return []
+    if isinstance(value, (int, float, Decimal)):
+        return [Decimal(str(value))]
+
+    text = str(value).replace("−", "-").replace("—", "-").replace("\xa0", " ")
+    numbers: list[Decimal] = []
+    for match in re.findall(r"[-+]?\d+(?:[.,]\d+)?", text):
+        parsed = _to_decimal(match)
+        if parsed is not None:
+            numbers.append(parsed)
+    return numbers
+
+
+def _parse_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    text = str(value).strip().casefold()
+    if text in {"true", "1", "yes", "да", "есть", "поддерживается", "+", "✓", "✔"}:
+        return True
+    if text in {"false", "0", "no", "нет", "отсутствует", "none"}:
+        return False
+    return None
+
+
+def _text_for_unit_detection(value: Any, source_key: str | None = None) -> str:
+    text = f"{source_key or ''} {value or ''}".casefold()
+    return text.replace("\xa0", " ")
+
+
+def _has_kw(text: str) -> bool:
+    return bool(re.search(r"(?:квт|kw|kW)", text, re.IGNORECASE))
+
+
+def _has_watt(text: str) -> bool:
+    if _has_kw(text):
+        return False
+    return bool(re.search(r"(?:\bвт\b|\bw\b|ватт)", text, re.IGNORECASE))
+
+
+def _has_kg(text: str) -> bool:
+    return "кг" in text or re.search(r"\bkg\b", text) is not None
+
+
+def _has_gram(text: str) -> bool:
+    return (
+        re.search(r"(^|[^a-zа-я])г([^a-zа-я]|$)", text) is not None
+        or re.search(r"\bg\b", text) is not None
+        or "грамм" in text
+    )
+
+
+def _has_month(text: str) -> bool:
+    return bool(re.search(r"(?:мес|месяц|месяцев|месяца|month)", text))
+
+
+def _has_year(text: str) -> bool:
+    return bool(re.search(r"(?:год|года|лет|year)", text))
+
+
+def _convert_quantity(
+    number: Decimal,
+    *,
+    spec: SpecDefinition,
+    value: Any,
+    source_key: str | None,
+) -> Decimal:
+    detection_text = _text_for_unit_detection(value, source_key)
+
+    if spec.quantity_kind == QuantityKind.POWER and spec.canonical_unit == "kW":
+        if "btu" in detection_text:
+            return number * Decimal("0.00029307107")
+        if _has_watt(detection_text) and abs(number) >= 100:
+            return number / Decimal("1000")
+        return number
+
+    if spec.quantity_kind == QuantityKind.REFRIGERANT_MASS and spec.canonical_unit == "g":
+        has_kg = _has_kg(detection_text)
+        has_g = _has_gram(detection_text)
+        if has_kg and not has_g:
+            return number * Decimal("1000")
+        return number
+
+    if spec.quantity_kind == QuantityKind.WEIGHT and spec.canonical_unit == "kg":
+        value_text = _text_for_unit_detection(value)
+        source_text = _text_for_unit_detection(None, source_key)
+        value_has_g = _has_gram(value_text)
+        value_has_kg = _has_kg(value_text)
+        source_has_g = _has_gram(source_text)
+        source_has_kg = _has_kg(source_text)
+        if (value_has_g and not value_has_kg) or (source_has_g and not source_has_kg):
+            return number / Decimal("1000")
+        return number
+
+    if spec.quantity_kind == QuantityKind.LENGTH:
+        if spec.canonical_unit == "m":
+            if "мм" in detection_text or re.search(r"\bmm\b", detection_text):
+                return number / Decimal("1000")
+            if "см" in detection_text or re.search(r"\bcm\b", detection_text):
+                return number / Decimal("100")
+        if spec.canonical_unit == "mm":
+            if re.search(r"(?<![а-я])м(?![а-я])", detection_text) or re.search(r"\bm\b", detection_text):
+                return number * Decimal("1000")
+            if "см" in detection_text or re.search(r"\bcm\b", detection_text):
+                return number * Decimal("10")
+
+    if spec.quantity_kind == QuantityKind.COUNT and spec.canonical_unit == "month":
+        if _has_year(detection_text) and not _has_month(detection_text):
+            return number * Decimal("12")
+        return number
+
+    return number
+
+
+def normalize_registered_value(
+    key: str,
+    value: Any,
+    *,
+    source_key: str | None = None,
+) -> Any | None:
+    """Normalize a value according to the typed registry.
+
+    Returns None when the registry has no numeric conversion for the key, so
+    the legacy normalizer can continue with its existing rules.
+    """
+
+    spec = get_spec_definition(key)
+    if spec is None or spec.value_type not in {SpecValueType.QUANTITY, SpecValueType.NUMBER_LIST}:
+        return None
+
+    detection_text = _text_for_unit_detection(value, source_key)
+    has_explicit_conversion_unit = False
+    if spec.quantity_kind == QuantityKind.POWER and spec.canonical_unit == "kW":
+        has_explicit_conversion_unit = _has_watt(detection_text) or "btu" in detection_text
+    elif spec.quantity_kind == QuantityKind.REFRIGERANT_MASS and spec.canonical_unit == "g":
+        has_explicit_conversion_unit = (
+            _has_kg(detection_text)
+            or _has_gram(detection_text)
+        )
+    elif spec.quantity_kind == QuantityKind.WEIGHT and spec.canonical_unit == "kg":
+        has_explicit_conversion_unit = _has_gram(detection_text)
+    elif spec.quantity_kind == QuantityKind.LENGTH:
+        has_explicit_conversion_unit = (
+            "мм" in detection_text
+            or "см" in detection_text
+            or re.search(r"(?<![а-я])м(?![а-я])", detection_text) is not None
+            or re.search(r"\b(?:mm|cm|m)\b", detection_text) is not None
+        )
+    elif spec.quantity_kind == QuantityKind.COUNT and spec.canonical_unit == "month":
+        has_explicit_conversion_unit = _has_month(detection_text) or _has_year(detection_text)
+
+    if not has_explicit_conversion_unit:
+        return None
+
+    numbers = _extract_numbers(value)
+    if not numbers:
+        return None
+
+    if spec.value_type == SpecValueType.NUMBER_LIST and len(numbers) > 1:
+        converted = [
+            _normalize_decimal(_convert_quantity(number, spec=spec, value=value, source_key=source_key))
+            for number in numbers
+        ]
+        return " / ".join(converted)
+
+    selected = numbers[0]
+    if key in _NOMINAL_FROM_TRIPLET_KEYS and len(numbers) >= 3 and "/" in str(value):
+        selected = numbers[1]
+    if key == "area_m2" and len(numbers) > 1 and any(token in str(value).casefold() for token in ("-", "до", "~")):
+        selected = max(numbers)
+
+    converted = _convert_quantity(selected, spec=spec, value=value, source_key=source_key)
+    return _normalize_decimal(converted)
+
+
+def _base_typed_payload(spec: SpecDefinition, raw_value: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": spec.value_type.value}
+    if spec.quantity_kind:
+        payload["kind"] = spec.quantity_kind.value
+    if spec.canonical_unit:
+        payload["unit"] = spec.canonical_unit
+    if raw_value is not None:
+        payload["raw"] = raw_value
+    return payload
+
+
+def _build_quantity_payload(
+    spec: SpecDefinition,
+    value: Any,
+    *,
+    source_key: str | None = None,
+) -> dict[str, Any] | None:
+    numbers = _extract_numbers(value)
+    if not numbers:
+        return None
+
+    selected = numbers[0]
+    if spec.key in _NOMINAL_FROM_TRIPLET_KEYS and len(numbers) >= 3 and "/" in str(value):
+        selected = numbers[1]
+
+    converted = _convert_quantity(selected, spec=spec, value=value, source_key=source_key)
+    payload = _base_typed_payload(spec, value)
+    payload["value"] = _to_json_number(converted)
+    return payload
+
+
+def _build_number_list_payload(spec: SpecDefinition, value: Any) -> dict[str, Any] | None:
+    numbers = _extract_numbers(value)
+    if not numbers:
+        return None
+    values = [
+        _to_json_number(_convert_quantity(number, spec=spec, value=value, source_key=spec.key))
+        for number in numbers
+    ]
+    payload = _base_typed_payload(spec, value)
+    payload["values"] = values
+    payload["min"] = min(values)
+    payload["max"] = max(values)
+    return payload
+
+
+def _build_range_payload(spec: SpecDefinition, value: Any) -> dict[str, Any] | None:
+    numbers = _extract_numbers(value)
+    if not numbers:
+        return None
+    values = [
+        _to_json_number(_convert_quantity(number, spec=spec, value=value, source_key=spec.key))
+        for number in numbers
+    ]
+    payload = _base_typed_payload(spec, value)
+    payload["values"] = values
+    if len(values) == 1:
+        text = str(value).casefold()
+        if "до" in text:
+            payload["max"] = values[0]
+        else:
+            payload["min"] = values[0]
+    else:
+        payload["min"] = min(values)
+        payload["max"] = max(values)
+    return payload
+
+
+def _build_scalar_payload(spec: SpecDefinition, value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    payload = _base_typed_payload(spec, value)
+    if spec.value_type == SpecValueType.BOOLEAN:
+        parsed = _parse_bool(value)
+        if parsed is None:
+            return None
+        payload["value"] = parsed
+        return payload
+    if spec.value_type in {SpecValueType.ENUM, SpecValueType.STATE, SpecValueType.TEXT}:
+        text = str(value).strip()
+        if not text:
+            return None
+        if spec.key == "indoor_type":
+            normalized = text.casefold().replace("ё", "е")
+            if "каналь" in normalized or "duct" in normalized:
+                text = "duct"
+            elif "кассет" in normalized or "cassette" in normalized:
+                text = "cassette"
+            elif (
+                "напольно" in normalized
+                or "подпотолоч" in normalized
+                or "потолоч" in normalized
+                or "универсальн" in normalized
+                or "floor-ceiling" in normalized
+                or "floor ceiling" in normalized
+            ):
+                text = "floor_ceiling"
+            elif "колон" in normalized or "column" in normalized or "console" in normalized:
+                text = "column"
+        payload["value"] = text
+        return payload
+    return None
+
+
+def build_typed_specs(specs: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Build a machine-readable typed layer from normalized flat specs.
+
+    The returned structure is designed to live under ``__typed_specs`` while
+    legacy flat keys remain the public compatibility layer.
+    """
+
+    typed: dict[str, dict[str, Any]] = {}
+    for key, raw_value in specs.items():
+        if str(key).startswith("__"):
+            continue
+        spec = get_spec_definition(str(key))
+        if not spec:
+            continue
+
+        payload: dict[str, Any] | None
+        if spec.value_type == SpecValueType.QUANTITY:
+            payload = _build_quantity_payload(spec, raw_value)
+        elif spec.value_type == SpecValueType.NUMBER_LIST:
+            payload = _build_number_list_payload(spec, raw_value)
+        elif spec.value_type == SpecValueType.RANGE:
+            payload = _build_range_payload(spec, raw_value)
+        else:
+            payload = _build_scalar_payload(spec, raw_value)
+
+        if payload:
+            typed[spec.key] = payload
+
+    for nominal_key, (min_key, max_key) in _TRIPLET_COMPANION_KEYS.items():
+        nominal_payload = typed.get(nominal_key)
+        if not nominal_payload:
+            continue
+        for source_key, target_key in ((min_key, "min"), (max_key, "max")):
+            source_payload = typed.get(source_key)
+            if source_payload and "value" in source_payload:
+                nominal_payload[target_key] = source_payload["value"]
+        if "value" in nominal_payload:
+            nominal_payload["nominal"] = nominal_payload["value"]
+
+    return typed

--- a/services/spec_typed_backfill_service.py
+++ b/services/spec_typed_backfill_service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from services.spec_normalizer import normalize_specs
+
+
+INTERNAL_SPEC_KEYS = (
+    "__typed_specs",
+    "__filter_min_heat",
+    "__filter_wifi",
+    "__filter_wifi_builtin",
+    "__filter_noise_min",
+    "__filter_indoor_type",
+    "compressor_type_norm",
+)
+
+
+def build_specs_with_typed_internal_layer(
+    specs: Mapping[str, Any] | None,
+    *,
+    wifi_tag_slugs: Sequence[str] | None = None,
+    strict_wifi_from_tags: bool = False,
+    title: str = "",
+) -> dict[str, Any]:
+    """Return specs with refreshed internal typed/filter keys only.
+
+    The regular normalizer may also rename public flat keys. For a safe legacy
+    backfill we want only the machine-readable internal layer so existing
+    storefront/admin displays keep their current flat values.
+    """
+
+    original = dict(specs or {})
+    normalized = normalize_specs(
+        original,
+        keep_units=True,
+        wifi_tag_slugs=wifi_tag_slugs,
+        strict_wifi_from_tags=strict_wifi_from_tags,
+        title=title,
+    )
+    updated = dict(original)
+    for key in INTERNAL_SPEC_KEYS:
+        if key in normalized:
+            updated[key] = normalized[key]
+        else:
+            updated.pop(key, None)
+    return updated
+

--- a/tests/unit/test_product_dao_typed_filters.py
+++ b/tests/unit/test_product_dao_typed_filters.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from sqlmodel import select
+
+from crud.product import ProductDAO
+from models import Product
+
+
+def _session(dialect_name: str):
+    return SimpleNamespace(bind=SimpleNamespace(dialect=SimpleNamespace(name=dialect_name)))
+
+
+def _compiled_sql(stmt, dialect_name: str = "postgresql") -> str:
+    if dialect_name == "sqlite":
+        from sqlalchemy.dialects import sqlite
+
+        dialect = sqlite.dialect()
+    else:
+        from sqlalchemy.dialects import postgresql
+
+        dialect = postgresql.dialect()
+    return str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+
+def test_common_filters_prefer_typed_heat_with_legacy_fallback_postgres():
+    stmt = ProductDAO._apply_common_filters(
+        _session("postgresql"),
+        select(Product),
+        heating_min=-20,
+    )
+
+    sql = _compiled_sql(stmt)
+
+    assert "jsonb_extract_path_text" in sql
+    assert "'__typed_specs', 'temp_range_heat', 'min'" in sql
+    assert "'__filter_min_heat'" in sql
+    assert "coalesce" in sql.lower()
+
+
+def test_common_filters_prefer_typed_wifi_state_with_legacy_fallback_postgres():
+    stmt = ProductDAO._apply_common_filters(
+        _session("postgresql"),
+        select(Product),
+        has_wifi=True,
+    )
+
+    sql = _compiled_sql(stmt)
+
+    assert "'__typed_specs', 'wifi_state', 'value'" in sql
+    assert "'__filter_wifi'" in sql
+    assert "IN ('builtin', 'ready')" in sql
+
+
+def test_common_filters_prefer_typed_indoor_type_with_legacy_fallback_sqlite():
+    stmt = ProductDAO._apply_common_filters(
+        _session("sqlite"),
+        select(Product),
+        indoor_types=["duct"],
+    )
+
+    sql = _compiled_sql(stmt, "sqlite")
+
+    assert "json_extract(product.specs, '$.__typed_specs.indoor_type.value')" in sql
+    assert "json_extract(product.specs, '$.__filter_indoor_type')" in sql
+    assert "coalesce" in sql.lower()

--- a/tests/unit/test_spec_normalizer_filters.py
+++ b/tests/unit/test_spec_normalizer_filters.py
@@ -45,6 +45,8 @@ def test_wifi_module_alias_sets_wifi_filter_flags():
     specs = normalize_specs({"wifi_module": "true"})
 
     assert specs["wifi_ready"] is True
+    assert specs["wifi_builtin"] is True
+    assert specs["wifi_state"] == "builtin"
     assert specs["__filter_wifi"] is True
     assert specs["__filter_wifi_builtin"] is True
 
@@ -60,6 +62,8 @@ def test_dynamic_wifi_key_mapping_from_onliner_specs():
     specs = normalize_specs({"Wi-Fi модуль (опция)": "приобретается отдельно"})
 
     assert specs["wifi_ready"] == "ready"
+    assert specs["wifi_builtin"] is False
+    assert specs["wifi_state"] == "ready"
     assert specs["__filter_wifi"] is True
     assert specs["__filter_wifi_builtin"] is False
 
@@ -68,8 +72,33 @@ def test_wifi_option_value_maps_to_ready():
     specs = normalize_specs({"Wi-Fi": "Опция"})
 
     assert specs["wifi_ready"] == "ready"
+    assert specs["wifi_builtin"] is False
+    assert specs["wifi_state"] == "ready"
     assert specs["__filter_wifi"] is True
     assert specs["__filter_wifi_builtin"] is False
+
+
+def test_explicit_wifi_ready_and_builtin_fields_can_represent_optional_module():
+    specs = normalize_specs({"wifi_ready": True, "wifi_builtin": False})
+
+    assert specs["wifi_ready"] == "ready"
+    assert specs["wifi_builtin"] is False
+    assert specs["wifi_state"] == "ready"
+    assert specs["__filter_wifi"] is True
+    assert specs["__filter_wifi_builtin"] is False
+
+
+def test_wifi_state_can_drive_normalized_wifi_fields():
+    builtin = normalize_specs({"wifi_state": "builtin"})
+    assert builtin["wifi_ready"] is True
+    assert builtin["wifi_builtin"] is True
+    assert builtin["wifi_state"] == "builtin"
+
+    ready = normalize_specs({"wifi_state": "ready"})
+    assert ready["wifi_ready"] == "ready"
+    assert ready["wifi_builtin"] is False
+    assert ready["__filter_wifi"] is True
+    assert ready["__filter_wifi_builtin"] is False
 
 
 def test_severcon_keys_are_normalized_for_catalog_filters():
@@ -213,6 +242,71 @@ def test_severcon_semi_industrial_extra_keys_are_normalized():
     assert specs["installation_orientation"] == "Горизонтальная"
 
 
+def test_registry_aliases_convert_watts_and_refrigerant_units():
+    specs = normalize_specs(
+        {
+            "Охлаждение максимум, Вт": "3400",
+            "Номинальная потребляемая мощность (охлаждение), Вт": "2030",
+            "Заправка хладагента, кг": "0,51",
+            "Заводская заправка хладагента R410a (до 5 м)": "1300 г",
+        }
+    )
+
+    assert specs["capacity_cooling_max_kw"] == "3.4"
+    assert specs["power_cons_cooling_kw"] == "2.03"
+    assert specs["refrigerant_charge_g"] == "1300"
+
+
+def test_registry_keeps_small_mislabeled_watt_values_as_kw():
+    specs = normalize_specs({"Охлаждение максимум, Вт": "3,4"})
+
+    assert specs["capacity_cooling_max_kw"] == "3.4"
+
+
+def test_registry_maps_real_unmapped_catalog_keys():
+    specs = normalize_specs(
+        {
+            "Габаритные размеры без упаковки (Ш/Г/В), мм": "975 × 220 × 320",
+            "Внутренний блок: Расход воздуха (высокая скорость), м 3 /ч": "1000",
+            "Наружный блок: Уровень звукового давления, дБ, А": "50",
+            "Увлажнение воздуха": "нет",
+            "Датчик присутствия": "да",
+            "Компрессор: Инверторный компрессор": "Да",
+        }
+    )
+
+    assert specs["width_indoor"] == "975"
+    assert specs["depth_indoor"] == "220"
+    assert specs["height_indoor"] == "320"
+    assert specs["airflow_max"] == "1000"
+    assert specs["noise_outdoor"] == "50"
+    assert specs["humidification"] is False
+    assert specs["presence_sensor"] is True
+    assert specs["inverter"] is True
+
+
+def test_registry_maps_temperature_and_energy_class_aliases():
+    specs = normalize_specs(
+        {
+            "min_temp_cool": "-15",
+            "min_temp_heat": "-25",
+            "Класс энергоэффективности (охлаждение/нагрев)": "A++ / A+",
+            "Энергоэффективность EER/COP": "3,21 / 3,61",
+            "Максимальное количество подключаемых внутренних блоков": "4",
+            "multi_max_height_diff": "10 м",
+        }
+    )
+
+    assert specs["temp_range_cool"] == "-15"
+    assert specs["temp_range_heat"] == "-25"
+    assert specs["energy_class_cooling"] == "A++"
+    assert specs["energy_class_heating"] == "A+"
+    assert specs["eer"] == "3.21"
+    assert specs["cop"] == "3.61"
+    assert specs["multi_max_indoor_units"] == "4"
+    assert specs["pipe_max_height"] == "10"
+
+
 def test_brand_normalization_and_auto_tag_slug_output():
     auto_slugs = []
     specs = normalize_specs(
@@ -258,6 +352,7 @@ def test_indoor_type_filter_key_for_semi_industrial():
     cassette = normalize_specs({"Тип внутреннего блока": "кассетный"})
     assert cassette["__filter_indoor_type"] == "cassette"
     assert cassette["indoor_type"] == "кассетный"
+    assert cassette["__typed_specs"]["indoor_type"]["value"] == "cassette"
 
     duct = normalize_specs({"indoor_type": "Канальный"})
     assert duct["__filter_indoor_type"] == "duct"
@@ -331,10 +426,62 @@ def test_min_nom_max_values_use_nominal_component():
     )
 
     assert specs["capacity_cooling_kw"] == "2.5"
+    assert specs["capacity_cooling_min_kw"] == "0.89"
+    assert specs["capacity_cooling_max_kw"] == "3.7"
     assert specs["capacity_heating_kw"] == "3.3"
+    assert specs["capacity_heating_min_kw"] == "0.89"
+    assert specs["capacity_heating_max_kw"] == "4.1"
     assert specs["power_cons_cooling_kw"] == "0.656"
+    assert specs["power_cons_cooling_min_kw"] == "0.20"
+    assert specs["power_cons_cooling_max_kw"] == "1.4"
     assert specs["power_cons_heating_kw"] == "0.800"
+    assert specs["power_cons_heating_min_kw"] == "0.195"
+    assert specs["power_cons_heating_max_kw"] == "1.6"
     assert specs["inverter"] is True
+
+    typed = specs["__typed_specs"]
+    assert typed["capacity_cooling_kw"]["value"] == 2.5
+    assert typed["capacity_cooling_kw"]["nominal"] == 2.5
+    assert typed["capacity_cooling_kw"]["min"] == 0.89
+    assert typed["capacity_cooling_kw"]["max"] == 3.7
+    assert typed["capacity_cooling_kw"]["unit"] == "kW"
+
+
+def test_typed_specs_capture_ranges_lists_quantities_and_wifi_state():
+    specs = normalize_specs(
+        {
+            "Рабочая температура при обогреве": "от -20 до +30 °C",
+            "Уровень звукового давления внутреннего блока": "23/26/31/35",
+            "Расход воздуха внутреннего блока": "400",
+            "Заправка хладагента, кг": "0,51",
+            "Wi-Fi": "Опция",
+        }
+    )
+
+    typed = specs["__typed_specs"]
+
+    assert typed["temp_range_heat"]["type"] == "range"
+    assert typed["temp_range_heat"]["unit"] == "C"
+    assert typed["temp_range_heat"]["min"] == -20
+    assert typed["temp_range_heat"]["max"] == 30
+    assert typed["temp_range_heat"]["values"] == [-20, 30]
+
+    assert typed["noise_indoor"]["type"] == "number_list"
+    assert typed["noise_indoor"]["unit"] == "dB"
+    assert typed["noise_indoor"]["values"] == [23, 26, 31, 35]
+    assert typed["noise_indoor"]["min"] == 23
+    assert typed["noise_indoor"]["max"] == 35
+
+    assert typed["airflow_max"]["type"] == "number_list"
+    assert typed["airflow_max"]["unit"] == "m3/h"
+    assert typed["airflow_max"]["values"] == [400]
+
+    assert typed["refrigerant_charge_g"]["value"] == 510
+    assert typed["refrigerant_charge_g"]["unit"] == "g"
+
+    assert typed["wifi_state"]["type"] == "state"
+    assert typed["wifi_state"]["value"] == "ready"
+    assert typed["wifi_builtin"]["value"] is False
 
 
 def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
@@ -361,6 +508,34 @@ def test_haier_packaging_weight_and_import_rate_keys_are_normalized():
     assert "source_fx_rub_byn" not in specs
     assert "Цена источника" not in specs
     assert "Курс RUB/BYN (импорт)" not in specs
+
+
+def test_registry_unit_conversions_for_weight_and_warranty():
+    specs = normalize_specs(
+        {
+            "Вес внутреннего блока, кг": "6500 г",
+            "Вес наружного блока, кг": "32 кг",
+            "Гарантия": "2 года",
+        }
+    )
+
+    assert specs["weight_indoor"] == "6.5"
+    assert specs["weight_outdoor"] == "32"
+    assert specs["warranty_months"] == "24"
+
+    typed = specs["__typed_specs"]
+    assert typed["weight_indoor"]["value"] == 6.5
+    assert typed["weight_indoor"]["unit"] == "kg"
+    assert typed["weight_outdoor"]["value"] == 32
+    assert typed["warranty_months"]["value"] == 24
+    assert typed["warranty_months"]["unit"] == "month"
+
+
+def test_registry_weight_conversion_does_not_reformat_plain_kg_values():
+    specs = normalize_specs({"Вес наружного блока, кг": "20,0"})
+
+    assert specs["weight_outdoor"] == "20.0"
+    assert specs["__typed_specs"]["weight_outdoor"]["value"] == 20
 
 
 def test_dynamic_temp_and_pipe_aliases_are_normalized():

--- a/tests/unit/test_spec_registry.py
+++ b/tests/unit/test_spec_registry.py
@@ -1,0 +1,110 @@
+from services.spec_normalizer import KEY_MAP, _DIMENSIONS_MAP
+from services.spec_registry import (
+    REGISTRY_DIMENSIONS_MAP,
+    REGISTRY_KEY_MAP,
+    REGISTRY_UNORDERED_DIMENSION_KEYS,
+    SPEC_DEFINITIONS,
+    get_specs_registry_payload,
+)
+from services.product_serialization import sanitize_specs
+
+
+def test_registry_covers_all_normalized_spec_keys():
+    canonical_keys = set(KEY_MAP.values())
+    for dimensions_keys in _DIMENSIONS_MAP.values():
+        canonical_keys.update(dimensions_keys)
+
+    missing = sorted(key for key in canonical_keys if key not in SPEC_DEFINITIONS)
+
+    assert missing == []
+
+
+def test_normalizer_alias_map_is_registry_projection():
+    assert KEY_MAP == REGISTRY_KEY_MAP
+
+
+def test_normalizer_dimension_map_is_registry_projection():
+    from services.spec_normalizer import _UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS
+
+    assert _DIMENSIONS_MAP == REGISTRY_DIMENSIONS_MAP
+    assert _UNORDERED_WIDTH_HEIGHT_DIMENSION_KEYS == set(REGISTRY_UNORDERED_DIMENSION_KEYS)
+
+
+def test_specs_registry_payload_exposes_typed_metadata():
+    payload = get_specs_registry_payload()
+
+    assert payload["total"] == len(payload["items"])
+    by_key = {item["key"]: item for item in payload["items"]}
+
+    cooling = by_key["capacity_cooling_kw"]
+    assert cooling["value_type"] == "quantity"
+    assert cooling["quantity_kind"] == "power"
+    assert cooling["canonical_unit"] == "kW"
+    assert cooling["description"]
+
+    inverter = by_key["inverter"]
+    assert inverter["value_type"] == "boolean"
+
+    weight = by_key["weight_indoor"]
+    assert weight["value_type"] == "quantity"
+    assert weight["quantity_kind"] == "weight"
+    assert weight["canonical_unit"] == "kg"
+
+    pipe = by_key["pipe_gas"]
+    assert pipe["value_type"] == "enum"
+    assert '5/8"' in pipe["enum_values"]
+
+
+def test_specs_registry_payload_includes_legacy_aliases():
+    payload = get_specs_registry_payload()
+    by_key = {item["key"]: item for item in payload["items"]}
+
+    assert "Мощность охлаждения" in by_key["capacity_cooling_kw"]["aliases"]
+    assert "Потребление электроэнергии в режиме охлаждения (Мин / Ном / Макс), кВт" in by_key[
+        "power_cons_cooling_kw"
+    ]["aliases"]
+    assert "Wi-Fi модуль" in by_key["wifi_ready"]["aliases"]
+    assert "Габаритные размеры в упаковке (Ш/Г/В), мм" in by_key["dimensions_outdoor_package_mm"]["aliases"]
+
+
+def test_specs_registry_payload_has_help_for_core_public_specs():
+    payload = get_specs_registry_payload()
+    by_key = {item["key"]: item for item in payload["items"]}
+    core_keys = {
+        "capacity_cooling_kw",
+        "capacity_heating_kw",
+        "power_cons_cooling_kw",
+        "power_cons_heating_kw",
+        "area_m2",
+        "temp_range_heat",
+        "airflow_max",
+        "noise_indoor",
+        "energy_class_cooling",
+        "eer",
+        "cop",
+        "pipe_max_length",
+        "pipe_gas",
+        "freon_type",
+        "refrigerant_charge_g",
+        "width_indoor",
+        "weight_outdoor",
+        "warranty_months",
+    }
+
+    missing = sorted(key for key in core_keys if not by_key[key]["description"])
+
+    assert missing == []
+
+
+def test_specs_registry_payload_has_descriptions_for_all_specs():
+    payload = get_specs_registry_payload()
+
+    missing = sorted(item["key"] for item in payload["items"] if not item["description"])
+
+    assert missing == []
+
+
+def test_typed_specs_are_internal_serialization_details():
+    specs = sanitize_specs({"capacity_cooling_kw": "2.5", "__typed_specs": {"capacity_cooling_kw": {"value": 2.5}}})
+
+    assert specs == {"capacity_cooling_kw": "2.5"}

--- a/tests/unit/test_spec_typed_backfill_service.py
+++ b/tests/unit/test_spec_typed_backfill_service.py
@@ -1,0 +1,39 @@
+from services.spec_typed_backfill_service import build_specs_with_typed_internal_layer
+
+
+def test_typed_backfill_preserves_public_flat_specs():
+    original = {
+        "Мощность охлаждения": "2,5 кВт",
+        "Шум внутреннего блока": "23/26/31/35",
+        "Wi-Fi": "Опция",
+    }
+
+    updated = build_specs_with_typed_internal_layer(original)
+
+    assert updated["Мощность охлаждения"] == "2,5 кВт"
+    assert updated["Шум внутреннего блока"] == "23/26/31/35"
+    assert updated["Wi-Fi"] == "Опция"
+    assert "capacity_cooling_kw" not in updated
+    assert "noise_indoor" not in updated
+    assert updated["__filter_wifi"] is True
+    assert updated["__filter_wifi_builtin"] is False
+    assert updated["__typed_specs"]["capacity_cooling_kw"]["value"] == 2.5
+    assert updated["__typed_specs"]["noise_indoor"]["values"] == [23, 26, 31, 35]
+    assert updated["__typed_specs"]["wifi_state"]["value"] == "ready"
+
+
+def test_typed_backfill_refreshes_stale_internal_specs():
+    original = {
+        "Рабочая температура при обогреве": "от -20 до +30 °C",
+        "__filter_min_heat": -5,
+        "__typed_specs": {"old": {"value": "stale"}},
+    }
+
+    updated = build_specs_with_typed_internal_layer(original)
+
+    assert updated["Рабочая температура при обогреве"] == "от -20 до +30 °C"
+    assert updated["__filter_min_heat"] == -20
+    assert "old" not in updated["__typed_specs"]
+    assert updated["__typed_specs"]["temp_range_heat"]["min"] == -20
+    assert updated["__typed_specs"]["temp_range_heat"]["max"] == 30
+


### PR DESCRIPTION
## Что изменилось

- Добавлен единый typed-реестр характеристик каталога с типами данных, единицами, алиасами и описаниями.
- Нормализатор спецификаций теперь строит внутренний слой `__typed_specs`, сохраняя совместимость со старым flat JSON.
- Добавлен публичный endpoint `/api/v1/specs/registry` и обновлен OpenAPI/manager client.
- Менеджер товаров и bulk-редактор используют metadata реестра для типов полей, единиц, select-значений и подсказок.
- Каталожные фильтры Wi-Fi, температуры и типа внутреннего блока читают typed-слой первыми и fallback-ятся на legacy-поля.
- Добавлен безопасный dry-run backfill `scripts/backfill_typed_specs.py`, который обновляет только внутренние ключи.

## Почему

Нужен фундамент для масштабируемого каталога: разные источники должны приводиться к единой модели свойств, чтобы дальше строить фильтры, сравнения, описания и импорт без ручного хаоса в ключах и единицах.

## Проверки

- `scripts/test_local.sh --host tests/unit -q` -> 593 passed
- `scripts/test_local.sh --host tests/integration/test_specs.py tests/integration/test_catalog_api.py tests/integration/test_filters_config_api.py -q` -> 22 passed
- `python3 scripts/analyze_spec_keys.py` -> все ключи покрыты
- `python3 scripts/backfill_typed_specs.py --limit 10` -> dry-run, меняется только internal typed layer
- `python3 -m compileall services/spec_registry.py services/spec_normalizer.py services/spec_typed_backfill_service.py scripts/backfill_typed_specs.py`
- `git diff --check`
- `cd manager_frontend && npm run build`
