### PR TITLE
[codex] Add typed spec editor controls

### DIFF
--- a/manager_frontend/src/components/BulkSpecsModal.vue
+++ b/manager_frontend/src/components/BulkSpecsModal.vue
@@ -4,6 +4,7 @@ import { api } from '../api';
 import { X, Plus, Trash2, Save, AlertTriangle, CircleHelp } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import SpecKeyCombobox from './SpecKeyCombobox.vue';
+import SpecValueInput from './SpecValueInput.vue';
 import { useSpecRegistry } from '../composables/useSpecRegistry';
 
 const props = defineProps<{
@@ -22,9 +23,6 @@ const loading = ref(false);
 const formMessage = ref('');
 const formServerErrors = ref<Record<string, string>>({});
 const {
-    formatSelectOptionLabel,
-    getSelectOptions,
-    getSpecConfig,
     getSpecHelpText,
     knownSpecKeys,
     loadSpecRegistry,
@@ -180,67 +178,12 @@ const save = async () => {
                         
                         <!-- Value Input (Disabled if deleting keys) -->
                         <div class="flex-1">
-                            <template v-if="getSpecConfig(row.key)?.type === 'boolean'">
-                                <div class="flex items-center h-[38px]">
-                                    <button 
-                                        type="button"
-                                        @click="row.value = (row.value === 'true') ? 'false' : 'true'"
-                                        :disabled="operation === 'delete_keys'"
-                                        class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                                        :class="(row.value === 'true') ? 'bg-teal-600' : 'bg-gray-200 dark:bg-slate-700'"
-                                        role="switch"
-                                        :aria-checked="row.value === 'true'"
-                                    >
-                                        <span class="sr-only">Toggle boolean</span>
-                                        <span 
-                                            aria-hidden="true" 
-                                            class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                                            :class="(row.value === 'true') ? 'translate-x-5' : 'translate-x-0'"
-                                        />
-                                    </button>
-                                    <span class="ml-3 text-sm font-medium text-gray-900 dark:text-slate-200">
-                                        {{ (row.value === 'true') ? 'Да' : 'Нет' }}
-                                    </span>
-                                </div>
-                            </template>
-                            
-                            <template v-else-if="getSpecConfig(row.key)?.type === 'select'">
-                                <select 
-                                    v-model="row.value"
-                                    :disabled="operation === 'delete_keys'"
-                                    class="w-full h-[38px] border dark:border-slate-700 bg-white dark:bg-slate-900 dark:text-slate-200 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500"
-                                >
-                                    <option value="" disabled>{{ operation === 'delete_keys' ? 'Пропускается' : 'Выберите значение' }}</option>
-                                    <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
-                                        {{ formatSelectOptionLabel(row.key, opt) }}
-                                    </option>
-                                </select>
-                            </template>
-                            
-                            <template v-else-if="getSpecConfig(row.key)?.type === 'number'">
-                                <div class="flex h-[38px] rounded shadow-sm">
-                                    <input 
-                                        type="number"
-                                        v-model="row.value" 
-                                        :disabled="operation === 'delete_keys'"
-                                        :placeholder="operation === 'delete_keys' ? 'Пропускается' : 'Значение'" 
-                                        class="flex-1 min-w-0 block w-full border dark:border-slate-700 bg-white dark:bg-slate-900 dark:text-slate-200 rounded-none rounded-l px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500"
-                                    />
-                                    <span v-if="getSpecConfig(row.key)?.unit" class="inline-flex items-center px-3 rounded-r border border-l-0 border-gray-300 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-sm">
-                                        {{ getSpecConfig(row.key)?.unit }}
-                                    </span>
-                                </div>
-                            </template>
-                            
-                            <template v-else>
-                                <input 
-                                    type="text"
-                                    v-model="row.value" 
-                                    :disabled="operation === 'delete_keys'"
-                                    :placeholder="operation === 'delete_keys' ? 'Пропускается' : 'Значение (например: Белый)'" 
-                                    class="w-full h-[38px] border dark:border-slate-700 bg-white dark:bg-slate-900 dark:text-slate-200 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500"
-                                />
-                            </template>
+                            <SpecValueInput
+                                v-model="row.value"
+                                :spec-key="row.key"
+                                :disabled="operation === 'delete_keys'"
+                                :placeholder="operation === 'delete_keys' ? 'Пропускается' : 'Значение'"
+                            />
                         </div>
                         
                         <button @click="removeRow(idx)" class="p-2 text-gray-400 hover:text-red-500 transition-colors">

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -4,6 +4,7 @@ import { api, type Product, type ManagerBrand, type ProductCreate, type ProductD
 import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag, CircleHelp } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import SpecKeyCombobox from './SpecKeyCombobox.vue';
+import SpecValueInput from './SpecValueInput.vue';
 import { useSpecRegistry } from '../composables/useSpecRegistry';
 
 interface TagItem {
@@ -132,19 +133,31 @@ const saveButtonText = computed(() => {
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
 const {
-    formatSelectOptionLabel,
-    getSelectOptions,
     getSpecConfig,
+    getSpecGroup,
+    getSpecGroupLabel,
     getSpecHelpText,
     isHiddenSpecKey,
     knownSpecKeys,
     loadSpecRegistry,
     normalizeValueForEdit,
     serializeSpecValue,
+    specGroupOrder,
 } = useSpecRegistry();
 const showSpecHelp = (key: string) => {
     const text = getSpecHelpText(key);
     if (text) window.alert(text);
+};
+const getSpecLabel = (key: string): string => getSpecConfig(key)?.label || key || 'Новая характеристика';
+const getSpecTypeHint = (key: string): string => {
+    const config = getSpecConfig(key);
+    if (!config) return '';
+    if (config.type === 'range') return 'диапазон';
+    if (config.type === 'number_list') return 'список';
+    if (config.type === 'number') return config.unit ? `число, ${config.unit}` : 'число';
+    if (config.type === 'select') return 'выбор';
+    if (config.type === 'boolean') return 'да / нет';
+    return '';
 };
 const INVALID_BRAND_TOKENS = new Set([
     'мультисплитсистема',
@@ -858,6 +871,34 @@ const filteredTagGroups = computed(() => {
             tags: g.tags.filter(t => t.title.toLowerCase().includes(q)),
         }))
         .filter(g => g.tags.length > 0);
+});
+
+const groupedSpecRows = computed(() => {
+    const groups = new Map<string, {
+        group: string;
+        label: string;
+        entries: Array<{ row: { key: string; value: string }; index: number }>;
+    }>();
+
+    specs.value.forEach((row, index) => {
+        const group = row.key.trim() ? getSpecGroup(row.key) : 'other';
+        if (!groups.has(group)) {
+            groups.set(group, {
+                group,
+                label: getSpecGroupLabel(group),
+                entries: [],
+            });
+        }
+        groups.get(group)?.entries.push({ row, index });
+    });
+
+    return Array.from(groups.values()).sort((a, b) => {
+        const aIndex = specGroupOrder.indexOf(a.group as any);
+        const bIndex = specGroupOrder.indexOf(b.group as any);
+        const safeA = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
+        const safeB = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
+        return safeA - safeB || a.label.localeCompare(b.label, 'ru');
+    });
 });
 
 const isTagSelected = (id: number) => selectedTagIds.value.has(id);
@@ -1829,89 +1870,62 @@ const unlinkSupplierOffer = async (offer: any) => {
                             </button>
                         </div>
 
-                        <div class="space-y-2 bg-slate-100/50 dark:bg-slate-800/50 p-3 rounded-2xl border border-gray-100 dark:border-slate-800 max-h-[400px] overflow-y-auto">
-                            <div v-for="(row, idx) in specs" :key="idx" class="flex gap-1.5 items-start group">
-                                <div class="relative flex-1">
-                                    <SpecKeyCombobox 
-                                        v-model="row.key" 
-                                        :known-keys="knownSpecKeys"
-                                    />
+                        <div class="space-y-4 bg-slate-100/50 dark:bg-slate-800/50 p-3 rounded-2xl border border-gray-100 dark:border-slate-800 max-h-[460px] overflow-y-auto">
+                            <div v-for="group in groupedSpecRows" :key="group.group" class="space-y-2">
+                                <div class="flex items-center gap-2 px-1">
+                                    <p class="text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
+                                        {{ group.label }}
+                                    </p>
+                                    <span class="rounded-full bg-white px-2 py-0.5 text-[10px] font-bold text-slate-400 shadow-sm dark:bg-slate-800 dark:text-slate-500">
+                                        {{ group.entries.length }}
+                                    </span>
                                 </div>
-                                <button
-                                    v-if="getSpecHelpText(row.key)"
-                                    type="button"
-                                    class="mt-2 shrink-0 rounded-full p-1 text-slate-400 transition hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-700 dark:hover:text-teal-300"
-                                    :title="getSpecHelpText(row.key)"
-                                    @click="showSpecHelp(row.key)"
+
+                                <div
+                                    v-for="{ row, index } in group.entries"
+                                    :key="index"
+                                    class="rounded-xl border border-white/80 bg-white/70 p-2 shadow-sm transition-colors hover:border-teal-100 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:border-teal-900"
                                 >
-                                    <CircleHelp class="h-4 w-4" />
-                                </button>
-                                
-                                <div class="flex-1">
-                                    <template v-if="getSpecConfig(row.key)?.type === 'boolean'">
-                                        <div class="flex items-center h-[38px]">
-                                            <button 
-                                                type="button"
-                                                @click="row.value = (row.value === 'true') ? 'false' : 'true'"
-                                                class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
-                                                :class="(row.value === 'true') ? 'bg-teal-600' : 'bg-gray-200 dark:bg-slate-700'"
-                                                role="switch"
-                                                :aria-checked="row.value === 'true'"
-                                            >
-                                                <span class="sr-only">Toggle boolean</span>
-                                                <span 
-                                                    aria-hidden="true" 
-                                                    class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                                                    :class="(row.value === 'true') ? 'translate-x-5' : 'translate-x-0'"
-                                                />
-                                            </button>
-                                            <span class="ml-3 text-sm font-medium text-gray-900 dark:text-slate-200">
-                                                {{ (row.value === 'true') ? 'Да' : 'Нет' }}
-                                            </span>
-                                        </div>
-                                    </template>
-                                    
-                                    <template v-else-if="getSpecConfig(row.key)?.type === 'select'">
-                                        <select 
-                                            v-model="row.value"
-                                            class="w-full h-[38px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all text-gray-900 dark:text-slate-200 shadow-inner"
-                                        >
-                                            <option value="" disabled>Выберите значение</option>
-                                            <option v-for="opt in getSelectOptions(row.key, row.value)" :key="opt" :value="opt">
-                                                {{ formatSelectOptionLabel(row.key, opt) }}
-                                            </option>
-                                        </select>
-                                    </template>
-                                    
-                                    <template v-else-if="getSpecConfig(row.key)?.type === 'number'">
-                                        <div class="flex h-[38px] rounded-lg shadow-inner">
-                                            <input 
-                                                type="number"
-                                                v-model="row.value" 
-                                                placeholder="Значение" 
-                                                class="flex-1 min-w-0 block w-full border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 text-gray-900 dark:text-slate-200 rounded-none rounded-l-lg px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all"
+                                    <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)_auto] sm:items-start">
+                                        <div class="min-w-0">
+                                            <SpecKeyCombobox
+                                                v-model="row.key"
+                                                :known-keys="knownSpecKeys"
                                             />
-                                            <span v-if="getSpecConfig(row.key)?.unit" class="inline-flex items-center px-2.5 rounded-r-lg border border-l-0 border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300 text-xs">
-                                                {{ getSpecConfig(row.key)?.unit }}
-                                            </span>
+                                            <div v-if="row.key" class="mt-1 flex min-w-0 items-center gap-1.5">
+                                                <span class="truncate text-[11px] font-semibold text-slate-500 dark:text-slate-400" :title="getSpecLabel(row.key)">
+                                                    {{ getSpecLabel(row.key) }}
+                                                </span>
+                                                <span v-if="getSpecTypeHint(row.key)" class="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-bold text-slate-400 dark:bg-slate-800 dark:text-slate-500">
+                                                    {{ getSpecTypeHint(row.key) }}
+                                                </span>
+                                            </div>
                                         </div>
-                                    </template>
-                                    
-                                    <template v-else>
-                                        <input 
-                                            type="text"
-                                            v-model="row.value" 
-                                            placeholder="Значение" 
-                                            class="w-full h-[38px] border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 rounded-lg px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all text-gray-900 dark:text-slate-200 dark:placeholder-slate-500 shadow-inner"
+
+                                        <SpecValueInput
+                                            v-model="row.value"
+                                            :spec-key="row.key"
+                                            compact
                                         />
-                                    </template>
+
+                                        <div class="flex items-center justify-end gap-1 sm:pt-1">
+                                            <button
+                                                v-if="getSpecHelpText(row.key)"
+                                                type="button"
+                                                class="rounded-full p-1.5 text-slate-400 transition hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-700 dark:hover:text-teal-300"
+                                                :title="getSpecHelpText(row.key)"
+                                                @click="showSpecHelp(row.key)"
+                                            >
+                                                <CircleHelp class="h-4 w-4" />
+                                            </button>
+                                            <button @click="removeRow(index)" class="rounded-lg p-1.5 text-gray-300 transition-all hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30">
+                                                <Trash2 class="w-3.5 h-3.5" />
+                                            </button>
+                                        </div>
+                                    </div>
                                 </div>
-                                
-                                <button @click="removeRow(idx)" class="p-1.5 text-gray-300 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all">
-                                    <Trash2 class="w-3.5 h-3.5" />
-                                </button>
                             </div>
-                            
+
                             <div v-if="specs.length === 0" class="text-center py-6 text-gray-400 dark:text-slate-500">
                                  <Hash class="w-6 h-6 mx-auto mb-1.5 opacity-20" />
                                  <p class="text-xs">Нет характеристик</p>

--- a/manager_frontend/src/components/SpecValueInput.vue
+++ b/manager_frontend/src/components/SpecValueInput.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useSpecRegistry } from '../composables/useSpecRegistry';
+
+const props = withDefaults(defineProps<{
+    modelValue: string;
+    specKey: string;
+    disabled?: boolean;
+    compact?: boolean;
+    placeholder?: string;
+}>(), {
+    disabled: false,
+    compact: false,
+    placeholder: 'Значение',
+});
+
+const emit = defineEmits<{
+    (e: 'update:modelValue', value: string): void;
+}>();
+
+const {
+    formatSelectOptionLabel,
+    getSelectOptions,
+    getSpecConfig,
+} = useSpecRegistry();
+
+const config = computed(() => getSpecConfig(props.specKey));
+const value = computed({
+    get: () => String(props.modelValue ?? ''),
+    set: (next: string) => emit('update:modelValue', next),
+});
+const controlTextClass = computed(() => props.compact ? 'text-xs' : 'text-sm');
+const inputBaseClass = computed(() => [
+    'block w-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-200',
+    'focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 transition-all',
+    'disabled:bg-gray-100 dark:disabled:bg-slate-800 disabled:text-gray-400 dark:disabled:text-slate-500',
+    props.compact ? 'h-[38px] px-2.5 py-1.5 text-xs' : 'h-[38px] px-3 py-1.5 text-sm',
+].join(' '));
+const softInputClass = computed(() => [
+    inputBaseClass.value,
+    'bg-slate-100 dark:bg-slate-800 shadow-inner',
+].join(' '));
+const unitPillClass = computed(() => [
+    'inline-flex items-center border border-l-0 border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-700 text-gray-500 dark:text-slate-300',
+    props.compact ? 'px-2.5 text-xs' : 'px-3 text-sm',
+].join(' '));
+
+const extractNumbers = (raw: string): string[] => {
+    const normalized = String(raw || '').replace('−', '-').replace('—', '-').replace(/,/g, '.');
+    return Array.from(normalized.matchAll(/[-+]?\d+(?:\.\d+)?/g)).map((match) => match[0]);
+};
+const eventValue = (event: Event): string => (event.target as HTMLInputElement | null)?.value || '';
+
+const rangeNumbers = computed(() => extractNumbers(value.value));
+const rangeMin = computed(() => {
+    const text = value.value.toLowerCase();
+    if (rangeNumbers.value.length === 0) return '';
+    if (rangeNumbers.value.length === 1 && text.includes('до') && !text.includes('от')) return '';
+    return rangeNumbers.value[0] || '';
+});
+const rangeMax = computed(() => {
+    const text = value.value.toLowerCase();
+    if (rangeNumbers.value.length >= 2) return rangeNumbers.value[1] || '';
+    if (rangeNumbers.value.length === 1 && text.includes('до') && !text.includes('от')) return rangeNumbers.value[0] || '';
+    return '';
+});
+
+const withUnit = (raw: string): string => {
+    const trimmed = raw.trim();
+    if (!trimmed || !config.value?.unit) return trimmed;
+    const lower = trimmed.toLowerCase();
+    const localized = config.value.unit.toLowerCase();
+    const canonical = String(config.value.canonicalUnit || '').toLowerCase();
+    if (lower.includes(localized) || (canonical && lower.includes(canonical))) return trimmed;
+    return `${trimmed} ${config.value.unit}`.trim();
+};
+
+const updateRange = (part: 'min' | 'max', nextValue: string) => {
+    const min = (part === 'min' ? nextValue : rangeMin.value).trim();
+    const max = (part === 'max' ? nextValue : rangeMax.value).trim();
+    if (min && max) {
+        value.value = withUnit(`от ${min} до ${max}`);
+    } else if (min) {
+        value.value = withUnit(`от ${min}`);
+    } else if (max) {
+        value.value = withUnit(`до ${max}`);
+    } else {
+        value.value = '';
+    }
+};
+
+const normalizeNumberList = () => {
+    if (config.value?.type !== 'number_list' || !value.value.trim()) return;
+    const numbers = extractNumbers(value.value);
+    if (numbers.length === 0) return;
+    value.value = withUnit(numbers.join(' / '));
+};
+
+const dimensionNumbers = computed(() => extractNumbers(value.value));
+const updateDimension = (index: number, nextValue: string) => {
+    const values = [dimensionNumbers.value[0] || '', dimensionNumbers.value[1] || '', dimensionNumbers.value[2] || ''];
+    values[index] = nextValue.trim();
+    const filled = values.filter(Boolean);
+    value.value = filled.length ? withUnit(values.map((item) => item || '').join(' × ')) : '';
+};
+</script>
+
+<template>
+    <template v-if="config?.type === 'boolean'">
+        <div class="flex h-[38px] items-center">
+            <button
+                type="button"
+                :disabled="disabled"
+                class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                :class="value === 'true' ? 'bg-teal-600' : 'bg-gray-200 dark:bg-slate-700'"
+                role="switch"
+                :aria-checked="value === 'true'"
+                @click="value = value === 'true' ? 'false' : 'true'"
+            >
+                <span class="sr-only">Переключить значение</span>
+                <span
+                    aria-hidden="true"
+                    class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                    :class="value === 'true' ? 'translate-x-5' : 'translate-x-0'"
+                />
+            </button>
+            <span class="ml-3 font-medium text-gray-900 dark:text-slate-200" :class="controlTextClass">
+                {{ value === 'true' ? 'Да' : 'Нет' }}
+            </span>
+        </div>
+    </template>
+
+    <template v-else-if="config?.type === 'select'">
+        <select
+            v-model="value"
+            :disabled="disabled"
+            class="rounded-lg"
+            :class="softInputClass"
+        >
+            <option value="" disabled>{{ disabled ? 'Пропускается' : 'Выберите значение' }}</option>
+            <option v-for="opt in getSelectOptions(specKey, value)" :key="opt" :value="opt">
+                {{ formatSelectOptionLabel(specKey, opt) }}
+            </option>
+        </select>
+    </template>
+
+    <template v-else-if="config?.type === 'number'">
+        <div class="flex h-[38px] rounded-lg shadow-inner">
+            <input
+                v-model="value"
+                type="number"
+                :disabled="disabled"
+                :placeholder="disabled ? 'Пропускается' : placeholder"
+                class="min-w-0 flex-1 rounded-none rounded-l-lg"
+                :class="softInputClass"
+            />
+            <span v-if="config?.unit" class="rounded-r-lg" :class="unitPillClass">
+                {{ config.unit }}
+            </span>
+        </div>
+    </template>
+
+    <template v-else-if="config?.type === 'range'">
+        <div class="flex h-[38px] rounded-lg shadow-inner">
+            <input
+                :value="rangeMin"
+                type="number"
+                :disabled="disabled"
+                placeholder="от"
+                class="min-w-0 flex-1 rounded-none rounded-l-lg"
+                :class="softInputClass"
+                @input="updateRange('min', eventValue($event))"
+            />
+            <span class="inline-flex items-center border-y border-gray-200 bg-white px-2 text-slate-400 dark:border-slate-700 dark:bg-slate-900" :class="controlTextClass">
+                до
+            </span>
+            <input
+                :value="rangeMax"
+                type="number"
+                :disabled="disabled"
+                placeholder="до"
+                class="min-w-0 flex-1 rounded-none"
+                :class="softInputClass"
+                @input="updateRange('max', eventValue($event))"
+            />
+            <span v-if="config?.unit" class="rounded-r-lg" :class="unitPillClass">
+                {{ config.unit }}
+            </span>
+        </div>
+    </template>
+
+    <template v-else-if="config?.type === 'number_list'">
+        <div class="flex h-[38px] rounded-lg shadow-inner">
+            <input
+                v-model="value"
+                type="text"
+                :disabled="disabled"
+                placeholder="23 / 26 / 31"
+                class="min-w-0 flex-1 rounded-none rounded-l-lg"
+                :class="softInputClass"
+                @blur="normalizeNumberList"
+            />
+            <span v-if="config?.unit" class="rounded-r-lg" :class="unitPillClass">
+                {{ config.unit }}
+            </span>
+        </div>
+    </template>
+
+    <template v-else-if="config?.type === 'dimensions'">
+        <div class="grid grid-cols-[1fr_1fr_1fr_auto] gap-1">
+            <input
+                :value="dimensionNumbers[0] || ''"
+                type="number"
+                :disabled="disabled"
+                placeholder="Ш"
+                class="rounded-lg"
+                :class="softInputClass"
+                @input="updateDimension(0, eventValue($event))"
+            />
+            <input
+                :value="dimensionNumbers[1] || ''"
+                type="number"
+                :disabled="disabled"
+                placeholder="В"
+                class="rounded-lg"
+                :class="softInputClass"
+                @input="updateDimension(1, eventValue($event))"
+            />
+            <input
+                :value="dimensionNumbers[2] || ''"
+                type="number"
+                :disabled="disabled"
+                placeholder="Г"
+                class="rounded-lg"
+                :class="softInputClass"
+                @input="updateDimension(2, eventValue($event))"
+            />
+            <span v-if="config?.unit" class="inline-flex items-center rounded-lg border border-gray-200 bg-gray-50 px-2 text-gray-500 dark:border-slate-700 dark:bg-slate-700 dark:text-slate-300" :class="controlTextClass">
+                {{ config.unit }}
+            </span>
+        </div>
+    </template>
+
+    <template v-else>
+        <input
+            v-model="value"
+            type="text"
+            :disabled="disabled"
+            :placeholder="disabled ? 'Пропускается' : placeholder"
+            class="rounded-lg"
+            :class="softInputClass"
+        />
+    </template>
+</template>

--- a/manager_frontend/src/composables/useSpecRegistry.ts
+++ b/manager_frontend/src/composables/useSpecRegistry.ts
@@ -3,6 +3,16 @@ import { api, type SpecRegistryResponse } from '../api';
 import { hiddenSpecKeys, specsTranslations, type SpecConfig } from '../utils/specsTranslations';
 
 type RegistryItem = SpecRegistryResponse['items'][number];
+type SpecGroupKey =
+    | 'identity'
+    | 'performance'
+    | 'efficiency'
+    | 'operation'
+    | 'installation'
+    | 'dimensions'
+    | 'comfort'
+    | 'logistics'
+    | 'other';
 
 const registryConfigs = ref<Record<string, SpecConfig>>({ ...specsTranslations });
 const knownSpecKeys = ref<string[]>(Object.keys(specsTranslations).filter((key) => !hiddenSpecKeys.has(key)));
@@ -26,11 +36,164 @@ const unitLabels: Record<string, string> = {
     month: 'мес.',
 };
 
+const specGroupLabels: Record<SpecGroupKey, string> = {
+    identity: 'Основное',
+    performance: 'Производительность',
+    efficiency: 'Эффективность',
+    operation: 'Работа и управление',
+    installation: 'Монтаж',
+    dimensions: 'Габариты и вес',
+    comfort: 'Фильтры и комфорт',
+    logistics: 'Логистика',
+    other: 'Прочее',
+};
+
+const specGroupOrder: SpecGroupKey[] = [
+    'identity',
+    'performance',
+    'efficiency',
+    'operation',
+    'installation',
+    'dimensions',
+    'comfort',
+    'logistics',
+    'other',
+];
+
 const registryTypeToControl = (item: RegistryItem): SpecConfig['type'] => {
     if (item.value_type === 'boolean') return 'boolean';
     if (item.value_type === 'enum' || item.value_type === 'state') return 'select';
     if (item.value_type === 'quantity') return 'number';
+    if (item.value_type === 'range') return 'range';
+    if (item.value_type === 'number_list') return 'number_list';
+    if (item.value_type === 'dimensions') return 'dimensions';
     return 'text';
+};
+
+const groupForSpecKey = (key: string, item?: RegistryItem | null): SpecGroupKey => {
+    const normalized = key.trim();
+    const quantityKind = item?.quantity_kind || registryConfigs.value[normalized]?.quantityKind || '';
+
+    if (
+        [
+            'type',
+            'indoor_type',
+            'brand',
+            'series',
+            'model',
+            'model_indoor',
+            'model_outdoor',
+            'sku',
+            'sku_list',
+            'country',
+            'color',
+            'availability',
+            'release_year',
+        ].includes(normalized)
+    ) {
+        return 'identity';
+    }
+
+    if (
+        normalized.startsWith('capacity_')
+        || normalized.startsWith('power_cons_')
+        || normalized.startsWith('airflow_')
+        || normalized === 'area_m2'
+        || normalized === 'dehumidification_l_h'
+        || quantityKind === 'power'
+        || quantityKind === 'airflow'
+        || quantityKind === 'area'
+        || quantityKind === 'volume_rate'
+    ) {
+        return 'performance';
+    }
+
+    if (
+        normalized.startsWith('energy_class')
+        || ['eer', 'cop', 'seer', 'scop', 'annual_energy_cooling_kwh', 'annual_energy_heating_kwh'].includes(normalized)
+        || quantityKind === 'energy'
+    ) {
+        return 'efficiency';
+    }
+
+    if (
+        normalized.startsWith('temp_range_')
+        || normalized.startsWith('wifi_')
+        || [
+            'inverter',
+            'inverter_type',
+            'compressor_type',
+            'compressor_brand',
+            'modes',
+            'remote_control',
+            'timer',
+            'fan_speed',
+            'airflow_direction',
+            'autorestart',
+            'sleep_mode',
+            'turbo_mode',
+            'power_supply_location',
+        ].includes(normalized)
+        || quantityKind === 'temperature'
+        || quantityKind === 'noise'
+    ) {
+        return 'operation';
+    }
+
+    if (
+        normalized.startsWith('pipe_')
+        || normalized.startsWith('refrigerant_')
+        || normalized.startsWith('power_supply')
+        || normalized.startsWith('current_')
+        || normalized.startsWith('cable_')
+        || ['drain_pipe_diameter', 'multi_max_total_pipe_length', 'multi_max_indoor_units'].includes(normalized)
+    ) {
+        return 'installation';
+    }
+
+    if (
+        normalized.startsWith('width_')
+        || normalized.startsWith('height_')
+        || normalized.startsWith('depth_')
+        || normalized.startsWith('weight_')
+        || normalized.startsWith('dimensions_')
+        || quantityKind === 'weight'
+    ) {
+        return 'dimensions';
+    }
+
+    if (
+        normalized.endsWith('_filter')
+        || [
+            'bio_filter',
+            'carbon_filter',
+            'electrostatic_filter',
+            'fresh_air',
+            'humidification',
+            'ionizer',
+            'photocatalytic_filter',
+            'plasma_filter',
+            'presence_sensor',
+            'self_cleaning',
+            'self_diagnosis',
+            'smart_home_integration',
+            'uv_sterilization',
+            'voice_control',
+            'winter_kit',
+        ].includes(normalized)
+    ) {
+        return 'comfort';
+    }
+
+    if (
+        normalized.includes('package')
+        || normalized.startsWith('includes_')
+        || normalized === 'warranty_months'
+    ) {
+        return 'logistics';
+    }
+
+    return 'other';
 };
 
 const mapRegistryItem = (item: RegistryItem): SpecConfig => {
@@ -40,6 +203,10 @@ const mapRegistryItem = (item: RegistryItem): SpecConfig => {
         type: registryTypeToControl(item),
         options: options.length ? options : undefined,
         unit: item.canonical_unit ? (unitLabels[item.canonical_unit] || item.canonical_unit) : undefined,
+        canonicalUnit: item.canonical_unit || undefined,
+        quantityKind: item.quantity_kind || undefined,
+        valueType: item.value_type || undefined,
+        group: groupForSpecKey(item.key, item),
         description: item.description || undefined,
         managerNote: item.manager_note || undefined,
         source: 'registry',
@@ -57,6 +224,20 @@ const mergeKnownKeys = (...groups: Array<Iterable<string> | undefined>) => {
         }
     }
     knownSpecKeys.value = Array.from(combined).sort((a, b) => a.localeCompare(b, 'ru'));
+};
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const valueHasUnit = (value: string, config?: SpecConfig): boolean => {
+    const text = value.toLowerCase();
+    const candidates = [config?.unit, config?.canonicalUnit].filter(Boolean) as string[];
+    return candidates.some((unit) => text.includes(unit.toLowerCase()));
+};
+
+const appendUnitIfNeeded = (value: string, config?: SpecConfig): string => {
+    const trimmed = value.trim();
+    if (!trimmed || !config?.unit || valueHasUnit(trimmed, config)) return trimmed;
+    return `${trimmed} ${config.unit}`.trim();
 };
 
 export const useSpecRegistry = () => {
@@ -92,7 +273,13 @@ export const useSpecRegistry = () => {
         }
     };
 
-    const getSpecConfig = (key: string): SpecConfig | undefined => registryConfigs.value[key];
+    const getSpecConfig = (key: string): SpecConfig | undefined => {
+        const normalized = String(key || '').trim();
+        const config = registryConfigs.value[normalized];
+        if (!config) return undefined;
+        if (config.group) return config;
+        return { ...config, group: groupForSpecKey(normalized) };
+    };
 
     const getSelectOptions = (key: string, value: unknown): string[] => {
         const base = [...(getSpecConfig(key)?.options || [])];
@@ -124,7 +311,10 @@ export const useSpecRegistry = () => {
         const config = getSpecConfig(key);
         let result = String(value ?? '');
         if (config?.type === 'number' && config.unit) {
-            result = result.replace(new RegExp(`${config.unit}$`, 'i'), '').trim();
+            result = result.replace(new RegExp(`${escapeRegExp(config.unit)}$`, 'i'), '').trim();
+            if (config.canonicalUnit) {
+                result = result.replace(new RegExp(`${escapeRegExp(config.canonicalUnit)}$`, 'i'), '').trim();
+            }
             const match = result.match(/^-?\d*[.,]?\d*/);
             result = match && match[0] ? match[0].replace(',', '.') : '';
         }
@@ -135,16 +325,26 @@ export const useSpecRegistry = () => {
         let finalValue = String(value ?? '');
         const config = getSpecConfig(key);
         if (config?.type === 'number' && config.unit && finalValue.trim() !== '') {
-            finalValue = `${finalValue} ${config.unit}`.trim();
+            finalValue = appendUnitIfNeeded(finalValue, config);
+        } else if ((config?.type === 'range' || config?.type === 'number_list') && finalValue.trim() !== '') {
+            finalValue = appendUnitIfNeeded(finalValue, config);
         } else if (config?.type === 'boolean') {
             finalValue = finalValue === 'true' ? 'true' : 'false';
         }
         return finalValue.trim();
     };
 
+    const getSpecGroup = (key: string): SpecGroupKey => {
+        const config = getSpecConfig(key);
+        return (config?.group as SpecGroupKey | undefined) || groupForSpecKey(String(key || ''));
+    };
+
     return {
         getSelectOptions,
         getSpecConfig,
+        getSpecGroup,
+        getSpecGroupLabel: (group: string): string => specGroupLabels[group as SpecGroupKey] || specGroupLabels.other,
+        specGroupOrder,
         getSpecHelpText,
         formatSelectOptionLabel,
         isHiddenSpecKey: (key: string) => hiddenSpecKeys.has(key),

--- a/manager_frontend/src/utils/specsTranslations.ts
+++ b/manager_frontend/src/utils/specsTranslations.ts
@@ -1,8 +1,12 @@
 export interface SpecConfig {
     label: string;
-    type: 'boolean' | 'select' | 'number' | 'text';
+    type: 'boolean' | 'select' | 'number' | 'text' | 'range' | 'number_list' | 'dimensions';
     options?: string[];
     unit?: string;
+    canonicalUnit?: string;
+    quantityKind?: string;
+    valueType?: string;
+    group?: string;
     description?: string;
     managerNote?: string;
     source?: 'registry' | 'fallback';


### PR DESCRIPTION
## Summary
- add reusable typed spec value controls for registry-backed product specs
- group specs in the product editor by registry category with type/unit hints
- reuse the same value input in the bulk specs editor

## Validation
- npm run build (manager_frontend)
- git diff --check
- bash scripts/audit_theme_hardcodes.sh
- browser QA on desktop and mobile product editor flows
