### PR TITLE
[codex] Add catalog quality dashboard

### DIFF
--- a/alembic/versions/c9d0e1f2a3b4_extend_product_series_pim_content.py
+++ b/alembic/versions/c9d0e1f2a3b4_extend_product_series_pim_content.py
@@ -1,0 +1,57 @@
+"""extend product series pim content
+
+Revision ID: c9d0e1f2a3b4
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-27 15:55:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("product_series", sa.Column("tagline", sa.String(), nullable=True))
+    op.add_column("product_series", sa.Column("short_description", sa.Text(), nullable=True))
+    op.add_column(
+        "product_series",
+        sa.Column("gallery_images", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "product_series",
+        sa.Column("feature_blocks", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "product_series",
+        sa.Column("content_blocks", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "product_series",
+        sa.Column("footnotes", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column("product_series", sa.Column("seo_title", sa.String(), nullable=True))
+    op.add_column("product_series", sa.Column("seo_description", sa.Text(), nullable=True))
+    op.add_column("product_series", sa.Column("source_url", sa.String(), nullable=True))
+
+    for column_name in ("gallery_images", "feature_blocks", "content_blocks", "footnotes"):
+        op.alter_column("product_series", column_name, server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("product_series", "source_url")
+    op.drop_column("product_series", "seo_description")
+    op.drop_column("product_series", "seo_title")
+    op.drop_column("product_series", "footnotes")
+    op.drop_column("product_series", "content_blocks")
+    op.drop_column("product_series", "feature_blocks")
+    op.drop_column("product_series", "gallery_images")
+    op.drop_column("product_series", "short_description")
+    op.drop_column("product_series", "tagline")

--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, nextTick, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import type { Component } from 'vue';
-import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, ChevronDown, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText, Image as ImageIcon } from 'lucide-vue-next';
+import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, ChevronDown, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText, Image as ImageIcon, ShieldCheck } from 'lucide-vue-next';
 import { api } from './api';
 import { getApiErrorMessage } from './utils/api-errors';
 import type { TelegramLoginPayload } from './api';
@@ -24,6 +24,7 @@ const TagsView = defineAsyncComponent(() => import('./views/TagsView.vue'));
 const BrandsView = defineAsyncComponent(() => import('./views/BrandsView.vue'));
 const SupplierFeedsView = defineAsyncComponent(() => import('./views/SupplierFeedsView.vue'));
 const SupplierMappingView = defineAsyncComponent(() => import('./views/SupplierMappingView.vue'));
+const CatalogQualityView = defineAsyncComponent(() => import('./views/CatalogQualityView.vue'));
 
 const isAuthenticated = ref(false);
 const showLoginModal = ref(false);
@@ -82,6 +83,7 @@ const navSections: NavSection[] = [
     label: 'Каталог',
     items: [
       { path: '/manager/products', label: 'Кондиционеры', icon: Package, match: 'prefix' },
+      { path: '/manager/catalog-quality', label: 'Качество каталога', icon: ShieldCheck, match: 'prefix' },
       { path: '/manager/suppliers', label: 'Прайсы поставщиков', icon: FileSpreadsheet, match: 'prefix' },
       { path: '/manager/supplier-mapping', label: 'Маппинг прайсов', icon: Link2, match: 'prefix' },
       { path: '/manager/brands', label: 'Бренды', icon: Award, match: 'prefix' },
@@ -187,6 +189,7 @@ const currentView = computed(() => {
   if (path.startsWith('/manager/orders')) return 'orders';
   if (path.startsWith('/manager/calendar')) return 'calendar';
   if (path.startsWith('/manager/media')) return 'media-library';
+  if (path.startsWith('/manager/catalog-quality')) return 'catalog-quality';
   if (path.startsWith('/manager/customers/profile')) return 'customer-profile';
   if (path.startsWith('/manager/customers')) return 'customers';
   if (path.startsWith('/manager/staff') || path.startsWith('/manager/users') || path.startsWith('/manager/installers')) return 'installers';
@@ -574,6 +577,7 @@ watch(currentPath, () => {
       <OrdersKanbanView v-else-if="currentView === 'orders'" :key="currentLocation" />
       <CalendarDashboard v-else-if="currentView === 'calendar'" :key="currentLocation" />
       <MediaLibraryView v-else-if="currentView === 'media-library'" :key="currentLocation" />
+      <CatalogQualityView v-else-if="currentView === 'catalog-quality'" :key="currentLocation" />
       <CustomerProfileView v-else-if="currentView === 'customer-profile'" :key="currentLocation" />
       <CustomersView v-else-if="currentView === 'customers'" :key="currentLocation" />
       <InstallersView v-else-if="currentView === 'installers'" :key="currentLocation" />

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -13,6 +13,7 @@ import {
     ManagerServiceEstimatesService,
     ManagerBrandsService,
     ManagerMediaService,
+    ManagerCatalogQualityService,
     SystemService,
     ApiService,
     type Body_upload_media_assets,
@@ -70,6 +71,7 @@ import {
     type ManagerBrandSeriesResponse,
     type ManagerBrandSeriesUpdatePayload,
     type ManagerBrandUpdatePayload,
+    type ManagerCatalogQualityReportResponse,
     type ManagerBackgroundRemovalConfigResponse,
     type ManagerMediaAssetCropPayload,
     type ManagerMediaAssetListResponse,
@@ -144,6 +146,7 @@ export type {
     ManagerBrandSeriesUpdatePayload,
     ManagerBrandUpdatePayload,
 };
+export type { ManagerCatalogQualityReportResponse };
 export type {
     Body_upload_media_assets,
     ManagerBackgroundRemovalConfigResponse,
@@ -245,6 +248,26 @@ export const api = {
 
     async getDashboardStats() {
         return await ManagerDashboardService.getDashboardStats();
+    },
+
+    async getCatalogQualityReport(params: {
+        page?: number;
+        limit?: number;
+        q?: string | null;
+        category?: 'media' | 'identity' | 'specs' | 'commerce' | 'supplier' | null;
+        severity?: 'critical' | 'warning' | 'info' | null;
+        issueCode?: string | null;
+        onlyProblems?: boolean;
+    } = {}): Promise<ManagerCatalogQualityReportResponse> {
+        return await ManagerCatalogQualityService.getManagerCatalogQualityReport(
+            params.page ?? 1,
+            params.limit ?? 50,
+            params.q ?? null,
+            params.category ?? null,
+            params.severity ?? null,
+            params.issueCode ?? null,
+            params.onlyProblems ?? true,
+        );
     },
 
     async listMediaAssets(params: {

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -106,6 +106,11 @@ export type { ManagerCatalogProductItemResponse } from './models/ManagerCatalogP
 export type { ManagerCatalogProductListResponse } from './models/ManagerCatalogProductListResponse';
 export type { ManagerCatalogProductManualResponse } from './models/ManagerCatalogProductManualResponse';
 export type { ManagerCatalogProductTagResponse } from './models/ManagerCatalogProductTagResponse';
+export type { ManagerCatalogQualityCategoryResponse } from './models/ManagerCatalogQualityCategoryResponse';
+export type { ManagerCatalogQualityIssueResponse } from './models/ManagerCatalogQualityIssueResponse';
+export type { ManagerCatalogQualityProductResponse } from './models/ManagerCatalogQualityProductResponse';
+export type { ManagerCatalogQualityReportResponse } from './models/ManagerCatalogQualityReportResponse';
+export type { ManagerCatalogQualitySummaryItemResponse } from './models/ManagerCatalogQualitySummaryItemResponse';
 export type { ManagerCrmHealthReportResponse } from './models/ManagerCrmHealthReportResponse';
 export type { ManagerCustomerBranchCreatePayload } from './models/ManagerCustomerBranchCreatePayload';
 export type { ManagerCustomerBranchItemResponse } from './models/ManagerCustomerBranchItemResponse';
@@ -299,6 +304,8 @@ export type { ProductMainImageCleanupSkipReasonsResponse } from './models/Produc
 export type { ProductManualPayload } from './models/ProductManualPayload';
 export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';
+export type { ProductSeriesContentBlockResponse } from './models/ProductSeriesContentBlockResponse';
+export type { ProductSeriesFeatureBlockResponse } from './models/ProductSeriesFeatureBlockResponse';
 export type { ProductSeriesNavigationItemResponse } from './models/ProductSeriesNavigationItemResponse';
 export type { ProductSeriesNavigationResponse } from './models/ProductSeriesNavigationResponse';
 export type { ProductSeriesResponse } from './models/ProductSeriesResponse';
@@ -344,6 +351,7 @@ export { ManagerService } from './services/ManagerService';
 export { ManagerBackupsService } from './services/ManagerBackupsService';
 export { ManagerBrandsService } from './services/ManagerBrandsService';
 export { ManagerCalendarService } from './services/ManagerCalendarService';
+export { ManagerCatalogQualityService } from './services/ManagerCatalogQualityService';
 export { ManagerContractsService } from './services/ManagerContractsService';
 export { ManagerCrmService } from './services/ManagerCrmService';
 export { ManagerDashboardService } from './services/ManagerDashboardService';

--- a/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
@@ -2,12 +2,23 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
+import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ManagerBrandSeriesCreatePayload = {
     title: string;
     slug?: (string | null);
+    tagline?: (string | null);
+    short_description?: (string | null);
     description?: (string | null);
     hero_image?: (string | null);
+    gallery_images?: Array<string>;
     features?: Array<string>;
+    feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
+    content_blocks?: Array<ProductSeriesContentBlockResponse>;
+    footnotes?: Array<string>;
+    seo_title?: (string | null);
+    seo_description?: (string | null);
+    source_url?: (string | null);
     is_published?: boolean;
     sort_order?: number;
 };

--- a/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
@@ -2,14 +2,25 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
+import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ManagerBrandSeriesResponse = {
     id: number;
     brand_id?: (number | null);
     title: string;
     slug: string;
+    tagline?: (string | null);
+    short_description?: (string | null);
     description?: (string | null);
     hero_image?: (string | null);
+    gallery_images?: Array<string>;
     features?: Array<string>;
+    feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
+    content_blocks?: Array<ProductSeriesContentBlockResponse>;
+    footnotes?: Array<string>;
+    seo_title?: (string | null);
+    seo_description?: (string | null);
+    source_url?: (string | null);
     is_published: boolean;
     sort_order: number;
     created_at: string;

--- a/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
@@ -2,12 +2,23 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
+import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ManagerBrandSeriesUpdatePayload = {
     title?: (string | null);
     slug?: (string | null);
+    tagline?: (string | null);
+    short_description?: (string | null);
     description?: (string | null);
     hero_image?: (string | null);
+    gallery_images?: (Array<string> | null);
     features?: (Array<string> | null);
+    feature_blocks?: (Array<ProductSeriesFeatureBlockResponse> | null);
+    content_blocks?: (Array<ProductSeriesContentBlockResponse> | null);
+    footnotes?: (Array<string> | null);
+    seo_title?: (string | null);
+    seo_description?: (string | null);
+    source_url?: (string | null);
     is_published?: (boolean | null);
     sort_order?: (number | null);
 };

--- a/manager_frontend/src/client/models/ManagerCatalogQualityCategoryResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityCategoryResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerCatalogQualityCategoryResponse = {
+    category: string;
+    label: string;
+    count: number;
+    critical?: number;
+    warning?: number;
+    info?: number;
+};
+

--- a/manager_frontend/src/client/models/ManagerCatalogQualityIssueResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityIssueResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerCatalogQualityIssueResponse = {
+    code: string;
+    label: string;
+    category: string;
+    severity: 'critical' | 'warning' | 'info';
+    message: string;
+    detail?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerCatalogQualityProductResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityProductResponse.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerCatalogQualityIssueResponse } from './ManagerCatalogQualityIssueResponse';
+export type ManagerCatalogQualityProductResponse = {
+    product_id: number;
+    title: string;
+    slug?: (string | null);
+    brand_id?: (number | null);
+    brand_title?: (string | null);
+    series_id?: (number | null);
+    series_title?: (string | null);
+    main_image?: (string | null);
+    price?: number;
+    is_published?: boolean;
+    score: number;
+    issue_count: number;
+    image_count?: number;
+    main_image_width?: (number | null);
+    main_image_height?: (number | null);
+    media_status?: string;
+    supplier_mapping_count?: number;
+    available_qty?: number;
+    issues?: Array<ManagerCatalogQualityIssueResponse>;
+};
+

--- a/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerCatalogQualityCategoryResponse } from './ManagerCatalogQualityCategoryResponse';
+import type { ManagerCatalogQualityProductResponse } from './ManagerCatalogQualityProductResponse';
+import type { ManagerCatalogQualitySummaryItemResponse } from './ManagerCatalogQualitySummaryItemResponse';
+import type { Meta } from './Meta';
+export type ManagerCatalogQualityReportResponse = {
+    generated_at: string;
+    total_products: number;
+    problem_products: number;
+    critical_products: number;
+    average_score: number;
+    items: Array<ManagerCatalogQualityProductResponse>;
+    summary: Array<ManagerCatalogQualitySummaryItemResponse>;
+    categories: Array<ManagerCatalogQualityCategoryResponse>;
+    meta: Meta;
+};
+

--- a/manager_frontend/src/client/models/ManagerCatalogQualitySummaryItemResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualitySummaryItemResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerCatalogQualitySummaryItemResponse = {
+    code: string;
+    label: string;
+    category: string;
+    severity: 'critical' | 'warning' | 'info';
+    count: number;
+};
+

--- a/manager_frontend/src/client/models/ProductSeriesContentBlockResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesContentBlockResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductSeriesContentBlockResponse = {
+    kind?: 'text' | 'image_text' | 'media';
+    title?: (string | null);
+    text?: (string | null);
+    image_url?: (string | null);
+    layout?: 'text_left' | 'text_right' | 'full';
+};
+

--- a/manager_frontend/src/client/models/ProductSeriesFeatureBlockResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesFeatureBlockResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductSeriesFeatureBlockResponse = {
+    title: string;
+    text?: (string | null);
+    image_url?: (string | null);
+    icon?: (string | null);
+    footnote?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/ProductSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesResponse.ts
@@ -2,12 +2,23 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
+import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ProductSeriesResponse = {
     id: number;
     title: string;
     slug: string;
+    tagline?: (string | null);
+    short_description?: (string | null);
     description?: (string | null);
     hero_image?: (string | null);
+    gallery_images?: Array<string>;
     features?: Array<string>;
+    feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
+    content_blocks?: Array<ProductSeriesContentBlockResponse>;
+    footnotes?: Array<string>;
+    seo_title?: (string | null);
+    seo_description?: (string | null);
+    source_url?: (string | null);
 };
 

--- a/manager_frontend/src/client/services/ManagerCatalogQualityService.ts
+++ b/manager_frontend/src/client/services/ManagerCatalogQualityService.ts
@@ -1,0 +1,48 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerCatalogQualityReportResponse } from '../models/ManagerCatalogQualityReportResponse';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ManagerCatalogQualityService {
+    /**
+     * Get Manager Catalog Quality Report
+     * @param page
+     * @param limit
+     * @param q
+     * @param category
+     * @param severity
+     * @param issueCode
+     * @param onlyProblems
+     * @returns ManagerCatalogQualityReportResponse Successful Response
+     * @throws ApiError
+     */
+    public static getManagerCatalogQualityReport(
+        page: number = 1,
+        limit: number = 40,
+        q?: (string | null),
+        category?: ('media' | 'identity' | 'specs' | 'commerce' | 'supplier' | null),
+        severity?: ('critical' | 'warning' | 'info' | null),
+        issueCode?: (string | null),
+        onlyProblems: boolean = true,
+    ): CancelablePromise<ManagerCatalogQualityReportResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/catalog-quality/report',
+            query: {
+                'page': page,
+                'limit': limit,
+                'q': q,
+                'category': category,
+                'severity': severity,
+                'issue_code': issueCode,
+                'only_problems': onlyProblems,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/manager_frontend/src/components/MediaField.vue
+++ b/manager_frontend/src/components/MediaField.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { api } from '../api';
+import {
+    ClipboardPaste,
+    Download,
+    Image as ImageIcon,
+    Images,
+    Search,
+    Trash2,
+    UploadCloud,
+    X,
+} from 'lucide-vue-next';
+import { api, type ManagerMediaAssetResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
 
 const props = withDefaults(defineProps<{
@@ -21,11 +31,25 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
     'update:modelValue': [value: string];
     uploaded: [url: string];
+    picked: [url: string];
 }>();
+
+type ClipboardImageItem = {
+    types: readonly string[];
+    getType: (type: string) => Promise<Blob>;
+};
 
 const fileInput = ref<HTMLInputElement | null>(null);
 const uploading = ref(false);
 const error = ref('');
+const pickerOpen = ref(false);
+const assets = ref<ManagerMediaAssetResponse[]>([]);
+const assetsLoading = ref(false);
+const pickerQuery = ref('');
+const pickerPage = ref(1);
+const pickerPages = ref(1);
+const pickerTotal = ref(0);
+const remoteUrl = ref('');
 
 const value = computed({
     get: () => props.modelValue || '',
@@ -33,9 +57,38 @@ const value = computed({
 });
 
 const normalizedUrl = computed(() => value.value.trim());
+const canImportCurrentUrl = computed(() => /^https?:\/\//i.test(normalizedUrl.value));
+
+const imageUrl = (path?: string | null) => {
+    if (!path) return '';
+    if (path.startsWith('http')) return path;
+    return path.startsWith('/') ? path : `/${path}`;
+};
+
+const mediaErrorMessage = (err: unknown, fallback: string) => {
+    const message = getApiErrorMessage(err);
+    if (!message) return fallback;
+    if (/permission|notallowed|denied/i.test(message)) {
+        return 'Браузер не дал прямой доступ к буферу. Нажмите Ctrl+V или Cmd+V на странице.';
+    }
+    if (/fetch/i.test(message)) {
+        return 'API медиатеки недоступен. Проверьте backend и повторите действие.';
+    }
+    return message;
+};
 
 const chooseFile = () => {
     fileInput.value?.click();
+};
+
+const pickedUrl = (url: string) => {
+    value.value = url;
+    emit('picked', url);
+};
+
+const rememberUploadedAsset = (asset: ManagerMediaAssetResponse) => {
+    assets.value = [asset, ...assets.value.filter((item) => item.id !== asset.id)];
+    pickerTotal.value = Math.max(pickerTotal.value + 1, assets.value.length);
 };
 
 const uploadFile = async (file: File) => {
@@ -51,10 +104,11 @@ const uploadFile = async (file: File) => {
         if (!uploaded?.url) {
             throw new Error('Загрузка завершилась без URL файла');
         }
-        value.value = uploaded.url;
+        pickedUrl(uploaded.url);
         emit('uploaded', uploaded.url);
+        rememberUploadedAsset(uploaded);
     } catch (err) {
-        error.value = getApiErrorMessage(err);
+        error.value = mediaErrorMessage(err, 'Не удалось загрузить файл');
     } finally {
         uploading.value = false;
         if (fileInput.value) fileInput.value.value = '';
@@ -72,6 +126,96 @@ const clearValue = () => {
     value.value = '';
     error.value = '';
 };
+
+const loadAssets = async (page = pickerPage.value) => {
+    assetsLoading.value = true;
+    error.value = '';
+    try {
+        pickerPage.value = page;
+        const response = await api.listMediaAssets({
+            page: pickerPage.value,
+            limit: 24,
+            q: pickerQuery.value.trim() || null,
+            kind: null,
+            status: null,
+        });
+        assets.value = response.items || [];
+        pickerTotal.value = response.meta.total;
+        pickerPages.value = response.meta.pages || 1;
+    } catch (err) {
+        error.value = mediaErrorMessage(err, 'Не удалось загрузить медиатеку');
+    } finally {
+        assetsLoading.value = false;
+    }
+};
+
+const openPicker = async () => {
+    pickerOpen.value = true;
+    if (!assets.value.length) {
+        await loadAssets(1);
+    }
+};
+
+const selectAsset = (asset: ManagerMediaAssetResponse) => {
+    pickedUrl(asset.url);
+    pickerOpen.value = false;
+};
+
+const uploadFromUrl = async (urlValue = remoteUrl.value.trim() || normalizedUrl.value) => {
+    const url = urlValue.trim();
+    if (!url) {
+        error.value = 'Укажите URL изображения';
+        return;
+    }
+    if (!/^https?:\/\//i.test(url)) {
+        error.value = 'Для скачивания нужна внешняя ссылка http или https';
+        return;
+    }
+    uploading.value = true;
+    error.value = '';
+    try {
+        const response = await api.uploadMediaAssetFromUrl({
+            url,
+            kind: props.kind,
+            tags: props.tags,
+        });
+        const uploaded = response.items?.[0];
+        if (!uploaded?.url) {
+            throw new Error('Загрузка завершилась без URL файла');
+        }
+        pickedUrl(uploaded.url);
+        emit('uploaded', uploaded.url);
+        remoteUrl.value = '';
+        rememberUploadedAsset(uploaded);
+    } catch (err) {
+        error.value = mediaErrorMessage(err, 'Не удалось загрузить изображение по URL');
+    } finally {
+        uploading.value = false;
+    }
+};
+
+const extensionFromMime = (mimeType: string) => mimeType.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+
+const pasteFromClipboard = async () => {
+    const clipboard = navigator.clipboard as Clipboard & { read?: () => Promise<ClipboardImageItem[]> };
+    if (!clipboard?.read) {
+        error.value = 'Вставьте изображение через Ctrl+V или Cmd+V на странице.';
+        return;
+    }
+    try {
+        const items = await clipboard.read();
+        for (const item of items) {
+            const imageType = item.types.find((type) => type.startsWith('image/'));
+            if (!imageType) continue;
+            const blob = await item.getType(imageType);
+            await uploadFile(new File([blob], `clipboard-${Date.now()}.${extensionFromMime(imageType)}`, { type: imageType }));
+            return;
+        }
+        error.value = 'В буфере нет изображения';
+    } catch (err) {
+        error.value = mediaErrorMessage(err, 'Не удалось прочитать изображение из буфера');
+    }
+};
 </script>
 
 <template>
@@ -83,11 +227,31 @@ const clearValue = () => {
                     type="button"
                     class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 hover:text-teal-700 disabled:cursor-wait disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-200"
                     :disabled="uploading"
+                    title="Выбрать из медиатеки"
+                    aria-label="Выбрать из медиатеки"
+                    @click="openPicker"
+                >
+                    <Images class="h-4 w-4" />
+                </button>
+                <button
+                    type="button"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 hover:text-teal-700 disabled:cursor-wait disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-200"
+                    :disabled="uploading"
                     title="Загрузить файл"
                     aria-label="Загрузить файл"
                     @click="chooseFile"
                 >
-                    <span class="material-icons-round text-[18px]">upload</span>
+                    <UploadCloud class="h-4 w-4" />
+                </button>
+                <button
+                    type="button"
+                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 hover:text-teal-700 disabled:cursor-wait disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-200"
+                    :disabled="uploading"
+                    title="Вставить из буфера"
+                    aria-label="Вставить из буфера"
+                    @click="pasteFromClipboard"
+                >
+                    <ClipboardPaste class="h-4 w-4" />
                 </button>
                 <button
                     v-if="normalizedUrl"
@@ -97,7 +261,7 @@ const clearValue = () => {
                     aria-label="Очистить"
                     @click="clearValue"
                 >
-                    <span class="material-icons-round text-[18px]">close</span>
+                    <Trash2 class="h-4 w-4" />
                 </button>
             </div>
         </div>
@@ -114,19 +278,33 @@ const clearValue = () => {
             <div class="flex h-24 w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-slate-700 dark:bg-slate-950 sm:w-24">
                 <img
                     v-if="normalizedUrl"
-                    :src="normalizedUrl"
+                    :src="imageUrl(normalizedUrl)"
                     :alt="label"
                     class="max-h-full max-w-full object-contain"
                 />
-                <span v-else class="material-icons-round text-[28px] text-gray-300 dark:text-slate-600">image</span>
+                <ImageIcon v-else class="h-8 w-8 text-gray-300 dark:text-slate-600" />
             </div>
             <label class="min-w-0 text-sm">
-                <input
-                    v-model="value"
-                    type="text"
-                    :placeholder="placeholder"
-                    class="w-full rounded-lg border border-gray-200 bg-slate-100 px-3 py-2 dark:border-slate-700 dark:bg-slate-900"
-                />
+                <span class="relative block">
+                    <input
+                        v-model="value"
+                        type="text"
+                        :placeholder="placeholder"
+                        class="w-full rounded-lg border border-gray-200 bg-slate-100 px-3 py-2 pr-10 dark:border-slate-700 dark:bg-slate-900"
+                        @keydown.enter.prevent="canImportCurrentUrl ? uploadFromUrl() : undefined"
+                    />
+                    <button
+                        v-if="canImportCurrentUrl"
+                        type="button"
+                        class="absolute right-1 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-teal-700 transition hover:bg-teal-50 disabled:cursor-wait disabled:opacity-50 dark:text-teal-200 dark:hover:bg-teal-950/40"
+                        :disabled="uploading"
+                        title="Скачать URL в медиатеку"
+                        aria-label="Скачать URL в медиатеку"
+                        @click="uploadFromUrl()"
+                    >
+                        <Download class="h-4 w-4" />
+                    </button>
+                </span>
                 <span v-if="uploading" class="mt-1 block text-xs font-medium text-teal-700 dark:text-teal-300">
                     Загрузка...
                 </span>
@@ -134,6 +312,144 @@ const clearValue = () => {
                     {{ error }}
                 </span>
             </label>
+        </div>
+
+        <div
+            v-if="pickerOpen"
+            class="fixed inset-0 z-[95] flex items-center justify-center bg-slate-950/55 p-3 backdrop-blur-sm"
+            @click.self="pickerOpen = false"
+        >
+            <div class="flex max-h-[88vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-slate-700 dark:bg-slate-900">
+                <header class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-slate-700">
+                    <div class="min-w-0">
+                        <h3 class="text-base font-bold text-gray-900 dark:text-slate-100">Выбор изображения</h3>
+                        <p class="text-xs text-gray-500 dark:text-slate-400">Медиатека, загрузка, URL и буфер обмена в одном месте.</p>
+                    </div>
+                    <button
+                        type="button"
+                        class="inline-flex h-9 w-9 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                        aria-label="Закрыть"
+                        @click="pickerOpen = false"
+                    >
+                        <X class="h-5 w-5" />
+                    </button>
+                </header>
+
+                <div class="space-y-3 border-b border-gray-200 p-4 dark:border-slate-700">
+                    <div class="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_auto_auto]">
+                        <label class="relative block">
+                            <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                            <input
+                                v-model="pickerQuery"
+                                type="search"
+                                class="w-full rounded-lg border border-gray-200 bg-slate-100 py-2 pl-9 pr-3 text-sm dark:border-slate-700 dark:bg-slate-950"
+                                placeholder="Поиск по медиатеке"
+                                @keydown.enter.prevent="loadAssets(1)"
+                            />
+                        </label>
+                        <button
+                            type="button"
+                            class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                            :disabled="assetsLoading"
+                            @click="loadAssets(1)"
+                        >
+                            <Search class="h-4 w-4" />
+                            Найти
+                        </button>
+                        <button
+                            type="button"
+                            class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-3 py-2 text-sm font-semibold text-white hover:bg-teal-700 disabled:cursor-wait disabled:opacity-60"
+                            :disabled="uploading"
+                            @click="chooseFile"
+                        >
+                            <UploadCloud class="h-4 w-4" />
+                            Загрузить
+                        </button>
+                    </div>
+
+                    <div class="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,1fr)_auto_auto]">
+                        <input
+                            v-model="remoteUrl"
+                            type="url"
+                            class="w-full rounded-lg border border-gray-200 bg-slate-100 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+                            placeholder="https://site.by/image.webp"
+                            @keydown.enter.prevent="uploadFromUrl(remoteUrl)"
+                        />
+                        <button
+                            type="button"
+                            class="inline-flex items-center justify-center gap-2 rounded-lg border border-teal-200 px-3 py-2 text-sm font-semibold text-teal-700 hover:bg-teal-50 disabled:cursor-wait disabled:opacity-60 dark:border-teal-900/70 dark:text-teal-200 dark:hover:bg-teal-950/30"
+                            :disabled="uploading"
+                            @click="uploadFromUrl(remoteUrl)"
+                        >
+                            <Download class="h-4 w-4" />
+                            Скачать URL
+                        </button>
+                        <button
+                            type="button"
+                            class="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                            :disabled="uploading"
+                            @click="pasteFromClipboard"
+                        >
+                            <ClipboardPaste class="h-4 w-4" />
+                            Вставить
+                        </button>
+                    </div>
+                </div>
+
+                <div class="min-h-0 flex-1 overflow-y-auto p-4">
+                    <div v-if="assetsLoading" class="grid grid-cols-2 gap-3 md:grid-cols-4">
+                        <div v-for="idx in 8" :key="idx" class="h-40 animate-pulse rounded-xl bg-gray-100 dark:bg-slate-800" />
+                    </div>
+                    <div v-else-if="!assets.length" class="flex min-h-[260px] items-center justify-center rounded-xl border border-dashed border-gray-300 text-center dark:border-slate-700">
+                        <div>
+                            <ImageIcon class="mx-auto h-10 w-10 text-gray-300 dark:text-slate-600" />
+                            <p class="mt-2 text-sm font-semibold text-gray-900 dark:text-slate-100">Изображений не найдено</p>
+                            <p class="mt-1 text-xs text-gray-500 dark:text-slate-400">Загрузите файл или скачайте картинку по URL.</p>
+                        </div>
+                    </div>
+                    <div v-else class="grid grid-cols-2 gap-3 md:grid-cols-4">
+                        <button
+                            v-for="asset in assets"
+                            :key="asset.id"
+                            type="button"
+                            class="group overflow-hidden rounded-xl border bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-teal-400 hover:shadow-md dark:bg-slate-950"
+                            :class="asset.url === normalizedUrl ? 'border-teal-500 ring-2 ring-teal-500/20' : 'border-gray-200 dark:border-slate-700'"
+                            @click="selectAsset(asset)"
+                        >
+                            <span class="flex aspect-[4/3] items-center justify-center bg-gray-100 dark:bg-slate-900">
+                                <img :src="imageUrl(asset.url)" :alt="asset.alt_text || asset.title" class="h-full w-full object-contain" loading="lazy" />
+                            </span>
+                            <span class="block space-y-1 p-2">
+                                <span class="block truncate text-xs font-semibold text-gray-900 dark:text-slate-100">{{ asset.title || asset.source_filename || asset.url }}</span>
+                                <span class="block truncate text-[11px] text-gray-500 dark:text-slate-400">{{ asset.width || 0 }}×{{ asset.height || 0 }} · {{ asset.kind }}</span>
+                            </span>
+                        </button>
+                    </div>
+                </div>
+
+                <footer class="flex items-center justify-between gap-3 border-t border-gray-200 px-4 py-3 text-sm text-gray-500 dark:border-slate-700 dark:text-slate-400">
+                    <span>Найдено: {{ pickerTotal }}</span>
+                    <div class="flex items-center gap-2">
+                        <button
+                            type="button"
+                            class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-50 dark:border-slate-700"
+                            :disabled="pickerPage <= 1 || assetsLoading"
+                            @click="loadAssets(pickerPage - 1)"
+                        >
+                            Назад
+                        </button>
+                        <span>{{ pickerPage }} / {{ pickerPages }}</span>
+                        <button
+                            type="button"
+                            class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-50 dark:border-slate-700"
+                            :disabled="pickerPage >= pickerPages || assetsLoading"
+                            @click="loadAssets(pickerPage + 1)"
+                        >
+                            Вперёд
+                        </button>
+                    </div>
+                </footer>
+            </div>
         </div>
     </div>
 </template>

--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -16,11 +16,36 @@ type BrandForm = {
 type SeriesForm = {
     title: string;
     slug: string;
+    tagline: string;
+    short_description: string;
     description: string;
     hero_image: string;
+    galleryImages: string[];
     featuresText: string;
+    featureBlocks: SeriesFeatureBlockForm[];
+    contentBlocks: SeriesContentBlockForm[];
+    footnotesText: string;
+    seo_title: string;
+    seo_description: string;
+    source_url: string;
     sort_order: number;
     is_published: boolean;
+};
+
+type SeriesFeatureBlockForm = {
+    title: string;
+    text: string;
+    image_url: string;
+    icon: string;
+    footnote: string;
+};
+
+type SeriesContentBlockForm = {
+    kind: 'text' | 'image_text' | 'media';
+    title: string;
+    text: string;
+    image_url: string;
+    layout: 'text_left' | 'text_right' | 'full';
 };
 
 const brands = ref<ManagerBrand[]>([]);
@@ -56,12 +81,22 @@ const form = ref<BrandForm>({
 const seriesForm = ref<SeriesForm>({
     title: '',
     slug: '',
+    tagline: '',
+    short_description: '',
     description: '',
     hero_image: '',
+    galleryImages: [],
     featuresText: '',
+    featureBlocks: [],
+    contentBlocks: [],
+    footnotesText: '',
+    seo_title: '',
+    seo_description: '',
+    source_url: '',
     sort_order: 0,
     is_published: true,
 });
+const pendingGalleryImage = ref('');
 
 const filteredBrands = computed(() => {
     const q = query.value.trim().toLowerCase();
@@ -114,7 +149,20 @@ const moveItemById = <T extends { id: number }>(items: T[], draggedId: number, t
 
 const isSeriesExpanded = (seriesId: number) => expandedSeriesIds.value.has(seriesId);
 
-const hasSeriesDetails = (series: ManagerBrandSeries) => Boolean(series.description || series.features?.length);
+const hasSeriesDetails = (series: ManagerBrandSeries) => Boolean(
+    series.tagline
+    || series.short_description
+    || series.description
+    || series.hero_image
+    || series.gallery_images?.length
+    || series.features?.length
+    || series.feature_blocks?.length
+    || series.content_blocks?.length
+    || series.footnotes?.length
+    || series.seo_title
+    || series.seo_description
+    || series.source_url
+);
 
 const toggleSeriesExpanded = (seriesId: number) => {
     const next = new Set(expandedSeriesIds.value);
@@ -156,12 +204,22 @@ const resetForm = () => {
 };
 
 const resetSeriesForm = () => {
+    pendingGalleryImage.value = '';
     seriesForm.value = {
         title: '',
         slug: '',
+        tagline: '',
+        short_description: '',
         description: '',
         hero_image: '',
+        galleryImages: [],
         featuresText: '',
+        featureBlocks: [],
+        contentBlocks: [],
+        footnotesText: '',
+        seo_title: '',
+        seo_description: '',
+        source_url: '',
         sort_order: getNextSortOrder(seriesItems.value),
         is_published: true,
     };
@@ -256,9 +314,30 @@ const openSeriesEdit = (series: ManagerBrandSeries) => {
     seriesForm.value = {
         title: String(series.title || ''),
         slug: String(series.slug || ''),
+        tagline: String(series.tagline || ''),
+        short_description: String(series.short_description || ''),
         description: String(series.description || ''),
         hero_image: String(series.hero_image || ''),
+        galleryImages: [...(series.gallery_images || [])],
         featuresText: (series.features || []).join('\n'),
+        featureBlocks: (series.feature_blocks || []).map((block) => ({
+            title: String(block.title || ''),
+            text: String(block.text || ''),
+            image_url: String(block.image_url || ''),
+            icon: String(block.icon || ''),
+            footnote: String(block.footnote || ''),
+        })),
+        contentBlocks: (series.content_blocks || []).map((block) => ({
+            kind: block.kind || 'text',
+            title: String(block.title || ''),
+            text: String(block.text || ''),
+            image_url: String(block.image_url || ''),
+            layout: block.layout || 'text_left',
+        })),
+        footnotesText: (series.footnotes || []).join('\n'),
+        seo_title: String(series.seo_title || ''),
+        seo_description: String(series.seo_description || ''),
+        source_url: String(series.source_url || ''),
         sort_order: Number(series.sort_order || 0),
         is_published: Boolean(series.is_published),
     };
@@ -273,6 +352,10 @@ const closeSeriesModal = () => {
 };
 
 const normalizeFeatures = (value: string) => {
+    return normalizeTextList(value);
+};
+
+const normalizeTextList = (value: string) => {
     const seen = new Set<string>();
     return String(value || '')
         .split('\n')
@@ -284,6 +367,85 @@ const normalizeFeatures = (value: string) => {
             seen.add(key);
             return true;
         });
+};
+
+const normalizeUrlList = (value: string[]) => {
+    const seen = new Set<string>();
+    return value
+        .map((item) => String(item || '').trim())
+        .filter((item) => {
+            if (!item) return false;
+            const key = item.toLowerCase();
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+};
+
+const normalizeFeatureBlocks = (blocks: SeriesFeatureBlockForm[]) => (
+    blocks
+        .map((block) => ({
+            title: String(block.title || '').trim(),
+            text: String(block.text || '').trim() || undefined,
+            image_url: String(block.image_url || '').trim() || undefined,
+            icon: String(block.icon || '').trim() || undefined,
+            footnote: String(block.footnote || '').trim() || undefined,
+        }))
+        .filter((block) => block.title)
+);
+
+const normalizeContentBlocks = (blocks: SeriesContentBlockForm[]) => (
+    blocks
+        .map((block) => ({
+            kind: block.kind || 'text',
+            title: String(block.title || '').trim() || undefined,
+            text: String(block.text || '').trim() || undefined,
+            image_url: String(block.image_url || '').trim() || undefined,
+            layout: block.layout || 'text_left',
+        }))
+        .filter((block) => block.title || block.text || block.image_url)
+);
+
+const addFeatureBlock = () => {
+    seriesForm.value.featureBlocks.push({
+        title: '',
+        text: '',
+        image_url: '',
+        icon: '',
+        footnote: '',
+    });
+};
+
+const removeFeatureBlock = (index: number) => {
+    seriesForm.value.featureBlocks.splice(index, 1);
+};
+
+const addContentBlock = () => {
+    seriesForm.value.contentBlocks.push({
+        kind: 'text',
+        title: '',
+        text: '',
+        image_url: '',
+        layout: 'text_left',
+    });
+};
+
+const removeContentBlock = (index: number) => {
+    seriesForm.value.contentBlocks.splice(index, 1);
+};
+
+const addGalleryImage = (url = pendingGalleryImage.value) => {
+    const normalized = String(url || '').trim();
+    if (!normalized) return;
+    const exists = seriesForm.value.galleryImages.some((item) => item.trim().toLowerCase() === normalized.toLowerCase());
+    if (!exists) {
+        seriesForm.value.galleryImages.push(normalized);
+    }
+    pendingGalleryImage.value = '';
+};
+
+const removeGalleryImage = (index: number) => {
+    seriesForm.value.galleryImages.splice(index, 1);
 };
 
 const saveBrand = async () => {
@@ -398,9 +560,18 @@ const saveSeries = async () => {
         const payload = {
             title,
             slug: String(seriesForm.value.slug || '').trim() || undefined,
+            tagline: String(seriesForm.value.tagline || '').trim() || undefined,
+            short_description: String(seriesForm.value.short_description || '').trim() || undefined,
             description: String(seriesForm.value.description || '').trim() || undefined,
             hero_image: String(seriesForm.value.hero_image || '').trim() || undefined,
+            gallery_images: normalizeUrlList(seriesForm.value.galleryImages),
             features: normalizeFeatures(seriesForm.value.featuresText),
+            feature_blocks: normalizeFeatureBlocks(seriesForm.value.featureBlocks),
+            content_blocks: normalizeContentBlocks(seriesForm.value.contentBlocks),
+            footnotes: normalizeTextList(seriesForm.value.footnotesText),
+            seo_title: String(seriesForm.value.seo_title || '').trim() || undefined,
+            seo_description: String(seriesForm.value.seo_description || '').trim() || undefined,
+            source_url: String(seriesForm.value.source_url || '').trim() || undefined,
             sort_order: wasEditing ? Number(seriesForm.value.sort_order || 0) : getNextSortOrder(seriesItems.value),
             is_published: Boolean(seriesForm.value.is_published),
         };
@@ -752,6 +923,12 @@ onMounted(() => {
                                     <span class="text-xs text-gray-500 dark:text-slate-400">{{ series.products_count }} товаров</span>
                                 </div>
                                 <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
+                                <p v-if="series.tagline" class="mt-0.5 text-sm font-semibold text-gray-700 dark:text-slate-200">
+                                    {{ series.tagline }}
+                                </p>
+                                <p v-else-if="series.short_description" class="mt-0.5 line-clamp-2 text-sm text-gray-500 dark:text-slate-400">
+                                    {{ series.short_description }}
+                                </p>
                             </div>
                         </div>
                         <div v-if="series.features?.length && !isSeriesExpanded(series.id)" class="flex min-w-0 flex-1 flex-wrap gap-1.5 lg:max-w-[34%]">
@@ -800,9 +977,44 @@ onMounted(() => {
                         </div>
                     </div>
                     <div
+                        v-if="!isSeriesExpanded(series.id)"
+                        class="mt-2 flex flex-wrap gap-1.5 text-[11px] font-semibold"
+                    >
+                        <span
+                            v-if="series.gallery_images?.length"
+                            class="rounded-full bg-blue-50 px-2 py-0.5 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200"
+                        >
+                            галерея {{ series.gallery_images.length }}
+                        </span>
+                        <span
+                            v-if="series.feature_blocks?.length"
+                            class="rounded-full bg-purple-50 px-2 py-0.5 text-purple-700 dark:bg-purple-950/30 dark:text-purple-200"
+                        >
+                            преимущества {{ series.feature_blocks.length }}
+                        </span>
+                        <span
+                            v-if="series.content_blocks?.length"
+                            class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700 dark:bg-amber-950/30 dark:text-amber-200"
+                        >
+                            контент {{ series.content_blocks.length }}
+                        </span>
+                        <span
+                            v-if="series.seo_title || series.seo_description"
+                            class="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200"
+                        >
+                            SEO
+                        </span>
+                    </div>
+                    <div
                         v-if="isSeriesExpanded(series.id)"
                         class="mt-2 border-t border-gray-200 dark:border-slate-700 pt-2 text-sm text-gray-600 dark:text-slate-300"
                     >
+                        <p v-if="series.tagline" class="font-semibold text-gray-800 dark:text-slate-100">
+                            {{ series.tagline }}
+                        </p>
+                        <p v-if="series.short_description" class="mt-1">
+                            {{ series.short_description }}
+                        </p>
                         <p v-if="series.description">
                             {{ series.description }}
                         </p>
@@ -814,6 +1026,16 @@ onMounted(() => {
                             >
                                 {{ feature }}
                             </span>
+                        </div>
+                        <div v-if="series.feature_blocks?.length" class="mt-2 grid gap-1.5 sm:grid-cols-2">
+                            <div
+                                v-for="block in series.feature_blocks"
+                                :key="`${series.id}-${block.title}`"
+                                class="rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs dark:border-slate-700 dark:bg-slate-900"
+                            >
+                                <span class="font-semibold text-gray-800 dark:text-slate-100">{{ block.title }}</span>
+                                <p v-if="block.text" class="mt-0.5 text-gray-500 dark:text-slate-400">{{ block.text }}</p>
+                            </div>
                         </div>
                     </div>
                 </article>
@@ -878,44 +1100,256 @@ onMounted(() => {
             class="fixed inset-0 z-[70] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
             @click.self="closeSeriesModal"
         >
-            <div class="w-full max-w-3xl rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-2xl overflow-hidden">
+            <div class="w-full max-w-5xl rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-2xl overflow-hidden">
                 <header class="px-5 py-4 border-b border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60">
                     <h2 class="text-lg font-bold text-gray-900 dark:text-slate-100">
                         {{ editingSeries ? 'Редактирование серии' : 'Новая серия' }}
                     </h2>
                     <p v-if="selectedBrand" class="text-sm text-gray-500 dark:text-slate-400">{{ selectedBrand.title }}</p>
                 </header>
-                <div class="p-5 space-y-3">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <label class="text-sm space-y-1">
-                            <span class="text-gray-600 dark:text-slate-300 font-medium">Название</span>
-                            <input v-model="seriesForm.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                <div class="max-h-[72vh] overflow-y-auto p-5 space-y-5">
+                    <section class="space-y-3">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                            <label class="text-sm space-y-1">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Название</span>
+                                <input v-model="seriesForm.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                            <label class="text-sm space-y-1">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Slug</span>
+                                <input v-model="seriesForm.slug" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                            <label class="text-sm space-y-1">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Слоган</span>
+                                <input v-model="seriesForm.tagline" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Охлаждение без прямого потока" />
+                            </label>
+                            <label class="text-sm space-y-1">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Источник</span>
+                                <input v-model="seriesForm.source_url" type="url" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="https://..." />
+                            </label>
+                        </div>
+                        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                            <label class="text-sm space-y-1 block">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Короткое описание</span>
+                                <textarea v-model="seriesForm.short_description" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                            <label class="text-sm space-y-1 block">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Описание серии</span>
+                                <textarea v-model="seriesForm.description" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                        </div>
+                    </section>
+
+                    <section class="space-y-4 border-t border-gray-200 pt-4 dark:border-slate-700">
+                        <div class="max-w-2xl">
+                            <MediaField
+                                v-model="seriesForm.hero_image"
+                                label="Hero image"
+                                kind="brand"
+                                :tags="['series', 'hero']"
+                                accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                placeholder="/media/library/original/series.webp"
+                            />
+                        </div>
+                        <div class="space-y-3">
+                            <div>
+                                <h3 class="text-sm font-medium text-gray-600 dark:text-slate-300">Галерея</h3>
+                                <p class="mt-1 text-xs text-gray-500 dark:text-slate-400">Изображения серии для лендингов, карточек и промо-блоков.</p>
+                            </div>
+                            <div v-if="seriesForm.galleryImages.length" class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                                <div
+                                    v-for="(_, index) in seriesForm.galleryImages"
+                                    :key="`gallery-${index}`"
+                                    class="rounded-xl border border-gray-200 p-3 dark:border-slate-700"
+                                >
+                                    <div class="mb-2 flex items-center justify-between gap-3">
+                                        <span class="text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-slate-400">Изображение {{ index + 1 }}</span>
+                                        <button
+                                            type="button"
+                                            class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30"
+                                            title="Удалить из галереи"
+                                            aria-label="Удалить из галереи"
+                                            @click="removeGalleryImage(index)"
+                                        >
+                                            <span class="material-icons-round text-[18px]">delete</span>
+                                        </button>
+                                    </div>
+                                    <MediaField
+                                        v-model="seriesForm.galleryImages[index]"
+                                        :label="`URL ${index + 1}`"
+                                        kind="brand"
+                                        :tags="['series', 'gallery']"
+                                        accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                        placeholder="/media/library/original/series-gallery.webp"
+                                    />
+                                </div>
+                            </div>
+                            <p v-else class="rounded-xl border border-dashed border-gray-300 px-3 py-3 text-sm text-gray-500 dark:border-slate-700 dark:text-slate-400">
+                                Галерея пока пустая.
+                            </p>
+                            <div class="rounded-xl border border-teal-100 bg-teal-50/40 p-3 dark:border-teal-900/60 dark:bg-teal-950/20">
+                                <MediaField
+                                    v-model="pendingGalleryImage"
+                                    label="Добавить изображение"
+                                    kind="brand"
+                                    :tags="['series', 'gallery']"
+                                    accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                    placeholder="/media/library/original/series-gallery.webp"
+                                    @picked="addGalleryImage"
+                                />
+                                <button
+                                    v-if="pendingGalleryImage"
+                                    type="button"
+                                    class="mt-3 inline-flex items-center gap-1 rounded-lg bg-teal-600 px-3 py-2 text-xs font-semibold text-white hover:bg-teal-700"
+                                    @click="addGalleryImage()"
+                                >
+                                    <span class="material-icons-round text-[16px]">add</span>
+                                    Добавить в галерею
+                                </button>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="space-y-3 border-t border-gray-200 pt-4 dark:border-slate-700">
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-gray-500 dark:text-slate-400">Преимущества</h3>
+                                <p class="text-xs text-gray-500 dark:text-slate-400">Короткие фичи идут чипсами, блоки можно раскрыть на сайте подробнее.</p>
+                            </div>
+                            <button type="button" class="inline-flex items-center gap-1 rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 dark:border-teal-900/60 dark:text-teal-200 dark:hover:bg-teal-950/30" @click="addFeatureBlock">
+                                <span class="material-icons-round text-[16px]">add</span>
+                                Блок
+                            </button>
+                        </div>
+                        <label class="text-sm space-y-1 block">
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Фичи серии</span>
+                            <textarea v-model="seriesForm.featuresText" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна фича на строку" />
                         </label>
-                        <label class="text-sm space-y-1">
-                            <span class="text-gray-600 dark:text-slate-300 font-medium">Slug</span>
-                            <input v-model="seriesForm.slug" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                        <div v-if="seriesForm.featureBlocks.length" class="space-y-3">
+                            <div
+                                v-for="(block, index) in seriesForm.featureBlocks"
+                                :key="`feature-${index}`"
+                                class="rounded-xl border border-gray-200 p-3 dark:border-slate-700"
+                            >
+                                <div class="mb-3 flex items-center justify-between gap-3">
+                                    <span class="text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-slate-400">Преимущество {{ index + 1 }}</span>
+                                    <button type="button" class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30" @click="removeFeatureBlock(index)">
+                                        <span class="material-icons-round text-[18px]">delete</span>
+                                    </button>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Заголовок</span>
+                                        <input v-model="block.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                                    </label>
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Иконка</span>
+                                        <input v-model="block.icon" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="air / bolt / self_cleaning" />
+                                    </label>
+                                    <MediaField
+                                        v-model="block.image_url"
+                                        label="Изображение"
+                                        kind="brand"
+                                        :tags="['series', 'feature']"
+                                        accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                        placeholder="/media/library/original/feature.webp"
+                                    />
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Сноска</span>
+                                        <input v-model="block.footnote" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                                    </label>
+                                </div>
+                                <label class="mt-3 block text-sm space-y-1">
+                                    <span class="text-gray-600 dark:text-slate-300 font-medium">Описание</span>
+                                    <textarea v-model="block.text" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                                </label>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="space-y-3 border-t border-gray-200 pt-4 dark:border-slate-700">
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <h3 class="text-sm font-bold uppercase tracking-[0.16em] text-gray-500 dark:text-slate-400">Контентные блоки</h3>
+                                <p class="text-xs text-gray-500 dark:text-slate-400">Основа для будущих секций серии как на фирменных страницах.</p>
+                            </div>
+                            <button type="button" class="inline-flex items-center gap-1 rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 dark:border-teal-900/60 dark:text-teal-200 dark:hover:bg-teal-950/30" @click="addContentBlock">
+                                <span class="material-icons-round text-[16px]">add</span>
+                                Секция
+                            </button>
+                        </div>
+                        <div v-if="seriesForm.contentBlocks.length" class="space-y-3">
+                            <div
+                                v-for="(block, index) in seriesForm.contentBlocks"
+                                :key="`content-${index}`"
+                                class="rounded-xl border border-gray-200 p-3 dark:border-slate-700"
+                            >
+                                <div class="mb-3 flex items-center justify-between gap-3">
+                                    <span class="text-xs font-bold uppercase tracking-[0.14em] text-gray-500 dark:text-slate-400">Секция {{ index + 1 }}</span>
+                                    <button type="button" class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30" @click="removeContentBlock(index)">
+                                        <span class="material-icons-round text-[18px]">delete</span>
+                                    </button>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Тип</span>
+                                        <select v-model="block.kind" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900">
+                                            <option value="text">Текст</option>
+                                            <option value="image_text">Текст + изображение</option>
+                                            <option value="media">Медиа</option>
+                                        </select>
+                                    </label>
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Макет</span>
+                                        <select v-model="block.layout" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900">
+                                            <option value="text_left">Текст слева</option>
+                                            <option value="text_right">Текст справа</option>
+                                            <option value="full">На всю ширину</option>
+                                        </select>
+                                    </label>
+                                    <label class="text-sm space-y-1">
+                                        <span class="text-gray-600 dark:text-slate-300 font-medium">Заголовок</span>
+                                        <input v-model="block.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                                    </label>
+                                    <MediaField
+                                        v-model="block.image_url"
+                                        label="Изображение"
+                                        kind="brand"
+                                        :tags="['series', 'content']"
+                                        accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                        placeholder="/media/library/original/series-content.webp"
+                                    />
+                                </div>
+                                <label class="mt-3 block text-sm space-y-1">
+                                    <span class="text-gray-600 dark:text-slate-300 font-medium">Текст</span>
+                                    <textarea v-model="block.text" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                                </label>
+                            </div>
+                        </div>
+                        <p v-else class="rounded-xl border border-dashed border-gray-300 px-3 py-3 text-sm text-gray-500 dark:border-slate-700 dark:text-slate-400">
+                            Контентных секций пока нет.
+                        </p>
+                    </section>
+
+                    <section class="grid grid-cols-1 lg:grid-cols-2 gap-4 border-t border-gray-200 pt-4 dark:border-slate-700">
+                        <label class="text-sm space-y-1 block">
+                            <span class="text-gray-600 dark:text-slate-300 font-medium">Сноски</span>
+                            <textarea v-model="seriesForm.footnotesText" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна сноска на строку" />
                         </label>
-                    </div>
-                    <MediaField
-                        v-model="seriesForm.hero_image"
-                        label="Hero image"
-                        kind="brand"
-                        :tags="['series', 'hero']"
-                        accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
-                        placeholder="/media/library/original/series.webp"
-                    />
-                    <label class="text-sm space-y-1 block">
-                        <span class="text-gray-600 dark:text-slate-300 font-medium">Описание серии</span>
-                        <textarea v-model="seriesForm.description" rows="5" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
-                        <span class="block text-xs text-gray-500 dark:text-slate-400">
-                            Короткий текст для страницы бренда и карточки товара.
-                        </span>
-                    </label>
-                    <label class="text-sm space-y-1 block">
-                        <span class="text-gray-600 dark:text-slate-300 font-medium">Фичи серии</span>
-                        <textarea v-model="seriesForm.featuresText" rows="5" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна фича на строку" />
-                    </label>
-                    <label class="text-sm flex items-center gap-2">
+                        <div class="space-y-3">
+                            <label class="text-sm space-y-1 block">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">SEO title</span>
+                                <input v-model="seriesForm.seo_title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                            <label class="text-sm space-y-1 block">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">SEO description</span>
+                                <textarea v-model="seriesForm.seo_description" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                        </div>
+                    </section>
+
+                    <label class="text-sm flex items-center gap-2 border-t border-gray-200 pt-4 dark:border-slate-700">
                         <input v-model="seriesForm.is_published" type="checkbox" class="rounded border-gray-300 dark:border-slate-700" />
                         <span class="text-gray-600 dark:text-slate-300 font-medium">Публиковать серию</span>
                     </label>

--- a/manager_frontend/src/views/CatalogQualityView.vue
+++ b/manager_frontend/src/views/CatalogQualityView.vue
@@ -1,0 +1,515 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { watchDebounced } from '@vueuse/core';
+import {
+  AlertTriangle,
+  BadgeDollarSign,
+  CheckCircle2,
+  CircleAlert,
+  Image as ImageIcon,
+  Info,
+  ListChecks,
+  PackageCheck,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  SlidersHorizontal,
+  Sparkles,
+  Truck,
+  X,
+} from 'lucide-vue-next';
+import { api, type ManagerCatalogQualityReportResponse } from '../api';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+type QualityProduct = ManagerCatalogQualityReportResponse['items'][number];
+type QualityIssue = NonNullable<QualityProduct['issues']>[number];
+type CategoryFilter = 'all' | 'media' | 'identity' | 'specs' | 'commerce' | 'supplier';
+type SeverityFilter = 'all' | 'critical' | 'warning' | 'info';
+
+const report = ref<ManagerCatalogQualityReportResponse | null>(null);
+const loading = ref(false);
+const error = ref('');
+const search = ref('');
+const activeCategory = ref<CategoryFilter>('all');
+const activeSeverity = ref<SeverityFilter>('all');
+const selectedIssueCode = ref<string | null>(null);
+const onlyProblems = ref(true);
+const page = ref(1);
+const limit = 50;
+
+const categoryFilters: Array<{ value: CategoryFilter; label: string; icon: unknown }> = [
+  { value: 'all', label: 'Все', icon: Sparkles },
+  { value: 'media', label: 'Медиа', icon: ImageIcon },
+  { value: 'identity', label: 'Бренд и серия', icon: PackageCheck },
+  { value: 'specs', label: 'Характеристики', icon: ListChecks },
+  { value: 'supplier', label: 'Поставщики', icon: Truck },
+  { value: 'commerce', label: 'Цена и наличие', icon: BadgeDollarSign },
+];
+
+const severityFilters: Array<{ value: SeverityFilter; label: string; icon: unknown }> = [
+  { value: 'all', label: 'Все приоритеты', icon: SlidersHorizontal },
+  { value: 'critical', label: 'Критично', icon: CircleAlert },
+  { value: 'warning', label: 'Предупреждения', icon: AlertTriangle },
+  { value: 'info', label: 'Заметки', icon: Info },
+];
+
+const items = computed(() => report.value?.items ?? []);
+const meta = computed(() => report.value?.meta);
+const totalPages = computed(() => meta.value?.pages ?? 1);
+const hasActiveFilters = computed(() => (
+  activeCategory.value !== 'all'
+  || activeSeverity.value !== 'all'
+  || !!selectedIssueCode.value
+  || !!search.value.trim()
+  || !onlyProblems.value
+));
+
+const categoryCounts = computed(() => {
+  const map: Record<string, number> = {};
+  for (const item of report.value?.categories ?? []) {
+    map[item.category] = item.count;
+  }
+  return map;
+});
+
+const severityCounts = computed(() => {
+  const counts: Record<SeverityFilter, number> = { all: 0, critical: 0, warning: 0, info: 0 };
+  for (const item of report.value?.summary ?? []) {
+    counts[item.severity] += item.count;
+    counts.all += item.count;
+  }
+  return counts;
+});
+
+const topSummary = computed(() => (report.value?.summary ?? []).slice(0, 10));
+
+const healthTone = computed(() => {
+  const score = report.value?.average_score ?? 100;
+  if (score >= 85) return 'text-emerald-700 bg-emerald-50 border-emerald-200';
+  if (score >= 65) return 'text-amber-700 bg-amber-50 border-amber-200';
+  return 'text-red-700 bg-red-50 border-red-200';
+});
+
+const loadReport = async () => {
+  loading.value = true;
+  error.value = '';
+  try {
+    report.value = await api.getCatalogQualityReport({
+      page: page.value,
+      limit,
+      q: search.value.trim() || null,
+      category: activeCategory.value === 'all' ? null : activeCategory.value,
+      severity: activeSeverity.value === 'all' ? null : activeSeverity.value,
+      issueCode: selectedIssueCode.value,
+      onlyProblems: onlyProblems.value,
+    });
+  } catch (e) {
+    error.value = getApiErrorMessage(e);
+  } finally {
+    loading.value = false;
+  }
+};
+
+watchDebounced(search, async () => {
+  page.value = 1;
+  await loadReport();
+}, { debounce: 350 });
+
+watch([activeCategory, activeSeverity, selectedIssueCode, onlyProblems], async () => {
+  page.value = 1;
+  await loadReport();
+});
+
+const refresh = async () => {
+  await loadReport();
+};
+
+const resetFilters = async () => {
+  search.value = '';
+  activeCategory.value = 'all';
+  activeSeverity.value = 'all';
+  selectedIssueCode.value = null;
+  onlyProblems.value = true;
+  page.value = 1;
+  await loadReport();
+};
+
+const goToPage = async (nextPage: number) => {
+  page.value = Math.min(Math.max(1, nextPage), totalPages.value);
+  await loadReport();
+};
+
+const selectIssue = (issueCode: string | null) => {
+  selectedIssueCode.value = selectedIssueCode.value === issueCode ? null : issueCode;
+};
+
+const openProduct = (product: QualityProduct) => {
+  const params = new URLSearchParams({
+    editProductId: String(product.product_id),
+    returnTo: '/manager/catalog-quality',
+  });
+  if (product.title) {
+    params.set('editProductQuery', product.title);
+  }
+  window.location.href = `/manager/products?${params.toString()}`;
+};
+
+const formatNumber = (value: number | null | undefined) => new Intl.NumberFormat('ru-RU').format(Number(value || 0));
+
+const formatCurrency = (value: number | null | undefined) =>
+  `${formatNumber(value)} BYN`;
+
+const scoreClass = (score: number) => {
+  if (score >= 85) return 'bg-emerald-50 text-emerald-700 ring-emerald-200';
+  if (score >= 65) return 'bg-amber-50 text-amber-700 ring-amber-200';
+  return 'bg-red-50 text-red-700 ring-red-200';
+};
+
+const severityClass = (severity: QualityIssue['severity']) => {
+  if (severity === 'critical') return 'bg-red-50 text-red-700 ring-red-200';
+  if (severity === 'warning') return 'bg-amber-50 text-amber-700 ring-amber-200';
+  return 'bg-sky-50 text-sky-700 ring-sky-200';
+};
+
+const cardToneClass = (product: QualityProduct) => {
+  const issues = product.issues ?? [];
+  if (issues.some((issue) => issue.severity === 'critical')) {
+    return 'border-red-200 shadow-[0_16px_40px_rgba(239,68,68,0.08)]';
+  }
+  if (issues.some((issue) => issue.severity === 'warning')) {
+    return 'border-amber-200 shadow-[0_16px_40px_rgba(245,158,11,0.08)]';
+  }
+  return 'border-emerald-200 shadow-[0_16px_40px_rgba(16,185,129,0.08)]';
+};
+
+const categoryIcon = (category: string) => {
+  if (category === 'media') return ImageIcon;
+  if (category === 'identity') return PackageCheck;
+  if (category === 'specs') return ListChecks;
+  if (category === 'supplier') return Truck;
+  if (category === 'commerce') return BadgeDollarSign;
+  return Info;
+};
+
+const imageSizeLabel = (product: QualityProduct) => {
+  if (!product.main_image_width || !product.main_image_height) return 'размер неизвестен';
+  return `${product.main_image_width}x${product.main_image_height}px`;
+};
+
+const mediaStatusLabel = (status?: string) => {
+  if (status === 'missing') return 'нет фото';
+  if (status === 'low_resolution') return 'маленькое фото';
+  if (status === 'unknown_dimensions') return 'размер неизвестен';
+  if (status === 'ok') return 'медиа ок';
+  return 'медиа не проверено';
+};
+
+const imageSrc = (url?: string | null) => {
+  if (!url) return '';
+  if (url.startsWith('http') || url.startsWith('/')) return url;
+  return `/${url}`;
+};
+
+onMounted(loadReport);
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-50 px-4 pb-5 pt-12 text-gray-950 sm:px-6 md:py-5 lg:px-8">
+    <div class="mx-auto max-w-7xl space-y-5">
+      <header class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div class="min-w-0">
+            <p class="text-xs font-semibold uppercase tracking-[0.22em] text-gray-500">PIM quality</p>
+            <h1 class="mt-1 text-2xl font-semibold tracking-normal text-gray-950 sm:text-3xl">
+              Качество каталога
+            </h1>
+            <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600">
+              Контроль карточек перед публикацией: медиа, бренд/серия, нормализованные характеристики, цена и связи с поставщиками.
+            </p>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              class="inline-flex h-10 items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-700 transition hover:border-teal-200 hover:text-teal-700 disabled:opacity-60"
+              :disabled="loading"
+              @click="refresh"
+            >
+              <RefreshCw class="h-4 w-4" :class="loading ? 'animate-spin' : ''" />
+              Обновить
+            </button>
+            <button
+              v-if="hasActiveFilters"
+              class="inline-flex h-10 items-center gap-2 rounded-xl bg-gray-100 px-3 text-sm font-semibold text-gray-700 transition hover:bg-gray-200"
+              @click="resetFilters"
+            >
+              <X class="h-4 w-4" />
+              Сбросить
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <article class="rounded-2xl border p-4 shadow-sm" :class="healthTone">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-sm font-medium opacity-80">Средний score</p>
+              <p class="mt-2 text-3xl font-semibold">{{ report?.average_score ?? '...' }}</p>
+            </div>
+            <ShieldCheck class="h-9 w-9 opacity-80" />
+          </div>
+        </article>
+        <article class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+          <p class="text-sm font-medium text-gray-500">Товаров в проверке</p>
+          <p class="mt-2 text-3xl font-semibold">{{ formatNumber(report?.total_products) }}</p>
+        </article>
+        <article class="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-800 shadow-sm">
+          <p class="text-sm font-medium opacity-80">С проблемами</p>
+          <p class="mt-2 text-3xl font-semibold">{{ formatNumber(report?.problem_products) }}</p>
+        </article>
+        <article class="rounded-2xl border border-red-200 bg-red-50 p-4 text-red-800 shadow-sm">
+          <p class="text-sm font-medium opacity-80">Критичных карточек</p>
+          <p class="mt-2 text-3xl font-semibold">{{ formatNumber(report?.critical_products) }}</p>
+        </article>
+      </section>
+
+      <section class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div class="grid gap-3 xl:grid-cols-[minmax(240px,1fr)_auto] xl:items-center">
+          <label class="relative block">
+            <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              v-model="search"
+              class="h-11 w-full rounded-xl border border-gray-200 bg-gray-50 pl-10 pr-3 text-sm font-medium outline-none transition focus:border-teal-300 focus:bg-white focus:ring-4 focus:ring-teal-100"
+              placeholder="Найти товар, slug или модель"
+            >
+          </label>
+          <label class="inline-flex h-11 items-center justify-between gap-3 rounded-xl border border-gray-200 bg-gray-50 px-3 text-sm font-semibold text-gray-700 sm:justify-start">
+            <input v-model="onlyProblems" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500" type="checkbox">
+            Только карточки с проблемами
+          </label>
+        </div>
+
+        <div class="mt-4 flex gap-2 overflow-x-auto pb-1">
+          <button
+            v-for="item in categoryFilters"
+            :key="item.value"
+            class="inline-flex h-10 shrink-0 items-center gap-2 rounded-full border px-3 text-sm font-semibold transition"
+            :class="activeCategory === item.value ? 'border-teal-600 bg-teal-600 text-white shadow-sm' : 'border-gray-200 bg-white text-gray-600 hover:border-teal-200 hover:text-teal-700'"
+            @click="activeCategory = item.value"
+          >
+            <component :is="item.icon" class="h-4 w-4" />
+            {{ item.label }}
+            <span v-if="item.value !== 'all'" class="rounded-full bg-black/10 px-2 py-0.5 text-xs">
+              {{ categoryCounts[item.value] || 0 }}
+            </span>
+          </button>
+        </div>
+
+        <div class="mt-3 flex gap-2 overflow-x-auto pb-1">
+          <button
+            v-for="item in severityFilters"
+            :key="item.value"
+            class="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border px-3 text-xs font-semibold transition"
+            :class="activeSeverity === item.value ? 'border-gray-900 bg-gray-900 text-white' : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-gray-300 hover:text-gray-900'"
+            @click="activeSeverity = item.value"
+          >
+            <component :is="item.icon" class="h-3.5 w-3.5" />
+            {{ item.label }}
+            <span class="rounded-full bg-black/10 px-1.5 py-0.5">{{ severityCounts[item.value] || 0 }}</span>
+          </button>
+        </div>
+      </section>
+
+      <div v-if="error" class="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-semibold text-red-700">
+        {{ error }}
+      </div>
+
+      <div class="grid gap-5 xl:grid-cols-[minmax(0,1fr)_340px]">
+        <section class="space-y-3">
+          <div class="flex items-center justify-between gap-3">
+            <p class="text-sm font-semibold text-gray-500">
+              Найдено: {{ formatNumber(meta?.total) }}
+            </p>
+            <p class="text-xs font-medium text-gray-400">
+              Стр. {{ meta?.page || 1 }} из {{ totalPages }}
+            </p>
+          </div>
+
+          <div v-if="loading && !report" class="grid gap-3">
+            <div v-for="index in 4" :key="index" class="h-32 animate-pulse rounded-2xl bg-white shadow-sm" />
+          </div>
+
+          <div v-else-if="!items.length" class="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center text-emerald-800">
+            <CheckCircle2 class="mx-auto h-10 w-10" />
+            <h2 class="mt-3 text-xl font-semibold">Здесь чисто</h2>
+            <p class="mt-2 text-sm opacity-80">По текущим фильтрам проблемных карточек не найдено.</p>
+          </div>
+
+          <template v-else>
+            <article
+              v-for="product in items"
+              :key="product.product_id"
+              class="overflow-hidden rounded-2xl border bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+              :class="cardToneClass(product)"
+            >
+              <div class="grid gap-4 p-4 sm:grid-cols-[132px,minmax(0,1fr)]">
+                <button
+                  class="group relative aspect-[4/3] overflow-hidden rounded-xl bg-gray-100 text-left"
+                  @click="openProduct(product)"
+                >
+                  <img
+                    v-if="product.main_image"
+                    :src="imageSrc(product.main_image)"
+                    :alt="product.title"
+                    class="h-full w-full object-contain transition group-hover:scale-105"
+                    loading="lazy"
+                  >
+                  <div v-else class="flex h-full w-full items-center justify-center bg-gray-100 text-gray-400">
+                    <ImageIcon class="h-9 w-9" />
+                  </div>
+                  <span
+                    class="absolute left-2 top-2 rounded-full px-2 py-1 text-xs font-bold ring-1"
+                    :class="scoreClass(product.score)"
+                  >
+                    {{ product.score }}
+                  </span>
+                </button>
+
+                <div class="min-w-0">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div class="min-w-0">
+                      <button class="block text-left text-lg font-semibold leading-snug text-gray-950 hover:text-teal-700" @click="openProduct(product)">
+                        {{ product.title }}
+                      </button>
+                      <p class="mt-1 truncate text-sm font-medium text-gray-500">
+                        {{ product.brand_title || 'Без бренда' }}
+                        <span class="text-gray-300">/</span>
+                        {{ product.series_title || 'без серии' }}
+                      </p>
+                    </div>
+                    <button
+                      class="inline-flex h-10 shrink-0 items-center justify-center rounded-xl bg-teal-600 px-3 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-700"
+                      @click="openProduct(product)"
+                    >
+                      Открыть товар
+                    </button>
+                  </div>
+
+                  <div class="mt-4 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                    <p class="rounded-xl bg-gray-50 px-3 py-2">
+                      <span class="block text-xs font-semibold uppercase text-gray-400">Цена</span>
+                      <span class="font-semibold">{{ formatCurrency(product.price) }}</span>
+                    </p>
+                    <p class="rounded-xl bg-gray-50 px-3 py-2">
+                      <span class="block text-xs font-semibold uppercase text-gray-400">Фото</span>
+                      <span class="font-semibold">{{ product.image_count || 0 }} шт. · {{ mediaStatusLabel(product.media_status) }}</span>
+                    </p>
+                    <p class="rounded-xl bg-gray-50 px-3 py-2">
+                      <span class="block text-xs font-semibold uppercase text-gray-400">Главное</span>
+                      <span class="font-semibold">{{ imageSizeLabel(product) }}</span>
+                    </p>
+                    <p class="rounded-xl bg-gray-50 px-3 py-2">
+                      <span class="block text-xs font-semibold uppercase text-gray-400">Поставщики</span>
+                      <span class="font-semibold">{{ product.supplier_mapping_count || 0 }} связей · {{ product.available_qty || 0 }} шт.</span>
+                    </p>
+                  </div>
+
+                  <div class="mt-4 flex flex-wrap gap-2">
+                    <button
+                      v-for="issue in product.issues || []"
+                      :key="`${product.product_id}-${issue.code}`"
+                      class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 transition hover:brightness-95"
+                      :class="severityClass(issue.severity)"
+                      :title="issue.detail || issue.message"
+                      @click="selectIssue(issue.code)"
+                    >
+                      <component :is="categoryIcon(issue.category)" class="h-3.5 w-3.5" />
+                      {{ issue.label }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </template>
+
+          <div v-if="report && totalPages > 1" class="flex items-center justify-between rounded-2xl border border-gray-200 bg-white p-3 shadow-sm">
+            <button
+              class="rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 disabled:opacity-40"
+              :disabled="page <= 1 || loading"
+              @click="goToPage(page - 1)"
+            >
+              Назад
+            </button>
+            <span class="text-sm font-semibold text-gray-500">{{ page }} / {{ totalPages }}</span>
+            <button
+              class="rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 disabled:opacity-40"
+              :disabled="page >= totalPages || loading"
+              @click="goToPage(page + 1)"
+            >
+              Дальше
+            </button>
+          </div>
+        </section>
+
+        <aside class="space-y-4">
+          <section class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm xl:sticky xl:top-4">
+            <div class="flex items-center justify-between gap-3">
+              <h2 class="text-base font-semibold text-gray-950">Частые причины</h2>
+              <span class="rounded-full bg-gray-100 px-2 py-1 text-xs font-bold text-gray-500">
+                {{ formatNumber(report?.summary?.length) }}
+              </span>
+            </div>
+
+            <div class="mt-3 space-y-2">
+              <button
+                v-for="item in topSummary"
+                :key="item.code"
+                class="flex w-full items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left transition hover:border-teal-200 hover:bg-teal-50/60"
+                :class="selectedIssueCode === item.code ? 'border-teal-300 bg-teal-50' : 'border-gray-100 bg-gray-50'"
+                @click="selectIssue(item.code)"
+              >
+                <span class="flex min-w-0 items-center gap-2">
+                  <component :is="categoryIcon(item.category)" class="h-4 w-4 shrink-0 text-gray-500" />
+                  <span class="truncate text-sm font-semibold text-gray-800">{{ item.label }}</span>
+                </span>
+                <span
+                  class="shrink-0 rounded-full px-2 py-1 text-xs font-bold ring-1"
+                  :class="severityClass(item.severity)"
+                >
+                  {{ item.count }}
+                </span>
+              </button>
+
+              <p v-if="!topSummary.length" class="rounded-xl bg-emerald-50 px-3 py-3 text-sm font-semibold text-emerald-700">
+                Массовых проблем не найдено.
+              </p>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+            <h2 class="text-base font-semibold text-gray-950">Категории</h2>
+            <div class="mt-3 space-y-2">
+              <div
+                v-for="item in report?.categories || []"
+                :key="item.category"
+                class="rounded-xl border border-gray-100 bg-gray-50 p-3"
+              >
+                <div class="flex items-center justify-between gap-3">
+                  <span class="flex items-center gap-2 text-sm font-semibold text-gray-800">
+                    <component :is="categoryIcon(item.category)" class="h-4 w-4 text-teal-700" />
+                    {{ item.label }}
+                  </span>
+                  <span class="text-sm font-bold text-gray-950">{{ item.count }}</span>
+                </div>
+                <div class="mt-2 flex gap-1.5 text-xs font-semibold">
+                  <span class="rounded-full bg-red-50 px-2 py-0.5 text-red-700">{{ item.critical || 0 }}</span>
+                  <span class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700">{{ item.warning || 0 }}</span>
+                  <span class="rounded-full bg-sky-50 px-2 py-0.5 text-sky-700">{{ item.info || 0 }}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </div>
+    </div>
+  </div>
+</template>

--- a/models/brand.py
+++ b/models/brand.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import Column, JSON, Text, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
@@ -34,9 +34,18 @@ class ProductSeries(SQLModel, table=True):
     brand_id: Optional[int] = Field(default=None, foreign_key="brand.id", index=True)
     title: str = Field(index=True)
     slug: str = Field(index=True)
+    tagline: Optional[str] = Field(default=None)
+    short_description: Optional[str] = Field(default=None, sa_column=Column(Text))
     description: Optional[str] = Field(default=None, sa_column=Column(Text))
     hero_image: Optional[str] = Field(default=None)
-    features: List[str] = Field(default=[], sa_column=Column(JSON))
+    gallery_images: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    features: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    feature_blocks: List[dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    content_blocks: List[dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    footnotes: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    seo_title: Optional[str] = Field(default=None)
+    seo_description: Optional[str] = Field(default=None, sa_column=Column(Text))
+    source_url: Optional[str] = Field(default=None)
     is_published: bool = Field(default=True, index=True)
     sort_order: int = Field(default=0)
     created_at: datetime = Field(default_factory=datetime.now)

--- a/openapi.json
+++ b/openapi.json
@@ -3754,6 +3754,153 @@
         }
       }
     },
+    "/api/manager/catalog-quality/report": {
+      "get": {
+        "tags": [
+          "manager catalog quality"
+        ],
+        "summary": "Get Manager Catalog Quality Report",
+        "operationId": "get_manager_catalog_quality_report",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 40,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "media",
+                    "identity",
+                    "specs",
+                    "commerce",
+                    "supplier"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Category"
+            }
+          },
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "critical",
+                    "warning",
+                    "info"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Severity"
+            }
+          },
+          {
+            "name": "issue_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Issue Code"
+            }
+          },
+          {
+            "name": "only_problems",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Only Problems"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerCatalogQualityReportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/main-image-cleanup/batches": {
       "post": {
         "tags": [
@@ -18442,6 +18589,28 @@
             ],
             "title": "Slug"
           },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "short_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Description"
+          },
           "description": {
             "anyOf": [
               {
@@ -18464,12 +18633,73 @@
             ],
             "title": "Hero Image"
           },
+          "gallery_images": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Gallery Images"
+          },
           "features": {
             "items": {
               "type": "string"
             },
             "type": "array",
             "title": "Features"
+          },
+          "feature_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesFeatureBlockResponse"
+            },
+            "type": "array",
+            "title": "Feature Blocks"
+          },
+          "content_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesContentBlockResponse"
+            },
+            "type": "array",
+            "title": "Content Blocks"
+          },
+          "footnotes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Footnotes"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "seo_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Description"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           },
           "is_published": {
             "type": "boolean",
@@ -18529,6 +18759,28 @@
             "type": "string",
             "title": "Slug"
           },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "short_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Description"
+          },
           "description": {
             "anyOf": [
               {
@@ -18551,12 +18803,73 @@
             ],
             "title": "Hero Image"
           },
+          "gallery_images": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Gallery Images"
+          },
           "features": {
             "items": {
               "type": "string"
             },
             "type": "array",
             "title": "Features"
+          },
+          "feature_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesFeatureBlockResponse"
+            },
+            "type": "array",
+            "title": "Feature Blocks"
+          },
+          "content_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesContentBlockResponse"
+            },
+            "type": "array",
+            "title": "Content Blocks"
+          },
+          "footnotes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Footnotes"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "seo_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Description"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           },
           "is_published": {
             "type": "boolean",
@@ -18612,6 +18925,28 @@
             ],
             "title": "Slug"
           },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "short_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Description"
+          },
           "description": {
             "anyOf": [
               {
@@ -18634,6 +18969,20 @@
             ],
             "title": "Hero Image"
           },
+          "gallery_images": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gallery Images"
+          },
           "features": {
             "anyOf": [
               {
@@ -18647,6 +18996,81 @@
               }
             ],
             "title": "Features"
+          },
+          "feature_blocks": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ProductSeriesFeatureBlockResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feature Blocks"
+          },
+          "content_blocks": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ProductSeriesContentBlockResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Blocks"
+          },
+          "footnotes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnotes"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "seo_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Description"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           },
           "is_published": {
             "anyOf": [
@@ -19431,6 +19855,347 @@
           "group_color"
         ],
         "title": "ManagerCatalogProductTagResponse"
+      },
+      "ManagerCatalogQualityCategoryResponse": {
+        "properties": {
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "critical": {
+            "type": "integer",
+            "title": "Critical",
+            "default": 0
+          },
+          "warning": {
+            "type": "integer",
+            "title": "Warning",
+            "default": 0
+          },
+          "info": {
+            "type": "integer",
+            "title": "Info",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "category",
+          "label",
+          "count"
+        ],
+        "title": "ManagerCatalogQualityCategoryResponse"
+      },
+      "ManagerCatalogQualityIssueResponse": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "warning",
+              "info"
+            ],
+            "title": "Severity"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "label",
+          "category",
+          "severity",
+          "message"
+        ],
+        "title": "ManagerCatalogQualityIssueResponse"
+      },
+      "ManagerCatalogQualityProductResponse": {
+        "properties": {
+          "product_id": {
+            "type": "integer",
+            "title": "Product Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "brand_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Id"
+          },
+          "brand_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Title"
+          },
+          "series_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Id"
+          },
+          "series_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Series Title"
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "price": {
+            "type": "integer",
+            "title": "Price",
+            "default": 0
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "issue_count": {
+            "type": "integer",
+            "title": "Issue Count"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count",
+            "default": 0
+          },
+          "main_image_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image Width"
+          },
+          "main_image_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image Height"
+          },
+          "media_status": {
+            "type": "string",
+            "title": "Media Status",
+            "default": "unknown"
+          },
+          "supplier_mapping_count": {
+            "type": "integer",
+            "title": "Supplier Mapping Count",
+            "default": 0
+          },
+          "available_qty": {
+            "type": "integer",
+            "title": "Available Qty",
+            "default": 0
+          },
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerCatalogQualityIssueResponse"
+            },
+            "type": "array",
+            "title": "Issues",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "product_id",
+          "title",
+          "score",
+          "issue_count"
+        ],
+        "title": "ManagerCatalogQualityProductResponse"
+      },
+      "ManagerCatalogQualityReportResponse": {
+        "properties": {
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          },
+          "total_products": {
+            "type": "integer",
+            "title": "Total Products"
+          },
+          "problem_products": {
+            "type": "integer",
+            "title": "Problem Products"
+          },
+          "critical_products": {
+            "type": "integer",
+            "title": "Critical Products"
+          },
+          "average_score": {
+            "type": "integer",
+            "title": "Average Score"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerCatalogQualityProductResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "summary": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerCatalogQualitySummaryItemResponse"
+            },
+            "type": "array",
+            "title": "Summary"
+          },
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerCatalogQualityCategoryResponse"
+            },
+            "type": "array",
+            "title": "Categories"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "generated_at",
+          "total_products",
+          "problem_products",
+          "critical_products",
+          "average_score",
+          "items",
+          "summary",
+          "categories",
+          "meta"
+        ],
+        "title": "ManagerCatalogQualityReportResponse"
+      },
+      "ManagerCatalogQualitySummaryItemResponse": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "warning",
+              "info"
+            ],
+            "title": "Severity"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "label",
+          "category",
+          "severity",
+          "count"
+        ],
+        "title": "ManagerCatalogQualitySummaryItemResponse"
       },
       "ManagerCrmHealthReportResponse": {
         "properties": {
@@ -33413,6 +34178,122 @@
         ],
         "title": "ProductResponse"
       },
+      "ProductSeriesContentBlockResponse": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "text",
+              "image_text",
+              "media"
+            ],
+            "title": "Kind",
+            "default": "text"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "layout": {
+            "type": "string",
+            "enum": [
+              "text_left",
+              "text_right",
+              "full"
+            ],
+            "title": "Layout",
+            "default": "text_left"
+          }
+        },
+        "type": "object",
+        "title": "ProductSeriesContentBlockResponse"
+      },
+      "ProductSeriesFeatureBlockResponse": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "footnote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnote"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ProductSeriesFeatureBlockResponse"
+      },
       "ProductSeriesNavigationItemResponse": {
         "properties": {
           "series": {
@@ -33465,6 +34346,28 @@
             "type": "string",
             "title": "Slug"
           },
+          "tagline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagline"
+          },
+          "short_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Description"
+          },
           "description": {
             "anyOf": [
               {
@@ -33487,12 +34390,73 @@
             ],
             "title": "Hero Image"
           },
+          "gallery_images": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Gallery Images"
+          },
           "features": {
             "items": {
               "type": "string"
             },
             "type": "array",
             "title": "Features"
+          },
+          "feature_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesFeatureBlockResponse"
+            },
+            "type": "array",
+            "title": "Feature Blocks"
+          },
+          "content_blocks": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesContentBlockResponse"
+            },
+            "type": "array",
+            "title": "Content Blocks"
+          },
+          "footnotes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Footnotes"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "seo_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Description"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
           }
         },
         "type": "object",

--- a/routers/manager.py
+++ b/routers/manager.py
@@ -5,6 +5,7 @@ from routers import manager_backups
 from routers import manager_brands
 from routers import manager_calendar
 from routers import manager_catalog
+from routers import manager_catalog_quality
 from routers import manager_crm
 from routers import manager_contracts
 from routers import manager_dashboard
@@ -31,6 +32,7 @@ router = APIRouter()
 router.include_router(manager_backups.router)
 router.include_router(manager_google_auth.router)
 router.include_router(manager_catalog.router)
+router.include_router(manager_catalog_quality.router)
 router.include_router(manager_media.router)
 router.include_router(manager_specs.router)
 router.include_router(manager_auth.router)

--- a/routers/manager_catalog_quality.py
+++ b/routers/manager_catalog_quality.py
@@ -1,0 +1,41 @@
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_session
+from core.security import get_current_username
+from routers.manager_operation_ids import GET_MANAGER_CATALOG_QUALITY_REPORT
+from schemas import ManagerCatalogQualityReportResponse
+from services.catalog_quality_service import CatalogQualityService
+
+
+router = APIRouter(prefix="/api/manager/catalog-quality", tags=["manager catalog quality"])
+
+
+@router.get(
+    "/report",
+    response_model=ManagerCatalogQualityReportResponse,
+    operation_id=GET_MANAGER_CATALOG_QUALITY_REPORT,
+)
+async def get_manager_catalog_quality_report(
+    page: int = Query(1, ge=1),
+    limit: int = Query(40, ge=1, le=100),
+    q: Optional[str] = Query(None),
+    category: Optional[Literal["media", "identity", "specs", "commerce", "supplier"]] = Query(None),
+    severity: Optional[Literal["critical", "warning", "info"]] = Query(None),
+    issue_code: Optional[str] = Query(None),
+    only_problems: bool = Query(True),
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    return await CatalogQualityService.build_report(
+        session=session,
+        page=page,
+        limit=limit,
+        q=q,
+        category=category,
+        severity=severity,
+        issue_code=issue_code,
+        only_problems=only_problems,
+    )

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -4,6 +4,7 @@ READ_USER_ME = "read_user_me"
 GET_MANAGER_CALENDAR_EVENTS = "get_manager_calendar_events"
 
 GET_MANAGER_PRODUCTS = "get_manager_products"
+GET_MANAGER_CATALOG_QUALITY_REPORT = "get_manager_catalog_quality_report"
 GET_MANAGER_CUSTOMERS = "get_manager_customers"
 GET_MANAGER_CUSTOMER_DETAIL = "get_manager_customer_detail"
 GET_MANAGER_CUSTOMER_DOCS = "get_manager_customer_docs"
@@ -232,6 +233,7 @@ ALL_MANAGER_OPERATION_IDS = (
     READ_USER_ME,
     GET_MANAGER_CALENDAR_EVENTS,
     GET_MANAGER_PRODUCTS,
+    GET_MANAGER_CATALOG_QUALITY_REPORT,
     GET_MANAGER_CUSTOMERS,
     GET_MANAGER_CUSTOMER_DETAIL,
     GET_MANAGER_CUSTOMER_DOCS,

--- a/schemas.py
+++ b/schemas.py
@@ -255,13 +255,38 @@ class ProductBrandResponse(BaseModel):
     logo_url: Optional[str] = None
 
 
+class ProductSeriesFeatureBlockResponse(BaseModel):
+    title: str
+    text: Optional[str] = None
+    image_url: Optional[str] = None
+    icon: Optional[str] = None
+    footnote: Optional[str] = None
+
+
+class ProductSeriesContentBlockResponse(BaseModel):
+    kind: Literal["text", "image_text", "media"] = "text"
+    title: Optional[str] = None
+    text: Optional[str] = None
+    image_url: Optional[str] = None
+    layout: Literal["text_left", "text_right", "full"] = "text_left"
+
+
 class ProductSeriesResponse(BaseModel):
     id: int
     title: str
     slug: str
+    tagline: Optional[str] = None
+    short_description: Optional[str] = None
     description: Optional[str] = None
     hero_image: Optional[str] = None
+    gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
+    content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
+    footnotes: List[str] = Field(default_factory=list)
+    seo_title: Optional[str] = None
+    seo_description: Optional[str] = None
+    source_url: Optional[str] = None
 
 
 class ProductSeriesNavigationItemResponse(BaseModel):
@@ -1617,6 +1642,66 @@ class ManagerCatalogProductListResponse(BaseModel):
     meta: Meta
 
 
+class ManagerCatalogQualityIssueResponse(BaseModel):
+    code: str
+    label: str
+    category: str
+    severity: Literal["critical", "warning", "info"]
+    message: str
+    detail: Optional[str] = None
+
+
+class ManagerCatalogQualitySummaryItemResponse(BaseModel):
+    code: str
+    label: str
+    category: str
+    severity: Literal["critical", "warning", "info"]
+    count: int
+
+
+class ManagerCatalogQualityCategoryResponse(BaseModel):
+    category: str
+    label: str
+    count: int
+    critical: int = 0
+    warning: int = 0
+    info: int = 0
+
+
+class ManagerCatalogQualityProductResponse(BaseModel):
+    product_id: int
+    title: str
+    slug: Optional[str] = None
+    brand_id: Optional[int] = None
+    brand_title: Optional[str] = None
+    series_id: Optional[int] = None
+    series_title: Optional[str] = None
+    main_image: Optional[str] = None
+    price: int = 0
+    is_published: bool = True
+    score: int
+    issue_count: int
+    image_count: int = 0
+    main_image_width: Optional[int] = None
+    main_image_height: Optional[int] = None
+    media_status: str = "unknown"
+    supplier_mapping_count: int = 0
+    available_qty: int = 0
+    issues: List[ManagerCatalogQualityIssueResponse] = []
+
+
+class ManagerCatalogQualityReportResponse(BaseModel):
+    generated_at: datetime
+    total_products: int
+    problem_products: int
+    critical_products: int
+    average_score: int
+    items: List[ManagerCatalogQualityProductResponse]
+    summary: List[ManagerCatalogQualitySummaryItemResponse]
+    categories: List[ManagerCatalogQualityCategoryResponse]
+    meta: Meta
+
+
 class ManagerCatalogCustomerItemResponse(BaseModel):
     id: int
     name: Optional[str]
@@ -2238,9 +2323,18 @@ class ManagerBrandSeriesResponse(BaseModel):
     brand_id: Optional[int] = None
     title: str
     slug: str
+    tagline: Optional[str] = None
+    short_description: Optional[str] = None
     description: Optional[str] = None
     hero_image: Optional[str] = None
+    gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
+    content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
+    footnotes: List[str] = Field(default_factory=list)
+    seo_title: Optional[str] = None
+    seo_description: Optional[str] = None
+    source_url: Optional[str] = None
     is_published: bool
     sort_order: int
     created_at: datetime
@@ -2254,9 +2348,18 @@ class ManagerBrandSeriesListResponse(BaseModel):
 class ManagerBrandSeriesCreatePayload(BaseModel):
     title: str
     slug: Optional[str] = None
+    tagline: Optional[str] = None
+    short_description: Optional[str] = None
     description: Optional[str] = None
     hero_image: Optional[str] = None
+    gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
+    content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
+    footnotes: List[str] = Field(default_factory=list)
+    seo_title: Optional[str] = None
+    seo_description: Optional[str] = None
+    source_url: Optional[str] = None
     is_published: bool = True
     sort_order: int = 0
 
@@ -2264,9 +2367,18 @@ class ManagerBrandSeriesCreatePayload(BaseModel):
 class ManagerBrandSeriesUpdatePayload(BaseModel):
     title: Optional[str] = None
     slug: Optional[str] = None
+    tagline: Optional[str] = None
+    short_description: Optional[str] = None
     description: Optional[str] = None
     hero_image: Optional[str] = None
+    gallery_images: Optional[List[str]] = None
     features: Optional[List[str]] = None
+    feature_blocks: Optional[List[ProductSeriesFeatureBlockResponse]] = None
+    content_blocks: Optional[List[ProductSeriesContentBlockResponse]] = None
+    footnotes: Optional[List[str]] = None
+    seo_title: Optional[str] = None
+    seo_description: Optional[str] = None
+    source_url: Optional[str] = None
     is_published: Optional[bool] = None
     sort_order: Optional[int] = None
 

--- a/services/catalog_quality_service.py
+++ b/services/catalog_quality_service.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from PIL import Image, UnidentifiedImageError
+from sqlalchemy import func, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models.media import MediaAsset
+from models.product import Product
+from models.supplier import ProductSupplierMapping, SupplierOffer
+
+
+CATEGORY_LABELS = {
+    "media": "Медиа",
+    "identity": "Бренд и серия",
+    "specs": "Характеристики",
+    "commerce": "Цена и наличие",
+    "supplier": "Поставщики",
+}
+
+SEVERITY_PENALTIES = {
+    "critical": 30,
+    "warning": 14,
+    "info": 6,
+}
+
+ISSUE_LABELS = {
+    "missing_brand": "Нет бренда",
+    "missing_series": "Нет серии",
+    "missing_main_image": "Нет главного фото",
+    "single_image": "Только одно фото",
+    "low_resolution_main_image": "Маленькое главное фото",
+    "all_images_low_resolution": "Все фото маленькие",
+    "external_media_not_ingested": "Фото вне медиатеки",
+    "missing_price": "Нет цены",
+    "missing_area": "Нет площади",
+    "missing_cooling_power": "Нет мощности охлаждения",
+    "missing_supplier_mapping": "Нет связи с поставщиком",
+    "out_of_stock": "Нет доступного наличия",
+}
+
+
+@dataclass(frozen=True)
+class ImageInfo:
+    url: str
+    width: int | None = None
+    height: int | None = None
+    source: str = "unknown"
+
+
+@dataclass(frozen=True)
+class QualityIssue:
+    code: str
+    category: str
+    severity: str
+    message: str
+    detail: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "label": ISSUE_LABELS.get(self.code, self.code),
+            "category": self.category,
+            "severity": self.severity,
+            "message": self.message,
+            "detail": self.detail,
+        }
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(str(value).replace(",", ".").strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(str(value).replace(",", ".").strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_url(value: Any) -> str | None:
+    if not value:
+        return None
+    url = str(value).strip()
+    return url or None
+
+
+def _image_urls_from_product(product: Product) -> list[str]:
+    urls: list[str] = []
+
+    def add(value: Any) -> None:
+        url = _normalize_url(value)
+        if url and url not in urls:
+            urls.append(url)
+
+    add(product.main_image)
+    raw_images = product.images or []
+    if isinstance(raw_images, dict):
+        iterable_images = raw_images.values()
+    elif isinstance(raw_images, list):
+        iterable_images = raw_images
+    else:
+        iterable_images = [raw_images]
+    for value in iterable_images:
+        if isinstance(value, dict):
+            add(value.get("url") or value.get("src"))
+        else:
+            add(value)
+    for image in product.gallery_images or []:
+        add(image.url)
+    return urls
+
+
+def _url_keys(url: str) -> set[str]:
+    keys = {url}
+    if url.startswith("/"):
+        keys.add(url.lstrip("/"))
+    else:
+        keys.add(f"/{url}")
+
+    parsed = urlparse(url)
+    if parsed.path:
+        keys.add(parsed.path)
+        keys.add(parsed.path.lstrip("/"))
+    return {key for key in keys if key}
+
+
+def _is_local_media_url(url: str) -> bool:
+    parsed = urlparse(url)
+    path = parsed.path if parsed.scheme else url
+    return path.startswith("/media/") or path.startswith("media/")
+
+
+def _local_media_path(base_dir: Path, url: str) -> Path | None:
+    if not _is_local_media_url(url):
+        return None
+    parsed = urlparse(url)
+    path = parsed.path if parsed.scheme else url
+    clean_path = path.lstrip("/")
+    if clean_path.startswith("media/"):
+        return base_dir / clean_path
+    return None
+
+
+def _read_local_image_size(base_dir: Path, url: str) -> ImageInfo | None:
+    path = _local_media_path(base_dir, url)
+    if not path or not path.exists() or not path.is_file():
+        return None
+    try:
+        with Image.open(path) as image:
+            width, height = image.size
+            return ImageInfo(url=url, width=width, height=height, source="file")
+    except (OSError, UnidentifiedImageError):
+        return None
+
+
+def _spec_value(specs: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in specs and specs[key] not in (None, "", []):
+            return specs[key]
+    return None
+
+
+class CatalogQualityService:
+    @staticmethod
+    async def build_report(
+        session: AsyncSession,
+        *,
+        page: int = 1,
+        limit: int = 40,
+        q: str | None = None,
+        category: str | None = None,
+        severity: str | None = None,
+        issue_code: str | None = None,
+        only_problems: bool = True,
+    ) -> dict[str, Any]:
+        base_dir = Path.cwd()
+        products = await CatalogQualityService._load_products(session=session, q=q)
+        media_by_url = await CatalogQualityService._load_media_assets(session, products)
+        offer_qty_by_product = await CatalogQualityService._load_offer_qty_by_product(session)
+        local_size_cache: dict[str, ImageInfo | None] = {}
+
+        rows = [
+            CatalogQualityService._inspect_product(
+                product=product,
+                media_by_url=media_by_url,
+                offer_qty_by_product=offer_qty_by_product,
+                base_dir=base_dir,
+                local_size_cache=local_size_cache,
+            )
+            for product in products
+        ]
+
+        summary = CatalogQualityService._build_summary(rows)
+        categories = CatalogQualityService._build_categories(rows)
+        filtered = CatalogQualityService._filter_rows(
+            rows,
+            category=category,
+            severity=severity,
+            issue_code=issue_code,
+            only_problems=only_problems,
+        )
+
+        total_filtered = len(filtered)
+        offset = (page - 1) * limit
+        page_items = filtered[offset : offset + limit]
+        score_values = [item["score"] for item in rows]
+        average_score = round(sum(score_values) / len(score_values)) if score_values else 100
+        problem_products = sum(1 for item in rows if item["issue_count"] > 0)
+        critical_products = sum(
+            1
+            for item in rows
+            if any(issue["severity"] == "critical" for issue in item["issues"])
+        )
+
+        return {
+            "generated_at": datetime.now(),
+            "total_products": len(rows),
+            "problem_products": problem_products,
+            "critical_products": critical_products,
+            "average_score": average_score,
+            "items": page_items,
+            "summary": summary,
+            "categories": categories,
+            "meta": {
+                "total": total_filtered,
+                "page": page,
+                "limit": limit,
+                "pages": max(1, (total_filtered + limit - 1) // limit),
+            },
+        }
+
+    @staticmethod
+    async def _load_products(session: AsyncSession, q: str | None = None) -> list[Product]:
+        stmt = (
+            select(Product)
+            .options(
+                selectinload(Product.brand),
+                selectinload(Product.series),
+                selectinload(Product.gallery_images),
+                selectinload(Product.supplier_mappings),
+                selectinload(Product.local_stocks),
+            )
+            .order_by(Product.title)
+        )
+        query = (q or "").strip()
+        if query:
+            like = f"%{query}%"
+            stmt = stmt.where(or_(Product.title.ilike(like), Product.slug.ilike(like)))
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def _load_media_assets(
+        session: AsyncSession,
+        products: list[Product],
+    ) -> dict[str, ImageInfo]:
+        urls: set[str] = set()
+        for product in products:
+            for url in _image_urls_from_product(product):
+                urls.update(_url_keys(url))
+        if not urls:
+            return {}
+
+        stmt = select(MediaAsset).where(MediaAsset.url.in_(urls))
+        result = await session.execute(stmt)
+        media_by_url: dict[str, ImageInfo] = {}
+        for asset in result.scalars().all():
+            info = ImageInfo(
+                url=asset.url,
+                width=asset.width,
+                height=asset.height,
+                source="media_asset",
+            )
+            for key in _url_keys(asset.url):
+                media_by_url[key] = info
+        return media_by_url
+
+    @staticmethod
+    async def _load_offer_qty_by_product(session: AsyncSession) -> dict[int, int]:
+        stmt = (
+            select(ProductSupplierMapping.product_id, func.coalesce(func.sum(SupplierOffer.qty), 0))
+            .join(
+                SupplierOffer,
+                (SupplierOffer.supplier_id == ProductSupplierMapping.supplier_id)
+                & (SupplierOffer.external_id == ProductSupplierMapping.external_id),
+            )
+            .where(ProductSupplierMapping.is_active == True)  # noqa: E712
+            .where(SupplierOffer.is_active == True)  # noqa: E712
+            .group_by(ProductSupplierMapping.product_id)
+        )
+        result = await session.execute(stmt)
+        return {int(product_id): int(qty or 0) for product_id, qty in result.all()}
+
+    @staticmethod
+    def _inspect_product(
+        *,
+        product: Product,
+        media_by_url: dict[str, ImageInfo],
+        offer_qty_by_product: dict[int, int],
+        base_dir: Path,
+        local_size_cache: dict[str, ImageInfo | None],
+    ) -> dict[str, Any]:
+        product_id = int(product.id or 0)
+        specs = product.specs or {}
+        image_infos = CatalogQualityService._resolve_product_images(
+            product=product,
+            media_by_url=media_by_url,
+            base_dir=base_dir,
+            local_size_cache=local_size_cache,
+        )
+        main_image_info = CatalogQualityService._resolve_image_info(
+            product.main_image,
+            media_by_url=media_by_url,
+            base_dir=base_dir,
+            local_size_cache=local_size_cache,
+        )
+        local_qty = sum(int(stock.qty or 0) for stock in product.local_stocks or [])
+        offer_qty = offer_qty_by_product.get(product_id, 0)
+        available_qty = local_qty + offer_qty
+        active_mapping_count = sum(1 for mapping in product.supplier_mappings or [] if mapping.is_active)
+        issues = CatalogQualityService._collect_issues(
+            product=product,
+            specs=specs,
+            image_infos=image_infos,
+            main_image_info=main_image_info,
+            available_qty=available_qty,
+            active_mapping_count=active_mapping_count,
+        )
+        issue_dicts = [issue.as_dict() for issue in issues]
+        score = CatalogQualityService._score(issues)
+        media_status = CatalogQualityService._media_status(product, image_infos)
+        return {
+            "product_id": product_id,
+            "title": product.title,
+            "slug": product.slug,
+            "brand_id": product.brand_id,
+            "brand_title": product.brand.title if product.brand else None,
+            "series_id": product.series_id,
+            "series_title": product.series.title if product.series else None,
+            "main_image": product.main_image,
+            "price": int(product.price or 0),
+            "is_published": bool(product.is_published),
+            "score": score,
+            "issue_count": len(issue_dicts),
+            "image_count": len(image_infos),
+            "main_image_width": main_image_info.width if main_image_info else None,
+            "main_image_height": main_image_info.height if main_image_info else None,
+            "media_status": media_status,
+            "supplier_mapping_count": active_mapping_count,
+            "available_qty": available_qty,
+            "issues": issue_dicts,
+        }
+
+    @staticmethod
+    def _resolve_product_images(
+        *,
+        product: Product,
+        media_by_url: dict[str, ImageInfo],
+        base_dir: Path,
+        local_size_cache: dict[str, ImageInfo | None],
+    ) -> list[ImageInfo]:
+        image_infos: list[ImageInfo] = []
+        for url in _image_urls_from_product(product):
+            info = CatalogQualityService._resolve_image_info(
+                url,
+                media_by_url=media_by_url,
+                base_dir=base_dir,
+                local_size_cache=local_size_cache,
+            )
+            image_infos.append(info or ImageInfo(url=url))
+        return image_infos
+
+    @staticmethod
+    def _resolve_image_info(
+        url: str | None,
+        *,
+        media_by_url: dict[str, ImageInfo],
+        base_dir: Path,
+        local_size_cache: dict[str, ImageInfo | None],
+    ) -> ImageInfo | None:
+        normalized = _normalize_url(url)
+        if not normalized:
+            return None
+        for key in _url_keys(normalized):
+            if key in media_by_url:
+                return media_by_url[key]
+        cache_key = normalized
+        if cache_key not in local_size_cache:
+            local_size_cache[cache_key] = _read_local_image_size(base_dir, normalized)
+        return local_size_cache[cache_key]
+
+    @staticmethod
+    def _collect_issues(
+        *,
+        product: Product,
+        specs: dict[str, Any],
+        image_infos: list[ImageInfo],
+        main_image_info: ImageInfo | None,
+        available_qty: int,
+        active_mapping_count: int,
+    ) -> list[QualityIssue]:
+        issues: list[QualityIssue] = []
+        if not product.brand_id:
+            issues.append(
+                QualityIssue(
+                    code="missing_brand",
+                    category="identity",
+                    severity="critical",
+                    message="Карточка не привязана к бренду.",
+                )
+            )
+        if not product.series_id:
+            issues.append(
+                QualityIssue(
+                    code="missing_series",
+                    category="identity",
+                    severity="warning",
+                    message="Нет серии бренда, страница серии и группировка будут слабее.",
+                )
+            )
+        if not _normalize_url(product.main_image):
+            issues.append(
+                QualityIssue(
+                    code="missing_main_image",
+                    category="media",
+                    severity="critical",
+                    message="Главное фото отсутствует.",
+                )
+            )
+        if len(image_infos) == 1:
+            issues.append(
+                QualityIssue(
+                    code="single_image",
+                    category="media",
+                    severity="warning",
+                    message="У товара только одно изображение.",
+                    detail="Для каталога и карточки лучше иметь главное фото и 2-4 дополнительных ракурса.",
+                )
+            )
+        if main_image_info and CatalogQualityService._is_low_resolution(main_image_info):
+            issues.append(
+                QualityIssue(
+                    code="low_resolution_main_image",
+                    category="media",
+                    severity="warning",
+                    message="Главное фото слишком маленькое для нормальной карточки.",
+                    detail=CatalogQualityService._image_size_label(main_image_info),
+                )
+            )
+        known_sizes = [info for info in image_infos if info.width and info.height]
+        if known_sizes and all(CatalogQualityService._is_low_resolution(info) for info in known_sizes):
+            issues.append(
+                QualityIssue(
+                    code="all_images_low_resolution",
+                    category="media",
+                    severity="critical" if len(known_sizes) == len(image_infos) else "warning",
+                    message="Все изображения с известным размером низкого разрешения.",
+                )
+            )
+        unknown_external = [
+            info.url
+            for info in image_infos
+            if not info.width and not info.height and not _is_local_media_url(info.url)
+        ]
+        if unknown_external:
+            issues.append(
+                QualityIssue(
+                    code="external_media_not_ingested",
+                    category="media",
+                    severity="info",
+                    message="Часть изображений хранится внешними ссылками и не видна медиатеке.",
+                    detail=f"{len(unknown_external)} ссылок",
+                )
+            )
+        if int(product.price or 0) <= 0:
+            issues.append(
+                QualityIssue(
+                    code="missing_price",
+                    category="commerce",
+                    severity="critical",
+                    message="Цена не заполнена или равна нулю.",
+                )
+            )
+        if int(product.area or 0) <= 0 and not _as_int(_spec_value(specs, ("area_m2", "recommended_area_m2"))):
+            issues.append(
+                QualityIssue(
+                    code="missing_area",
+                    category="specs",
+                    severity="warning",
+                    message="Нет рекомендованной площади помещения.",
+                )
+            )
+        if not product.power_cooling and not _as_float(
+            _spec_value(specs, ("capacity_cooling_kw", "cooling_capacity_kw", "capacity_cooling"))
+        ):
+            issues.append(
+                QualityIssue(
+                    code="missing_cooling_power",
+                    category="specs",
+                    severity="warning",
+                    message="Нет нормализованной мощности охлаждения.",
+                )
+            )
+        if active_mapping_count <= 0:
+            issues.append(
+                QualityIssue(
+                    code="missing_supplier_mapping",
+                    category="supplier",
+                    severity="warning",
+                    message="Товар не связан с предложениями поставщиков.",
+                )
+            )
+        if available_qty <= 0:
+            issues.append(
+                QualityIssue(
+                    code="out_of_stock",
+                    category="commerce",
+                    severity="info",
+                    message="Нет подтвержденного наличия у поставщика или на локальном складе.",
+                )
+            )
+        return issues
+
+    @staticmethod
+    def _score(issues: list[QualityIssue]) -> int:
+        penalty = sum(SEVERITY_PENALTIES.get(issue.severity, 0) for issue in issues)
+        return max(0, min(100, 100 - penalty))
+
+    @staticmethod
+    def _is_low_resolution(info: ImageInfo) -> bool:
+        if not info.width or not info.height:
+            return False
+        return info.width < 600 or info.height < 400
+
+    @staticmethod
+    def _image_size_label(info: ImageInfo) -> str:
+        if not info.width or not info.height:
+            return "размер неизвестен"
+        return f"{info.width}x{info.height}px"
+
+    @staticmethod
+    def _media_status(product: Product, image_infos: list[ImageInfo]) -> str:
+        if not _normalize_url(product.main_image):
+            return "missing"
+        if any(CatalogQualityService._is_low_resolution(info) for info in image_infos):
+            return "low_resolution"
+        if any(info.source == "unknown" for info in image_infos):
+            return "unknown_dimensions"
+        return "ok"
+
+    @staticmethod
+    def _build_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        counts: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            seen_codes: set[str] = set()
+            for issue in row["issues"]:
+                code = issue["code"]
+                if code in seen_codes:
+                    continue
+                seen_codes.add(code)
+                if code not in counts:
+                    counts[code] = {
+                        "code": code,
+                        "label": issue["label"],
+                        "category": issue["category"],
+                        "severity": issue["severity"],
+                        "count": 0,
+                    }
+                counts[code]["count"] += 1
+        severity_rank = {"critical": 0, "warning": 1, "info": 2}
+        return sorted(
+            counts.values(),
+            key=lambda item: (severity_rank.get(item["severity"], 9), -item["count"], item["label"]),
+        )
+
+    @staticmethod
+    def _build_categories(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        categories = {
+            key: {
+                "category": key,
+                "label": label,
+                "count": 0,
+                "critical": 0,
+                "warning": 0,
+                "info": 0,
+            }
+            for key, label in CATEGORY_LABELS.items()
+        }
+        for row in rows:
+            row_categories: set[str] = set()
+            for issue in row["issues"]:
+                category = issue["category"]
+                severity = issue["severity"]
+                if category not in categories:
+                    categories[category] = {
+                        "category": category,
+                        "label": category,
+                        "count": 0,
+                        "critical": 0,
+                        "warning": 0,
+                        "info": 0,
+                    }
+                categories[category][severity] = int(categories[category].get(severity, 0)) + 1
+                row_categories.add(category)
+            for category in row_categories:
+                categories[category]["count"] += 1
+        return [item for item in categories.values() if item["count"] > 0]
+
+    @staticmethod
+    def _filter_rows(
+        rows: list[dict[str, Any]],
+        *,
+        category: str | None,
+        severity: str | None,
+        issue_code: str | None,
+        only_problems: bool,
+    ) -> list[dict[str, Any]]:
+        filtered: list[dict[str, Any]] = []
+        for row in rows:
+            issues = row["issues"]
+            if only_problems and not issues:
+                continue
+            if category and not any(issue["category"] == category for issue in issues):
+                continue
+            if severity and not any(issue["severity"] == severity for issue in issues):
+                continue
+            if issue_code and not any(issue["code"] == issue_code for issue in issues):
+                continue
+            filtered.append(row)
+        return filtered

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -292,9 +292,18 @@ class ManagerBrandService:
             brand_id=brand_id,
             title=title,
             slug=series_slug,
+            tagline=ManagerBrandService._clean_optional_text(payload.get("tagline")),
+            short_description=ManagerBrandService._clean_optional_text(payload.get("short_description")),
             description=ManagerBrandService._clean_optional_text(payload.get("description")),
             hero_image=ManagerBrandService._clean_optional_text(payload.get("hero_image")),
+            gallery_images=ManagerBrandService._normalize_string_list(payload.get("gallery_images")),
             features=ManagerBrandService._normalize_features(payload.get("features")),
+            feature_blocks=ManagerBrandService._normalize_feature_blocks(payload.get("feature_blocks")),
+            content_blocks=ManagerBrandService._normalize_content_blocks(payload.get("content_blocks")),
+            footnotes=ManagerBrandService._normalize_string_list(payload.get("footnotes")),
+            seo_title=ManagerBrandService._clean_optional_text(payload.get("seo_title")),
+            seo_description=ManagerBrandService._clean_optional_text(payload.get("seo_description")),
+            source_url=ManagerBrandService._clean_optional_text(payload.get("source_url")),
             is_published=bool(payload.get("is_published", True)),
             sort_order=int(payload.get("sort_order") or 0),
         )
@@ -339,12 +348,30 @@ class ManagerBrandService:
                 )
                 series.slug = new_slug
 
+        if "tagline" in payload:
+            series.tagline = ManagerBrandService._clean_optional_text(payload["tagline"])
+        if "short_description" in payload:
+            series.short_description = ManagerBrandService._clean_optional_text(payload["short_description"])
         if "description" in payload:
             series.description = ManagerBrandService._clean_optional_text(payload["description"])
         if "hero_image" in payload:
             series.hero_image = ManagerBrandService._clean_optional_text(payload["hero_image"])
+        if "gallery_images" in payload and payload["gallery_images"] is not None:
+            series.gallery_images = ManagerBrandService._normalize_string_list(payload["gallery_images"])
         if "features" in payload and payload["features"] is not None:
             series.features = ManagerBrandService._normalize_features(payload["features"])
+        if "feature_blocks" in payload and payload["feature_blocks"] is not None:
+            series.feature_blocks = ManagerBrandService._normalize_feature_blocks(payload["feature_blocks"])
+        if "content_blocks" in payload and payload["content_blocks"] is not None:
+            series.content_blocks = ManagerBrandService._normalize_content_blocks(payload["content_blocks"])
+        if "footnotes" in payload and payload["footnotes"] is not None:
+            series.footnotes = ManagerBrandService._normalize_string_list(payload["footnotes"])
+        if "seo_title" in payload:
+            series.seo_title = ManagerBrandService._clean_optional_text(payload["seo_title"])
+        if "seo_description" in payload:
+            series.seo_description = ManagerBrandService._clean_optional_text(payload["seo_description"])
+        if "source_url" in payload:
+            series.source_url = ManagerBrandService._clean_optional_text(payload["source_url"])
         if "is_published" in payload and payload["is_published"] is not None:
             series.is_published = bool(payload["is_published"])
         if "sort_order" in payload and payload["sort_order"] is not None:
@@ -417,9 +444,18 @@ class ManagerBrandService:
             "brand_id": series.brand_id,
             "title": series.title,
             "slug": series.slug,
+            "tagline": series.tagline,
+            "short_description": series.short_description,
             "description": series.description,
             "hero_image": series.hero_image,
+            "gallery_images": ManagerBrandService._normalize_string_list(series.gallery_images),
             "features": ManagerBrandService._normalize_features(series.features),
+            "feature_blocks": ManagerBrandService._normalize_feature_blocks(series.feature_blocks),
+            "content_blocks": ManagerBrandService._normalize_content_blocks(series.content_blocks),
+            "footnotes": ManagerBrandService._normalize_string_list(series.footnotes),
+            "seo_title": series.seo_title,
+            "seo_description": series.seo_description,
+            "source_url": series.source_url,
             "is_published": series.is_published,
             "sort_order": series.sort_order,
             "created_at": series.created_at,
@@ -482,10 +518,14 @@ class ManagerBrandService:
 
     @staticmethod
     def _normalize_features(value: Any) -> List[str]:
+        return ManagerBrandService._normalize_string_list(value)
+
+    @staticmethod
+    def _normalize_string_list(value: Any) -> List[str]:
         if not isinstance(value, list):
             return []
 
-        features: List[str] = []
+        items: List[str] = []
         seen: set[str] = set()
         for item in value:
             text = str(item or "").strip()
@@ -495,8 +535,60 @@ class ManagerBrandService:
             if dedupe_key in seen:
                 continue
             seen.add(dedupe_key)
-            features.append(text)
-        return features
+            items.append(text)
+        return items
+
+    @staticmethod
+    def _normalize_feature_blocks(value: Any) -> List[Dict[str, Optional[str]]]:
+        if not isinstance(value, list):
+            return []
+
+        blocks: List[Dict[str, Optional[str]]] = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            title = ManagerBrandService._clean_optional_text(item.get("title"))
+            if not title:
+                continue
+            blocks.append(
+                {
+                    "title": title,
+                    "text": ManagerBrandService._clean_optional_text(item.get("text")),
+                    "image_url": ManagerBrandService._clean_optional_text(item.get("image_url")),
+                    "icon": ManagerBrandService._clean_optional_text(item.get("icon")),
+                    "footnote": ManagerBrandService._clean_optional_text(item.get("footnote")),
+                }
+            )
+        return blocks
+
+    @staticmethod
+    def _normalize_content_blocks(value: Any) -> List[Dict[str, Optional[str]]]:
+        if not isinstance(value, list):
+            return []
+
+        allowed_kinds = {"text", "image_text", "media"}
+        allowed_layouts = {"text_left", "text_right", "full"}
+        blocks: List[Dict[str, Optional[str]]] = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            title = ManagerBrandService._clean_optional_text(item.get("title"))
+            text = ManagerBrandService._clean_optional_text(item.get("text"))
+            image_url = ManagerBrandService._clean_optional_text(item.get("image_url"))
+            if not any((title, text, image_url)):
+                continue
+            kind = str(item.get("kind") or "text").strip()
+            layout = str(item.get("layout") or "text_left").strip()
+            blocks.append(
+                {
+                    "kind": kind if kind in allowed_kinds else "text",
+                    "title": title,
+                    "text": text,
+                    "image_url": image_url,
+                    "layout": layout if layout in allowed_layouts else "text_left",
+                }
+            )
+        return blocks
 
     @staticmethod
     async def _ensure_brand_group(session: AsyncSession) -> TagGroup:

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -129,9 +129,18 @@ def map_product_to_response(
             id=series.id,
             title=series.title,
             slug=series.slug,
+            tagline=series.tagline,
+            short_description=series.short_description,
             description=series.description,
             hero_image=series.hero_image,
+            gallery_images=series.gallery_images or [],
             features=series.features or [],
+            feature_blocks=series.feature_blocks or [],
+            content_blocks=series.content_blocks or [],
+            footnotes=series.footnotes or [],
+            seo_title=series.seo_title,
+            seo_description=series.seo_description,
+            source_url=series.source_url,
         )
         if series and series.is_published
         else None

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -75,9 +75,18 @@ class ProductSeriesService:
             id=series.id,
             title=series.title,
             slug=series.slug,
+            tagline=series.tagline,
+            short_description=series.short_description,
             description=series.description,
             hero_image=series.hero_image,
+            gallery_images=series.gallery_images or [],
             features=series.features or [],
+            feature_blocks=series.feature_blocks or [],
+            content_blocks=series.content_blocks or [],
+            footnotes=series.footnotes or [],
+            seo_title=series.seo_title,
+            seo_description=series.seo_description,
+            source_url=series.source_url,
         )
 
     @staticmethod

--- a/tests/integration/test_manager_brands_api.py
+++ b/tests/integration/test_manager_brands_api.py
@@ -104,9 +104,35 @@ async def test_manager_brand_series_crud(async_client):
         headers=headers,
         json={
             "title": "FreshIN",
+            "tagline": "Fresh air without drafts",
+            "short_description": "Line preview text",
             "description": "Fresh air product line",
             "hero_image": "/media/series/freshin.webp",
+            "gallery_images": ["/media/series/freshin-1.webp", "", "/media/series/freshin-1.webp"],
             "features": [" fresh air ", "", "Wi-Fi", "Wi-Fi"],
+            "feature_blocks": [
+                {
+                    "title": "Fresh flow",
+                    "text": "Adds outside air",
+                    "image_url": "/media/series/fresh-flow.webp",
+                    "icon": "air",
+                    "footnote": "Depends on model",
+                },
+                {"title": "", "text": "ignored"},
+            ],
+            "content_blocks": [
+                {
+                    "kind": "image_text",
+                    "title": "How it works",
+                    "text": "A short section",
+                    "image_url": "/media/series/content.webp",
+                    "layout": "text_right",
+                }
+            ],
+            "footnotes": [" Test note ", "", "Test note"],
+            "seo_title": "FreshIN series",
+            "seo_description": "FreshIN SEO description",
+            "source_url": "https://example.com/freshin",
             "sort_order": 10,
         },
     )
@@ -114,7 +140,32 @@ async def test_manager_brand_series_crud(async_client):
     created = create_resp.json()
     assert created["title"] == "FreshIN"
     assert created["slug"] == "freshin"
+    assert created["tagline"] == "Fresh air without drafts"
+    assert created["short_description"] == "Line preview text"
+    assert created["gallery_images"] == ["/media/series/freshin-1.webp"]
     assert created["features"] == ["fresh air", "Wi-Fi"]
+    assert created["feature_blocks"] == [
+        {
+            "title": "Fresh flow",
+            "text": "Adds outside air",
+            "image_url": "/media/series/fresh-flow.webp",
+            "icon": "air",
+            "footnote": "Depends on model",
+        }
+    ]
+    assert created["content_blocks"] == [
+        {
+            "kind": "image_text",
+            "title": "How it works",
+            "text": "A short section",
+            "image_url": "/media/series/content.webp",
+            "layout": "text_right",
+        }
+    ]
+    assert created["footnotes"] == ["Test note"]
+    assert created["seo_title"] == "FreshIN series"
+    assert created["seo_description"] == "FreshIN SEO description"
+    assert created["source_url"] == "https://example.com/freshin"
     assert created["products_count"] == 0
     series_id = created["id"]
 
@@ -123,7 +174,9 @@ async def test_manager_brand_series_crud(async_client):
         headers=headers,
     )
     assert list_resp.status_code == 200
-    assert [item["id"] for item in list_resp.json()["items"]] == [series_id]
+    listed_items = list_resp.json()["items"]
+    assert [item["id"] for item in listed_items] == [series_id]
+    assert listed_items[0]["tagline"] == "Fresh air without drafts"
 
     update_resp = await async_client.put(
         f"/api/manager/brands/{brand_id}/series/{series_id}",
@@ -131,7 +184,13 @@ async def test_manager_brand_series_crud(async_client):
         json={
             "title": "FreshIN Updated",
             "slug": "freshin-updated",
+            "tagline": "Updated tagline",
+            "gallery_images": ["/media/series/updated.webp"],
             "features": ["Fresh air", "Self-cleaning"],
+            "feature_blocks": [{"title": "Self cleaning", "text": "Keeps exchanger clean"}],
+            "content_blocks": [],
+            "footnotes": ["Updated note"],
+            "seo_title": "Updated SEO",
             "is_published": False,
             "sort_order": 3,
         },
@@ -140,7 +199,21 @@ async def test_manager_brand_series_crud(async_client):
     updated = update_resp.json()
     assert updated["title"] == "FreshIN Updated"
     assert updated["slug"] == "freshin-updated"
+    assert updated["tagline"] == "Updated tagline"
+    assert updated["gallery_images"] == ["/media/series/updated.webp"]
     assert updated["features"] == ["Fresh air", "Self-cleaning"]
+    assert updated["feature_blocks"] == [
+        {
+            "title": "Self cleaning",
+            "text": "Keeps exchanger clean",
+            "image_url": None,
+            "icon": None,
+            "footnote": None,
+        }
+    ]
+    assert updated["content_blocks"] == []
+    assert updated["footnotes"] == ["Updated note"]
+    assert updated["seo_title"] == "Updated SEO"
     assert updated["is_published"] is False
     assert updated["sort_order"] == 3
 

--- a/tests/integration/test_product_series_siblings.py
+++ b/tests/integration/test_product_series_siblings.py
@@ -125,9 +125,18 @@ async def test_product_detail_contains_series_and_series_id_siblings(async_clien
         "id": series.id,
         "title": "FreshIN",
         "slug": "freshin",
+        "tagline": None,
+        "short_description": None,
         "description": "Fresh air product line",
         "hero_image": "/media/series/freshin.webp",
+        "gallery_images": [],
         "features": ["Fresh air intake", "Self-cleaning"],
+        "feature_blocks": [],
+        "content_blocks": [],
+        "footnotes": [],
+        "seo_title": None,
+        "seo_description": None,
+        "source_url": None,
     }
 
     sibling_slugs = [item["slug"] for item in data["series_siblings"]]

--- a/tests/unit/test_catalog_quality_service.py
+++ b/tests/unit/test_catalog_quality_service.py
@@ -1,0 +1,69 @@
+from models.product import Product, ProductImage
+from services.catalog_quality_service import (
+    CatalogQualityService,
+    ImageInfo,
+    _image_urls_from_product,
+)
+
+
+def test_image_urls_from_product_deduplicates_main_json_and_gallery():
+    product = Product(title="TCL Test", slug="tcl-test", price=1000)
+    product.main_image = "/media/products/main.webp"
+    product.images = [
+        "/media/products/main.webp",
+        {"url": "/media/products/side.webp"},
+        {"src": "/media/products/front.webp"},
+    ]
+    product.gallery_images = [
+        ProductImage(product_id=1, url="/media/products/side.webp"),
+        ProductImage(product_id=1, url="/media/products/remote.webp"),
+    ]
+
+    assert _image_urls_from_product(product) == [
+        "/media/products/main.webp",
+        "/media/products/side.webp",
+        "/media/products/front.webp",
+        "/media/products/remote.webp",
+    ]
+
+
+def test_collect_issues_flags_single_low_resolution_product_media():
+    product = Product(title="Onliner low", slug="onliner-low", price=1200)
+    product.main_image = "/media/products/small.webp"
+    product.brand_id = 1
+    product.series_id = 2
+    product.area = 25
+    product.power_cooling = 2.6
+    issues = CatalogQualityService._collect_issues(
+        product=product,
+        specs={},
+        image_infos=[ImageInfo(url=product.main_image, width=220, height=180, source="file")],
+        main_image_info=ImageInfo(url=product.main_image, width=220, height=180, source="file"),
+        available_qty=3,
+        active_mapping_count=1,
+    )
+
+    codes = {issue.code for issue in issues}
+    assert {"single_image", "low_resolution_main_image", "all_images_low_resolution"}.issubset(codes)
+
+
+def test_collect_issues_flags_supplier_and_identity_gaps():
+    product = Product(title="Draft", slug="draft", price=0)
+    issues = CatalogQualityService._collect_issues(
+        product=product,
+        specs={},
+        image_infos=[],
+        main_image_info=None,
+        available_qty=0,
+        active_mapping_count=0,
+    )
+
+    codes = {issue.code for issue in issues}
+    assert {
+        "missing_brand",
+        "missing_series",
+        "missing_main_image",
+        "missing_price",
+        "missing_supplier_mapping",
+        "out_of_stock",
+    }.issubset(codes)

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -157,9 +157,18 @@ def test_map_product_to_response_serializes_public_series():
         "id": 7,
         "title": "Elite",
         "slug": "elite",
+        "tagline": None,
+        "short_description": None,
         "description": "Quiet inverter product line",
         "hero_image": "/media/series/elite.webp",
+        "gallery_images": [],
         "features": [],
+        "feature_blocks": [],
+        "content_blocks": [],
+        "footnotes": [],
+        "seo_title": None,
+        "seo_description": None,
+        "source_url": None,
     }
 
 

--- a/tests/unit/test_public_product_series_payloads.py
+++ b/tests/unit/test_public_product_series_payloads.py
@@ -44,9 +44,34 @@ async def _seed_series_products(session: AsyncSession) -> dict[str, Product]:
         title="Elite",
         slug="elite",
         brand_id=brand.id,
+        tagline="Quiet comfort",
+        short_description="Short public intro",
         description="Quiet inverter product line",
         hero_image="/media/series/elite.webp",
+        gallery_images=["/media/series/elite-hero.webp"],
         features=["Quiet mode", "Wi-Fi ready"],
+        feature_blocks=[
+            {
+                "title": "Quiet mode",
+                "text": "Low indoor unit noise",
+                "image_url": "/media/series/quiet.webp",
+                "icon": "volume_2",
+                "footnote": "Depends on model",
+            }
+        ],
+        content_blocks=[
+            {
+                "kind": "image_text",
+                "title": "Comfort airflow",
+                "text": "Stable airflow in living rooms",
+                "image_url": "/media/series/airflow.webp",
+                "layout": "text_right",
+            }
+        ],
+        footnotes=["Performance depends on room conditions"],
+        seo_title="MDV Elite series",
+        seo_description="Quiet MDV Elite inverter air conditioners",
+        source_url="https://example.com/mdv-elite",
         is_published=True,
     )
     session.add(series)
@@ -130,9 +155,34 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
         "id": detail.series_id,
         "title": "Elite",
         "slug": "elite",
+        "tagline": "Quiet comfort",
+        "short_description": "Short public intro",
         "description": "Quiet inverter product line",
         "hero_image": "/media/series/elite.webp",
+        "gallery_images": ["/media/series/elite-hero.webp"],
         "features": ["Quiet mode", "Wi-Fi ready"],
+        "feature_blocks": [
+            {
+                "title": "Quiet mode",
+                "text": "Low indoor unit noise",
+                "image_url": "/media/series/quiet.webp",
+                "icon": "volume_2",
+                "footnote": "Depends on model",
+            }
+        ],
+        "content_blocks": [
+            {
+                "kind": "image_text",
+                "title": "Comfort airflow",
+                "text": "Stable airflow in living rooms",
+                "image_url": "/media/series/airflow.webp",
+                "layout": "text_right",
+            }
+        ],
+        "footnotes": ["Performance depends on room conditions"],
+        "seo_title": "MDV Elite series",
+        "seo_description": "Quiet MDV Elite inverter air conditioners",
+        "source_url": "https://example.com/mdv-elite",
     }
 
     catalog_products = await ProductDAO.get_filtered(
@@ -164,6 +214,8 @@ async def test_public_series_navigation_builds_slug_sibling_map(sqlite_session):
     main_item = navigation.products[seeded["main"].slug]
     assert main_item.series is not None
     assert main_item.series.slug == "elite"
+    assert main_item.series.tagline == "Quiet comfort"
+    assert main_item.series.feature_blocks[0].title == "Quiet mode"
     assert [item.slug for item in main_item.series_siblings] == [
         "mdv-elite-25",
         "mdv-elite-50",

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -47,9 +47,18 @@ interface Product {
         id?: number;
         title?: string | null;
         slug?: string | null;
+        tagline?: string | null;
+        short_description?: string | null;
         description?: string | null;
         hero_image?: string | null;
         features?: string[] | null;
+        feature_blocks?: Array<{
+            title?: string | null;
+            text?: string | null;
+            image_url?: string | null;
+            icon?: string | null;
+            footnote?: string | null;
+        }> | null;
     } | null;
     badges?: Array<{ text: string; class?: string }>;
     tags?: Array<{
@@ -129,6 +138,24 @@ const getProductSeriesTitle = (product: Product) =>
 const normalizeSeriesFeatures = (value: unknown) =>
     Array.isArray(value)
         ? value.map((item) => asText(item)).filter(Boolean)
+        : [];
+const normalizeSeriesFeatureBlocks = (value: unknown) =>
+    Array.isArray(value)
+        ? value
+            .map((item) => {
+                if (!item || typeof item !== "object") return null;
+                const block = item as Record<string, unknown>;
+                const title = asText(block.title);
+                if (!title) return null;
+                return {
+                    title,
+                    text: asText(block.text),
+                    imageUrl: asText(block.image_url),
+                    icon: asText(block.icon),
+                    footnote: asText(block.footnote),
+                };
+            })
+            .filter((item): item is { title: string; text: string; imageUrl: string; icon: string; footnote: string } => Boolean(item))
         : [];
 const getTagSlugs = (product: Product) =>
     (product.tags || []).map((tag) => normalizeText(tag.slug || tag.title));
@@ -309,9 +336,12 @@ const seriesGroupsMap = new Map<
     {
         key: string;
         title: string;
+        tagline: string;
+        shortDescription: string;
         description: string;
         heroImage: string;
         features: string[];
+        featureBlocks: NonNullable<ReturnType<typeof normalizeSeriesFeatureBlocks>>;
         catalogGroupKey: CatalogGroupKey;
         products: Product[];
     }
@@ -332,9 +362,12 @@ for (const product of seriesSourceProducts) {
         seriesGroupsMap.set(key, {
             key,
             title,
+            tagline: asText(product.series?.tagline),
+            shortDescription: asText(product.series?.short_description),
             description: asText(product.series?.description),
             heroImage: asText(product.series?.hero_image),
             features: normalizeSeriesFeatures(product.series?.features),
+            featureBlocks: normalizeSeriesFeatureBlocks(product.series?.feature_blocks),
             catalogGroupKey: getProductCatalogGroupKey(product),
             products: [],
         });
@@ -342,10 +375,15 @@ for (const product of seriesSourceProducts) {
 
     const group = seriesGroupsMap.get(key);
     if (group) {
+        if (!group.tagline) group.tagline = asText(product.series?.tagline);
+        if (!group.shortDescription) group.shortDescription = asText(product.series?.short_description);
         if (!group.description) group.description = asText(product.series?.description);
         if (!group.heroImage) group.heroImage = asText(product.series?.hero_image);
         if (group.features.length === 0) {
             group.features = normalizeSeriesFeatures(product.series?.features);
+        }
+        if (group.featureBlocks.length === 0) {
+            group.featureBlocks = normalizeSeriesFeatureBlocks(product.series?.feature_blocks);
         }
         group.products.push(product);
     }
@@ -486,8 +524,11 @@ const productsWithoutSeriesByCatalog = Object.values(CATALOG_GROUPS)
                                                                 </div>
                                                                 <span>{formatSeriesProductCount(group.products.length)}</span>
                                                             </div>
-                                                            {group.description ? (
-                                                                <p>{group.description}</p>
+                                                            {group.tagline && (
+                                                                <p class="brand-series-tagline">{group.tagline}</p>
+                                                            )}
+                                                            {group.shortDescription || group.description ? (
+                                                                <p>{group.shortDescription || group.description}</p>
                                                             ) : (
                                                                 <p>{formatSeriesProductCount(group.products.length)} в каталоге {brand.title}.</p>
                                                             )}
@@ -497,6 +538,16 @@ const productsWithoutSeriesByCatalog = Object.values(CATALOG_GROUPS)
                                                                         <li>{feature}</li>
                                                                     ))}
                                                                 </ul>
+                                                            )}
+                                                            {group.featureBlocks.length > 0 && (
+                                                                <div class="brand-series-feature-blocks" aria-label={`Преимущества серии ${group.displayTitle}`}>
+                                                                    {group.featureBlocks.slice(0, 3).map((block) => (
+                                                                        <article class="brand-series-feature-block">
+                                                                            <strong>{block.title}</strong>
+                                                                            {block.text && <span>{block.text}</span>}
+                                                                        </article>
+                                                                    ))}
+                                                                </div>
                                                             )}
                                                         </div>
                                                     </div>
@@ -837,6 +888,10 @@ const productsWithoutSeriesByCatalog = Object.values(CATALOG_GROUPS)
         font-size: 0.94rem;
         line-height: 1.6;
     }
+    .brand-series-head .brand-series-tagline {
+        color: var(--text);
+        font-weight: 750;
+    }
     .brand-series-features {
         display: flex;
         flex-wrap: wrap;
@@ -856,6 +911,28 @@ const productsWithoutSeriesByCatalog = Object.values(CATALOG_GROUPS)
         color: var(--text);
         font-size: 0.82rem;
         font-weight: 700;
+    }
+    .brand-series-feature-blocks {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.8rem;
+    }
+    .brand-series-feature-block {
+        display: grid;
+        gap: 0.2rem;
+        padding: 0.65rem 0.75rem;
+        border: 1px solid var(--panel-glass-border);
+        border-radius: 8px;
+        background: var(--panel-chip-bg);
+    }
+    .brand-series-feature-block strong {
+        color: var(--text);
+        font-size: 0.9rem;
+    }
+    .brand-series-feature-block span {
+        color: var(--text-muted);
+        font-size: 0.84rem;
+        line-height: 1.45;
     }
     .catalog-grid {
         display: grid;


### PR DESCRIPTION
## Что изменилось
- Расширена модель серий брендов: промо-контент, галереи, feature/content blocks, SEO и публичная выдача серии.
- В менеджере брендов добавлен полноценный редактор серии с переиспользуемым MediaField: выбор из медиатеки, загрузка файла, URL и вставка из буфера.
- Добавлен новый PIM-дэшборд `Каталог -> Качество каталога` с backend-анализом карточек: медиа, бренд/серия, характеристики, цена/наличие, связи с поставщиками.
- Добавлены проверки низкого разрешения и единичных фото, чтобы ловить слабые Onliner-импорты и похожие проблемные карточки.

## Почему
Каталог теперь движется к нормальной PIM-модели: серии становятся содержательными страницами, а качество карточек можно контролировать как отдельный рабочий процесс, а не искать проблемы вручную.

## Проверки
- `pytest tests/unit/test_catalog_quality_service.py tests/unit/test_public_product_series_payloads.py -q`
- `cd manager_frontend && npm run build`
- `bash scripts/audit_theme_hardcodes.sh`
- `cd web && npm run build`
- Browser QA: `/manager/catalog-quality` desktop/mobile, фильтр “Медиа”, без console errors

## Замечание
Локальный запуск integration-тестов из хоста заблокирован окружением: `db_test` не резолвится вне docker-сети. CI должен прогнать интеграции в правильной среде.
