### PR TITLE
[codex] Add brand feature library and supplier matching tokens

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_add_brand_feature_library.py
+++ b/alembic/versions/d1e2f3a4b5c6_add_brand_feature_library.py
@@ -1,0 +1,86 @@
+"""add brand feature library
+
+Revision ID: d1e2f3a4b5c6
+Revises: c9d0e1f2a3b4
+Create Date: 2026-06-28 02:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, Sequence[str], None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "brand_feature",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("brand_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.String(), nullable=True),
+        sa.Column("icon", sa.String(), nullable=True),
+        sa.Column("footnote", sa.String(), nullable=True),
+        sa.Column("source_url", sa.String(), nullable=True),
+        sa.Column("aliases", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["brand_id"], ["brand.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("brand_id", "slug", name="uq_brand_feature_brand_id_slug"),
+    )
+    op.create_index(op.f("ix_brand_feature_brand_id"), "brand_feature", ["brand_id"], unique=False)
+    op.create_index(op.f("ix_brand_feature_is_published"), "brand_feature", ["is_published"], unique=False)
+    op.create_index(op.f("ix_brand_feature_slug"), "brand_feature", ["slug"], unique=False)
+    op.create_index(op.f("ix_brand_feature_sort_order"), "brand_feature", ["sort_order"], unique=False)
+    op.create_index(op.f("ix_brand_feature_title"), "brand_feature", ["title"], unique=False)
+
+    op.create_table(
+        "product_series_feature_link",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("series_id", sa.Integer(), nullable=False),
+        sa.Column("feature_id", sa.Integer(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("title_override", sa.String(), nullable=True),
+        sa.Column("text_override", sa.Text(), nullable=True),
+        sa.Column("image_url_override", sa.String(), nullable=True),
+        sa.Column("icon_override", sa.String(), nullable=True),
+        sa.Column("footnote_override", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["feature_id"], ["brand_feature.id"]),
+        sa.ForeignKeyConstraint(["series_id"], ["product_series.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("series_id", "feature_id", name="uq_product_series_feature_link"),
+    )
+    op.create_index(op.f("ix_product_series_feature_link_feature_id"), "product_series_feature_link", ["feature_id"], unique=False)
+    op.create_index(op.f("ix_product_series_feature_link_series_id"), "product_series_feature_link", ["series_id"], unique=False)
+    op.create_index(op.f("ix_product_series_feature_link_sort_order"), "product_series_feature_link", ["sort_order"], unique=False)
+
+    op.alter_column("brand_feature", "aliases", server_default=None)
+    op.alter_column("brand_feature", "is_published", server_default=None)
+    op.alter_column("brand_feature", "sort_order", server_default=None)
+    op.alter_column("product_series_feature_link", "sort_order", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_product_series_feature_link_sort_order"), table_name="product_series_feature_link")
+    op.drop_index(op.f("ix_product_series_feature_link_series_id"), table_name="product_series_feature_link")
+    op.drop_index(op.f("ix_product_series_feature_link_feature_id"), table_name="product_series_feature_link")
+    op.drop_table("product_series_feature_link")
+
+    op.drop_index(op.f("ix_brand_feature_title"), table_name="brand_feature")
+    op.drop_index(op.f("ix_brand_feature_sort_order"), table_name="brand_feature")
+    op.drop_index(op.f("ix_brand_feature_slug"), table_name="brand_feature")
+    op.drop_index(op.f("ix_brand_feature_is_published"), table_name="brand_feature")
+    op.drop_index(op.f("ix_brand_feature_brand_id"), table_name="brand_feature")
+    op.drop_table("brand_feature")

--- a/alembic/versions/d2e3f4a5b6c7_add_supplier_offer_match_tokens.py
+++ b/alembic/versions/d2e3f4a5b6c7_add_supplier_offer_match_tokens.py
@@ -1,0 +1,50 @@
+"""add supplier offer match tokens
+
+Revision ID: d2e3f4a5b6c7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-06-28 03:05:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, Sequence[str], None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("supplier_offer", sa.Column("title_normalized", sa.String(), nullable=True))
+    op.add_column(
+        "supplier_offer",
+        sa.Column("model_tokens", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "supplier_offer",
+        sa.Column("indoor_model_tokens", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "supplier_offer",
+        sa.Column("outdoor_model_tokens", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column("supplier_offer", sa.Column("match_normalizer_version", sa.String(), nullable=True))
+    op.create_index(op.f("ix_supplier_offer_title_normalized"), "supplier_offer", ["title_normalized"], unique=False)
+    op.create_index(op.f("ix_supplier_offer_match_normalizer_version"), "supplier_offer", ["match_normalizer_version"], unique=False)
+
+    for column_name in ("model_tokens", "indoor_model_tokens", "outdoor_model_tokens"):
+        op.alter_column("supplier_offer", column_name, server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_supplier_offer_match_normalizer_version"), table_name="supplier_offer")
+    op.drop_index(op.f("ix_supplier_offer_title_normalized"), table_name="supplier_offer")
+    op.drop_column("supplier_offer", "match_normalizer_version")
+    op.drop_column("supplier_offer", "outdoor_model_tokens")
+    op.drop_column("supplier_offer", "indoor_model_tokens")
+    op.drop_column("supplier_offer", "model_tokens")
+    op.drop_column("supplier_offer", "title_normalized")

--- a/crud/product.py
+++ b/crud/product.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Brand, Product, ProductImage, Tag, TagGroup, ProductTagLink
+from models import Brand, Product, ProductImage, ProductSeries, ProductSeriesFeatureLink, Tag, TagGroup, ProductTagLink
 from models.product_constants import BTU_MAPPING
 from models.supplier import ProductLocalStock, ProductSupplierMapping, SupplierOffer
 
@@ -41,6 +41,14 @@ class ProductDAO:
         return option
 
     @staticmethod
+    def _series_option():
+        return (
+            selectinload(Product.series)
+            .selectinload(ProductSeries.feature_links)
+            .selectinload(ProductSeriesFeatureLink.feature)
+        )
+
+    @staticmethod
     async def get_by_id(
         session: AsyncSession,
         product_id: int,
@@ -53,7 +61,7 @@ class ProductDAO:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
             selectinload(Product.brand),
-            selectinload(Product.series),
+            ProductDAO._series_option(),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -74,7 +82,7 @@ class ProductDAO:
             stmt = stmt.where(Product.is_published == is_published)
         stmt = stmt.options(
             selectinload(Product.brand),
-            selectinload(Product.series),
+            ProductDAO._series_option(),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -90,7 +98,7 @@ class ProductDAO:
     ) -> List[Product]:
         stmt = select(Product).where(Product.is_published == True).options(
             selectinload(Product.brand),
-            selectinload(Product.series),
+            ProductDAO._series_option(),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
@@ -109,7 +117,7 @@ class ProductDAO:
             return []
         stmt = select(Product).where(Product.id.in_(product_ids)).options(
             selectinload(Product.brand),
-            selectinload(Product.series),
+            ProductDAO._series_option(),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),
         )
@@ -508,7 +516,7 @@ class ProductDAO:
     ) -> List[Product]:
         stmt = select(Product).options(
             selectinload(Product.brand),
-            selectinload(Product.series),
+            ProductDAO._series_option(),
             selectinload(Product.tags).selectinload(Tag.group),
             ProductDAO._gallery_images_option(load_image_variants=load_image_variants),
             selectinload(Product.attachments),

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -67,6 +67,9 @@ import {
     type CatalogImportJobStatusResponse,
     type ManagerBrandResponse,
     type ManagerBrandCreatePayload,
+    type ManagerBrandFeatureCreatePayload,
+    type ManagerBrandFeatureResponse,
+    type ManagerBrandFeatureUpdatePayload,
     type ManagerBrandSeriesCreatePayload,
     type ManagerBrandSeriesResponse,
     type ManagerBrandSeriesUpdatePayload,
@@ -136,11 +139,15 @@ export type {
 };
 
 type ManagerBrand = ManagerBrandResponse;
+type ManagerBrandFeature = ManagerBrandFeatureResponse;
 type ManagerBrandSeries = ManagerBrandSeriesResponse;
 
 export type {
     ManagerBrand,
     ManagerBrandCreatePayload,
+    ManagerBrandFeature,
+    ManagerBrandFeatureCreatePayload,
+    ManagerBrandFeatureUpdatePayload,
     ManagerBrandSeries,
     ManagerBrandSeriesCreatePayload,
     ManagerBrandSeriesUpdatePayload,
@@ -1026,12 +1033,55 @@ export const api = {
         return await ManagerBrandsService.deleteManagerBrand(brandId);
     },
 
+    async listManagerBrandFeatures(brandId: number): Promise<{ items: ManagerBrandFeature[] }> {
+        const response = await ManagerBrandsService.listManagerBrandFeatures(brandId);
+        return {
+            ...response,
+            items: (response.items || []).map((feature) => ({
+                ...feature,
+                aliases: feature.aliases || [],
+                series_count: feature.series_count ?? 0,
+            })),
+        };
+    },
+
+    async createManagerBrandFeature(
+        brandId: number,
+        payload: ManagerBrandFeatureCreatePayload,
+    ): Promise<ManagerBrandFeature> {
+        const feature = await ManagerBrandsService.createManagerBrandFeature(brandId, payload);
+        return {
+            ...feature,
+            aliases: feature.aliases || [],
+            series_count: feature.series_count ?? 0,
+        };
+    },
+
+    async updateManagerBrandFeature(
+        brandId: number,
+        featureId: number,
+        payload: ManagerBrandFeatureUpdatePayload,
+    ): Promise<ManagerBrandFeature> {
+        const feature = await ManagerBrandsService.updateManagerBrandFeature(brandId, featureId, payload);
+        return {
+            ...feature,
+            aliases: feature.aliases || [],
+            series_count: feature.series_count ?? 0,
+        };
+    },
+
+    async deleteManagerBrandFeature(brandId: number, featureId: number): Promise<{ message: string }> {
+        return await ManagerBrandsService.deleteManagerBrandFeature(brandId, featureId);
+    },
+
     async listManagerBrandSeries(brandId: number): Promise<{ items: ManagerBrandSeries[] }> {
         const response = await ManagerBrandsService.listManagerBrandSeries(brandId);
         return {
             ...response,
             items: (response.items || []).map((series) => ({
                 ...series,
+                brand_features: series.brand_features || [],
+                brand_feature_ids: series.brand_feature_ids || [],
                 features: series.features || [],
                 products_count: series.products_count ?? 0,
             })),
@@ -1045,6 +1095,8 @@ export const api = {
         const series = await ManagerBrandsService.createManagerBrandSeries(brandId, payload);
         return {
             ...series,
+            brand_features: series.brand_features || [],
+            brand_feature_ids: series.brand_feature_ids || [],
             features: series.features || [],
             products_count: series.products_count ?? 0,
         };
@@ -1058,6 +1110,8 @@ export const api = {
         const series = await ManagerBrandsService.updateManagerBrandSeries(brandId, seriesId, payload);
         return {
             ...series,
+            brand_features: series.brand_features || [],
+            brand_feature_ids: series.brand_feature_ids || [],
             features: series.features || [],
             products_count: series.products_count ?? 0,
         };

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -87,6 +87,10 @@ export type { ManagerBackupListResponse } from './models/ManagerBackupListRespon
 export type { ManagerBackupRunStartResponse } from './models/ManagerBackupRunStartResponse';
 export type { ManagerBackupRunStatusResponse } from './models/ManagerBackupRunStatusResponse';
 export type { ManagerBrandCreatePayload } from './models/ManagerBrandCreatePayload';
+export type { ManagerBrandFeatureCreatePayload } from './models/ManagerBrandFeatureCreatePayload';
+export type { ManagerBrandFeatureListResponse } from './models/ManagerBrandFeatureListResponse';
+export type { ManagerBrandFeatureResponse } from './models/ManagerBrandFeatureResponse';
+export type { ManagerBrandFeatureUpdatePayload } from './models/ManagerBrandFeatureUpdatePayload';
 export type { ManagerBrandListResponse } from './models/ManagerBrandListResponse';
 export type { ManagerBrandResponse } from './models/ManagerBrandResponse';
 export type { ManagerBrandSeriesCreatePayload } from './models/ManagerBrandSeriesCreatePayload';
@@ -304,6 +308,7 @@ export type { ProductMainImageCleanupSkipReasonsResponse } from './models/Produc
 export type { ProductManualPayload } from './models/ProductManualPayload';
 export type { ProductManualResponse } from './models/ProductManualResponse';
 export type { ProductResponse } from './models/ProductResponse';
+export type { ProductSeriesBrandFeatureResponse } from './models/ProductSeriesBrandFeatureResponse';
 export type { ProductSeriesContentBlockResponse } from './models/ProductSeriesContentBlockResponse';
 export type { ProductSeriesFeatureBlockResponse } from './models/ProductSeriesFeatureBlockResponse';
 export type { ProductSeriesNavigationItemResponse } from './models/ProductSeriesNavigationItemResponse';

--- a/manager_frontend/src/client/models/ManagerBrandFeatureCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandFeatureCreatePayload.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerBrandFeatureCreatePayload = {
+    title: string;
+    slug?: (string | null);
+    text?: (string | null);
+    image_url?: (string | null);
+    icon?: (string | null);
+    footnote?: (string | null);
+    source_url?: (string | null);
+    aliases?: Array<string>;
+    is_published?: boolean;
+    sort_order?: number;
+};
+

--- a/manager_frontend/src/client/models/ManagerBrandFeatureListResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandFeatureListResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ManagerBrandFeatureResponse } from './ManagerBrandFeatureResponse';
+export type ManagerBrandFeatureListResponse = {
+    items: Array<ManagerBrandFeatureResponse>;
+};
+

--- a/manager_frontend/src/client/models/ManagerBrandFeatureResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandFeatureResponse.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerBrandFeatureResponse = {
+    id: number;
+    title: string;
+    slug: string;
+    text?: (string | null);
+    image_url?: (string | null);
+    icon?: (string | null);
+    footnote?: (string | null);
+    source_url?: (string | null);
+    aliases?: Array<string>;
+    is_published?: boolean;
+    sort_order?: number;
+    brand_id: number;
+    created_at: string;
+    updated_at: string;
+    series_count?: number;
+};
+

--- a/manager_frontend/src/client/models/ManagerBrandFeatureUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandFeatureUpdatePayload.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerBrandFeatureUpdatePayload = {
+    title?: (string | null);
+    slug?: (string | null);
+    text?: (string | null);
+    image_url?: (string | null);
+    icon?: (string | null);
+    footnote?: (string | null);
+    source_url?: (string | null);
+    aliases?: (Array<string> | null);
+    is_published?: (boolean | null);
+    sort_order?: (number | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesCreatePayload.ts
@@ -13,6 +13,7 @@ export type ManagerBrandSeriesCreatePayload = {
     hero_image?: (string | null);
     gallery_images?: Array<string>;
     features?: Array<string>;
+    brand_feature_ids?: Array<number>;
     feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
     content_blocks?: Array<ProductSeriesContentBlockResponse>;
     footnotes?: Array<string>;

--- a/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesBrandFeatureResponse } from './ProductSeriesBrandFeatureResponse';
 import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
 import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ManagerBrandSeriesResponse = {
@@ -15,6 +16,8 @@ export type ManagerBrandSeriesResponse = {
     hero_image?: (string | null);
     gallery_images?: Array<string>;
     features?: Array<string>;
+    brand_features?: Array<ProductSeriesBrandFeatureResponse>;
+    brand_feature_ids?: Array<number>;
     feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
     content_blocks?: Array<ProductSeriesContentBlockResponse>;
     footnotes?: Array<string>;

--- a/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
+++ b/manager_frontend/src/client/models/ManagerBrandSeriesUpdatePayload.ts
@@ -13,6 +13,7 @@ export type ManagerBrandSeriesUpdatePayload = {
     hero_image?: (string | null);
     gallery_images?: (Array<string> | null);
     features?: (Array<string> | null);
+    brand_feature_ids?: (Array<number> | null);
     feature_blocks?: (Array<ProductSeriesFeatureBlockResponse> | null);
     content_blocks?: (Array<ProductSeriesContentBlockResponse> | null);
     footnotes?: (Array<string> | null);

--- a/manager_frontend/src/client/models/ProductSeriesBrandFeatureResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesBrandFeatureResponse.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ProductSeriesBrandFeatureResponse = {
+    id: number;
+    title: string;
+    slug: string;
+    text?: (string | null);
+    image_url?: (string | null);
+    icon?: (string | null);
+    footnote?: (string | null);
+    source_url?: (string | null);
+    aliases?: Array<string>;
+    is_published?: boolean;
+    sort_order?: number;
+};
+

--- a/manager_frontend/src/client/models/ProductSeriesResponse.ts
+++ b/manager_frontend/src/client/models/ProductSeriesResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ProductSeriesBrandFeatureResponse } from './ProductSeriesBrandFeatureResponse';
 import type { ProductSeriesContentBlockResponse } from './ProductSeriesContentBlockResponse';
 import type { ProductSeriesFeatureBlockResponse } from './ProductSeriesFeatureBlockResponse';
 export type ProductSeriesResponse = {
@@ -14,6 +15,7 @@ export type ProductSeriesResponse = {
     hero_image?: (string | null);
     gallery_images?: Array<string>;
     features?: Array<string>;
+    brand_features?: Array<ProductSeriesBrandFeatureResponse>;
     feature_blocks?: Array<ProductSeriesFeatureBlockResponse>;
     content_blocks?: Array<ProductSeriesContentBlockResponse>;
     footnotes?: Array<string>;

--- a/manager_frontend/src/client/models/SupplierOfferResponse.ts
+++ b/manager_frontend/src/client/models/SupplierOfferResponse.ts
@@ -9,6 +9,11 @@ export type SupplierOfferResponse = {
     supplier_name?: (string | null);
     external_id: string;
     title_raw?: (string | null);
+    title_normalized?: (string | null);
+    model_tokens?: Array<string>;
+    indoor_model_tokens?: Array<string>;
+    outdoor_model_tokens?: Array<string>;
+    match_normalizer_version?: (string | null);
     qty: number;
     qty_raw?: (string | null);
     wholesale_raw?: (string | null);

--- a/manager_frontend/src/client/models/SupplierOfferSuggestionCandidate.ts
+++ b/manager_frontend/src/client/models/SupplierOfferSuggestionCandidate.ts
@@ -6,5 +6,11 @@ export type SupplierOfferSuggestionCandidate = {
     product_id: number;
     title: string;
     price: number;
+    score?: number;
+    confidence?: number;
+    matched_tokens?: Array<string>;
+    missing_tokens?: Array<string>;
+    explanations?: Array<string>;
+    score_breakdown?: Record<string, number>;
 };
 

--- a/manager_frontend/src/client/models/SupplierOfferSuggestionItem.ts
+++ b/manager_frontend/src/client/models/SupplierOfferSuggestionItem.ts
@@ -7,6 +7,9 @@ export type SupplierOfferSuggestionItem = {
     supplier_id: number;
     external_id: string;
     normalized_query: string;
+    offer_tokens?: Array<string>;
+    indoor_model_tokens?: Array<string>;
+    outdoor_model_tokens?: Array<string>;
     candidates: Array<SupplierOfferSuggestionCandidate>;
     auto_eligible: boolean;
     reason: string;

--- a/manager_frontend/src/client/services/ManagerBrandsService.ts
+++ b/manager_frontend/src/client/services/ManagerBrandsService.ts
@@ -4,6 +4,10 @@
 /* eslint-disable */
 import type { ManagerActionMessageResponse } from '../models/ManagerActionMessageResponse';
 import type { ManagerBrandCreatePayload } from '../models/ManagerBrandCreatePayload';
+import type { ManagerBrandFeatureCreatePayload } from '../models/ManagerBrandFeatureCreatePayload';
+import type { ManagerBrandFeatureListResponse } from '../models/ManagerBrandFeatureListResponse';
+import type { ManagerBrandFeatureResponse } from '../models/ManagerBrandFeatureResponse';
+import type { ManagerBrandFeatureUpdatePayload } from '../models/ManagerBrandFeatureUpdatePayload';
 import type { ManagerBrandListResponse } from '../models/ManagerBrandListResponse';
 import type { ManagerBrandResponse } from '../models/ManagerBrandResponse';
 import type { ManagerBrandSeriesCreatePayload } from '../models/ManagerBrandSeriesCreatePayload';
@@ -83,6 +87,100 @@ export class ManagerBrandsService {
             url: '/api/manager/brands/{brand_id}',
             path: {
                 'brand_id': brandId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * List Manager Brand Features
+     * @param brandId
+     * @returns ManagerBrandFeatureListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listManagerBrandFeatures(
+        brandId: number,
+    ): CancelablePromise<ManagerBrandFeatureListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/brands/{brand_id}/features',
+            path: {
+                'brand_id': brandId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Manager Brand Feature
+     * @param brandId
+     * @param requestBody
+     * @returns ManagerBrandFeatureResponse Successful Response
+     * @throws ApiError
+     */
+    public static createManagerBrandFeature(
+        brandId: number,
+        requestBody: ManagerBrandFeatureCreatePayload,
+    ): CancelablePromise<ManagerBrandFeatureResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/brands/{brand_id}/features',
+            path: {
+                'brand_id': brandId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Manager Brand Feature
+     * @param brandId
+     * @param featureId
+     * @param requestBody
+     * @returns ManagerBrandFeatureResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateManagerBrandFeature(
+        brandId: number,
+        featureId: number,
+        requestBody: ManagerBrandFeatureUpdatePayload,
+    ): CancelablePromise<ManagerBrandFeatureResponse> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/manager/brands/{brand_id}/features/{feature_id}',
+            path: {
+                'brand_id': brandId,
+                'feature_id': featureId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Manager Brand Feature
+     * @param brandId
+     * @param featureId
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static deleteManagerBrandFeature(
+        brandId: number,
+        featureId: number,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/brands/{brand_id}/features/{feature_id}',
+            path: {
+                'brand_id': brandId,
+                'feature_id': featureId,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/components/IconPicker.vue
+++ b/manager_frontend/src/components/IconPicker.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+
+type IconOption = {
+    value: string;
+    icon: string;
+    label: string;
+};
+
+const props = withDefaults(defineProps<{
+    modelValue: string;
+    options: IconOption[];
+    tone?: 'indigo' | 'teal';
+    label?: string;
+}>(), {
+    tone: 'indigo',
+    label: 'Иконка',
+});
+
+const emit = defineEmits<{
+    'update:modelValue': [value: string];
+}>();
+
+const root = ref<HTMLElement | null>(null);
+const isOpen = ref(false);
+
+const selectedOption = computed(() => (
+    props.options.find((option) => option.value === (props.modelValue || ''))
+    || props.options[0]
+    || { value: '', icon: 'hide_image', label: 'Без' }
+));
+
+const accentClasses = computed(() => {
+    if (props.tone === 'teal') {
+        return {
+            trigger: 'border-teal-100 bg-teal-50/60 text-teal-800 hover:border-teal-300 dark:border-teal-900/50 dark:bg-teal-950/20 dark:text-teal-100',
+            selected: 'border-teal-500 bg-teal-600 text-white shadow-sm',
+            idle: 'border-gray-200 bg-white text-gray-600 hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300 dark:hover:border-teal-700 dark:hover:text-teal-200',
+            icon: 'bg-teal-50 text-teal-700 group-hover:bg-teal-100 dark:bg-slate-800 dark:text-teal-200',
+            chip: 'bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-100',
+        };
+    }
+    return {
+        trigger: 'border-indigo-100 bg-indigo-50/60 text-indigo-800 hover:border-indigo-300 dark:border-indigo-900/50 dark:bg-indigo-950/20 dark:text-indigo-100',
+        selected: 'border-indigo-500 bg-indigo-600 text-white shadow-sm',
+        idle: 'border-indigo-100 bg-indigo-50/60 text-gray-600 hover:border-indigo-300 hover:bg-white hover:text-indigo-700 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-300 dark:hover:border-indigo-700 dark:hover:bg-slate-900 dark:hover:text-indigo-200',
+        icon: 'bg-white text-indigo-700 group-hover:bg-indigo-50 dark:bg-slate-800 dark:text-indigo-200',
+        chip: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-100',
+    };
+});
+
+const choose = (value: string) => {
+    emit('update:modelValue', value);
+    isOpen.value = false;
+};
+
+const onFocusOut = () => {
+    window.setTimeout(() => {
+        if (!root.value?.contains(document.activeElement)) {
+            isOpen.value = false;
+        }
+    }, 0);
+};
+
+const onDocumentPointerDown = (event: PointerEvent) => {
+    const target = event.target;
+    if (target instanceof Node && !root.value?.contains(target)) {
+        isOpen.value = false;
+    }
+};
+
+onMounted(() => {
+    document.addEventListener('pointerdown', onDocumentPointerDown);
+});
+
+onBeforeUnmount(() => {
+    document.removeEventListener('pointerdown', onDocumentPointerDown);
+});
+</script>
+
+<template>
+    <div ref="root" class="relative" @focusin="isOpen = true" @focusout="onFocusOut" @keydown.escape.stop="isOpen = false">
+        <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-sm transition"
+            :class="accentClasses.trigger"
+            :aria-expanded="isOpen"
+            @click="isOpen = true"
+        >
+            <span class="flex min-w-0 items-center gap-2">
+                <span class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/70 dark:bg-slate-900/70">
+                    <span class="material-icons-round text-[20px]">{{ selectedOption.icon }}</span>
+                </span>
+                <span class="min-w-0">
+                    <span class="block text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-400 dark:text-slate-500">{{ label }}</span>
+                    <span class="block truncate font-semibold">{{ selectedOption.label }}</span>
+                </span>
+            </span>
+            <span class="inline-flex min-w-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold" :class="accentClasses.chip">
+                <span class="truncate">{{ modelValue || 'без иконки' }}</span>
+                <span class="material-icons-round text-[15px]">expand_more</span>
+            </span>
+        </button>
+
+        <div
+            v-if="isOpen"
+            class="absolute left-0 right-0 top-full z-40 mt-2 rounded-xl border border-gray-200 bg-white p-2 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+        >
+            <div class="grid grid-cols-4 gap-1.5 sm:grid-cols-6 lg:grid-cols-9">
+                <button
+                    v-for="option in options"
+                    :key="`icon-picker-${option.value || 'none'}`"
+                    type="button"
+                    class="group flex min-h-[60px] flex-col items-center justify-center gap-1 rounded-lg border px-1.5 py-2 text-center transition"
+                    :class="(modelValue || '') === option.value ? accentClasses.selected : accentClasses.idle"
+                    :aria-pressed="(modelValue || '') === option.value"
+                    :title="option.value ? `${option.label}: ${option.value}` : 'Без иконки'"
+                    @click="choose(option.value)"
+                >
+                    <span
+                        class="inline-flex h-8 w-8 items-center justify-center rounded-lg transition"
+                        :class="(modelValue || '') === option.value ? 'bg-white/15 text-white' : accentClasses.icon"
+                    >
+                        <span class="material-icons-round text-[20px]">{{ option.icon }}</span>
+                    </span>
+                    <span class="max-w-full truncate text-[11px] font-semibold leading-tight">{{ option.label }}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
-import { api, type ManagerBrand, type ManagerBrandSeries } from '../api';
+import { api, type ManagerBrand, type ManagerBrandFeature, type ManagerBrandSeries } from '../api';
+import IconPicker from '../components/IconPicker.vue';
 import MediaField from '../components/MediaField.vue';
 import { getApiErrorMessage } from '../utils/api-errors';
 
@@ -22,6 +23,7 @@ type SeriesForm = {
     hero_image: string;
     galleryImages: string[];
     featuresText: string;
+    brandFeatureIds: number[];
     featureBlocks: SeriesFeatureBlockForm[];
     contentBlocks: SeriesContentBlockForm[];
     footnotesText: string;
@@ -48,6 +50,15 @@ type SeriesContentBlockForm = {
     layout: 'text_left' | 'text_right' | 'full';
 };
 
+type BrandFeatureDraft = {
+    title: string;
+    text: string;
+    image_url: string;
+    icon: string;
+    source_url: string;
+    aliasesText: string;
+};
+
 const brands = ref<ManagerBrand[]>([]);
 const loading = ref(true);
 const saving = ref(false);
@@ -58,8 +69,12 @@ const modalOpen = ref(false);
 const editingBrand = ref<ManagerBrand | null>(null);
 const selectedBrandId = ref<number | null>(null);
 const seriesItems = ref<ManagerBrandSeries[]>([]);
+const brandFeatures = ref<ManagerBrandFeature[]>([]);
 const seriesLoading = ref(false);
+const brandFeaturesLoading = ref(false);
 const seriesSaving = ref(false);
+const featureSaving = ref(false);
+const editingBrandFeatureId = ref<number | null>(null);
 const seriesError = ref('');
 const seriesModalOpen = ref(false);
 const editingSeries = ref<ManagerBrandSeries | null>(null);
@@ -87,6 +102,7 @@ const seriesForm = ref<SeriesForm>({
     hero_image: '',
     galleryImages: [],
     featuresText: '',
+    brandFeatureIds: [],
     featureBlocks: [],
     contentBlocks: [],
     footnotesText: '',
@@ -97,6 +113,15 @@ const seriesForm = ref<SeriesForm>({
     is_published: true,
 });
 const pendingGalleryImage = ref('');
+const seoPromptPreview = ref('');
+const featureDraft = ref<BrandFeatureDraft>({
+    title: '',
+    text: '',
+    image_url: '',
+    icon: '',
+    source_url: '',
+    aliasesText: '',
+});
 
 const filteredBrands = computed(() => {
     const q = query.value.trim().toLowerCase();
@@ -127,13 +152,64 @@ const isSeriesReorderDisabled = computed(() => (
     || seriesSaving.value
     || reorderingSeries.value
 ));
+const selectedBrandFeatureCount = computed(() => seriesForm.value.brandFeatureIds.length);
+const isEditingBrandFeature = computed(() => editingBrandFeatureId.value !== null);
 
 const SORT_ORDER_STEP = 10;
+const featureIconOptions = [
+    { value: '', icon: 'hide_image', label: 'Без' },
+    { value: 'air', icon: 'air', label: 'Воздух' },
+    { value: 'ac_unit', icon: 'ac_unit', label: 'Холод' },
+    { value: 'thermostat', icon: 'thermostat', label: 'Климат' },
+    { value: 'eco', icon: 'eco', label: 'ECO' },
+    { value: 'energy_savings_leaf', icon: 'energy_savings_leaf', label: 'Энергия' },
+    { value: 'bolt', icon: 'bolt', label: 'Мощность' },
+    { value: 'wifi', icon: 'wifi', label: 'Wi-Fi' },
+    { value: 'self_cleaning', icon: 'self_cleaning', label: 'Самооч.' },
+    { value: 'cleaning_services', icon: 'cleaning_services', label: 'Очистка' },
+    { value: 'filter_alt', icon: 'filter_alt', label: 'Фильтр' },
+    { value: 'water_drop', icon: 'water_drop', label: 'Осуш.' },
+    { value: 'waves', icon: 'waves', label: 'Поток' },
+    { value: 'volume_down', icon: 'volume_down', label: 'Тишина' },
+    { value: 'shield', icon: 'shield', label: 'Защита' },
+    { value: 'auto_awesome', icon: 'auto_awesome', label: 'AI' },
+    { value: 'settings_suggest', icon: 'settings_suggest', label: 'Авто' },
+];
 
 const getNextSortOrder = <T extends { sort_order?: number | null }>(items: T[]) => {
     const maxOrder = items.reduce((max, item) => Math.max(max, Number(item.sort_order || 0)), 0);
     return maxOrder + SORT_ORDER_STEP;
 };
+
+const sortBrandFeatures = (items: ManagerBrandFeature[]) => (
+    [...items].sort((a, b) => (
+        Number(a.sort_order || 0) - Number(b.sort_order || 0)
+        || String(a.title || '').localeCompare(String(b.title || ''))
+    ))
+);
+
+const compactText = (value: string, maxLength = 160) => {
+    const text = String(value || '').replace(/\s+/g, ' ').trim();
+    if (text.length <= maxLength) return text;
+    return `${text.slice(0, maxLength - 1).trim()}…`;
+};
+
+const getSelectedBrandFeatureTitles = () => {
+    const selectedIds = new Set(seriesForm.value.brandFeatureIds);
+    return brandFeatures.value
+        .filter((feature) => selectedIds.has(feature.id))
+        .map((feature) => String(feature.title || '').trim())
+        .filter(Boolean);
+};
+
+const suggestedSeriesFeatureTitles = computed(() => {
+    const titles = [
+        ...getSelectedBrandFeatureTitles(),
+        ...seriesForm.value.featureBlocks.map((block) => String(block.title || '').trim()),
+        ...seriesForm.value.contentBlocks.map((block) => String(block.title || '').trim()),
+    ];
+    return normalizeTextList(titles.join('\n'));
+});
 
 const moveItemById = <T extends { id: number }>(items: T[], draggedId: number, targetId: number) => {
     const sourceIndex = items.findIndex((item) => item.id === draggedId);
@@ -156,6 +232,7 @@ const hasSeriesDetails = (series: ManagerBrandSeries) => Boolean(
     || series.hero_image
     || series.gallery_images?.length
     || series.features?.length
+    || series.brand_features?.length
     || series.feature_blocks?.length
     || series.content_blocks?.length
     || series.footnotes?.length
@@ -205,6 +282,7 @@ const resetForm = () => {
 
 const resetSeriesForm = () => {
     pendingGalleryImage.value = '';
+    seoPromptPreview.value = '';
     seriesForm.value = {
         title: '',
         slug: '',
@@ -214,6 +292,7 @@ const resetSeriesForm = () => {
         hero_image: '',
         galleryImages: [],
         featuresText: '',
+        brandFeatureIds: [],
         featureBlocks: [],
         contentBlocks: [],
         footnotesText: '',
@@ -271,7 +350,30 @@ const fetchSeries = async () => {
     }
 };
 
+const fetchBrandFeatures = async () => {
+    if (!selectedBrandId.value) {
+        brandFeatures.value = [];
+        return;
+    }
+
+    brandFeaturesLoading.value = true;
+    seriesError.value = '';
+    try {
+        const res = await api.listManagerBrandFeatures(selectedBrandId.value);
+        brandFeatures.value = sortBrandFeatures(res.items || []);
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        brandFeaturesLoading.value = false;
+    }
+};
+
 const selectBrand = (brand: ManagerBrand) => {
+    if (selectedBrandId.value === brand.id) {
+        selectedBrandId.value = null;
+        seriesError.value = '';
+        return;
+    }
     selectedBrandId.value = brand.id;
 };
 
@@ -311,6 +413,7 @@ const openSeriesCreate = () => {
 
 const openSeriesEdit = (series: ManagerBrandSeries) => {
     editingSeries.value = series;
+    seoPromptPreview.value = '';
     seriesForm.value = {
         title: String(series.title || ''),
         slug: String(series.slug || ''),
@@ -320,6 +423,7 @@ const openSeriesEdit = (series: ManagerBrandSeries) => {
         hero_image: String(series.hero_image || ''),
         galleryImages: [...(series.gallery_images || [])],
         featuresText: (series.features || []).join('\n'),
+        brandFeatureIds: [...(series.brand_feature_ids || (series.brand_features || []).map((feature) => feature.id))],
         featureBlocks: (series.feature_blocks || []).map((block) => ({
             title: String(block.title || ''),
             text: String(block.text || ''),
@@ -380,6 +484,99 @@ const normalizeUrlList = (value: string[]) => {
             seen.add(key);
             return true;
         });
+};
+
+const syncSeriesFeaturesFromStructuredBlocks = () => {
+    const suggestions = suggestedSeriesFeatureTitles.value;
+    if (suggestions.length === 0) {
+        seriesError.value = 'Сначала добавьте фичи бренда, блоки преимуществ или контентные секции.';
+        return;
+    }
+    const existing = normalizeTextList(seriesForm.value.featuresText);
+    seriesForm.value.featuresText = normalizeTextList([...existing, ...suggestions].join('\n')).join('\n');
+    setToast('Фичи серии собраны из блоков');
+};
+
+const buildSeriesSeoDescriptionSource = () => {
+    const selectedFeatureDescriptions = brandFeatures.value
+        .filter((feature) => seriesForm.value.brandFeatureIds.includes(feature.id))
+        .map((feature) => [feature.title, feature.text].filter(Boolean).join(': '));
+    return normalizeTextList([
+        seriesForm.value.tagline,
+        seriesForm.value.short_description,
+        seriesForm.value.description,
+        ...selectedFeatureDescriptions,
+        ...seriesForm.value.featureBlocks.map((block) => [block.title, block.text].filter(Boolean).join(': ')),
+        ...seriesForm.value.contentBlocks.map((block) => [block.title, block.text].filter(Boolean).join(': ')),
+    ].join('\n'));
+};
+
+const generateSeriesSeoDraft = () => {
+    const brandTitle = selectedBrand.value?.title || '';
+    const seriesTitle = String(seriesForm.value.title || '').trim();
+    if (!seriesTitle && !brandTitle) {
+        seriesError.value = 'Заполните название серии или бренд, чтобы собрать SEO.';
+        return;
+    }
+
+    const titleBase = [brandTitle, seriesTitle].filter(Boolean).join(' ');
+    const titleTail = String(seriesForm.value.tagline || seriesForm.value.short_description || '').trim();
+    seriesForm.value.seo_title = compactText([titleBase, titleTail].filter(Boolean).join(' — '), 68);
+
+    const descriptionParts = buildSeriesSeoDescriptionSource();
+    const fallbackFeatures = suggestedSeriesFeatureTitles.value.slice(0, 4).join(', ');
+    const description = descriptionParts.length
+        ? descriptionParts.join(' ')
+        : [titleBase, fallbackFeatures].filter(Boolean).join(': ');
+    seriesForm.value.seo_description = compactText(description, 158);
+    setToast('SEO-черновик собран из описаний');
+};
+
+const buildSeriesSeoPrompt = () => {
+    const payload = {
+        brand: selectedBrand.value?.title || '',
+        series: seriesForm.value.title,
+        tagline: seriesForm.value.tagline,
+        short_description: seriesForm.value.short_description,
+        description: seriesForm.value.description,
+        reusable_features: brandFeatures.value
+            .filter((feature) => seriesForm.value.brandFeatureIds.includes(feature.id))
+            .map((feature) => ({ title: feature.title, text: feature.text || '' })),
+        feature_blocks: seriesForm.value.featureBlocks.map((block) => ({
+            title: block.title,
+            text: block.text,
+        })),
+        content_blocks: seriesForm.value.contentBlocks.map((block) => ({
+            title: block.title,
+            text: block.text,
+        })),
+        current_seo_title: seriesForm.value.seo_title,
+        current_seo_description: seriesForm.value.seo_description,
+    };
+    return [
+        'Ты SEO-редактор интернет-магазина климатической техники.',
+        'Составь SEO title и SEO description для страницы серии кондиционеров на русском языке.',
+        'Правила:',
+        '- Верни только JSON без markdown: {"seo_title":"...","seo_description":"..."}',
+        '- seo_title: до 68 символов, без кликбейта, бренд и серия должны быть в начале.',
+        '- seo_description: до 158 символов, живая польза серии, без выдуманных характеристик.',
+        '- Используй только факты из входных данных.',
+        '- Не перечисляй все фичи, выбери 2-3 самые сильные.',
+        '',
+        'Входные данные:',
+        JSON.stringify(payload, null, 2),
+    ].join('\n');
+};
+
+const prepareSeriesSeoPrompt = async () => {
+    const prompt = buildSeriesSeoPrompt();
+    seoPromptPreview.value = prompt;
+    try {
+        await navigator.clipboard.writeText(prompt);
+        setToast('Промпт для AI скопирован');
+    } catch {
+        setToast('Промпт подготовлен ниже');
+    }
 };
 
 const normalizeFeatureBlocks = (blocks: SeriesFeatureBlockForm[]) => (
@@ -446,6 +643,116 @@ const addGalleryImage = (url = pendingGalleryImage.value) => {
 
 const removeGalleryImage = (index: number) => {
     seriesForm.value.galleryImages.splice(index, 1);
+};
+
+const isBrandFeatureSelected = (featureId: number) => seriesForm.value.brandFeatureIds.includes(featureId);
+
+const toggleBrandFeature = (featureId: number) => {
+    const current = new Set(seriesForm.value.brandFeatureIds);
+    if (current.has(featureId)) {
+        current.delete(featureId);
+    } else {
+        current.add(featureId);
+    }
+    seriesForm.value.brandFeatureIds = [...current];
+};
+
+const resetFeatureDraft = () => {
+    editingBrandFeatureId.value = null;
+    featureDraft.value = {
+        title: '',
+        text: '',
+        image_url: '',
+        icon: '',
+        source_url: '',
+        aliasesText: '',
+    };
+};
+
+const startEditBrandFeature = (feature: ManagerBrandFeature) => {
+    editingBrandFeatureId.value = feature.id;
+    featureDraft.value = {
+        title: String(feature.title || ''),
+        text: String(feature.text || ''),
+        image_url: String(feature.image_url || ''),
+        icon: String(feature.icon || ''),
+        source_url: String(feature.source_url || ''),
+        aliasesText: (feature.aliases || []).join('\n'),
+    };
+};
+
+const saveBrandFeatureFromDraft = async () => {
+    if (!selectedBrandId.value) return;
+    const title = String(featureDraft.value.title || '').trim();
+    if (!title) {
+        seriesError.value = 'Название фичи обязательно.';
+        return;
+    }
+
+    featureSaving.value = true;
+    seriesError.value = '';
+    try {
+        const existingFeature = brandFeatures.value.find((feature) => feature.id === editingBrandFeatureId.value);
+        const payload = {
+            title,
+            text: String(featureDraft.value.text || '').trim() || undefined,
+            image_url: String(featureDraft.value.image_url || '').trim() || undefined,
+            icon: String(featureDraft.value.icon || '').trim() || undefined,
+            source_url: String(featureDraft.value.source_url || '').trim() || undefined,
+            aliases: normalizeTextList(featureDraft.value.aliasesText),
+            is_published: true,
+            sort_order: existingFeature ? Number(existingFeature.sort_order || 0) : getNextSortOrder(brandFeatures.value),
+        };
+
+        if (editingBrandFeatureId.value) {
+            const updated = await api.updateManagerBrandFeature(
+                selectedBrandId.value,
+                editingBrandFeatureId.value,
+                payload,
+            );
+            brandFeatures.value = sortBrandFeatures(
+                brandFeatures.value.map((feature) => (feature.id === updated.id ? updated : feature)),
+            );
+            setToast('Фича обновлена');
+        } else {
+            const created = await api.createManagerBrandFeature(selectedBrandId.value, payload);
+            brandFeatures.value = sortBrandFeatures([...brandFeatures.value, created]);
+            if (created.id && !seriesForm.value.brandFeatureIds.includes(created.id)) {
+                seriesForm.value.brandFeatureIds.push(created.id);
+            }
+            setToast('Фича добавлена в библиотеку');
+        }
+        resetFeatureDraft();
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        featureSaving.value = false;
+    }
+};
+
+const deleteBrandFeature = async (feature: ManagerBrandFeature) => {
+    if (!selectedBrandId.value) return;
+    if (Number(feature.series_count || 0) > 0) {
+        seriesError.value = `Фича "${feature.title}" используется в сериях. Сначала отвяжите ее от серий, затем удалите.`;
+        return;
+    }
+    if (!confirm(`Удалить фичу "${feature.title}" из библиотеки бренда?`)) return;
+
+    featureSaving.value = true;
+    seriesError.value = '';
+    try {
+        await api.deleteManagerBrandFeature(selectedBrandId.value, feature.id);
+        brandFeatures.value = brandFeatures.value.filter((item) => item.id !== feature.id);
+        seriesForm.value.brandFeatureIds = seriesForm.value.brandFeatureIds.filter((id) => id !== feature.id);
+        if (editingBrandFeatureId.value === feature.id) {
+            resetFeatureDraft();
+        }
+        setToast('Фича удалена');
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        featureSaving.value = false;
+    }
 };
 
 const saveBrand = async () => {
@@ -566,6 +873,7 @@ const saveSeries = async () => {
             hero_image: String(seriesForm.value.hero_image || '').trim() || undefined,
             gallery_images: normalizeUrlList(seriesForm.value.galleryImages),
             features: normalizeFeatures(seriesForm.value.featuresText),
+            brand_feature_ids: [...seriesForm.value.brandFeatureIds],
             feature_blocks: normalizeFeatureBlocks(seriesForm.value.featureBlocks),
             content_blocks: normalizeContentBlocks(seriesForm.value.contentBlocks),
             footnotes: normalizeTextList(seriesForm.value.footnotesText),
@@ -581,6 +889,7 @@ const saveSeries = async () => {
             await api.createManagerBrandSeries(selectedBrandId.value, payload);
         }
         await fetchSeries();
+        await fetchBrandFeatures();
         closeSeriesModal();
         setToast(wasEditing ? 'Серия обновлена' : 'Серия создана');
     } catch (err) {
@@ -659,6 +968,7 @@ const deleteSeries = async (series: ManagerBrandSeries) => {
 
 watch(selectedBrandId, () => {
     fetchSeries();
+    fetchBrandFeatures();
 });
 
 onMounted(() => {
@@ -780,265 +1090,280 @@ onMounted(() => {
                                 </span>
                             </td>
                             <td class="py-2 text-right">
-                                <div class="inline-flex items-center gap-1">
+                                <div class="inline-flex items-center justify-end gap-1">
                                     <button
                                         type="button"
-                                        class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-gray-50 dark:hover:bg-slate-700"
-                                        @click.stop="selectBrand(brand)"
-                                    >
-                                        Серии
-                                    </button>
-                                    <button
-                                        type="button"
-                                        class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-gray-50 dark:hover:bg-slate-700"
+                                        class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 text-gray-600 transition-colors hover:bg-gray-50 hover:text-teal-700 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-teal-200"
+                                        title="Изменить бренд"
+                                        aria-label="Изменить бренд"
                                         @click.stop="openEdit(brand)"
                                     >
-                                        Изменить
+                                        <span class="material-icons-round text-[18px]">edit</span>
                                     </button>
                                     <button
                                         type="button"
-                                        class="px-2.5 py-1 rounded border border-red-200 text-red-600 text-xs font-semibold hover:bg-red-50 disabled:opacity-50"
+                                        class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red-200 text-red-500 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-red-900/50 dark:text-red-300 dark:hover:bg-red-950/30"
                                         :disabled="(brand.products_count ?? 0) > 0"
+                                        :title="(brand.products_count ?? 0) > 0 ? 'Нельзя удалить бренд с товарами' : 'Удалить бренд'"
+                                        aria-label="Удалить бренд"
                                         @click.stop="deleteBrand(brand)"
                                     >
-                                        Удалить
+                                        <span class="material-icons-round text-[18px]">delete</span>
                                     </button>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr v-if="selectedBrandId === brand.id" class="border-b border-teal-100 bg-teal-50/50 dark:border-teal-900/40 dark:bg-teal-950/10">
+                            <td colspan="6" class="p-0">
+                                <div class="mx-3 my-3 rounded-2xl border border-teal-100 bg-white p-4 shadow-sm dark:border-teal-900/60 dark:bg-slate-900">
+                                    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                        <div class="min-w-0">
+                                            <p class="text-xs uppercase tracking-[0.18em] font-bold text-teal-600 dark:text-teal-300">Серии бренда</p>
+                                            <h2 class="text-lg font-bold text-gray-900 dark:text-white">{{ brand.title }}</h2>
+                                            <p v-if="brand.description" class="mt-1 max-w-4xl text-sm text-gray-500 dark:text-slate-400">
+                                                {{ brand.description }}
+                                            </p>
+                                            <p class="mt-1 text-xs text-gray-500 dark:text-slate-400">
+                                                Описания и фичи попадут на брендовые страницы и в блок связанных моделей. Порядок меняется перетаскиванием карточек.
+                                            </p>
+                                        </div>
+                                        <div class="flex shrink-0 flex-wrap items-center gap-2">
+                                            <div v-if="reorderingSeries" class="text-xs font-semibold text-teal-600 dark:text-teal-300">
+                                                Сохраняем порядок...
+                                            </div>
+                                            <button
+                                                type="button"
+                                                class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-teal-500"
+                                                @click.stop="openSeriesCreate"
+                                            >
+                                                <span class="material-icons-round text-[18px]">add</span>
+                                                Новая серия
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <div v-if="seriesError" class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+                                        {{ seriesError }}
+                                    </div>
+
+                                    <div v-if="seriesLoading" class="py-6 text-sm text-gray-500 dark:text-slate-400">
+                                        Загрузка серий...
+                                    </div>
+                                    <div v-else-if="seriesItems.length === 0" class="mt-3 rounded-xl border border-dashed border-gray-300 px-4 py-8 text-sm text-gray-500 dark:border-slate-700 dark:text-slate-400">
+                                        У бренда пока нет серий. Можно добавить первую вручную.
+                                    </div>
+                                    <div v-else class="mt-3 space-y-2">
+                                        <article
+                                            v-for="series in seriesItems"
+                                            :key="series.id"
+                                            class="relative rounded-xl border border-gray-200 bg-slate-50 px-3 py-2.5 pr-20 transition-shadow dark:border-slate-700 dark:bg-slate-900/50 lg:pr-3"
+                                            :class="[
+                                                draggedSeriesId === series.id ? 'opacity-50' : '',
+                                                hasSeriesDetails(series) ? 'cursor-pointer lg:cursor-default' : '',
+                                            ]"
+                                            :draggable="!isSeriesReorderDisabled"
+                                            @click="toggleSeriesExpandedFromCard(series)"
+                                            @dragstart="onSeriesDragStart($event, series)"
+                                            @dragover="onSeriesDragOver($event, series)"
+                                            @dragleave="seriesDropTargetId = seriesDropTargetId === series.id ? null : seriesDropTargetId"
+                                            @drop.prevent="onSeriesDrop(series)"
+                                            @dragend="resetSeriesDragState"
+                                        >
+                                            <span
+                                                v-if="seriesDropTargetId === series.id"
+                                                aria-hidden="true"
+                                                class="pointer-events-none absolute -top-2 left-3 right-3 h-1 rounded-full bg-teal-400 shadow-[0_0_18px_rgba(20,184,166,0.75)] dark:bg-teal-300"
+                                            />
+                                            <div class="absolute right-2 top-2 z-10 inline-flex items-center gap-1 lg:hidden" @click.stop>
+                                                <button
+                                                    type="button"
+                                                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white/85 text-gray-600 shadow-sm backdrop-blur hover:text-teal-700 dark:border-slate-700 dark:bg-slate-900/85 dark:text-slate-300 dark:hover:text-teal-200"
+                                                    title="Изменить серию"
+                                                    aria-label="Изменить серию"
+                                                    @click.stop="openSeriesEdit(series)"
+                                                >
+                                                    <span class="material-icons-round text-[18px]">edit</span>
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red-200 bg-white/85 text-red-500 shadow-sm backdrop-blur hover:bg-red-50 disabled:opacity-40 dark:border-red-900/60 dark:bg-slate-900/85 dark:hover:bg-red-950/30"
+                                                    :disabled="(series.products_count ?? 0) > 0"
+                                                    title="Удалить серию"
+                                                    aria-label="Удалить серию"
+                                                    @click.stop="deleteSeries(series)"
+                                                >
+                                                    <span class="material-icons-round text-[18px]">delete</span>
+                                                </button>
+                                            </div>
+                                            <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+                                                <div class="flex min-w-0 flex-1 items-start gap-2">
+                                                    <button
+                                                        type="button"
+                                                        class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 text-gray-400 transition-colors dark:border-slate-700 dark:text-slate-500"
+                                                        :class="isSeriesReorderDisabled ? 'cursor-not-allowed opacity-40' : 'cursor-grab hover:bg-white hover:text-teal-600 active:cursor-grabbing dark:hover:bg-slate-800 dark:hover:text-teal-300'"
+                                                        :disabled="isSeriesReorderDisabled"
+                                                        title="Перетащите серию выше или ниже"
+                                                        @click.stop
+                                                    >
+                                                        <span class="material-icons-round text-[22px]">drag_indicator</span>
+                                                    </button>
+                                                    <img
+                                                        v-if="series.hero_image"
+                                                        :src="series.hero_image"
+                                                        :alt="series.title"
+                                                        class="h-10 w-10 shrink-0 rounded-lg border border-gray-200 bg-white object-cover dark:border-slate-700"
+                                                    />
+                                                    <div class="min-w-0 flex-1">
+                                                        <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                                            <h3 class="min-w-0 break-words font-bold leading-tight text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
+                                                            <span
+                                                                class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+                                                                :class="series.is_published ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'"
+                                                            >
+                                                                {{ series.is_published ? 'Публичная' : 'Скрыта' }}
+                                                            </span>
+                                                            <span class="text-xs text-gray-500 dark:text-slate-400">{{ series.products_count }} товаров</span>
+                                                        </div>
+                                                        <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
+                                                        <p v-if="series.tagline" class="mt-0.5 text-sm font-semibold text-gray-700 dark:text-slate-200">
+                                                            {{ series.tagline }}
+                                                        </p>
+                                                        <p v-else-if="series.short_description" class="mt-0.5 line-clamp-2 text-sm text-gray-500 dark:text-slate-400">
+                                                            {{ series.short_description }}
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                                <div v-if="series.features?.length && !isSeriesExpanded(series.id)" class="flex min-w-0 flex-1 flex-wrap gap-1.5 lg:max-w-[34%]">
+                                                    <span
+                                                        v-for="feature in series.features.slice(0, 3)"
+                                                        :key="feature"
+                                                        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:border-teal-900/60 dark:bg-teal-950/30 dark:text-teal-200"
+                                                    >
+                                                        {{ feature }}
+                                                    </span>
+                                                    <span
+                                                        v-if="series.features.length > 3"
+                                                        class="rounded-full border border-gray-200 px-2 py-0.5 text-xs font-semibold text-gray-500 dark:border-slate-700 dark:text-slate-400"
+                                                    >
+                                                        +{{ series.features.length - 3 }}
+                                                    </span>
+                                                </div>
+                                                <div class="hidden shrink-0 items-center gap-1 lg:inline-flex">
+                                                    <button
+                                                        v-if="hasSeriesDetails(series)"
+                                                        type="button"
+                                                        class="inline-flex items-center gap-1 rounded border border-gray-200 px-2.5 py-1 text-xs font-semibold hover:bg-white dark:border-slate-700 dark:hover:bg-slate-800"
+                                                        :aria-expanded="isSeriesExpanded(series.id)"
+                                                        @click.stop="toggleSeriesExpanded(series.id)"
+                                                    >
+                                                        <span class="material-icons-round text-[16px]">
+                                                            {{ isSeriesExpanded(series.id) ? 'expand_less' : 'expand_more' }}
+                                                        </span>
+                                                        Детали
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="rounded border border-gray-200 px-2.5 py-1 text-xs font-semibold hover:bg-white dark:border-slate-700 dark:hover:bg-slate-800"
+                                                        @click.stop="openSeriesEdit(series)"
+                                                    >
+                                                        Изменить
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        class="rounded border border-red-200 px-2.5 py-1 text-xs font-semibold text-red-600 hover:bg-red-50 disabled:opacity-50"
+                                                        :disabled="(series.products_count ?? 0) > 0"
+                                                        @click.stop="deleteSeries(series)"
+                                                    >
+                                                        Удалить
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <div
+                                                v-if="!isSeriesExpanded(series.id)"
+                                                class="mt-2 flex flex-wrap gap-1.5 text-[11px] font-semibold"
+                                            >
+                                                <span
+                                                    v-if="series.gallery_images?.length"
+                                                    class="rounded-full bg-blue-50 px-2 py-0.5 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200"
+                                                >
+                                                    галерея {{ series.gallery_images.length }}
+                                                </span>
+                                                <span
+                                                    v-if="series.brand_features?.length"
+                                                    class="rounded-full bg-indigo-50 px-2 py-0.5 text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-200"
+                                                >
+                                                    из библиотеки {{ series.brand_features.length }}
+                                                </span>
+                                                <span
+                                                    v-if="series.feature_blocks?.length"
+                                                    class="rounded-full bg-purple-50 px-2 py-0.5 text-purple-700 dark:bg-purple-950/30 dark:text-purple-200"
+                                                >
+                                                    преимущества {{ series.feature_blocks.length }}
+                                                </span>
+                                                <span
+                                                    v-if="series.content_blocks?.length"
+                                                    class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700 dark:bg-amber-950/30 dark:text-amber-200"
+                                                >
+                                                    контент {{ series.content_blocks.length }}
+                                                </span>
+                                                <span
+                                                    v-if="series.seo_title || series.seo_description"
+                                                    class="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200"
+                                                >
+                                                    SEO
+                                                </span>
+                                            </div>
+                                            <div
+                                                v-if="isSeriesExpanded(series.id)"
+                                                class="mt-2 border-t border-gray-200 pt-2 text-sm text-gray-600 dark:border-slate-700 dark:text-slate-300"
+                                            >
+                                                <p v-if="series.tagline" class="font-semibold text-gray-800 dark:text-slate-100">
+                                                    {{ series.tagline }}
+                                                </p>
+                                                <p v-if="series.short_description" class="mt-1">
+                                                    {{ series.short_description }}
+                                                </p>
+                                                <p v-if="series.description">
+                                                    {{ series.description }}
+                                                </p>
+                                                <div v-if="series.features?.length" class="mt-2 flex flex-wrap gap-1.5">
+                                                    <span
+                                                        v-for="feature in series.features"
+                                                        :key="feature"
+                                                        class="rounded-full border border-teal-200 bg-teal-50 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:border-teal-900/60 dark:bg-teal-950/30 dark:text-teal-200"
+                                                    >
+                                                        {{ feature }}
+                                                    </span>
+                                                </div>
+                                                <div v-if="series.brand_features?.length" class="mt-2 grid gap-1.5 sm:grid-cols-2">
+                                                    <div
+                                                        v-for="feature in series.brand_features"
+                                                        :key="`${series.id}-brand-feature-${feature.id}`"
+                                                        class="rounded-lg border border-indigo-100 bg-indigo-50/60 px-2 py-1.5 text-xs dark:border-indigo-900/60 dark:bg-indigo-950/20"
+                                                    >
+                                                        <span class="font-semibold text-indigo-800 dark:text-indigo-100">{{ feature.title }}</span>
+                                                        <p v-if="feature.text" class="mt-0.5 line-clamp-2 text-indigo-700/70 dark:text-indigo-200/70">{{ feature.text }}</p>
+                                                    </div>
+                                                </div>
+                                                <div v-if="series.feature_blocks?.length" class="mt-2 grid gap-1.5 sm:grid-cols-2">
+                                                    <div
+                                                        v-for="block in series.feature_blocks"
+                                                        :key="`${series.id}-${block.title}`"
+                                                        class="rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs dark:border-slate-700 dark:bg-slate-900"
+                                                    >
+                                                        <span class="font-semibold text-gray-800 dark:text-slate-100">{{ block.title }}</span>
+                                                        <p v-if="block.text" class="mt-0.5 text-gray-500 dark:text-slate-400">{{ block.text }}</p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    </div>
                                 </div>
                             </td>
                         </tr>
                         </template>
                     </tbody>
                 </table>
-            </div>
-        </div>
-
-        <div class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800/70 p-4 space-y-4">
-            <div class="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
-                <div>
-                    <p class="text-xs uppercase tracking-[0.18em] font-bold text-teal-600 dark:text-teal-300">Серии бренда</p>
-                    <h2 class="text-lg font-bold text-gray-900 dark:text-white">
-                        {{ selectedBrand ? selectedBrand.title : 'Выберите бренд' }}
-                    </h2>
-                    <p class="text-sm text-gray-500 dark:text-slate-400">
-                        Описания и фичи попадут на брендовые страницы и в блок связанных моделей. Порядок меняется перетаскиванием карточек.
-                    </p>
-                </div>
-                <div v-if="reorderingSeries" class="text-xs font-semibold text-teal-600 dark:text-teal-300">
-                    Сохраняем порядок серий...
-                </div>
-                <button
-                    type="button"
-                    class="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-500 transition-all disabled:opacity-50"
-                    :disabled="!selectedBrand"
-                    @click="openSeriesCreate"
-                >
-                    <span class="material-icons-round text-[18px]">add</span>
-                    Новая серия
-                </button>
-            </div>
-
-            <div v-if="seriesError" class="rounded-lg border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-300">
-                {{ seriesError }}
-            </div>
-
-            <div v-if="!selectedBrand" class="py-6 text-sm text-gray-500 dark:text-slate-400">
-                Выберите бренд в таблице выше.
-            </div>
-            <div v-else-if="seriesLoading" class="py-6 text-sm text-gray-500 dark:text-slate-400">
-                Загрузка серий...
-            </div>
-            <div v-else-if="seriesItems.length === 0" class="rounded-xl border border-dashed border-gray-300 dark:border-slate-700 px-4 py-8 text-sm text-gray-500 dark:text-slate-400">
-                У бренда пока нет серий. Можно добавить первую вручную.
-            </div>
-            <div v-else class="space-y-2">
-                <article
-                    v-for="series in seriesItems"
-                    :key="series.id"
-                    class="relative rounded-xl border border-gray-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 px-3 py-2.5 pr-20 transition-shadow lg:pr-3"
-                    :class="[
-                        draggedSeriesId === series.id ? 'opacity-50' : '',
-                        hasSeriesDetails(series) ? 'cursor-pointer lg:cursor-default' : '',
-                    ]"
-                    :draggable="!isSeriesReorderDisabled"
-                    @click="toggleSeriesExpandedFromCard(series)"
-                    @dragstart="onSeriesDragStart($event, series)"
-                    @dragover="onSeriesDragOver($event, series)"
-                    @dragleave="seriesDropTargetId = seriesDropTargetId === series.id ? null : seriesDropTargetId"
-                    @drop.prevent="onSeriesDrop(series)"
-                    @dragend="resetSeriesDragState"
-                >
-                    <span
-                        v-if="seriesDropTargetId === series.id"
-                        aria-hidden="true"
-                        class="pointer-events-none absolute -top-2 left-3 right-3 h-1 rounded-full bg-teal-400 shadow-[0_0_18px_rgba(20,184,166,0.75)] dark:bg-teal-300"
-                    />
-                    <div class="absolute right-2 top-2 z-10 inline-flex items-center gap-1 lg:hidden" @click.stop>
-                        <button
-                            type="button"
-                            class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white/85 text-gray-600 shadow-sm backdrop-blur hover:text-teal-700 dark:border-slate-700 dark:bg-slate-900/85 dark:text-slate-300 dark:hover:text-teal-200"
-                            title="Изменить серию"
-                            aria-label="Изменить серию"
-                            @click.stop="openSeriesEdit(series)"
-                        >
-                            <span class="material-icons-round text-[18px]">edit</span>
-                        </button>
-                        <button
-                            type="button"
-                            class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red-200 bg-white/85 text-red-500 shadow-sm backdrop-blur hover:bg-red-50 disabled:opacity-40 dark:border-red-900/60 dark:bg-slate-900/85 dark:hover:bg-red-950/30"
-                            :disabled="(series.products_count ?? 0) > 0"
-                            title="Удалить серию"
-                            aria-label="Удалить серию"
-                            @click.stop="deleteSeries(series)"
-                        >
-                            <span class="material-icons-round text-[18px]">delete</span>
-                        </button>
-                    </div>
-                    <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
-                        <div class="flex min-w-0 flex-1 items-start gap-2">
-                            <button
-                                type="button"
-                                class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 dark:border-slate-700 text-gray-400 dark:text-slate-500 transition-colors"
-                                :class="isSeriesReorderDisabled ? 'cursor-not-allowed opacity-40' : 'cursor-grab hover:bg-white hover:text-teal-600 dark:hover:bg-slate-800 dark:hover:text-teal-300 active:cursor-grabbing'"
-                                :disabled="isSeriesReorderDisabled"
-                                title="Перетащите серию выше или ниже"
-                                @click.stop
-                            >
-                                <span class="material-icons-round text-[22px]">drag_indicator</span>
-                            </button>
-                            <img
-                                v-if="series.hero_image"
-                                :src="series.hero_image"
-                                :alt="series.title"
-                                class="h-10 w-10 shrink-0 rounded-lg object-cover border border-gray-200 dark:border-slate-700 bg-white"
-                            />
-                            <div class="min-w-0 flex-1">
-                                <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-                                    <h3 class="min-w-0 break-words font-bold leading-tight text-gray-900 dark:text-slate-100">{{ series.title }}</h3>
-                                    <span
-                                        class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
-                                        :class="series.is_published ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300'"
-                                    >
-                                        {{ series.is_published ? 'Публичная' : 'Скрыта' }}
-                                    </span>
-                                    <span class="text-xs text-gray-500 dark:text-slate-400">{{ series.products_count }} товаров</span>
-                                </div>
-                                <p class="text-xs font-mono text-gray-500 dark:text-slate-400">{{ series.slug }}</p>
-                                <p v-if="series.tagline" class="mt-0.5 text-sm font-semibold text-gray-700 dark:text-slate-200">
-                                    {{ series.tagline }}
-                                </p>
-                                <p v-else-if="series.short_description" class="mt-0.5 line-clamp-2 text-sm text-gray-500 dark:text-slate-400">
-                                    {{ series.short_description }}
-                                </p>
-                            </div>
-                        </div>
-                        <div v-if="series.features?.length && !isSeriesExpanded(series.id)" class="flex min-w-0 flex-1 flex-wrap gap-1.5 lg:max-w-[34%]">
-                            <span
-                                v-for="feature in series.features.slice(0, 3)"
-                                :key="feature"
-                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
-                            >
-                                {{ feature }}
-                            </span>
-                            <span
-                                v-if="series.features.length > 3"
-                                class="rounded-full border border-gray-200 dark:border-slate-700 px-2 py-0.5 text-xs font-semibold text-gray-500 dark:text-slate-400"
-                            >
-                                +{{ series.features.length - 3 }}
-                            </span>
-                        </div>
-                        <div class="hidden shrink-0 items-center gap-1 lg:inline-flex">
-                            <button
-                                v-if="hasSeriesDetails(series)"
-                                type="button"
-                                class="inline-flex items-center gap-1 px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
-                                :aria-expanded="isSeriesExpanded(series.id)"
-                                @click.stop="toggleSeriesExpanded(series.id)"
-                            >
-                                <span class="material-icons-round text-[16px]">
-                                    {{ isSeriesExpanded(series.id) ? 'expand_less' : 'expand_more' }}
-                                </span>
-                                Детали
-                            </button>
-                            <button
-                                type="button"
-                                class="px-2.5 py-1 rounded border border-gray-200 dark:border-slate-700 text-xs font-semibold hover:bg-white dark:hover:bg-slate-800"
-                                @click.stop="openSeriesEdit(series)"
-                            >
-                                Изменить
-                            </button>
-                            <button
-                                type="button"
-                                class="px-2.5 py-1 rounded border border-red-200 text-red-600 text-xs font-semibold hover:bg-red-50 disabled:opacity-50"
-                                :disabled="(series.products_count ?? 0) > 0"
-                                @click.stop="deleteSeries(series)"
-                            >
-                                Удалить
-                            </button>
-                        </div>
-                    </div>
-                    <div
-                        v-if="!isSeriesExpanded(series.id)"
-                        class="mt-2 flex flex-wrap gap-1.5 text-[11px] font-semibold"
-                    >
-                        <span
-                            v-if="series.gallery_images?.length"
-                            class="rounded-full bg-blue-50 px-2 py-0.5 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200"
-                        >
-                            галерея {{ series.gallery_images.length }}
-                        </span>
-                        <span
-                            v-if="series.feature_blocks?.length"
-                            class="rounded-full bg-purple-50 px-2 py-0.5 text-purple-700 dark:bg-purple-950/30 dark:text-purple-200"
-                        >
-                            преимущества {{ series.feature_blocks.length }}
-                        </span>
-                        <span
-                            v-if="series.content_blocks?.length"
-                            class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700 dark:bg-amber-950/30 dark:text-amber-200"
-                        >
-                            контент {{ series.content_blocks.length }}
-                        </span>
-                        <span
-                            v-if="series.seo_title || series.seo_description"
-                            class="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200"
-                        >
-                            SEO
-                        </span>
-                    </div>
-                    <div
-                        v-if="isSeriesExpanded(series.id)"
-                        class="mt-2 border-t border-gray-200 dark:border-slate-700 pt-2 text-sm text-gray-600 dark:text-slate-300"
-                    >
-                        <p v-if="series.tagline" class="font-semibold text-gray-800 dark:text-slate-100">
-                            {{ series.tagline }}
-                        </p>
-                        <p v-if="series.short_description" class="mt-1">
-                            {{ series.short_description }}
-                        </p>
-                        <p v-if="series.description">
-                            {{ series.description }}
-                        </p>
-                        <div v-if="series.features?.length" class="mt-2 flex flex-wrap gap-1.5">
-                            <span
-                                v-for="feature in series.features"
-                                :key="feature"
-                                class="rounded-full border border-teal-200 dark:border-teal-900/60 bg-teal-50 dark:bg-teal-950/30 px-2 py-0.5 text-xs font-semibold text-teal-700 dark:text-teal-200"
-                            >
-                                {{ feature }}
-                            </span>
-                        </div>
-                        <div v-if="series.feature_blocks?.length" class="mt-2 grid gap-1.5 sm:grid-cols-2">
-                            <div
-                                v-for="block in series.feature_blocks"
-                                :key="`${series.id}-${block.title}`"
-                                class="rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs dark:border-slate-700 dark:bg-slate-900"
-                            >
-                                <span class="font-semibold text-gray-800 dark:text-slate-100">{{ block.title }}</span>
-                                <p v-if="block.text" class="mt-0.5 text-gray-500 dark:text-slate-400">{{ block.text }}</p>
-                            </div>
-                        </div>
-                    </div>
-                </article>
             </div>
         </div>
 
@@ -1222,9 +1547,186 @@ onMounted(() => {
                                 Блок
                             </button>
                         </div>
+                        <div class="rounded-2xl border border-indigo-100 bg-indigo-50/40 p-3 dark:border-indigo-900/60 dark:bg-indigo-950/20">
+                            <div class="mb-3 flex flex-wrap items-start justify-between gap-2">
+                                <div>
+                                    <h4 class="text-sm font-semibold text-gray-800 dark:text-slate-100">Библиотека фич бренда</h4>
+                                    <p class="text-xs text-gray-500 dark:text-slate-400">
+                                        Переиспользуемые блоки для нескольких серий. Выбрано: {{ selectedBrandFeatureCount }}.
+                                    </p>
+                                </div>
+                                <span v-if="brandFeaturesLoading" class="text-xs font-semibold text-indigo-700 dark:text-indigo-200">Загрузка...</span>
+                            </div>
+                            <div v-if="brandFeatures.length" class="grid gap-2 md:grid-cols-2">
+                                <article
+                                    v-for="feature in brandFeatures"
+                                    :key="feature.id"
+                                    class="min-h-[88px] rounded-xl border px-3 py-2 transition"
+                                    :class="isBrandFeatureSelected(feature.id)
+                                        ? 'border-indigo-300 bg-white shadow-sm dark:border-indigo-700 dark:bg-slate-900'
+                                        : 'border-white/70 bg-white/70 hover:border-indigo-200 dark:border-slate-800 dark:bg-slate-900/50 dark:hover:border-indigo-800'"
+                                >
+                                    <div class="flex items-start gap-2">
+                                        <button
+                                            type="button"
+                                            class="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border text-[14px]"
+                                            :class="isBrandFeatureSelected(feature.id)
+                                                ? 'border-indigo-500 bg-indigo-600 text-white'
+                                                : 'border-gray-300 text-transparent hover:border-indigo-300 dark:border-slate-600'"
+                                            :aria-pressed="isBrandFeatureSelected(feature.id)"
+                                            @click="toggleBrandFeature(feature.id)"
+                                        >
+                                            <span class="material-icons-round text-[15px]">check</span>
+                                        </button>
+                                        <span
+                                            v-if="feature.icon"
+                                            class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-200"
+                                            :title="feature.icon"
+                                        >
+                                            <span class="material-icons-round text-[18px]">{{ feature.icon }}</span>
+                                        </span>
+                                        <button type="button" class="min-w-0 flex-1 text-left" @click="toggleBrandFeature(feature.id)">
+                                            <span class="block truncate text-sm font-semibold text-gray-900 dark:text-slate-100">{{ feature.title }}</span>
+                                            <span v-if="feature.text" class="mt-0.5 line-clamp-2 text-xs text-gray-500 dark:text-slate-400">{{ feature.text }}</span>
+                                            <span v-if="feature.aliases?.length" class="mt-1 block truncate text-[11px] text-indigo-700/70 dark:text-indigo-200/70">
+                                                {{ feature.aliases.join(', ') }}
+                                            </span>
+                                            <span v-if="Number(feature.series_count || 0) > 0" class="mt-1 block text-[11px] font-semibold text-gray-500 dark:text-slate-400">
+                                                Используется в сериях: {{ feature.series_count }}
+                                            </span>
+                                        </button>
+                                        <div class="flex shrink-0 items-center gap-1">
+                                            <button
+                                                type="button"
+                                                class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:bg-indigo-50 hover:text-indigo-700 dark:text-slate-400 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                                title="Редактировать фичу"
+                                                @click.stop="startEditBrandFeature(feature)"
+                                            >
+                                                <span class="material-icons-round text-[17px]">edit</span>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-400 dark:hover:bg-red-950/30 dark:hover:text-red-300"
+                                                :disabled="featureSaving || Number(feature.series_count || 0) > 0"
+                                                :title="Number(feature.series_count || 0) > 0 ? 'Сначала отвяжите фичу от серий' : 'Удалить фичу'"
+                                                @click.stop="deleteBrandFeature(feature)"
+                                            >
+                                                <span class="material-icons-round text-[17px]">delete</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </article>
+                            </div>
+                            <p v-else class="rounded-xl border border-dashed border-indigo-200 px-3 py-3 text-sm text-gray-500 dark:border-indigo-900/60 dark:text-slate-400">
+                                У бренда пока нет reusable-фич.
+                            </p>
+                            <div class="mt-3 border-t border-indigo-100 pt-3 dark:border-indigo-900/60">
+                                <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+                                    <div>
+                                        <h5 class="text-xs font-bold uppercase tracking-[0.14em] text-indigo-800 dark:text-indigo-200">
+                                            {{ isEditingBrandFeature ? 'Редактирование фичи' : 'Новая фича бренда' }}
+                                        </h5>
+                                        <p class="text-[11px] text-gray-500 dark:text-slate-400">
+                                            Иконка выбирается из Material Icons, это не ссылка и не файл.
+                                        </p>
+                                    </div>
+                                    <button
+                                        v-if="isEditingBrandFeature"
+                                        type="button"
+                                        class="inline-flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-600 hover:bg-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-900"
+                                        :disabled="featureSaving"
+                                        @click="resetFeatureDraft"
+                                    >
+                                        <span class="material-icons-round text-[16px]">close</span>
+                                        Отменить
+                                    </button>
+                                </div>
+                                <div class="grid gap-2 lg:grid-cols-[1fr_1fr_auto]">
+                                <input
+                                    v-model="featureDraft.title"
+                                    type="text"
+                                    class="rounded-lg border border-indigo-100 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                                    placeholder="Фича: Gentle Breeze"
+                                />
+                                <input
+                                    v-model="featureDraft.text"
+                                    type="text"
+                                    class="rounded-lg border border-indigo-100 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                                    placeholder="Короткое описание"
+                                />
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center justify-center gap-1 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+                                    :disabled="featureSaving"
+                                    @click="saveBrandFeatureFromDraft"
+                                >
+                                    <span class="material-icons-round text-[16px]">{{ isEditingBrandFeature ? 'save' : 'library_add' }}</span>
+                                    {{ featureSaving ? 'Сохраняем...' : (isEditingBrandFeature ? 'Сохранить' : 'Создать') }}
+                                </button>
+                                <MediaField
+                                    v-model="featureDraft.image_url"
+                                    label="Изображение фичи"
+                                    kind="brand"
+                                    :tags="['brand-feature']"
+                                    accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                    placeholder="/media/library/original/brand-feature.webp"
+                                />
+                                <IconPicker
+                                    v-model="featureDraft.icon"
+                                    class="lg:col-span-3"
+                                    :options="featureIconOptions"
+                                    label="Иконка"
+                                    tone="indigo"
+                                />
+                                <label class="lg:col-span-3 rounded-lg border border-indigo-100 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900">
+                                    <span class="mb-1 block text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-400 dark:text-slate-500">Источник</span>
+                                    <input
+                                        v-model="featureDraft.source_url"
+                                        type="url"
+                                        class="w-full bg-transparent text-sm outline-none"
+                                        placeholder="URL страницы производителя или материала"
+                                    />
+                                    <span class="mt-1 block text-[11px] text-gray-500 dark:text-slate-400">
+                                        Служебная ссылка на первоисточник фичи: откуда взяли описание, цифры или картинку. На сайте не выводится.
+                                    </span>
+                                </label>
+                                <textarea
+                                    v-model="featureDraft.aliasesText"
+                                    rows="2"
+                                    class="lg:col-span-3 rounded-lg border border-indigo-100 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                                    placeholder="Синонимы, по одному на строку"
+                                />
+                                </div>
+                            </div>
+                        </div>
                         <label class="text-sm space-y-1 block">
-                            <span class="text-gray-600 dark:text-slate-300 font-medium">Фичи серии</span>
+                            <span class="flex flex-wrap items-center justify-between gap-2">
+                                <span>
+                                    <span class="block text-gray-600 dark:text-slate-300 font-medium">Фичи серии</span>
+                                    <span class="block text-xs text-gray-500 dark:text-slate-400">
+                                        Короткие legacy-чипсы для карточек. Можно собрать из выбранных фич бренда, преимуществ и контентных секций.
+                                    </span>
+                                </span>
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-1 rounded-lg border border-indigo-200 px-3 py-1.5 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 disabled:opacity-40 dark:border-indigo-900/60 dark:text-indigo-200 dark:hover:bg-indigo-950/30"
+                                    :disabled="suggestedSeriesFeatureTitles.length === 0"
+                                    @click="syncSeriesFeaturesFromStructuredBlocks"
+                                >
+                                    <span class="material-icons-round text-[15px]">auto_fix_high</span>
+                                    Собрать из блоков
+                                </button>
+                            </span>
                             <textarea v-model="seriesForm.featuresText" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна фича на строку" />
+                            <span v-if="suggestedSeriesFeatureTitles.length" class="flex flex-wrap gap-1.5">
+                                <span
+                                    v-for="title in suggestedSeriesFeatureTitles"
+                                    :key="`suggested-feature-${title}`"
+                                    class="rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-200"
+                                >
+                                    {{ title }}
+                                </span>
+                            </span>
                         </label>
                         <div v-if="seriesForm.featureBlocks.length" class="space-y-3">
                             <div
@@ -1243,10 +1745,15 @@ onMounted(() => {
                                         <span class="text-gray-600 dark:text-slate-300 font-medium">Заголовок</span>
                                         <input v-model="block.title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
                                     </label>
-                                    <label class="text-sm space-y-1">
+                                    <div class="text-sm space-y-1 md:col-span-2">
                                         <span class="text-gray-600 dark:text-slate-300 font-medium">Иконка</span>
-                                        <input v-model="block.icon" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="air / bolt / self_cleaning" />
-                                    </label>
+                                        <IconPicker
+                                            v-model="block.icon"
+                                            :options="featureIconOptions"
+                                            label="Иконка блока"
+                                            tone="teal"
+                                        />
+                                    </div>
                                     <MediaField
                                         v-model="block.image_url"
                                         label="Изображение"
@@ -1335,9 +1842,36 @@ onMounted(() => {
                     <section class="grid grid-cols-1 lg:grid-cols-2 gap-4 border-t border-gray-200 pt-4 dark:border-slate-700">
                         <label class="text-sm space-y-1 block">
                             <span class="text-gray-600 dark:text-slate-300 font-medium">Сноски</span>
+                            <span class="block text-xs text-gray-500 dark:text-slate-400">
+                                Мелкие примечания внизу страницы серии: условия сравнения, ограничения функций, ссылки на испытания. Одна сноска на строку.
+                            </span>
                             <textarea v-model="seriesForm.footnotesText" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" placeholder="Одна сноска на строку" />
                         </label>
                         <div class="space-y-3">
+                            <div class="flex flex-wrap items-center justify-between gap-2">
+                                <div>
+                                    <h3 class="text-sm font-semibold text-gray-700 dark:text-slate-200">SEO</h3>
+                                    <p class="text-xs text-gray-500 dark:text-slate-400">Черновик можно собрать из описания и фич, а промпт отдать DeepSeek.</p>
+                                </div>
+                                <div class="flex flex-wrap gap-2">
+                                    <button
+                                        type="button"
+                                        class="inline-flex items-center gap-1 rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 dark:border-teal-900/60 dark:text-teal-200 dark:hover:bg-teal-950/30"
+                                        @click="generateSeriesSeoDraft"
+                                    >
+                                        <span class="material-icons-round text-[15px]">auto_awesome</span>
+                                        SEO из контента
+                                    </button>
+                                    <button
+                                        type="button"
+                                        class="inline-flex items-center gap-1 rounded-lg border border-indigo-200 px-3 py-1.5 text-xs font-semibold text-indigo-700 hover:bg-indigo-50 dark:border-indigo-900/60 dark:text-indigo-200 dark:hover:bg-indigo-950/30"
+                                        @click="prepareSeriesSeoPrompt"
+                                    >
+                                        <span class="material-icons-round text-[15px]">content_copy</span>
+                                        Промпт для AI
+                                    </button>
+                                </div>
+                            </div>
                             <label class="text-sm space-y-1 block">
                                 <span class="text-gray-600 dark:text-slate-300 font-medium">SEO title</span>
                                 <input v-model="seriesForm.seo_title" type="text" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
@@ -1345,6 +1879,15 @@ onMounted(() => {
                             <label class="text-sm space-y-1 block">
                                 <span class="text-gray-600 dark:text-slate-300 font-medium">SEO description</span>
                                 <textarea v-model="seriesForm.seo_description" rows="3" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-900" />
+                            </label>
+                            <label v-if="seoPromptPreview" class="text-sm space-y-1 block">
+                                <span class="text-gray-600 dark:text-slate-300 font-medium">Промпт для DeepSeek</span>
+                                <textarea
+                                    v-model="seoPromptPreview"
+                                    rows="5"
+                                    class="w-full px-3 py-2 rounded-lg border border-indigo-100 dark:border-indigo-900/60 bg-indigo-50/40 dark:bg-indigo-950/20 text-xs"
+                                    readonly
+                                />
                             </label>
                         </div>
                     </section>

--- a/manager_frontend/src/views/SupplierMappingView.vue
+++ b/manager_frontend/src/views/SupplierMappingView.vue
@@ -21,6 +21,18 @@ const inlineSearchQuery = ref<Record<string, string>>({});
 const inlineCandidates = ref<Record<string, any[]>>({});
 
 const keyOf = (offer: any) => `${offer.supplier_id}:${offer.external_id}`;
+const readyToApplyCount = computed(() => Object.keys(bulkSelection.value).filter((k) => bulkSelection.value[k] && selectedProductMap.value[k]).length);
+
+const normalizeCandidate = (candidate: any) => ({
+  ...candidate,
+  id: candidate?.id ?? candidate?.product_id,
+});
+
+const confidenceClass = (confidence: number) => {
+  if (confidence >= 75) return 'bg-green-50 text-green-700 border-green-200';
+  if (confidence >= 45) return 'bg-amber-50 text-amber-700 border-amber-200';
+  return 'bg-gray-50 text-gray-600 border-gray-200';
+};
 
 const setToast = (message: string) => {
   toast.value = message;
@@ -71,7 +83,7 @@ const runSuggestions = async (offers: any[]) => {
       const key = `${row.supplier_id}:${row.external_id}`;
       suggestionMap.value[key] = row;
       inlineSearchQuery.value[key] = row.normalized_query || '';
-      inlineCandidates.value[key] = row.candidates || [];
+      inlineCandidates.value[key] = (row.candidates || []).map(normalizeCandidate);
       if (row.auto_eligible && row.candidates?.length === 1) {
         const candidate = row.candidates?.[0];
         selectedProductMap.value[key] = candidate ? candidate.product_id : null;
@@ -102,7 +114,7 @@ const searchInline = async (offer: any) => {
   const q = (inlineSearchQuery.value[key] || '').trim();
   if (!q) return;
   try {
-    inlineCandidates.value[key] = await api.smartSearchProducts(q, 20);
+    inlineCandidates.value[key] = (await api.smartSearchProducts(q, 20)).map(normalizeCandidate);
     suggestionMap.value[key] = {
       ...(suggestionMap.value[key] || {}),
       auto_eligible: inlineCandidates.value[key].length === 1,
@@ -217,7 +229,7 @@ onMounted(async () => {
         </button>
         <span class="text-sm text-gray-600">
           Готово к подтверждению:
-          {{ Object.keys(bulkSelection).filter((k) => bulkSelection[k] && selectedProductMap[k]).length }}
+          {{ readyToApplyCount }}
         </span>
         <button
           class="px-3 py-2 rounded bg-teal-600 text-white disabled:opacity-50"
@@ -259,11 +271,23 @@ onMounted(async () => {
               <td class="p-3">{{ offer.qty }}</td>
               <td class="p-3">{{ offer.wholesale_value || '—' }} <span v-if="offer.wholesale_currency">{{ offer.wholesale_currency }}</span></td>
               <td class="p-3">
+                <div v-if="offer.model_tokens?.length" class="mb-1 flex flex-wrap gap-1">
+                  <span v-for="token in offer.model_tokens.slice(0, 4)" :key="`${keyOf(offer)}-${token}`" class="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[11px] text-slate-600">
+                    {{ token }}
+                  </span>
+                </div>
                 <span
                   v-if="suggestionMap[keyOf(offer)]?.auto_eligible"
                   class="inline-flex rounded px-2 py-1 text-xs bg-green-50 text-green-700 border border-green-200"
                 >
-                  1:1
+                  {{ suggestionMap[keyOf(offer)]?.candidates?.[0]?.confidence ?? 100 }}%
+                </span>
+                <span
+                  v-else-if="suggestionMap[keyOf(offer)]"
+                  class="inline-flex rounded px-2 py-1 text-xs border"
+                  :class="confidenceClass(suggestionMap[keyOf(offer)]?.candidates?.[0]?.confidence || 0)"
+                >
+                  {{ suggestionMap[keyOf(offer)]?.reason || 'проверить' }}
                 </span>
                 <span
                   v-else
@@ -290,9 +314,17 @@ onMounted(async () => {
                     <button @click="searchInline(offer)" class="px-3 py-2 rounded bg-slate-900 text-white">Найти</button>
                   </div>
                   <div class="grid md:grid-cols-2 gap-2 max-h-64 overflow-y-auto">
-                    <label v-for="p in inlineCandidates[keyOf(offer)] || []" :key="p.id" class="flex items-center gap-2 border rounded px-3 py-2 bg-white">
+                    <label v-for="p in inlineCandidates[keyOf(offer)] || []" :key="p.id" class="flex items-start gap-2 border rounded px-3 py-2 bg-white">
                       <input v-model.number="selectedProductMap[keyOf(offer)]" type="radio" :value="p.id" />
-                      <span>{{ p.title }} ({{ p.price }} BYN)</span>
+                      <span class="min-w-0">
+                        <span class="block font-medium">{{ p.title }} ({{ p.price }} BYN)</span>
+                        <span v-if="p.confidence !== undefined" class="mt-1 inline-flex rounded border px-1.5 py-0.5 text-[11px]" :class="confidenceClass(p.confidence)">
+                          {{ p.confidence }}% · score {{ p.score }}
+                        </span>
+                        <span v-if="p.explanations?.length" class="mt-1 block text-xs text-gray-500">
+                          {{ p.explanations.join(' · ') }}
+                        </span>
+                      </span>
                     </label>
                   </div>
                   <div class="flex justify-end gap-2">

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -15,7 +15,7 @@ from .common import (
 )
 from .customer import Customer, CustomerBranch, CustomerContract, CustomerRequisitesRecognition, Lead
 from .equipment import CustomerEquipment, EquipmentComponent, EquipmentServiceHistory
-from .brand import Brand, ProductSeries
+from .brand import Brand, BrandFeature, ProductSeries, ProductSeriesFeatureLink
 from .bot_fsm import BotFsmState
 from .cart import Cart, CartItem
 from .catalog_import import CatalogImportJob
@@ -74,6 +74,7 @@ __all__ = [
     "Cart",
     "CartItem",
     "Brand",
+    "BrandFeature",
     "BotFsmState",
     "CatalogImportJob",
     "Customer",
@@ -125,6 +126,7 @@ __all__ = [
     "ProductMainImageCleanupItem",
     "ProductImageVariant",
     "ProductSeries",
+    "ProductSeriesFeatureLink",
     "ProductTagLink",
     "Service",
     "StaffUser",

--- a/models/brand.py
+++ b/models/brand.py
@@ -19,6 +19,7 @@ class Brand(SQLModel, table=True):
 
     products: List["Product"] = Relationship(back_populates="brand")
     series: List["ProductSeries"] = Relationship(back_populates="brand")
+    feature_library: List["BrandFeature"] = Relationship(back_populates="brand")
 
     def __str__(self) -> str:
         return self.title
@@ -52,6 +53,59 @@ class ProductSeries(SQLModel, table=True):
 
     brand: Optional[Brand] = Relationship(back_populates="series")
     products: List["Product"] = Relationship(back_populates="series")
+    feature_links: List["ProductSeriesFeatureLink"] = Relationship(back_populates="series")
 
     def __str__(self) -> str:
         return self.title
+
+
+class BrandFeature(SQLModel, table=True):
+    __tablename__ = "brand_feature"
+    __table_args__ = (
+        UniqueConstraint("brand_id", "slug", name="uq_brand_feature_brand_id_slug"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    brand_id: int = Field(foreign_key="brand.id", index=True)
+    title: str = Field(index=True)
+    slug: str = Field(index=True)
+    text: Optional[str] = Field(default=None, sa_column=Column(Text))
+    image_url: Optional[str] = Field(default=None)
+    icon: Optional[str] = Field(default=None)
+    footnote: Optional[str] = Field(default=None)
+    source_url: Optional[str] = Field(default=None)
+    aliases: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    is_published: bool = Field(default=True, index=True)
+    sort_order: int = Field(default=0, index=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(
+        default_factory=datetime.now,
+        sa_column_kwargs={"onupdate": datetime.now},
+    )
+
+    brand: Optional[Brand] = Relationship(back_populates="feature_library")
+    series_links: List["ProductSeriesFeatureLink"] = Relationship(back_populates="feature")
+
+    def __str__(self) -> str:
+        return self.title
+
+
+class ProductSeriesFeatureLink(SQLModel, table=True):
+    __tablename__ = "product_series_feature_link"
+    __table_args__ = (
+        UniqueConstraint("series_id", "feature_id", name="uq_product_series_feature_link"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    series_id: int = Field(foreign_key="product_series.id", index=True)
+    feature_id: int = Field(foreign_key="brand_feature.id", index=True)
+    sort_order: int = Field(default=0, index=True)
+    title_override: Optional[str] = None
+    text_override: Optional[str] = Field(default=None, sa_column=Column(Text))
+    image_url_override: Optional[str] = None
+    icon_override: Optional[str] = None
+    footnote_override: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    series: Optional[ProductSeries] = Relationship(back_populates="feature_links")
+    feature: Optional[BrandFeature] = Relationship(back_populates="series_links")

--- a/models/supplier.py
+++ b/models/supplier.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, ForeignKeyConstraint, Numeric, UniqueConstraint
+from sqlalchemy import Column, DateTime, ForeignKeyConstraint, JSON, Numeric, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -71,6 +71,11 @@ class SupplierOffer(SQLModel, table=True):
     external_id: str = Field(index=True)
 
     title_raw: Optional[str] = None
+    title_normalized: Optional[str] = Field(default=None, index=True)
+    model_tokens: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    indoor_model_tokens: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    outdoor_model_tokens: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    match_normalizer_version: Optional[str] = Field(default=None, index=True)
     qty_raw: Optional[str] = None
     wholesale_raw: Optional[str] = None
     rrc_raw: Optional[str] = None

--- a/openapi.json
+++ b/openapi.json
@@ -11697,6 +11697,228 @@
         }
       }
     },
+    "/api/manager/brands/{brand_id}/features": {
+      "get": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "List Manager Brand Features",
+        "operationId": "list_manager_brand_features",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandFeatureListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Create Manager Brand Feature",
+        "operationId": "create_manager_brand_feature",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerBrandFeatureCreatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandFeatureResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/brands/{brand_id}/features/{feature_id}": {
+      "put": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Update Manager Brand Feature",
+        "operationId": "update_manager_brand_feature",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          },
+          {
+            "name": "feature_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Feature Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerBrandFeatureUpdatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerBrandFeatureResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Delete Manager Brand Feature",
+        "operationId": "delete_manager_brand_feature",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          },
+          {
+            "name": "feature_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Feature Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/brands/{brand_id}/series": {
       "get": {
         "tags": [
@@ -18490,6 +18712,354 @@
         ],
         "title": "ManagerBrandCreatePayload"
       },
+      "ManagerBrandFeatureCreatePayload": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "footnote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnote"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ManagerBrandFeatureCreatePayload"
+      },
+      "ManagerBrandFeatureListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ManagerBrandFeatureResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "ManagerBrandFeatureListResponse"
+      },
+      "ManagerBrandFeatureResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "footnote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnote"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          },
+          "brand_id": {
+            "type": "integer",
+            "title": "Brand Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "series_count": {
+            "type": "integer",
+            "title": "Series Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "brand_id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagerBrandFeatureResponse"
+      },
+      "ManagerBrandFeatureUpdatePayload": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slug"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "footnote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnote"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "aliases": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aliases"
+          },
+          "is_published": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Published"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order"
+          }
+        },
+        "type": "object",
+        "title": "ManagerBrandFeatureUpdatePayload"
+      },
       "ManagerBrandListResponse": {
         "properties": {
           "items": {
@@ -18646,6 +19216,13 @@
             },
             "type": "array",
             "title": "Features"
+          },
+          "brand_feature_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Brand Feature Ids"
           },
           "feature_blocks": {
             "items": {
@@ -18816,6 +19393,20 @@
             },
             "type": "array",
             "title": "Features"
+          },
+          "brand_features": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesBrandFeatureResponse"
+            },
+            "type": "array",
+            "title": "Brand Features"
+          },
+          "brand_feature_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Brand Feature Ids"
           },
           "feature_blocks": {
             "items": {
@@ -18996,6 +19587,20 @@
               }
             ],
             "title": "Features"
+          },
+          "brand_feature_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Brand Feature Ids"
           },
           "feature_blocks": {
             "anyOf": [
@@ -34178,6 +34783,101 @@
         ],
         "title": "ProductResponse"
       },
+      "ProductSeriesBrandFeatureResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Url"
+          },
+          "icon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icon"
+          },
+          "footnote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Footnote"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases"
+          },
+          "is_published": {
+            "type": "boolean",
+            "title": "Is Published",
+            "default": true
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug"
+        ],
+        "title": "ProductSeriesBrandFeatureResponse"
+      },
       "ProductSeriesContentBlockResponse": {
         "properties": {
           "kind": {
@@ -34403,6 +35103,13 @@
             },
             "type": "array",
             "title": "Features"
+          },
+          "brand_features": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesBrandFeatureResponse"
+            },
+            "type": "array",
+            "title": "Brand Features"
           },
           "feature_blocks": {
             "items": {
@@ -35274,6 +35981,49 @@
             ],
             "title": "Title Raw"
           },
+          "title_normalized": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title Normalized"
+          },
+          "model_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Model Tokens"
+          },
+          "indoor_model_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Indoor Model Tokens"
+          },
+          "outdoor_model_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Outdoor Model Tokens"
+          },
+          "match_normalizer_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Normalizer Version"
+          },
           "qty": {
             "type": "integer",
             "title": "Qty"
@@ -35410,6 +36160,44 @@
           "price": {
             "type": "integer",
             "title": "Price"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score",
+            "default": 0
+          },
+          "confidence": {
+            "type": "integer",
+            "title": "Confidence",
+            "default": 0
+          },
+          "matched_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Matched Tokens"
+          },
+          "missing_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Tokens"
+          },
+          "explanations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Explanations"
+          },
+          "score_breakdown": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Score Breakdown"
           }
         },
         "type": "object",
@@ -35433,6 +36221,27 @@
           "normalized_query": {
             "type": "string",
             "title": "Normalized Query"
+          },
+          "offer_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Offer Tokens"
+          },
+          "indoor_model_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Indoor Model Tokens"
+          },
+          "outdoor_model_tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Outdoor Model Tokens"
           },
           "candidates": {
             "items": {

--- a/routers/manager_brands.py
+++ b/routers/manager_brands.py
@@ -5,17 +5,25 @@ from core.database import get_session
 from core.security import get_current_username
 from routers.manager_operation_ids import (
     CREATE_MANAGER_BRAND_SERIES,
+    CREATE_MANAGER_BRAND_FEATURE,
     CREATE_MANAGER_BRAND,
+    DELETE_MANAGER_BRAND_FEATURE,
     DELETE_MANAGER_BRAND_SERIES,
     DELETE_MANAGER_BRAND,
+    LIST_MANAGER_BRAND_FEATURES,
     LIST_MANAGER_BRAND_SERIES,
     LIST_MANAGER_BRANDS,
+    UPDATE_MANAGER_BRAND_FEATURE,
     UPDATE_MANAGER_BRAND_SERIES,
     UPDATE_MANAGER_BRAND,
 )
 from schemas import (
     ManagerActionMessageResponse,
     ManagerBrandCreatePayload,
+    ManagerBrandFeatureCreatePayload,
+    ManagerBrandFeatureListResponse,
+    ManagerBrandFeatureResponse,
+    ManagerBrandFeatureUpdatePayload,
     ManagerBrandListResponse,
     ManagerBrandResponse,
     ManagerBrandSeriesCreatePayload,
@@ -68,6 +76,75 @@ async def update_manager_brand(
         payload=payload.model_dump(exclude_unset=True),
     )
     return ManagerBrandResponse(**updated)
+
+
+@router.get(
+    "/{brand_id}/features",
+    response_model=ManagerBrandFeatureListResponse,
+    operation_id=LIST_MANAGER_BRAND_FEATURES,
+)
+async def list_manager_brand_features(
+    brand_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    items = await ManagerBrandService.list_brand_features(session=session, brand_id=brand_id)
+    return ManagerBrandFeatureListResponse(items=items)
+
+
+@router.post(
+    "/{brand_id}/features",
+    response_model=ManagerBrandFeatureResponse,
+    operation_id=CREATE_MANAGER_BRAND_FEATURE,
+)
+async def create_manager_brand_feature(
+    brand_id: int,
+    payload: ManagerBrandFeatureCreatePayload,
+    session: AsyncSession = Depends(get_session),
+):
+    created = await ManagerBrandService.create_brand_feature(
+        session=session,
+        brand_id=brand_id,
+        payload=payload.model_dump(exclude_unset=True),
+    )
+    return ManagerBrandFeatureResponse(**created)
+
+
+@router.put(
+    "/{brand_id}/features/{feature_id}",
+    response_model=ManagerBrandFeatureResponse,
+    operation_id=UPDATE_MANAGER_BRAND_FEATURE,
+)
+async def update_manager_brand_feature(
+    brand_id: int,
+    feature_id: int,
+    payload: ManagerBrandFeatureUpdatePayload,
+    session: AsyncSession = Depends(get_session),
+):
+    updated = await ManagerBrandService.update_brand_feature(
+        session=session,
+        brand_id=brand_id,
+        feature_id=feature_id,
+        payload=payload.model_dump(exclude_unset=True),
+    )
+    return ManagerBrandFeatureResponse(**updated)
+
+
+@router.delete(
+    "/{brand_id}/features/{feature_id}",
+    response_model=ManagerActionMessageResponse,
+    operation_id=DELETE_MANAGER_BRAND_FEATURE,
+)
+async def delete_manager_brand_feature(
+    brand_id: int,
+    feature_id: int,
+    session: AsyncSession = Depends(get_session),
+):
+    await ManagerBrandService.delete_brand_feature(
+        session=session,
+        brand_id=brand_id,
+        feature_id=feature_id,
+    )
+    return ManagerActionMessageResponse(message="Фича успешно удалена")
 
 
 @router.get(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -206,6 +206,10 @@ LIST_MANAGER_BRANDS = "list_manager_brands"
 CREATE_MANAGER_BRAND = "create_manager_brand"
 UPDATE_MANAGER_BRAND = "update_manager_brand"
 DELETE_MANAGER_BRAND = "delete_manager_brand"
+LIST_MANAGER_BRAND_FEATURES = "list_manager_brand_features"
+CREATE_MANAGER_BRAND_FEATURE = "create_manager_brand_feature"
+UPDATE_MANAGER_BRAND_FEATURE = "update_manager_brand_feature"
+DELETE_MANAGER_BRAND_FEATURE = "delete_manager_brand_feature"
 LIST_MANAGER_BRAND_SERIES = "list_manager_brand_series"
 CREATE_MANAGER_BRAND_SERIES = "create_manager_brand_series"
 UPDATE_MANAGER_BRAND_SERIES = "update_manager_brand_series"
@@ -420,6 +424,10 @@ ALL_MANAGER_OPERATION_IDS = (
     CREATE_MANAGER_BRAND,
     UPDATE_MANAGER_BRAND,
     DELETE_MANAGER_BRAND,
+    LIST_MANAGER_BRAND_FEATURES,
+    CREATE_MANAGER_BRAND_FEATURE,
+    UPDATE_MANAGER_BRAND_FEATURE,
+    DELETE_MANAGER_BRAND_FEATURE,
     LIST_MANAGER_BRAND_SERIES,
     CREATE_MANAGER_BRAND_SERIES,
     UPDATE_MANAGER_BRAND_SERIES,

--- a/schemas.py
+++ b/schemas.py
@@ -263,6 +263,20 @@ class ProductSeriesFeatureBlockResponse(BaseModel):
     footnote: Optional[str] = None
 
 
+class ProductSeriesBrandFeatureResponse(BaseModel):
+    id: int
+    title: str
+    slug: str
+    text: Optional[str] = None
+    image_url: Optional[str] = None
+    icon: Optional[str] = None
+    footnote: Optional[str] = None
+    source_url: Optional[str] = None
+    aliases: List[str] = Field(default_factory=list)
+    is_published: bool = True
+    sort_order: int = 0
+
+
 class ProductSeriesContentBlockResponse(BaseModel):
     kind: Literal["text", "image_text", "media"] = "text"
     title: Optional[str] = None
@@ -281,6 +295,7 @@ class ProductSeriesResponse(BaseModel):
     hero_image: Optional[str] = None
     gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    brand_features: List[ProductSeriesBrandFeatureResponse] = Field(default_factory=list)
     feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
     content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
     footnotes: List[str] = Field(default_factory=list)
@@ -2329,6 +2344,8 @@ class ManagerBrandSeriesResponse(BaseModel):
     hero_image: Optional[str] = None
     gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    brand_features: List[ProductSeriesBrandFeatureResponse] = Field(default_factory=list)
+    brand_feature_ids: List[int] = Field(default_factory=list)
     feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
     content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
     footnotes: List[str] = Field(default_factory=list)
@@ -2354,6 +2371,7 @@ class ManagerBrandSeriesCreatePayload(BaseModel):
     hero_image: Optional[str] = None
     gallery_images: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
+    brand_feature_ids: List[int] = Field(default_factory=list)
     feature_blocks: List[ProductSeriesFeatureBlockResponse] = Field(default_factory=list)
     content_blocks: List[ProductSeriesContentBlockResponse] = Field(default_factory=list)
     footnotes: List[str] = Field(default_factory=list)
@@ -2373,12 +2391,50 @@ class ManagerBrandSeriesUpdatePayload(BaseModel):
     hero_image: Optional[str] = None
     gallery_images: Optional[List[str]] = None
     features: Optional[List[str]] = None
+    brand_feature_ids: Optional[List[int]] = None
     feature_blocks: Optional[List[ProductSeriesFeatureBlockResponse]] = None
     content_blocks: Optional[List[ProductSeriesContentBlockResponse]] = None
     footnotes: Optional[List[str]] = None
     seo_title: Optional[str] = None
     seo_description: Optional[str] = None
     source_url: Optional[str] = None
+    is_published: Optional[bool] = None
+    sort_order: Optional[int] = None
+
+
+class ManagerBrandFeatureResponse(ProductSeriesBrandFeatureResponse):
+    brand_id: int
+    created_at: datetime
+    updated_at: datetime
+    series_count: int = 0
+
+
+class ManagerBrandFeatureListResponse(BaseModel):
+    items: List[ManagerBrandFeatureResponse]
+
+
+class ManagerBrandFeatureCreatePayload(BaseModel):
+    title: str
+    slug: Optional[str] = None
+    text: Optional[str] = None
+    image_url: Optional[str] = None
+    icon: Optional[str] = None
+    footnote: Optional[str] = None
+    source_url: Optional[str] = None
+    aliases: List[str] = Field(default_factory=list)
+    is_published: bool = True
+    sort_order: int = 0
+
+
+class ManagerBrandFeatureUpdatePayload(BaseModel):
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    text: Optional[str] = None
+    image_url: Optional[str] = None
+    icon: Optional[str] = None
+    footnote: Optional[str] = None
+    source_url: Optional[str] = None
+    aliases: Optional[List[str]] = None
     is_published: Optional[bool] = None
     sort_order: Optional[int] = None
 
@@ -2814,6 +2870,11 @@ class SupplierOfferResponse(BaseModel):
     supplier_name: Optional[str] = None
     external_id: str
     title_raw: Optional[str] = None
+    title_normalized: Optional[str] = None
+    model_tokens: List[str] = Field(default_factory=list)
+    indoor_model_tokens: List[str] = Field(default_factory=list)
+    outdoor_model_tokens: List[str] = Field(default_factory=list)
+    match_normalizer_version: Optional[str] = None
     qty: int
     qty_raw: Optional[str] = None
     wholesale_raw: Optional[str] = None
@@ -2872,12 +2933,21 @@ class SupplierOfferSuggestionCandidate(BaseModel):
     product_id: int
     title: str
     price: int
+    score: int = 0
+    confidence: int = 0
+    matched_tokens: List[str] = Field(default_factory=list)
+    missing_tokens: List[str] = Field(default_factory=list)
+    explanations: List[str] = Field(default_factory=list)
+    score_breakdown: Dict[str, int] = Field(default_factory=dict)
 
 
 class SupplierOfferSuggestionItem(BaseModel):
     supplier_id: int
     external_id: str
     normalized_query: str
+    offer_tokens: List[str] = Field(default_factory=list)
+    indoor_model_tokens: List[str] = Field(default_factory=list)
+    outdoor_model_tokens: List[str] = Field(default_factory=list)
     candidates: List[SupplierOfferSuggestionCandidate]
     auto_eligible: bool
     reason: str

--- a/services/catalog.py
+++ b/services/catalog.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Brand, Product, ProductImage, Tag
+from models import Brand, Product, ProductImage, ProductSeries, ProductSeriesFeatureLink, Tag
 from models.supplier import ProductLocalStock
 
 
@@ -32,7 +32,9 @@ class CatalogService:
             .join(ProductLocalStock, Product.id == ProductLocalStock.product_id)
             .options(
                 selectinload(Product.brand).load_only(Brand.id, Brand.title, Brand.slug, Brand.logo_url),
-                selectinload(Product.series),
+                selectinload(Product.series)
+                .selectinload(ProductSeries.feature_links)
+                .selectinload(ProductSeriesFeatureLink.feature),
                 selectinload(Product.tags).selectinload(Tag.group),
                 selectinload(Product.gallery_images).selectinload(ProductImage.variants),
                 selectinload(Product.attachments),

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -5,7 +5,7 @@ from slugify import slugify
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models import Brand, Product, ProductSeries, ProductTagLink, Tag, TagGroup
+from models import Brand, BrandFeature, Product, ProductSeries, ProductSeriesFeatureLink, ProductTagLink, Tag, TagGroup
 from services.brand_series_service import extract_series_name, sync_product_brand_series
 from services.catalog_revision_service import CatalogRevisionService
 
@@ -26,6 +26,147 @@ class ManagerBrandService:
             ManagerBrandService._serialize_brand(brand, products_count=int(products_count or 0))
             for brand, products_count in rows
         ]
+
+    @staticmethod
+    async def list_brand_features(
+        session: AsyncSession,
+        brand_id: int,
+    ) -> List[Dict[str, Any]]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        rows = (
+            await session.execute(
+                select(BrandFeature, func.count(ProductSeriesFeatureLink.id).label("series_count"))
+                .outerjoin(ProductSeriesFeatureLink, ProductSeriesFeatureLink.feature_id == BrandFeature.id)
+                .where(BrandFeature.brand_id == brand_id)
+                .group_by(BrandFeature.id)
+                .order_by(BrandFeature.sort_order.asc(), BrandFeature.title.asc())
+            )
+        ).all()
+        return [
+            ManagerBrandService._serialize_brand_feature(feature, series_count=int(series_count or 0))
+            for feature, series_count in rows
+        ]
+
+    @staticmethod
+    async def create_brand_feature(
+        session: AsyncSession,
+        brand_id: int,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        title = str(payload.get("title") or "").strip()
+        if not title:
+            raise HTTPException(status_code=400, detail="Название фичи не может быть пустым.")
+
+        slug = ManagerBrandService._build_feature_slug(payload.get("slug"), title)
+        await ManagerBrandService._ensure_brand_feature_slug_available(session, brand_id=brand_id, slug=slug)
+
+        feature = BrandFeature(
+            brand_id=brand_id,
+            title=title,
+            slug=slug,
+            text=ManagerBrandService._clean_optional_text(payload.get("text")),
+            image_url=ManagerBrandService._clean_optional_text(payload.get("image_url")),
+            icon=ManagerBrandService._clean_optional_text(payload.get("icon")),
+            footnote=ManagerBrandService._clean_optional_text(payload.get("footnote")),
+            source_url=ManagerBrandService._clean_optional_text(payload.get("source_url")),
+            aliases=ManagerBrandService._normalize_string_list(payload.get("aliases")),
+            is_published=bool(payload.get("is_published", True)),
+            sort_order=int(payload.get("sort_order") or 0),
+        )
+        session.add(feature)
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_feature_create",
+            brand_slugs=[brand.slug],
+        )
+        await session.refresh(feature)
+        return ManagerBrandService._serialize_brand_feature(feature, series_count=0)
+
+    @staticmethod
+    async def update_brand_feature(
+        session: AsyncSession,
+        brand_id: int,
+        feature_id: int,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        feature = await ManagerBrandService._get_brand_feature(session, brand_id, feature_id)
+        if "title" in payload and payload["title"] is not None:
+            title = str(payload["title"]).strip()
+            if not title:
+                raise HTTPException(status_code=400, detail="Название фичи не может быть пустым.")
+            feature.title = title
+        if "slug" in payload and payload["slug"] is not None:
+            slug = ManagerBrandService._build_feature_slug(payload["slug"], feature.title)
+            if slug != feature.slug:
+                await ManagerBrandService._ensure_brand_feature_slug_available(
+                    session,
+                    brand_id=brand_id,
+                    slug=slug,
+                    exclude_feature_id=feature_id,
+                )
+                feature.slug = slug
+        if "text" in payload:
+            feature.text = ManagerBrandService._clean_optional_text(payload["text"])
+        if "image_url" in payload:
+            feature.image_url = ManagerBrandService._clean_optional_text(payload["image_url"])
+        if "icon" in payload:
+            feature.icon = ManagerBrandService._clean_optional_text(payload["icon"])
+        if "footnote" in payload:
+            feature.footnote = ManagerBrandService._clean_optional_text(payload["footnote"])
+        if "source_url" in payload:
+            feature.source_url = ManagerBrandService._clean_optional_text(payload["source_url"])
+        if "aliases" in payload and payload["aliases"] is not None:
+            feature.aliases = ManagerBrandService._normalize_string_list(payload["aliases"])
+        if "is_published" in payload and payload["is_published"] is not None:
+            feature.is_published = bool(payload["is_published"])
+        if "sort_order" in payload and payload["sort_order"] is not None:
+            feature.sort_order = int(payload["sort_order"])
+
+        session.add(feature)
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_feature_update",
+            brand_slugs=[brand.slug],
+        )
+        await session.refresh(feature)
+        series_count = await ManagerBrandService._brand_feature_series_count(session, feature_id)
+        return ManagerBrandService._serialize_brand_feature(feature, series_count=series_count)
+
+    @staticmethod
+    async def delete_brand_feature(
+        session: AsyncSession,
+        brand_id: int,
+        feature_id: int,
+    ) -> None:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        feature = await ManagerBrandService._get_brand_feature(session, brand_id, feature_id)
+        series_count = await ManagerBrandService._brand_feature_series_count(session, feature_id)
+        if series_count > 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Нельзя удалить фичу: она используется в сериях. Сначала уберите ее из серий.",
+            )
+
+        await session.delete(feature)
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_feature_delete",
+            brand_slugs=[brand.slug],
+        )
 
     @staticmethod
     async def create_brand(
@@ -220,8 +361,16 @@ class ManagerBrandService:
                 .order_by(ProductSeries.sort_order.asc(), ProductSeries.title.asc())
             )
         ).all()
+        feature_map = await ManagerBrandService._load_series_brand_features(
+            session,
+            [series.id for series, _ in rows if series.id is not None],
+        )
         return [
-            ManagerBrandService._serialize_series(series, products_count=int(products_count or 0))
+            ManagerBrandService._serialize_series(
+                series,
+                products_count=int(products_count or 0),
+                brand_features=feature_map.get(int(series.id or 0), []),
+            )
             for series, products_count in rows
         ]
 
@@ -309,6 +458,13 @@ class ManagerBrandService:
         )
         session.add(series)
         await session.flush()
+        if "brand_feature_ids" in payload and payload["brand_feature_ids"] is not None:
+            await ManagerBrandService._sync_series_brand_features(
+                session,
+                series=series,
+                brand_id=brand_id,
+                feature_ids=payload.get("brand_feature_ids"),
+            )
 
         await CatalogRevisionService.bump_commit_and_purge(
             session,
@@ -316,7 +472,12 @@ class ManagerBrandService:
             brand_slugs=[brand.slug],
         )
         await session.refresh(series)
-        return ManagerBrandService._serialize_series(series, products_count=0)
+        feature_map = await ManagerBrandService._load_series_brand_features(session, [int(series.id or 0)])
+        return ManagerBrandService._serialize_series(
+            series,
+            products_count=0,
+            brand_features=feature_map.get(int(series.id or 0), []),
+        )
 
     @staticmethod
     async def update_brand_series(
@@ -379,6 +540,13 @@ class ManagerBrandService:
 
         session.add(series)
         await session.flush()
+        if "brand_feature_ids" in payload and payload["brand_feature_ids"] is not None:
+            await ManagerBrandService._sync_series_brand_features(
+                session,
+                series=series,
+                brand_id=brand_id,
+                feature_ids=payload.get("brand_feature_ids"),
+            )
 
         await CatalogRevisionService.bump_commit_and_purge(
             session,
@@ -392,7 +560,12 @@ class ManagerBrandService:
                 select(func.count(Product.id)).where(Product.series_id == series.id)
             )
         ).scalar_one()
-        return ManagerBrandService._serialize_series(series, products_count=int(products_count or 0))
+        feature_map = await ManagerBrandService._load_series_brand_features(session, [int(series.id or 0)])
+        return ManagerBrandService._serialize_series(
+            series,
+            products_count=int(products_count or 0),
+            brand_features=feature_map.get(int(series.id or 0), []),
+        )
 
     @staticmethod
     async def delete_brand_series(
@@ -416,6 +589,13 @@ class ManagerBrandService:
                 detail="Нельзя удалить серию: к ней привязаны товары. Скройте серию вместо удаления.",
             )
 
+        link_rows = (
+            await session.execute(
+                select(ProductSeriesFeatureLink).where(ProductSeriesFeatureLink.series_id == series.id)
+            )
+        ).scalars().all()
+        for link in link_rows:
+            await session.delete(link)
         await session.delete(series)
         await CatalogRevisionService.bump_commit_and_purge(
             session,
@@ -438,7 +618,13 @@ class ManagerBrandService:
         }
 
     @staticmethod
-    def _serialize_series(series: ProductSeries, *, products_count: int = 0) -> Dict[str, Any]:
+    def _serialize_series(
+        series: ProductSeries,
+        *,
+        products_count: int = 0,
+        brand_features: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        selected_features = brand_features or []
         return {
             "id": series.id,
             "brand_id": series.brand_id,
@@ -450,6 +636,8 @@ class ManagerBrandService:
             "hero_image": series.hero_image,
             "gallery_images": ManagerBrandService._normalize_string_list(series.gallery_images),
             "features": ManagerBrandService._normalize_features(series.features),
+            "brand_features": selected_features,
+            "brand_feature_ids": [int(item["id"]) for item in selected_features if item.get("id") is not None],
             "feature_blocks": ManagerBrandService._normalize_feature_blocks(series.feature_blocks),
             "content_blocks": ManagerBrandService._normalize_content_blocks(series.content_blocks),
             "footnotes": ManagerBrandService._normalize_string_list(series.footnotes),
@@ -461,6 +649,163 @@ class ManagerBrandService:
             "created_at": series.created_at,
             "products_count": int(products_count or 0),
         }
+
+    @staticmethod
+    def _serialize_brand_feature(feature: BrandFeature, *, series_count: int = 0) -> Dict[str, Any]:
+        return {
+            "id": feature.id,
+            "brand_id": feature.brand_id,
+            "title": feature.title,
+            "slug": feature.slug,
+            "text": feature.text,
+            "image_url": feature.image_url,
+            "icon": feature.icon,
+            "footnote": feature.footnote,
+            "source_url": feature.source_url,
+            "aliases": ManagerBrandService._normalize_string_list(feature.aliases),
+            "is_published": feature.is_published,
+            "sort_order": int(feature.sort_order or 0),
+            "created_at": feature.created_at,
+            "updated_at": feature.updated_at,
+            "series_count": int(series_count or 0),
+        }
+
+    @staticmethod
+    def _serialize_series_feature_link(
+        link: ProductSeriesFeatureLink,
+        feature: BrandFeature,
+    ) -> Dict[str, Any]:
+        return {
+            "id": feature.id,
+            "title": link.title_override or feature.title,
+            "slug": feature.slug,
+            "text": link.text_override if link.text_override is not None else feature.text,
+            "image_url": link.image_url_override or feature.image_url,
+            "icon": link.icon_override or feature.icon,
+            "footnote": link.footnote_override or feature.footnote,
+            "source_url": feature.source_url,
+            "aliases": ManagerBrandService._normalize_string_list(feature.aliases),
+            "is_published": feature.is_published,
+            "sort_order": int(link.sort_order if link.sort_order is not None else feature.sort_order or 0),
+        }
+
+    @staticmethod
+    async def _load_series_brand_features(
+        session: AsyncSession,
+        series_ids: List[int],
+    ) -> Dict[int, List[Dict[str, Any]]]:
+        normalized_ids = [int(value) for value in dict.fromkeys(series_ids) if value]
+        if not normalized_ids:
+            return {}
+
+        rows = (
+            await session.execute(
+                select(ProductSeriesFeatureLink, BrandFeature)
+                .join(BrandFeature, BrandFeature.id == ProductSeriesFeatureLink.feature_id)
+                .where(ProductSeriesFeatureLink.series_id.in_(normalized_ids))
+                .order_by(
+                    ProductSeriesFeatureLink.series_id.asc(),
+                    ProductSeriesFeatureLink.sort_order.asc(),
+                    BrandFeature.sort_order.asc(),
+                    BrandFeature.title.asc(),
+                )
+            )
+        ).all()
+        out: Dict[int, List[Dict[str, Any]]] = {series_id: [] for series_id in normalized_ids}
+        for link, feature in rows:
+            out.setdefault(int(link.series_id), []).append(
+                ManagerBrandService._serialize_series_feature_link(link, feature)
+            )
+        return out
+
+    @staticmethod
+    async def _sync_series_brand_features(
+        session: AsyncSession,
+        *,
+        series: ProductSeries,
+        brand_id: int,
+        feature_ids: Any,
+    ) -> None:
+        if not series.id:
+            return
+
+        normalized_ids: List[int] = []
+        for value in feature_ids or []:
+            try:
+                feature_id = int(value)
+            except (TypeError, ValueError):
+                continue
+            if feature_id > 0 and feature_id not in normalized_ids:
+                normalized_ids.append(feature_id)
+
+        if normalized_ids:
+            found_ids = set(
+                (
+                    await session.execute(
+                        select(BrandFeature.id).where(
+                            BrandFeature.brand_id == brand_id,
+                            BrandFeature.id.in_(normalized_ids),
+                        )
+                    )
+                ).scalars().all()
+            )
+            missing_ids = [feature_id for feature_id in normalized_ids if feature_id not in found_ids]
+            if missing_ids:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Фичи не найдены у этого бренда: {', '.join(map(str, missing_ids))}",
+                )
+
+        existing_links = (
+            await session.execute(
+                select(ProductSeriesFeatureLink).where(ProductSeriesFeatureLink.series_id == series.id)
+            )
+        ).scalars().all()
+        existing_by_feature_id = {int(link.feature_id): link for link in existing_links}
+        keep_ids = set(normalized_ids)
+
+        for link in existing_links:
+            if int(link.feature_id) not in keep_ids:
+                await session.delete(link)
+
+        for index, feature_id in enumerate(normalized_ids):
+            link = existing_by_feature_id.get(feature_id)
+            if link is None:
+                link = ProductSeriesFeatureLink(
+                    series_id=int(series.id),
+                    feature_id=feature_id,
+                )
+            link.sort_order = (index + 1) * 10
+            session.add(link)
+
+    @staticmethod
+    async def _brand_feature_series_count(session: AsyncSession, feature_id: int) -> int:
+        count = (
+            await session.execute(
+                select(func.count(ProductSeriesFeatureLink.id)).where(
+                    ProductSeriesFeatureLink.feature_id == feature_id
+                )
+            )
+        ).scalar_one()
+        return int(count or 0)
+
+    @staticmethod
+    async def _get_brand_feature(
+        session: AsyncSession,
+        brand_id: int,
+        feature_id: int,
+    ) -> BrandFeature:
+        feature = (
+            await session.execute(
+                select(BrandFeature).where(
+                    BrandFeature.id == feature_id,
+                    BrandFeature.brand_id == brand_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if feature is None:
+            raise HTTPException(status_code=404, detail="Фича не найдена.")
+        return feature
 
     @staticmethod
     async def _get_brand_series(
@@ -502,12 +847,41 @@ class ManagerBrandService:
             )
 
     @staticmethod
+    async def _ensure_brand_feature_slug_available(
+        session: AsyncSession,
+        *,
+        brand_id: int,
+        slug: str,
+        exclude_feature_id: Optional[int] = None,
+    ) -> None:
+        query = select(BrandFeature).where(
+            BrandFeature.brand_id == brand_id,
+            BrandFeature.slug == slug,
+        )
+        if exclude_feature_id is not None:
+            query = query.where(BrandFeature.id != exclude_feature_id)
+        existing = (await session.execute(query)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Фича со slug '{slug}' уже существует у этого бренда.",
+            )
+
+    @staticmethod
     def _build_series_slug(value: Any, fallback_title: str) -> str:
         requested_slug = str(value or "").strip()
         series_slug = requested_slug or slugify(fallback_title, lowercase=True)
         if not series_slug:
             raise HTTPException(status_code=400, detail="Не удалось сформировать slug серии.")
         return series_slug
+
+    @staticmethod
+    def _build_feature_slug(value: Any, fallback_title: str) -> str:
+        requested_slug = str(value or "").strip()
+        feature_slug = requested_slug or slugify(fallback_title, lowercase=True)
+        if not feature_slug:
+            raise HTTPException(status_code=400, detail="Не удалось сформировать slug фичи.")
+        return feature_slug
 
     @staticmethod
     def _clean_optional_text(value: Any) -> Optional[str]:

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -8,7 +8,6 @@ from schemas import (
     ProductManualResponse,
     ProductBrandResponse,
     ProductResponse,
-    ProductSeriesResponse,
     ProductSiblingResponse,
     TagGroupResponse,
     TagResponse,
@@ -18,6 +17,7 @@ from services.product_image_processing_contract import (
     ProductImageProcessingStatus,
     ProductImageVariantType,
 )
+from services.product_series_payloads import build_product_series_response
 from services.product_serialization import parse_legacy_images, sanitize_specs
 
 
@@ -124,27 +124,7 @@ def map_product_to_response(
     ]
 
     series = product.series if product.series_id else None
-    series_payload = (
-        ProductSeriesResponse(
-            id=series.id,
-            title=series.title,
-            slug=series.slug,
-            tagline=series.tagline,
-            short_description=series.short_description,
-            description=series.description,
-            hero_image=series.hero_image,
-            gallery_images=series.gallery_images or [],
-            features=series.features or [],
-            feature_blocks=series.feature_blocks or [],
-            content_blocks=series.content_blocks or [],
-            footnotes=series.footnotes or [],
-            seo_title=series.seo_title,
-            seo_description=series.seo_description,
-            source_url=series.source_url,
-        )
-        if series and series.is_published
-        else None
-    )
+    series_payload = build_product_series_response(series)
 
     manuals_payload = [
         ProductManualResponse(

--- a/services/product_series_payloads.py
+++ b/services/product_series_payloads.py
@@ -1,0 +1,78 @@
+"""Shared serializers for public product series payloads."""
+
+from typing import Any, List
+
+from models import ProductSeries
+from schemas import ProductSeriesBrandFeatureResponse, ProductSeriesResponse
+
+
+def serialize_series_brand_features(series: ProductSeries) -> List[ProductSeriesBrandFeatureResponse]:
+    # Relationships must be eager-loaded by callers. Reading __dict__ avoids
+    # accidental async lazy loads from synchronous serializers.
+    links = list(getattr(series, "__dict__", {}).get("feature_links") or [])
+    if not links:
+        return []
+
+    payload: list[ProductSeriesBrandFeatureResponse] = []
+    for link in links:
+        feature = getattr(link, "__dict__", {}).get("feature")
+        if not feature or not getattr(feature, "is_published", False):
+            continue
+        payload.append(
+            ProductSeriesBrandFeatureResponse(
+                id=feature.id,
+                title=getattr(link, "title_override", None) or feature.title,
+                slug=feature.slug,
+                text=(
+                    getattr(link, "text_override", None)
+                    if getattr(link, "text_override", None) is not None
+                    else feature.text
+                ),
+                image_url=getattr(link, "image_url_override", None) or feature.image_url,
+                icon=getattr(link, "icon_override", None) or feature.icon,
+                footnote=getattr(link, "footnote_override", None) or feature.footnote,
+                source_url=feature.source_url,
+                aliases=_normalize_string_list(feature.aliases),
+                is_published=feature.is_published,
+                sort_order=int(
+                    getattr(link, "sort_order", None)
+                    if getattr(link, "sort_order", None) is not None
+                    else feature.sort_order or 0
+                ),
+            )
+        )
+    return sorted(payload, key=lambda item: (item.sort_order, item.title.casefold(), item.id))
+
+
+def build_product_series_response(series: ProductSeries | None) -> ProductSeriesResponse | None:
+    if not series or not series.is_published:
+        return None
+    return ProductSeriesResponse(
+        id=series.id,
+        title=series.title,
+        slug=series.slug,
+        tagline=series.tagline,
+        short_description=series.short_description,
+        description=series.description,
+        hero_image=series.hero_image,
+        gallery_images=series.gallery_images or [],
+        features=series.features or [],
+        brand_features=serialize_series_brand_features(series),
+        feature_blocks=series.feature_blocks or [],
+        content_blocks=series.content_blocks or [],
+        footnotes=series.footnotes or [],
+        seo_title=series.seo_title,
+        seo_description=series.seo_description,
+        source_url=series.source_url,
+    )
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if text and text not in out:
+            out.append(text)
+    return out

--- a/services/product_series_service.py
+++ b/services/product_series_service.py
@@ -6,13 +6,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Product, ProductTagLink, Tag
+from models import Product, ProductSeries, ProductSeriesFeatureLink, ProductTagLink, Tag
 from schemas import (
     ProductSeriesNavigationItemResponse,
     ProductSeriesNavigationResponse,
     ProductSeriesResponse,
     ProductSiblingResponse,
 )
+from services.product_series_payloads import build_product_series_response
 
 
 class ProductSeriesService:
@@ -69,25 +70,7 @@ class ProductSeriesService:
     @staticmethod
     def _series_payload(product: Product) -> ProductSeriesResponse | None:
         series = product.series if product.series_id else None
-        if not series or not series.is_published:
-            return None
-        return ProductSeriesResponse(
-            id=series.id,
-            title=series.title,
-            slug=series.slug,
-            tagline=series.tagline,
-            short_description=series.short_description,
-            description=series.description,
-            hero_image=series.hero_image,
-            gallery_images=series.gallery_images or [],
-            features=series.features or [],
-            feature_blocks=series.feature_blocks or [],
-            content_blocks=series.content_blocks or [],
-            footnotes=series.footnotes or [],
-            seo_title=series.seo_title,
-            seo_description=series.seo_description,
-            source_url=series.source_url,
-        )
+        return build_product_series_response(series)
 
     @staticmethod
     def _series_group_keys(product: Product) -> List[str]:
@@ -149,7 +132,9 @@ class ProductSeriesService:
             select(Product)
             .where(Product.is_published == True)
             .options(
-                selectinload(Product.series),
+                selectinload(Product.series)
+                .selectinload(ProductSeries.feature_links)
+                .selectinload(ProductSeriesFeatureLink.feature),
                 selectinload(Product.tags).selectinload(Tag.group),
             )
         )

--- a/services/supplier_mapping_service.py
+++ b/services/supplier_mapping_service.py
@@ -225,6 +225,11 @@ class SupplierMappingService:
                     "supplier_name": supplier.name if supplier else None,
                     "external_id": offer.external_id,
                     "title_raw": offer.title_raw,
+                    "title_normalized": offer.title_normalized,
+                    "model_tokens": offer.model_tokens or [],
+                    "indoor_model_tokens": offer.indoor_model_tokens or [],
+                    "outdoor_model_tokens": offer.outdoor_model_tokens or [],
+                    "match_normalizer_version": offer.match_normalizer_version,
                     "qty": int(offer.qty or 0),
                     "qty_raw": offer.qty_raw,
                     "wholesale_raw": offer.wholesale_raw,
@@ -326,9 +331,15 @@ class SupplierMappingService:
     ) -> dict:
         out = []
         for item in items:
+            supplier_id = item.get("supplier_id")
+            external_id = item.get("external_id")
+            offer = None
+            if supplier_id is not None and external_id is not None:
+                offer = await SupplierOfferDAO.get_by_key(session, int(supplier_id), str(external_id))
             result = await suggest_products_for_offer(
                 session=session,
                 title_raw=item.get("title_raw"),
+                offer=offer,
                 limit=limit_per_offer,
             )
             out.append(
@@ -376,6 +387,11 @@ class SupplierMappingService:
                     "supplier_name": supplier.name if supplier else None,
                     "external_id": offer.external_id,
                     "title_raw": offer.title_raw,
+                    "title_normalized": offer.title_normalized,
+                    "model_tokens": offer.model_tokens or [],
+                    "indoor_model_tokens": offer.indoor_model_tokens or [],
+                    "outdoor_model_tokens": offer.outdoor_model_tokens or [],
+                    "match_normalizer_version": offer.match_normalizer_version,
                     "qty": int(offer.qty or 0),
                     "qty_raw": offer.qty_raw,
                     "wholesale_raw": offer.wholesale_raw,

--- a/services/supplier_match_service.py
+++ b/services/supplier_match_service.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Iterable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.supplier import SupplierOffer
 from services.product_manager_service import ProductManagerService
+
+
+MATCH_NORMALIZER_VERSION = "supplier-match-v2"
 
 _PARASITE_PATTERNS = [
     r"\bсплит[-\s]*система\b",
@@ -15,43 +21,369 @@ _PARASITE_PATTERNS = [
     r"\bкондиционер\b",
 ]
 
+_INDOOR_MARKERS = ("внутрен", "indoor", "внутр.")
+_OUTDOOR_MARKERS = ("наруж", "outdoor", "внешн.")
+_CAPACITY_MARKERS = {"07", "09", "12", "18", "24", "25", "28", "30", "35", "36", "48", "50", "55", "60", "70"}
+_MODEL_TOKEN_RE = re.compile(r"(?<![A-Z0-9])(?=[A-Z0-9/-]*\d)(?=[A-Z0-9/-]*[A-Z])[A-Z0-9]{1,12}(?:[-/][A-Z0-9]{1,12})+(?![A-Z0-9])|(?<![A-Z0-9])(?=[A-Z0-9]*\d)(?=[A-Z0-9]*[A-Z])(?:[A-Z]{1,5}|[0-9][A-Z])[A-Z0-9]{3,16}(?![A-Z0-9])")
+_CYRILLIC_LOOKALIKES = str.maketrans(
+    {
+        "А": "A",
+        "В": "B",
+        "Е": "E",
+        "К": "K",
+        "М": "M",
+        "Н": "H",
+        "О": "O",
+        "Р": "P",
+        "С": "C",
+        "Т": "T",
+        "У": "Y",
+        "Х": "X",
+        "а": "A",
+        "в": "B",
+        "е": "E",
+        "к": "K",
+        "м": "M",
+        "н": "H",
+        "о": "O",
+        "р": "P",
+        "с": "C",
+        "т": "T",
+        "у": "Y",
+        "х": "X",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MatchProfile:
+    title_normalized: str
+    model_tokens: list[str]
+    indoor_model_tokens: list[str]
+    outdoor_model_tokens: list[str]
+
 
 def normalize_offer_title_for_search(title_raw: str | None) -> str:
-    value = (title_raw or "").lower()
+    value = _normalize_text(title_raw)
     for pattern in _PARASITE_PATTERNS:
         value = re.sub(pattern, " ", value, flags=re.IGNORECASE)
-    value = re.sub(r"[^0-9a-zA-Zа-яА-ЯёЁ\-+/ ]+", " ", value)
     value = re.sub(r"\s+", " ", value).strip()
     return value or (title_raw or "").strip()
+
+
+def build_offer_match_profile(title_raw: str | None) -> MatchProfile:
+    normalized = normalize_offer_title_for_search(title_raw)
+    token_profile = _extract_model_tokens(title_raw or "")
+    return MatchProfile(
+        title_normalized=normalized,
+        model_tokens=token_profile["model_tokens"],
+        indoor_model_tokens=token_profile["indoor_model_tokens"],
+        outdoor_model_tokens=token_profile["outdoor_model_tokens"],
+    )
+
+
+def supplier_offer_match_payload(title_raw: str | None) -> dict[str, Any]:
+    profile = build_offer_match_profile(title_raw)
+    return {
+        "title_normalized": profile.title_normalized,
+        "model_tokens": profile.model_tokens,
+        "indoor_model_tokens": profile.indoor_model_tokens,
+        "outdoor_model_tokens": profile.outdoor_model_tokens,
+        "match_normalizer_version": MATCH_NORMALIZER_VERSION,
+    }
+
+
+def build_product_match_profile(product: dict[str, Any]) -> MatchProfile:
+    specs = product.get("specs") if isinstance(product.get("specs"), dict) else {}
+    raw_parts = [
+        product.get("title"),
+        _first_spec_value(specs, ("model_indoor", "Модель внутреннего блока", "UNIT_INDOOR")),
+        _first_spec_value(specs, ("model_outdoor", "Модель наружного блока", "UNIT_OUTDOOR")),
+    ]
+    title_profile = _extract_model_tokens(" ".join(str(part or "") for part in raw_parts))
+    indoor_tokens = _extract_model_tokens(str(raw_parts[1] or ""))["model_tokens"]
+    outdoor_tokens = _extract_model_tokens(str(raw_parts[2] or ""))["model_tokens"]
+    return MatchProfile(
+        title_normalized=normalize_offer_title_for_search(product.get("title")),
+        model_tokens=_dedupe([*title_profile["model_tokens"], *indoor_tokens, *outdoor_tokens]),
+        indoor_model_tokens=_dedupe([*title_profile["indoor_model_tokens"], *indoor_tokens]),
+        outdoor_model_tokens=_dedupe([*title_profile["outdoor_model_tokens"], *outdoor_tokens]),
+    )
 
 
 async def suggest_products_for_offer(
     session: AsyncSession,
     *,
     title_raw: str | None,
+    offer: SupplierOffer | None = None,
     limit: int = 5,
 ) -> dict[str, Any]:
-    normalized_query = normalize_offer_title_for_search(title_raw)
-    if not normalized_query:
+    offer_profile = _profile_from_offer_or_title(offer, title_raw)
+    if not offer_profile.title_normalized and not offer_profile.model_tokens:
         return {
             "normalized_query": "",
+            "offer_tokens": [],
+            "indoor_model_tokens": [],
+            "outdoor_model_tokens": [],
             "candidates": [],
             "auto_eligible": False,
             "reason": "empty_query",
         }
 
-    result = await ProductManagerService.smart_search(session=session, q=normalized_query, limit=limit)
-    items = result.get("items", [])
-    candidates = [{"product_id": i["id"], "title": i["title"], "price": i["price"]} for i in items]
-    if len(candidates) == 1:
-        reason = "single_exact"
-    elif len(candidates) > 1:
-        reason = "multiple_candidates"
-    else:
-        reason = "no_candidates"
+    candidate_rows = await _collect_candidate_products(session, offer_profile, limit=max(limit * 3, 12))
+    scored = [
+        _score_candidate(
+            offer_profile=offer_profile,
+            product=item,
+            offer_rrc=_decimal_to_float(offer.rrc_byn) if offer else None,
+        )
+        for item in candidate_rows
+    ]
+    scored.sort(key=lambda item: (-item["score"], item["title"].casefold(), item["product_id"]))
+    candidates = scored[:limit]
+    reason, auto_eligible = _suggestion_status(candidates)
     return {
-        "normalized_query": normalized_query,
+        "normalized_query": offer_profile.title_normalized,
+        "offer_tokens": offer_profile.model_tokens,
+        "indoor_model_tokens": offer_profile.indoor_model_tokens,
+        "outdoor_model_tokens": offer_profile.outdoor_model_tokens,
         "candidates": candidates,
-        "auto_eligible": len(candidates) == 1,
+        "auto_eligible": auto_eligible,
         "reason": reason,
     }
+
+
+def _profile_from_offer_or_title(offer: SupplierOffer | None, title_raw: str | None) -> MatchProfile:
+    if offer and offer.match_normalizer_version == MATCH_NORMALIZER_VERSION:
+        return MatchProfile(
+            title_normalized=offer.title_normalized or normalize_offer_title_for_search(offer.title_raw),
+            model_tokens=_normalize_token_list(offer.model_tokens),
+            indoor_model_tokens=_normalize_token_list(offer.indoor_model_tokens),
+            outdoor_model_tokens=_normalize_token_list(offer.outdoor_model_tokens),
+        )
+    return build_offer_match_profile(offer.title_raw if offer else title_raw)
+
+
+async def _collect_candidate_products(
+    session: AsyncSession,
+    offer_profile: MatchProfile,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    queries = _dedupe([
+        offer_profile.title_normalized,
+        *offer_profile.model_tokens[:6],
+        *[" ".join(offer_profile.model_tokens[:2]) if len(offer_profile.model_tokens) >= 2 else ""],
+    ])
+    by_id: dict[int, dict[str, Any]] = {}
+    for query in queries:
+        if not query:
+            continue
+        result = await ProductManagerService.smart_search(session=session, q=query, limit=limit)
+        for item in result.get("items", []):
+            product_id = item.get("id")
+            if product_id is None:
+                continue
+            by_id[int(product_id)] = item
+    return list(by_id.values())
+
+
+def _score_candidate(
+    *,
+    offer_profile: MatchProfile,
+    product: dict[str, Any],
+    offer_rrc: float | None = None,
+) -> dict[str, Any]:
+    product_profile = build_product_match_profile(product)
+    offer_tokens = set(offer_profile.model_tokens)
+    product_tokens = set(product_profile.model_tokens)
+    matched_tokens = sorted(offer_tokens & product_tokens)
+    missing_tokens = sorted(offer_tokens - product_tokens)
+    indoor_matches = sorted(set(offer_profile.indoor_model_tokens) & set(product_profile.indoor_model_tokens))
+    outdoor_matches = sorted(set(offer_profile.outdoor_model_tokens) & set(product_profile.outdoor_model_tokens))
+    cross_indoor = sorted(set(offer_profile.indoor_model_tokens) & set(product_profile.outdoor_model_tokens))
+    cross_outdoor = sorted(set(offer_profile.outdoor_model_tokens) & set(product_profile.indoor_model_tokens))
+
+    score = 0
+    breakdown: dict[str, int] = {}
+    explanations: list[str] = []
+
+    if matched_tokens:
+        value = min(85, 42 * len(matched_tokens))
+        score += value
+        breakdown["model_token"] = value
+        explanations.append(f"Совпали модели: {', '.join(matched_tokens[:4])}")
+    if indoor_matches:
+        score += 24
+        breakdown["indoor_token"] = 24
+        explanations.append(f"Внутренний блок: {', '.join(indoor_matches[:3])}")
+    if outdoor_matches:
+        score += 24
+        breakdown["outdoor_token"] = 24
+        explanations.append(f"Наружный блок: {', '.join(outdoor_matches[:3])}")
+    if cross_indoor or cross_outdoor:
+        score -= 45
+        breakdown["role_mismatch"] = -45
+        explanations.append("Есть риск перепутать внутренний и наружный блок")
+
+    offer_capacity = _capacity_markers_from_tokens(offer_profile.model_tokens)
+    product_capacity = _capacity_markers_from_tokens(product_profile.model_tokens)
+    if offer_capacity and product_capacity:
+        common_capacity = sorted(offer_capacity & product_capacity)
+        if common_capacity:
+            score += 10
+            breakdown["capacity"] = 10
+            explanations.append(f"Совпал индекс мощности: {', '.join(common_capacity[:3])}")
+        else:
+            score -= 10
+            breakdown["capacity_mismatch"] = -10
+            explanations.append("Индекс мощности отличается")
+
+    if offer_rrc:
+        product_price = _decimal_to_float(product.get("price"))
+        if product_price and product_price > 0:
+            delta = abs(product_price - offer_rrc) / max(product_price, offer_rrc)
+            if delta <= 0.2:
+                score += 6
+                breakdown["price_close"] = 6
+                explanations.append("Цена близка к РРЦ поставщика")
+            elif delta >= 0.5:
+                score -= 8
+                breakdown["price_far"] = -8
+                explanations.append("Цена заметно отличается от РРЦ поставщика")
+
+    if not explanations:
+        explanations.append("Подобрано только текстовым поиском")
+
+    confidence = max(0, min(100, score))
+    return {
+        "product_id": product["id"],
+        "title": product["title"],
+        "price": product["price"],
+        "score": score,
+        "confidence": confidence,
+        "matched_tokens": matched_tokens,
+        "missing_tokens": missing_tokens,
+        "explanations": explanations,
+        "score_breakdown": breakdown,
+    }
+
+
+def _suggestion_status(candidates: list[dict[str, Any]]) -> tuple[str, bool]:
+    if not candidates:
+        return "no_candidates", False
+    top = candidates[0]
+    second = candidates[1] if len(candidates) > 1 else None
+    top_score = int(top.get("score") or 0)
+    second_score = int(second.get("score") or 0) if second else 0
+    if top_score >= 75 and (second is None or top_score - second_score >= 15):
+        return "high_score", True
+    if second and top_score - second_score < 15:
+        return "ambiguous", False
+    return "low_confidence", False
+
+
+def _extract_model_tokens(raw: str) -> dict[str, list[str]]:
+    text = _normalize_token_text(raw)
+    raw_context_source = (raw or "").replace("\xa0", " ")
+    model_tokens: list[str] = []
+    indoor_tokens: list[str] = []
+    outdoor_tokens: list[str] = []
+    for match in _MODEL_TOKEN_RE.finditer(text):
+        context = text[max(0, match.start() - 42): min(len(text), match.end() + 14)].lower()
+        raw_context = raw_context_source[max(0, match.start() - 42): min(len(raw_context_source), match.end() + 14)].lower()
+        has_indoor_context = any(marker in context or marker in raw_context for marker in _INDOOR_MARKERS)
+        has_outdoor_context = any(marker in context or marker in raw_context for marker in _OUTDOOR_MARKERS)
+        raw_token = str(match.group(0))
+        token_candidates = [_normalize_model_token(raw_token)]
+        if "/" in raw_token:
+            token_candidates.extend(_normalize_model_token(part) for part in raw_token.split("/"))
+        for token in token_candidates:
+            if not _looks_like_model_token(token):
+                continue
+            model_tokens.append(token)
+            if has_indoor_context or token.startswith(("MDS", "AS", "HSU", "RC", "RCI")):
+                indoor_tokens.append(token)
+            if has_outdoor_context or token.startswith(("MDO", "1U", "UU", "CU")):
+                outdoor_tokens.append(token)
+    return {
+        "model_tokens": _dedupe(model_tokens),
+        "indoor_model_tokens": _dedupe(indoor_tokens),
+        "outdoor_model_tokens": _dedupe(outdoor_tokens),
+    }
+
+
+def _normalize_text(raw: str | None) -> str:
+    value = (raw or "").lower().replace("\xa0", " ")
+    value = re.sub(r"[^0-9a-zA-Zа-яА-ЯёЁ\-+/ .]+", " ", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _normalize_token_text(raw: str | None) -> str:
+    value = (raw or "").replace("\xa0", " ").translate(_CYRILLIC_LOOKALIKES).upper()
+    value = value.replace("–", "-").replace("—", "-").replace("_", "-")
+    value = re.sub(r"[^0-9A-Zа-яА-ЯёЁ\-+/ .]+", " ", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _normalize_model_token(raw: str) -> str:
+    token = raw.translate(_CYRILLIC_LOOKALIKES).upper().strip(" ,.;:")
+    token = token.replace(" ", "").replace("_", "-").replace("–", "-").replace("—", "-")
+    token = re.sub(r"-{2,}", "-", token)
+    return token.strip("-/")
+
+
+def _normalize_token_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return _dedupe(_normalize_model_token(str(value or "")) for value in values)
+
+
+def _looks_like_model_token(token: str) -> bool:
+    if len(token) < 4 or len(token) > 32:
+        return False
+    if not re.search(r"[A-Z]", token) or not re.search(r"\d", token):
+        return False
+    if token in {"E-POS", "E-MAIL", "YCJ-A002"}:
+        return False
+    return True
+
+
+def _capacity_markers_from_tokens(tokens: Iterable[str]) -> set[str]:
+    markers: set[str] = set()
+    for token in tokens:
+        for value in re.findall(r"\d{2}", token):
+            if value in _CAPACITY_MARKERS:
+                markers.add(value)
+    return markers
+
+
+def _first_spec_value(specs: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = specs.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _decimal_to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        if isinstance(value, Decimal):
+            return float(value)
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = str(value or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(normalized)
+    return out

--- a/services/supplier_sync_service.py
+++ b/services/supplier_sync_service.py
@@ -11,6 +11,7 @@ from crud.supplier import SupplierDAO, SupplierOfferDAO, SupplierSourceDAO, Supp
 from models.supplier import SupplierOffer, SupplierPriceSource
 from services.supplier_availability import parse_qty_with_text_fallback
 from services.google_service import get_google_service
+from services.supplier_match_service import supplier_offer_match_payload
 
 
 def _col_to_idx(col: str) -> int:
@@ -178,6 +179,7 @@ class SupplierSyncService:
                     "source_id": source.id,
                     "external_id": ext_id,
                     "title_raw": title_raw or None,
+                    **supplier_offer_match_payload(title_raw),
                     "qty_raw": qty_raw or None,
                     "wholesale_raw": wholesale_raw or None,
                     "rrc_raw": rrc_raw or None,

--- a/tests/integration/test_manager_brands_api.py
+++ b/tests/integration/test_manager_brands_api.py
@@ -99,6 +99,22 @@ async def test_manager_brand_series_crud(async_client):
     assert brand_resp.status_code == 200
     brand_id = brand_resp.json()["id"]
 
+    feature_resp = await async_client.post(
+        f"/api/manager/brands/{brand_id}/features",
+        headers=headers,
+        json={
+            "title": "Gentle Breeze",
+            "text": "Soft airflow pattern",
+            "image_url": "/media/series/gentle-breeze.webp",
+            "aliases": ["breeze", "soft airflow"],
+            "sort_order": 2,
+        },
+    )
+    assert feature_resp.status_code == 200, feature_resp.text
+    feature = feature_resp.json()
+    assert feature["slug"] == "gentle-breeze"
+    assert feature["series_count"] == 0
+
     create_resp = await async_client.post(
         f"/api/manager/brands/{brand_id}/series",
         headers=headers,
@@ -134,6 +150,7 @@ async def test_manager_brand_series_crud(async_client):
             "seo_description": "FreshIN SEO description",
             "source_url": "https://example.com/freshin",
             "sort_order": 10,
+            "brand_feature_ids": [feature["id"]],
         },
     )
     assert create_resp.status_code == 200, create_resp.text
@@ -167,6 +184,8 @@ async def test_manager_brand_series_crud(async_client):
     assert created["seo_description"] == "FreshIN SEO description"
     assert created["source_url"] == "https://example.com/freshin"
     assert created["products_count"] == 0
+    assert created["brand_feature_ids"] == [feature["id"]]
+    assert created["brand_features"][0]["title"] == "Gentle Breeze"
     series_id = created["id"]
 
     list_resp = await async_client.get(
@@ -177,6 +196,20 @@ async def test_manager_brand_series_crud(async_client):
     listed_items = list_resp.json()["items"]
     assert [item["id"] for item in listed_items] == [series_id]
     assert listed_items[0]["tagline"] == "Fresh air without drafts"
+    assert listed_items[0]["brand_features"][0]["id"] == feature["id"]
+
+    features_list_resp = await async_client.get(
+        f"/api/manager/brands/{brand_id}/features",
+        headers=headers,
+    )
+    assert features_list_resp.status_code == 200
+    assert features_list_resp.json()["items"][0]["series_count"] == 1
+
+    blocked_feature_delete = await async_client.delete(
+        f"/api/manager/brands/{brand_id}/features/{feature['id']}",
+        headers=headers,
+    )
+    assert blocked_feature_delete.status_code == 400
 
     update_resp = await async_client.put(
         f"/api/manager/brands/{brand_id}/series/{series_id}",
@@ -193,6 +226,7 @@ async def test_manager_brand_series_crud(async_client):
             "seo_title": "Updated SEO",
             "is_published": False,
             "sort_order": 3,
+            "brand_feature_ids": [],
         },
     )
     assert update_resp.status_code == 200, update_resp.text
@@ -216,12 +250,19 @@ async def test_manager_brand_series_crud(async_client):
     assert updated["seo_title"] == "Updated SEO"
     assert updated["is_published"] is False
     assert updated["sort_order"] == 3
+    assert updated["brand_features"] == []
 
     delete_resp = await async_client.delete(
         f"/api/manager/brands/{brand_id}/series/{series_id}",
         headers=headers,
     )
     assert delete_resp.status_code == 200
+
+    delete_feature_resp = await async_client.delete(
+        f"/api/manager/brands/{brand_id}/features/{feature['id']}",
+        headers=headers,
+    )
+    assert delete_feature_resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_manager_supplier_api.py
+++ b/tests/integration/test_manager_supplier_api.py
@@ -28,7 +28,7 @@ async def test_manager_supplier_sync_and_mapping_flow(async_client, db, monkeypa
         def read_sheet_values(self, spreadsheet_id: str, **kwargs):
             return [
                 ["sku", "title", "wholesale", "currency", "rrc", "qty"],
-                ["SKU-1", "Split AC", "479", "USD", "2670", "5"],
+                ["SKU-1", "Split AC MDSAG-09HRFN8", "479", "USD", "2670", "5"],
             ]
 
     from services import supplier_mapping_service, supplier_sync_service
@@ -85,8 +85,11 @@ async def test_manager_supplier_sync_and_mapping_flow(async_client, db, monkeypa
     )
     assert unmapped_by_source.status_code == 200
     assert len(unmapped_by_source.json()["items"]) >= 1
+    offer_item = unmapped_by_source.json()["items"][0]
+    assert offer_item["title_normalized"] == "split ac mdsag-09hrfn8"
+    assert "MDSAG-09HRFN8" in offer_item["model_tokens"]
 
-    product = Product(title="Split AC", slug="mapped-ac", price=3000, area=25)
+    product = Product(title="Split AC MDSAG-09HRFN8", slug="mapped-ac", price=3000, area=25)
     db.add(product)
     await db.commit()
     await db.refresh(product)
@@ -96,12 +99,13 @@ async def test_manager_supplier_sync_and_mapping_flow(async_client, db, monkeypa
         "/api/manager/supplier-offers/suggestions",
         headers=headers,
         json={
-            "items": [{"supplier_id": supplier_id, "external_id": "SKU-1", "title_raw": "Split AC"}],
+            "items": [{"supplier_id": supplier_id, "external_id": "SKU-1", "title_raw": "Split AC MDSAG-09HRFN8"}],
             "limit_per_offer": 5,
         },
     )
     assert suggestions.status_code == 200
     assert suggestions.json()["items"][0]["auto_eligible"] is True
+    assert suggestions.json()["items"][0]["offer_tokens"] == ["MDSAG-09HRFN8"]
 
     create_mapping = await async_client.post(
         "/api/manager/supplier-mappings",

--- a/tests/integration/test_product_series_siblings.py
+++ b/tests/integration/test_product_series_siblings.py
@@ -131,6 +131,7 @@ async def test_product_detail_contains_series_and_series_id_siblings(async_clien
         "hero_image": "/media/series/freshin.webp",
         "gallery_images": [],
         "features": ["Fresh air intake", "Self-cleaning"],
+        "brand_features": [],
         "feature_blocks": [],
         "content_blocks": [],
         "footnotes": [],

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -163,6 +163,7 @@ def test_map_product_to_response_serializes_public_series():
         "hero_image": "/media/series/elite.webp",
         "gallery_images": [],
         "features": [],
+        "brand_features": [],
         "feature_blocks": [],
         "content_blocks": [],
         "footnotes": [],

--- a/tests/unit/test_public_product_series_payloads.py
+++ b/tests/unit/test_public_product_series_payloads.py
@@ -9,9 +9,11 @@ from sqlmodel import SQLModel
 from crud.product import ProductDAO
 from models import (
     Brand,
+    BrandFeature,
     Product,
     ProductLocalStock,
     ProductSeries,
+    ProductSeriesFeatureLink,
     ProductTagLink,
     Tag,
     TagGroup,
@@ -75,6 +77,29 @@ async def _seed_series_products(session: AsyncSession) -> dict[str, Product]:
         is_published=True,
     )
     session.add(series)
+    await session.flush()
+
+    brand_feature = BrandFeature(
+        brand_id=brand.id,
+        title="Gentle Breeze",
+        slug="gentle-breeze",
+        text="Soft airflow without direct draft",
+        image_url="/media/series/gentle-breeze.webp",
+        icon="wind",
+        footnote="Available on selected models",
+        aliases=["soft airflow"],
+        is_published=True,
+        sort_order=5,
+    )
+    session.add(brand_feature)
+    await session.flush()
+    session.add(
+        ProductSeriesFeatureLink(
+            series_id=series.id,
+            feature_id=brand_feature.id,
+            sort_order=10,
+        )
+    )
     await session.flush()
 
     main = Product(
@@ -149,6 +174,7 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
 
     assert detail is not None
     assert "series" not in inspect(detail).unloaded
+    assert "feature_links" not in inspect(detail.series).unloaded
     detail_payload = map_product_to_response(detail)
     assert detail_payload.series is not None
     assert detail_payload.series.model_dump() == {
@@ -161,6 +187,21 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
         "hero_image": "/media/series/elite.webp",
         "gallery_images": ["/media/series/elite-hero.webp"],
         "features": ["Quiet mode", "Wi-Fi ready"],
+        "brand_features": [
+            {
+                "id": detail_payload.series.brand_features[0].id,
+                "title": "Gentle Breeze",
+                "slug": "gentle-breeze",
+                "text": "Soft airflow without direct draft",
+                "image_url": "/media/series/gentle-breeze.webp",
+                "icon": "wind",
+                "footnote": "Available on selected models",
+                "source_url": None,
+                "aliases": ["soft airflow"],
+                "is_published": True,
+                "sort_order": 10,
+            }
+        ],
         "feature_blocks": [
             {
                 "title": "Quiet mode",
@@ -194,12 +235,16 @@ async def test_public_product_queries_eager_load_series_and_siblings(sqlite_sess
     )
     catalog_main = next(item for item in catalog_products if item.slug == seeded["main"].slug)
     assert "series" not in inspect(catalog_main).unloaded
+    assert "feature_links" not in inspect(catalog_main.series).unloaded
     assert map_product_to_response(catalog_main).series.slug == "elite"
+    assert map_product_to_response(catalog_main).series.brand_features[0].slug == "gentle-breeze"
 
     featured = await CatalogService.get_vitebsk_featured_products(sqlite_session, limit=3)
     featured_main = next(item for item in featured if item.slug == seeded["main"].slug)
     assert "series" not in inspect(featured_main).unloaded
+    assert "feature_links" not in inspect(featured_main.series).unloaded
     assert map_product_to_response(featured_main).series.slug == "elite"
+    assert map_product_to_response(featured_main).series.brand_features[0].slug == "gentle-breeze"
 
     siblings = await ProductSeriesService.get_series_siblings(sqlite_session, detail, limit=8)
     assert [item.slug for item in siblings] == ["mdv-elite-25", "mdv-elite-50"]
@@ -215,6 +260,7 @@ async def test_public_series_navigation_builds_slug_sibling_map(sqlite_session):
     assert main_item.series is not None
     assert main_item.series.slug == "elite"
     assert main_item.series.tagline == "Quiet comfort"
+    assert main_item.series.brand_features[0].slug == "gentle-breeze"
     assert main_item.series.feature_blocks[0].title == "Quiet mode"
     assert [item.slug for item in main_item.series_siblings] == [
         "mdv-elite-25",

--- a/tests/unit/test_supplier_mapping_v2.py
+++ b/tests/unit/test_supplier_mapping_v2.py
@@ -2,7 +2,7 @@ import pytest
 
 from models.supplier import Supplier
 from services.supplier_mapping_service import SupplierCatalogService
-from services.supplier_match_service import normalize_offer_title_for_search
+from services.supplier_match_service import build_offer_match_profile, normalize_offer_title_for_search
 
 
 def test_normalize_offer_title_for_search_strips_parasites():
@@ -11,6 +11,40 @@ def test_normalize_offer_title_for_search_strips_parasites():
     assert "сплит" not in normalized
     assert "внутренний блок" not in normalized
     assert "mdsa-12hrfn8" in normalized
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_tokens", "expected_indoor", "expected_outdoor"),
+    [
+        (
+            "MDV Integra Pro внутренний MDSAG-09HRFN8 / наружный MDOAG-09HFN8",
+            ["MDSAG-09HRFN8", "MDOAG-09HFN8"],
+            ["MDSAG-09HRFN8"],
+            ["MDOAG-09HFN8"],
+        ),
+        (
+            "TCL TAC-09CHSD/XA71IN BreezeIN",
+            ["TAC-09CHSD/XA71IN", "TAC-09CHSD", "XA71IN"],
+            [],
+            [],
+        ),
+        (
+            "Haier Flexis внутренний AS25S2SF3FA-W наружный 1U25S2SM3FA",
+            ["AS25S2SF3FA-W", "1U25S2SM3FA"],
+            ["AS25S2SF3FA-W"],
+            ["1U25S2SM3FA"],
+        ),
+    ],
+)
+def test_build_offer_match_profile_extracts_model_tokens(raw, expected_tokens, expected_indoor, expected_outdoor):
+    profile = build_offer_match_profile(raw)
+
+    for token in expected_tokens:
+        assert token in profile.model_tokens
+    for token in expected_indoor:
+        assert token in profile.indoor_model_tokens
+    for token in expected_outdoor:
+        assert token in profile.outdoor_model_tokens
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a reusable brand feature library with series-level feature links and manager CRUD/API support
- extend product/series payloads so public catalog responses can include brand feature content
- add supplier-offer match normalization fields and expose normalized titles/model tokens in manager supplier mapping
- update supplier matching to use tokenized model hints and improve suggestion confidence metadata
- refresh OpenAPI and generated manager client types/services

## Validation
- `POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/unit/test_supplier_mapping_v2.py tests/unit/test_public_product_series_payloads.py tests/unit/test_product_response_mapper_variants.py tests/integration/test_manager_brands_api.py tests/integration/test_manager_supplier_api.py tests/integration/test_product_series_siblings.py -q` -> `29 passed`
- `python3 scripts/legacy/extract_openapi.py`
- `cd manager_frontend && npm run gen:api`
- `cd manager_frontend && npm run build`
- local smoke: `/manager/supplier-mapping` loads and `/api/manager/supplier-offers/unmapped?page=1&limit=100` returns 200 after applying migrations