### PR TITLE
[codex] Add text requisites recognition in bot

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -1,9 +1,11 @@
 from io import BytesIO
 from html import escape
 import os
+import re
 import secrets
 
 from aiogram import Router, types, F
+from aiogram.filters import StateFilter
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
@@ -98,6 +100,31 @@ def _preview_keyboard(data: dict) -> InlineKeyboardMarkup:
             buttons.append([InlineKeyboardButton(text="Обновить существующего", callback_data=f"ocr_update_{recognition_id}")])
     buttons.append([InlineKeyboardButton(text="Отменить", callback_data=f"ocr_cancel_{recognition_id}")])
     return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def _looks_like_requisites_text(text: str | None) -> bool:
+    normalized = str(text or "").strip()
+    if len(normalized) < 40:
+        return False
+    lowered = normalized.casefold()
+    markers = (
+        "унп",
+        "р/с",
+        "расчетный счет",
+        "расчётный счет",
+        "iban",
+        "bic",
+        "банк",
+        "банковские реквизиты",
+        "юридический адрес",
+        "почтовый адрес",
+        "свидетельство",
+    )
+    marker_count = sum(1 for marker in markers if marker in lowered)
+    has_unp = bool(re.search(r"\bунп\s*\d{9}\b", lowered))
+    has_iban = bool(re.search(r"\bBY[0-9A-ZА-ЯЁ ]{20,40}\b", normalized, flags=re.IGNORECASE))
+    has_bic = bool(re.search(r"\bBIC\s+[A-Z0-9]{8,11}\b", normalized, flags=re.IGNORECASE))
+    return marker_count >= 2 or has_iban or (has_unp and marker_count >= 1) or (has_unp and has_bic)
 
 
 def _requisites_file_intent_keyboard(
@@ -531,6 +558,31 @@ async def _run_requisites_recognition(
     await progress_message.edit_text(_preview_text(data), reply_markup=_preview_keyboard(data), parse_mode="HTML")
 
 
+async def _run_requisites_text_recognition(
+    progress_message: types.Message,
+    *,
+    text: str,
+    telegram_user_id: int | None,
+    telegram_chat_id: int | None,
+    telegram_message_id: int | None,
+):
+    try:
+        async with async_session_maker() as session:
+            data = await CustomerRequisitesRecognitionService.recognize_text(
+                session,
+                text=text,
+                source="telegram_text",
+                telegram_user_id=telegram_user_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+            )
+    except Exception as exc:
+        await progress_message.edit_text(f"❌ Не удалось распознать реквизиты: {escape(str(exc))}")
+        return
+
+    await progress_message.edit_text(_preview_text(data), reply_markup=_preview_keyboard(data), parse_mode="HTML")
+
+
 async def _handle_requisites_file(
     message: types.Message,
     *,
@@ -631,6 +683,25 @@ async def recognize_requisites_document(message: types.Message, state: FSMContex
         filename=document.file_name or f"telegram-document-{message.message_id}",
         mime_type=mime_type,
         file_size=getattr(document, "file_size", None),
+    )
+
+
+@router.message(StateFilter(None), F.text)
+async def recognize_requisites_text(message: types.Message):
+    text = message.text or ""
+    if not _looks_like_requisites_text(text):
+        return
+    user_id = message.from_user.id if message.from_user else None
+    if not await _is_admin_user(user_id):
+        return
+
+    progress = await message.answer("Распознаю реквизиты из текста…")
+    await _run_requisites_text_recognition(
+        progress,
+        text=text,
+        telegram_user_id=user_id,
+        telegram_chat_id=message.chat.id if message.chat else None,
+        telegram_message_id=message.message_id,
     )
 
 

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 from aiogram import Router, types, F
+from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.filters import Command, StateFilter
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
@@ -293,7 +294,7 @@ async def auto_search_process(message: types.Message):
     query = (message.text or "").strip()
     user_id = message.from_user.id if message.from_user else None
     if not _is_inline_search_query(query):
-        return
+        raise SkipHandler()
     if not await _is_staff_user(user_id):
         return
 

--- a/services/customer_requisites_recognition_service.py
+++ b/services/customer_requisites_recognition_service.py
@@ -413,6 +413,47 @@ class CustomerRequisitesRecognitionService:
         return cls._recognition_response(recognition, duplicate)
 
     @classmethod
+    async def recognize_text(
+        cls,
+        session: AsyncSession,
+        *,
+        text: str,
+        source: str,
+        telegram_user_id: Optional[int] = None,
+        telegram_chat_id: Optional[int] = None,
+        telegram_message_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        raw_text = cls._clean_text(text, max_length=12000)
+        if not raw_text:
+            raise ValueError("Текст пустой")
+        if len(raw_text) < 20:
+            raise ValueError("Слишком мало текста для распознавания реквизитов")
+
+        extracted_raw = await cls.extract_requisites(raw_text)
+        extracted, validation_flags = cls._normalize_extracted(extracted_raw, raw_text)
+        duplicate = await cls._find_duplicate(session, extracted.get("inn"))
+
+        recognition = CustomerRequisitesRecognition(
+            source=source,
+            status=cls.STATUS_RECOGNIZED,
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            original_filename=None,
+            mime_type="text/plain",
+            local_file_path=None,
+            local_file_url=None,
+            raw_text=raw_text,
+            extracted_json=extracted,
+            validation_flags=validation_flags,
+            duplicate_customer_id=duplicate.id if duplicate else None,
+        )
+        session.add(recognition)
+        await session.commit()
+        await session.refresh(recognition)
+        return cls._recognition_response(recognition, duplicate)
+
+    @classmethod
     def _customer_payload(cls, extracted: dict[str, Any]) -> dict[str, Any]:
         return {
             "name": extracted.get("name") or extracted.get("full_legal_name") or "Новый клиент",

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -254,6 +254,68 @@ async def test_requisites_file_sends_preview_for_admin(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_requisites_text_sends_preview_for_admin(monkeypatch):
+    progress = _DummyProgress()
+    message = _DummyMessage(
+        text=(
+            "Частное унитарное предприятие «МегаЕвроКлимат»\n"
+            "УНП 392053942\n"
+            "Р/с BY83 BPSB 3012 3542 9501 1933 0000\n"
+            "ОАО «Сбербанк» BIC BPSBBY2X"
+        ),
+        user_id=5,
+    )
+    message.answer = AsyncMock(return_value=progress)
+
+    monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
+
+    async def fake_recognize(session, **kwargs):
+        assert "МегаЕвроКлимат" in kwargs["text"]
+        assert kwargs["source"] == "telegram_text"
+        assert kwargs["telegram_user_id"] == 5
+        assert kwargs["telegram_chat_id"] == 100
+        assert kwargs["telegram_message_id"] == 55
+        return {
+            "id": 12,
+            "status": "recognized",
+            "source": "telegram_text",
+            "raw_text": kwargs["text"],
+            "extracted": {
+                "name": "ЧУП «МегаЕвроКлимат»",
+                "inn": "392053942",
+                "iban": "BY83BPSB30123542950119330000",
+                "bic": "BPSBBY2X",
+            },
+            "validation_flags": {"field_errors": {}, "warnings": {}, "is_valid": True},
+            "duplicate_customer": None,
+        }
+
+    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_text", fake_recognize)
+    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+
+    await admin_handler.recognize_requisites_text(message)
+
+    message.answer.assert_awaited_once_with("Распознаю реквизиты из текста…")
+    progress.edit_text.assert_awaited_once()
+    args, kwargs = progress.edit_text.await_args
+    assert "МегаЕвроКлимат" in args[0]
+    assert "392053942" in args[0]
+    assert kwargs["parse_mode"] == "HTML"
+
+
+@pytest.mark.asyncio
+async def test_requisites_text_ignores_non_requisites(monkeypatch):
+    message = _DummyMessage(text="просто заметка без реквизитов", user_id=5)
+    admin_check = AsyncMock(return_value=True)
+    monkeypatch.setattr(admin_handler, "_is_admin_user", admin_check)
+
+    await admin_handler.recognize_requisites_text(message)
+
+    admin_check.assert_not_called()
+    message.answer.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_requisites_photo_prompts_for_action_without_recognition(monkeypatch):
     message = _DummyMessage(text="", user_id=5)
     message.photo = [

--- a/tests/unit/test_bot_auto_search_query.py
+++ b/tests/unit/test_bot_auto_search_query.py
@@ -1,3 +1,10 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.dispatcher.event.bases import SkipHandler
+
+from bot_app.handlers import catalog as catalog_handler
 from bot_app.handlers.catalog import _choose_search_products, _is_inline_search_query
 from bot_app.utils import _availability_badge
 
@@ -42,3 +49,15 @@ def test_availability_badge():
     assert _availability_badge({"availability_status": "out_of_stock"}) == "⛔ <b>Нет в наличии</b>\n"
     assert _availability_badge({"vitebsk_qty": 1}) == "✅ <b>В наличии</b>\n"
     assert _availability_badge({"title": "No supply fields"}) == ""
+
+
+@pytest.mark.asyncio
+async def test_auto_search_skips_non_search_text(monkeypatch):
+    staff_check = AsyncMock(return_value=True)
+    monkeypatch.setattr(catalog_handler, "_is_staff_user", staff_check)
+    message = SimpleNamespace(text="УНП 392053942\nР/с BY83 BPSB 3012 3542 9501 1933 0000", from_user=SimpleNamespace(id=5))
+
+    with pytest.raises(SkipHandler):
+        await catalog_handler.auto_search_process(message)
+
+    staff_check.assert_not_called()

--- a/tests/unit/test_customer_requisites_recognition_service.py
+++ b/tests/unit/test_customer_requisites_recognition_service.py
@@ -1,6 +1,25 @@
-import pytest
+from pathlib import Path
 
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import CustomerRequisitesRecognition
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'requisites.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
 
 
 def test_normalize_vitebsk_landline_from_context():
@@ -54,3 +73,43 @@ async def test_recognize_rejects_too_large_file_before_ocr(monkeypatch):
             mime_type="application/pdf",
             source="test",
         )
+
+
+@pytest.mark.asyncio
+async def test_recognize_text_creates_recognition_without_file(sqlite_session, monkeypatch):
+    async def fake_extract(raw_text):
+        assert "МегаЕвроКлимат" in raw_text
+        return {
+            "name": "ЧУП «МегаЕвроКлимат»",
+            "full_legal_name": "Частное унитарное предприятие «МегаЕвроКлимат»",
+            "inn": "392053942",
+            "legal_address": "г. Витебск, пр-т Победы, 15 ТРЦ «Мега», пав.127",
+            "iban": "BY83BPSB30123542950119330000",
+            "bic": "BPSBBY2X",
+            "bank_name": "ОАО «Сбербанк»",
+            "phone_raw": "8 (029) 722-03-63",
+            "email": "7220363m@mail.ru",
+        }
+
+    monkeypatch.setattr(CustomerRequisitesRecognitionService, "extract_requisites", fake_extract)
+
+    result = await CustomerRequisitesRecognitionService.recognize_text(
+        sqlite_session,
+        text="Частное унитарное предприятие «МегаЕвроКлимат»\nУНП 392053942\nР/с BY83 BPSB 3012 3542 9501 1933 0000\nBIC BPSBBY2X",
+        source="telegram_text",
+        telegram_user_id=7,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+    )
+
+    assert result["source"] == "telegram_text"
+    assert result["local_file_url"] is None
+    assert result["extracted"]["inn"] == "392053942"
+    assert result["extracted"]["iban"] == "BY83BPSB30123542950119330000"
+    assert result["extracted"]["bic"] == "BPSBBY2X"
+    assert result["validation_flags"]["is_valid"] is True
+
+    stored = await sqlite_session.get(CustomerRequisitesRecognition, result["id"])
+    assert stored is not None
+    assert stored.mime_type == "text/plain"
+    assert stored.local_file_path is None


### PR DESCRIPTION
## Summary
- add plain-text requisites recognition for Telegram admin messages
- reuse the existing requisites preview/create/update flow without requiring an image or PDF
- let catalog auto-search skip non-search text so requisites messages can reach the admin handler

## Validation
- `pytest tests/unit/test_customer_requisites_recognition_service.py tests/unit/test_bot_admin_handler.py tests/unit/test_bot_auto_search_query.py -q`
