### PR TITLE
[codex] Detach bank receipt when linked payment is deleted

### DIFF
--- a/services/order_service.py
+++ b/services/order_service.py
@@ -2973,7 +2973,7 @@ class OrderService:
 
     @staticmethod
     async def delete_payment(session: AsyncSession, order_id: int, payment_id: int):
-        from models import Payment
+        from models import BankReceipt, Payment
         order = await session.get(Order, order_id)
         if not order:
             raise ValueError("Order not found")
@@ -2981,15 +2981,59 @@ class OrderService:
         payment = await session.get(Payment, payment_id)
         if not payment or payment.order_id != order_id:
             raise ValueError("Payment not found on this order")
-            
-        await session.delete(payment)
+
+        bank_receipt_id = int(payment.bank_receipt_id) if payment.bank_receipt_id else None
+        affected_order_ids = {int(order_id)}
+
+        if bank_receipt_id:
+            linked_payments_result = await session.execute(
+                select(Payment).where(Payment.bank_receipt_id == bank_receipt_id)
+            )
+            linked_payments = list(linked_payments_result.scalars().all())
+            deleted_payment_ids = [int(item.id or 0) for item in linked_payments if item.id]
+            for linked_payment in linked_payments:
+                if linked_payment.order_id:
+                    affected_order_ids.add(int(linked_payment.order_id))
+                await session.delete(linked_payment)
+
+            receipt = await session.get(BankReceipt, bank_receipt_id)
+            if receipt:
+                meta = dict(receipt.match_meta or {})
+                meta.update(
+                    {
+                        "manual_status": "requires_review",
+                        "manual_reason": "payment_deleted_from_order",
+                        "previous_status": receipt.status,
+                        "previous_matched_order_id": receipt.matched_order_id,
+                        "previous_matched_payment_id": receipt.matched_payment_id,
+                        "previous_matched_payment_ids": deleted_payment_ids or None,
+                    }
+                )
+                receipt.status = "requires_review"
+                receipt.matched_order_id = None
+                receipt.matched_payment_id = None
+                receipt.match_meta = meta
+                session.add(receipt)
+        else:
+            await session.delete(payment)
         await session.flush()
-        
-        await OrderService._refresh_order_financials(session, order)
-        session.add(order)
+
+        for affected_order_id in affected_order_ids:
+            affected_order = await session.get(Order, affected_order_id)
+            if not affected_order:
+                continue
+            await OrderService._refresh_order_financials(session, affected_order)
+            affected_order.is_paid = affected_order.balance_due <= 0.01
+            session.add(affected_order)
         await session.commit()
-        
-        return [OrderService._map_payment(p) for p in sorted(order.payments, key=lambda d: d.date, reverse=True)]
+
+        current_payments_result = await session.execute(
+            select(Payment)
+            .where(Payment.order_id == order_id)
+            .options(selectinload(Payment.bank_receipt))
+            .order_by(Payment.date.desc())
+        )
+        return [OrderService._map_payment(p) for p in current_payments_result.scalars().all()]
 
     # -----------------------------------------------------------------
     # Leads Inbox (Order-based triage)

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -580,6 +580,75 @@ async def test_bank_receipt_suggests_and_attaches_exact_group_subset(sqlite_sess
 
 
 @pytest.mark.asyncio
+async def test_delete_order_payment_detaches_group_bank_receipt(sqlite_session):
+    customer = Customer(name='ТД "Витебск Агропродукт"', phone="+375291111117", type="company", inn="300123457")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    orders = [
+        Order(customer_id=customer.id, status="execution", title="Акт 1"),
+        Order(customer_id=customer.id, status="execution", title="Акт 2"),
+    ]
+    sqlite_session.add_all(orders)
+    await sqlite_session.commit()
+    for order in orders:
+        await sqlite_session.refresh(order)
+
+    sqlite_session.add_all(
+        [
+            OrderServiceLink(order_id=orders[0].id, title="Монтаж", quantity=1, price=2700, cost=0),
+            OrderServiceLink(order_id=orders[1].id, title="ТО", quantity=1, price=2200, cost=0),
+        ]
+    )
+    receipt = BankReceipt(
+        status="new",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="group-delete-payment-receipt-fingerprint",
+        received_at=datetime(2026, 6, 29, 11, 30),
+        amount=4900,
+        currency=PaymentCurrency.BYN,
+        payer_name='ТД "Витебск Агропродукт"',
+        payer_unp="300123457",
+        payment_purpose="Оплата по актам за июнь",
+        raw_body="statement row",
+    )
+    sqlite_session.add(receipt)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(receipt)
+
+    await BankReceiptService.match_receipt(sqlite_session, receipt)
+    attached = await BankReceiptService.attach_receipt_to_order_group(sqlite_session, receipt_id=receipt.id)
+    assert attached.status == "matched"
+
+    payments = (
+        await sqlite_session.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id).order_by(Payment.amount))
+    ).scalars().all()
+    assert len(payments) == 2
+
+    await OrderService.delete_payment(sqlite_session, payments[0].order_id, payments[0].id)
+
+    refreshed_receipt = await sqlite_session.get(BankReceipt, receipt.id)
+    assert refreshed_receipt.status == "requires_review"
+    assert refreshed_receipt.matched_order_id is None
+    assert refreshed_receipt.matched_payment_id is None
+    assert refreshed_receipt.match_meta["manual_reason"] == "payment_deleted_from_order"
+    assert set(refreshed_receipt.match_meta["previous_matched_payment_ids"]) == {payment.id for payment in payments}
+
+    remaining_payments = (
+        await sqlite_session.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id))
+    ).scalars().all()
+    assert remaining_payments == []
+
+    await sqlite_session.refresh(orders[0])
+    await sqlite_session.refresh(orders[1])
+    assert orders[0].balance_due == 2700
+    assert orders[1].balance_due == 2200
+
+
+@pytest.mark.asyncio
 async def test_bank_receipt_can_be_manually_attached_to_order(sqlite_session):
     customer = Customer(name="УКС Витебск", phone="+375291111111", type="company", inn="300200572")
     sqlite_session.add(customer)


### PR DESCRIPTION
## What changed
- When a manager deletes a payment linked to a bank receipt, the receipt is moved back to `requires_review` and its matched order/payment pointers are cleared.
- For group bank allocations, deleting one linked payment now removes all payments tied to that receipt and refreshes all affected order balances.
- Added a regression test covering group receipt allocation followed by deleting one payment from an order.

## Why
A receipt could remain visually `matched` after its actual `Payment` rows were removed from an order. That left the receipt in a zombie state: marked as allocated while the related orders still had open debt.

## Production data note
Receipt #36 was found in exactly that state on production and was manually reset to `requires_review` without creating/deleting any payments; its orders still have open debt and can now be allocated with the visible group action.

## Validation
- `pytest tests/unit/test_mail_services.py -q`
- `git diff --check`
