### PR TITLE
Stabilize noisy manager error paths

### DIFF
--- a/core/manager_error_codes.py
+++ b/core/manager_error_codes.py
@@ -8,6 +8,7 @@ EQUIPMENT_NOT_FOUND = "equipment_not_found"
 PRODUCT_NOT_FOUND = "product_not_found"
 DOCUMENT_GENERATION_FAILED = "document_generation_failed"
 DOCUMENT_NOT_FOUND = "document_not_found"
+DOCUMENT_HAS_DEPENDENTS = "document_has_dependents"
 
 
 # Shared message map for manager API responses and frontend fallback mapping.
@@ -22,6 +23,7 @@ DEFAULT_MANAGER_ERROR_MESSAGES = {
     PRODUCT_NOT_FOUND: "Товар не найден",
     DOCUMENT_GENERATION_FAILED: "Не удалось сформировать документ",
     DOCUMENT_NOT_FOUND: "Документ не найден",
+    DOCUMENT_HAS_DEPENDENTS: "Нельзя удалить документ-основание: сначала удалите связанные акты или накладные",
 
 }
 

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
-from core.manager_error_codes import DOCUMENT_NOT_FOUND, BAD_REQUEST
+from core.manager_error_codes import BAD_REQUEST, DOCUMENT_HAS_DEPENDENTS, DOCUMENT_NOT_FOUND
 from core.security import get_current_username
 from routers.manager_operation_ids import (
     GET_MANAGER_ORDER_DOCUMENTS,
@@ -34,7 +34,7 @@ from schemas import (
     DocumentTemplatePayload,
     DocumentTemplateUpdatePayload,
 )
-from services.document_service import DocumentService
+from services.document_service import DocumentHasDependentsError, DocumentService
 from services.document_template_service import DocumentTemplateService
 from services.google_service import get_google_service
 
@@ -241,7 +241,15 @@ async def delete_manager_doc(
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
 ):
-    order_id = await DocumentService.delete_document(session, doc_id)
+    try:
+        order_id = await DocumentService.delete_document(session, doc_id)
+    except DocumentHasDependentsError as exc:
+        raise manager_http_error(
+            status_code=409,
+            endpoint=DELETE_MANAGER_DOC,
+            error_code=DOCUMENT_HAS_DEPENDENTS,
+            message=str(exc),
+        ) from exc
     
     if not order_id:
         raise manager_http_error(

--- a/routers/manager_media_gallery_write.py
+++ b/routers/manager_media_gallery_write.py
@@ -68,7 +68,7 @@ async def link_search_result(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post(
@@ -159,7 +159,7 @@ async def remove_product_image_background(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post(

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -239,7 +239,7 @@ async def remove_media_asset_background(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.delete(

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -15,6 +15,10 @@ from services.document_role_service import DocumentRoleService
 from services.document_template_service import DocumentTemplateService
 
 
+class DocumentHasDependentsError(ValueError):
+    """Raised when a document is used as a basis for other documents."""
+
+
 class DocumentService:
     """Сервис для работы с документами заказов через Google Drive"""
 
@@ -329,15 +333,25 @@ class DocumentService:
             return None
 
         order_id = document.order_id
+        google_file_id = document.google_file_id
 
-        if document.google_file_id:
-            try:
-                get_google_service().delete_file(document.google_file_id)
-            except Exception as exc:
-                print(f"Error deleting file from Drive: {exc}")
+        dependent_query = select(OrderDocument.id).where(
+            OrderDocument.base_document_id == document.id
+        ).limit(1)
+        dependent_result = await session.execute(dependent_query)
+        if dependent_result.scalar_one_or_none() is not None:
+            raise DocumentHasDependentsError(
+                "Нельзя удалить документ-основание: сначала удалите связанные акты или накладные"
+            )
 
         await session.delete(document)
         await session.commit()
+
+        if google_file_id:
+            try:
+                get_google_service().delete_file(google_file_id)
+            except Exception as exc:
+                print(f"Error deleting file from Drive: {exc}")
 
         return order_id
 

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -269,9 +269,10 @@ class ManagerMediaService:
                 lambda: list(DDGS().images(query, max_results=max_results))
             )
         except Exception as exc:
-            logger.error(f"Error searching images (DDG): {exc}")
             if "Ratelimit" in str(exc) or "403" in str(exc):
                 logger.warning(f"DDG Ratelimit hit for query: {query}")
+            else:
+                logger.warning(f"Image search provider error (DDG): {exc}")
             return []
 
         images = []
@@ -303,7 +304,7 @@ class ManagerMediaService:
                 response.raise_for_status()
                 image_content = response.content
         except Exception as exc:
-            logger.error(f"Failed to download image: {exc}")
+            logger.warning(f"Failed to download external image: {exc}")
             raise ValueError(f"Failed to download image: {exc}") from exc
 
         return await ManagerMediaService.save_image_from_bytes(
@@ -586,6 +587,17 @@ class ManagerMediaService:
             if exclude_installation:
                 stmt = stmt.where(ProductImage.is_installation_photo == False)  # noqa: E712
             rows = (await session.execute(stmt)).scalars().all()
+            row_ids = [row.id for row in rows if row.id is not None]
+            if row_ids:
+                variant_rows = (
+                    await session.execute(
+                        select(ProductImageVariant).where(
+                            ProductImageVariant.product_image_id.in_(row_ids)
+                        )
+                    )
+                ).scalars().all()
+                for variant in variant_rows:
+                    await session.delete(variant)
             for row in rows:
                 await session.delete(row)
                 deleted_links += 1

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import Any, Dict, List
 from sqlmodel import select
 from core.config import settings
@@ -100,8 +99,8 @@ class SchedulerService:
 
                 # Sleep to avoid rate limiting
                 await asyncio.sleep(2)
-            except Exception as e:
-                logger.error(f"Error updating price for {product['title']}: {e}")
+            except Exception:
+                logger.exception("Error updating price for %s", product["title"])
 
         if updates:
             updated_count = 0
@@ -162,8 +161,8 @@ class SchedulerService:
         while True:
             try:
                 await self.update_all_prices()
-            except Exception as e:
-                logger.error(f"Critical error in price sync loop: {e}")
+            except Exception:
+                logger.exception("Critical error in price sync loop")
             await asyncio.sleep(interval_hours * 3600)
 
     async def _stalled_deal_loop(self):
@@ -175,37 +174,48 @@ class SchedulerService:
                     await self.check_stalled_deals(session)
                 logger.info("✅ Stalled Deal Check Done. Sleeping 24 hours.")
                 await asyncio.sleep(24 * 3600)
-            except Exception as e:
-                logger.error(f"❌ Stalled Deal Check Error: {e}")
+            except Exception:
+                logger.exception("❌ Stalled Deal Check Error")
                 await asyncio.sleep(3600)  # Retry in 1 hour
 
     async def check_stalled_deals(self, session):
         """
-        Moves deals from NEGOTIATION to DEFERRED if updated_at > 14 days ago.
+        Marks stale negotiation orders for follow-up instead of moving them to
+        a legacy deferred status.
         """
         from models import Order, OrderStatus
         from datetime import datetime, timedelta
-        
+
         cutoff_date = datetime.now() - timedelta(days=14)
         
         # Select orders in Negotiation older than 14 days
         stmt = select(Order).where(
             Order.status == OrderStatus.NEGOTIATION,
-            Order.updated_at < cutoff_date
+            Order.updated_at < cutoff_date,
+            Order.negotiation_status != "follow_up",
         )
         res = await session.execute(stmt)
         stalled_orders = res.scalars().all()
         
         for order in stalled_orders:
-            logger.warning(f"⚠️ Deferring Stalled Order #{order.id} (Last update: {order.updated_at})")
-            order.status = OrderStatus.DEFERRED
-            order.technical_meta = {**(order.technical_meta or {}), "deferred_reason": "Auto-deferred: >14 days in Negotiation"}
+            logger.warning(
+                "⚠️ Marking stalled negotiation order #%s for follow-up (Last update: %s)",
+                order.id,
+                order.updated_at,
+            )
+            order.status = OrderStatus.NEGOTIATION
+            order.negotiation_status = "follow_up"
+            order.negotiation_status_changed_at = datetime.now()
+            order.technical_meta = {
+                **(order.technical_meta or {}),
+                "stalled_follow_up_reason": "Auto follow-up: >14 days in Negotiation",
+            }
             order.next_followup_date = datetime.now() + timedelta(days=7)
             session.add(order)
             
         if stalled_orders:
             await session.commit()
-            logger.info(f"🔄 Auto-deferred {len(stalled_orders)} stalled orders.")
+            logger.info("🔄 Marked %s stalled orders for follow-up.", len(stalled_orders))
 
     async def _backup_loop(self):
         """Runs database backup every day at 3:00 AM."""
@@ -228,8 +238,8 @@ class SchedulerService:
                 await asyncio.to_thread(backup_service.perform_backup, cleanup=True)
                 logger.info("✅ Daily Backup Completed.")
                 
-            except Exception as e:
-                logger.error(f"❌ Backup Loop Error: {e}")
+            except Exception:
+                logger.exception("❌ Backup Loop Error")
                 # Retry in 1 hour if it crashed to avoid loop spam
                 await asyncio.sleep(3600)
 
@@ -243,8 +253,8 @@ class SchedulerService:
                     archived_count = await LeadService.archive_expired_lost_leads(session=session, older_than_days=90)
                 logger.info(f"✅ Lead archive job done. Archived: {archived_count}")
                 await asyncio.sleep(24 * 3600)
-            except Exception as e:
-                logger.error(f"❌ Lead archive loop error: {e}")
+            except Exception:
+                logger.exception("❌ Lead archive loop error")
                 await asyncio.sleep(3600)
 
     async def _supplier_sync_loop(self):
@@ -266,8 +276,8 @@ class SchedulerService:
                     await asyncio.sleep(interval_minutes * 60)
                 else:
                     await asyncio.sleep(300)
-            except Exception as e:
-                logger.error(f"❌ Supplier sync loop error: {e}")
+            except Exception:
+                logger.exception("❌ Supplier sync loop error")
                 await asyncio.sleep(300)
 
     async def _bank_mail_import_loop(self):
@@ -300,8 +310,8 @@ class SchedulerService:
                     result.failed,
                     notified_admins,
                 )
-            except Exception as e:
-                logger.error(f"❌ Bank mail import loop error: {e}")
+            except Exception:
+                logger.exception("❌ Bank mail import loop error")
             await asyncio.sleep(interval_minutes * 60)
 
     async def _email_lead_import_loop(self):
@@ -352,8 +362,8 @@ class SchedulerService:
                     result.failed,
                     snapshot.notified_admins,
                 )
-            except Exception as e:
-                logger.error(f"❌ Email lead import loop error: {e}")
+            except Exception:
+                logger.exception("❌ Email lead import loop error")
             await asyncio.sleep(interval_minutes * 60)
 
 scheduler_service = SchedulerService()

--- a/tests/integration/test_manager_gallery_bulk.py
+++ b/tests/integration/test_manager_gallery_bulk.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from sqlmodel import select
 
 from core.config import settings
-from models import Product, ProductImage
+from models import Product, ProductImage, ProductImageVariant
 
 
 def _make_product(idx: int) -> Product:
@@ -102,6 +102,75 @@ async def test_bulk_delete_common_removes_only_selected_products(async_client: A
     ).scalars().all()
     assert len(left) == 1
     assert left[0].product_id == p3_id
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_common_removes_variants_only_for_deleted_links(async_client: AsyncClient, db):
+    p1 = _make_product(31)
+    p2 = _make_product(32)
+    p3 = _make_product(33)
+    db.add_all([p1, p2, p3])
+    await db.commit()
+    for p in [p1, p2, p3]:
+        await db.refresh(p)
+
+    common_url = "/media/products/shared/with-variants.webp"
+    img1 = ProductImage(product_id=p1.id, url=common_url, is_installation_photo=False)
+    img2 = ProductImage(product_id=p2.id, url=common_url, is_installation_photo=False)
+    img3 = ProductImage(product_id=p3.id, url=common_url, is_installation_photo=False)
+    db.add_all([img1, img2, img3])
+    await db.commit()
+    for img in [img1, img2, img3]:
+        await db.refresh(img)
+    p3_id = p3.id
+    img3_id = img3.id
+
+    db.add_all([
+        ProductImageVariant(
+            product_image_id=img1.id,
+            variant_type="card",
+            url="/media/products/shared/with-variants-p1-card.webp",
+            processing_status="ready",
+        ),
+        ProductImageVariant(
+            product_image_id=img2.id,
+            variant_type="card",
+            url="/media/products/shared/with-variants-p2-card.webp",
+            processing_status="ready",
+        ),
+        ProductImageVariant(
+            product_image_id=img3.id,
+            variant_type="card",
+            url="/media/products/shared/with-variants-p3-card.webp",
+            processing_status="ready",
+        ),
+    ])
+    await db.commit()
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        "/api/manager/gallery/bulk-delete-common",
+        json={
+            "product_ids": [p1.id, p2.id],
+            "urls": [common_url],
+            "exclude_installation": True,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    db.expire_all()
+
+    remaining_images = (
+        await db.execute(select(ProductImage).where(ProductImage.url == common_url))
+    ).scalars().all()
+    assert [image.product_id for image in remaining_images] == [p3_id]
+
+    remaining_variants = (
+        await db.execute(select(ProductImageVariant).order_by(ProductImageVariant.id))
+    ).scalars().all()
+    assert len(remaining_variants) == 1
+    assert remaining_variants[0].product_image_id == img3_id
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -2913,6 +2913,65 @@ async def test_manager_doc_delete_success(async_client, db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_manager_doc_delete_blocks_base_document_with_dependents(async_client, db, monkeypatch):
+    customer = Customer(name="DocBaseGuard", phone="+375290000001", type=CustomerType.individual)
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    from models import OrderDocument
+    base_doc = OrderDocument(
+        order_id=order.id,
+        doc_type="invoice",
+        number="I-BASE",
+        google_file_id="fid_base",
+        google_edit_url="http://edit_base",
+    )
+    db.add(base_doc)
+    await db.flush()
+    dependent_doc = OrderDocument(
+        order_id=order.id,
+        doc_type="act",
+        number="A-DEP",
+        base_document_id=base_doc.id,
+        google_file_id="fid_dep",
+        google_edit_url="http://edit_dep",
+    )
+    db.add(dependent_doc)
+    await db.commit()
+    await db.refresh(base_doc)
+    await db.refresh(dependent_doc)
+
+    from services.google_service import get_google_service
+    deleted_ids = []
+
+    def _fake_delete_file(file_id):
+        deleted_ids.append(file_id)
+
+    monkeypatch.setattr(get_google_service(), "delete_file", _fake_delete_file)
+
+    headers = await _auth_headers(async_client)
+    resp = await async_client.delete(f"/api/manager/docs/{base_doc.id}", headers=headers)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error_code"] == "document_has_dependents"
+    assert deleted_ids == []
+
+    from sqlmodel import select
+
+    base_res = await db.execute(select(OrderDocument).where(OrderDocument.id == base_doc.id))
+    dep_res = await db.execute(select(OrderDocument).where(OrderDocument.id == dependent_doc.id))
+
+    assert base_res.scalar_one_or_none() is not None
+    assert dep_res.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
 async def test_manager_order_delete_cascades_related_entities(async_client, db, monkeypatch):
     customer = Customer(name="Delete Order", phone="+375290001234", type=CustomerType.individual)
     product = Product(title="Delete Product", slug="delete-product", price=4000, area=35)

--- a/tests/unit/test_scheduler_service.py
+++ b/tests/unit/test_scheduler_service.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Customer, Order, OrderStatus
+from services.scheduler_service import SchedulerService
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'scheduler.db'}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_check_stalled_deals_marks_old_negotiations_for_follow_up(sqlite_session):
+    customer = Customer(name="Scheduler Customer", phone="+375290000000")
+    sqlite_session.add(customer)
+    await sqlite_session.flush()
+
+    old_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEGOTIATION,
+        negotiation_status="awaiting_offer",
+        updated_at=datetime.now() - timedelta(days=16),
+        technical_meta={"source": "test"},
+    )
+    recent_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEGOTIATION,
+        negotiation_status="awaiting_offer",
+        updated_at=datetime.now() - timedelta(days=2),
+    )
+    execution_order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        negotiation_status="awaiting_offer",
+        updated_at=datetime.now() - timedelta(days=16),
+    )
+    sqlite_session.add_all([old_order, recent_order, execution_order])
+    await sqlite_session.commit()
+
+    await SchedulerService().check_stalled_deals(sqlite_session)
+
+    rows = (
+        await sqlite_session.execute(select(Order).order_by(Order.id))
+    ).scalars().all()
+    old_order, recent_order, execution_order = rows
+
+    assert old_order.status == OrderStatus.NEGOTIATION
+    assert old_order.negotiation_status == "follow_up"
+    assert old_order.next_followup_date is not None
+    assert old_order.technical_meta["source"] == "test"
+    assert old_order.technical_meta["stalled_follow_up_reason"]
+
+    assert recent_order.negotiation_status == "awaiting_offer"
+    assert recent_order.next_followup_date is None
+    assert execution_order.status == OrderStatus.EXECUTION
+    assert execution_order.negotiation_status == "awaiting_offer"
+
+    first_followup = old_order.next_followup_date
+    await SchedulerService().check_stalled_deals(sqlite_session)
+    await sqlite_session.refresh(old_order)
+
+    assert old_order.next_followup_date == first_followup


### PR DESCRIPTION
## Summary
- replace legacy stalled-deal auto-defer with follow-up marking instead of missing OrderStatus.DEFERRED
- make document deletion safe when a base document has dependent acts/waybills, deleting Drive files only after DB delete succeeds
- remove product image variants during bulk common-gallery cleanup and downgrade expected media/provider failures away from 500/error logs
- improve scheduler loop logging with tracebacks for real background failures

## Tests
- pytest tests/unit/test_scheduler_service.py -q
- python3 -m compileall core/manager_error_codes.py routers/manager_docs.py routers/manager_media_gallery_write.py routers/manager_media_library.py services/document_service.py services/manager_media_service.py services/scheduler_service.py tests/unit/test_scheduler_service.py tests/integration/test_manager_gallery_bulk.py tests/integration/test_manager_orders_api.py
- POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_gallery_bulk.py -q
- POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py::test_manager_doc_delete_success tests/integration/test_manager_orders_api.py::test_manager_doc_delete_blocks_base_document_with_dependents -q
- POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/unit/test_scheduler_service.py tests/integration/test_manager_gallery_bulk.py tests/integration/test_manager_orders_api.py::test_manager_doc_delete_success tests/integration/test_manager_orders_api.py::test_manager_doc_delete_blocks_base_document_with_dependents -q
- POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/unit -q
- POSTGRES_PASSWORD=v9f2K7mS1a TEST_DB_HOST=localhost TEST_DB_PORT=5433 pytest tests/integration/test_manager_orders_api.py -q