### PR TITLE
Make test observability local-safe

### DIFF
--- a/core/app_observability.py
+++ b/core/app_observability.py
@@ -4,7 +4,7 @@ from core.config import settings
 
 
 def init_sentry() -> None:
-    if settings.SENTRY_DSN:
+    if settings.SENTRY_DSN and settings.ENVIRONMENT != "test":
         sentry_sdk.init(
             dsn=settings.SENTRY_DSN,
             traces_sample_rate=1.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,35 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
+# Tests should never emit events into the real Sentry project, even when a
+# developer has production-like values in a local .env.
+os.environ["ENVIRONMENT"] = "test"
+os.environ["SENTRY_DSN"] = ""
+
+
+def _running_inside_docker() -> bool:
+    return os.path.exists("/.dockerenv")
+
+
+def _resolve_test_database_url() -> str:
+    configured_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if configured_url and "test" in configured_url.lower():
+        return configured_url
+
+    pg_user = os.environ.get("POSTGRES_USER", "mvnadmin")
+    pg_pass = os.environ.get("POSTGRES_PASSWORD", "securepass")
+    test_db_host = os.environ.get("TEST_DB_HOST")
+    if not test_db_host:
+        test_db_host = "db_test" if _running_inside_docker() else "localhost"
+    test_db_port = os.environ.get("TEST_DB_PORT") or os.environ.get("POSTGRES_PORT")
+    if not test_db_port:
+        test_db_port = "5432" if test_db_host == "db_test" else "5433"
+    test_db_name = os.environ.get("TEST_POSTGRES_DB", "air_conditioners_test")
+    return f"postgresql+asyncpg://{pg_user}:{pg_pass}@{test_db_host}:{test_db_port}/{test_db_name}"
+
+
 # CRITICAL: Always use the TEST database for tests.
-# Construct the test DB URL from env vars, pointing to the db_test service.
-_pg_user = os.environ.get("POSTGRES_USER", "mvnadmin")
-_pg_pass = os.environ.get("POSTGRES_PASSWORD", "securepass")
-_test_db_host = os.environ.get("TEST_DB_HOST", "db_test")  # Docker service name
-_test_db_port = os.environ.get("TEST_DB_PORT", "5432")
-_test_db_name = "air_conditioners_test"
-TEST_DATABASE_URL = f"postgresql+asyncpg://{_pg_user}:{_pg_pass}@{_test_db_host}:{_test_db_port}/{_test_db_name}"
+TEST_DATABASE_URL = _resolve_test_database_url()
 
 # Safety net: abort if the URL doesn't contain 'test'
 assert "test" in TEST_DATABASE_URL.lower(), (


### PR DESCRIPTION
## Summary
- make pytest resolve the test database correctly both inside Docker and from the host
- respect TEST_DATABASE_URL/DATABASE_URL when they point to a test database, while keeping the existing safety guard
- disable Sentry initialization/events for test runs

## Tests
- pytest tests/integration/test_manager_gallery_bulk.py -q
- pytest tests/integration/test_manager_orders_api.py::test_manager_doc_delete_success tests/integration/test_manager_orders_api.py::test_manager_doc_delete_blocks_base_document_with_dependents -q
- python3 -m compileall tests/conftest.py core/app_observability.py
- pytest tests/unit -q