### PR TITLE
[codex] Make API deploy target configurable

### DIFF
--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -61,6 +61,10 @@ jobs:
           CHECK_BACKUPS: ${{ inputs.check_backups }}
           API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
           API_SSH_USER: ${{ secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_COMPOSE_SERVICE_CHECKS: ${{ vars.API_COMPOSE_SERVICE_CHECKS || vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot db' }}
+          API_LOCAL_HEALTH_URL: ${{ vars.API_LOCAL_HEALTH_URL || 'http://127.0.0.1:8000/api/health' }}
         run: |
           set -euo pipefail
 
@@ -77,6 +81,10 @@ jobs:
             echo "## API VPS Health Check"
             echo "- mode: ${{ inputs.mode }}"
             echo "- base_url: https://api.mvn.by"
+            echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
+            echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"
+            echo "- api_compose_service_checks: ${{ vars.API_COMPOSE_SERVICE_CHECKS || vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot db' }}"
+            echo "- api_local_health_url: ${{ vars.API_LOCAL_HEALTH_URL || 'http://127.0.0.1:8000/api/health' }}"
             echo "- backup_max_age_hours: ${{ inputs.backup_max_age_hours }}"
             echo "- check_backups: ${{ inputs.check_backups }}"
             echo "- log_artifact: api-vps-health-log-${{ github.run_id }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,20 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   # Secrets needed:
   # SSH_KEY (Private Key for root@api and user@web)
-  # SSH_HOST_API (185.250.45.54)
+  # SSH_HOST_API (current API primary host)
   # SSH_HOST_WEB (153.80.244.78)
   # SSH_USER_API (root)
   # SSH_USER_WEB (deploy)
   # SSH_WEB_TARGET (/var/www/mvn.by/current/)
+  # Optional repo/environment variables:
+  # API_PROJECT_DIR (/opt/air-api by default)
+  # API_COMPOSE_FILE (docker-compose.prod.yml by default)
+  # API_COPY_COMPOSE (true by default; set false for emergency host-local compose)
+  # API_DEPLOY_SERVICES (app bot by default; set app for app-only reserve compose)
+  # API_BASE_URL (http://localhost:8000 by default)
+  # API_SMOKE_COMPOSE_SERVICE_CHECKS (app bot by default)
+  # API_BOT_EXPECT_ENABLED (true by default)
+  # API_TUNNEL_REMOTE_PORT (8000 by default)
 
 jobs:
   # ======================================================
@@ -114,6 +123,17 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+      API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+      API_COPY_COMPOSE: ${{ vars.API_COPY_COMPOSE || 'true' }}
+      API_DEPLOY_SERVICES: ${{ vars.API_DEPLOY_SERVICES || 'app bot' }}
+      API_MIGRATION_SERVICE: ${{ vars.API_MIGRATION_SERVICE || 'app' }}
+      API_RUN_MIGRATIONS: ${{ vars.API_RUN_MIGRATIONS || 'true' }}
+      API_RUN_DEFAULTS: ${{ vars.API_RUN_DEFAULTS || 'true' }}
+      API_BASE_URL: ${{ vars.API_BASE_URL || 'http://localhost:8000' }}
+      API_SMOKE_COMPOSE_SERVICE_CHECKS: ${{ vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot' }}
+      API_BOT_EXPECT_ENABLED: ${{ vars.API_BOT_EXPECT_ENABLED || 'true' }}
 
     steps:
       - name: Checkout
@@ -183,6 +203,8 @@ jobs:
           echo "🔍 Testing connection to API server..."
           echo "Host: ${{ secrets.SSH_HOST_API }}"
           echo "User: ${{ secrets.SSH_USER_API }}"
+          echo "Project dir: ${API_PROJECT_DIR}"
+          echo "Compose file: ${API_COMPOSE_FILE}"
           
           # Test if host is reachable (allow failure for diagnosis)
           ping -c 3 ${{ secrets.SSH_HOST_API }} || echo "⚠️ Ping failed, but SSH might still work"
@@ -214,17 +236,24 @@ jobs:
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
-          
-          # Copy compose files to project dir (requires write access)
-          scp \
-            -i ~/.ssh/deploy_key \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ConnectTimeout=20 \
-            -o ServerAliveInterval=15 \
-            -o ServerAliveCountMax=3 \
-            -v docker-compose.prod.yml \
-            ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}:/opt/air-api/
+
+          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
+          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "mkdir -p '${API_PROJECT_DIR}'"
+
+          if [ "${API_COPY_COMPOSE}" = "true" ]; then
+            echo "📄 Copying docker-compose.prod.yml to ${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
+            scp \
+              -i ~/.ssh/deploy_key \
+              -o BatchMode=yes \
+              -o StrictHostKeyChecking=yes \
+              -o ConnectTimeout=20 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=3 \
+              -v docker-compose.prod.yml \
+              "${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}:${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
+          else
+            echo "⏭️ API_COPY_COMPOSE=${API_COPY_COMPOSE}; keeping remote compose unchanged"
+          fi
           
       - name: Execute Deployment Script
         id: deploy_backend
@@ -236,7 +265,17 @@ jobs:
           cat scripts/deploy.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy.sh"
           
           # Execute script
-          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "chmod +x /tmp/deploy.sh && GHCR_PAT='${{ secrets.GHCR_PAT }}' GITHUB_ACTOR='${{ github.actor }}' bash /tmp/deploy.sh"
+          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+            chmod +x /tmp/deploy.sh && \
+            GHCR_PAT='${{ secrets.GHCR_PAT }}' \
+            GITHUB_ACTOR='${{ github.actor }}' \
+            API_PROJECT_DIR='${API_PROJECT_DIR}' \
+            API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
+            API_DEPLOY_SERVICES='${API_DEPLOY_SERVICES}' \
+            API_MIGRATION_SERVICE='${API_MIGRATION_SERVICE}' \
+            API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}' \
+            API_RUN_DEFAULTS='${API_RUN_DEFAULTS}' \
+            bash /tmp/deploy.sh"
 
       - name: Optional Post-Deploy Backend Ops
         id: post_deploy_ops
@@ -276,6 +315,8 @@ jobs:
             RUN_REPORT_LEGACY_LINKS='${RUN_REPORT_LEGACY_LINKS}' \
             RUN_CLEANUP_LEGACY_LINKS='${RUN_CLEANUP_LEGACY_LINKS}' \
             DRY_RUN='${DRY_RUN}' \
+            API_PROJECT_DIR='${API_PROJECT_DIR}' \
+            API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
             OPS_SUMMARY_FILE='/tmp/ops_summary.txt' \
             bash /tmp/ops_post_deploy.sh && cat /tmp/ops_summary.txt" | tee backend_ops.log
 
@@ -287,7 +328,10 @@ jobs:
           cat scripts/post_deploy_smoke_check.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/post_deploy_smoke_check.sh"
           ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
             chmod +x /tmp/post_deploy_smoke_check.sh && \
-            BASE_URL='http://localhost:8000' \
+            BASE_URL='${API_BASE_URL}' \
+            COMPOSE_FILE='${API_PROJECT_DIR}/${API_COMPOSE_FILE}' \
+            COMPOSE_SERVICE_CHECKS='${API_SMOKE_COMPOSE_SERVICE_CHECKS}' \
+            BOT_EXPECT_ENABLED='${API_BOT_EXPECT_ENABLED}' \
             SMOKE_SUMMARY_FILE='/tmp/smoke_summary.txt' \
             bash /tmp/post_deploy_smoke_check.sh && cat /tmp/smoke_summary.txt" | tee backend_smoke.log
 
@@ -319,6 +363,9 @@ jobs:
             echo "- image: ghcr.io/${{ steps.prep.outputs.repo }}/backend"
             echo "- digest: ${digest}"
             echo "- commit_sha: ${{ github.sha }}"
+            echo "- api_project_dir: ${API_PROJECT_DIR}"
+            echo "- api_compose_file: ${API_COMPOSE_FILE}"
+            echo "- api_deploy_services: ${API_DEPLOY_SERVICES}"
             echo "- deploy_status: ${{ steps.deploy_backend.outcome }}"
             echo "- ops_status: ${{ steps.post_deploy_ops.outcome }}"
             echo "- smoke_status: ${{ steps.post_deploy_smoke.outcome }}"
@@ -360,7 +407,9 @@ jobs:
         working-directory: ./web
         env:
            # SSR Build: bypass public CDN/WAF checks via SSH tunnel to the API host.
-           INTERNAL_API_URL: http://127.0.0.1:18000/api/v1
+           API_TUNNEL_LOCAL_PORT: ${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}
+           API_TUNNEL_REMOTE_PORT: ${{ vars.API_TUNNEL_REMOTE_PORT || '8000' }}
+           INTERNAL_API_URL: http://127.0.0.1:${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}/api/v1
            # Client-side: Use production API  
            # CRITICAL: API Router prefix is /api, full path: https://api.mvn.by/api/v1
            PUBLIC_API_URL: https://api.mvn.by/api/v1
@@ -373,14 +422,14 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
           ssh -f -N \
-            -L 18000:127.0.0.1:8000 \
+            -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
             -i ~/.ssh/deploy_key \
             -o BatchMode=yes \
             -o StrictHostKeyChecking=yes \
             -o ExitOnForwardFailure=yes \
             -o ConnectTimeout=20 \
             ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}
-          curl -fsS --retry 10 --retry-delay 3 http://127.0.0.1:18000/api/v1/config >/dev/null
+          curl -fsS --retry 10 --retry-delay 3 "http://127.0.0.1:${API_TUNNEL_LOCAL_PORT}/api/v1/config" >/dev/null
           npm run build
 
       - name: Setup SSH Key for Web Server

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,14 +64,62 @@ to `178.159.240.174`, restore the legacy web deploy secrets if needed, and run t
 manual web rebuild workflow.
 
 ### API Server
-- **Host alias:** `mvn-api`
+- **Host alias:** `mvn-api` for the original API VPS; `zakup` for the emergency API primary.
 - **User:** `root`
-- **IP:** `185.250.45.54`
+- **Original API IP:** `185.250.45.54`
+- **Emergency `zakup` IP:** `193.47.42.213`
 - **SSH Key:** `~/.ssh/id_ed25519`
-- **DNS:** `api.mvn.by` A-record must point to `185.250.45.54`
-- **GitHub secret:** `SSH_HOST_API` must be `185.250.45.54`
-- **Public entrypoint:** nginx on `80/443`, proxying `api.mvn.by` to `127.0.0.1:8000`
+- **DNS:** `api.mvn.by` A-record must point to the current API primary.
+- **GitHub secret:** `SSH_HOST_API` must point to the current API primary.
+- **Public entrypoint:** reverse proxy on `80/443`, proxying `api.mvn.by` to the current API app port.
 - **Health endpoint:** `/api/health`
+
+The backend deploy workflow is primary-host configurable. Keep sensitive values
+in GitHub secrets and non-secret routing values in GitHub variables.
+
+Required API secrets:
+
+| Name | Purpose |
+| --- | --- |
+| `SSH_HOST_API` | Current API primary host/IP. |
+| `SSH_USER_API` | SSH user for the API host. |
+| `SSH_KEY` | Private deploy key. |
+| `GHCR_PAT` | Token used by the VPS to pull backend images from GHCR. |
+
+Optional API variables:
+
+| Name | Default | Purpose |
+| --- | --- | --- |
+| `API_PROJECT_DIR` | `/opt/air-api` | Directory containing `.env`, compose file, media, and runtime files. |
+| `API_COMPOSE_FILE` | `docker-compose.prod.yml` | Compose file name inside `API_PROJECT_DIR`. |
+| `API_COPY_COMPOSE` | `true` | Copy repo `docker-compose.prod.yml` to the host before deploy. Set `false` for host-local emergency compose. |
+| `API_DEPLOY_SERVICES` | `app bot` | Compose services to recreate after pulling images. |
+| `API_BASE_URL` | `http://localhost:8000` | Local base URL used by post-deploy smoke. |
+| `API_SMOKE_COMPOSE_SERVICE_CHECKS` | `app bot` | Services expected to be running during smoke. |
+| `API_BOT_EXPECT_ENABLED` | `true` | Whether smoke requires bot runtime controls to be enabled. |
+| `API_TUNNEL_REMOTE_PORT` | `8000` | Remote localhost API port used by frontend build SSH tunnel. |
+| `API_COMPOSE_SERVICE_CHECKS` | `app bot db` | Services expected by the manual API VPS health workflow. |
+| `API_LOCAL_HEALTH_URL` | `http://127.0.0.1:8000/api/health` | Host-local health URL for the manual API VPS health workflow. |
+
+Current emergency `zakup` values:
+
+```text
+SSH_HOST_API=193.47.42.213
+SSH_USER_API=root
+API_PROJECT_DIR=/opt/mvn-reserve
+API_COMPOSE_FILE=docker-compose.reserve.yml
+API_COPY_COMPOSE=false
+API_DEPLOY_SERVICES=app
+API_BASE_URL=http://localhost:18000
+API_SMOKE_COMPOSE_SERVICE_CHECKS=app db
+API_BOT_EXPECT_ENABLED=false
+API_TUNNEL_REMOTE_PORT=18000
+API_COMPOSE_SERVICE_CHECKS=app db
+API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health
+```
+
+This keeps the emergency Caddy/network compose on `zakup` intact while still
+allowing backend image deploys from `main`.
 
 Production compose binds backend-only ports to localhost:
 

--- a/scripts/check_api_vps_health.sh
+++ b/scripts/check_api_vps_health.sh
@@ -13,6 +13,8 @@ API_SSH_STRICT_HOST_KEY_CHECKING="${API_SSH_STRICT_HOST_KEY_CHECKING:-accept-new
 API_SSH_CONNECT_TIMEOUT="${API_SSH_CONNECT_TIMEOUT:-10}"
 API_PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 API_COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
+API_COMPOSE_SERVICE_CHECKS="${API_COMPOSE_SERVICE_CHECKS:-app bot db}"
+API_LOCAL_HEALTH_URL="${API_LOCAL_HEALTH_URL:-http://127.0.0.1:8000/api/health}"
 API_TLS_HOST="${API_TLS_HOST:-api.mvn.by}"
 
 DISK_WARN_PCT="${DISK_WARN_PCT:-80}"
@@ -50,6 +52,10 @@ Common env:
   API_SSH_HOST=mvn-api
   API_SSH_USER=root
   API_SSH_KEY_PATH=~/.ssh/id_ed25519
+  API_PROJECT_DIR=/opt/air-api
+  API_COMPOSE_FILE=docker-compose.prod.yml
+  API_COMPOSE_SERVICE_CHECKS="app bot db"
+  API_LOCAL_HEALTH_URL=http://127.0.0.1:8000/api/health
   BACKUP_MAX_AGE_HOURS=36
   CHECK_BACKUPS=true
 
@@ -260,6 +266,8 @@ PY
 }
 
 run_ssh_checks() {
+  local api_compose_service_checks_arg
+  api_compose_service_checks_arg="${API_COMPOSE_SERVICE_CHECKS// /,}"
   local ssh_cmd=(
     ssh
     -p "${API_SSH_PORT}"
@@ -287,7 +295,9 @@ run_ssh_checks() {
     "${TLS_CRITICAL_DAYS}" \
     "${BACKUP_MAX_AGE_HOURS}" \
     "${CHECK_BACKUPS}" \
-    "${API_TLS_HOST}" <<'REMOTE'
+    "${API_TLS_HOST}" \
+    "${api_compose_service_checks_arg}" \
+    "${API_LOCAL_HEALTH_URL}" <<'REMOTE'
 set -euo pipefail
 
 PROJECT_DIR="$1"
@@ -301,6 +311,8 @@ TLS_CRITICAL_DAYS="$8"
 BACKUP_MAX_AGE_HOURS="$9"
 CHECK_BACKUPS="${10}"
 API_TLS_HOST="${11}"
+API_COMPOSE_SERVICE_CHECKS="${12//,/ }"
+API_LOCAL_HEALTH_URL="${13}"
 
 remote_failures=0
 remote_warnings=0
@@ -397,7 +409,7 @@ elif [[ -d "${PROJECT_DIR}" && -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]]; then
   fi
 
   running_services="$("${COMPOSE[@]}" ps --services --filter status=running 2>/dev/null || true)"
-  for service in app bot db; do
+  for service in ${API_COMPOSE_SERVICE_CHECKS}; do
     if printf '%s\n' "${running_services}" | grep -Fxq "${service}"; then
       remote_ok "container running: ${service}"
     else
@@ -412,7 +424,7 @@ elif [[ -d "${PROJECT_DIR}" && -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]]; then
   fi
 
   if command -v curl >/dev/null 2>&1; then
-    if local_health_payload="$(curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8000/api/health 2>/dev/null)"; then
+    if local_health_payload="$(curl -fsS --connect-timeout 3 --max-time 10 "${API_LOCAL_HEALTH_URL}" 2>/dev/null)"; then
       if command -v python3 >/dev/null 2>&1; then
         if HEALTH_PAYLOAD="${local_health_payload}" python3 - <<'PY' >/dev/null 2>&1
 import json
@@ -431,7 +443,7 @@ PY
         remote_ok "localhost app health responded; python3 unavailable on host so payload shape was not validated"
       fi
     else
-      remote_fail "localhost app health failed at http://127.0.0.1:8000/api/health"
+      remote_fail "localhost app health failed at ${API_LOCAL_HEALTH_URL}"
     fi
   else
     remote_warn "curl is not installed on host; localhost app health skipped"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,26 @@ set -o pipefail
 
 echo "🚀 Starting deployment script on server..."
 
-cd /opt/air-api
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
+DEPLOY_SERVICES="${API_DEPLOY_SERVICES:-app bot}"
+MIGRATION_SERVICE="${API_MIGRATION_SERVICE:-app}"
+RUN_MIGRATIONS="${API_RUN_MIGRATIONS:-true}"
+RUN_DEFAULTS="${API_RUN_DEFAULTS:-true}"
+
+if [[ ! -d "${PROJECT_DIR}" ]]; then
+    echo "❌ Project dir not found: ${PROJECT_DIR}"
+    exit 1
+fi
+
+cd "${PROJECT_DIR}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+    echo "❌ Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}"
+    exit 1
+fi
+
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
 
 mkdir -p media model-cache/u2net
 
@@ -14,24 +33,32 @@ echo "$GHCR_PAT" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
 # 2. Pull images
 echo "📥 Pulling latest Docker images..."
-docker compose -f docker-compose.prod.yml pull
+"${COMPOSE[@]}" pull
 
 # 3. Migrations
-echo "📦 Running database migrations..."
-# Use -T to avoid TTY issues
-docker compose -f docker-compose.prod.yml run -T --rm app alembic upgrade head
+if [[ "${RUN_MIGRATIONS}" == "true" ]]; then
+    echo "📦 Running database migrations..."
+    # Use -T to avoid TTY issues
+    "${COMPOSE[@]}" run -T --rm "${MIGRATION_SERVICE}" alembic upgrade head
+else
+    echo "⏭️ Skipping database migrations (API_RUN_MIGRATIONS=${RUN_MIGRATIONS})"
+fi
 
 # 3.1 Ensure required global settings exist (idempotent).
-echo "⚙️ Ensuring default global settings..."
-docker compose -f docker-compose.prod.yml run -T --rm app python3 scripts/ensure_global_config_defaults.py
+if [[ "${RUN_DEFAULTS}" == "true" ]]; then
+    echo "⚙️ Ensuring default global settings..."
+    "${COMPOSE[@]}" run -T --rm "${MIGRATION_SERVICE}" python3 scripts/ensure_global_config_defaults.py
+else
+    echo "⏭️ Skipping default global settings (API_RUN_DEFAULTS=${RUN_DEFAULTS})"
+fi
 
 # 4. Stop old containers
 echo "🛑 Stopping old containers..."
-docker compose -f docker-compose.prod.yml stop app bot || true
+"${COMPOSE[@]}" stop ${DEPLOY_SERVICES} || true
 
 # 5. Start new containers
 echo "🔄 Starting services..."
-docker compose -f docker-compose.prod.yml up -d --force-recreate app bot
+"${COMPOSE[@]}" up -d --force-recreate ${DEPLOY_SERVICES}
 
 # 6. Cleanup
 echo "🧹 Cleaning up unused Docker objects (images, containers, networks)..."

--- a/scripts/ops_post_deploy.sh
+++ b/scripts/ops_post_deploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-COMPOSE="docker compose -f docker-compose.prod.yml"
-PROJECT_DIR="/opt/air-api"
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
 OPS_SUMMARY_FILE="${OPS_SUMMARY_FILE:-/tmp/ops_summary.txt}"
 
 OPS_MODE="${OPS_MODE:-report_only}" # report_only | normalize_report | full
@@ -70,13 +70,14 @@ if [[ ! -d "${PROJECT_DIR}" ]]; then
 fi
 
 cd "${PROJECT_DIR}"
-if [[ ! -f "docker-compose.prod.yml" ]]; then
-  log preflight "docker-compose.prod.yml not found in ${PROJECT_DIR}"
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  log preflight "${COMPOSE_FILE} not found in ${PROJECT_DIR}"
   exit 1
 fi
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
 
 run_in_app() {
-  ${COMPOSE} exec -T app sh -lc "$1"
+  "${COMPOSE[@]}" exec -T app sh -lc "$1"
 }
 
 script_exists() {
@@ -120,7 +121,7 @@ if [[ "${RUN_REPORT_LEGACY_LINKS}" == "false" ]]; then
 fi
 
 log preflight "Ensuring app is running..."
-${COMPOSE} up -d app >/dev/null
+"${COMPOSE[@]}" up -d app >/dev/null
 
 ops_actions=()
 ops_skipped=()


### PR DESCRIPTION
## What changed
- Made backend deploy configurable through GitHub variables for project dir, compose file, compose-copy behavior, deploy services, smoke base URL, and bot expectations.
- Updated deploy and optional post-deploy ops scripts to respect `API_PROJECT_DIR` and `API_COMPOSE_FILE` instead of hardcoding `/opt/air-api/docker-compose.prod.yml`.
- Made frontend build SSH tunnel use a configurable remote API port.
- Updated the API VPS health workflow/script to support host-local reserve compose checks such as `app db` on `127.0.0.1:18000`.
- Documented current emergency `zakup` settings and the new deploy variables.

## Why
`api.mvn.by` is currently served from the emergency `zakup` host using `/opt/mvn-reserve/docker-compose.reserve.yml`. The old deploy workflow only targeted one hardcoded `/opt/air-api` primary and would overwrite the host-local reserve compose if pointed at `zakup` directly.

## Validation
- `bash -n scripts/deploy.sh scripts/ops_post_deploy.sh scripts/post_deploy_smoke_check.sh scripts/check_api_vps_health.sh`
- YAML parse for `.github/workflows/deploy.yml` and `.github/workflows/check-api-vps-health.yml`
- Public API health check via `scripts/check_api_vps_health.sh --public-only`
- SSH-mode API health check against `zakup` with `API_PROJECT_DIR=/opt/mvn-reserve`, `API_COMPOSE_FILE=docker-compose.reserve.yml`, `API_COMPOSE_SERVICE_CHECKS='app db'`, `API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health`, `CHECK_BACKUPS=false`