### PR TITLE
Auto-apply exact bank receipt groups

### DIFF
--- a/services/bank_receipt_service.py
+++ b/services/bank_receipt_service.py
@@ -344,6 +344,86 @@ class BankReceiptService:
         }
 
     @staticmethod
+    async def _apply_group_receipt_payment(
+        session: AsyncSession,
+        receipt: BankReceipt,
+        orders: list[Order],
+        *,
+        payment_type: PaymentType = PaymentType.POSTPAYMENT,
+        manual: bool = False,
+        base_meta: Optional[dict[str, Any]] = None,
+    ) -> BankReceipt:
+        debt_orders = [order for order in orders if float(order.balance_due or 0) > BankReceiptService.EXACT_AMOUNT_TOLERANCE]
+        if len(debt_orders) < 2:
+            raise ValueError("Group payment requires at least two orders with unpaid balance")
+
+        total_balance_due = BankReceiptService._money(sum(float(order.balance_due or 0) for order in debt_orders))
+        receipt_amount = BankReceiptService._money(receipt.amount)
+        if abs(total_balance_due - receipt_amount) > BankReceiptService.EXACT_AMOUNT_TOLERANCE:
+            raise ValueError(f"Receipt amount {receipt_amount} does not match group debt {total_balance_due}")
+
+        payments: list[Payment] = []
+        allocated = 0.0
+        for index, order in enumerate(debt_orders):
+            if index == len(debt_orders) - 1:
+                amount = BankReceiptService._money(receipt_amount - allocated)
+            else:
+                amount = BankReceiptService._money(order.balance_due)
+                allocated = BankReceiptService._money(allocated + amount)
+            if amount <= BankReceiptService.EXACT_AMOUNT_TOLERANCE:
+                continue
+            payment = Payment(
+                order_id=int(order.id),
+                bank_receipt_id=receipt.id,
+                amount=amount,
+                currency=receipt.currency,
+                date=receipt.received_at,
+                type=payment_type,
+                comment=(
+                    f"{'Разнесено вручную' if manual else 'Автоматически разнесено'} "
+                    f"по группе заказов из банковского поступления #{receipt.id}"
+                ),
+            )
+            session.add(payment)
+            payments.append(payment)
+
+        await session.flush()
+
+        for order in debt_orders:
+            await OrderService._refresh_order_financials(session, order)
+            session.add(order)
+
+        payment_items = [
+            {
+                "payment_id": int(payment.id or 0),
+                "order_id": int(payment.order_id),
+                "amount": BankReceiptService._money(payment.amount),
+            }
+            for payment in payments
+        ]
+        meta = dict(base_meta or receipt.match_meta or {})
+        meta.update(
+            {
+                "group_order_ids": [item["order_id"] for item in payment_items],
+                "group_payment_ids": [item["payment_id"] for item in payment_items],
+                "group_payments": payment_items,
+                "group_total": receipt_amount,
+            }
+        )
+        if manual:
+            meta["manual_group_attached"] = True
+        else:
+            meta["auto_group_attached"] = True
+
+        receipt.status = "matched"
+        receipt.matched_order_id = payment_items[0]["order_id"]
+        receipt.matched_payment_id = payment_items[0]["payment_id"]
+        receipt.match_meta = meta
+        session.add(receipt)
+        await session.flush()
+        return receipt
+
+    @staticmethod
     async def match_receipt(session: AsyncSession, receipt: BankReceipt) -> BankReceipt:
         if receipt.id and receipt.matched_payment_id:
             return receipt
@@ -414,10 +494,27 @@ class BankReceiptService:
                 "group_match": group_match,
                 "document_candidates": document_candidates,
             }
+        elif group_match["is_exact"] and len(group_match.get("order_ids") or []) > 1:
+            selected_order_ids = {int(order_id) for order_id in group_match["order_ids"]}
+            selected_orders = [order for order in orders if int(order.id or 0) in selected_order_ids]
+            receipt.match_meta = {
+                **base_meta,
+                "reason": "group_balance_due_exact",
+                "candidate_order_ids": candidate_ids,
+                "exact_order_ids": exact_ids,
+                "group_match": group_match,
+                "document_candidates": document_candidates,
+            }
+            receipt = await BankReceiptService._apply_group_receipt_payment(
+                session,
+                receipt,
+                selected_orders,
+                payment_type=PaymentType.POSTPAYMENT,
+                manual=False,
+                base_meta=receipt.match_meta,
+            )
         else:
-            if group_match["is_exact"]:
-                reason = "group_balance_due_exact"
-            elif BankReceiptService._looks_like_multi_document_payment(receipt.payment_purpose):
+            if BankReceiptService._looks_like_multi_document_payment(receipt.payment_purpose):
                 reason = "multi_document_payment"
             else:
                 reason = "not_exactly_one_candidate"
@@ -528,66 +625,13 @@ class BankReceiptService:
         if foreign_orders:
             raise ValueError("Selected orders do not belong to the bank receipt payer UNP")
 
-        debt_orders = [order for order in orders if float(order.balance_due or 0) > BankReceiptService.EXACT_AMOUNT_TOLERANCE]
-        if len(debt_orders) < 2:
-            raise ValueError("Group payment requires at least two orders with unpaid balance")
-
-        total_balance_due = BankReceiptService._money(sum(float(order.balance_due or 0) for order in debt_orders))
-        receipt_amount = BankReceiptService._money(receipt.amount)
-        if abs(total_balance_due - receipt_amount) > BankReceiptService.EXACT_AMOUNT_TOLERANCE:
-            raise ValueError(f"Receipt amount {receipt_amount} does not match group debt {total_balance_due}")
-
-        payments: list[Payment] = []
-        allocated = 0.0
-        for index, order in enumerate(debt_orders):
-            if index == len(debt_orders) - 1:
-                amount = BankReceiptService._money(receipt_amount - allocated)
-            else:
-                amount = BankReceiptService._money(order.balance_due)
-                allocated = BankReceiptService._money(allocated + amount)
-            if amount <= BankReceiptService.EXACT_AMOUNT_TOLERANCE:
-                continue
-            payment = Payment(
-                order_id=int(order.id),
-                bank_receipt_id=receipt.id,
-                amount=amount,
-                currency=receipt.currency,
-                date=receipt.received_at,
-                type=ptype,
-                comment=f"Разнесено по группе заказов из банковского поступления #{receipt.id}",
-            )
-            session.add(payment)
-            payments.append(payment)
-
-        await session.flush()
-
-        for order in debt_orders:
-            await OrderService._refresh_order_financials(session, order)
-            session.add(order)
-
-        payment_items = [
-            {
-                "payment_id": int(payment.id or 0),
-                "order_id": int(payment.order_id),
-                "amount": BankReceiptService._money(payment.amount),
-            }
-            for payment in payments
-        ]
-        meta = dict(receipt.match_meta or {})
-        meta.update(
-            {
-                "manual_group_attached": True,
-                "group_order_ids": [item["order_id"] for item in payment_items],
-                "group_payment_ids": [item["payment_id"] for item in payment_items],
-                "group_payments": payment_items,
-                "group_total": receipt_amount,
-            }
+        await BankReceiptService._apply_group_receipt_payment(
+            session,
+            receipt,
+            orders,
+            payment_type=ptype,
+            manual=True,
         )
-        receipt.status = "matched"
-        receipt.matched_order_id = payment_items[0]["order_id"]
-        receipt.matched_payment_id = payment_items[0]["payment_id"]
-        receipt.match_meta = meta
-        session.add(receipt)
         await session.commit()
         await session.refresh(receipt)
         return receipt

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -87,6 +87,12 @@ class OrderService:
         return fallback if fallback in OrderService.EXECUTION_STATUSES else OrderService.DEFAULT_EXECUTION_STATUS
 
     @staticmethod
+    def _status_value(value: Any) -> str:
+        if hasattr(value, "value"):
+            return str(value.value)
+        return str(value or "").strip()
+
+    @staticmethod
     def _infer_execution_status(order: Order) -> str:
         raw_status = getattr(order, "execution_status", None)
         if raw_status is not None:
@@ -635,18 +641,20 @@ class OrderService:
             return
         is_fully_paid = float(order.balance_due or 0) <= OrderService.PAYMENT_COMPLETE_TOLERANCE
         order.is_paid = is_fully_paid
+        status = OrderService._status_value(order.status)
         if (
             is_fully_paid
             and bool(getattr(order, "auto_execution_on_payment", False))
-            and order.status == OrderStatus.NEGOTIATION
+            and status == OrderStatus.NEGOTIATION.value
         ):
             order.status = OrderStatus.EXECUTION
+            status = OrderStatus.EXECUTION.value
             order.status_changed_at = datetime.now()
             order.proposal_status = "approved"
         if (
             is_fully_paid
             and bool(getattr(order, "auto_close_on_payment", False))
-            and order.status == OrderStatus.EXECUTION
+            and status == OrderStatus.EXECUTION.value
             and OrderService._normalize_execution_status(getattr(order, "execution_status", None)) == "awaiting_payment"
         ):
             order.status = OrderStatus.CLOSED

--- a/tests/integration/test_manager_mail_api.py
+++ b/tests/integration/test_manager_mail_api.py
@@ -61,7 +61,7 @@ async def test_manager_mail_lists_bank_receipts(async_client, db):
 
 
 @pytest.mark.asyncio
-async def test_manager_mail_attaches_exact_group_bank_receipt(async_client, db):
+async def test_manager_mail_auto_attaches_exact_group_bank_receipt(async_client, db):
     customer = Customer(
         name='ТД "Витебск Агропродукт"',
         phone="+375291234567",
@@ -114,24 +114,14 @@ async def test_manager_mail_attaches_exact_group_bank_receipt(async_client, db):
     await db.commit()
     await db.refresh(receipt)
 
-    assert receipt.status == "requires_review"
+    assert receipt.status == "matched"
     assert receipt.match_meta["reason"] == "group_balance_due_exact"
+    assert receipt.match_meta["auto_group_attached"] is True
     assert receipt.match_meta["group_match"]["is_exact"] is True
     assert receipt.match_meta["group_match"]["total_balance_due"] == 4900
     assert set(receipt.match_meta["group_match"]["order_ids"]) == {order_a.id, order_b.id}
-
-    headers = await _auth_headers(async_client)
-    response = await async_client.post(
-        f"/api/manager/mail/bank-receipts/{receipt.id}/attach-group",
-        headers=headers,
-        json={},
-    )
-
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["status"] == "matched"
-    assert set(payload["match_meta"]["group_order_ids"]) == {order_a.id, order_b.id}
-    assert len(payload["match_meta"]["group_payment_ids"]) == 2
+    assert set(receipt.match_meta["group_order_ids"]) == {order_a.id, order_b.id}
+    assert len(receipt.match_meta["group_payment_ids"]) == 2
 
     payments = (
         await db.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id).order_by(Payment.amount))
@@ -144,6 +134,68 @@ async def test_manager_mail_attaches_exact_group_bank_receipt(async_client, db):
     await db.refresh(order_a)
     await db.refresh(order_b)
     assert (await db.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id))).scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_manager_mail_manually_attaches_review_group_bank_receipt(async_client, db):
+    customer = Customer(
+        name='ТД "Витебск Агропродукт"',
+        phone="+375291234568",
+        type=CustomerType.company,
+        inn="300123457",
+    )
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    order_a = Order(customer_id=customer.id, status=OrderStatus.EXECUTION, title="Акт 1")
+    order_b = Order(customer_id=customer.id, status=OrderStatus.EXECUTION, title="Акт 2")
+    db.add_all([order_a, order_b])
+    await db.commit()
+    await db.refresh(order_a)
+    await db.refresh(order_b)
+
+    db.add_all(
+        [
+            OrderServiceLink(order_id=order_a.id, title="Монтаж", quantity=1, price=2700, cost=0),
+            OrderServiceLink(order_id=order_b.id, title="ТО", quantity=1, price=2200, cost=0),
+        ]
+    )
+    receipt = BankReceipt(
+        status="requires_review",
+        operation_type="incoming_funds",
+        sender_email="bank-statement@local",
+        subject="Bank statement CSV import",
+        fingerprint="manual-group-receipt-test",
+        received_at=datetime(2026, 6, 29, 11, 30),
+        amount=4900,
+        currency=PaymentCurrency.BYN,
+        payer_name='ТД "Витебск Агропродукт"',
+        payer_unp="300123457",
+        payment_purpose="Оплата по актам за июнь",
+        raw_body="raw",
+        match_meta={"group_match": {"order_ids": [order_a.id, order_b.id]}},
+    )
+    db.add(receipt)
+    await db.commit()
+    await db.refresh(receipt)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/mail/bank-receipts/{receipt.id}/attach-group",
+        headers=headers,
+        json={},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "matched"
+    assert payload["match_meta"]["manual_group_attached"] is True
+    assert set(payload["match_meta"]["group_order_ids"]) == {order_a.id, order_b.id}
+    payments = (
+        await db.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id).order_by(Payment.amount))
+    ).scalars().all()
+    assert [payment.amount for payment in payments] == [2200, 2700]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -474,6 +474,42 @@ async def test_bank_receipt_dedupes_and_creates_exact_order_payment(sqlite_sessi
 
 
 @pytest.mark.asyncio
+async def test_bank_receipt_payment_applies_order_payment_automation(sqlite_session):
+    customer = Customer(name="УКС Витебск", phone="+375291111111", type="company", inn="300200572")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status="negotiation",
+        negotiation_status="awaiting_payment",
+        auto_execution_on_payment=True,
+    )
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+    sqlite_session.add(OrderServiceLink(order_id=order.id, title="Ремонт", quantity=1, price=1015, cost=0))
+    await sqlite_session.commit()
+
+    receipt, created = await BankReceiptService.process_email(
+        sqlite_session,
+        sender_email="noreply@service.belapb.by",
+        subject="Поступление средств на счет Индивидуальный предприниматель Янулевич Дмитрий Викторович 08.05.26 14:57",
+        raw_body=SAMPLE_BANK_EMAIL,
+        message_id="<bank-auto-execution@example.test>",
+    )
+
+    await sqlite_session.refresh(order)
+    assert created is True
+    assert receipt.status == "matched"
+    assert order.status == OrderStatus.EXECUTION
+    assert order.proposal_status == "approved"
+    assert order.is_paid is True
+    assert order.balance_due == 0
+
+
+@pytest.mark.asyncio
 async def test_bank_receipt_multi_act_payment_requires_review(sqlite_session):
     customer = Customer(name="УКС Витебск", phone="+375291111111", type="company", inn="300200572")
     sqlite_session.add(customer)
@@ -503,7 +539,7 @@ async def test_bank_receipt_multi_act_payment_requires_review(sqlite_session):
 
 
 @pytest.mark.asyncio
-async def test_bank_receipt_suggests_and_attaches_exact_group_subset(sqlite_session):
+async def test_bank_receipt_auto_attaches_exact_group_subset(sqlite_session):
     customer = Customer(name='ТД "Витебск Агропродукт"', phone="+375291111116", type="company", inn="300123456")
     sqlite_session.add(customer)
     await sqlite_session.commit()
@@ -547,22 +583,15 @@ async def test_bank_receipt_suggests_and_attaches_exact_group_subset(sqlite_sess
     matched = await BankReceiptService.match_receipt(sqlite_session, receipt)
     await sqlite_session.commit()
 
-    assert matched.status == "requires_review"
+    assert matched.status == "matched"
     assert matched.match_meta["reason"] == "group_balance_due_exact"
+    assert matched.match_meta["auto_group_attached"] is True
     assert matched.match_meta["group_match"]["selection_mode"] == "exact_subset"
     assert matched.match_meta["group_match"]["total_balance_due"] == 4900
     assert matched.match_meta["group_match"]["open_balance_due"] == 5400
     assert set(matched.match_meta["group_match"]["order_ids"]) == {orders[0].id, orders[1].id}
     assert set(matched.match_meta["group_match"]["open_order_ids"]) == {order.id for order in orders}
-
-    attached = await BankReceiptService.attach_receipt_to_order_group(
-        sqlite_session,
-        receipt_id=receipt.id,
-        payment_type="postpayment",
-    )
-
-    assert attached.status == "matched"
-    assert set(attached.match_meta["group_order_ids"]) == {orders[0].id, orders[1].id}
+    assert set(matched.match_meta["group_order_ids"]) == {orders[0].id, orders[1].id}
     payments = (
         await sqlite_session.execute(select(Payment).where(Payment.bank_receipt_id == receipt.id).order_by(Payment.amount))
     ).scalars().all()
@@ -619,8 +648,7 @@ async def test_delete_order_payment_detaches_group_bank_receipt(sqlite_session):
     await sqlite_session.commit()
     await sqlite_session.refresh(receipt)
 
-    await BankReceiptService.match_receipt(sqlite_session, receipt)
-    attached = await BankReceiptService.attach_receipt_to_order_group(sqlite_session, receipt_id=receipt.id)
+    attached = await BankReceiptService.match_receipt(sqlite_session, receipt)
     assert attached.status == "matched"
 
     payments = (


### PR DESCRIPTION
## Summary
- auto-apply exact multi-order bank receipt matches instead of leaving them in review
- reuse one group-payment implementation for automatic and manual attach paths
- make payment automation robust for receipt-created payments and string/enum order statuses

## Validation
- pytest tests/unit/test_mail_services.py tests/unit/test_order_service_manager.py::test_service_auto_execution_on_payment_moves_order_to_work tests/unit/test_order_service_manager.py::test_service_auto_close_on_payment_closes_execution_order tests/unit/test_order_service_manager.py::test_service_auto_close_on_payment_waits_for_payment_execution_status tests/integration/test_manager_mail_api.py -q