### PR TITLE
Add API HA readiness controls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ env:
   # API_COPY_COMPOSE (true by default; set false for emergency host-local compose)
   # API_DEPLOY_SERVICES (app bot by default; set app for app-only reserve compose)
   # API_BASE_URL (http://localhost:8000 by default)
+  # API_READY_URL (optional full readiness URL checked by backend smoke)
   # API_SMOKE_COMPOSE_SERVICE_CHECKS (app bot by default)
   # API_BOT_EXPECT_ENABLED (true by default)
   # API_TUNNEL_REMOTE_PORT (8000 by default)
@@ -132,6 +133,7 @@ jobs:
       API_RUN_MIGRATIONS: ${{ vars.API_RUN_MIGRATIONS || 'true' }}
       API_RUN_DEFAULTS: ${{ vars.API_RUN_DEFAULTS || 'true' }}
       API_BASE_URL: ${{ vars.API_BASE_URL || 'http://localhost:8000' }}
+      API_READY_URL: ${{ vars.API_READY_URL || '' }}
       API_SMOKE_COMPOSE_SERVICE_CHECKS: ${{ vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot' }}
       API_BOT_EXPECT_ENABLED: ${{ vars.API_BOT_EXPECT_ENABLED || 'true' }}
 
@@ -329,6 +331,7 @@ jobs:
           ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
             chmod +x /tmp/post_deploy_smoke_check.sh && \
             BASE_URL='${API_BASE_URL}' \
+            READY_URL='${API_READY_URL}' \
             COMPOSE_FILE='${API_PROJECT_DIR}/${API_COMPOSE_FILE}' \
             COMPOSE_SERVICE_CHECKS='${API_SMOKE_COMPOSE_SERVICE_CHECKS}' \
             BOT_EXPECT_ENABLED='${API_BOT_EXPECT_ENABLED}' \

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -4,7 +4,9 @@ from aiogram.types import BotCommand
 from .config import bot, dp
 from .handlers import admin, base, catalog, work
 from core.config import settings
+from core.database import async_session_maker
 from core.logger import setup_logging
+from services.runtime_lock_service import RuntimeLockService
 
 # Setup logging with session-specific bot.log (cleared on restart)
 logger = setup_logging(session_log_file="logs/bot.log", clear_session_log=True)
@@ -43,6 +45,20 @@ async def main(*, wait_when_disabled: bool = True):
             await _idle_when_disabled()
         return
 
+    if wait_when_disabled:
+        runtime_lock = await RuntimeLockService.wait_until_acquired(
+            async_session_maker,
+            "mvn:telegram_bot",
+        )
+    else:
+        runtime_lock = await RuntimeLockService.try_acquire(
+            async_session_maker,
+            "mvn:telegram_bot",
+        )
+    if not runtime_lock.acquired:
+        logger.warning("Telegram bot polling disabled: %s.", runtime_lock.reason)
+        return
+
     logger.info("Starting bot polling: %s.", decision.reason)
     # Register routers in specific order
     dp.include_router(base.router)
@@ -50,9 +66,12 @@ async def main(*, wait_when_disabled: bool = True):
     dp.include_router(catalog.router)
     dp.include_router(admin.router)
     
-    await _setup_bot_commands()
-    await bot.delete_webhook(drop_pending_updates=settings.BOT_DROP_PENDING_UPDATES)
-    await dp.start_polling(bot)
+    try:
+        await _setup_bot_commands()
+        await bot.delete_webhook(drop_pending_updates=settings.BOT_DROP_PENDING_UPDATES)
+        await dp.start_polling(bot)
+    finally:
+        await runtime_lock.release()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -1,11 +1,12 @@
 import asyncio
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
 
 from core.config import settings
 from core.database import async_session_maker, init_db
 from core.logger import logger
+from services.runtime_lock_service import RuntimeLockService
 
 
 async def _seed_installation_defaults() -> None:
@@ -16,18 +17,28 @@ async def _seed_installation_defaults() -> None:
 
 
 async def _resume_catalog_import_jobs() -> bool:
-    decision = settings.scheduler_control_decision
-    if not decision.enabled:
-        logger.warning("Catalog import job resume skipped: %s.", decision.reason)
-        return False
-
     from services.catalog_import_runtime_service import catalog_import_runtime_service
 
     await catalog_import_runtime_service.resume_pending_jobs()
     return True
 
 
-def _start_scheduler_loop() -> bool:
+async def _acquire_scheduler_runtime_lock():
+    decision = settings.scheduler_control_decision
+    if not decision.enabled:
+        logger.warning("Scheduler runtime startup skipped: %s.", decision.reason)
+        return None
+
+    lock = await RuntimeLockService.try_acquire(async_session_maker, "mvn:scheduler")
+    if not lock.acquired:
+        logger.warning("Scheduler runtime startup skipped: %s.", lock.reason)
+        return None
+
+    logger.info("Scheduler runtime lock acquired: %s.", lock.reason)
+    return lock
+
+
+def _start_scheduler_loop(app: FastAPI) -> bool:
     decision = settings.scheduler_control_decision
     if not decision.enabled:
         logger.warning("Scheduler startup skipped: %s.", decision.reason)
@@ -40,7 +51,7 @@ def _start_scheduler_loop() -> bool:
     )
     from services.scheduler_service import scheduler_service
 
-    asyncio.create_task(
+    app.state.scheduler_task = asyncio.create_task(
         scheduler_service.start_loop(interval_hours=settings.SCHEDULER_INTERVAL)
     )
     return True
@@ -52,9 +63,25 @@ async def app_lifespan(app: FastAPI):
 
     await init_db()
     await _seed_installation_defaults()
-    await _resume_catalog_import_jobs()
-    _start_scheduler_loop()
+    scheduler_lock = await _acquire_scheduler_runtime_lock()
+    if scheduler_lock:
+        app.state.scheduler_runtime_lock = scheduler_lock
+        try:
+            await _resume_catalog_import_jobs()
+            _start_scheduler_loop(app)
+        except Exception:
+            await scheduler_lock.release()
+            raise
 
     yield
+
+    scheduler_task = getattr(app.state, "scheduler_task", None)
+    if scheduler_task:
+        scheduler_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await scheduler_task
+    scheduler_lock = getattr(app.state, "scheduler_runtime_lock", None)
+    if scheduler_lock:
+        await scheduler_lock.release()
 
     logger.info("Stopping Application...")

--- a/core/config.py
+++ b/core/config.py
@@ -109,8 +109,12 @@ class Settings(BaseSettings):
     SCHEDULER_ENABLED: bool | None = None
     BOT_ENABLED: bool | None = None
     BOT_DROP_PENDING_UPDATES: bool = False
+    API_READY_ENABLED: bool | None = None
+    READINESS_REQUIRE_WRITABLE_DB: bool = True
+    RUNTIME_DB_LOCKS_ENABLED: bool = True
+    RUNTIME_LOCK_RETRY_SECONDS: int = 15
 
-    @field_validator("SCHEDULER_ENABLED", "BOT_ENABLED", mode="before")
+    @field_validator("SCHEDULER_ENABLED", "BOT_ENABLED", "API_READY_ENABLED", mode="before")
     @classmethod
     def _blank_runtime_switch_is_unset(cls, value: object) -> object | None:
         if isinstance(value, str) and not value.strip():
@@ -133,6 +137,15 @@ class Settings(BaseSettings):
             explicit_enabled=self.BOT_ENABLED,
             env_var_name="BOT_ENABLED",
             process_label="Telegram bot polling",
+        )
+
+    @property
+    def api_ready_control_decision(self) -> RuntimeControlDecision:
+        return resolve_single_active_control(
+            app_role=self.APP_ROLE,
+            explicit_enabled=self.API_READY_ENABLED,
+            env_var_name="API_READY_ENABLED",
+            process_label="public API traffic",
         )
 
     # Monitoring

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -1,0 +1,219 @@
+# API HA Runbook
+
+This runbook describes the target high-availability shape for `api.mvn.by`
+after the emergency move to `zakup`.
+
+## Current Hosts
+
+| Host | SSH alias | Role today | Recommended HA role |
+| --- | --- | --- | --- |
+| `zakup` | `zakup` | Current active API origin. Also runs `belzakupki`. | API origin A and initial DB source of truth. |
+| Original API VPS | `mvn-api` | Recovered reserve origin. | API origin B and PostgreSQL replica/promote target. |
+| Web VPS | `mvn-web` | Storefront/web reserve resources. | Witness only, not a PostgreSQL data node, unless the host is rebuilt into a normal service host. |
+
+Do not run two independent writable PostgreSQL databases. The last incident
+already showed why: one host had fresher orders and another host had fresher
+payment reconciliation. Cloudflare must not route write traffic to two separate
+databases.
+
+## Target Architecture
+
+```mermaid
+flowchart LR
+  U["Clients"] --> CF["Cloudflare Load Balancer"]
+  CF --> ZA["zakup API origin"]
+  CF --> API["mvn-api API origin"]
+  ZA --> DBP["PostgreSQL leader"]
+  API --> DBP
+  DBP --> DBR["Streaming replica"]
+  DBP --> WAL["R2 WAL/backups"]
+  ZA --> R2["Cloudflare R2 media"]
+  API --> R2
+  DCS["Patroni DCS / witness"] --> DBP
+  DCS --> DBR
+```
+
+Rules:
+
+- Exactly one PostgreSQL leader accepts writes.
+- API origins are allowed to receive public traffic only when `/api/ready`
+  returns HTTP 200.
+- `/api/ready` is stricter than `/api/health`: it checks runtime traffic
+  controls, DB connectivity, and PostgreSQL writability.
+- Scheduler loops and Telegram polling are single-active runtime processes.
+  They use PostgreSQL advisory locks when enabled on more than one app origin.
+- Product media must not depend on the local disk of one API server. R2 becomes
+  the shared media target; local media stays as rollback/fallback until the
+  full media migration is complete.
+
+## Recommended Phases
+
+### Phase 1: Code And Load Balancer Readiness
+
+Deploy the backend with:
+
+- `GET /api/ready` for Cloudflare origin health.
+- PostgreSQL advisory locks for scheduler startup and Telegram polling.
+- Optional deploy smoke variable `API_READY_URL`.
+
+Cloudflare Load Balancer monitor:
+
+```text
+Type: HTTPS
+Path: /api/ready
+Expected status: 200
+Method: GET
+Interval: 60s
+Retries: 2
+Timeout: 5s
+```
+
+Initial origin settings:
+
+| Origin | Public traffic env | Background env |
+| --- | --- | --- |
+| Active origin | `APP_ROLE=primary`, `API_READY_ENABLED=true` | `SCHEDULER_ENABLED=true`, `BOT_ENABLED=true` |
+| Reserve origin | `APP_ROLE=standby`, `API_READY_ENABLED=false` or unset | `SCHEDULER_ENABLED=false`, `BOT_ENABLED=false` |
+
+During the current transition, if `zakup` must keep serving traffic while bot
+and scheduler are intentionally off, set only:
+
+```dotenv
+API_READY_ENABLED=true
+```
+
+Do not enable `SCHEDULER_ENABLED=true` or `BOT_ENABLED=true` on two origins
+while they still use separate local databases.
+
+GitHub deploy variables for an origin that should also verify readiness:
+
+```text
+API_READY_URL=http://localhost:18000/api/ready
+```
+
+Use `http://localhost:8000/api/ready` on the original API VPS if it is the
+active deploy target.
+
+### Phase 2: Media Shared State
+
+Short-term safe state:
+
+- Keep `/opt/.../media` mounted and backed up on each API host.
+- Use one-way active-to-standby media refresh only for drills and planned
+  promotion.
+- Never use bidirectional rsync for product media.
+
+Target state:
+
+- Store new product media variants/original rows in Cloudflare R2.
+- Serve public image URLs from `https://cdn.mvn.by/media/...`.
+- Keep local media as fallback until all product-facing original fields and
+  importer paths have an owner-approved migration path.
+
+R2 is the right shared storage layer because it removes media from API-host
+failover. A third VPS with another local copy only moves the same failure mode
+around.
+
+### Phase 3: PostgreSQL HA
+
+Recommended implementation for the existing VPS budget:
+
+- PostgreSQL streaming replication from the current source-of-truth DB.
+- WAL archiving and base backups to R2 using `pgBackRest` or `WAL-G`.
+- Patroni for leader election and promotion.
+- A small third witness/DCS node. Use `mvn-web` only if we can safely run and
+  monitor the witness service there; otherwise buy a tiny dedicated VPS.
+
+Replication mode:
+
+- Start with asynchronous streaming replication across providers/regions.
+  Expected RPO is normally seconds, but not mathematically zero.
+- Do not use strict synchronous cross-region replication unless the business
+  accepts that writes can block when the standby or network link is unhealthy.
+- If true zero data loss is required, prefer a managed HA PostgreSQL provider
+  with an SLA over self-managed cross-provider sync.
+
+Initial source of truth:
+
+1. Freeze writes.
+2. Confirm `zakup` has the intended current DB state.
+3. Take a verified dump and base backup from `zakup`.
+4. Rebuild the original API host as replica from that backup.
+5. Keep the old independent database stopped or isolated after replica creation.
+
+Failover rule:
+
+- Promote a replica only through Patroni or a documented manual promotion
+  command.
+- After promotion, make only the promoted origin return 200 from `/api/ready`.
+- Do not point Cloudflare at a host whose database is still in recovery or
+  read-only.
+
+### Phase 4: Cloudflare Cutover
+
+Use Cloudflare Load Balancing as active-passive first:
+
+- Pool A: current active API origin.
+- Pool B: reserve API origin.
+- Monitor path: `/api/ready`.
+- Session affinity: off unless a future stateful API feature requires it.
+
+Manual failover checklist:
+
+1. Confirm backups/WAL are current.
+2. Stop bot/scheduler on the old active origin or set:
+
+   ```dotenv
+   SCHEDULER_ENABLED=false
+   BOT_ENABLED=false
+   API_READY_ENABLED=false
+   ```
+
+3. Promote PostgreSQL on the reserve side.
+4. Set the promoted API origin:
+
+   ```dotenv
+   APP_ROLE=primary
+   API_READY_ENABLED=true
+   SCHEDULER_ENABLED=true
+   BOT_ENABLED=true
+   ```
+
+5. Recreate `app` and `bot`.
+6. Verify locally:
+
+   ```bash
+   curl -fsS http://127.0.0.1:8000/api/ready
+   curl -fsS http://127.0.0.1:8000/api/health
+   curl -fsS 'http://127.0.0.1:8000/api/v1/products?limit=5'
+   ```
+
+7. Confirm Cloudflare marks the origin healthy.
+8. Confirm public:
+
+   ```bash
+   curl -fsS https://api.mvn.by/api/ready
+   curl -fsS https://api.mvn.by/api/health
+   curl -fsS 'https://api.mvn.by/api/v1/products?limit=5'
+   ```
+
+## What Not To Do
+
+- Do not use Cloudflare LB health on `/api/health` for failover. It can be
+  healthy while the origin must not receive writes.
+- Do not run two local writable databases and try to reconcile them later.
+- Do not make `mvn-web` a full Postgres data node just because it has spare CPU
+  and disk. It is a web/cPanel-style host today; using it as a witness is much
+  safer than storing primary data there.
+- Do not delete local media after enabling R2 until product originals and
+  importer paths are covered.
+
+## Cloudflare Access Needed For Automation
+
+Manual dashboard changes are enough. If Codex/GitHub should manage Cloudflare
+directly, create a scoped token for the `mvn.by` zone with:
+
+- DNS edit/read.
+- Load Balancing edit/read.
+
+Do not grant account-wide admin unless a specific operation requires it.

--- a/docs/api-reliability-plan.md
+++ b/docs/api-reliability-plan.md
@@ -2,9 +2,12 @@
 
 Related issue: #429
 
-This plan is a decision document for the API VPS after the public raw Postgres
-and FastAPI ports were closed and after single-active runtime controls were
-added for the scheduler and Telegram bot. It does not make production changes.
+This plan is a decision document for the earlier single-VPS/passive-reserve API
+stage after the public raw Postgres and FastAPI ports were closed and after
+single-active runtime controls were added for the scheduler and Telegram bot.
+The current multi-origin HA target lives in
+[`api-ha-runbook.md`](api-ha-runbook.md). This document remains useful as
+background and for single-VPS migration context.
 
 Related repo artifacts:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,6 +73,11 @@ manual web rebuild workflow.
 - **GitHub secret:** `SSH_HOST_API` must point to the current API primary.
 - **Public entrypoint:** reverse proxy on `80/443`, proxying `api.mvn.by` to the current API app port.
 - **Health endpoint:** `/api/health`
+- **Load balancer readiness endpoint:** `/api/ready`
+
+The multi-origin API HA target and Cloudflare/DB/media runbook is documented in
+[`api-ha-runbook.md`](api-ha-runbook.md). Use `/api/health` for basic smoke
+checks and `/api/ready` for Cloudflare Load Balancer origin health.
 
 The backend deploy workflow is primary-host configurable. Keep sensitive values
 in GitHub secrets and non-secret routing values in GitHub variables.
@@ -95,6 +100,7 @@ Optional API variables:
 | `API_COPY_COMPOSE` | `true` | Copy repo `docker-compose.prod.yml` to the host before deploy. Set `false` for host-local emergency compose. |
 | `API_DEPLOY_SERVICES` | `app bot` | Compose services to recreate after pulling images. |
 | `API_BASE_URL` | `http://localhost:8000` | Local base URL used by post-deploy smoke. |
+| `API_READY_URL` | unset | Optional full readiness URL used by post-deploy smoke, for example `http://localhost:18000/api/ready`. |
 | `API_SMOKE_COMPOSE_SERVICE_CHECKS` | `app bot` | Services expected to be running during smoke. |
 | `API_BOT_EXPECT_ENABLED` | `true` | Whether smoke requires bot runtime controls to be enabled. |
 | `API_TUNNEL_REMOTE_PORT` | `8000` | Remote localhost API port used by frontend build SSH tunnel. |
@@ -111,6 +117,7 @@ API_COMPOSE_FILE=docker-compose.reserve.yml
 API_COPY_COMPOSE=false
 API_DEPLOY_SERVICES=app
 API_BASE_URL=http://localhost:18000
+API_READY_URL=http://localhost:18000/api/ready
 API_SMOKE_COMPOSE_SERVICE_CHECKS=app db
 API_BOT_EXPECT_ENABLED=false
 API_TUNNEL_REMOTE_PORT=18000
@@ -153,6 +160,11 @@ as the active primary default.
 `SCHEDULER_ENABLED` and `BOT_ENABLED` are explicit overrides. If either is set
 to `false`, that process stays disabled even when `APP_ROLE=primary`; remove the
 override or set it to `true` before promoting a standby host.
+
+`API_READY_ENABLED` controls whether `/api/ready` may return HTTP 200 for public
+traffic. It follows `APP_ROLE` by default. Set `API_READY_ENABLED=true` only on
+the origin that Cloudflare may route to. Set it to `false`, or leave it unset
+with `APP_ROLE=standby`, on reserve origins.
 
 These controls do not enable Cloudflare load balancing, automatic failover, or
 public standby cutover. Do not route public write traffic to a standby host.

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -112,6 +112,18 @@ export class ApiService {
         });
     }
     /**
+     * Readiness Check
+     * Check whether this API node should receive public traffic.
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static readinessCheckApiReadyGet(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/ready',
+        });
+    }
+    /**
      * Get Catalog Revision
      * @returns CatalogRevisionResponse Successful Response
      * @throws ApiError

--- a/openapi.json
+++ b/openapi.json
@@ -291,6 +291,27 @@
         }
       }
     },
+    "/api/ready": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Readiness Check",
+        "description": "Check whether this API node should receive public traffic.",
+        "operationId": "readiness_check_api_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/catalog/revision": {
       "get": {
         "tags": [

--- a/routers/api_admin.py
+++ b/routers/api_admin.py
@@ -1,6 +1,7 @@
 """Admin/search/health endpoints split from the main API router."""
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
@@ -8,6 +9,7 @@ from core.database import get_session
 from core.security import get_current_username
 from services.admin_api_service import AdminApiService
 from services.product_service import ProductService
+from services.readiness_service import ReadinessService
 
 router = APIRouter(tags=["api"])
 
@@ -54,3 +56,10 @@ async def admin_search_services(
 async def health_check(session: AsyncSession = Depends(get_session)):
     """Check API and database availability."""
     return await AdminApiService.health_check(session)
+
+
+@router.get("/ready")
+async def readiness_check(session: AsyncSession = Depends(get_session)):
+    """Check whether this API node should receive public traffic."""
+    status_code, payload = await ReadinessService.check(session)
+    return JSONResponse(status_code=status_code, content=payload)

--- a/scripts/post_deploy_smoke_check.sh
+++ b/scripts/post_deploy_smoke_check.sh
@@ -7,6 +7,7 @@ COMPOSE_FILE="${COMPOSE_FILE:-/opt/air-api/docker-compose.prod.yml}"
 COMPOSE_SERVICE_CHECKS="${COMPOSE_SERVICE_CHECKS:-app bot}"
 BOT_RUNTIME_CHECK_SERVICE="${BOT_RUNTIME_CHECK_SERVICE:-bot}"
 BOT_EXPECT_ENABLED="${BOT_EXPECT_ENABLED:-true}"
+READY_URL="${READY_URL:-}"
 MAX_RETRIES=${MAX_RETRIES:-20}
 RETRY_DELAY=${RETRY_DELAY:-2}
 
@@ -115,6 +116,25 @@ print(f"products_count={len(items)}")
 print(f"filters_keys={','.join(sorted(filters_cfg.keys()))}")
 PY
 
+checks_done="health,products,filters_config"
+if [[ -n "${READY_URL}" ]]; then
+  log request "GET ${READY_URL}"
+  ready_payload="$(curl -fsS "${READY_URL}")"
+  READY_PAYLOAD="${ready_payload}" python3 - <<'PY'
+import json
+import os
+
+ready = json.loads(os.environ["READY_PAYLOAD"])
+if ready.get("status") != "ok" or ready.get("api") != "ready":
+    raise SystemExit("readiness payload is not ready")
+
+print(f"ready_status={ready.get('status')}")
+print(f"ready_traffic={ready.get('traffic')}")
+print(f"ready_database={ready.get('database')}")
+PY
+  checks_done="${checks_done},readiness"
+fi
+
 log request "docker compose ps --status running --services"
 running_services="$(docker compose -f "${COMPOSE_FILE}" ps --status running --services 2>/dev/null || true)"
 for service in ${COMPOSE_SERVICE_CHECKS}; do
@@ -129,7 +149,7 @@ for service in ${COMPOSE_SERVICE_CHECKS}; do
 done
 log success "✅ Compose services running: ${COMPOSE_SERVICE_CHECKS}"
 
-checks_done="health,products,filters_config,compose_services"
+checks_done="${checks_done},compose_services"
 if [[ "${BOT_EXPECT_ENABLED}" == "true" ]]; then
   log request "docker compose exec ${BOT_RUNTIME_CHECK_SERVICE} python3 - read bot runtime decision"
   bot_runtime_payload="$(docker compose -f "${COMPOSE_FILE}" exec -T "${BOT_RUNTIME_CHECK_SERVICE}" python3 - <<'PY'

--- a/scripts/sync_manager_api_client.sh
+++ b/scripts/sync_manager_api_client.sh
@@ -9,11 +9,19 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v npm >/dev/null 2>&1; then
-  echo "npm is required to generate manager API client" >&2
+python3 scripts/legacy/extract_openapi.py
+if command -v npm >/dev/null 2>&1; then
+  (cd manager_frontend && npm run gen:api)
+elif [[ -x "$REPO_ROOT/manager_frontend/node_modules/.bin/openapi" ]]; then
+  (
+    cd manager_frontend
+    PATH="$PWD/node_modules/.bin:$PATH" openapi \
+      --input ../openapi.json \
+      --output ./src/client \
+      --client fetch \
+      --useUnionTypes
+  )
+else
+  echo "npm or manager_frontend/node_modules/.bin/openapi is required to generate manager API client" >&2
   exit 1
 fi
-
-python3 scripts/legacy/extract_openapi.py
-(cd manager_frontend && npm run gen:api)
-

--- a/services/readiness_service.py
+++ b/services/readiness_service.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+
+
+class ReadinessService:
+    @staticmethod
+    async def check(session: AsyncSession) -> tuple[int, dict[str, Any]]:
+        decision = settings.api_ready_control_decision
+        payload: dict[str, Any] = {
+            "status": "ok",
+            "api": "ready",
+            "app_role": settings.APP_ROLE,
+            "traffic": "enabled" if decision.enabled else "disabled",
+            "reason": decision.reason,
+        }
+        if not decision.enabled:
+            payload.update({"status": "error", "api": "not_ready"})
+            return 503, payload
+
+        try:
+            await session.execute(text("SELECT 1"))
+        except Exception as exc:
+            payload.update(
+                {
+                    "status": "error",
+                    "api": "not_ready",
+                    "database": "offline",
+                    "detail": str(exc),
+                }
+            )
+            return 503, payload
+
+        payload["database"] = "online"
+        bind = session.get_bind()
+        dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
+        if settings.READINESS_REQUIRE_WRITABLE_DB and dialect_name == "postgresql":
+            recovery_result = await session.execute(text("SELECT pg_is_in_recovery()"))
+            in_recovery = bool(recovery_result.scalar())
+            read_only_result = await session.execute(text("SHOW transaction_read_only"))
+            transaction_read_only = str(read_only_result.scalar() or "").lower() == "on"
+            payload["database_writable"] = not in_recovery and not transaction_read_only
+            if in_recovery or transaction_read_only:
+                payload.update(
+                    {
+                        "status": "error",
+                        "api": "not_ready",
+                        "database": "read_only",
+                    }
+                )
+                return 503, payload
+        else:
+            payload["database_writable"] = None
+
+        return 200, payload

--- a/services/runtime_lock_service.py
+++ b/services/runtime_lock_service.py
@@ -1,0 +1,82 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from core.logger import logger
+
+
+@dataclass
+class RuntimeLock:
+    name: str
+    session: Optional[AsyncSession]
+    acquired: bool
+    reason: str
+
+    async def release(self) -> None:
+        if not self.acquired or self.session is None:
+            return
+        try:
+            bind = self.session.get_bind()
+            dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
+            if dialect_name == "postgresql":
+                await self.session.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:lock_name))"),
+                    {"lock_name": self.name},
+                )
+        finally:
+            await self.session.close()
+            self.acquired = False
+
+
+class RuntimeLockService:
+    @staticmethod
+    async def try_acquire(
+        session_factory: Callable[[], AsyncSession],
+        lock_name: str,
+    ) -> RuntimeLock:
+        if not settings.RUNTIME_DB_LOCKS_ENABLED:
+            return RuntimeLock(lock_name, None, True, "RUNTIME_DB_LOCKS_ENABLED=false")
+
+        session = session_factory()
+        bind = session.get_bind()
+        dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
+        if dialect_name != "postgresql":
+            return RuntimeLock(
+                lock_name,
+                session,
+                True,
+                f"database dialect {dialect_name!r} has no runtime lock",
+            )
+
+        try:
+            result = await session.execute(
+                text("SELECT pg_try_advisory_lock(hashtext(:lock_name))"),
+                {"lock_name": lock_name},
+            )
+            acquired = bool(result.scalar())
+        except Exception:
+            await session.close()
+            raise
+
+        if not acquired:
+            await session.close()
+            return RuntimeLock(lock_name, None, False, f"runtime lock {lock_name!r} is already held")
+
+        return RuntimeLock(lock_name, session, True, f"runtime lock {lock_name!r} acquired")
+
+    @staticmethod
+    async def wait_until_acquired(
+        session_factory: Callable[[], AsyncSession],
+        lock_name: str,
+    ) -> RuntimeLock:
+        retry_seconds = max(1, int(settings.RUNTIME_LOCK_RETRY_SECONDS or 15))
+        while True:
+            lock = await RuntimeLockService.try_acquire(session_factory, lock_name)
+            if lock.acquired:
+                return lock
+            logger.warning("%s; retrying in %ss", lock.reason, retry_seconds)
+            await asyncio.sleep(retry_seconds)

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -124,16 +124,18 @@ class SchedulerService:
         Запускает фоновые задачи: синхронизация цен и автоматизация CRM.
         """
         logger.info(f"Scheduler started. Price Interval: {interval_hours}h.")
-        
+
+        tasks = []
+
         # Run price sync loop
-        asyncio.create_task(self._price_sync_loop(interval_hours))
-        
+        tasks.append(asyncio.create_task(self._price_sync_loop(interval_hours)))
+
         # Run stalled deal loop (once a day)
-        asyncio.create_task(self._stalled_deal_loop())
+        tasks.append(asyncio.create_task(self._stalled_deal_loop()))
 
         # Run backup loop (once a day)
         if settings.is_production:
-            asyncio.create_task(self._backup_loop())
+            tasks.append(asyncio.create_task(self._backup_loop()))
         else:
             logger.warning(
                 "Daily backup loop is disabled for ENVIRONMENT=%s. "
@@ -142,20 +144,26 @@ class SchedulerService:
             )
 
         # Run lead archive loop (once a day)
-        asyncio.create_task(self._lead_archive_loop())
+        tasks.append(asyncio.create_task(self._lead_archive_loop()))
 
         # Run supplier sheets sync loop
-        asyncio.create_task(self._supplier_sync_loop())
+        tasks.append(asyncio.create_task(self._supplier_sync_loop()))
 
         # Run bank receipt IMAP import loop
-        asyncio.create_task(self._bank_mail_import_loop())
+        tasks.append(asyncio.create_task(self._bank_mail_import_loop()))
 
         # Run email lead IMAP import loop. Disabled by default to avoid unplanned AI usage.
-        asyncio.create_task(self._email_lead_import_loop())
+        tasks.append(asyncio.create_task(self._email_lead_import_loop()))
 
-        # Keep the main loop alive 
-        while True:
-            await asyncio.sleep(3600)
+        try:
+            # Keep the main loop alive.
+            while True:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
     async def _price_sync_loop(self, interval_hours: int):
         while True:

--- a/tests/integration/test_api_readiness.py
+++ b/tests/integration/test_api_readiness.py
@@ -1,0 +1,32 @@
+import pytest
+
+from core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_api_ready_returns_503_when_public_traffic_disabled(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(settings, "API_READY_ENABLED", None, raising=False)
+
+    response = await async_client.get("/api/ready")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "error"
+    assert payload["api"] == "not_ready"
+    assert payload["traffic"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_api_ready_returns_200_when_public_traffic_enabled(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(settings, "API_READY_ENABLED", True, raising=False)
+
+    response = await async_client.get("/api/ready")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["api"] == "ready"
+    assert payload["traffic"] == "enabled"
+    assert payload["database"] == "online"

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -8,6 +8,14 @@ import pytest
 from core.runtime_controls import resolve_single_active_control
 
 
+class FakeRuntimeLock:
+    acquired = True
+    reason = "test lock"
+
+    async def release(self):
+        return None
+
+
 def _set_required_env(monkeypatch):
     monkeypatch.setenv("BOT_TOKEN", "123:test")
     monkeypatch.setenv("SECRET_KEY", "test-secret")
@@ -74,46 +82,50 @@ def test_empty_runtime_switch_env_values_are_unset(monkeypatch):
         ADMIN_PASSWORD="admin",
         SCHEDULER_ENABLED="",
         BOT_ENABLED="",
+        API_READY_ENABLED="",
         _env_file=None,
     )
 
     assert settings.SCHEDULER_ENABLED is None
     assert settings.BOT_ENABLED is None
+    assert settings.API_READY_ENABLED is None
     assert settings.scheduler_control_decision.enabled is True
     assert settings.bot_control_decision.enabled is True
-
-
-def test_start_scheduler_loop_skips_for_standby(monkeypatch):
-    _set_required_env(monkeypatch)
-    app_lifespan = importlib.import_module("core.app_lifespan")
-
-    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
-    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
-    create_task = Mock()
-    monkeypatch.setattr(app_lifespan.asyncio, "create_task", create_task)
-
-    assert app_lifespan._start_scheduler_loop() is False
-    create_task.assert_not_called()
+    assert settings.api_ready_control_decision.enabled is True
 
 
 @pytest.mark.asyncio
-async def test_catalog_import_resume_skips_for_standby(monkeypatch):
+async def test_scheduler_runtime_lock_skips_for_standby(monkeypatch):
     _set_required_env(monkeypatch)
     app_lifespan = importlib.import_module("core.app_lifespan")
 
     monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
     monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
 
-    assert await app_lifespan._resume_catalog_import_jobs() is False
+    assert await app_lifespan._acquire_scheduler_runtime_lock() is None
 
 
 @pytest.mark.asyncio
-async def test_catalog_import_resume_runs_for_primary(monkeypatch):
+async def test_scheduler_runtime_lock_requires_free_lock(monkeypatch):
     _set_required_env(monkeypatch)
     app_lifespan = importlib.import_module("core.app_lifespan")
 
     monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "primary", raising=False)
     monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "try_acquire",
+        AsyncMock(return_value=SimpleNamespace(acquired=False, reason="held elsewhere")),
+    )
+
+    assert await app_lifespan._acquire_scheduler_runtime_lock() is None
+
+
+@pytest.mark.asyncio
+async def test_catalog_import_resume_runs_inside_scheduler_lock(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
     resume_pending_jobs = AsyncMock()
     monkeypatch.setitem(
         sys.modules,
@@ -127,6 +139,19 @@ async def test_catalog_import_resume_runs_for_primary(monkeypatch):
 
     assert await app_lifespan._resume_catalog_import_jobs() is True
     resume_pending_jobs.assert_awaited_once_with()
+
+
+def test_start_scheduler_loop_skips_for_standby(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
+    create_task = Mock()
+    monkeypatch.setattr(app_lifespan.asyncio, "create_task", create_task)
+
+    assert app_lifespan._start_scheduler_loop(SimpleNamespace(state=SimpleNamespace())) is False
+    create_task.assert_not_called()
 
 
 def test_bot_main_registers_staff_commands(monkeypatch):
@@ -207,6 +232,11 @@ async def test_bot_main_preserves_pending_updates_by_default(monkeypatch):
     monkeypatch.setattr(bot_main, "_setup_bot_commands", setup_commands)
     monkeypatch.setattr(bot_main.bot, "delete_webhook", delete_webhook)
     monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
+    monkeypatch.setattr(
+        bot_main.RuntimeLockService,
+        "try_acquire",
+        AsyncMock(return_value=FakeRuntimeLock()),
+    )
 
     await bot_main.main(wait_when_disabled=False)
 

--- a/tests/unit/test_scheduler_service.py
+++ b/tests/unit/test_scheduler_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
 from models import Customer, Order, OrderStatus
+import services.scheduler_service as scheduler_module
 from services.scheduler_service import SchedulerService
 
 
@@ -74,3 +76,41 @@ async def test_check_stalled_deals_marks_old_negotiations_for_follow_up(sqlite_s
     await sqlite_session.refresh(old_order)
 
     assert old_order.next_followup_date == first_followup
+
+
+@pytest.mark.asyncio
+async def test_start_loop_cancels_child_tasks(monkeypatch):
+    service = SchedulerService()
+    monkeypatch.setattr(scheduler_module.settings, "ENVIRONMENT", "development", raising=False)
+    started = 0
+    cancelled = 0
+
+    async def child_loop():
+        nonlocal started, cancelled
+        started += 1
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+
+    for method_name in (
+        "_price_sync_loop",
+        "_stalled_deal_loop",
+        "_lead_archive_loop",
+        "_supplier_sync_loop",
+        "_bank_mail_import_loop",
+        "_email_lead_import_loop",
+    ):
+        monkeypatch.setattr(service, method_name, lambda *args: child_loop())
+
+    task = asyncio.create_task(service.start_loop(interval_hours=1))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert started == 6
+    assert cancelled == 6


### PR DESCRIPTION
## Summary
- add /api/ready for Cloudflare origin readiness with runtime traffic and writable-DB checks
- guard scheduler startup, catalog-import resume, and Telegram polling with PostgreSQL advisory runtime locks
- make deploy smoke optionally verify readiness via API_READY_URL and document the current HA runbook

## Tests
- pytest tests/unit -q
- pytest tests/unit/test_runtime_controls.py tests/unit/test_scheduler_service.py tests/integration/test_api_readiness.py -q
- pytest tests/integration/test_api_readiness.py -q
- bash -n scripts/post_deploy_smoke_check.sh scripts/sync_manager_api_client.sh
- python3 scripts/legacy/extract_openapi.py
- manager client generation via local openapi binary
- manager_frontend: vue-tsc -b && vite build