### PR TITLE
Add standby database bootstrap control

### DIFF
--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -16,6 +16,18 @@ async def _seed_installation_defaults() -> None:
         await InstallationService.seed_defaults(session)
 
 
+async def _bootstrap_database() -> bool:
+    decision = settings.db_bootstrap_control_decision
+    if not decision.enabled:
+        logger.warning("Database bootstrap skipped: %s.", decision.reason)
+        return False
+
+    logger.info("Database bootstrap enabled: %s.", decision.reason)
+    await init_db()
+    await _seed_installation_defaults()
+    return True
+
+
 async def _resume_catalog_import_jobs() -> bool:
     from services.catalog_import_runtime_service import catalog_import_runtime_service
 
@@ -61,8 +73,7 @@ def _start_scheduler_loop(app: FastAPI) -> bool:
 async def app_lifespan(app: FastAPI):
     logger.info("Starting Application...")
 
-    await init_db()
-    await _seed_installation_defaults()
+    await _bootstrap_database()
     scheduler_lock = await _acquire_scheduler_runtime_lock()
     if scheduler_lock:
         app.state.scheduler_runtime_lock = scheduler_lock

--- a/core/config.py
+++ b/core/config.py
@@ -110,11 +110,18 @@ class Settings(BaseSettings):
     BOT_ENABLED: bool | None = None
     BOT_DROP_PENDING_UPDATES: bool = False
     API_READY_ENABLED: bool | None = None
+    DB_BOOTSTRAP_ENABLED: bool | None = None
     READINESS_REQUIRE_WRITABLE_DB: bool = True
     RUNTIME_DB_LOCKS_ENABLED: bool = True
     RUNTIME_LOCK_RETRY_SECONDS: int = 15
 
-    @field_validator("SCHEDULER_ENABLED", "BOT_ENABLED", "API_READY_ENABLED", mode="before")
+    @field_validator(
+        "SCHEDULER_ENABLED",
+        "BOT_ENABLED",
+        "API_READY_ENABLED",
+        "DB_BOOTSTRAP_ENABLED",
+        mode="before",
+    )
     @classmethod
     def _blank_runtime_switch_is_unset(cls, value: object) -> object | None:
         if isinstance(value, str) and not value.strip():
@@ -146,6 +153,15 @@ class Settings(BaseSettings):
             explicit_enabled=self.API_READY_ENABLED,
             env_var_name="API_READY_ENABLED",
             process_label="public API traffic",
+        )
+
+    @property
+    def db_bootstrap_control_decision(self) -> RuntimeControlDecision:
+        return resolve_single_active_control(
+            app_role=self.APP_ROLE,
+            explicit_enabled=self.DB_BOOTSTRAP_ENABLED,
+            env_var_name="DB_BOOTSTRAP_ENABLED",
+            process_label="database bootstrap",
         )
 
     # Monitoring

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -83,15 +83,69 @@ def test_empty_runtime_switch_env_values_are_unset(monkeypatch):
         SCHEDULER_ENABLED="",
         BOT_ENABLED="",
         API_READY_ENABLED="",
+        DB_BOOTSTRAP_ENABLED="",
         _env_file=None,
     )
 
     assert settings.SCHEDULER_ENABLED is None
     assert settings.BOT_ENABLED is None
     assert settings.API_READY_ENABLED is None
+    assert settings.DB_BOOTSTRAP_ENABLED is None
     assert settings.scheduler_control_decision.enabled is True
     assert settings.bot_control_decision.enabled is True
     assert settings.api_ready_control_decision.enabled is True
+    assert settings.db_bootstrap_control_decision.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_database_bootstrap_skips_for_standby(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "DB_BOOTSTRAP_ENABLED", None, raising=False)
+    init_db = AsyncMock()
+    seed_defaults = AsyncMock()
+    monkeypatch.setattr(app_lifespan, "init_db", init_db)
+    monkeypatch.setattr(app_lifespan, "_seed_installation_defaults", seed_defaults)
+
+    assert await app_lifespan._bootstrap_database() is False
+    init_db.assert_not_awaited()
+    seed_defaults.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_database_bootstrap_runs_for_primary(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "primary", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "DB_BOOTSTRAP_ENABLED", None, raising=False)
+    init_db = AsyncMock()
+    seed_defaults = AsyncMock()
+    monkeypatch.setattr(app_lifespan, "init_db", init_db)
+    monkeypatch.setattr(app_lifespan, "_seed_installation_defaults", seed_defaults)
+
+    assert await app_lifespan._bootstrap_database() is True
+    init_db.assert_awaited_once_with()
+    seed_defaults.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_database_bootstrap_explicit_switch_overrides_standby(monkeypatch):
+    _set_required_env(monkeypatch)
+    app_lifespan = importlib.import_module("core.app_lifespan")
+
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "DB_BOOTSTRAP_ENABLED", True, raising=False)
+    init_db = AsyncMock()
+    seed_defaults = AsyncMock()
+    monkeypatch.setattr(app_lifespan, "init_db", init_db)
+    monkeypatch.setattr(app_lifespan, "_seed_installation_defaults", seed_defaults)
+
+    assert await app_lifespan._bootstrap_database() is True
+    init_db.assert_awaited_once_with()
+    seed_defaults.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add DB_BOOTSTRAP_ENABLED runtime control using the same single-active role rules as scheduler/bot/readiness
- skip init_db and installation seed writes when database bootstrap is disabled
- cover standby/default/explicit override behavior in runtime-control tests

## Tests
- pytest tests/unit/test_runtime_controls.py tests/integration/test_api_readiness.py -q