### PR TITLE
Schedule API VPS health checks

### DIFF
--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -1,6 +1,8 @@
 name: API VPS Health Check
 
 on:
+  schedule:
+    - cron: "17 */6 * * *"
   workflow_dispatch:
     inputs:
       mode:
@@ -37,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup API SSH Key
-        if: ${{ inputs.mode == 'ssh' }}
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh' }}
         env:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
@@ -57,8 +59,8 @@ jobs:
       - name: Run API VPS Health Check
         env:
           BASE_URL: https://api.mvn.by
-          BACKUP_MAX_AGE_HOURS: ${{ inputs.backup_max_age_hours }}
-          CHECK_BACKUPS: ${{ inputs.check_backups }}
+          BACKUP_MAX_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}
+          CHECK_BACKUPS: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}
           API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
           API_SSH_USER: ${{ secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
@@ -68,7 +70,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ inputs.mode }}" = "public-only" ]; then
+          mode="${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'ssh' }}"
+          if [ "${mode}" = "public-only" ]; then
             bash scripts/check_api_vps_health.sh --public-only | tee api-vps-health.log
           else
             API_SSH_KEY_PATH="${HOME}/.ssh/api_vps_health_key" bash scripts/check_api_vps_health.sh | tee api-vps-health.log
@@ -79,14 +82,15 @@ jobs:
         run: |
           {
             echo "## API VPS Health Check"
-            echo "- mode: ${{ inputs.mode }}"
+            echo "- trigger: ${{ github.event_name }}"
+            echo "- mode: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'ssh' }}"
             echo "- base_url: https://api.mvn.by"
             echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
             echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"
             echo "- api_compose_service_checks: ${{ vars.API_COMPOSE_SERVICE_CHECKS || vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot db' }}"
             echo "- api_local_health_url: ${{ vars.API_LOCAL_HEALTH_URL || 'http://127.0.0.1:8000/api/health' }}"
-            echo "- backup_max_age_hours: ${{ inputs.backup_max_age_hours }}"
-            echo "- check_backups: ${{ inputs.check_backups }}"
+            echo "- backup_max_age_hours: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}"
+            echo "- check_backups: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}"
             echo "- log_artifact: api-vps-health-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary
- run API VPS Health Check every 6 hours in SSH mode
- keep manual public-only and SSH modes working
- check Google Drive backup freshness by default for scheduled runs

## Validation
- python3 YAML parse for .github/workflows/check-api-vps-health.yml
- local SSH run: BASE_URL=https://api.mvn.by API_SSH_HOST=zakup API_PROJECT_DIR=/opt/mvn-reserve API_COMPOSE_FILE=docker-compose.reserve.yml API_COMPOSE_SERVICE_CHECKS='app bot db' API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health BACKUP_MAX_AGE_HOURS=36 CHECK_BACKUPS=true bash scripts/check_api_vps_health.sh