### PR TITLE
Skip public checks for SSH health monitor

### DIFF
--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -61,6 +61,7 @@ jobs:
           BASE_URL: https://api.mvn.by
           BACKUP_MAX_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}
           CHECK_BACKUPS: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}
+          SKIP_PUBLIC_CHECKS: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh' }}
           API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
           API_SSH_USER: ${{ secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
@@ -91,6 +92,7 @@ jobs:
             echo "- api_local_health_url: ${{ vars.API_LOCAL_HEALTH_URL || 'http://127.0.0.1:8000/api/health' }}"
             echo "- backup_max_age_hours: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}"
             echo "- check_backups: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}"
+            echo "- skip_public_checks: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh' }}"
             echo "- log_artifact: api-vps-health-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/check_api_vps_health.sh
+++ b/scripts/check_api_vps_health.sh
@@ -25,6 +25,7 @@ TLS_WARN_DAYS="${TLS_WARN_DAYS:-14}"
 TLS_CRITICAL_DAYS="${TLS_CRITICAL_DAYS:-3}"
 BACKUP_MAX_AGE_HOURS="${BACKUP_MAX_AGE_HOURS:-36}"
 CHECK_BACKUPS="${CHECK_BACKUPS:-true}"
+SKIP_PUBLIC_CHECKS="${SKIP_PUBLIC_CHECKS:-false}"
 
 PUBLIC_ONLY=false
 critical_failures=0
@@ -39,7 +40,7 @@ Usage:
 Checks the current API VPS without printing secret values.
 
 Default behavior:
-  1. Always checks public API endpoints from BASE_URL.
+  1. Checks public API endpoints from BASE_URL unless SKIP_PUBLIC_CHECKS=true.
   2. Runs SSH host checks only when API_SSH_HOST and API_SSH_USER are set.
   3. Works as public-only automatically when SSH env is absent.
 
@@ -58,6 +59,7 @@ Common env:
   API_LOCAL_HEALTH_URL=http://127.0.0.1:8000/api/health
   BACKUP_MAX_AGE_HOURS=36
   CHECK_BACKUPS=true
+  SKIP_PUBLIC_CHECKS=false
 
 Exit code:
   0 when critical checks pass.
@@ -157,6 +159,9 @@ if ! is_unsigned_number "${BACKUP_MAX_AGE_HOURS}"; then
 fi
 if ! CHECK_BACKUPS="$(normalize_bool "${CHECK_BACKUPS}")"; then
   fail "CHECK_BACKUPS must be true or false"
+fi
+if ! SKIP_PUBLIC_CHECKS="$(normalize_bool "${SKIP_PUBLIC_CHECKS}")"; then
+  fail "SKIP_PUBLIC_CHECKS must be true or false"
 fi
 
 if (( critical_failures > 0 )); then
@@ -565,7 +570,11 @@ REMOTE
   fi
 }
 
-run_public_checks
+if [[ "${SKIP_PUBLIC_CHECKS}" == "true" ]]; then
+  log public "skipped (SKIP_PUBLIC_CHECKS=true)"
+else
+  run_public_checks
+fi
 
 if [[ "${PUBLIC_ONLY}" == "true" ]]; then
   log ssh "skipped (--public-only)"


### PR DESCRIPTION
## Summary
- add SKIP_PUBLIC_CHECKS to the API VPS health script
- use it for scheduled/manual SSH health checks because Cloudflare can block GitHub runner public probes with 403
- keep public-only mode unchanged for explicit public checks

## Validation
- SKIP_PUBLIC_CHECKS=true BASE_URL=https://api.mvn.by API_SSH_HOST=zakup API_SSH_USER=root API_SSH_KEY_PATH=~/.ssh/id_ed25519 API_PROJECT_DIR=/opt/mvn-reserve API_COMPOSE_FILE=docker-compose.reserve.yml API_COMPOSE_SERVICE_CHECKS='app bot db' API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health BACKUP_MAX_AGE_HOURS=36 CHECK_BACKUPS=true bash scripts/check_api_vps_health.sh
- python3 YAML parse for .github/workflows/check-api-vps-health.yml