### PR TITLE
Harden API HA operations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ env:
   # Optional repo/environment variables:
   # API_PROJECT_DIR (/opt/air-api by default)
   # API_COMPOSE_FILE (docker-compose.prod.yml by default)
+  # API_COMPOSE_SOURCE_FILE (docker-compose.prod.yml by default; copied to API_COMPOSE_FILE)
   # API_COPY_COMPOSE (true by default; set false for emergency host-local compose)
   # API_DEPLOY_SERVICES (app bot by default; set app for app-only reserve compose)
   # API_BASE_URL (http://localhost:8000 by default)
@@ -37,6 +38,8 @@ env:
   # API_STANDBY_USER (root by default)
   # API_STANDBY_PROJECT_DIR (/opt/air-api by default)
   # API_STANDBY_COMPOSE_FILE (docker-compose.prod.yml by default)
+  # API_STANDBY_COPY_COMPOSE (false by default)
+  # API_STANDBY_COMPOSE_SOURCE_FILE (API_STANDBY_COMPOSE_FILE by default)
   # API_STANDBY_HEALTH_URL (http://localhost:8000/api/health by default)
 
 jobs:
@@ -132,6 +135,7 @@ jobs:
     env:
       API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
       API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+      API_COMPOSE_SOURCE_FILE: ${{ vars.API_COMPOSE_SOURCE_FILE || 'docker-compose.prod.yml' }}
       API_COPY_COMPOSE: ${{ vars.API_COPY_COMPOSE || 'true' }}
       API_DEPLOY_SERVICES: ${{ vars.API_DEPLOY_SERVICES || 'app bot' }}
       API_MIGRATION_SERVICE: ${{ vars.API_MIGRATION_SERVICE || 'app' }}
@@ -212,6 +216,7 @@ jobs:
           echo "User: ${{ secrets.SSH_USER_API }}"
           echo "Project dir: ${API_PROJECT_DIR}"
           echo "Compose file: ${API_COMPOSE_FILE}"
+          echo "Compose source file: ${API_COMPOSE_SOURCE_FILE}"
           
           # Test if host is reachable (allow failure for diagnosis)
           ping -c 3 ${{ secrets.SSH_HOST_API }} || echo "⚠️ Ping failed, but SSH might still work"
@@ -248,7 +253,11 @@ jobs:
           ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "mkdir -p '${API_PROJECT_DIR}'"
 
           if [ "${API_COPY_COMPOSE}" = "true" ]; then
-            echo "📄 Copying docker-compose.prod.yml to ${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
+            if [ ! -f "${API_COMPOSE_SOURCE_FILE}" ]; then
+              echo "::error::API_COMPOSE_SOURCE_FILE not found: ${API_COMPOSE_SOURCE_FILE}"
+              exit 1
+            fi
+            echo "📄 Copying ${API_COMPOSE_SOURCE_FILE} to ${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
             scp \
               -i ~/.ssh/deploy_key \
               -o BatchMode=yes \
@@ -256,7 +265,7 @@ jobs:
               -o ConnectTimeout=20 \
               -o ServerAliveInterval=15 \
               -o ServerAliveCountMax=3 \
-              -v docker-compose.prod.yml \
+              -v "${API_COMPOSE_SOURCE_FILE}" \
               "${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}:${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
           else
             echo "⏭️ API_COPY_COMPOSE=${API_COPY_COMPOSE}; keeping remote compose unchanged"
@@ -402,9 +411,14 @@ jobs:
       API_STANDBY_USER: ${{ vars.API_STANDBY_USER || 'root' }}
       API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/air-api' }}
       API_STANDBY_COMPOSE_FILE: ${{ vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+      API_STANDBY_COPY_COMPOSE: ${{ vars.API_STANDBY_COPY_COMPOSE || 'false' }}
+      API_STANDBY_COMPOSE_SOURCE_FILE: ${{ vars.API_STANDBY_COMPOSE_SOURCE_FILE || vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.prod.yml' }}
       API_STANDBY_HEALTH_URL: ${{ vars.API_STANDBY_HEALTH_URL || 'http://localhost:8000/api/health' }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup SSH Key
         run: |
           set -euo pipefail
@@ -417,6 +431,19 @@ jobs:
         run: |
           set -euo pipefail
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          SCP_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+
+          if [ "${API_STANDBY_COPY_COMPOSE}" = "true" ]; then
+            if [ ! -f "${API_STANDBY_COMPOSE_SOURCE_FILE}" ]; then
+              echo "::error::API_STANDBY_COMPOSE_SOURCE_FILE not found: ${API_STANDBY_COMPOSE_SOURCE_FILE}"
+              exit 1
+            fi
+            ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "mkdir -p '${API_STANDBY_PROJECT_DIR}'"
+            scp ${SCP_OPTS} "${API_STANDBY_COMPOSE_SOURCE_FILE}" \
+              "${API_STANDBY_USER}@${API_STANDBY_HOST}:${API_STANDBY_PROJECT_DIR}/${API_STANDBY_COMPOSE_FILE}"
+          else
+            echo "⏭️ API_STANDBY_COPY_COMPOSE=${API_STANDBY_COPY_COMPOSE}; keeping remote standby compose unchanged"
+          fi
 
           ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
             set -euo pipefail && \
@@ -443,6 +470,8 @@ jobs:
             echo "- standby_host: ${API_STANDBY_HOST}"
             echo "- standby_project_dir: ${API_STANDBY_PROJECT_DIR}"
             echo "- standby_compose_file: ${API_STANDBY_COMPOSE_FILE}"
+            echo "- standby_copy_compose: ${API_STANDBY_COPY_COMPOSE}"
+            echo "- standby_compose_source_file: ${API_STANDBY_COMPOSE_SOURCE_FILE}"
             echo "- health_url: ${API_STANDBY_HEALTH_URL}"
             echo "- status: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/ha/mvn-api/docker-compose.primary.yml
+++ b/deploy/ha/mvn-api/docker-compose.primary.yml
@@ -1,0 +1,58 @@
+services:
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "127.0.0.1:5432:5432"
+      - "10.77.0.2:5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  app:
+    image: ghcr.io/mvnby/air-api/backend:latest
+    restart: always
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      APP_ROLE: primary
+      SCHEDULER_ENABLED: "true"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "true"
+      DB_BOOTSTRAP_ENABLED: "true"
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      - ./media:/app/media
+      - ./model-cache/u2net:/root/.u2net
+      - ./token.json:/app/token.json
+      - ./client_secret.json:/app/client_secret.json
+      - ./credentials.json:/app/credentials.json
+      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+
+  bot:
+    image: ghcr.io/mvnby/air-api/backend:latest
+    restart: always
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      APP_ROLE: primary
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "true"
+      DB_BOOTSTRAP_ENABLED: "false"
+    volumes:
+      - ./media:/app/media
+      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    command: python -m bot_app.main
+
+volumes:
+  postgres_data:

--- a/deploy/ha/mvn-api/docker-compose.standby.yml
+++ b/deploy/ha/mvn-api/docker-compose.standby.yml
@@ -1,0 +1,67 @@
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    command:
+      - postgres
+      - -c
+      - max_connections=100
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "127.0.0.1:5432:5432"
+      - "10.77.0.2:5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  app:
+    image: ghcr.io/mvnby/air-api/backend:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      APP_ROLE: standby
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "false"
+      DB_BOOTSTRAP_ENABLED: "false"
+      MAIL_IMAP_AUTO_IMPORT_ENABLED: "false"
+      MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED: "false"
+      BACKGROUND_REMOVAL_PROVIDER: noop
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      - ./media:/app/media
+      - ./model-cache/u2net:/root/.u2net
+      - ./token.json:/app/token.json
+      - ./client_secret.json:/app/client_secret.json:ro
+      - ./credentials.json:/app/credentials.json:ro
+      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+
+  bot:
+    image: ghcr.io/mvnby/air-api/backend:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      APP_ROLE: standby
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "false"
+      DB_BOOTSTRAP_ENABLED: "false"
+      BACKGROUND_REMOVAL_PROVIDER: noop
+    volumes:
+      - ./media:/app/media
+      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    command: python -m bot_app.main
+
+volumes:
+  postgres_data:

--- a/deploy/ha/systemd/mvn-media-sync.service
+++ b/deploy/ha/systemd/mvn-media-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=MVN media sync pull from current API primary over WireGuard
+Wants=network-online.target wg-quick@wg-mvn.service
+After=network-online.target wg-quick@wg-mvn.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/mvn-media-sync-pull

--- a/deploy/ha/systemd/mvn-media-sync.timer
+++ b/deploy/ha/systemd/mvn-media-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MVN media sync pull every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Unit=mvn-media-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ha/zakup/docker-compose.primary.yml
+++ b/deploy/ha/zakup/docker-compose.primary.yml
@@ -1,0 +1,96 @@
+name: mvn_reserve
+
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    shm_size: 128mb
+    command:
+      - postgres
+      - -c
+      - shared_buffers=64MB
+      - -c
+      - max_connections=100
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-air_conditioners}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-air_conditioners}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "10.77.0.1:5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    mem_limit: ${MVN_RESERVE_DB_MEMORY:-220m}
+    networks:
+      - reserve
+
+  app:
+    image: ${BACKEND_IMAGE:-ghcr.io/mvnby/air-api/backend:latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+    environment:
+      ENVIRONMENT: production
+      APP_ROLE: primary
+      SCHEDULER_ENABLED: "true"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "true"
+      DB_BOOTSTRAP_ENABLED: "true"
+      MAIL_IMAP_AUTO_IMPORT_ENABLED: "true"
+      MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED: "false"
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      BACKGROUND_REMOVAL_PROVIDER: noop
+      BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
+      BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
+      BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+    ports:
+      - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
+    volumes:
+      - ./media:/app/media
+      - ./model-cache/u2net:/root/.u2net
+      - ./secrets/token.json:/app/token.json
+      - ./secrets/client_secret.json:/app/client_secret.json:ro
+      - ./secrets/credentials.json:/app/credentials.json:ro
+      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    mem_limit: ${MVN_RESERVE_APP_MEMORY:-520m}
+    networks:
+      - reserve
+
+  bot:
+    image: ${BACKEND_IMAGE:-ghcr.io/mvnby/air-api/backend:latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+    environment:
+      ENVIRONMENT: production
+      APP_ROLE: primary
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "true"
+      API_READY_ENABLED: "true"
+      DB_BOOTSTRAP_ENABLED: "false"
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      BACKGROUND_REMOVAL_PROVIDER: noop
+    command: python -m bot_app.main
+    volumes:
+      - ./media:/app/media
+      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
+    networks:
+      - reserve
+
+volumes:
+  postgres_data:
+
+networks:
+  reserve:
+    driver: bridge

--- a/deploy/ha/zakup/docker-compose.standby.yml
+++ b/deploy/ha/zakup/docker-compose.standby.yml
@@ -1,0 +1,98 @@
+name: mvn_reserve
+
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    shm_size: 128mb
+    command:
+      - postgres
+      - -c
+      - shared_buffers=64MB
+      - -c
+      - max_connections=100
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-air_conditioners}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-air_conditioners}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "10.77.0.1:5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    mem_limit: ${MVN_RESERVE_DB_MEMORY:-220m}
+    networks:
+      - reserve
+
+  app:
+    image: ${BACKEND_IMAGE:-ghcr.io/mvnby/air-api/backend:latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+    environment:
+      ENVIRONMENT: production
+      APP_ROLE: standby
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "false"
+      DB_BOOTSTRAP_ENABLED: "false"
+      MAIL_IMAP_AUTO_IMPORT_ENABLED: "false"
+      MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED: "false"
+      CLOUDFLARE_PURGE_ENABLED: "false"
+      CLOUDFLARE_PURGE_DRY_RUN: "true"
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      BACKGROUND_REMOVAL_PROVIDER: noop
+      BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
+      BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
+      BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+    ports:
+      - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
+    volumes:
+      - ./media:/app/media
+      - ./model-cache/u2net:/root/.u2net
+      - ./secrets/token.json:/app/token.json
+      - ./secrets/client_secret.json:/app/client_secret.json:ro
+      - ./secrets/credentials.json:/app/credentials.json:ro
+      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    mem_limit: ${MVN_RESERVE_APP_MEMORY:-520m}
+    networks:
+      - reserve
+
+  bot:
+    image: ${BACKEND_IMAGE:-ghcr.io/mvnby/air-api/backend:latest}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+    environment:
+      ENVIRONMENT: production
+      APP_ROLE: standby
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "false"
+      API_READY_ENABLED: "false"
+      DB_BOOTSTRAP_ENABLED: "false"
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      BACKGROUND_REMOVAL_PROVIDER: noop
+    command: python -m bot_app.main
+    volumes:
+      - ./media:/app/media
+      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
+    networks:
+      - reserve
+
+volumes:
+  postgres_data:
+
+networks:
+  reserve:
+    driver: bridge

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -35,6 +35,23 @@ Runtime split:
 | Telegram bot | enabled only in `bot` | stopped/disabled |
 | Google Drive backups | enabled on primary scheduler | disabled |
 
+## Repo-Tracked HA Files
+
+The active-passive setup is tracked in the repo so deploys do not depend on
+unreviewed host-local compose edits:
+
+| Purpose | File |
+| --- | --- |
+| `mvn-api` as primary | `deploy/ha/mvn-api/docker-compose.primary.yml` |
+| `mvn-api` as rebuilt standby | `deploy/ha/mvn-api/docker-compose.standby.yml` |
+| `zakup` as primary after promotion | `deploy/ha/zakup/docker-compose.primary.yml` |
+| `zakup` as standby | `deploy/ha/zakup/docker-compose.standby.yml` |
+| Active-passive invariant check | `scripts/ha/check_active_passive.sh` |
+| Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
+| Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
+| Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
+| Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
+
 ## Daily Status Checks
 
 Primary:
@@ -63,6 +80,12 @@ Expected:
 - direct `mvn-api`: 200;
 - direct `zakup`: 503.
 
+Repo check:
+
+```bash
+bash scripts/ha/check_active_passive.sh
+```
+
 GitHub health check:
 
 ```bash
@@ -77,7 +100,8 @@ Current production variables must match the active primary:
 SSH_HOST_API=185.250.45.54
 API_PROJECT_DIR=/opt/air-api
 API_COMPOSE_FILE=docker-compose.prod.yml
-API_COPY_COMPOSE=false
+API_COMPOSE_SOURCE_FILE=deploy/ha/mvn-api/docker-compose.primary.yml
+API_COPY_COMPOSE=true
 API_BASE_URL=http://localhost:8000
 API_READY_URL=http://localhost:8000/api/ready
 API_LOCAL_HEALTH_URL=http://127.0.0.1:8000/api/health
@@ -89,12 +113,14 @@ API_BOT_EXPECT_ENABLED=true
 API_STANDBY_HOST=193.47.42.213
 API_STANDBY_PROJECT_DIR=/opt/mvn-reserve
 API_STANDBY_COMPOSE_FILE=docker-compose.reserve.yml
+API_STANDBY_COPY_COMPOSE=true
+API_STANDBY_COMPOSE_SOURCE_FILE=deploy/ha/zakup/docker-compose.standby.yml
 API_STANDBY_HEALTH_URL=http://localhost:18000/api/health
 ```
 
-`API_COPY_COMPOSE=false` is intentional while the primary uses a host-local
-compose file with HA-specific PostgreSQL binding and role split. Do not switch
-it back to `true` until the repo has a reviewed HA compose overlay.
+If an emergency requires manual host-local compose edits, set
+`API_COPY_COMPOSE=false` and/or `API_STANDBY_COPY_COMPOSE=false` temporarily.
+Switch back to the repo-tracked files after the emergency is resolved.
 
 Manual deploy verification:
 
@@ -136,6 +162,16 @@ important than order and fallback.
 
 Use this only when `mvn-api` is actually unavailable or must be taken out.
 
+Preferred helper path, run on `zakup` after copying
+`deploy/ha/zakup/docker-compose.primary.yml` to
+`/opt/mvn-reserve/docker-compose.primary.yml`:
+
+```bash
+ssh zakup 'OLD_PRIMARY_SSH=root@10.77.0.2 CONFIRM_PROMOTE=true /usr/local/sbin/mvn-promote-local-standby'
+```
+
+The manual steps below are the same procedure expanded for review.
+
 1. Fence the old primary first if reachable:
 
    ```bash
@@ -162,6 +198,8 @@ Use this only when `mvn-api` is actually unavailable or must be taken out.
    - `BOT_ENABLED=false` in `app`
    - `BOT_ENABLED=true` and `SCHEDULER_ENABLED=false` in `bot`
 
+   Use `deploy/ha/zakup/docker-compose.primary.yml` as the source of truth.
+
 5. Start primary services on `zakup`:
 
    ```bash
@@ -185,6 +223,27 @@ Use this only when `mvn-api` is actually unavailable or must be taken out.
 
 9. Do not restart `mvn-api` as primary. Rebuild it as standby from the promoted
    database.
+
+GitHub Actions variables after `zakup` promotion:
+
+```text
+SSH_HOST_API=193.47.42.213
+API_PROJECT_DIR=/opt/mvn-reserve
+API_COMPOSE_FILE=docker-compose.reserve.yml
+API_COMPOSE_SOURCE_FILE=deploy/ha/zakup/docker-compose.primary.yml
+API_COPY_COMPOSE=true
+API_BASE_URL=http://localhost:18000
+API_READY_URL=http://localhost:18000/api/ready
+API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health
+API_TUNNEL_REMOTE_PORT=18000
+API_DEPLOY_SERVICES=app bot
+API_STANDBY_HOST=185.250.45.54
+API_STANDBY_PROJECT_DIR=/opt/air-api
+API_STANDBY_COMPOSE_FILE=docker-compose.prod.yml
+API_STANDBY_COPY_COMPOSE=true
+API_STANDBY_COMPOSE_SOURCE_FILE=deploy/ha/mvn-api/docker-compose.standby.yml
+API_STANDBY_HEALTH_URL=http://localhost:8000/api/health
+```
 
 ## Rebuild A Former Primary As Standby
 
@@ -210,6 +269,22 @@ Required steps:
 7. Set media sync to pull from the new primary to the standby.
 8. Verify `/api/ready=503` on standby and replication slot active on primary.
 
+## Restore Drill
+
+Backups are stored in Google Drive. Freshness alone is not enough; periodically
+prove that the latest DB dump restores.
+
+Run on the current primary:
+
+```bash
+ssh mvn-api /usr/local/sbin/mvn-restore-drill-latest-db
+```
+
+The drill downloads the latest DB backup through the app container, starts a
+disposable PostgreSQL container on the same Docker network, restores the dump
+there, checks that public tables exist, and then removes the disposable
+container. It does not touch the production or standby database.
+
 ## Hard Rules
 
 - Never let both origins return `/api/ready=200`.
@@ -223,11 +298,7 @@ Required steps:
 
 ## Next Improvements
 
-- Move HA-specific compose overlays into the repo and stop relying on
-  host-local compose edits.
-- Add a single audited promote script that performs fencing, promotion,
-  role-switching, media-sync direction, and verification.
 - Add Cloudflare API automation for pool order/fallback changes.
 - Add owner-visible alerts from GitHub Actions or Cloudflare to Telegram/email.
-- Keep Google Drive backups, but add a scheduled restore drill to a disposable
-  volume/host.
+- Add a scheduled restore drill to a disposable volume/host after the first
+  manual restore drill passes.

--- a/scripts/ha/check_active_passive.sh
+++ b/scripts/ha/check_active_passive.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_HOST="${API_HOST:-api.mvn.by}"
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${API_HOST}}"
+PRIMARY_ORIGIN="${PRIMARY_ORIGIN:-185.250.45.54}"
+STANDBY_ORIGIN="${STANDBY_ORIGIN:-193.47.42.213}"
+PRIMARY_ROLE="${PRIMARY_ROLE:-primary}"
+STANDBY_ROLE="${STANDBY_ROLE:-standby}"
+CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+log() {
+  printf '[ha-check] %s\n' "$*" >&2
+}
+
+curl_json() {
+  local label="$1"
+  local url="$2"
+  local output_file="$3"
+  shift 3
+
+  log "GET ${label}: ${url}"
+  curl -ksS \
+    --connect-timeout "${CURL_CONNECT_TIMEOUT}" \
+    --max-time "${CURL_MAX_TIME}" \
+    -o "${output_file}" \
+    -w '%{http_code}' \
+    "$@" \
+    "${url}"
+}
+
+validate_payload() {
+  local label="$1"
+  local file="$2"
+  local expected_role="$3"
+  local expected_ready="$4"
+
+  python3 - "$label" "$file" "$expected_role" "$expected_ready" <<'PY'
+import json
+import sys
+
+label, path, expected_role, expected_ready = sys.argv[1:5]
+with open(path, "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+
+role = payload.get("app_role")
+if role != expected_role:
+    raise SystemExit(f"{label}: expected app_role={expected_role!r}, got {role!r}")
+
+api_state = payload.get("api")
+traffic = payload.get("traffic")
+if expected_ready == "ready":
+    if payload.get("status") != "ok" or api_state != "ready" or traffic != "enabled":
+        raise SystemExit(f"{label}: payload is not ready: {payload}")
+    if payload.get("database") != "online":
+        raise SystemExit(f"{label}: database is not online: {payload}")
+    if payload.get("database_writable") is not True:
+        raise SystemExit(f"{label}: database is not writable: {payload}")
+else:
+    if api_state != "not_ready" or traffic != "disabled":
+        raise SystemExit(f"{label}: payload is not fenced standby: {payload}")
+
+print(f"{label}: role={role} api={api_state} traffic={traffic}")
+PY
+}
+
+public_file="${TMP_DIR}/public-ready.json"
+primary_file="${TMP_DIR}/primary-ready.json"
+standby_file="${TMP_DIR}/standby-ready.json"
+
+public_code="$(curl_json "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}")"
+printf '\n'
+if [[ "${public_code}" != "200" ]]; then
+  log "public /api/ready expected HTTP 200, got ${public_code}"
+  cat "${public_file}" || true
+  exit 1
+fi
+validate_payload "public" "${public_file}" "${PRIMARY_ROLE}" ready
+
+primary_code="$(curl_json "primary direct ready" "https://${API_HOST}/api/ready" "${primary_file}" --resolve "${API_HOST}:443:${PRIMARY_ORIGIN}")"
+printf '\n'
+if [[ "${primary_code}" != "200" ]]; then
+  log "primary direct /api/ready expected HTTP 200, got ${primary_code}"
+  cat "${primary_file}" || true
+  exit 1
+fi
+validate_payload "primary" "${primary_file}" "${PRIMARY_ROLE}" ready
+
+standby_code="$(curl_json "standby direct ready" "https://${API_HOST}/api/ready" "${standby_file}" --resolve "${API_HOST}:443:${STANDBY_ORIGIN}")"
+printf '\n'
+if [[ "${standby_code}" == "200" ]]; then
+  log "standby direct /api/ready returned HTTP 200; split-brain risk"
+  cat "${standby_file}" || true
+  exit 1
+fi
+validate_payload "standby" "${standby_file}" "${STANDBY_ROLE}" not_ready
+
+log "active-passive invariant passed: primary ready, standby fenced"

--- a/scripts/ha/media_sync_pull.sh
+++ b/scripts/ha/media_sync_pull.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCK="${LOCK:-/run/mvn-media-sync.lock}"
+SOURCE_HOST="${SOURCE_HOST:-root@10.77.0.2}"
+SOURCE_DIR="${SOURCE_DIR:-/opt/air-api/media/}"
+DEST_DIR="${DEST_DIR:-/opt/mvn-reserve/media/}"
+SSH_KEY="${SSH_KEY:-/root/.ssh/mvn_media_sync_ed25519}"
+
+SSH_OPTS=(
+  ssh
+  -i "${SSH_KEY}"
+  -o BatchMode=yes
+  -o ConnectTimeout=10
+  -o StrictHostKeyChecking=accept-new
+)
+
+mkdir -p "${DEST_DIR}"
+exec flock -n "${LOCK}" rsync -a --delete --delay-updates --numeric-ids -e "${SSH_OPTS[*]}" "${SOURCE_HOST}:${SOURCE_DIR}" "${DEST_DIR}"

--- a/scripts/ha/mvn-primary-status.sh
+++ b/scripts/ha/mvn-primary-status.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+LOCAL_READY_URL="${LOCAL_READY_URL:-http://127.0.0.1:8000/api/ready}"
+
+cd "${PROJECT_DIR}"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+echo "containers:"
+"${COMPOSE[@]}" ps
+
+echo
+echo "api_ready:"
+curl -fsS "${LOCAL_READY_URL}" || true
+printf '\n'
+
+echo
+echo "runtime:"
+"${COMPOSE[@]}" exec -T app python - <<'PY'
+from core.config import settings
+
+print("APP_ROLE", settings.APP_ROLE)
+print("API_READY", settings.api_ready_control_decision)
+print("SCHEDULER", settings.scheduler_control_decision)
+print("BOT_IN_APP", settings.bot_control_decision)
+print("MAIL_IMAP_AUTO_IMPORT_ENABLED", settings.MAIL_IMAP_AUTO_IMPORT_ENABLED)
+print("MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED", settings.MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED)
+PY
+
+echo
+echo "bot_runtime:"
+"${COMPOSE[@]}" exec -T bot python - <<'PY'
+from core.config import settings
+
+print("APP_ROLE", settings.APP_ROLE)
+print("BOT", settings.bot_control_decision)
+print("SCHEDULER", settings.scheduler_control_decision)
+PY
+
+echo
+echo "postgres_primary_and_replication:"
+"${COMPOSE[@]}" exec -T db sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -v ON_ERROR_STOP=1' <<'SQL'
+SELECT pg_is_in_recovery() AS in_recovery, pg_current_wal_lsn() AS current_lsn;
+SELECT slot_name, active, active_pid, restart_lsn FROM pg_replication_slots;
+SELECT application_name, client_addr, state, sync_state, replay_lsn FROM pg_stat_replication;
+SELECT locktype, granted, objid::bigint, pid, mode FROM pg_locks WHERE locktype = 'advisory' ORDER BY pid;
+SQL
+
+echo
+echo "backups:"
+"${COMPOSE[@]}" exec -T app python - <<'PY'
+from datetime import datetime, timezone
+from services.backup_service import backup_service
+
+items = backup_service.list_backups(limit=20)
+now = datetime.now(timezone.utc)
+for kind in ("db", "media"):
+    latest = next((item for item in items if item.get("kind") == kind), None)
+    if not latest:
+        print(kind, "missing")
+        continue
+    created = latest.get("created_at")
+    if created and created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    age = (now - created).total_seconds() / 3600 if created else -1
+    print(kind, f"age_hours={age:.1f}", latest.get("name"), created)
+PY

--- a/scripts/ha/mvn-standby-status.sh
+++ b/scripts/ha/mvn-standby-status.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/mvn-reserve}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.reserve.yml}"
+LOCAL_HEALTH_URL="${LOCAL_HEALTH_URL:-http://127.0.0.1:18000/api/health}"
+LOCAL_READY_URL="${LOCAL_READY_URL:-http://127.0.0.1:18000/api/ready}"
+
+cd "${PROJECT_DIR}"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+printf 'containers:\n'
+"${COMPOSE[@]}" ps
+
+printf '\npostgres:\n'
+"${COMPOSE[@]}" exec -T db sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -v ON_ERROR_STOP=1' <<'SQL'
+SELECT pg_is_in_recovery() AS in_recovery, pg_last_wal_receive_lsn() AS receive_lsn, pg_last_wal_replay_lsn() AS replay_lsn;
+SELECT status, sender_host, sender_port, slot_name, latest_end_lsn FROM pg_stat_wal_receiver;
+SQL
+
+printf '\napi:\n'
+printf 'health_status='
+curl -s -o /tmp/mvn-health.out -w '%{http_code}' "${LOCAL_HEALTH_URL}"
+printf ' body='
+cat /tmp/mvn-health.out
+printf '\n'
+printf 'ready_status='
+curl -s -o /tmp/mvn-ready.out -w '%{http_code}' "${LOCAL_READY_URL}"
+printf ' body='
+cat /tmp/mvn-ready.out
+printf '\n'
+
+printf '\nmedia timer:\n'
+systemctl is-active mvn-media-sync.timer || true
+systemctl list-timers --all | grep mvn-media-sync || true

--- a/scripts/ha/promote_local_standby.sh
+++ b/scripts/ha/promote_local_standby.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/mvn-reserve}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.reserve.yml}"
+PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE:-docker-compose.primary.yml}"
+LOCAL_READY_URL="${LOCAL_READY_URL:-http://127.0.0.1:18000/api/ready}"
+OLD_PRIMARY_SSH="${OLD_PRIMARY_SSH:-}"
+OLD_PRIMARY_PROJECT_DIR="${OLD_PRIMARY_PROJECT_DIR:-/opt/air-api}"
+OLD_PRIMARY_COMPOSE_FILE="${OLD_PRIMARY_COMPOSE_FILE:-docker-compose.prod.yml}"
+CONFIRM_PROMOTE="${CONFIRM_PROMOTE:-false}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  CONFIRM_PROMOTE=true bash scripts/ha/promote_local_standby.sh
+
+Runs on the standby host. It fences the old primary when OLD_PRIMARY_SSH is set,
+promotes local PostgreSQL, swaps the local compose file to the prepared primary
+compose, starts app+bot, disables media pull, and verifies local /api/ready.
+
+Important env:
+  PROJECT_DIR=/opt/mvn-reserve
+  COMPOSE_FILE=docker-compose.reserve.yml
+  PRIMARY_COMPOSE_FILE=docker-compose.primary.yml
+  OLD_PRIMARY_SSH=root@10.77.0.2
+  OLD_PRIMARY_PROJECT_DIR=/opt/air-api
+  OLD_PRIMARY_COMPOSE_FILE=docker-compose.prod.yml
+  LOCAL_READY_URL=http://127.0.0.1:18000/api/ready
+  CONFIRM_PROMOTE=true
+USAGE
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --yes)
+      CONFIRM_PROMOTE=true
+      ;;
+    *)
+      echo "Unsupported argument: ${arg}" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${CONFIRM_PROMOTE}" != "true" ]]; then
+  if [[ -t 0 ]]; then
+    read -r -p "Promote this standby to primary? Type PROMOTE: " answer
+    if [[ "${answer}" != "PROMOTE" ]]; then
+      echo "Cancelled."
+      exit 1
+    fi
+  else
+    echo "Refusing to promote without CONFIRM_PROMOTE=true or --yes." >&2
+    exit 1
+  fi
+fi
+
+cd "${PROJECT_DIR}"
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+fi
+if [[ ! -f "${PRIMARY_COMPOSE_FILE}" ]]; then
+  echo "Prepared primary compose file not found: ${PROJECT_DIR}/${PRIMARY_COMPOSE_FILE}" >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+read_recovery_state() {
+  "${COMPOSE[@]}" exec -T db sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -Atqc "SELECT pg_is_in_recovery()"'
+}
+
+recovery_state="$(read_recovery_state)"
+if [[ "${recovery_state}" != "t" ]]; then
+  echo "Local Postgres is not in recovery (pg_is_in_recovery=${recovery_state}). Refusing to promote." >&2
+  exit 1
+fi
+
+if [[ -n "${OLD_PRIMARY_SSH}" ]]; then
+  echo "Fencing old primary app/bot on ${OLD_PRIMARY_SSH}..."
+  ssh -o BatchMode=yes -o ConnectTimeout=10 "${OLD_PRIMARY_SSH}" \
+    "cd '${OLD_PRIMARY_PROJECT_DIR}' && docker compose -f '${OLD_PRIMARY_COMPOSE_FILE}' stop app bot"
+else
+  echo "WARNING: OLD_PRIMARY_SSH is empty; old primary was not fenced by this script." >&2
+fi
+
+echo "Promoting local PostgreSQL..."
+"${COMPOSE[@]}" exec -T db sh -lc 'pg_ctl promote -D "$PGDATA"'
+
+for _ in $(seq 1 30); do
+  recovery_state="$(read_recovery_state || true)"
+  if [[ "${recovery_state}" == "f" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${recovery_state}" != "f" ]]; then
+  echo "PostgreSQL did not leave recovery in time." >&2
+  exit 1
+fi
+
+timestamp="$(date -u +%Y%m%d%H%M%S)"
+backup_file="${COMPOSE_FILE}.pre-promote.${timestamp}"
+cp "${COMPOSE_FILE}" "${backup_file}"
+cp "${PRIMARY_COMPOSE_FILE}" "${COMPOSE_FILE}"
+echo "Swapped ${COMPOSE_FILE}; previous standby compose saved as ${backup_file}"
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl disable --now mvn-media-sync.timer mvn-media-sync.service >/dev/null 2>&1 || true
+fi
+
+echo "Starting promoted primary services..."
+"${COMPOSE[@]}" up -d db app bot
+
+echo "Verifying local readiness..."
+for _ in $(seq 1 30); do
+  if curl -fsS "${LOCAL_READY_URL}" >/tmp/mvn-promote-ready.out; then
+    cat /tmp/mvn-promote-ready.out
+    printf '\n'
+    echo "Promote completed. Update GitHub variables and Cloudflare pool/fallback now."
+    exit 0
+  fi
+  sleep 2
+done
+
+"${COMPOSE[@]}" logs --tail=120 app
+echo "Promoted DB, but API readiness did not become healthy." >&2
+exit 1

--- a/scripts/ha/restore_drill_latest_db.sh
+++ b/scripts/ha/restore_drill_latest_db.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+DB_SERVICE="${DB_SERVICE:-db}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15-alpine}"
+DRILL_DIR="${DRILL_DIR:-/tmp/mvn-restore-drill}"
+KEEP_DRILL_CONTAINER="${KEEP_DRILL_CONTAINER:-false}"
+KEEP_DRILL_FILES="${KEEP_DRILL_FILES:-false}"
+
+log() {
+  printf '[restore-drill] %s\n' "$*"
+}
+
+cd "${PROJECT_DIR}"
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+mkdir -p "${DRILL_DIR}"
+chmod 700 "${DRILL_DIR}"
+
+container="mvn_restore_drill_$(date -u +%Y%m%d%H%M%S)"
+backup_path=""
+sql_path="${DRILL_DIR}/latest-db-backup.sql"
+
+cleanup() {
+  if [[ "${KEEP_DRILL_CONTAINER}" != "true" ]]; then
+    docker rm -f "${container}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_DRILL_FILES}" != "true" ]]; then
+    rm -f "${DRILL_DIR}"/latest-db-backup*
+  fi
+}
+trap cleanup EXIT
+
+db_container="$("${COMPOSE[@]}" ps -q "${DB_SERVICE}")"
+if [[ -z "${db_container}" ]]; then
+  echo "DB service is not running: ${DB_SERVICE}" >&2
+  exit 1
+fi
+
+mapfile -t db_env < <("${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'printf "%s\n%s\n%s\n" "$POSTGRES_USER" "$POSTGRES_PASSWORD" "${POSTGRES_DB:-air_conditioners}"')
+POSTGRES_USER="${db_env[0]:-}"
+POSTGRES_PASSWORD="${db_env[1]:-}"
+POSTGRES_DB="${db_env[2]:-air_conditioners}"
+
+if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_PASSWORD}" || -z "${POSTGRES_DB}" ]]; then
+  echo "Could not read POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB from ${DB_SERVICE} container." >&2
+  exit 1
+fi
+
+network="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "${db_container}" | head -n 1)"
+if [[ -z "${network}" ]]; then
+  echo "Could not detect Docker network for ${DB_SERVICE}" >&2
+  exit 1
+fi
+
+log "Downloading latest DB backup from Google Drive via ${APP_SERVICE}..."
+"${COMPOSE[@]}" run -T --rm -v "${DRILL_DIR}:/restore-drill" "${APP_SERVICE}" python - <<'PY'
+from pathlib import Path
+from services.backup_service import backup_service
+
+items = backup_service.list_backups(limit=100)
+latest = next((item for item in items if item.get("kind") == "db"), None)
+if not latest:
+    raise SystemExit("No DB backups found")
+
+name = Path(str(latest.get("name") or "latest-db-backup.sql")).name
+dest = Path("/restore-drill") / f"latest-db-backup{name[name.rfind('.'):] if '.' in name else '.sql'}"
+if name.endswith(".sql.gz"):
+    dest = Path("/restore-drill/latest-db-backup.sql.gz")
+elif name.endswith(".sql"):
+    dest = Path("/restore-drill/latest-db-backup.sql")
+
+backup_service.download_backup_file(str(latest["id"]), str(dest))
+print(f"backup_name={name}")
+print(f"backup_created_at={latest.get('created_at')}")
+print(f"backup_size_bytes={latest.get('size_bytes')}")
+print(f"downloaded_path={dest}")
+PY
+
+if [[ -f "${DRILL_DIR}/latest-db-backup.sql.gz" ]]; then
+  backup_path="${DRILL_DIR}/latest-db-backup.sql.gz"
+  gzip -dc "${backup_path}" > "${sql_path}"
+elif [[ -f "${DRILL_DIR}/latest-db-backup.sql" ]]; then
+  backup_path="${DRILL_DIR}/latest-db-backup.sql"
+else
+  echo "Downloaded backup file was not found in ${DRILL_DIR}" >&2
+  exit 1
+fi
+
+sed -i.bak '/^SET transaction_timeout = .*;$/d' "${sql_path}"
+rm -f "${sql_path}.bak"
+
+log "Starting disposable PostgreSQL container on network ${network}..."
+docker run -d \
+  --name "${container}" \
+  --network "${network}" \
+  -e POSTGRES_USER="${POSTGRES_USER}" \
+  -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  -e POSTGRES_DB="${POSTGRES_DB}" \
+  "${POSTGRES_IMAGE}" >/dev/null
+
+for _ in $(seq 1 30); do
+  if docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+  docker logs "${container}" || true
+  echo "Disposable PostgreSQL did not become ready." >&2
+  exit 1
+fi
+
+log "Restoring backup into disposable PostgreSQL..."
+docker cp "${sql_path}" "${container}:/tmp/restore.sql"
+if ! docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" \
+  psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/restore.sql \
+  >"${DRILL_DIR}/restore.log" 2>&1; then
+  tail -n 120 "${DRILL_DIR}/restore.log" || true
+  echo "Restore drill failed during psql restore." >&2
+  exit 1
+fi
+
+tables_count="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -Atqc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" \
+  -U "${POSTGRES_USER}" -d "${POSTGRES_DB}")"
+
+if [[ "${tables_count}" -lt 10 ]]; then
+  echo "Restore drill produced too few public tables: ${tables_count}" >&2
+  exit 1
+fi
+
+log "public_tables=${tables_count}"
+docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
+SELECT 'product_count=' || count(*) FROM product;
+SELECT 'payment_count=' || count(*) FROM payment;
+SELECT 'order_count=' || count(*) FROM "order";
+SQL
+
+log "restore drill passed; production and standby databases were not modified"

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -47,6 +47,38 @@ DB_HOST = os.environ.get('POSTGRES_SERVER', 'db')
 DB_PORT = os.environ.get('POSTGRES_PORT', '5432')
 DB_NAME = os.environ.get('POSTGRES_DB', 'air_conditioners')
 
+PLAIN_SQL_DUMP_SETTINGS_TO_STRIP = {
+    'transaction_timeout',
+}
+
+
+def sanitize_plain_sql_dump(dump_path):
+    """Remove pg_dump client-version SET commands unsupported by older servers."""
+    if not dump_path.endswith('.sql') or not os.path.exists(dump_path):
+        return False
+
+    changed = False
+    temp_path = f"{dump_path}.sanitized"
+    with open(dump_path, 'r', encoding='utf-8', errors='replace') as source, open(
+        temp_path,
+        'w',
+        encoding='utf-8',
+    ) as dest:
+        for line in source:
+            stripped = line.strip()
+            if stripped.startswith('SET ') and stripped.endswith(';'):
+                setting_name = stripped[4:].split('=', 1)[0].strip()
+                if setting_name in PLAIN_SQL_DUMP_SETTINGS_TO_STRIP:
+                    changed = True
+                    continue
+            dest.write(line)
+
+    if changed:
+        os.replace(temp_path, dump_path)
+    else:
+        os.remove(temp_path)
+    return changed
+
 
 def get_credentials():
     """Load Google API credentials from token.json."""
@@ -103,6 +135,9 @@ def download_file(creds, file_id, dest_path):
 
 def restore_sql(dump_path):
     """Restore a SQL dump into the local PostgreSQL database."""
+    if sanitize_plain_sql_dump(dump_path):
+        logger.info("🧹 Removed client-version-only SET commands from SQL dump.")
+
     env = os.environ.copy()
     env['PGPASSWORD'] = DB_PASS
 

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -16,6 +16,13 @@ BACKUP_DIR = "backups"
 
 
 class BackupService:
+    # pg_dump from a newer client can emit SET commands unsupported by our
+    # current postgres:15 server. Keep plain SQL dumps restorable on the server
+    # version we actually run in production.
+    _PLAIN_SQL_DUMP_SETTINGS_TO_STRIP = {
+        "transaction_timeout",
+    }
+
     def __init__(self):
         self.db_user = os.getenv("POSTGRES_USER", "mvnadmin")
         self.db_password = os.getenv("POSTGRES_PASSWORD", "securepass")
@@ -132,11 +139,46 @@ class BackupService:
         logger.info("Starting backup for %s...", self.db_name)
         try:
             subprocess.run(command, env=env, check=True)
+            self.sanitize_plain_sql_dump(filepath)
             logger.info("Backup created successfully: %s", filepath)
             return filepath
         except subprocess.CalledProcessError as exc:
             logger.error("Backup failed: %s", exc)
             raise Exception("Backup creation failed")
+
+    @classmethod
+    def sanitize_plain_sql_dump(cls, filepath: str) -> bool:
+        """
+        Removes known client-version-only SET commands from plain SQL dumps.
+
+        This is intentionally conservative: it only edits `.sql` files and only
+        removes exact `SET <name> = ...;` lines for settings that are safe to
+        omit during restore.
+        """
+        if not filepath.endswith(".sql") or not os.path.exists(filepath):
+            return False
+
+        changed = False
+        temp_path = f"{filepath}.sanitized"
+        with open(filepath, "r", encoding="utf-8", errors="replace") as source, open(
+            temp_path,
+            "w",
+            encoding="utf-8",
+        ) as dest:
+            for line in source:
+                stripped = line.strip()
+                if stripped.startswith("SET ") and stripped.endswith(";"):
+                    setting_name = stripped[4:].split("=", 1)[0].strip()
+                    if setting_name in cls._PLAIN_SQL_DUMP_SETTINGS_TO_STRIP:
+                        changed = True
+                        continue
+                dest.write(line)
+
+        if changed:
+            os.replace(temp_path, filepath)
+        else:
+            os.remove(temp_path)
+        return changed
 
     def create_media_archive(self) -> Optional[str]:
         """
@@ -318,6 +360,7 @@ class BackupService:
         """
         Restores DB from local SQL file using non-blocking subprocess.
         """
+        self.sanitize_plain_sql_dump(filepath)
         env = os.environ.copy()
         env["PGPASSWORD"] = self.db_password
         command = [
@@ -370,6 +413,7 @@ class BackupService:
         """
         Legacy synchronous restore (used by scripts).
         """
+        self.sanitize_plain_sql_dump(filepath)
         env = os.environ.copy()
         env["PGPASSWORD"] = self.db_password
         command = [

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -51,6 +51,29 @@ def test_list_backups_classifies_and_sorts(monkeypatch):
     assert items[0]["created_at"] > items[1]["created_at"]
 
 
+def test_sanitize_plain_sql_dump_removes_client_only_settings(tmp_path: Path):
+    dump_path = tmp_path / "backup.sql"
+    dump_path.write_text(
+        "\n".join(
+            [
+                "SET statement_timeout = 0;",
+                "SET transaction_timeout = 0;",
+                "CREATE TABLE product (id integer);",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    changed = BackupService.sanitize_plain_sql_dump(str(dump_path))
+
+    assert changed is True
+    sanitized = dump_path.read_text(encoding="utf-8")
+    assert "SET statement_timeout = 0;" in sanitized
+    assert "SET transaction_timeout = 0;" not in sanitized
+    assert "CREATE TABLE product" in sanitized
+
+
 @pytest.mark.asyncio
 async def test_restore_from_file_async_uses_psql(monkeypatch):
     service = BackupService()


### PR DESCRIPTION
## Summary
- add repo-tracked HA compose templates for `mvn-api` and `zakup` in primary/standby roles
- add HA operational scripts for active-passive checks, local standby promotion, status helpers, media sync, and disposable DB restore drills
- teach deploy workflow to copy compose from role-specific source files for primary and standby
- sanitize plain SQL backups/restores for pg_dump 17 -> PostgreSQL 15 compatibility (`SET transaction_timeout`)
- update the API HA runbook with the repo-tracked topology and failover variable sets

## Verification
- `pytest tests/unit/test_backup_service.py tests/unit/test_backup_restore_runtime_service.py tests/unit/test_runtime_controls.py -q`
- `python3 -m py_compile services/backup_service.py scripts/restore_db.py`
- `bash -n scripts/ha/check_active_passive.sh scripts/ha/mvn-primary-status.sh scripts/ha/mvn-standby-status.sh scripts/ha/media_sync_pull.sh scripts/ha/promote_local_standby.sh scripts/ha/restore_drill_latest_db.sh scripts/deploy.sh scripts/post_deploy_smoke_check.sh scripts/check_api_vps_health.sh`
- compose config validation for all four HA compose templates with dummy env
- `bash scripts/ha/check_active_passive.sh`
- live restore drill on `mvn-api`: latest Google Drive DB backup restored into disposable PostgreSQL; production and standby DBs were not modified

## Notes
- Local integration readiness tests require a test DB on `localhost:5433`; unit coverage and live HA checks passed locally, CI should validate its own integration environment.
