### PR TITLE
Add scheduled API HA checks

### DIFF
--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -1,0 +1,56 @@
+name: API Restore Drill
+
+on:
+  schedule:
+    - cron: "42 4 * * *"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  restore-drill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Setup API SSH Key
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/api_restore_drill_key
+          chmod 600 ~/.ssh/api_restore_drill_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+
+      - name: Run restore drill on current API primary
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-i ~/.ssh/api_restore_drill_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
+            PROJECT_DIR='${API_PROJECT_DIR}' \
+            COMPOSE_FILE='${API_COMPOSE_FILE}' \
+            /usr/local/sbin/mvn-restore-drill-latest-db" | tee api-restore-drill.log
+
+      - name: Upload restore drill log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-restore-drill-log-${{ github.run_id }}
+          path: api-restore-drill.log
+          if-no-files-found: warn

--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -1,0 +1,49 @@
+name: API HA Invariant Check
+
+on:
+  schedule:
+    - cron: "7,37 * * * *"
+  workflow_dispatch:
+    inputs:
+      primary_origin:
+        description: "Current primary origin IP"
+        type: string
+        required: false
+        default: ""
+      standby_origin:
+        description: "Current standby origin IP"
+        type: string
+        required: false
+        default: ""
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run active-passive invariant check
+        env:
+          API_HOST: api.mvn.by
+          PUBLIC_BASE_URL: https://api.mvn.by
+          PRIMARY_ORIGIN: ${{ github.event.inputs.primary_origin || vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
+          STANDBY_ORIGIN: ${{ github.event.inputs.standby_origin || vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
+          PRIMARY_ROLE: primary
+          STANDBY_ROLE: standby
+        run: bash scripts/ha/check_active_passive.sh | tee api-ha-invariant.log
+
+      - name: Upload HA invariant log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-ha-invariant-log-${{ github.run_id }}
+          path: api-ha-invariant.log
+          if-no-files-found: warn

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -92,6 +92,14 @@ GitHub health check:
 gh workflow run check-api-vps-health.yml --repo mvnby/air-api --ref main -f mode=ssh
 ```
 
+Scheduled monitors:
+
+| Workflow | Schedule | Purpose |
+| --- | --- | --- |
+| `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups |
+| `check-api-ha-invariants.yml` | every 30 minutes | public/primary ready and standby fenced |
+| `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
+
 ## GitHub Actions Routing
 
 Current production variables must match the active primary:
@@ -285,6 +293,12 @@ disposable PostgreSQL container on the same Docker network, restores the dump
 there, checks that public tables exist, and then removes the disposable
 container. It does not touch the production or standby database.
 
+GitHub also runs this daily:
+
+```bash
+gh workflow run api-restore-drill.yml --repo mvnby/air-api --ref main
+```
+
 ## Hard Rules
 
 - Never let both origins return `/api/ready=200`.
@@ -299,6 +313,5 @@ container. It does not touch the production or standby database.
 ## Next Improvements
 
 - Add Cloudflare API automation for pool order/fallback changes.
-- Add owner-visible alerts from GitHub Actions or Cloudflare to Telegram/email.
-- Add a scheduled restore drill to a disposable volume/host after the first
-  manual restore drill passes.
+- Add owner-visible alerts from GitHub Actions or Cloudflare to Telegram/email
+  beyond the default GitHub failed-workflow notification path.


### PR DESCRIPTION
## Summary
- add scheduled active-passive invariant workflow for `api.mvn.by`
- add scheduled restore drill workflow that SSHes into the current API primary and runs `/usr/local/sbin/mvn-restore-drill-latest-db`
- update HA runbook with the new scheduled monitors

## Verification
- parsed both workflow YAML files with Python/yaml
- `bash scripts/ha/check_active_passive.sh`
- `git diff --check`
