### PR TITLE
Persist backend image tag during API deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -456,6 +456,12 @@ jobs:
             set -euo pipefail && \
             cd '${API_STANDBY_PROJECT_DIR}' && \
             export BACKEND_IMAGE='${BACKEND_IMAGE}' && \
+            tmp=\$(mktemp) && \
+            touch .env && \
+            { grep -v '^BACKEND_IMAGE=' .env > \"\${tmp}\" || true; } && \
+            printf 'BACKEND_IMAGE=%s\n' \"\${BACKEND_IMAGE}\" >> \"\${tmp}\" && \
+            mv \"\${tmp}\" .env && \
+            echo '💾 Persisted immutable standby backend image in .env' && \
             echo '${{ secrets.GHCR_PAT }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin >/dev/null && \
             docker compose -f '${API_STANDBY_COMPOSE_FILE}' pull app && \
             docker compose -f '${API_STANDBY_COMPOSE_FILE}' up -d --force-recreate app && \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,6 +31,17 @@ if [[ ! -f "${COMPOSE_FILE}" ]]; then
     exit 1
 fi
 
+if [[ -n "${BACKEND_IMAGE}" ]]; then
+    ENV_FILE="${PROJECT_DIR}/.env"
+    touch "${ENV_FILE}"
+    if grep -q '^BACKEND_IMAGE=' "${ENV_FILE}"; then
+        sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${BACKEND_IMAGE}|" "${ENV_FILE}"
+    else
+        printf '\nBACKEND_IMAGE=%s\n' "${BACKEND_IMAGE}" >> "${ENV_FILE}"
+    fi
+    echo "💾 Persisted immutable backend image in ${ENV_FILE}"
+fi
+
 COMPOSE=(docker compose -f "${COMPOSE_FILE}")
 
 mkdir -p media model-cache/u2net


### PR DESCRIPTION
## Summary
- persist BACKEND_IMAGE into the primary API server .env during backend deploys
- persist BACKEND_IMAGE into the standby API server .env during standby deploys
- prevents manual docker compose recreates from falling back to latest or an older pinned image

## Checks
- bash -n scripts/deploy.sh
- python3 YAML parse for .github/workflows/deploy.yml
- git diff --check