### PR TITLE
Use CDN originals as public image fallback

### DIFF
--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -938,8 +938,10 @@ class BotRepairNameplateService:
             repair_meta,
             default_status=OrderService.REPAIR_DEFAULT_STATUS,
         )
-        meta.update(order.technical_meta if isinstance(order.technical_meta, dict) else {})
-        order.technical_meta = meta
+        updated_meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        if not already_attached:
+            updated_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
+        order.technical_meta = updated_meta
         flag_modified(order, "technical_meta")
         session.add(order)
         await session.commit()

--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -39,6 +39,21 @@ def _approved_ready_variant_url(image: Any, variant_type: ProductImageVariantTyp
     return None
 
 
+def _ready_original_variant_url(image: Any) -> Optional[str]:
+    for variant in getattr(image, "variants", None) or []:
+        if (
+            variant.variant_type == ProductImageVariantType.ORIGINAL.value
+            and variant.processing_status == ProductImageProcessingStatus.READY.value
+            and variant.url
+        ):
+            return variant.url
+    return None
+
+
+def _public_image_url(image: Any) -> Optional[str]:
+    return _ready_original_variant_url(image) or image.url
+
+
 def _main_image_variant_or_fallback(
     product: Product,
     variant_type: ProductImageVariantType,
@@ -57,7 +72,29 @@ def _main_image_variant_or_fallback(
     if not source_image:
         return product.main_image
 
-    return _approved_ready_variant_url(source_image, variant_type) or product.main_image
+    return (
+        _approved_ready_variant_url(source_image, variant_type)
+        or _ready_original_variant_url(source_image)
+        or product.main_image
+    )
+
+
+def _main_image_public_url(product: Product) -> Optional[str]:
+    if not product.main_image:
+        return None
+
+    source_image = next(
+        (
+            image
+            for image in (product.gallery_images or [])
+            if _is_same_image_url(image.url, product.main_image)
+        ),
+        None,
+    )
+    if not source_image:
+        return product.main_image
+
+    return _ready_original_variant_url(source_image) or product.main_image
 
 
 def map_product_to_response(
@@ -96,7 +133,7 @@ def map_product_to_response(
             gallery.append(
                 ProductImageResponse(
                     id=img.id,
-                    url=img.url,
+                    url=_public_image_url(img),
                     is_installation_photo=img.is_installation_photo,
                     card_variant_url=_approved_ready_variant_url(
                         img,
@@ -147,7 +184,7 @@ def map_product_to_response(
         area=product.area,
         is_inverter=product.is_inverter,
         power_cooling=product.power_cooling,
-        main_image=product.main_image,
+        main_image=_main_image_public_url(product),
         card_image=_main_image_variant_or_fallback(product, ProductImageVariantType.CARD),
         full_image=_main_image_variant_or_fallback(product, ProductImageVariantType.FULL),
         is_published=product.is_published,

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -301,6 +301,64 @@ async def test_apply_to_order_stores_repair_nameplate_content(
 
 
 @pytest.mark.asyncio
+async def test_apply_to_order_preserves_new_attachment_when_order_already_has_telegram_attachment(
+    sqlite_repair_nameplate_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "services.bot_order_attachment_service.get_general_media_storage",
+        lambda: FakeGeneralMediaStorage(),
+    )
+    order = Order(
+        id=42,
+        title="Ремонт",
+        status=OrderStatus.EXECUTION,
+        workflow_type="repair",
+        technical_meta={
+            BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY: [
+                {
+                    "source": "telegram_bot",
+                    "file_id": "old-photo",
+                    "filename": "old.jpg",
+                    "mime_type": "image/jpeg",
+                    "kind": "photo",
+                    "purpose": "repair_nameplate",
+                    "attached_at": "2026-07-02T13:39:43",
+                }
+            ],
+            "repair": {"repair_status": "scheduled"},
+        },
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotRepairNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        extracted={"equipment_serial_number": "SN-002"},
+        raw_text="SERIAL SN-002",
+        validation_flags={"warnings": {}, "is_valid": True},
+        file_id="new-photo",
+        filename="nameplate.jpeg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=56,
+        can_attach_any=True,
+        file_content=b"second-nameplate-content",
+    )
+
+    assert result is not None
+    await sqlite_repair_nameplate_session.refresh(order)
+    attachments = order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY]
+    assert [attachment["file_id"] for attachment in attachments] == ["old-photo", "new-photo"]
+    assert attachments[1]["url"] == "https://cdn.mvn.by/media/orders/42/telegram/photo/hash.jpg"
+    assert attachments[1]["storage_provider"] == "r2"
+    assert order.technical_meta["repair"]["repair_status"] == "scheduled"
+    assert order.technical_meta["repair"]["nameplate_recognitions"][0]["content_hash"] == "b" * 64
+
+
+@pytest.mark.asyncio
 async def test_apply_to_order_accepts_negotiation_repair_order(sqlite_repair_nameplate_session):
     order = Order(title="Ремонт", status=OrderStatus.NEGOTIATION, workflow_type="repair")
     sqlite_repair_nameplate_session.add(order)

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -69,6 +69,32 @@ def test_map_product_to_response_selects_only_approved_ready_card_and_full_varia
     assert payload.gallery_images[0].full_variant_url == "/media/products/variants/full/source.webp"
 
 
+def test_map_product_to_response_uses_ready_original_variant_as_public_cdn_fallback():
+    product = _product_with_variant(
+        processing_status=ProductImageProcessingStatus.READY.value,
+        manual_quality_status=ProductImageManualQualityStatus.UNREVIEWED.value,
+        variant_url="/media/products/variants/card/unapproved.webp",
+    )
+    product.gallery_images[0].variants.append(
+        ProductImageVariant(
+            id=102,
+            product_image_id=product.gallery_images[0].id,
+            variant_type=ProductImageVariantType.ORIGINAL.value,
+            url="https://cdn.mvn.by/products/variants/original/source.webp",
+            processing_status=ProductImageProcessingStatus.READY.value,
+            manual_quality_status=ProductImageManualQualityStatus.UNREVIEWED.value,
+        )
+    )
+
+    payload = map_product_to_response(product)
+
+    assert payload.main_image == "https://cdn.mvn.by/products/variants/original/source.webp"
+    assert payload.card_image == "https://cdn.mvn.by/products/variants/original/source.webp"
+    assert payload.full_image == "https://cdn.mvn.by/products/variants/original/source.webp"
+    assert payload.gallery_images[0].url == "https://cdn.mvn.by/products/variants/original/source.webp"
+    assert payload.gallery_images[0].card_variant_url is None
+
+
 @pytest.mark.parametrize(
     ("processing_status", "manual_quality_status", "variant_url"),
     [


### PR DESCRIPTION
## Summary
- use ready original image variants as the public CDN fallback for product main/card/full image fields
- keep card/full processed variants gated by ready + approved before exposing them publicly
- return CDN original URLs for public gallery image entries when available

## Production context
- current production has 4435 ready original variants on cdn.mvn.by and 0 approved card/full variants
- this lets mvn.by start using CDN image URLs without bulk-approving processed variants blindly

## Tests
- python3 -m py_compile services/product_response_mapper.py
- pytest tests/unit/test_product_response_mapper_variants.py tests/unit/test_product_image_variants.py -q
- pytest tests/unit/test_product_response_mapper_variants.py tests/unit/test_public_product_series_payloads.py tests/unit/test_product_filtering_jsonb.py -q *(14 passed, then local setup error because Postgres on localhost:5433 is not running)*