### PR TITLE
Add legacy main image R2 backfill

### DIFF
--- a/docs/media-storage-r2.md
+++ b/docs/media-storage-r2.md
@@ -132,6 +132,19 @@ The command updates `ProductImageVariant` rows only. It does not rewrite
 `ProductImage.url`, `Product.main_image`, or `Product.images`, and it does not
 delete local media files.
 
+For legacy `Product.main_image` values that point at local files but do not have
+a matching `ProductImage` row yet, use the main-image backfill helper:
+
+```bash
+python3 scripts/backfill_product_main_images_storage.py --provider r2 --limit 50
+python3 scripts/backfill_product_main_images_storage.py --provider r2 --limit 50 --execute
+```
+
+This helper also preserves `Product.main_image`. When needed, it creates the
+missing canonical `ProductImage(url=main_image)` row and stores an `original`
+variant in R2, so public API mappers can expose the CDN URL through an exact
+main-image match instead of guessing from gallery order.
+
 Manual and legacy writers that write under `media/products` remain local/manual
 tools unless a future issue explicitly migrates them: examples include
 `services/image_service.py` via older product/article/order paths,

--- a/scripts/backfill_product_main_images_storage.py
+++ b/scripts/backfill_product_main_images_storage.py
@@ -1,0 +1,201 @@
+"""Backfill legacy Product.main_image files into product media storage.
+
+Default mode is dry-run. Use --execute only after reviewing planned uploads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+sys.path.append(".")
+
+from services.media_storage_service import get_product_media_storage  # noqa: E402
+from services.product_main_image_backfill_service import (  # noqa: E402
+    ProductMainImageBackfillService,
+)
+
+
+STORAGE_PROVIDERS = ("local", "r2", "s3", "s3_compatible")
+
+
+async def backfill_product_main_images_storage(
+    *,
+    session: AsyncSession,
+    execute: bool,
+    provider: str | None,
+    limit: int,
+    product_id: int | None,
+    after_product_id: int | None,
+    published_only: bool,
+    force: bool,
+) -> dict[str, Any]:
+    storage = get_product_media_storage(provider, require_write=execute)
+    return await ProductMainImageBackfillService.backfill_to_storage(
+        session=session,
+        storage=storage,
+        execute=execute,
+        limit=limit,
+        product_id=product_id,
+        after_product_id=after_product_id,
+        published_only=published_only,
+        force=force,
+    )
+
+
+async def run(
+    *,
+    execute: bool,
+    provider: str | None,
+    limit: int,
+    product_id: int | None,
+    after_product_id: int | None,
+    published_only: bool,
+    force: bool,
+) -> dict[str, Any]:
+    from core.database import async_session_maker
+
+    async with async_session_maker() as session:
+        return await backfill_product_main_images_storage(
+            session=session,
+            execute=execute,
+            provider=provider,
+            limit=limit,
+            product_id=product_id,
+            after_product_id=after_product_id,
+            published_only=published_only,
+            force=force,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan or execute upload of legacy Product.main_image local files "
+            "to the configured product media storage provider."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Upload files and create/update ProductImage original variants.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Force report-only mode. This is already the default.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=STORAGE_PROVIDERS,
+        default=None,
+        help="Storage provider override. Defaults to PRODUCT_MEDIA_STORAGE_PROVIDER.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum products to inspect in this run (1-1000, default: 50).",
+    )
+    parser.add_argument(
+        "--product-id",
+        type=int,
+        default=None,
+        help="Limit backfill plan to one product id.",
+    )
+    parser.add_argument(
+        "--after-product-id",
+        type=int,
+        default=None,
+        help="Only inspect products with id greater than this value.",
+    )
+    parser.add_argument(
+        "--published-only",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Only inspect published products by default.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-upload even if the exact ProductImage original is already on target storage.",
+    )
+    return parser
+
+
+def print_report(report: dict[str, Any]) -> None:
+    print("Product Main Image Storage Backfill")
+    print(f"  mode={'DRY-RUN' if report['dry_run'] else 'EXECUTE'}")
+    print(f"  storage_provider={report['storage_provider']}")
+    print(f"  product_id={report['product_id'] or 'all'}")
+    print(f"  limit={report['limit']}")
+    print(f"  after_product_id={report['after_product_id'] or 'none'}")
+    print(f"  published_only={report['published_only']}")
+    print(f"  force={report['force']}")
+    print(f"  inspected={report['inspected']}")
+    print(f"  planned_uploads={report['planned_uploads']}")
+    print(f"  skipped={report['skipped_count']}")
+    if not report["dry_run"]:
+        print(f"  uploaded={report['uploaded']}")
+        print(f"  updated_variants={report['updated_variants']}")
+        print(f"  errors={len(report['errors'])}")
+
+    if report["items"]:
+        print("\nPlanned uploads" if report["dry_run"] else "\nUploaded")
+        rows = report["items"] if report["dry_run"] else report.get("uploaded_items", [])
+        for item in rows[:50]:
+            create_marker = " create-image" if item.get("will_create_product_image") else ""
+            print(
+                "  - "
+                f"product#{item['product_id']} main={item['main_image']} "
+                f"target={item['target_url']}{create_marker}"
+            )
+        if len(rows) > 50:
+            print(f"  ... {len(rows) - 50} more")
+
+    if report["skipped"]:
+        print("\nSkipped")
+        for item in report["skipped"][:30]:
+            print(
+                "  - "
+                f"product#{item['product_id']} reason={item.get('skip_reason')} "
+                f"main={item.get('main_image')}"
+            )
+        if len(report["skipped"]) > 30:
+            print(f"  ... {len(report['skipped']) - 30} more")
+
+    if report["errors"]:
+        print("\nErrors")
+        for item in report["errors"]:
+            print(
+                "  - "
+                f"product#{item['product_id']} main={item['main_image']} "
+                f"error={item['error']}"
+            )
+
+    if report["dry_run"]:
+        print("\nDry run only. Use --execute after reviewing this bounded plan.")
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    report = asyncio.run(
+        run(
+            execute=bool(args.execute and not args.dry_run),
+            provider=args.provider,
+            limit=args.limit,
+            product_id=args.product_id,
+            after_product_id=args.after_product_id,
+            published_only=args.published_only,
+            force=args.force,
+        )
+    )
+    print_report(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/product_main_image_backfill_service.py
+++ b/services/product_main_image_backfill_service.py
@@ -1,0 +1,277 @@
+"""Backfill legacy product main images into canonical image variants."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Product, ProductImage, ProductImageVariant
+from services.media_storage_service import ProductMediaStorage
+from services.product_image_processing_contract import (
+    ProductImageManualQualityStatus,
+    ProductImageProcessingProvider,
+    ProductImageProcessingStage,
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
+from services.product_image_variant_service import ProductImageVariantService
+
+
+class ProductMainImageBackfillService:
+    @staticmethod
+    async def backfill_to_storage(
+        session: AsyncSession,
+        *,
+        storage: ProductMediaStorage,
+        execute: bool,
+        limit: int = 50,
+        product_id: int | None = None,
+        after_product_id: int | None = None,
+        published_only: bool = True,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        safe_limit = max(1, min(int(limit), 1000))
+        plan = await ProductMainImageBackfillService.build_backfill_plan(
+            session,
+            storage=storage,
+            limit=safe_limit,
+            product_id=product_id,
+            after_product_id=after_product_id,
+            published_only=published_only,
+            force=force,
+        )
+        plan["dry_run"] = not execute
+        if not execute:
+            return plan
+
+        uploaded: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        now = datetime.now()
+
+        for item in plan["items"]:
+            try:
+                source_path = Path(item["source_path"])
+                content = source_path.read_bytes()
+                image = await ProductMainImageBackfillService._resolve_product_image(
+                    session,
+                    product_id=item["product_id"],
+                    image_id=item.get("product_image_id"),
+                    url=item["main_image"],
+                )
+                stored = await storage.save_product_variant(
+                    content=content,
+                    variant_type=ProductImageVariantType.ORIGINAL.value,
+                    extension=item["extension"],
+                )
+                variant = await ProductImageVariantService._get_or_create_variant(
+                    session,
+                    product_image_id=image.id,
+                    variant_type=ProductImageVariantType.ORIGINAL.value,
+                )
+                width, height = ProductImageVariantService._image_size(content)
+                variant.url = stored.url
+                variant.storage_provider = stored.storage_provider
+                variant.content_hash = stored.content_hash
+                variant.width = variant.width or width
+                variant.height = variant.height or height
+                variant.processing_status = ProductImageProcessingStatus.READY.value
+                variant.processing_stage = ProductImageProcessingStage.ORIGINAL_INGEST.value
+                variant.processing_provider = ProductImageProcessingProvider.MANUAL.value
+                variant.manual_quality_status = ProductImageManualQualityStatus.UNREVIEWED.value
+                variant.processing_error = None
+                variant.processed_at = variant.processed_at or now
+                variant.updated_at = now
+                session.add(variant)
+                uploaded.append(
+                    {
+                        **item,
+                        "product_image_id": image.id,
+                        "target_url": stored.url,
+                        "target_path": stored.path,
+                        "storage_provider": stored.storage_provider,
+                    }
+                )
+            except Exception as exc:
+                errors.append(
+                    {
+                        "product_id": item["product_id"],
+                        "main_image": item["main_image"],
+                        "error": str(exc),
+                    }
+                )
+
+        await session.commit()
+        return {
+            **plan,
+            "uploaded": len(uploaded),
+            "updated_variants": len(uploaded),
+            "uploaded_items": uploaded,
+            "errors": errors,
+        }
+
+    @staticmethod
+    async def build_backfill_plan(
+        session: AsyncSession,
+        *,
+        storage: ProductMediaStorage,
+        limit: int,
+        product_id: int | None,
+        after_product_id: int | None,
+        published_only: bool,
+        force: bool,
+    ) -> dict[str, Any]:
+        stmt = (
+            select(Product)
+            .where(Product.main_image.is_not(None))
+            .order_by(Product.id)
+            .limit(max(1, min(int(limit), 1000)))
+        )
+        if published_only:
+            stmt = stmt.where(Product.is_published.is_(True))
+        if product_id is not None:
+            stmt = stmt.where(Product.id == product_id)
+        if after_product_id is not None:
+            stmt = stmt.where(Product.id > after_product_id)
+
+        products = (await session.execute(stmt)).scalars().all()
+        items: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        for product in products:
+            item = await ProductMainImageBackfillService._plan_product(
+                session,
+                storage=storage,
+                product=product,
+                force=force,
+            )
+            if item["planned"]:
+                items.append(item)
+            else:
+                skipped.append(item)
+
+        return {
+            "dry_run": True,
+            "storage_provider": storage.provider_name,
+            "limit": limit,
+            "product_id": product_id,
+            "after_product_id": after_product_id,
+            "published_only": published_only,
+            "force": force,
+            "inspected": len(products),
+            "planned_uploads": len(items),
+            "skipped_count": len(skipped),
+            "items": items,
+            "skipped": skipped,
+            "uploaded": 0,
+            "updated_variants": 0,
+            "uploaded_items": [],
+            "errors": [],
+        }
+
+    @staticmethod
+    async def _plan_product(
+        session: AsyncSession,
+        *,
+        storage: ProductMediaStorage,
+        product: Product,
+        force: bool,
+    ) -> dict[str, Any]:
+        base = {
+            "planned": False,
+            "product_id": product.id,
+            "main_image": product.main_image,
+            "product_image_id": None,
+            "variant_id": None,
+            "current_storage_provider": None,
+            "current_variant_url": None,
+        }
+        main_image = str(product.main_image or "").strip()
+        source_path = ProductImageVariantService._local_media_path_for_url(main_image)
+        if source_path is None:
+            return {**base, "skip_reason": "non_local_url"}
+        if not source_path.exists():
+            return {
+                **base,
+                "source_path": str(source_path),
+                "skip_reason": "missing_local_file",
+            }
+
+        image = (
+            await session.execute(
+                select(ProductImage).where(
+                    ProductImage.product_id == product.id,
+                    ProductImage.url == main_image,
+                )
+            )
+        ).scalar_one_or_none()
+        variant = None
+        if image:
+            variant = (
+                await session.execute(
+                    select(ProductImageVariant).where(
+                        ProductImageVariant.product_image_id == image.id,
+                        ProductImageVariant.variant_type
+                        == ProductImageVariantType.ORIGINAL.value,
+                    )
+                )
+            ).scalar_one_or_none()
+            if (
+                variant
+                and not force
+                and variant.storage_provider == storage.provider_name
+                and variant.url
+                and variant.processing_status == ProductImageProcessingStatus.READY.value
+            ):
+                return {
+                    **base,
+                    "product_image_id": image.id,
+                    "variant_id": variant.id,
+                    "current_storage_provider": variant.storage_provider,
+                    "current_variant_url": variant.url,
+                    "skip_reason": "already_on_target_provider",
+                }
+
+        content = source_path.read_bytes()
+        content_hash = hashlib.sha256(content).hexdigest()
+        extension = source_path.suffix.lower().lstrip(".") or "webp"
+        target = storage.build_product_variant_object(
+            content_hash=content_hash,
+            variant_type=ProductImageVariantType.ORIGINAL.value,
+            extension=extension,
+        )
+        return {
+            **base,
+            "planned": True,
+            "product_image_id": image.id if image else None,
+            "variant_id": variant.id if variant else None,
+            "current_storage_provider": variant.storage_provider if variant else None,
+            "current_variant_url": variant.url if variant else None,
+            "will_create_product_image": image is None,
+            "source_path": str(source_path),
+            "extension": extension,
+            "content_hash": content_hash,
+            "target_url": target.url,
+            "target_path": target.path,
+            "target_storage_provider": target.storage_provider,
+        }
+
+    @staticmethod
+    async def _resolve_product_image(
+        session: AsyncSession,
+        *,
+        product_id: int,
+        image_id: int | None,
+        url: str,
+    ) -> ProductImage:
+        if image_id:
+            image = await session.get(ProductImage, image_id)
+            if image:
+                return image
+        image = ProductImage(product_id=product_id, url=url)
+        session.add(image)
+        await session.flush()
+        return image

--- a/tests/unit/test_product_main_image_backfill_service.py
+++ b/tests/unit/test_product_main_image_backfill_service.py
@@ -1,0 +1,224 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import Product, ProductImage, ProductImageVariant
+from services.media_storage_service import StoredMediaObject
+from services.product_image_processing_contract import (
+    ProductImageProcessingStatus,
+    ProductImageVariantType,
+)
+from services.product_main_image_backfill_service import ProductMainImageBackfillService
+
+
+class RecordingStorage:
+    provider_name = "r2"
+
+    def __init__(self):
+        self.uploads = []
+
+    def build_product_variant_object(
+        self,
+        *,
+        content_hash: str,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        path = f"products/variants/{variant_type}/{content_hash}.{extension}"
+        return StoredMediaObject(
+            url=f"https://cdn.mvn.by/{path}",
+            content_hash=content_hash,
+            storage_provider=self.provider_name,
+            path=path,
+        )
+
+    async def save_product_variant(
+        self,
+        *,
+        content: bytes,
+        variant_type: str,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        import hashlib
+
+        self.uploads.append(
+            {
+                "content": content,
+                "variant_type": variant_type,
+                "extension": extension,
+            }
+        )
+        return self.build_product_variant_object(
+            content_hash=hashlib.sha256(content).hexdigest(),
+            variant_type=variant_type,
+            extension=extension,
+        )
+
+
+def _image_bytes(color=(40, 90, 180), *, fmt: str = "WEBP") -> bytes:
+    image = Image.new("RGB", (12, 10), color)
+    output = BytesIO()
+    image.save(output, format=fmt)
+    return output.getvalue()
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'main_image_backfill.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _make_product(
+    session: AsyncSession,
+    *,
+    product_id: int | None = None,
+    main_image: str = "/media/products/legacy-main.webp",
+    is_published: bool = True,
+) -> Product:
+    product = Product(
+        id=product_id,
+        title=f"Legacy main {product_id or ''}".strip(),
+        slug=f"legacy-main-{product_id or 'auto'}",
+        price=1000,
+        area=20,
+        specs={},
+        main_image=main_image,
+        is_published=is_published,
+    )
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+
+@pytest.mark.asyncio
+async def test_main_image_backfill_dry_run_plans_without_db_writes(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    media_path = tmp_path / "media/products/legacy-main.webp"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(_image_bytes())
+    product = await _make_product(sqlite_session)
+    storage = RecordingStorage()
+
+    report = await ProductMainImageBackfillService.backfill_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=False,
+        limit=10,
+    )
+
+    image = (
+        await sqlite_session.execute(
+            select(ProductImage).where(ProductImage.product_id == product.id)
+        )
+    ).scalar_one_or_none()
+    assert report["dry_run"] is True
+    assert report["planned_uploads"] == 1
+    assert report["items"][0]["will_create_product_image"] is True
+    assert report["items"][0]["target_url"].startswith(
+        "https://cdn.mvn.by/products/variants/original/"
+    )
+    assert image is None
+    assert storage.uploads == []
+
+
+@pytest.mark.asyncio
+async def test_main_image_backfill_execute_creates_exact_image_and_original_variant(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    media_path = tmp_path / "media/products/legacy-main.webp"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(_image_bytes())
+    product = await _make_product(sqlite_session)
+    storage = RecordingStorage()
+
+    report = await ProductMainImageBackfillService.backfill_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=True,
+        limit=10,
+    )
+
+    image = (
+        await sqlite_session.execute(
+            select(ProductImage).where(
+                ProductImage.product_id == product.id,
+                ProductImage.url == product.main_image,
+            )
+        )
+    ).scalar_one()
+    variant = (
+        await sqlite_session.execute(
+            select(ProductImageVariant).where(
+                ProductImageVariant.product_image_id == image.id,
+                ProductImageVariant.variant_type == ProductImageVariantType.ORIGINAL.value,
+            )
+        )
+    ).scalar_one()
+
+    assert report["dry_run"] is False
+    assert report["uploaded"] == 1
+    assert len(storage.uploads) == 1
+    assert image.url == "/media/products/legacy-main.webp"
+    assert variant.storage_provider == "r2"
+    assert variant.processing_status == ProductImageProcessingStatus.READY.value
+    assert variant.url.startswith("https://cdn.mvn.by/products/variants/original/")
+
+
+@pytest.mark.asyncio
+async def test_main_image_backfill_skips_existing_ready_r2_exact_match(
+    sqlite_session,
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    media_path = tmp_path / "media/products/legacy-main.webp"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(_image_bytes())
+    product = await _make_product(sqlite_session)
+    image = ProductImage(product_id=product.id, url=product.main_image)
+    sqlite_session.add(image)
+    await sqlite_session.flush()
+    sqlite_session.add(
+        ProductImageVariant(
+            product_image_id=image.id,
+            variant_type=ProductImageVariantType.ORIGINAL.value,
+            url="https://cdn.mvn.by/products/variants/original/existing.webp",
+            storage_provider="r2",
+            processing_status=ProductImageProcessingStatus.READY.value,
+            processing_stage="original_ingest",
+        )
+    )
+    await sqlite_session.commit()
+    storage = RecordingStorage()
+
+    report = await ProductMainImageBackfillService.backfill_to_storage(
+        sqlite_session,
+        storage=storage,
+        execute=True,
+        limit=10,
+    )
+
+    assert report["planned_uploads"] == 0
+    assert report["uploaded"] == 0
+    assert report["skipped"][0]["skip_reason"] == "already_on_target_provider"
+    assert storage.uploads == []


### PR DESCRIPTION
## Summary
- add a dry-run-first helper to backfill legacy Product.main_image local files into canonical ProductImage original variants on R2
- keep Product.main_image unchanged while creating missing ProductImage(url=main_image) rows when needed
- document the bounded production commands for R2 media cleanup

## Tests
- pytest tests/unit/test_product_main_image_backfill_service.py tests/unit/test_product_media_migration_service.py tests/unit/test_product_response_mapper_variants.py -q
- python3 -m py_compile services/product_main_image_backfill_service.py scripts/backfill_product_main_images_storage.py