### PR TITLE
Map legacy product images to CDN variants

### DIFF
--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -54,6 +54,29 @@ def _public_image_url(image: Any) -> Optional[str]:
     return _ready_original_variant_url(image) or image.url
 
 
+def _public_image_url_map(product: Product) -> Dict[str, str]:
+    url_map = {}
+    for image in product.gallery_images or []:
+        public_url = _public_image_url(image)
+        source_url = getattr(image, "url", None)
+        if not source_url or not public_url:
+            continue
+        url_map[source_url] = public_url
+        url_map[source_url.strip("/")] = public_url
+    return url_map
+
+
+def _public_legacy_image_urls(product: Product, image_urls: List[str]) -> List[str]:
+    url_map = _public_image_url_map(product)
+    public_urls = []
+    for url in image_urls:
+        if not isinstance(url, str):
+            public_urls.append(url)
+            continue
+        public_urls.append(url_map.get(url) or url_map.get(url.strip("/")) or url)
+    return public_urls
+
+
 def _main_image_variant_or_fallback(
     product: Product,
     variant_type: ProductImageVariantType,
@@ -205,7 +228,7 @@ def map_product_to_response(
         series=series_payload,
         tags=tags_payload,
         specs=specs or {},
-        images=images or [],
+        images=_public_legacy_image_urls(product, images or []),
         gallery_images=gallery,
         manuals=manuals_payload,
         series_siblings=siblings_payload,

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -95,6 +95,52 @@ def test_map_product_to_response_uses_ready_original_variant_as_public_cdn_fallb
     assert payload.gallery_images[0].card_variant_url is None
 
 
+def test_map_product_to_response_rewrites_legacy_images_to_public_original_variants():
+    product = _product_with_variant()
+    product.images = [
+        "/media/products/source.webp",
+        "media/products/extra.webp",
+        "/media/products/missing.webp",
+        "https://example.com/vendor.jpg",
+    ]
+    product.gallery_images[0].variants.append(
+        ProductImageVariant(
+            id=102,
+            product_image_id=product.gallery_images[0].id,
+            variant_type=ProductImageVariantType.ORIGINAL.value,
+            url="https://cdn.mvn.by/products/variants/original/source.webp",
+            processing_status=ProductImageProcessingStatus.READY.value,
+            manual_quality_status=ProductImageManualQualityStatus.UNREVIEWED.value,
+        )
+    )
+    extra_image = ProductImage(
+        id=11,
+        product_id=product.id,
+        url="/media/products/extra.webp",
+        is_installation_photo=False,
+    )
+    extra_image.variants = [
+        ProductImageVariant(
+            id=103,
+            product_image_id=extra_image.id,
+            variant_type=ProductImageVariantType.ORIGINAL.value,
+            url="https://cdn.mvn.by/products/variants/original/extra.webp",
+            processing_status=ProductImageProcessingStatus.READY.value,
+            manual_quality_status=ProductImageManualQualityStatus.UNREVIEWED.value,
+        )
+    ]
+    product.gallery_images.append(extra_image)
+
+    payload = map_product_to_response(product)
+
+    assert payload.images == [
+        "https://cdn.mvn.by/products/variants/original/source.webp",
+        "https://cdn.mvn.by/products/variants/original/extra.webp",
+        "/media/products/missing.webp",
+        "https://example.com/vendor.jpg",
+    ]
+
+
 @pytest.mark.parametrize(
     ("processing_status", "manual_quality_status", "variant_url"),
     [


### PR DESCRIPTION
## Summary
- map legacy Product.images entries to ready original CDN variants in public product responses
- preserve unmatched local/external URLs as-is
- add unit coverage for legacy image URL rewriting

## Tests
- pytest tests/unit/test_product_response_mapper_variants.py -q
- python3 -m py_compile services/product_response_mapper.py