### PR TITLE
Hide unmapped legacy product image URLs

### DIFF
--- a/services/product_response_mapper.py
+++ b/services/product_response_mapper.py
@@ -73,8 +73,16 @@ def _public_legacy_image_urls(product: Product, image_urls: List[str]) -> List[s
         if not isinstance(url, str):
             public_urls.append(url)
             continue
-        public_urls.append(url_map.get(url) or url_map.get(url.strip("/")) or url)
+        public_url = url_map.get(url) or url_map.get(url.strip("/"))
+        if public_url:
+            public_urls.append(public_url)
+        elif not _is_legacy_product_media_url(url):
+            public_urls.append(url)
     return public_urls
+
+
+def _is_legacy_product_media_url(url: str) -> bool:
+    return url.strip().lstrip("/").startswith("media/products/")
 
 
 def _main_image_variant_or_fallback(

--- a/tests/unit/test_product_response_mapper_variants.py
+++ b/tests/unit/test_product_response_mapper_variants.py
@@ -136,7 +136,6 @@ def test_map_product_to_response_rewrites_legacy_images_to_public_original_varia
     assert payload.images == [
         "https://cdn.mvn.by/products/variants/original/source.webp",
         "https://cdn.mvn.by/products/variants/original/extra.webp",
-        "/media/products/missing.webp",
         "https://example.com/vendor.jpg",
     ]
 


### PR DESCRIPTION
## Summary
- stop exposing legacy local Product.images URLs when no canonical ProductImage/R2 mapping exists
- keep mapped CDN URLs and external vendor URLs in public responses
- update mapper coverage for this behavior

## Tests
- pytest tests/unit/test_product_response_mapper_variants.py -q
- python3 -m py_compile services/product_response_mapper.py