### PR TITLE
Add Postgres PITR ops

### DIFF
--- a/deploy/ha/mvn-api/docker-compose.primary.yml
+++ b/deploy/ha/mvn-api/docker-compose.primary.yml
@@ -2,6 +2,16 @@ services:
   db:
     image: postgres:15-alpine
     restart: always
+    command:
+      - postgres
+      - -c
+      - wal_keep_size=512MB
+      - -c
+      - archive_mode=on
+      - -c
+      - archive_timeout=300s
+      - -c
+      - "archive_command=test ! -f /postgres-wal-archive/%f && cp %p /postgres-wal-archive/%f || test -f /postgres-wal-archive/%f"
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -11,6 +21,7 @@ services:
       - "10.77.0.2:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./postgres-wal-archive:/postgres-wal-archive
 
   app:
     image: ${BACKEND_IMAGE:-ghcr.io/mvnby/air-api/backend:latest}
@@ -30,6 +41,7 @@ services:
       - "127.0.0.1:8000:8000"
     volumes:
       - ./media:/app/media
+      - ./postgres-wal-archive:/postgres-wal-archive
       - ./model-cache/u2net:/root/.u2net
       - ./token.json:/app/token.json
       - ./client_secret.json:/app/client_secret.json

--- a/deploy/ha/systemd/mvn-postgres-basebackup.service
+++ b/deploy/ha/systemd/mvn-postgres-basebackup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MVN PostgreSQL PITR physical basebackup upload
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+Environment=PROJECT_DIR=/opt/air-api
+Environment=COMPOSE_FILE=docker-compose.prod.yml
+EnvironmentFile=-/etc/mvn-postgres-pitr.env
+ExecStart=/usr/local/sbin/mvn-postgres-pitr-basebackup

--- a/deploy/ha/systemd/mvn-postgres-basebackup.timer
+++ b/deploy/ha/systemd/mvn-postgres-basebackup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MVN PostgreSQL PITR physical basebackup daily
+
+[Timer]
+OnCalendar=*-*-* 04:20:00 UTC
+Persistent=true
+AccuracySec=5min
+Unit=mvn-postgres-basebackup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ha/systemd/mvn-postgres-wal-upload.service
+++ b/deploy/ha/systemd/mvn-postgres-wal-upload.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MVN PostgreSQL PITR WAL upload
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+Environment=PROJECT_DIR=/opt/air-api
+Environment=COMPOSE_FILE=docker-compose.prod.yml
+EnvironmentFile=-/etc/mvn-postgres-pitr.env
+ExecStart=/usr/local/sbin/mvn-postgres-pitr-upload-wal

--- a/deploy/ha/systemd/mvn-postgres-wal-upload.timer
+++ b/deploy/ha/systemd/mvn-postgres-wal-upload.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run MVN PostgreSQL PITR WAL upload every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=15s
+Unit=mvn-postgres-wal-upload.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ha/zakup/docker-compose.primary.yml
+++ b/deploy/ha/zakup/docker-compose.primary.yml
@@ -11,6 +11,14 @@ services:
       - shared_buffers=64MB
       - -c
       - max_connections=100
+      - -c
+      - wal_keep_size=512MB
+      - -c
+      - archive_mode=on
+      - -c
+      - archive_timeout=300s
+      - -c
+      - "archive_command=test ! -f /postgres-wal-archive/%f && cp %p /postgres-wal-archive/%f || test -f /postgres-wal-archive/%f"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
@@ -24,6 +32,7 @@ services:
       - "10.77.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./postgres-wal-archive:/postgres-wal-archive
     mem_limit: ${MVN_RESERVE_DB_MEMORY:-220m}
     networks:
       - reserve
@@ -54,6 +63,7 @@ services:
       - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
     volumes:
       - ./media:/app/media
+      - ./postgres-wal-archive:/postgres-wal-archive
       - ./model-cache/u2net:/root/.u2net
       - ./secrets/token.json:/app/token.json
       - ./secrets/client_secret.json:/app/client_secret.json:ro

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -49,6 +49,8 @@ unreviewed host-local compose edits:
 | Active-passive invariant check | `scripts/ha/check_active_passive.sh` |
 | Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
 | Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
+| PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
+| PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
 
@@ -99,6 +101,109 @@ Scheduled monitors:
 | `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups |
 | `check-api-ha-invariants.yml` | every 30 minutes | public/primary ready and standby fenced |
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
+
+## PostgreSQL PITR
+
+Streaming replication protects us from a dead primary host. PITR protects us
+from operator mistakes, corrupted writes, or needing to restore to a timestamp
+before bad data was committed.
+
+The current PITR design uses native PostgreSQL archiving:
+
+```text
+primary PostgreSQL archive_command
+  -> /opt/air-api/postgres-wal-archive
+  -> mvn-postgres-wal-upload.timer
+  -> private Cloudflare R2/S3 bucket
+
+mvn-postgres-basebackup.timer
+  -> pg_basebackup -Ft -z -X stream
+  -> same private Cloudflare R2/S3 bucket
+```
+
+Important rules:
+
+- Use a **private** bucket or private prefix for database backups. Do not reuse
+  a public media bucket exposed through `cdn.mvn.by`.
+- `archive_timeout=300s` bounds low-traffic WAL upload lag to about five
+  minutes. The streaming standby still normally has lower failover lag.
+- Only the current primary compose enables `archive_mode=on`. Standby compose
+  keeps archiving disabled until it is promoted and restarted with a primary
+  compose file.
+
+Required `.env` values on the current primary:
+
+```text
+POSTGRES_PITR_CLUSTER=mvn-api
+POSTGRES_PITR_S3_BUCKET=<private-r2-bucket>
+POSTGRES_PITR_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+POSTGRES_PITR_S3_REGION=auto
+POSTGRES_PITR_S3_ACCESS_KEY_ID=<private-r2-token-access-key>
+POSTGRES_PITR_S3_SECRET_ACCESS_KEY=<private-r2-token-secret>
+POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr
+```
+
+If `zakup` is promoted, change `POSTGRES_PITR_CLUSTER=zakup` on that host before
+enabling its PITR timers. The prefix can stay the same; cluster name separates
+the timelines.
+
+Enable on the current primary after the private bucket/token exist:
+
+```bash
+# From local repo checkout, copy/install repo-tracked PITR helpers as root on
+# the primary. The installer also creates postgres-wal-archive and chowns it to
+# the postgres container UID. No git checkout is required on production.
+tar -czf - \
+  scripts/ha/upload_postgres_pitr_to_s3.py \
+  scripts/ha/upload_postgres_pitr_wal.sh \
+  scripts/ha/create_postgres_pitr_basebackup.sh \
+  scripts/ha/install_postgres_pitr_units.sh \
+  deploy/ha/systemd/mvn-postgres-wal-upload.service \
+  deploy/ha/systemd/mvn-postgres-wal-upload.timer \
+  deploy/ha/systemd/mvn-postgres-basebackup.service \
+  deploy/ha/systemd/mvn-postgres-basebackup.timer \
+| ssh mvn-api 'tmp="$(mktemp -d)" && tar -xzf - -C "$tmp" && cd "$tmp" && PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml bash scripts/ha/install_postgres_pitr_units.sh && rm -rf "$tmp"'
+
+# Copy deploy/ha/mvn-api/docker-compose.primary.yml through CI.
+gh workflow run deploy.yml --repo mvnby/air-api --ref main -f deploy_frontend=false
+
+# In a short maintenance window, recreate only db so archive_mode=on and the
+# /postgres-wal-archive mount become active. Normal app/bot deploys do not
+# recreate db.
+ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml up -d --force-recreate db'
+
+# Prove WAL upload before enabling timers permanently.
+ssh mvn-api 'PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml DRY_RUN_UPLOAD=true /usr/local/sbin/mvn-postgres-pitr-upload-wal'
+ssh mvn-api 'PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml /usr/local/sbin/mvn-postgres-pitr-basebackup'
+
+# Then enable recurring PITR.
+ssh mvn-api 'systemctl enable --now mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer'
+```
+
+Quick PITR status:
+
+```bash
+ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml exec -T db sh -lc '\''psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -c "select archived_count,last_archived_wal,last_archived_time,failed_count,last_failed_wal,last_failed_time from pg_stat_archiver;"'\'''
+ssh mvn-api 'systemctl list-timers --all | grep mvn-postgres'
+```
+
+Point-in-time restore outline:
+
+1. Pick the latest basebackup before the target timestamp from
+   `postgres/pitr/<cluster>/basebackups/*/manifest.json`.
+2. Restore `base.tar.gz` and `pg_wal.tar.gz` into a clean PostgreSQL data
+   directory.
+3. Provide a `restore_command` that fetches archived WAL from
+   `postgres/pitr/<cluster>/wal/<timeline>/%f`.
+4. Set `recovery_target_time` to the target timestamp and start PostgreSQL with
+   `recovery.signal`.
+5. Validate the restored DB in an isolated container before replacing any
+   production role.
+
+The repo currently contains upload and basebackup automation. A full
+one-command PITR restore helper is intentionally a separate step because restore
+must be rehearsed against real private bucket credentials without touching
+production.
 
 ## GitHub Actions Routing
 

--- a/scripts/ha/create_postgres_pitr_basebackup.sh
+++ b/scripts/ha/create_postgres_pitr_basebackup.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+DB_SERVICE="${DB_SERVICE:-db}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15-alpine}"
+BACKUP_ROOT="${BACKUP_ROOT:-/tmp/mvn-postgres-pitr-basebackups}"
+KEEP_LOCAL_BACKUP="${KEEP_LOCAL_BACKUP:-false}"
+DRY_RUN_UPLOAD="${DRY_RUN_UPLOAD:-false}"
+
+log() {
+  printf '[pitr-basebackup] %s\n' "$*"
+}
+
+cd "${PROJECT_DIR}"
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+fi
+
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+db_container="$("${COMPOSE[@]}" ps -q "${DB_SERVICE}")"
+if [[ -z "${db_container}" ]]; then
+  echo "DB service is not running: ${DB_SERVICE}" >&2
+  exit 1
+fi
+
+mapfile -t db_env < <("${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'printf "%s\n%s\n%s\n" "$POSTGRES_USER" "$POSTGRES_PASSWORD" "${POSTGRES_DB:-air_conditioners}"')
+POSTGRES_USER="${db_env[0]:-}"
+POSTGRES_PASSWORD="${db_env[1]:-}"
+POSTGRES_DB="${db_env[2]:-air_conditioners}"
+
+if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_PASSWORD}" || -z "${POSTGRES_DB}" ]]; then
+  echo "Could not read POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB from ${DB_SERVICE} container." >&2
+  exit 1
+fi
+
+if ! "${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -Atqc "SELECT NOT pg_is_in_recovery()"' | grep -qx t; then
+  echo "Refusing basebackup: ${DB_SERVICE} is not the writable primary." >&2
+  exit 1
+fi
+
+network="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "${db_container}" | head -n 1)"
+db_ip="$(docker inspect -f '{{range $_, $network := .NetworkSettings.Networks}}{{println $network.IPAddress}}{{end}}' "${db_container}" | head -n 1)"
+if [[ -z "${network}" || -z "${db_ip}" ]]; then
+  echo "Could not detect Docker network/IP for ${DB_SERVICE}." >&2
+  exit 1
+fi
+
+backup_id="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_dir="${BACKUP_ROOT}/${backup_id}"
+mkdir -p "${backup_dir}"
+chmod 700 "${BACKUP_ROOT}" "${backup_dir}"
+
+cleanup() {
+  if [[ "${KEEP_LOCAL_BACKUP}" != "true" ]]; then
+    rm -rf "${backup_dir}"
+  fi
+}
+trap cleanup EXIT
+
+log "Creating physical pg_basebackup ${backup_id} from ${db_ip} on ${network}..."
+docker run --rm \
+  --network "${network}" \
+  -e PGPASSWORD="${POSTGRES_PASSWORD}" \
+  -e PGHOST="${db_ip}" \
+  -e PGUSER="${POSTGRES_USER}" \
+  -e PGLABEL="mvn-pitr-${backup_id}" \
+  -v "${backup_dir}:/backup" \
+  "${POSTGRES_IMAGE}" \
+  sh -lc 'pg_basebackup -h "$PGHOST" -U "$PGUSER" -D /backup -Ft -z -X stream -l "$PGLABEL" -P'
+
+cat >"${backup_dir}/metadata.json" <<JSON
+{
+  "backup_id": "${backup_id}",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "project_dir": "${PROJECT_DIR}",
+  "compose_file": "${COMPOSE_FILE}",
+  "db_service": "${DB_SERVICE}",
+  "postgres_db": "${POSTGRES_DB}"
+}
+JSON
+
+log "Uploading physical basebackup ${backup_id} through ${APP_SERVICE}..."
+upload_flags=()
+if [[ "${DRY_RUN_UPLOAD}" == "true" ]]; then
+  upload_flags+=(--dry-run)
+fi
+
+"${COMPOSE[@]}" run -T --rm \
+  -v "${backup_dir}:/pitr-basebackup:ro" \
+  "${APP_SERVICE}" \
+  python scripts/ha/upload_postgres_pitr_to_s3.py basebackup \
+    --source-dir /pitr-basebackup \
+    --backup-id "${backup_id}" \
+    "${upload_flags[@]}"
+
+log "basebackup ${backup_id} completed"

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15-alpine}"
+ENABLE_TIMERS="${ENABLE_TIMERS:-false}"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run as root on the current PostgreSQL primary host." >&2
+  exit 1
+fi
+
+if [[ ! -f "scripts/ha/upload_postgres_pitr_to_s3.py" ]]; then
+  echo "Run from the air-api repository root, or copy scripts/ha first." >&2
+  exit 1
+fi
+
+install -m 0755 scripts/ha/upload_postgres_pitr_to_s3.py /usr/local/sbin/mvn-postgres-pitr-upload
+install -m 0755 scripts/ha/upload_postgres_pitr_wal.sh /usr/local/sbin/mvn-postgres-pitr-upload-wal
+install -m 0755 scripts/ha/create_postgres_pitr_basebackup.sh /usr/local/sbin/mvn-postgres-pitr-basebackup
+install -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.service /etc/systemd/system/mvn-postgres-wal-upload.service
+install -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.timer /etc/systemd/system/mvn-postgres-wal-upload.timer
+install -m 0644 deploy/ha/systemd/mvn-postgres-basebackup.service /etc/systemd/system/mvn-postgres-basebackup.service
+install -m 0644 deploy/ha/systemd/mvn-postgres-basebackup.timer /etc/systemd/system/mvn-postgres-basebackup.timer
+
+archive_dir="${PROJECT_DIR}/postgres-wal-archive"
+mkdir -p "${archive_dir}"
+postgres_owner="$(docker run --rm "${POSTGRES_IMAGE}" sh -lc 'printf "%s:%s" "$(id -u postgres)" "$(id -g postgres)"')"
+chown "${postgres_owner}" "${archive_dir}"
+chmod 700 "${archive_dir}"
+{
+  printf 'PROJECT_DIR=%q\n' "${PROJECT_DIR}"
+  printf 'COMPOSE_FILE=%q\n' "${COMPOSE_FILE}"
+} >/etc/mvn-postgres-pitr.env
+chmod 600 /etc/mvn-postgres-pitr.env
+
+systemctl daemon-reload
+
+if [[ "${ENABLE_TIMERS}" == "true" ]]; then
+  systemctl enable --now mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer
+else
+  echo "Installed PITR units. Timers are not enabled yet."
+  echo "After POSTGRES_PITR_* env and archive_mode are active, run:"
+  echo "  systemctl enable --now mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer"
+fi

--- a/scripts/ha/mvn-primary-status.sh
+++ b/scripts/ha/mvn-primary-status.sh
@@ -45,8 +45,16 @@ echo "postgres_primary_and_replication:"
 SELECT pg_is_in_recovery() AS in_recovery, pg_current_wal_lsn() AS current_lsn;
 SELECT slot_name, active, active_pid, restart_lsn FROM pg_replication_slots;
 SELECT application_name, client_addr, state, sync_state, replay_lsn FROM pg_stat_replication;
+SELECT name, setting FROM pg_settings WHERE name IN ('archive_mode', 'archive_timeout', 'archive_command') ORDER BY name;
+SELECT archived_count, last_archived_wal, last_archived_time, failed_count, last_failed_wal, last_failed_time FROM pg_stat_archiver;
 SELECT locktype, granted, objid::bigint, pid, mode FROM pg_locks WHERE locktype = 'advisory' ORDER BY pid;
 SQL
+
+echo
+echo "pitr_timers:"
+systemctl is-active mvn-postgres-wal-upload.timer || true
+systemctl is-active mvn-postgres-basebackup.timer || true
+systemctl list-timers --all | grep mvn-postgres || true
 
 echo
 echo "backups:"

--- a/scripts/ha/upload_postgres_pitr_to_s3.py
+++ b/scripts/ha/upload_postgres_pitr_to_s3.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Upload PostgreSQL PITR artifacts to a private S3-compatible bucket.
+
+This is intended to run from the backend image, which already includes boto3.
+It deliberately requires POSTGRES_PITR_* variables and does not fall back to
+public product-media R2 credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import socket
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+WAL_NAME_RE = re.compile(
+    r"^(?:[0-9A-F]{24}|[0-9A-F]{24}\.[0-9A-F]{8}\.backup|[0-9A-F]{8}\.history)$"
+)
+
+
+@dataclass(frozen=True)
+class PitrS3Config:
+    bucket: str
+    endpoint_url: str
+    region: str
+    access_key_id: str
+    secret_access_key: str
+    key_prefix: str
+    cluster: str
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def load_config() -> PitrS3Config:
+    config = PitrS3Config(
+        bucket=_env("POSTGRES_PITR_S3_BUCKET"),
+        endpoint_url=_env("POSTGRES_PITR_S3_ENDPOINT_URL"),
+        region=_env("POSTGRES_PITR_S3_REGION", "auto"),
+        access_key_id=_env("POSTGRES_PITR_S3_ACCESS_KEY_ID"),
+        secret_access_key=_env("POSTGRES_PITR_S3_SECRET_ACCESS_KEY"),
+        key_prefix=_env("POSTGRES_PITR_S3_KEY_PREFIX", "postgres/pitr").strip("/"),
+        cluster=_env("POSTGRES_PITR_CLUSTER").strip("/"),
+    )
+    missing = [
+        name
+        for name, value in (
+            ("POSTGRES_PITR_S3_BUCKET", config.bucket),
+            ("POSTGRES_PITR_S3_ENDPOINT_URL", config.endpoint_url),
+            ("POSTGRES_PITR_S3_ACCESS_KEY_ID", config.access_key_id),
+            ("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", config.secret_access_key),
+            ("POSTGRES_PITR_CLUSTER", config.cluster),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit(
+            "Missing private PostgreSQL PITR S3 settings: " + ", ".join(missing)
+        )
+    return config
+
+
+def build_client(config: PitrS3Config):
+    try:
+        import boto3
+        from botocore.config import Config
+    except ImportError as exc:  # pragma: no cover - dependency check
+        raise SystemExit("boto3/botocore are required for PITR uploads") from exc
+
+    return boto3.client(
+        "s3",
+        endpoint_url=config.endpoint_url,
+        region_name=config.region,
+        aws_access_key_id=config.access_key_id,
+        aws_secret_access_key=config.secret_access_key,
+        config=Config(signature_version="s3v4"),
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def iter_wal_files(archive_dir: Path) -> Iterable[Path]:
+    for path in sorted(archive_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if WAL_NAME_RE.match(path.name):
+            yield path
+
+
+def wal_key(config: PitrS3Config, filename: str) -> str:
+    timeline = filename[:8]
+    return f"{config.key_prefix}/{config.cluster}/wal/{timeline}/{filename}"
+
+
+def basebackup_key(config: PitrS3Config, backup_id: str, filename: str) -> str:
+    return f"{config.key_prefix}/{config.cluster}/basebackups/{backup_id}/{filename}"
+
+
+def upload_file(client, config: PitrS3Config, source: Path, key: str, dry_run: bool) -> None:
+    if dry_run:
+        print(json.dumps({"action": "dry_run_upload", "key": key, "path": str(source)}))
+        return
+
+    client.upload_file(
+        str(source),
+        config.bucket,
+        key,
+        ExtraArgs={
+            "ContentType": "application/octet-stream",
+            "CacheControl": "private, max-age=0, no-store",
+            "Metadata": {
+                "sha256": sha256_file(source),
+                "uploaded-by": "mvn-postgres-pitr",
+            },
+        },
+    )
+    client.head_object(Bucket=config.bucket, Key=key)
+
+
+def upload_wal(args: argparse.Namespace) -> int:
+    config = load_config()
+    archive_dir = Path(args.archive_dir)
+    if not archive_dir.is_dir():
+        raise SystemExit(f"WAL archive dir does not exist: {archive_dir}")
+
+    client = build_client(config)
+    uploaded = 0
+    for path in iter_wal_files(archive_dir):
+        key = wal_key(config, path.name)
+        upload_file(client, config, path, key, args.dry_run)
+        uploaded += 1
+        print(
+            json.dumps(
+                {
+                    "action": "uploaded_wal" if not args.dry_run else "planned_wal",
+                    "filename": path.name,
+                    "key": key,
+                    "size_bytes": path.stat().st_size,
+                },
+                sort_keys=True,
+            )
+        )
+        if args.delete_after_upload and not args.dry_run:
+            path.unlink()
+
+    print(json.dumps({"kind": "wal", "count": uploaded}, sort_keys=True))
+    return 0
+
+
+def iter_basebackup_files(source_dir: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(source_dir.iterdir())
+        if path.is_file() and not path.name.startswith(".")
+    ]
+
+
+def upload_basebackup(args: argparse.Namespace) -> int:
+    config = load_config()
+    source_dir = Path(args.source_dir)
+    if not source_dir.is_dir():
+        raise SystemExit(f"Basebackup dir does not exist: {source_dir}")
+
+    backup_id = args.backup_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    files = iter_basebackup_files(source_dir)
+    if not files:
+        raise SystemExit(f"No basebackup files found in {source_dir}")
+
+    client = build_client(config)
+    manifest = {
+        "backup_id": backup_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "cluster": config.cluster,
+        "hostname": socket.gethostname(),
+        "files": [],
+    }
+
+    for path in files:
+        digest = sha256_file(path)
+        key = basebackup_key(config, backup_id, path.name)
+        upload_file(client, config, path, key, args.dry_run)
+        manifest["files"].append(
+            {
+                "name": path.name,
+                "key": key,
+                "size_bytes": path.stat().st_size,
+                "sha256": digest,
+            }
+        )
+        print(
+            json.dumps(
+                {
+                    "action": "uploaded_basebackup"
+                    if not args.dry_run
+                    else "planned_basebackup",
+                    "filename": path.name,
+                    "key": key,
+                    "size_bytes": path.stat().st_size,
+                },
+                sort_keys=True,
+            )
+        )
+
+    manifest_bytes = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+    manifest_key = basebackup_key(config, backup_id, "manifest.json")
+    if args.dry_run:
+        print(json.dumps({"action": "dry_run_manifest", "key": manifest_key}))
+    else:
+        client.put_object(
+            Bucket=config.bucket,
+            Key=manifest_key,
+            Body=manifest_bytes,
+            ContentType="application/json",
+            CacheControl="private, max-age=0, no-store",
+        )
+        client.head_object(Bucket=config.bucket, Key=manifest_key)
+
+    print(
+        json.dumps(
+            {
+                "kind": "basebackup",
+                "backup_id": backup_id,
+                "files": len(files),
+                "manifest_key": manifest_key,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Upload PostgreSQL PITR WAL/basebackup files to private S3/R2."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    wal = subparsers.add_parser("wal", help="Upload archived WAL files")
+    wal.add_argument("--archive-dir", default="/postgres-wal-archive")
+    wal.add_argument("--dry-run", action="store_true")
+    wal.add_argument(
+        "--delete-after-upload",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Delete local WAL files only after successful upload and head check.",
+    )
+    wal.set_defaults(func=upload_wal)
+
+    basebackup = subparsers.add_parser("basebackup", help="Upload a pg_basebackup dir")
+    basebackup.add_argument("--source-dir", required=True)
+    basebackup.add_argument("--backup-id", default="")
+    basebackup.add_argument("--dry-run", action="store_true")
+    basebackup.set_defaults(func=upload_basebackup)
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ha/upload_postgres_pitr_wal.sh
+++ b/scripts/ha/upload_postgres_pitr_wal.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+ARCHIVE_DIR="${ARCHIVE_DIR:-/postgres-wal-archive}"
+DRY_RUN_UPLOAD="${DRY_RUN_UPLOAD:-false}"
+DELETE_AFTER_UPLOAD="${DELETE_AFTER_UPLOAD:-true}"
+
+cd "${PROJECT_DIR}"
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+fi
+
+upload_flags=()
+if [[ "${DRY_RUN_UPLOAD}" == "true" ]]; then
+  upload_flags+=(--dry-run)
+fi
+if [[ "${DELETE_AFTER_UPLOAD}" == "true" ]]; then
+  upload_flags+=(--delete-after-upload)
+else
+  upload_flags+=(--no-delete-after-upload)
+fi
+
+docker compose -f "${COMPOSE_FILE}" run -T --rm "${APP_SERVICE}" \
+  python scripts/ha/upload_postgres_pitr_to_s3.py wal \
+    --archive-dir "${ARCHIVE_DIR}" \
+    "${upload_flags[@]}"

--- a/tests/unit/test_postgres_pitr_upload.py
+++ b/tests/unit/test_postgres_pitr_upload.py
@@ -1,0 +1,66 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts/ha/upload_postgres_pitr_to_s3.py"
+SPEC = importlib.util.spec_from_file_location("upload_postgres_pitr_to_s3", MODULE_PATH)
+assert SPEC and SPEC.loader
+pitr = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pitr
+SPEC.loader.exec_module(pitr)
+
+
+def test_wal_filename_filter_accepts_postgres_archive_files(tmp_path):
+    accepted = [
+        "00000001000000000000000A",
+        "00000001000000000000000A.00000028.backup",
+        "00000002.history",
+    ]
+    rejected = [
+        ".hidden",
+        "00000001000000000000000A.partial",
+        "README",
+        "00000001000000000000000",
+    ]
+
+    for name in accepted + rejected:
+        (tmp_path / name).write_bytes(b"x")
+
+    assert [path.name for path in pitr.iter_wal_files(tmp_path)] == accepted
+
+
+def test_wal_key_groups_by_cluster_and_timeline():
+    config = pitr.PitrS3Config(
+        bucket="private",
+        endpoint_url="https://example.invalid",
+        region="auto",
+        access_key_id="key",
+        secret_access_key="secret",
+        key_prefix="postgres/pitr",
+        cluster="mvn-api",
+    )
+
+    assert (
+        pitr.wal_key(config, "00000001000000000000000A")
+        == "postgres/pitr/mvn-api/wal/00000001/00000001000000000000000A"
+    )
+
+
+def test_pitr_config_does_not_fall_back_to_public_media_env(monkeypatch):
+    monkeypatch.delenv("POSTGRES_PITR_S3_BUCKET", raising=False)
+    monkeypatch.delenv("POSTGRES_PITR_S3_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_PITR_S3_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("POSTGRES_PITR_CLUSTER", "mvn-api")
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_BUCKET", "public-media")
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_ENDPOINT_URL", "https://public.invalid")
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_ACCESS_KEY_ID", "public-key")
+    monkeypatch.setenv("PRODUCT_MEDIA_S3_SECRET_ACCESS_KEY", "public-secret")
+
+    with pytest.raises(SystemExit) as exc:
+        pitr.load_config()
+
+    assert "POSTGRES_PITR_S3_BUCKET" in str(exc.value)


### PR DESCRIPTION
## Summary
- add native Postgres WAL archive settings to repo-tracked primary compose files
- add private R2/S3 PITR upload helpers for WAL and physical basebackups
- add systemd timers, installer, status output, and HA runbook instructions

## Verification
- pytest tests/unit/test_postgres_pitr_upload.py -q
- python3 -m py_compile scripts/ha/upload_postgres_pitr_to_s3.py
- bash -n scripts/ha/create_postgres_pitr_basebackup.sh scripts/ha/upload_postgres_pitr_wal.sh scripts/ha/install_postgres_pitr_units.sh scripts/ha/mvn-primary-status.sh
- docker compose config for mvn-api and zakup primary HA compose files
- bash scripts/ha/check_active_passive.sh