### PR TITLE
Update existing bot attachment media URLs

### DIFF
--- a/services/bot_order_attachment_service.py
+++ b/services/bot_order_attachment_service.py
@@ -18,6 +18,23 @@ from services.staff_user_service import StaffUserService
 
 class BotOrderAttachmentService:
     TELEGRAM_ATTACHMENTS_META_KEY = "telegram_attachments"
+    PERSISTED_ENTRY_KEYS = {
+        "source",
+        "file_id",
+        "filename",
+        "mime_type",
+        "kind",
+        "telegram_user_id",
+        "telegram_chat_id",
+        "telegram_message_id",
+        "attached_at",
+        "purpose",
+        "url",
+        "storage_provider",
+        "storage_path",
+        "content_hash",
+        "size_bytes",
+    }
     ACTIVE_STATUSES = {
         OrderStatus.NEW_LEAD,
         OrderStatus.NEGOTIATION,
@@ -86,6 +103,44 @@ class BotOrderAttachmentService:
         if size_bytes is not None:
             entry["size_bytes"] = size_bytes
         return entry
+
+    @classmethod
+    def persisted_entry(cls, entry: dict[str, Any]) -> dict[str, Any]:
+        return {key: value for key, value in entry.items() if key in cls.PERSISTED_ENTRY_KEYS}
+
+    @classmethod
+    def upsert_telegram_attachment(
+        cls,
+        meta: dict[str, Any],
+        entry: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], bool]:
+        persisted = cls.persisted_entry(entry)
+        raw_attachments = meta.get(cls.TELEGRAM_ATTACHMENTS_META_KEY)
+        attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
+        file_id = persisted.get("file_id")
+        purpose = persisted.get("purpose")
+        existing_index = next(
+            (
+                index
+                for index, item in enumerate(attachments)
+                if isinstance(item, dict)
+                and item.get("file_id") == file_id
+                and item.get("purpose") == purpose
+            ),
+            None,
+        )
+
+        if existing_index is None:
+            attachments.append(persisted)
+            already_attached = False
+        else:
+            current = dict(attachments[existing_index])
+            current.update(persisted)
+            attachments[existing_index] = current
+            already_attached = True
+
+        meta[cls.TELEGRAM_ATTACHMENTS_META_KEY] = attachments
+        return attachments, already_attached
 
     @staticmethod
     def _comment_line(entry: dict[str, Any], attached_at: datetime) -> str:
@@ -203,17 +258,18 @@ class BotOrderAttachmentService:
         meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
         raw_attachments = meta.get(cls.TELEGRAM_ATTACHMENTS_META_KEY)
         attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
-        existing_entry = next(
+        existing_index = next(
             (
-                item
-                for item in attachments
+                index
+                for index, item in enumerate(attachments)
                 if isinstance(item, dict) and item.get("file_id") == file_id
             ),
             None,
         )
-        already_attached = existing_entry is not None
+        existing_entry = attachments[existing_index] if existing_index is not None else None
+        already_attached = isinstance(existing_entry, dict)
         storage_meta: dict[str, Any] = {}
-        if content and not already_attached:
+        if content and (not already_attached or not existing_entry.get("url")):
             stored = await cls.store_attachment_content(
                 order_id=order_id,
                 content=content,
@@ -228,21 +284,27 @@ class BotOrderAttachmentService:
                 "size_bytes": stored.size_bytes,
             }
 
-        entry = existing_entry or cls._build_entry(
-            file_id=file_id,
-            filename=filename,
-            mime_type=mime_type,
-            telegram_user_id=telegram_user_id,
-            telegram_chat_id=telegram_chat_id,
-            telegram_message_id=telegram_message_id,
-            attached_at=attached_at,
-            **storage_meta,
-        )
-        if not already_attached:
-            attachments.append(entry)
+        if already_attached:
+            entry = dict(existing_entry)
+            entry.update(storage_meta)
+        else:
+            entry = cls._build_entry(
+                file_id=file_id,
+                filename=filename,
+                mime_type=mime_type,
+                telegram_user_id=telegram_user_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+                attached_at=attached_at,
+                **storage_meta,
+            )
+
+        if not already_attached or storage_meta:
+            attachments, _ = cls.upsert_telegram_attachment(meta, entry)
             meta[cls.TELEGRAM_ATTACHMENTS_META_KEY] = attachments
             order.technical_meta = meta
-            order.comment = cls._append_comment(order.comment, cls._comment_line(entry, attached_at))
+            if not already_attached:
+                order.comment = cls._append_comment(order.comment, cls._comment_line(entry, attached_at))
             flag_modified(order, "technical_meta")
             session.add(order)
             await session.commit()

--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -898,40 +898,7 @@ class BotRepairNameplateService:
         repair_meta[cls.HISTORY_META_KEY] = attachments[-10:]
 
         meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
-        raw_attachments = meta.get(BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY)
-        telegram_attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
-        already_attached = any(
-            isinstance(item, dict)
-            and item.get("file_id") == file_id
-            and item.get("purpose") == "repair_nameplate"
-            for item in telegram_attachments
-        )
-        if not already_attached:
-            telegram_attachments.append(
-                {
-                    key: value
-                    for key, value in entry.items()
-                    if key
-                    in {
-                        "source",
-                        "file_id",
-                        "filename",
-                        "mime_type",
-                        "kind",
-                        "telegram_user_id",
-                        "telegram_chat_id",
-                        "telegram_message_id",
-                        "attached_at",
-                        "purpose",
-                        "url",
-                        "storage_provider",
-                        "storage_path",
-                        "content_hash",
-                        "size_bytes",
-                    }
-                }
-            )
-            meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
+        telegram_attachments, _ = BotOrderAttachmentService.upsert_telegram_attachment(meta, entry)
 
         OrderService._set_repair_meta(
             order,
@@ -939,8 +906,7 @@ class BotRepairNameplateService:
             default_status=OrderService.REPAIR_DEFAULT_STATUS,
         )
         updated_meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
-        if not already_attached:
-            updated_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
+        updated_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
         order.technical_meta = updated_meta
         flag_modified(order, "technical_meta")
         session.add(order)

--- a/services/bot_warranty_nameplate_service.py
+++ b/services/bot_warranty_nameplate_service.py
@@ -496,40 +496,7 @@ class BotWarrantyNameplateService:
         )
         history.append(entry)
         meta[cls.HISTORY_META_KEY] = history[-20:]
-        raw_attachments = meta.get(BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY)
-        telegram_attachments = list(raw_attachments) if isinstance(raw_attachments, list) else []
-        already_attached = any(
-            isinstance(item, dict)
-            and item.get("file_id") == file_id
-            and item.get("purpose") == "warranty_nameplate"
-            for item in telegram_attachments
-        )
-        if not already_attached:
-            telegram_attachments.append(
-                {
-                    key: value
-                    for key, value in entry.items()
-                    if key
-                    in {
-                        "source",
-                        "file_id",
-                        "filename",
-                        "mime_type",
-                        "kind",
-                        "telegram_user_id",
-                        "telegram_chat_id",
-                        "telegram_message_id",
-                        "attached_at",
-                        "purpose",
-                        "url",
-                        "storage_provider",
-                        "storage_path",
-                        "content_hash",
-                        "size_bytes",
-                    }
-                }
-            )
-            meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY] = telegram_attachments
+        BotOrderAttachmentService.upsert_telegram_attachment(meta, entry)
         order.technical_meta = meta
         flag_modified(order, "technical_meta")
         session.add(order)

--- a/tests/unit/test_bot_order_attachment_service.py
+++ b/tests/unit/test_bot_order_attachment_service.py
@@ -147,6 +147,61 @@ async def test_does_not_duplicate_same_file(sqlite_order_attachment_session):
 
 
 @pytest.mark.asyncio
+async def test_updates_existing_attachment_with_stored_content(
+    sqlite_order_attachment_session,
+    monkeypatch,
+):
+    fake_storage = FakeGeneralMediaStorage()
+    monkeypatch.setattr(
+        "services.bot_order_attachment_service.get_general_media_storage",
+        lambda: fake_storage,
+    )
+    order = Order(
+        id=121,
+        title="Монтаж",
+        technical_meta={
+            BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY: [
+                {
+                    "source": "telegram_bot",
+                    "file_id": "same-file",
+                    "filename": "объект.jpg",
+                    "mime_type": "image/jpeg",
+                    "kind": "photo",
+                    "telegram_user_id": 777,
+                    "telegram_chat_id": 100,
+                    "telegram_message_id": 55,
+                    "attached_at": "2026-07-02T13:39:43",
+                }
+            ]
+        },
+    )
+    sqlite_order_attachment_session.add(order)
+    await sqlite_order_attachment_session.commit()
+
+    result = await BotOrderAttachmentService.attach_to_order(
+        sqlite_order_attachment_session,
+        int(order.id),
+        file_id="same-file",
+        filename="объект.jpg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=55,
+        content=b"image-content",
+    )
+
+    assert result is not None
+    assert result["already_attached"] is True
+    assert result["attachment"]["url"] == "https://cdn.mvn.by/media/orders/121/telegram/photo/hash.jpg"
+    await sqlite_order_attachment_session.refresh(order)
+    attachments = order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY]
+    assert len(attachments) == 1
+    assert attachments[0]["url"] == "https://cdn.mvn.by/media/orders/121/telegram/photo/hash.jpg"
+    assert attachments[0]["storage_provider"] == "r2"
+    assert attachments[0]["content_hash"] == "a" * 64
+
+
+@pytest.mark.asyncio
 async def test_lists_recent_active_orders(sqlite_order_attachment_session):
     active = Order(title="Активный", status=OrderStatus.NEGOTIATION)
     closed = Order(title="Закрытый", status=OrderStatus.CLOSED)

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -359,6 +359,66 @@ async def test_apply_to_order_preserves_new_attachment_when_order_already_has_te
 
 
 @pytest.mark.asyncio
+async def test_apply_to_order_updates_existing_repair_nameplate_attachment_url(
+    sqlite_repair_nameplate_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "services.bot_order_attachment_service.get_general_media_storage",
+        lambda: FakeGeneralMediaStorage(),
+    )
+    order = Order(
+        id=42,
+        title="Ремонт",
+        status=OrderStatus.EXECUTION,
+        workflow_type="repair",
+        technical_meta={
+            BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY: [
+                {
+                    "source": "telegram_bot",
+                    "file_id": "photo-file",
+                    "filename": "nameplate.jpg",
+                    "mime_type": "image/jpeg",
+                    "kind": "photo",
+                    "purpose": "repair_nameplate",
+                    "attached_at": "2026-07-02T13:39:43",
+                }
+            ],
+            "repair": {"repair_status": "scheduled"},
+        },
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    result = await BotRepairNameplateService.apply_to_order(
+        sqlite_repair_nameplate_session,
+        int(order.id),
+        extracted={"equipment_serial_number": "SN-003"},
+        raw_text="SERIAL SN-003",
+        validation_flags={"warnings": {}, "is_valid": True},
+        file_id="photo-file",
+        filename="nameplate.jpeg",
+        mime_type="image/jpeg",
+        telegram_user_id=777,
+        telegram_chat_id=100,
+        telegram_message_id=56,
+        can_attach_any=True,
+        file_content=b"updated-nameplate-content",
+    )
+
+    assert result is not None
+    await sqlite_repair_nameplate_session.refresh(order)
+    attachments = order.technical_meta[BotOrderAttachmentService.TELEGRAM_ATTACHMENTS_META_KEY]
+    assert len(attachments) == 1
+    assert attachments[0]["file_id"] == "photo-file"
+    assert attachments[0]["url"] == "https://cdn.mvn.by/media/orders/42/telegram/photo/hash.jpg"
+    assert attachments[0]["storage_provider"] == "r2"
+    assert attachments[0]["content_hash"] == "b" * 64
+    repair_attachment = order.technical_meta["repair"]["nameplate_recognitions"][0]
+    assert repair_attachment["url"] == "https://cdn.mvn.by/media/orders/42/telegram/photo/hash.jpg"
+
+
+@pytest.mark.asyncio
 async def test_apply_to_order_accepts_negotiation_repair_order(sqlite_repair_nameplate_session):
     order = Order(title="Ремонт", status=OrderStatus.NEGOTIATION, workflow_type="repair")
     sqlite_repair_nameplate_session.add(order)


### PR DESCRIPTION
## Summary
- add a shared bot attachment upsert helper for persisted Telegram attachment metadata
- update existing bot attachments with R2/CDN storage fields when a repeated attach/nameplate recognition now has file content
- reuse the helper for repair and warranty nameplate attachment metadata

## Verification
- python3 -m py_compile services/bot_order_attachment_service.py services/bot_repair_nameplate_service.py services/bot_warranty_nameplate_service.py
- pytest tests/unit/test_bot_order_attachment_service.py tests/unit/test_bot_repair_nameplate_service.py -q