### PR TITLE
Add Postgres PITR env helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -50,6 +50,7 @@ unreviewed host-local compose edits:
 | Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
 | Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
 | PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
+| PostgreSQL PITR env configuration | `scripts/ha/configure_postgres_pitr_env.py` |
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
@@ -164,6 +165,7 @@ tar -czf - \
   scripts/ha/upload_postgres_pitr_to_s3.py \
   scripts/ha/upload_postgres_pitr_wal.sh \
   scripts/ha/create_postgres_pitr_basebackup.sh \
+  scripts/ha/configure_postgres_pitr_env.py \
   scripts/ha/check_postgres_pitr_status.sh \
   scripts/ha/check_postgres_pitr_remote.py \
   scripts/ha/install_postgres_pitr_units.sh \
@@ -176,13 +178,30 @@ tar -czf - \
 # Copy deploy/ha/mvn-api/docker-compose.primary.yml through CI.
 gh workflow run deploy.yml --repo mvnby/air-api --ref main -f deploy_frontend=false
 
+# Put the private R2 credentials in a temporary root-only file on the primary.
+# Do not paste these values in tickets, PRs, or chat.
+ssh mvn-api 'umask 077; cat > /root/mvn-postgres-pitr.env' <<'EOF'
+POSTGRES_PITR_CLUSTER=mvn-api
+POSTGRES_PITR_S3_BUCKET=<private-r2-bucket>
+POSTGRES_PITR_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+POSTGRES_PITR_S3_REGION=auto
+POSTGRES_PITR_S3_ACCESS_KEY_ID=<private-r2-token-access-key>
+POSTGRES_PITR_S3_SECRET_ACCESS_KEY=<private-r2-token-secret>
+POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr
+EOF
+
+# Write PITR credentials into /opt/air-api/.env with a backup. This keeps
+# POSTGRES_PITR_ARCHIVE_MODE=off until upload is proven.
+ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-configure-env --project-dir /opt/air-api --input-env-file /root/mvn-postgres-pitr.env'
+ssh mvn-api 'rm -f /root/mvn-postgres-pitr.env'
+
 # Prove private bucket upload with a physical basebackup first. This is a real
 # upload; it does not require archive_mode yet.
 ssh mvn-api 'PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml /usr/local/sbin/mvn-postgres-pitr-basebackup'
 
-# Then add these two values to /opt/air-api/.env:
-# POSTGRES_PITR_ARCHIVE_MODE=on
-# POSTGRES_PITR_ARCHIVE_TIMEOUT=300s
+# Then explicitly enable archive settings in /opt/air-api/.env with another
+# backup. This does not take effect until the db container is recreated.
+ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-configure-env --project-dir /opt/air-api --enable-archive'
 
 # In a short maintenance window, recreate db so archive_mode=on and the
 # /postgres-wal-archive mount become active.

--- a/scripts/ha/configure_postgres_pitr_env.py
+++ b/scripts/ha/configure_postgres_pitr_env.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Safely write PostgreSQL PITR settings into a production .env file.
+
+The helper is intentionally conservative:
+- it backs up the existing .env before writing;
+- it redacts secrets in output;
+- it defaults archive_mode to off unless --enable-archive is explicit;
+- it refuses to reuse the public media R2 bucket for database PITR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+
+PITR_KEYS = [
+    "POSTGRES_PITR_CLUSTER",
+    "POSTGRES_PITR_S3_BUCKET",
+    "POSTGRES_PITR_S3_ENDPOINT_URL",
+    "POSTGRES_PITR_S3_REGION",
+    "POSTGRES_PITR_S3_ACCESS_KEY_ID",
+    "POSTGRES_PITR_S3_SECRET_ACCESS_KEY",
+    "POSTGRES_PITR_S3_KEY_PREFIX",
+    "POSTGRES_PITR_ARCHIVE_MODE",
+    "POSTGRES_PITR_ARCHIVE_TIMEOUT",
+]
+REQUIRED_KEYS = [
+    "POSTGRES_PITR_CLUSTER",
+    "POSTGRES_PITR_S3_BUCKET",
+    "POSTGRES_PITR_S3_ENDPOINT_URL",
+    "POSTGRES_PITR_S3_ACCESS_KEY_ID",
+    "POSTGRES_PITR_S3_SECRET_ACCESS_KEY",
+]
+PUBLIC_MEDIA_BUCKET_KEYS = {
+    "MEDIA_S3_BUCKET",
+    "PRODUCT_MEDIA_S3_BUCKET",
+}
+LINE_RE = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+BUCKET_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$")
+
+
+def _clean(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _parse_dotenv_value(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def load_dotenv(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = LINE_RE.match(line.strip())
+        if not match:
+            continue
+        values[match.group(1)] = _parse_dotenv_value(match.group(2))
+    return values
+
+
+def _arg_value(args: argparse.Namespace, attr: str) -> str:
+    return _clean(getattr(args, attr, ""))
+
+
+def resolve_config(
+    *,
+    target_values: Mapping[str, str],
+    input_values: Mapping[str, str],
+    environ: Mapping[str, str],
+    args: argparse.Namespace,
+) -> dict[str, str]:
+    mapping = {
+        "cluster": "POSTGRES_PITR_CLUSTER",
+        "bucket": "POSTGRES_PITR_S3_BUCKET",
+        "endpoint_url": "POSTGRES_PITR_S3_ENDPOINT_URL",
+        "region": "POSTGRES_PITR_S3_REGION",
+        "access_key_id": "POSTGRES_PITR_S3_ACCESS_KEY_ID",
+        "secret_access_key": "POSTGRES_PITR_S3_SECRET_ACCESS_KEY",
+        "key_prefix": "POSTGRES_PITR_S3_KEY_PREFIX",
+        "archive_timeout": "POSTGRES_PITR_ARCHIVE_TIMEOUT",
+    }
+    config: dict[str, str] = {}
+    for attr, key in mapping.items():
+        config[key] = (
+            _arg_value(args, attr)
+            or _clean(environ.get(key))
+            or _clean(input_values.get(key))
+            or _clean(target_values.get(key))
+        )
+
+    config["POSTGRES_PITR_S3_REGION"] = config["POSTGRES_PITR_S3_REGION"] or "auto"
+    config["POSTGRES_PITR_S3_KEY_PREFIX"] = (
+        config["POSTGRES_PITR_S3_KEY_PREFIX"] or "postgres/pitr"
+    ).strip("/")
+    config["POSTGRES_PITR_ARCHIVE_MODE"] = "on" if args.enable_archive else "off"
+    config["POSTGRES_PITR_ARCHIVE_TIMEOUT"] = (
+        config["POSTGRES_PITR_ARCHIVE_TIMEOUT"] or "300s"
+    )
+    return config
+
+
+def validate_config(config: Mapping[str, str], all_values: Mapping[str, str]) -> None:
+    missing = [key for key in REQUIRED_KEYS if not _clean(config.get(key))]
+    if missing:
+        raise SystemExit("Missing required PITR settings: " + ", ".join(missing))
+
+    bucket = _clean(config["POSTGRES_PITR_S3_BUCKET"])
+    if not BUCKET_RE.match(bucket):
+        raise SystemExit(
+            "POSTGRES_PITR_S3_BUCKET must be an R2/S3 bucket name with lowercase letters, numbers, and hyphens"
+        )
+
+    endpoint = _clean(config["POSTGRES_PITR_S3_ENDPOINT_URL"])
+    if not endpoint.startswith("https://") or ".r2.cloudflarestorage.com" not in endpoint:
+        raise SystemExit(
+            "POSTGRES_PITR_S3_ENDPOINT_URL must look like https://<account-id>.r2.cloudflarestorage.com"
+        )
+
+    if ".r2.dev" in endpoint or "cdn.mvn.by" in endpoint:
+        raise SystemExit("PITR endpoint must use the private R2 S3 API endpoint, not a public CDN URL")
+
+    public_buckets = {
+        _clean(all_values.get(key))
+        for key in PUBLIC_MEDIA_BUCKET_KEYS
+        if _clean(all_values.get(key))
+    }
+    if bucket in public_buckets:
+        raise SystemExit(
+            "POSTGRES_PITR_S3_BUCKET must not reuse the public media bucket"
+        )
+
+    for key, value in config.items():
+        if "\n" in value or "\r" in value:
+            raise SystemExit(f"{key} must be a single-line value")
+        if not value or value != value.strip():
+            raise SystemExit(f"{key} must not be empty or padded")
+
+
+def render_env_value(value: str) -> str:
+    if not value or any(ch.isspace() for ch in value) or "#" in value or "'" in value or '"' in value:
+        raise SystemExit("PITR .env values must not contain whitespace, quotes, or #")
+    return value
+
+
+def update_env_text(existing_text: str, updates: Mapping[str, str]) -> str:
+    seen: set[str] = set()
+    lines: list[str] = []
+    for line in existing_text.splitlines():
+        match = LINE_RE.match(line.strip())
+        if match and match.group(1) in updates:
+            key = match.group(1)
+            lines.append(f"{key}={render_env_value(updates[key])}")
+            seen.add(key)
+        else:
+            lines.append(line)
+
+    missing = [key for key in PITR_KEYS if key not in seen]
+    if missing:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append("# PostgreSQL PITR")
+        for key in missing:
+            lines.append(f"{key}={render_env_value(updates[key])}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def backup_path(env_path: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return env_path.with_name(f"{env_path.name}.bak-pitr-{stamp}")
+
+
+def preserve_owner(path: Path, *, uid: int, gid: int) -> None:
+    try:
+        os.chown(path, uid, gid)
+    except PermissionError:
+        pass
+
+
+def write_env(env_path: Path, content: str, *, dry_run: bool) -> Path | None:
+    if dry_run:
+        return None
+
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    backup: Path | None = None
+    existing_stat = env_path.stat() if env_path.exists() else None
+    if env_path.exists():
+        backup = backup_path(env_path)
+        shutil.copy2(env_path, backup)
+        os.chmod(backup, 0o600)
+        if existing_stat is not None:
+            preserve_owner(backup, uid=existing_stat.st_uid, gid=existing_stat.st_gid)
+
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{env_path.name}.", dir=str(env_path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.chmod(tmp_path, 0o600)
+        if existing_stat is not None:
+            preserve_owner(tmp_path, uid=existing_stat.st_uid, gid=existing_stat.st_gid)
+        os.replace(tmp_path, env_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    return backup
+
+
+def print_summary(config: Mapping[str, str], *, env_path: Path, backup: Path | None, dry_run: bool) -> None:
+    print(
+        {
+            "env_path": str(env_path),
+            "dry_run": dry_run,
+            "backup": str(backup) if backup else None,
+            "archive_mode": config["POSTGRES_PITR_ARCHIVE_MODE"],
+            "archive_timeout": config["POSTGRES_PITR_ARCHIVE_TIMEOUT"],
+            "cluster": config["POSTGRES_PITR_CLUSTER"],
+            "bucket": config["POSTGRES_PITR_S3_BUCKET"],
+            "endpoint_url": config["POSTGRES_PITR_S3_ENDPOINT_URL"],
+            "key_prefix": config["POSTGRES_PITR_S3_KEY_PREFIX"],
+            "secret_values": "redacted",
+        }
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write private PostgreSQL PITR R2/S3 settings into /opt/air-api/.env safely."
+    )
+    parser.add_argument("--project-dir", default="/opt/air-api")
+    parser.add_argument("--env-file", default="")
+    parser.add_argument("--input-env-file", default="")
+    parser.add_argument("--cluster", default="")
+    parser.add_argument("--bucket", default="")
+    parser.add_argument("--endpoint-url", default="")
+    parser.add_argument("--region", default="")
+    parser.add_argument("--access-key-id", default="")
+    parser.add_argument("--secret-access-key", default="")
+    parser.add_argument("--key-prefix", default="")
+    parser.add_argument("--archive-timeout", default="")
+    parser.add_argument("--enable-archive", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    project_dir = Path(args.project_dir)
+    env_path = Path(args.env_file) if args.env_file else project_dir / ".env"
+    input_path = Path(args.input_env_file) if args.input_env_file else None
+
+    target_values = load_dotenv(env_path)
+    input_values = load_dotenv(input_path) if input_path else {}
+    merged_values = dict(target_values)
+    merged_values.update(input_values)
+    merged_values.update({key: value for key, value in os.environ.items() if value})
+
+    config = resolve_config(
+        target_values=target_values,
+        input_values=input_values,
+        environ=os.environ,
+        args=args,
+    )
+    validate_config(config, merged_values)
+
+    existing_text = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    updated_text = update_env_text(existing_text, config)
+    backup = write_env(env_path, updated_text, dry_run=args.dry_run)
+    print_summary(config, env_path=env_path, backup=backup, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -19,6 +19,7 @@ fi
 install -m 0755 scripts/ha/upload_postgres_pitr_to_s3.py /usr/local/sbin/mvn-postgres-pitr-upload
 install -m 0755 scripts/ha/upload_postgres_pitr_wal.sh /usr/local/sbin/mvn-postgres-pitr-upload-wal
 install -m 0755 scripts/ha/create_postgres_pitr_basebackup.sh /usr/local/sbin/mvn-postgres-pitr-basebackup
+install -m 0755 scripts/ha/configure_postgres_pitr_env.py /usr/local/sbin/mvn-postgres-pitr-configure-env
 install -m 0755 scripts/ha/check_postgres_pitr_status.sh /usr/local/sbin/mvn-postgres-pitr-status
 install -m 0755 scripts/ha/check_postgres_pitr_remote.py /usr/local/sbin/mvn-postgres-pitr-remote-status
 install -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.service /etc/systemd/system/mvn-postgres-wal-upload.service

--- a/tests/unit/test_postgres_pitr_env_config.py
+++ b/tests/unit/test_postgres_pitr_env_config.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/ha/configure_postgres_pitr_env.py"
+
+
+def _write_input_env(path: Path, *, bucket: str = "mvn-postgres-pitr") -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "POSTGRES_PITR_CLUSTER=mvn-api",
+                f"POSTGRES_PITR_S3_BUCKET={bucket}",
+                "POSTGRES_PITR_S3_ENDPOINT_URL=https://account-id.r2.cloudflarestorage.com",
+                "POSTGRES_PITR_S3_REGION=auto",
+                "POSTGRES_PITR_S3_ACCESS_KEY_ID=access-key-id",
+                "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=super-secret-key",
+                "POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_configure(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--project-dir", str(tmp_path), *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={},
+    )
+
+
+def test_configure_env_writes_backup_and_redacts_secret(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "POSTGRES_USER=postgres\nPRODUCT_MEDIA_S3_BUCKET=public-media\n",
+        encoding="utf-8",
+    )
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+
+    result = _run_configure(tmp_path, "--input-env-file", str(input_file))
+
+    assert result.returncode == 0, result.stderr
+    env_text = env_file.read_text(encoding="utf-8")
+    assert "POSTGRES_USER=postgres" in env_text
+    assert "POSTGRES_PITR_CLUSTER=mvn-api" in env_text
+    assert "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr" in env_text
+    assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=super-secret-key" in env_text
+    assert "POSTGRES_PITR_ARCHIVE_MODE=off" in env_text
+    assert "POSTGRES_PITR_ARCHIVE_TIMEOUT=300s" in env_text
+    assert "super-secret-key" not in result.stdout
+    assert "redacted" in result.stdout
+    assert list(tmp_path.glob(".env.bak-pitr-*"))
+    assert oct(os.stat(env_file).st_mode & 0o777) == "0o600"
+
+
+def test_configure_env_refuses_public_media_bucket(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MEDIA_S3_BUCKET=public-media\n", encoding="utf-8")
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file, bucket="public-media")
+
+    result = _run_configure(tmp_path, "--input-env-file", str(input_file))
+
+    assert result.returncode != 0
+    assert "must not reuse the public media bucket" in result.stderr
+    assert "POSTGRES_PITR_S3_BUCKET" not in env_file.read_text(encoding="utf-8")
+
+
+def test_configure_env_enable_archive_reuses_existing_values(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+    first = _run_configure(tmp_path, "--input-env-file", str(input_file))
+    assert first.returncode == 0, first.stderr
+
+    second = _run_configure(tmp_path, "--enable-archive")
+
+    assert second.returncode == 0, second.stderr
+    env_text = env_file.read_text(encoding="utf-8")
+    assert "POSTGRES_PITR_ARCHIVE_MODE=on" in env_text
+    assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=super-secret-key" in env_text
+    assert "super-secret-key" not in second.stdout
+    assert len(list(tmp_path.glob(".env.bak-pitr-*"))) >= 2
+
+
+def test_configure_env_dry_run_does_not_write(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+
+    result = _run_configure(tmp_path, "--input-env-file", str(input_file), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert env_file.read_text(encoding="utf-8") == "POSTGRES_USER=postgres\n"
+    assert not list(tmp_path.glob(".env.bak-pitr-*"))


### PR DESCRIPTION
## Summary
- add a conservative helper for writing POSTGRES_PITR_* values into production .env with backups
- keep archive_mode off by default unless --enable-archive is explicit
- install the helper with existing PITR host scripts and document the safer rollout path

## Verification
- python3 -m py_compile scripts/ha/configure_postgres_pitr_env.py scripts/ha/upload_postgres_pitr_to_s3.py scripts/ha/check_postgres_pitr_remote.py
- bash -n scripts/ha/install_postgres_pitr_units.sh scripts/ha/check_postgres_pitr_status.sh
- pytest tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_postgres_pitr_remote_check.py -q