### PR TITLE
Prune unused Docker images after API deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -355,6 +355,16 @@ jobs:
             SMOKE_SUMMARY_FILE='/tmp/smoke_summary.txt' \
             bash /tmp/post_deploy_smoke_check.sh && cat /tmp/smoke_summary.txt" | tee backend_smoke.log
 
+      - name: Prune Unused Backend Docker Images
+        id: prune_backend_images
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
+          cat scripts/prune_unused_docker_images.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/prune_unused_docker_images.sh"
+          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+            chmod +x /tmp/prune_unused_docker_images.sh && \
+            bash /tmp/prune_unused_docker_images.sh" | tee backend_docker_prune.log
+
       - name: Upload Backend Ops Logs
         if: always()
         uses: actions/upload-artifact@v7
@@ -363,6 +373,7 @@ jobs:
           path: |
             backend_ops.log
             backend_smoke.log
+            backend_docker_prune.log
           if-no-files-found: warn
 
       - name: Backend Deploy Summary
@@ -390,11 +401,15 @@ jobs:
             echo "- deploy_status: ${{ steps.deploy_backend.outcome }}"
             echo "- ops_status: ${{ steps.post_deploy_ops.outcome }}"
             echo "- smoke_status: ${{ steps.post_deploy_smoke.outcome }}"
+            echo "- docker_prune_status: ${{ steps.prune_backend_images.outcome }}"
             if [ -f backend_ops.log ]; then
               echo "- ops_log: collected"
             fi
             if [ -f backend_smoke.log ]; then
               echo "- smoke_log: collected"
+            fi
+            if [ -f backend_docker_prune.log ]; then
+              echo "- docker_prune_log: collected"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -476,6 +491,25 @@ jobs:
             docker compose -f '${API_STANDBY_COMPOSE_FILE}' logs --tail=120 app; \
             exit 1"
 
+      - name: Prune Unused Standby Docker Images
+        id: prune_standby_images
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          cat scripts/prune_unused_docker_images.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/prune_unused_docker_images.sh"
+          ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
+            chmod +x /tmp/prune_unused_docker_images.sh && \
+            bash /tmp/prune_unused_docker_images.sh" | tee standby_docker_prune.log
+
+      - name: Upload Standby Deploy Logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: standby-deploy-logs-${{ github.run_id }}
+          path: |
+            standby_docker_prune.log
+          if-no-files-found: warn
+
       - name: Standby Deploy Summary
         if: always()
         run: |
@@ -488,6 +522,10 @@ jobs:
             echo "- standby_compose_source_file: ${API_STANDBY_COMPOSE_SOURCE_FILE}"
             echo "- backend_image: ghcr.io/${GITHUB_REPOSITORY,,}/backend:${GITHUB_SHA}"
             echo "- health_url: ${API_STANDBY_HEALTH_URL}"
+            echo "- docker_prune_status: ${{ steps.prune_standby_images.outcome }}"
+            if [ -f standby_docker_prune.log ]; then
+              echo "- docker_prune_log: collected"
+            fi
             echo "- status: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -302,7 +302,23 @@ Expected deploy behavior:
 
 - primary `mvn-api`: recreate `app` and `bot`;
 - standby `zakup`: recreate only `app`, then stop `bot`;
+- both API hosts: prune unused Docker images after successful deploy; this does
+  not remove volumes or images used by running containers;
 - frontend deploy is skipped unless explicitly requested.
+
+Manual disk pressure check:
+
+```bash
+ssh mvn-api 'df -h / && docker system df'
+ssh zakup 'df -h / && docker system df'
+```
+
+Manual emergency image cleanup, safe for databases and media volumes:
+
+```bash
+ssh mvn-api 'docker image prune -af && df -h /'
+ssh zakup 'docker image prune -af && df -h /'
+```
 
 ## Cloudflare Load Balancer
 

--- a/scripts/prune_unused_docker_images.sh
+++ b/scripts/prune_unused_docker_images.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== Disk usage before Docker image prune =="
+df -h /
+docker system df || true
+
+echo "== Pruning unused Docker images =="
+docker image prune -af
+
+echo "== Disk usage after Docker image prune =="
+docker system df || true
+df -h /


### PR DESCRIPTION
## Summary
- add a small Docker image prune helper with disk usage logging
- run it after successful primary API smoke checks
- run it after standby API app deployment and collect prune logs
- document manual disk pressure checks and emergency image cleanup

## Tests
- bash -n scripts/prune_unused_docker_images.sh
- python3 - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('.github/workflows/deploy.yml').read_text())
print('yaml-ok')
PY