### PR TITLE
Add PostgreSQL PITR restore helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -55,6 +55,7 @@ unreviewed host-local compose edits:
 | Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
 | Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
 | PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
+| PostgreSQL PITR restore drill helper | `scripts/ha/restore_postgres_pitr_from_s3.py` |
 | PostgreSQL PITR env configuration | `scripts/ha/configure_postgres_pitr_env.py` |
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
@@ -177,6 +178,7 @@ tar -czf - \
   scripts/ha/upload_postgres_pitr_wal.sh \
   scripts/ha/create_postgres_pitr_basebackup.sh \
   scripts/ha/configure_postgres_pitr_env.py \
+  scripts/ha/restore_postgres_pitr_from_s3.py \
   scripts/ha/check_postgres_pitr_status.sh \
   scripts/ha/check_postgres_pitr_remote.py \
   scripts/ha/install_postgres_pitr_units.sh \
@@ -250,23 +252,36 @@ Manual GitHub monitor run:
 gh workflow run check-postgres-pitr.yml --repo mvnby/air-api --ref main -f required=true
 ```
 
-Point-in-time restore outline:
+Point-in-time restore drill after the first private basebackup and WAL upload:
 
-1. Pick the latest basebackup before the target timestamp from
-   `postgres/pitr/<cluster>/basebackups/*/manifest.json`.
-2. Restore `base.tar.gz` and `pg_wal.tar.gz` into a clean PostgreSQL data
-   directory.
-3. Provide a `restore_command` that fetches archived WAL from
-   `postgres/pitr/<cluster>/wal/<timeline>/%f`.
-4. Set `recovery_target_time` to the target timestamp and start PostgreSQL with
-   `recovery.signal`.
-5. Validate the restored DB in an isolated container before replacing any
-   production role.
+```bash
+# List available private PITR basebackups. This prints no secret values.
+ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml run -T --rm app python scripts/ha/restore_postgres_pitr_from_s3.py list-basebackups'
 
-The repo currently contains upload and basebackup automation. A full
-one-command PITR restore helper is intentionally a separate step because restore
-must be rehearsed against real private bucket credentials without touching
-production.
+# Prepare an isolated restore directory on the host. The target dir must be
+# empty. This downloads the selected basebackup, verifies checksums, extracts it
+# under data/, downloads archived WAL under wal/, writes recovery.signal, and
+# configures restore_command to copy WAL from that local drill directory.
+ssh mvn-api 'rm -rf /root/mvn-pitr-restore && mkdir -p /root/mvn-pitr-restore'
+ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml run -T --rm -v /root/mvn-pitr-restore:/pitr-restore app python scripts/ha/restore_postgres_pitr_from_s3.py prepare --target-dir /pitr-restore --target-time <target-time-utc>'
+
+# Start a disposable PostgreSQL container against the prepared data directory.
+# Use this only for validation, never as a production replacement.
+ssh mvn-api 'docker run -d --rm --name mvn-pitr-restore-check --env-file /opt/air-api/.env -v /root/mvn-pitr-restore/data:/var/lib/postgresql/data -v /root/mvn-pitr-restore/wal:/pitr-restore/wal:ro postgres:15-alpine postgres'
+ssh mvn-api 'docker logs --tail=120 mvn-pitr-restore-check'
+ssh mvn-api 'docker exec mvn-pitr-restore-check sh -lc '\''PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -c "select pg_is_in_recovery(), pg_is_wal_replay_paused();"'\'''
+ssh mvn-api 'docker stop mvn-pitr-restore-check'
+```
+
+Expected result:
+
+- PostgreSQL starts in recovery against the isolated `/root/mvn-pitr-restore`
+  data directory.
+- Missing WAL segments are copied from `/pitr-restore/wal`.
+- Recovery pauses at `recovery_target_time` because the helper writes
+  `recovery_target_action = 'pause'`.
+- Validate the restored DB with read-only SQL before replacing any production
+  role.
 
 ## GitHub Actions Routing
 

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -20,6 +20,7 @@ install -m 0755 scripts/ha/upload_postgres_pitr_to_s3.py /usr/local/sbin/mvn-pos
 install -m 0755 scripts/ha/upload_postgres_pitr_wal.sh /usr/local/sbin/mvn-postgres-pitr-upload-wal
 install -m 0755 scripts/ha/create_postgres_pitr_basebackup.sh /usr/local/sbin/mvn-postgres-pitr-basebackup
 install -m 0755 scripts/ha/configure_postgres_pitr_env.py /usr/local/sbin/mvn-postgres-pitr-configure-env
+install -m 0755 scripts/ha/restore_postgres_pitr_from_s3.py /usr/local/sbin/mvn-postgres-pitr-restore
 install -m 0755 scripts/ha/check_postgres_pitr_status.sh /usr/local/sbin/mvn-postgres-pitr-status
 install -m 0755 scripts/ha/check_postgres_pitr_remote.py /usr/local/sbin/mvn-postgres-pitr-remote-status
 install -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.service /etc/systemd/system/mvn-postgres-wal-upload.service

--- a/scripts/ha/restore_postgres_pitr_from_s3.py
+++ b/scripts/ha/restore_postgres_pitr_from_s3.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Prepare an isolated PostgreSQL PITR restore from private S3/R2 artifacts.
+
+This helper never touches the production data directory. It downloads a chosen
+physical basebackup into an operator-supplied empty target directory, extracts it
+under `data/`, and writes recovery settings that fetch archived WAL from the
+private PITR bucket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import json
+import os
+import re
+import shlex
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+WAL_NAME_RE = re.compile(
+    r"^(?:[0-9A-F]{24}|[0-9A-F]{24}\.[0-9A-F]{8}\.backup|[0-9A-F]{8}\.history)$"
+)
+
+
+def _load_upload_helpers() -> tuple[Any, Any, Any]:
+    try:
+        from scripts.ha.upload_postgres_pitr_to_s3 import (
+            build_client,
+            load_config,
+            sha256_file,
+        )
+
+        return build_client, load_config, sha256_file
+    except ModuleNotFoundError:
+        pass
+
+    candidates = [
+        os.getenv("POSTGRES_PITR_UPLOAD_HELPER", ""),
+        str(Path(__file__).with_name("upload_postgres_pitr_to_s3.py")),
+        "/opt/air-api/scripts/ha/upload_postgres_pitr_to_s3.py",
+        "/usr/local/sbin/mvn-postgres-pitr-upload",
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        helper_path = Path(candidate)
+        if not helper_path.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location("mvn_postgres_pitr_upload_helper", helper_path)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module.build_client, module.load_config, module.sha256_file
+
+    raise SystemExit(
+        "Could not load PostgreSQL PITR upload helper. "
+        "Run from the repo root, set POSTGRES_PITR_UPLOAD_HELPER, or install /usr/local/sbin/mvn-postgres-pitr-upload."
+    )
+
+
+build_client, load_config, sha256_file = _load_upload_helpers()
+
+
+@dataclass(frozen=True)
+class BasebackupManifest:
+    backup_id: str
+    created_at: datetime
+    key: str
+    payload: dict[str, Any]
+
+
+def _read_s3_body(body: Any) -> bytes:
+    data = body.read()
+    if isinstance(data, str):
+        return data.encode("utf-8")
+    return bytes(data)
+
+
+def _parse_datetime(value: str) -> datetime:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("empty datetime")
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _manifest_prefix(config: Any) -> str:
+    return f"{config.key_prefix}/{config.cluster}/basebackups/"
+
+
+def _wal_key(config: Any, wal_name: str) -> str:
+    timeline = wal_name[:8]
+    return f"{config.key_prefix}/{config.cluster}/wal/{timeline}/{wal_name}"
+
+
+def _list_manifest_keys(client: Any, bucket: str, prefix: str) -> list[str]:
+    paginator = client.get_paginator("list_objects_v2")
+    keys: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for item in page.get("Contents", []):
+            key = str(item.get("Key") or "")
+            if key.endswith("/manifest.json"):
+                keys.append(key)
+    return sorted(keys)
+
+
+def _list_wal_keys(client: Any, config: Any) -> list[str]:
+    prefix = f"{config.key_prefix}/{config.cluster}/wal/"
+    paginator = client.get_paginator("list_objects_v2")
+    keys: list[str] = []
+    for page in paginator.paginate(Bucket=config.bucket, Prefix=prefix):
+        for item in page.get("Contents", []):
+            key = str(item.get("Key") or "")
+            filename = key.rsplit("/", 1)[-1]
+            if key.endswith("/") or not WAL_NAME_RE.match(filename):
+                continue
+            keys.append(key)
+    return sorted(keys)
+
+
+def _load_manifest(client: Any, bucket: str, key: str) -> BasebackupManifest:
+    response = client.get_object(Bucket=bucket, Key=key)
+    payload = json.loads(_read_s3_body(response["Body"]).decode("utf-8"))
+    backup_id = str(payload.get("backup_id") or key.rstrip("/").split("/")[-2])
+    created_at = _parse_datetime(str(payload.get("created_at") or backup_id))
+    return BasebackupManifest(
+        backup_id=backup_id,
+        created_at=created_at,
+        key=key,
+        payload=payload,
+    )
+
+
+def list_manifests(client: Any, config: Any) -> list[BasebackupManifest]:
+    keys = _list_manifest_keys(client, config.bucket, _manifest_prefix(config))
+    manifests = [_load_manifest(client, config.bucket, key) for key in keys]
+    return sorted(manifests, key=lambda item: item.created_at)
+
+
+def select_manifest(
+    manifests: list[BasebackupManifest],
+    *,
+    backup_id: str = "",
+    target_time: datetime | None = None,
+) -> BasebackupManifest:
+    if backup_id:
+        for manifest in manifests:
+            if manifest.backup_id == backup_id:
+                return manifest
+        raise SystemExit(f"Basebackup not found: {backup_id}")
+
+    if not manifests:
+        raise SystemExit("No PITR basebackup manifests found")
+
+    if target_time is None:
+        return manifests[-1]
+
+    eligible = [manifest for manifest in manifests if manifest.created_at <= target_time]
+    if not eligible:
+        raise SystemExit(
+            "No basebackup exists before target time "
+            f"{target_time.isoformat()}"
+        )
+    return eligible[-1]
+
+
+def _ensure_empty_target_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if any(path.iterdir()):
+        raise SystemExit(f"Target directory must be empty: {path}")
+
+
+def _download_file(client: Any, bucket: str, key: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = destination.with_name(f".{destination.name}.tmp")
+    client.download_file(bucket, key, str(tmp_path))
+    tmp_path.replace(destination)
+
+
+def _verify_download(path: Path, expected_sha256: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected_sha256:
+        path.unlink(missing_ok=True)
+        raise SystemExit(
+            f"Checksum mismatch for {path.name}: expected {expected_sha256}, got {actual}"
+        )
+
+
+def _safe_extract_tar_gz(tar_path: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tar_path, "r:gz") as tar:
+        root = destination.resolve()
+        for member in tar.getmembers():
+            member_path = (destination / member.name).resolve()
+            if member_path != root and root not in member_path.parents:
+                raise SystemExit(f"Unsafe tar member path in {tar_path.name}: {member.name}")
+        tar.extractall(destination)
+
+
+def _postgres_conf_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _write_recovery_settings(
+    *,
+    data_dir: Path,
+    target_time: datetime | None,
+    wal_mode: str,
+    restore_mount_path: str,
+    restore_helper_path: str,
+) -> None:
+    if wal_mode == "local":
+        restore_command = f"cp {shlex.quote(restore_mount_path.rstrip('/') + '/wal/%f')} %p"
+    elif wal_mode == "remote":
+        restore_command = (
+            f"python3 {shlex.quote(restore_helper_path)} "
+            "fetch-wal --wal-name %f --destination %p"
+        )
+    else:
+        raise ValueError(f"Unsupported wal_mode={wal_mode!r}")
+    lines = [
+        "",
+        "# MVN PITR restore settings",
+        f"restore_command = {_postgres_conf_quote(restore_command)}",
+        "recovery_target_action = 'pause'",
+    ]
+    if target_time is not None:
+        lines.append(f"recovery_target_time = {_postgres_conf_quote(target_time.isoformat())}")
+
+    auto_conf = data_dir / "postgresql.auto.conf"
+    with auto_conf.open("a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    (data_dir / "recovery.signal").touch()
+
+
+def command_list(args: argparse.Namespace) -> int:
+    config = load_config()
+    client = build_client(config)
+    manifests = list_manifests(client, config)
+    for manifest in manifests:
+        print(
+            json.dumps(
+                {
+                    "backup_id": manifest.backup_id,
+                    "created_at": manifest.created_at.isoformat(),
+                    "manifest_key": manifest.key,
+                    "files": len(manifest.payload.get("files") or []),
+                },
+                sort_keys=True,
+            )
+        )
+    print(json.dumps({"kind": "basebackup_manifest", "count": len(manifests)}, sort_keys=True))
+    return 0
+
+
+def command_prepare(args: argparse.Namespace) -> int:
+    target_dir = Path(args.target_dir).resolve()
+    _ensure_empty_target_dir(target_dir)
+
+    target_time = _parse_datetime(args.target_time) if args.target_time else None
+    config = load_config()
+    client = build_client(config)
+    manifest = select_manifest(
+        list_manifests(client, config),
+        backup_id=args.backup_id,
+        target_time=target_time,
+    )
+
+    downloads_dir = target_dir / "downloads"
+    data_dir = target_dir / "data"
+    downloads_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True)
+
+    files = manifest.payload.get("files") or []
+    if not isinstance(files, list) or not files:
+        raise SystemExit(f"Basebackup manifest has no files: {manifest.key}")
+
+    downloaded: list[Path] = []
+    for item in files:
+        name = str(item.get("name") or "")
+        key = str(item.get("key") or "")
+        expected_sha256 = str(item.get("sha256") or "")
+        if not name or not key or not expected_sha256:
+            raise SystemExit(f"Basebackup manifest file entry is incomplete: {item!r}")
+        destination = downloads_dir / name
+        _download_file(client, config.bucket, key, destination)
+        _verify_download(destination, expected_sha256)
+        downloaded.append(destination)
+
+    base_tar = downloads_dir / "base.tar.gz"
+    if not base_tar.is_file():
+        raise SystemExit("Downloaded basebackup is missing base.tar.gz")
+    _safe_extract_tar_gz(base_tar, data_dir)
+
+    wal_tar = downloads_dir / "pg_wal.tar.gz"
+    if wal_tar.is_file():
+        _safe_extract_tar_gz(wal_tar, data_dir / "pg_wal")
+
+    downloaded_wal = 0
+    if args.wal_mode == "local":
+        wal_dir = target_dir / "wal"
+        wal_dir.mkdir(parents=True)
+        for key in _list_wal_keys(client, config):
+            filename = key.rsplit("/", 1)[-1]
+            _download_file(client, config.bucket, key, wal_dir / filename)
+            downloaded_wal += 1
+
+    manifest_path = target_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest.payload, indent=2, sort_keys=True) + "\n")
+    _write_recovery_settings(
+        data_dir=data_dir,
+        target_time=target_time,
+        wal_mode=args.wal_mode,
+        restore_mount_path=args.restore_mount_path,
+        restore_helper_path=args.restore_helper_path,
+    )
+
+    print(
+        json.dumps(
+            {
+                "status": "prepared",
+                "backup_id": manifest.backup_id,
+                "created_at": manifest.created_at.isoformat(),
+                "target_dir": str(target_dir),
+                "data_dir": str(data_dir),
+                "downloaded_files": len(downloaded),
+                "downloaded_wal": downloaded_wal,
+                "wal_mode": args.wal_mode,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def command_fetch_wal(args: argparse.Namespace) -> int:
+    wal_name = str(args.wal_name or "").strip()
+    if not WAL_NAME_RE.match(wal_name):
+        raise SystemExit(f"Invalid WAL filename: {wal_name}")
+
+    destination = Path(args.destination)
+    config = load_config()
+    client = build_client(config)
+    key = _wal_key(config, wal_name)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=str(destination.parent), delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        client.download_file(config.bucket, key, str(tmp_path))
+        if tmp_path.stat().st_size <= 0:
+            raise SystemExit(f"Downloaded WAL file is empty: {wal_name}")
+        tmp_path.replace(destination)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    print(json.dumps({"status": "fetched", "wal_name": wal_name, "key": key}, sort_keys=True))
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare an isolated PostgreSQL PITR restore from private S3/R2."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_cmd = subparsers.add_parser("list-basebackups", help="List remote basebackup manifests")
+    list_cmd.set_defaults(func=command_list)
+
+    prepare = subparsers.add_parser(
+        "prepare",
+        help="Download and extract a basebackup into an empty restore directory",
+    )
+    prepare.add_argument("--target-dir", required=True)
+    prepare.add_argument("--backup-id", default="")
+    prepare.add_argument(
+        "--target-time",
+        default="",
+        help="UTC restore target timestamp. The newest basebackup at or before this time is selected.",
+    )
+    prepare.add_argument(
+        "--wal-mode",
+        choices=("local", "remote"),
+        default="local",
+        help=(
+            "local downloads archived WAL into target-dir/wal and writes a cp restore_command; "
+            "remote writes a Python/R2 restore_command for containers that include this helper and boto3."
+        ),
+    )
+    prepare.add_argument(
+        "--restore-mount-path",
+        default="/pitr-restore",
+        help="Path where target-dir will be mounted inside the restore PostgreSQL container in local WAL mode.",
+    )
+    prepare.add_argument(
+        "--restore-helper-path",
+        default="/app/scripts/ha/restore_postgres_pitr_from_s3.py",
+        help="Path visible inside the restore PostgreSQL container for restore_command.",
+    )
+    prepare.set_defaults(func=command_prepare)
+
+    fetch_wal = subparsers.add_parser("fetch-wal", help="Fetch one WAL file for restore_command")
+    fetch_wal.add_argument("--wal-name", required=True)
+    fetch_wal.add_argument("--destination", required=True)
+    fetch_wal.set_defaults(func=command_fetch_wal)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_postgres_pitr_restore.py
+++ b/tests/unit/test_postgres_pitr_restore.py
@@ -1,0 +1,210 @@
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts/ha/restore_postgres_pitr_from_s3.py"
+SPEC = importlib.util.spec_from_file_location("restore_postgres_pitr_from_s3", MODULE_PATH)
+pitr_restore = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = pitr_restore
+SPEC.loader.exec_module(pitr_restore)
+
+
+class FakeConfig:
+    bucket = "private-pitr"
+    key_prefix = "postgres/pitr"
+    cluster = "mvn-api"
+
+
+class FakeBody:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def read(self):
+        return self.payload
+
+
+class FakePaginator:
+    def __init__(self, keys):
+        self.keys = keys
+
+    def paginate(self, **kwargs):
+        prefix = kwargs["Prefix"]
+        return [
+            {
+                "Contents": [
+                    {"Key": key, "LastModified": datetime(2026, 7, 2, tzinfo=timezone.utc)}
+                    for key in self.keys
+                    if key.startswith(prefix)
+                ]
+            }
+        ]
+
+
+class FakeClient:
+    def __init__(self, objects: dict[str, bytes]):
+        self.objects = objects
+        self.downloads = []
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        return FakePaginator(list(self.objects))
+
+    def get_object(self, *, Bucket, Key):
+        assert Bucket == FakeConfig.bucket
+        return {"Body": FakeBody(self.objects[Key])}
+
+    def download_file(self, bucket, key, filename):
+        assert bucket == FakeConfig.bucket
+        Path(filename).write_bytes(self.objects[key])
+        self.downloads.append((key, filename))
+
+
+def _tar_gz(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def _manifest(backup_id: str, created_at: str, files: list[dict]) -> bytes:
+    return json.dumps(
+        {
+            "backup_id": backup_id,
+            "created_at": created_at,
+            "cluster": "mvn-api",
+            "files": files,
+        }
+    ).encode("utf-8")
+
+
+def _file_entry(backup_id: str, name: str, content: bytes) -> dict:
+    return {
+        "name": name,
+        "key": f"postgres/pitr/mvn-api/basebackups/{backup_id}/{name}",
+        "size_bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def test_select_manifest_uses_latest_basebackup_before_target_time():
+    manifests = [
+        pitr_restore.BasebackupManifest(
+            backup_id="old",
+            created_at=datetime(2026, 7, 2, 1, tzinfo=timezone.utc),
+            key="old/manifest.json",
+            payload={"files": []},
+        ),
+        pitr_restore.BasebackupManifest(
+            backup_id="new",
+            created_at=datetime(2026, 7, 2, 3, tzinfo=timezone.utc),
+            key="new/manifest.json",
+            payload={"files": []},
+        ),
+    ]
+
+    selected = pitr_restore.select_manifest(
+        manifests,
+        target_time=datetime(2026, 7, 2, 2, tzinfo=timezone.utc),
+    )
+
+    assert selected.backup_id == "old"
+
+
+def test_prepare_downloads_extracts_and_writes_recovery_files(monkeypatch, tmp_path):
+    base_tar = _tar_gz({"PG_VERSION": b"15\n", "postgresql.conf": b""})
+    wal_tar = _tar_gz({"00000001000000000000000A": b"wal"})
+    metadata = b'{"backup_id":"backup-1"}'
+    files = [
+        _file_entry("backup-1", "base.tar.gz", base_tar),
+        _file_entry("backup-1", "pg_wal.tar.gz", wal_tar),
+        _file_entry("backup-1", "metadata.json", metadata),
+    ]
+    objects = {
+        "postgres/pitr/mvn-api/basebackups/backup-1/manifest.json": _manifest(
+            "backup-1",
+            "2026-07-02T01:00:00+00:00",
+            files,
+        ),
+        "postgres/pitr/mvn-api/basebackups/backup-1/base.tar.gz": base_tar,
+        "postgres/pitr/mvn-api/basebackups/backup-1/pg_wal.tar.gz": wal_tar,
+        "postgres/pitr/mvn-api/basebackups/backup-1/metadata.json": metadata,
+        "postgres/pitr/mvn-api/wal/00000001/00000001000000000000000B": b"archived-wal",
+    }
+    client = FakeClient(objects)
+    monkeypatch.setattr(pitr_restore, "load_config", lambda: FakeConfig)
+    monkeypatch.setattr(pitr_restore, "build_client", lambda config: client)
+
+    exit_code = pitr_restore.main(
+        [
+            "prepare",
+            "--target-dir",
+            str(tmp_path / "restore"),
+            "--backup-id",
+            "backup-1",
+            "--target-time",
+            "2026-07-02T02:30:00Z",
+        ]
+    )
+
+    data_dir = tmp_path / "restore" / "data"
+    assert exit_code == 0
+    assert (data_dir / "PG_VERSION").read_text() == "15\n"
+    assert (data_dir / "pg_wal" / "00000001000000000000000A").read_bytes() == b"wal"
+    assert (
+        tmp_path / "restore" / "wal" / "00000001000000000000000B"
+    ).read_bytes() == b"archived-wal"
+    assert (data_dir / "recovery.signal").exists()
+    auto_conf = (data_dir / "postgresql.auto.conf").read_text()
+    assert "restore_command" in auto_conf
+    assert "cp /pitr-restore/wal/%f %p" in auto_conf
+    assert "recovery_target_time = '2026-07-02T02:30:00+00:00'" in auto_conf
+    assert (tmp_path / "restore" / "manifest.json").exists()
+
+
+def test_prepare_refuses_non_empty_target_dir(monkeypatch, tmp_path):
+    target = tmp_path / "restore"
+    target.mkdir()
+    (target / "existing").write_text("do not overwrite")
+    monkeypatch.setattr(pitr_restore, "load_config", lambda: FakeConfig)
+    monkeypatch.setattr(pitr_restore, "build_client", lambda config: FakeClient({}))
+
+    with pytest.raises(SystemExit, match="Target directory must be empty"):
+        pitr_restore.main(["prepare", "--target-dir", str(target)])
+
+
+def test_fetch_wal_downloads_expected_timeline_key(monkeypatch, tmp_path):
+    wal_name = "00000001000000000000000A"
+    key = f"postgres/pitr/mvn-api/wal/00000001/{wal_name}"
+    client = FakeClient({key: b"wal-bytes"})
+    monkeypatch.setattr(pitr_restore, "load_config", lambda: FakeConfig)
+    monkeypatch.setattr(pitr_restore, "build_client", lambda config: client)
+
+    destination = tmp_path / "pg_wal" / wal_name
+    exit_code = pitr_restore.main(
+        ["fetch-wal", "--wal-name", wal_name, "--destination", str(destination)]
+    )
+
+    assert exit_code == 0
+    assert destination.read_bytes() == b"wal-bytes"
+    assert client.downloads[0][0] == key
+
+
+def test_fetch_wal_rejects_invalid_wal_name(monkeypatch, tmp_path):
+    monkeypatch.setattr(pitr_restore, "load_config", lambda: FakeConfig)
+    monkeypatch.setattr(pitr_restore, "build_client", lambda config: FakeClient({}))
+
+    with pytest.raises(SystemExit, match="Invalid WAL filename"):
+        pitr_restore.main(
+            ["fetch-wal", "--wal-name", "../../bad", "--destination", str(tmp_path / "bad")]
+        )


### PR DESCRIPTION
## Summary
- add a PostgreSQL PITR restore helper for isolated S3/R2 restore drills
- install the restore helper with the existing PITR systemd helper installer
- document the private basebackup/WAL restore rehearsal flow
- cover manifest selection, checksum-backed extraction, WAL fetch, and target-dir safety with unit tests

## Tests
- python3 -m py_compile scripts/ha/restore_postgres_pitr_from_s3.py
- bash -n scripts/ha/install_postgres_pitr_units.sh
- python3 scripts/ha/restore_postgres_pitr_from_s3.py --help
- python3 -m pytest tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_env_config.py -q