### PR TITLE
Fix installed PITR restore helper loader

### DIFF
--- a/scripts/ha/restore_postgres_pitr_from_s3.py
+++ b/scripts/ha/restore_postgres_pitr_from_s3.py
@@ -10,6 +10,7 @@ private PITR bucket.
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
 import importlib.util
 import io
 import json
@@ -29,6 +30,20 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 WAL_NAME_RE = re.compile(
     r"^(?:[0-9A-F]{24}|[0-9A-F]{24}\.[0-9A-F]{8}\.backup|[0-9A-F]{8}\.history)$"
 )
+
+
+def _load_python_module_from_path(module_name: str, path: Path) -> Any | None:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        loader = importlib.machinery.SourceFileLoader(module_name, str(path))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+    if spec is None or spec.loader is None:
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_upload_helpers() -> tuple[Any, Any, Any]:
@@ -55,12 +70,10 @@ def _load_upload_helpers() -> tuple[Any, Any, Any]:
         helper_path = Path(candidate)
         if not helper_path.is_file():
             continue
-        spec = importlib.util.spec_from_file_location("mvn_postgres_pitr_upload_helper", helper_path)
-        if spec is None or spec.loader is None:
+        module_name = "mvn_postgres_pitr_upload_helper"
+        module = _load_python_module_from_path(module_name, helper_path)
+        if module is None:
             continue
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)
         return module.build_client, module.load_config, module.sha256_file
 
     raise SystemExit(

--- a/tests/unit/test_postgres_pitr_restore.py
+++ b/tests/unit/test_postgres_pitr_restore.py
@@ -97,6 +97,29 @@ def _file_entry(backup_id: str, name: str, content: bytes) -> dict:
     }
 
 
+def test_load_python_module_from_path_supports_extensionless_helper(tmp_path):
+    helper = tmp_path / "mvn-postgres-pitr-upload"
+    helper.write_text(
+        "def build_client(config):\n"
+        "    return ('client', config)\n"
+        "def load_config():\n"
+        "    return 'config'\n"
+        "def sha256_file(path):\n"
+        "    return 'sha256'\n",
+        encoding="utf-8",
+    )
+
+    module = pitr_restore._load_python_module_from_path(
+        "test_extensionless_pitr_upload_helper",
+        helper,
+    )
+
+    assert module is not None
+    assert module.load_config() == "config"
+    assert module.build_client("cfg") == ("client", "cfg")
+    assert module.sha256_file("/tmp/file") == "sha256"
+
+
 def test_select_manifest_uses_latest_basebackup_before_target_time():
     manifests = [
         pitr_restore.BasebackupManifest(


### PR DESCRIPTION
## Summary
- teach the PITR restore helper to load installed Python helper files without a .py suffix
- add a regression test for the extensionless /usr/local/sbin-style helper path

## Tests
- python3 -m py_compile scripts/ha/restore_postgres_pitr_from_s3.py
- python3 scripts/ha/restore_postgres_pitr_from_s3.py --help
- python3 -m pytest tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_env_config.py -q