### PR TITLE
Fix installed PITR remote check loader

### DIFF
--- a/scripts/ha/check_postgres_pitr_remote.py
+++ b/scripts/ha/check_postgres_pitr_remote.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
 import importlib.util
 import os
 import sys
@@ -12,6 +13,20 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+def _load_python_module_from_path(module_name: str, path: Path) -> Any | None:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        loader = importlib.machinery.SourceFileLoader(module_name, str(path))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+    if spec is None or spec.loader is None:
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_upload_helpers() -> tuple[Any, Any]:
@@ -34,12 +49,9 @@ def _load_upload_helpers() -> tuple[Any, Any]:
         helper_path = Path(candidate)
         if not helper_path.is_file():
             continue
-        spec = importlib.util.spec_from_file_location("mvn_postgres_pitr_upload_helper", helper_path)
-        if spec is None or spec.loader is None:
+        module = _load_python_module_from_path("mvn_postgres_pitr_upload_helper", helper_path)
+        if module is None:
             continue
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)
         return module.build_client, module.load_config
 
     raise SystemExit(

--- a/tests/unit/test_postgres_pitr_remote_check.py
+++ b/tests/unit/test_postgres_pitr_remote_check.py
@@ -31,6 +31,26 @@ class FakeClient:
         return FakePaginator(self.pages)
 
 
+def test_load_python_module_from_path_supports_extensionless_helper(tmp_path):
+    helper = tmp_path / "mvn-postgres-pitr-upload"
+    helper.write_text(
+        "def build_client(config):\n"
+        "    return ('client', config)\n"
+        "def load_config():\n"
+        "    return 'config'\n",
+        encoding="utf-8",
+    )
+
+    module = pitr_remote._load_python_module_from_path(
+        "test_extensionless_pitr_remote_upload_helper",
+        helper,
+    )
+
+    assert module is not None
+    assert module.load_config() == "config"
+    assert module.build_client("cfg") == ("client", "cfg")
+
+
 def test_latest_object_picks_newest_matching_key():
     older = datetime(2026, 7, 1, 10, 0, tzinfo=timezone.utc)
     newer = datetime(2026, 7, 1, 11, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- make the PITR remote freshness checker load installed Python helpers without a .py suffix
- add a regression test for /usr/local/sbin-style extensionless helper files

## Tests
- python3 -m py_compile scripts/ha/check_postgres_pitr_remote.py
- python3 scripts/ha/check_postgres_pitr_remote.py --help
- python3 -m pytest tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_postgres_pitr_env_config.py -q