### PR TITLE
Add PostgreSQL PITR restore drill

### DIFF
--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -1,0 +1,130 @@
+name: PostgreSQL PITR Restore Drill
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      required:
+        description: "Run the drill even if POSTGRES_PITR_REQUIRED is not enabled"
+        type: boolean
+        required: false
+        default: false
+      backup_id:
+        description: "Optional PITR basebackup id to restore"
+        type: string
+        required: false
+        default: ""
+      target_time:
+        description: "Optional UTC point-in-time target, for example 2026-07-02T18:30:00Z"
+        type: string
+        required: false
+        default: ""
+      require_wal:
+        description: "Fail if no archived WAL files are downloaded"
+        type: boolean
+        required: false
+        default: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  PITR_RESTORE_DRILL_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && inputs.required || vars.POSTGRES_PITR_REQUIRED || 'false' }}
+  PITR_RESTORE_BACKUP_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_id || '' }}
+  PITR_RESTORE_TARGET_TIME: ${{ github.event_name == 'workflow_dispatch' && inputs.target_time || '' }}
+  PITR_RESTORE_REQUIRE_WAL: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.require_wal) || 'true' }}
+
+jobs:
+  pitr-restore-drill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+
+    steps:
+      - name: Decide Whether To Run
+        id: gate
+        run: |
+          set -euo pipefail
+          case "${PITR_RESTORE_DRILL_REQUIRED}" in
+            true|TRUE|True|1|yes|YES|Yes|on|ON|On)
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              echo "PITR restore drill skipped because POSTGRES_PITR_REQUIRED is not true."
+              ;;
+          esac
+
+      - name: Checkout
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - name: Setup API SSH Key
+        if: steps.gate.outputs.run == 'true'
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/postgres_pitr_restore_drill_key
+          chmod 600 ~/.ssh/postgres_pitr_restore_drill_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+
+      - name: Run PostgreSQL PITR Restore Drill
+        if: steps.gate.outputs.run == 'true'
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-i ~/.ssh/postgres_pitr_restore_drill_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          remote_script="/tmp/mvn-postgres-pitr-restore-drill-${GITHUB_RUN_ID}.sh"
+          quote() {
+            printf '%q' "$1"
+          }
+
+          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "cat > '${remote_script}' && chmod +x '${remote_script}'" \
+            < scripts/ha/restore_postgres_pitr_drill.sh
+
+          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
+            PROJECT_DIR=$(quote "${API_PROJECT_DIR}") \
+            COMPOSE_FILE=$(quote "${API_COMPOSE_FILE}") \
+            BACKUP_ID=$(quote "${PITR_RESTORE_BACKUP_ID}") \
+            TARGET_TIME=$(quote "${PITR_RESTORE_TARGET_TIME}") \
+            REQUIRE_WAL=$(quote "${PITR_RESTORE_REQUIRE_WAL}") \
+            bash '${remote_script}'; \
+            status=\$?; \
+            rm -f '${remote_script}'; \
+            exit \${status}" | tee postgres-pitr-restore-drill.log
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## PostgreSQL PITR Restore Drill"
+            echo "- required: ${PITR_RESTORE_DRILL_REQUIRED}"
+            echo "- ran: ${{ steps.gate.outputs.run || 'false' }}"
+            echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
+            echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"
+            echo "- backup_id: ${PITR_RESTORE_BACKUP_ID:-latest}"
+            echo "- target_time: ${PITR_RESTORE_TARGET_TIME:-latest}"
+            echo "- require_wal: ${PITR_RESTORE_REQUIRE_WAL}"
+            echo "- log_artifact: postgres-pitr-restore-drill-log-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PITR Restore Drill Log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: postgres-pitr-restore-drill-log-${{ github.run_id }}
+          path: postgres-pitr-restore-drill.log
+          if-no-files-found: warn

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -55,7 +55,7 @@ unreviewed host-local compose edits:
 | Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
 | Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
 | PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
-| PostgreSQL PITR restore drill helper | `scripts/ha/restore_postgres_pitr_from_s3.py` |
+| PostgreSQL PITR restore helpers | `scripts/ha/restore_postgres_pitr_from_s3.py`, `scripts/ha/restore_postgres_pitr_drill.sh`, `.github/workflows/postgres-pitr-restore-drill.yml` |
 | PostgreSQL PITR env configuration | `scripts/ha/configure_postgres_pitr_env.py` |
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
@@ -116,6 +116,7 @@ Scheduled monitors:
 | `check-api-ha-invariants.yml` | every 30 minutes | public/primary ready and standby fenced |
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
 | `check-postgres-pitr.yml` | every 6 hours | PITR archive/timer/backlog and remote R2 freshness |
+| `postgres-pitr-restore-drill.yml` | daily when `POSTGRES_PITR_REQUIRED=true` | disposable physical restore from PITR basebackup + WAL |
 
 ## PostgreSQL PITR
 
@@ -179,6 +180,7 @@ tar -czf - \
   scripts/ha/create_postgres_pitr_basebackup.sh \
   scripts/ha/configure_postgres_pitr_env.py \
   scripts/ha/restore_postgres_pitr_from_s3.py \
+  scripts/ha/restore_postgres_pitr_drill.sh \
   scripts/ha/check_postgres_pitr_status.sh \
   scripts/ha/check_postgres_pitr_remote.py \
   scripts/ha/install_postgres_pitr_units.sh \
@@ -252,36 +254,42 @@ Manual GitHub monitor run:
 gh workflow run check-postgres-pitr.yml --repo mvnby/air-api --ref main -f required=true
 ```
 
-Point-in-time restore drill after the first private basebackup and WAL upload:
+Physical PITR restore drill after the first private basebackup and WAL upload:
 
 ```bash
-# List available private PITR basebackups. This prints no secret values.
-ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml run -T --rm app python scripts/ha/restore_postgres_pitr_from_s3.py list-basebackups'
-
-# Prepare an isolated restore directory on the host. The target dir must be
-# empty. This downloads the selected basebackup, verifies checksums, extracts it
-# under data/, downloads archived WAL under wal/, writes recovery.signal, and
-# configures restore_command to copy WAL from that local drill directory.
-ssh mvn-api 'rm -rf /root/mvn-pitr-restore && mkdir -p /root/mvn-pitr-restore'
-ssh mvn-api 'cd /opt/air-api && docker compose -f docker-compose.prod.yml run -T --rm -v /root/mvn-pitr-restore:/pitr-restore app python scripts/ha/restore_postgres_pitr_from_s3.py prepare --target-dir /pitr-restore --target-time <target-time-utc>'
-
-# Start a disposable PostgreSQL container against the prepared data directory.
-# Use this only for validation, never as a production replacement.
-ssh mvn-api 'docker run -d --rm --name mvn-pitr-restore-check --env-file /opt/air-api/.env -v /root/mvn-pitr-restore/data:/var/lib/postgresql/data -v /root/mvn-pitr-restore/wal:/pitr-restore/wal:ro postgres:15-alpine postgres'
-ssh mvn-api 'docker logs --tail=120 mvn-pitr-restore-check'
-ssh mvn-api 'docker exec mvn-pitr-restore-check sh -lc '\''PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -c "select pg_is_in_recovery(), pg_is_wal_replay_paused();"'\'''
-ssh mvn-api 'docker stop mvn-pitr-restore-check'
+ssh mvn-api 'PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml /usr/local/sbin/mvn-postgres-pitr-restore-drill'
 ```
 
-Expected result:
+The drill:
 
-- PostgreSQL starts in recovery against the isolated `/root/mvn-pitr-restore`
-  data directory.
-- Missing WAL segments are copied from `/pitr-restore/wal`.
-- Recovery pauses at `recovery_target_time` because the helper writes
-  `recovery_target_action = 'pause'`.
-- Validate the restored DB with read-only SQL before replacing any production
-  role.
+- selects the latest private PITR basebackup unless `BACKUP_ID` is provided;
+- downloads and verifies basebackup files and archived WAL into a temporary
+  host directory;
+- starts a disposable PostgreSQL container against that restored data
+  directory;
+- checks that public tables and critical MVN tables are queryable;
+- removes the temporary container and files by default;
+- never mounts or modifies the production or standby PostgreSQL volumes.
+
+Optional point-in-time target:
+
+```bash
+ssh mvn-api 'PROJECT_DIR=/opt/air-api COMPOSE_FILE=docker-compose.prod.yml TARGET_TIME=2026-07-02T18:30:00Z /usr/local/sbin/mvn-postgres-pitr-restore-drill'
+```
+
+With `TARGET_TIME`, the drill expects PostgreSQL recovery to pause at the target
+time. Use this for periodic manual PITR proof after the scheduled latest-backup
+drill is green.
+
+Manual GitHub restore-drill run:
+
+```bash
+gh workflow run postgres-pitr-restore-drill.yml --repo mvnby/air-api --ref main -f required=true
+```
+
+The scheduled workflow skips itself while `POSTGRES_PITR_REQUIRED=false`.
+After PITR is enabled and the strict PITR freshness check is green, leave
+`POSTGRES_PITR_REQUIRED=true` so the daily physical restore drill runs.
 
 ## GitHub Actions Routing
 

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -21,6 +21,7 @@ install -m 0755 scripts/ha/upload_postgres_pitr_wal.sh /usr/local/sbin/mvn-postg
 install -m 0755 scripts/ha/create_postgres_pitr_basebackup.sh /usr/local/sbin/mvn-postgres-pitr-basebackup
 install -m 0755 scripts/ha/configure_postgres_pitr_env.py /usr/local/sbin/mvn-postgres-pitr-configure-env
 install -m 0755 scripts/ha/restore_postgres_pitr_from_s3.py /usr/local/sbin/mvn-postgres-pitr-restore
+install -m 0755 scripts/ha/restore_postgres_pitr_drill.sh /usr/local/sbin/mvn-postgres-pitr-restore-drill
 install -m 0755 scripts/ha/check_postgres_pitr_status.sh /usr/local/sbin/mvn-postgres-pitr-status
 install -m 0755 scripts/ha/check_postgres_pitr_remote.py /usr/local/sbin/mvn-postgres-pitr-remote-status
 install -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.service /etc/systemd/system/mvn-postgres-wal-upload.service

--- a/scripts/ha/restore_postgres_pitr_drill.sh
+++ b/scripts/ha/restore_postgres_pitr_drill.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+APP_SERVICE="${APP_SERVICE:-app}"
+DB_SERVICE="${DB_SERVICE:-db}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15-alpine}"
+DRILL_DIR="${DRILL_DIR:-/tmp/mvn-postgres-pitr-restore-drill}"
+RESTORE_MOUNT_PATH="${RESTORE_MOUNT_PATH:-/pitr-restore}"
+TARGET_TIME="${TARGET_TIME:-${PITR_RESTORE_TARGET_TIME:-}}"
+BACKUP_ID="${BACKUP_ID:-${PITR_RESTORE_BACKUP_ID:-}}"
+REQUIRE_WAL="${REQUIRE_WAL:-${PITR_RESTORE_REQUIRE_WAL:-true}}"
+EXPECT_RECOVERY_PAUSED="${EXPECT_RECOVERY_PAUSED:-auto}"
+START_TIMEOUT_SECONDS="${START_TIMEOUT_SECONDS:-180}"
+KEEP_DRILL_CONTAINER="${KEEP_DRILL_CONTAINER:-false}"
+KEEP_DRILL_FILES="${KEEP_DRILL_FILES:-false}"
+
+log() {
+  printf '[pitr-restore-drill] %s\n' "$*"
+}
+
+normalize_bool() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On) printf 'true' ;;
+    false|FALSE|False|0|no|NO|No|off|OFF|Off) printf 'false' ;;
+    *) return 1 ;;
+  esac
+}
+
+is_unsigned_int() {
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+if ! REQUIRE_WAL="$(normalize_bool "${REQUIRE_WAL}")"; then
+  echo "REQUIRE_WAL must be true or false" >&2
+  exit 1
+fi
+
+if [[ "${EXPECT_RECOVERY_PAUSED}" == "auto" ]]; then
+  if [[ -n "${TARGET_TIME}" ]]; then
+    EXPECT_RECOVERY_PAUSED="true"
+  else
+    EXPECT_RECOVERY_PAUSED="false"
+  fi
+elif ! EXPECT_RECOVERY_PAUSED="$(normalize_bool "${EXPECT_RECOVERY_PAUSED}")"; then
+  echo "EXPECT_RECOVERY_PAUSED must be auto, true, or false" >&2
+  exit 1
+fi
+
+if ! is_unsigned_int "${START_TIMEOUT_SECONDS}"; then
+  echo "START_TIMEOUT_SECONDS must be an unsigned integer" >&2
+  exit 1
+fi
+
+if [[ ! -d "${PROJECT_DIR}" ]]; then
+  echo "Project dir not found: ${PROJECT_DIR}" >&2
+  exit 1
+fi
+if [[ ! -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]]; then
+  echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is not installed" >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is not available" >&2
+  exit 1
+fi
+
+cd "${PROJECT_DIR}"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+db_container="$("${COMPOSE[@]}" ps -q "${DB_SERVICE}")"
+if [[ -z "${db_container}" ]]; then
+  echo "DB service is not running: ${DB_SERVICE}" >&2
+  exit 1
+fi
+
+if ! "${COMPOSE[@]}" config --services | grep -Fxq "${APP_SERVICE}"; then
+  echo "App service is not defined in compose: ${APP_SERVICE}" >&2
+  exit 1
+fi
+
+in_recovery="$("${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -Atqc "SELECT pg_is_in_recovery()"' || true)"
+if [[ "${in_recovery}" != "f" ]]; then
+  echo "Refusing PITR drill on a non-primary DB service; pg_is_in_recovery=${in_recovery:-<empty>}" >&2
+  exit 1
+fi
+
+mapfile -t db_env < <("${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'printf "%s\n%s\n%s\n" "$POSTGRES_USER" "$POSTGRES_PASSWORD" "${POSTGRES_DB:-air_conditioners}"')
+POSTGRES_USER="${db_env[0]:-}"
+POSTGRES_PASSWORD="${db_env[1]:-}"
+POSTGRES_DB="${db_env[2]:-air_conditioners}"
+
+if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_PASSWORD}" || -z "${POSTGRES_DB}" ]]; then
+  echo "Could not read POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_DB from ${DB_SERVICE} container." >&2
+  exit 1
+fi
+
+network="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "${db_container}" | head -n 1)"
+if [[ -z "${network}" ]]; then
+  echo "Could not detect Docker network for ${DB_SERVICE}" >&2
+  exit 1
+fi
+
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+run_dir="${DRILL_DIR}/${run_id}"
+target_dir="${run_dir}/restore"
+container="mvn_pitr_restore_drill_${run_id//[^A-Za-z0-9_]/_}"
+
+cleanup() {
+  if [[ "${KEEP_DRILL_CONTAINER}" != "true" ]]; then
+    docker rm -f "${container}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_DRILL_FILES}" != "true" ]]; then
+    rm -rf "${run_dir}"
+  else
+    log "kept drill files: ${run_dir}"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${target_dir}"
+chmod 700 "${run_dir}" "${target_dir}"
+
+prepare_args=(
+  python
+  scripts/ha/restore_postgres_pitr_from_s3.py
+  prepare
+  --target-dir "${RESTORE_MOUNT_PATH}"
+  --wal-mode local
+  --restore-mount-path "${RESTORE_MOUNT_PATH}"
+)
+if [[ -n "${BACKUP_ID}" ]]; then
+  prepare_args+=(--backup-id "${BACKUP_ID}")
+fi
+if [[ -n "${TARGET_TIME}" ]]; then
+  prepare_args+=(--target-time "${TARGET_TIME}")
+fi
+
+log "preparing isolated PITR restore under ${target_dir}"
+"${COMPOSE[@]}" run -T --rm \
+  -v "${target_dir}:${RESTORE_MOUNT_PATH}" \
+  "${APP_SERVICE}" \
+  "${prepare_args[@]}" | tee "${run_dir}/prepare.log"
+
+if [[ ! -d "${target_dir}/data" ]]; then
+  echo "Prepared PITR restore is missing data dir: ${target_dir}/data" >&2
+  exit 1
+fi
+if [[ ! -d "${target_dir}/wal" ]]; then
+  echo "Prepared PITR restore is missing WAL dir: ${target_dir}/wal" >&2
+  exit 1
+fi
+
+wal_count="$(find "${target_dir}/wal" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+log "downloaded_wal_files=${wal_count}"
+if [[ "${REQUIRE_WAL}" == "true" && "${wal_count}" -lt 1 ]]; then
+  echo "PITR restore drill expected at least one archived WAL file." >&2
+  exit 1
+fi
+
+log "starting disposable PostgreSQL container on network ${network}"
+docker run -d \
+  --name "${container}" \
+  --network "${network}" \
+  -e POSTGRES_USER="${POSTGRES_USER}" \
+  -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  -e POSTGRES_DB="${POSTGRES_DB}" \
+  -v "${target_dir}/data:/var/lib/postgresql/data" \
+  -v "${target_dir}/wal:${RESTORE_MOUNT_PATH}/wal:ro" \
+  "${POSTGRES_IMAGE}" \
+  postgres >/dev/null
+
+ready=false
+for _ in $(seq 1 "${START_TIMEOUT_SECONDS}"); do
+  if docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${ready}" != "true" ]]; then
+  docker logs --tail=160 "${container}" || true
+  echo "Disposable PostgreSQL did not become ready." >&2
+  exit 1
+fi
+
+state="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -AtF '|' \
+  -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+  -c "SELECT pg_is_in_recovery(), CASE WHEN pg_is_in_recovery() THEN pg_is_wal_replay_paused() ELSE false END, CASE WHEN pg_is_in_recovery() THEN coalesce(pg_last_wal_replay_lsn()::text, '<none>') ELSE '<not-in-recovery>' END;")"
+IFS='|' read -r restored_in_recovery restored_replay_paused restored_replay_lsn <<< "${state}"
+
+log "restored_in_recovery=${restored_in_recovery}"
+log "restored_replay_paused=${restored_replay_paused}"
+log "restored_replay_lsn=${restored_replay_lsn}"
+
+if [[ "${EXPECT_RECOVERY_PAUSED}" == "true" ]]; then
+  if [[ "${restored_in_recovery}" != "t" || "${restored_replay_paused}" != "t" ]]; then
+    docker logs --tail=160 "${container}" || true
+    echo "Expected recovery to pause at target time, got in_recovery=${restored_in_recovery} paused=${restored_replay_paused}" >&2
+    exit 1
+  fi
+fi
+
+tables_count="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -Atqc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" \
+  -U "${POSTGRES_USER}" -d "${POSTGRES_DB}")"
+
+if [[ "${tables_count}" -lt 10 ]]; then
+  echo "PITR restore drill produced too few public tables: ${tables_count}" >&2
+  exit 1
+fi
+
+log "public_tables=${tables_count}"
+docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
+SELECT 'product_count=' || count(*) FROM product;
+SELECT 'payment_count=' || count(*) FROM payment;
+SELECT 'order_count=' || count(*) FROM "order";
+SQL
+
+log "PITR restore drill passed; production and standby databases were not modified"


### PR DESCRIPTION
## Summary
- add a host-level PostgreSQL PITR restore drill helper that restores basebackup + WAL into a disposable Postgres container
- add a scheduled/manual GitHub Actions workflow gated by POSTGRES_PITR_REQUIRED
- update the HA runbook and PITR installer with the new restore-drill path

## Validation
- bash -n scripts/ha/restore_postgres_pitr_drill.sh scripts/ha/install_postgres_pitr_units.sh
- python3 -m pytest tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_postgres_pitr_env_config.py -q
- parsed .github/workflows/postgres-pitr-restore-drill.yml with PyYAML
- verified the recovery-state SQL against production Postgres with a read-only query
