### PR TITLE
Log skipped PITR restore drill

### DIFF
--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -52,6 +52,7 @@ jobs:
             *)
               echo "run=false" >> "$GITHUB_OUTPUT"
               echo "PITR restore drill skipped because POSTGRES_PITR_REQUIRED is not true."
+              printf '%s\n' "PITR restore drill skipped because POSTGRES_PITR_REQUIRED is not true." > postgres-pitr-restore-drill.log
               ;;
           esac
 


### PR DESCRIPTION
## Summary
- create a small restore-drill log even when the PITR restore drill is skipped
- avoids a noisy missing-artifact warning while POSTGRES_PITR_REQUIRED=false

## Validation
- parsed .github/workflows/postgres-pitr-restore-drill.yml with PyYAML
- git diff --check
