### PR TITLE
Harden standby promotion helper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -467,6 +467,9 @@ jobs:
             echo "⏭️ API_STANDBY_COPY_COMPOSE=${API_STANDBY_COPY_COMPOSE}; keeping remote standby compose unchanged"
           fi
 
+          cat scripts/ha/promote_local_standby.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-promote-local-standby"
+          cat scripts/ha/mvn-standby-status.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-standby-status"
+
           ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
             set -euo pipefail && \
             cd '${API_STANDBY_PROJECT_DIR}' && \

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -426,6 +426,13 @@ Preferred helper path, run on `zakup` after copying
 ssh zakup 'OLD_PRIMARY_SSH=root@10.77.0.2 CONFIRM_PROMOTE=true /usr/local/sbin/mvn-promote-local-standby'
 ```
 
+The helper refuses to promote without `OLD_PRIMARY_SSH` by default. If
+`mvn-api` is unreachable and cannot be fenced over SSH, make that risk explicit:
+
+```bash
+ssh zakup 'ALLOW_UNFENCED_PROMOTE=true CONFIRM_PROMOTE=true /usr/local/sbin/mvn-promote-local-standby'
+```
+
 The manual steps below are the same procedure expanded for review.
 
 1. Fence the old primary first if reachable:

--- a/scripts/ha/promote_local_standby.sh
+++ b/scripts/ha/promote_local_standby.sh
@@ -9,15 +9,21 @@ OLD_PRIMARY_SSH="${OLD_PRIMARY_SSH:-}"
 OLD_PRIMARY_PROJECT_DIR="${OLD_PRIMARY_PROJECT_DIR:-/opt/air-api}"
 OLD_PRIMARY_COMPOSE_FILE="${OLD_PRIMARY_COMPOSE_FILE:-docker-compose.prod.yml}"
 CONFIRM_PROMOTE="${CONFIRM_PROMOTE:-false}"
+ALLOW_UNFENCED_PROMOTE="${ALLOW_UNFENCED_PROMOTE:-false}"
 
 usage() {
   cat <<'USAGE'
 Usage:
   CONFIRM_PROMOTE=true bash scripts/ha/promote_local_standby.sh
+  CONFIRM_PROMOTE=true bash scripts/ha/promote_local_standby.sh --allow-unfenced
 
 Runs on the standby host. It fences the old primary when OLD_PRIMARY_SSH is set,
 promotes local PostgreSQL, swaps the local compose file to the prepared primary
 compose, starts app+bot, disables media pull, and verifies local /api/ready.
+
+By default the helper refuses to promote when OLD_PRIMARY_SSH is empty. If the
+old primary is unreachable and cannot be fenced over SSH, explicitly set
+ALLOW_UNFENCED_PROMOTE=true or pass --allow-unfenced.
 
 Important env:
   PROJECT_DIR=/opt/mvn-reserve
@@ -28,6 +34,7 @@ Important env:
   OLD_PRIMARY_COMPOSE_FILE=docker-compose.prod.yml
   LOCAL_READY_URL=http://127.0.0.1:18000/api/ready
   CONFIRM_PROMOTE=true
+  ALLOW_UNFENCED_PROMOTE=false
 USAGE
 }
 
@@ -39,6 +46,9 @@ for arg in "$@"; do
       ;;
     --yes)
       CONFIRM_PROMOTE=true
+      ;;
+    --allow-unfenced)
+      ALLOW_UNFENCED_PROMOTE=true
       ;;
     *)
       echo "Unsupported argument: ${arg}" >&2
@@ -59,6 +69,11 @@ if [[ "${CONFIRM_PROMOTE}" != "true" ]]; then
     echo "Refusing to promote without CONFIRM_PROMOTE=true or --yes." >&2
     exit 1
   fi
+fi
+
+if [[ -z "${OLD_PRIMARY_SSH}" && "${ALLOW_UNFENCED_PROMOTE}" != "true" ]]; then
+  echo "Refusing to promote without OLD_PRIMARY_SSH fencing. If the old primary is unreachable, set ALLOW_UNFENCED_PROMOTE=true or pass --allow-unfenced." >&2
+  exit 1
 fi
 
 cd "${PROJECT_DIR}"
@@ -88,7 +103,7 @@ if [[ -n "${OLD_PRIMARY_SSH}" ]]; then
   ssh -o BatchMode=yes -o ConnectTimeout=10 "${OLD_PRIMARY_SSH}" \
     "cd '${OLD_PRIMARY_PROJECT_DIR}' && docker compose -f '${OLD_PRIMARY_COMPOSE_FILE}' stop app bot"
 else
-  echo "WARNING: OLD_PRIMARY_SSH is empty; old primary was not fenced by this script." >&2
+  echo "WARNING: OLD_PRIMARY_SSH is empty and ALLOW_UNFENCED_PROMOTE=true; old primary was not fenced by this script." >&2
 fi
 
 echo "Promoting local PostgreSQL..."

--- a/tests/unit/test_promote_local_standby_script.py
+++ b/tests/unit/test_promote_local_standby_script.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/ha/promote_local_standby.sh"
+
+
+def run_script(*args, env=None):
+    merged_env = os.environ.copy()
+    merged_env.update(env or {})
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        env=merged_env,
+        text=True,
+    )
+
+
+def test_promote_refuses_without_old_primary_fencing(tmp_path):
+    result = run_script(
+        env={
+            "CONFIRM_PROMOTE": "true",
+            "PROJECT_DIR": str(tmp_path),
+            "OLD_PRIMARY_SSH": "",
+            "ALLOW_UNFENCED_PROMOTE": "false",
+        }
+    )
+
+    assert result.returncode == 1
+    assert "Refusing to promote without OLD_PRIMARY_SSH fencing" in result.stderr
+    assert "ALLOW_UNFENCED_PROMOTE=true" in result.stderr
+
+
+def test_promote_allow_unfenced_requires_explicit_opt_in(tmp_path):
+    result = run_script(
+        "--allow-unfenced",
+        env={
+            "CONFIRM_PROMOTE": "true",
+            "PROJECT_DIR": str(tmp_path),
+            "OLD_PRIMARY_SSH": "",
+            "ALLOW_UNFENCED_PROMOTE": "false",
+        },
+    )
+
+    assert result.returncode == 1
+    assert "Compose file not found" in result.stderr
+    assert "Refusing to promote without OLD_PRIMARY_SSH fencing" not in result.stderr
+
+
+def test_promote_help_documents_unfenced_guard():
+    result = run_script("--help")
+
+    assert result.returncode == 0
+    assert "ALLOW_UNFENCED_PROMOTE=false" in result.stdout
+    assert "--allow-unfenced" in result.stdout


### PR DESCRIPTION
## Summary
- require explicit old-primary fencing before local standby promotion unless ALLOW_UNFENCED_PROMOTE=true is set
- install the standby promotion and status helpers during standby deploys
- document the explicit unfenced emergency path in the HA runbook

## Validation
- pytest tests/unit/test_promote_local_standby_script.py -q
- bash -n scripts/ha/promote_local_standby.sh
- YAML parse for .github/workflows/deploy.yml
- git diff --check
- ssh zakup '/usr/local/sbin/mvn-promote-local-standby --help | head -n 18'