### PR TITLE
Harden Cloudflare LB audit gating

### DIFF
--- a/.github/workflows/check-cloudflare-lb-config.yml
+++ b/.github/workflows/check-cloudflare-lb-config.yml
@@ -20,9 +20,15 @@ on:
         type: string
         required: false
         default: ""
+      required:
+        description: "Fail if Cloudflare credentials are missing"
+        type: boolean
+        required: false
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  CF_LB_CONFIG_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && inputs.required || vars.CLOUDFLARE_LB_CONFIG_REQUIRED || 'false' }}
 
 jobs:
   check:
@@ -49,10 +55,29 @@ jobs:
           CF_LB_MONITOR_EXPECTED_CODE: "200"
           CF_LB_REQUIRE_ADAPTIVE_FAILOVER: "true"
           CF_LB_REQUIRE_SESSION_AFFINITY_OFF: "true"
-          CF_LB_SKIP_IF_MISSING_CREDENTIALS: "true"
         run: |
           set -euo pipefail
+          case "${CF_LB_CONFIG_REQUIRED}" in
+            true|TRUE|True|1|yes|YES|Yes|on|ON|On)
+              export CF_LB_SKIP_IF_MISSING_CREDENTIALS=false
+              ;;
+            *)
+              export CF_LB_SKIP_IF_MISSING_CREDENTIALS=true
+              ;;
+          esac
           python3 scripts/ha/check_cloudflare_lb_config.py | tee cloudflare-lb-config.log
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## Cloudflare LB Config Check"
+            echo "- required: ${CF_LB_CONFIG_REQUIRED}"
+            echo "- hostname: ${{ github.event.inputs.hostname || vars.CF_LB_HOSTNAME || 'api.mvn.by' }}"
+            echo "- primary_origin: ${{ github.event.inputs.primary_origin || vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}"
+            echo "- standby_origin: ${{ github.event.inputs.standby_origin || vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
+            echo "- log_artifact: cloudflare-lb-config-log-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Cloudflare LB config log
         if: always()

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -406,13 +406,16 @@ GitHub scheduled audit:
 gh secret set CLOUDFLARE_LB_READ_TOKEN --repo mvnby/air-api
 gh variable set CLOUDFLARE_ZONE_ID --repo mvnby/air-api --body <zone-id>
 gh variable set CLOUDFLARE_ACCOUNT_ID --repo mvnby/air-api --body <account-id>
-gh workflow run check-cloudflare-lb-config.yml --repo mvnby/air-api --ref main
+gh workflow run check-cloudflare-lb-config.yml --repo mvnby/air-api --ref main -f required=true
+gh variable set CLOUDFLARE_LB_CONFIG_REQUIRED --repo mvnby/air-api --body true
 ```
 
 Until those values exist, the scheduled workflow exits as skipped and does not
-fail. After the read-only token is configured, the workflow fails on config
-drift such as reversed pool order, fallback pointing to standby, missing Host
-header, or monitor path changing away from `/api/ready`.
+fail. After the read-only token is configured and the manual `required=true`
+run is green, set `CLOUDFLARE_LB_CONFIG_REQUIRED=true`. From that point the
+scheduled workflow fails if credentials disappear or config drifts, including
+reversed pool order, fallback pointing to standby, missing Host header, or
+monitor path changing away from `/api/ready`.
 
 ## Emergency Failover: `mvn-api` -> `zakup`
 

--- a/tests/unit/test_cloudflare_lb_workflow.py
+++ b/tests/unit/test_cloudflare_lb_workflow.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(".github/workflows/check-cloudflare-lb-config.yml")
+
+
+def test_cloudflare_lb_workflow_has_strict_required_gate():
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert "required:" in workflow
+    assert "CF_LB_CONFIG_REQUIRED:" in workflow
+    assert "CLOUDFLARE_LB_CONFIG_REQUIRED" in workflow
+    assert "CF_LB_SKIP_IF_MISSING_CREDENTIALS=false" in workflow
+    assert "CF_LB_SKIP_IF_MISSING_CREDENTIALS=true" in workflow
+    assert 'CF_LB_SKIP_IF_MISSING_CREDENTIALS: "true"' not in workflow


### PR DESCRIPTION
## Summary
- add a strict required mode to the Cloudflare LB config workflow
- keep scheduled checks soft-skipping until Cloudflare credentials are configured
- document enabling strict mode after the manual required check passes

## Tests
- pytest tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py -q
- yaml parse for .github/workflows/check-cloudflare-lb-config.yml
- soft/strict missing-credentials script checks