### PR TITLE
Harden PostgreSQL PITR workflow gates

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -222,7 +222,9 @@ ssh mvn-api 'CONFIRM_RECREATE_DB=true /usr/local/sbin/mvn-postgres-pitr-bootstra
 # Then enable recurring PITR.
 ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap enable-timers'
 
-# Finally make the scheduled GitHub PITR check strict.
+# Finally make the scheduled GitHub PITR check strict, but only after
+# `mvn-postgres-pitr-bootstrap verify` and one physical restore drill have both
+# passed with archived WAL present.
 gh variable set POSTGRES_PITR_REQUIRED --repo mvnby/air-api --body true
 ```
 
@@ -288,8 +290,9 @@ gh workflow run postgres-pitr-restore-drill.yml --repo mvnby/air-api --ref main 
 ```
 
 The scheduled workflow skips itself while `POSTGRES_PITR_REQUIRED=false`.
-After PITR is enabled and the strict PITR freshness check is green, leave
-`POSTGRES_PITR_REQUIRED=true` so the daily physical restore drill runs.
+Do not set `POSTGRES_PITR_REQUIRED=true` until both the strict freshness check
+and a physical restore drill pass. After that, leave it true so the daily drill
+keeps proving that basebackups plus archived WAL can actually be restored.
 
 ## GitHub Actions Routing
 

--- a/tests/unit/test_postgres_pitr_workflows.py
+++ b/tests/unit/test_postgres_pitr_workflows.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, job_name: str, step_name: str) -> dict:
+    steps = workflow["jobs"][job_name]["steps"]
+    return next(step for step in steps if step.get("name") == step_name)
+
+
+def test_postgres_pitr_check_workflow_preserves_strict_remote_gate():
+    workflow = _workflow(".github/workflows/check-postgres-pitr.yml")
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    check_step = _step(workflow, "check", "Run PostgreSQL PITR Check")
+    summary_step = _step(workflow, "check", "Write Summary")
+    artifact_step = _step(workflow, "check", "Upload PITR Check Log")
+
+    assert dispatch_inputs["required"]["default"] == "false"
+    assert "Fail if PITR is not fully enabled" in dispatch_inputs["required"]["description"]
+    assert "POSTGRES_PITR_REQUIRED" in check_step["env"]["PITR_REQUIRED"]
+    assert "POSTGRES_PITR_MAX_WAL_AGE_MINUTES" in check_step["env"]["PITR_MAX_WAL_AGE_MINUTES"]
+    assert "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS" in check_step["env"]["PITR_MAX_BASEBACKUP_AGE_HOURS"]
+    assert "scripts/ha/check_postgres_pitr_status.sh" in check_step["run"]
+    assert "PITR_REQUIRED='${PITR_REQUIRED}'" in check_step["run"]
+    assert "PITR_MAX_WAL_AGE_MINUTES='${PITR_MAX_WAL_AGE_MINUTES}'" in check_step["run"]
+    assert "PITR_MAX_BASEBACKUP_AGE_HOURS='${PITR_MAX_BASEBACKUP_AGE_HOURS}'" in check_step["run"]
+    assert "postgres-pitr-check.log" in check_step["run"]
+    assert "pitr_required:" in summary_step["run"]
+    assert artifact_step["if"] == "always()"
+    assert artifact_step["with"]["path"] == "postgres-pitr-check.log"
+
+
+def test_postgres_pitr_restore_drill_workflow_preserves_required_gate_and_wal_proof():
+    workflow = _workflow(".github/workflows/postgres-pitr-restore-drill.yml")
+    env = workflow["env"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    gate_step = _step(workflow, "pitr-restore-drill", "Decide Whether To Run")
+    drill_step = _step(workflow, "pitr-restore-drill", "Run PostgreSQL PITR Restore Drill")
+    summary_step = _step(workflow, "pitr-restore-drill", "Write Summary")
+    artifact_step = _step(workflow, "pitr-restore-drill", "Upload PITR Restore Drill Log")
+
+    assert "POSTGRES_PITR_REQUIRED" in env["PITR_RESTORE_DRILL_REQUIRED"]
+    assert dispatch_inputs["required"]["default"] == "false"
+    assert dispatch_inputs["require_wal"]["default"] == "true"
+    assert "PITR restore drill skipped because POSTGRES_PITR_REQUIRED is not true." in gate_step["run"]
+    assert "postgres-pitr-restore-drill.log" in gate_step["run"]
+    assert drill_step["if"] == "steps.gate.outputs.run == 'true'"
+    assert "scripts/ha/restore_postgres_pitr_drill.sh" in drill_step["run"]
+    assert "REQUIRE_WAL=$(quote \"${PITR_RESTORE_REQUIRE_WAL}\")" in drill_step["run"]
+    assert "postgres-pitr-restore-drill.log" in drill_step["run"]
+    assert "require_wal:" in summary_step["run"]
+    assert artifact_step["if"] == "always()"
+    assert artifact_step["with"]["path"] == "postgres-pitr-restore-drill.log"


### PR DESCRIPTION
## Summary
- add unit coverage for PostgreSQL PITR check and restore-drill workflow gates
- require the restore drill workflow to stay tied to POSTGRES_PITR_REQUIRED and WAL proof
- clarify in the HA runbook that POSTGRES_PITR_REQUIRED must only be enabled after strict freshness and physical restore drill pass

## Tests
- pytest tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_workflows.py -q
- python3 YAML parse check for PITR workflows
- git diff --check