### PR TITLE
Monitor DB-backed media CDN URLs

### DIFF
--- a/.github/workflows/check-media-cdn.yml
+++ b/.github/workflows/check-media-cdn.yml
@@ -20,6 +20,11 @@ on:
         type: string
         required: false
         default: "3"
+      min_db_cdn_urls:
+        description: "Minimum DB-backed object-storage CDN URLs"
+        type: string
+        required: false
+        default: "3"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -50,6 +55,49 @@ jobs:
             2>&1 \
             | tee media-cdn-check.log
 
+      - name: Setup API SSH Key
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/media_cdn_key
+          chmod 600 ~/.ssh/media_cdn_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+
+      - name: Run DB-backed media CDN check
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          EXPECTED_CDN_BASE: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_cdn_base || 'https://cdn.mvn.by' }}
+          MIN_DB_CDN_URLS: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls || '3' }}
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-i ~/.ssh/media_cdn_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          quote() {
+            printf '%q' "$1"
+          }
+
+          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
+            set -euo pipefail && \
+            cd $(quote "${API_PROJECT_DIR}") && \
+            docker compose -f $(quote "${API_COMPOSE_FILE}") exec -T app \
+              python3 scripts/check_media_cdn_db_urls.py \
+                --expected-cdn-base $(quote "${EXPECTED_CDN_BASE}") \
+                --min-db-cdn-urls $(quote "${MIN_DB_CDN_URLS}") \
+                --max-fetches 10" \
+            2>&1 \
+            | tee -a media-cdn-check.log
+
       - name: Write Summary
         if: always()
         run: |
@@ -58,6 +106,9 @@ jobs:
             echo "- products_url: ${{ github.event_name == 'workflow_dispatch' && inputs.products_url || 'https://api.mvn.by/api/v1/products?limit=5' }}"
             echo "- expected_cdn_base: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_cdn_base || 'https://cdn.mvn.by' }}"
             echo "- min_cdn_urls: ${{ github.event_name == 'workflow_dispatch' && inputs.min_cdn_urls || '3' }}"
+            echo "- min_db_cdn_urls: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls || '3' }}"
+            echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
+            echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"
             echo "- log_artifact: media-cdn-check-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -118,7 +118,7 @@ Scheduled monitors:
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
 | `check-postgres-pitr.yml` | every 6 hours | PITR archive/timer/backlog and remote R2 freshness |
 | `postgres-pitr-restore-drill.yml` | daily when `POSTGRES_PITR_REQUIRED=true` | disposable physical restore from PITR basebackup + WAL |
-| `check-media-cdn.yml` | every 6 hours | public product primary images use `cdn.mvn.by` and CDN objects are cacheable |
+| `check-media-cdn.yml` | every 6 hours | public product images and DB-backed object-storage media use `cdn.mvn.by`; sampled CDN objects are cacheable |
 
 ## PostgreSQL PITR
 

--- a/docs/media-storage-r2.md
+++ b/docs/media-storage-r2.md
@@ -385,7 +385,10 @@ After the bounded smoke passes and the owner approves the full switch:
 4. Monitor backend logs for `S3/R2 media storage` errors and Pillow processing
    failures during normal manager uploads/search attaches and variant
    generation.
-5. Spot-check new manager media rows daily during the first rollout window:
+5. Keep the scheduled `check-media-cdn.yml` workflow green. It samples public
+   catalog image URLs and DB-backed object-storage rows from the API primary,
+   including product variants, media library assets, and order/bot attachments.
+6. Spot-check new manager media rows daily during the first rollout window:
 
    ```sql
    select variant_type, storage_provider, processing_status, count(*)

--- a/scripts/check_media_cdn_db_urls.py
+++ b/scripts/check_media_cdn_db_urls.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Check stored DB media references against the public CDN.
+
+The script is intended to run inside the API app container. It only reads DB
+rows and fetches public CDN URLs; it does not print raw order metadata or any
+storage credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+for path in (SCRIPT_DIR, REPO_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from check_media_cdn_public import (  # noqa: E402
+    CdnFetchResult,
+    default_urlopen,
+    fetch_cdn_url,
+    validate_fetch_result,
+)
+
+
+OBJECT_STORAGE_PROVIDERS = {"r2", "s3", "s3_compatible"}
+UrlOpener = Callable[[Request, float], Any]
+
+
+@dataclass(frozen=True)
+class DbMediaRef:
+    source: str
+    object_id: str
+    field: str
+    storage_provider: str
+    url: str | None
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_url(value: Any) -> str | None:
+    cleaned = _clean_string(value)
+    return cleaned or None
+
+
+def _is_object_storage_provider(value: Any) -> bool:
+    return _clean_string(value).lower() in OBJECT_STORAGE_PROVIDERS
+
+
+def iter_object_storage_entries(value: Any, *, path: str = "$") -> Iterable[tuple[str, Mapping[str, Any]]]:
+    if isinstance(value, Mapping):
+        if _is_object_storage_provider(value.get("storage_provider")):
+            yield path, value
+        for key, nested in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            yield from iter_object_storage_entries(nested, path=child_path)
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            yield from iter_object_storage_entries(nested, path=f"{path}[{index}]")
+
+
+def refs_from_order_meta(order_id: int | str, technical_meta: Any) -> list[DbMediaRef]:
+    refs: list[DbMediaRef] = []
+    for path, entry in iter_object_storage_entries(technical_meta):
+        refs.append(
+            DbMediaRef(
+                source="order_technical_meta",
+                object_id=str(order_id),
+                field=path,
+                storage_provider=_clean_string(entry.get("storage_provider")).lower(),
+                url=_clean_url(entry.get("url")),
+            )
+        )
+    return refs
+
+
+def validate_db_media_refs(
+    refs: list[DbMediaRef],
+    *,
+    expected_cdn_base: str,
+    min_db_cdn_urls: int,
+) -> list[str]:
+    failures: list[str] = []
+    normalized_base = expected_cdn_base.rstrip("/")
+    cdn_count = 0
+
+    for ref in refs:
+        label = f"source={ref.source} object_id={ref.object_id} field={ref.field}"
+        if not _is_object_storage_provider(ref.storage_provider):
+            failures.append(f"{label} provider is not object storage: {ref.storage_provider or '-'}")
+            continue
+        if not ref.url:
+            failures.append(f"{label} provider={ref.storage_provider} is missing public URL")
+            continue
+
+        parsed = urlparse(ref.url)
+        if parsed.scheme not in {"http", "https"}:
+            failures.append(f"{label} url is not absolute: {ref.url}")
+            continue
+        if not ref.url.startswith(f"{normalized_base}/"):
+            failures.append(f"{label} url does not use {normalized_base}: {ref.url}")
+            continue
+        cdn_count += 1
+
+    if cdn_count < min_db_cdn_urls:
+        failures.append(f"only {cdn_count} DB CDN media urls found; expected at least {min_db_cdn_urls}")
+
+    return failures
+
+
+def unique_db_cdn_urls(refs: list[DbMediaRef], *, expected_cdn_base: str) -> list[str]:
+    normalized_base = expected_cdn_base.rstrip("/")
+    seen: set[str] = set()
+    urls: list[str] = []
+    for ref in refs:
+        if not ref.url or not ref.url.startswith(f"{normalized_base}/"):
+            continue
+        if ref.url in seen:
+            continue
+        seen.add(ref.url)
+        urls.append(ref.url)
+    return urls
+
+
+async def collect_db_media_refs(*, max_rows_per_source: int, order_scan_limit: int) -> list[DbMediaRef]:
+    from sqlalchemy import String, cast, select
+
+    from core.database import async_session_maker
+    from models import MediaAsset, Order, ProductImageVariant
+
+    refs: list[DbMediaRef] = []
+    async with async_session_maker() as session:
+        variant_rows = await session.execute(
+            select(
+                ProductImageVariant.id,
+                ProductImageVariant.variant_type,
+                ProductImageVariant.url,
+                ProductImageVariant.storage_provider,
+            )
+            .where(ProductImageVariant.storage_provider.in_(sorted(OBJECT_STORAGE_PROVIDERS)))
+            .order_by(ProductImageVariant.updated_at.desc(), ProductImageVariant.id.desc())
+            .limit(max_rows_per_source)
+        )
+        for variant_id, variant_type, url, storage_provider in variant_rows.all():
+            refs.append(
+                DbMediaRef(
+                    source="product_image_variant",
+                    object_id=str(variant_id),
+                    field=str(variant_type or "url"),
+                    storage_provider=_clean_string(storage_provider).lower(),
+                    url=_clean_url(url),
+                )
+            )
+
+        media_rows = await session.execute(
+            select(MediaAsset.id, MediaAsset.variant_type, MediaAsset.url, MediaAsset.storage_provider)
+            .where(MediaAsset.storage_provider.in_(sorted(OBJECT_STORAGE_PROVIDERS)))
+            .order_by(MediaAsset.updated_at.desc(), MediaAsset.id.desc())
+            .limit(max_rows_per_source)
+        )
+        for asset_id, variant_type, url, storage_provider in media_rows.all():
+            refs.append(
+                DbMediaRef(
+                    source="media_asset",
+                    object_id=str(asset_id),
+                    field=str(variant_type or "url"),
+                    storage_provider=_clean_string(storage_provider).lower(),
+                    url=_clean_url(url),
+                )
+            )
+
+        order_rows = await session.execute(
+            select(Order.id, Order.technical_meta)
+            .where(cast(Order.technical_meta, String).ilike("%storage_provider%"))
+            .order_by(Order.updated_at.desc(), Order.id.desc())
+            .limit(order_scan_limit)
+        )
+        for order_id, technical_meta in order_rows.all():
+            refs.extend(refs_from_order_meta(order_id, technical_meta))
+
+    return refs
+
+
+async def check_db_media_cdn(
+    *,
+    expected_cdn_base: str,
+    min_db_cdn_urls: int,
+    max_rows_per_source: int,
+    order_scan_limit: int,
+    max_fetches: int,
+    timeout: float,
+    opener: UrlOpener = default_urlopen,
+    skip_fetch: bool = False,
+) -> tuple[list[DbMediaRef], list[CdnFetchResult], list[str]]:
+    refs = await collect_db_media_refs(
+        max_rows_per_source=max_rows_per_source,
+        order_scan_limit=order_scan_limit,
+    )
+    failures = validate_db_media_refs(
+        refs,
+        expected_cdn_base=expected_cdn_base,
+        min_db_cdn_urls=min_db_cdn_urls,
+    )
+
+    fetch_results: list[CdnFetchResult] = []
+    if not skip_fetch:
+        for url in unique_db_cdn_urls(refs, expected_cdn_base=expected_cdn_base)[:max_fetches]:
+            try:
+                result = fetch_cdn_url(url, timeout=timeout, opener=opener)
+            except HTTPError as exc:
+                failures.append(f"url={url} failed with HTTP {exc.code}")
+                continue
+            except URLError as exc:
+                failures.append(f"url={url} failed: {exc.reason}")
+                continue
+            fetch_results.append(result)
+            failures.extend(validate_fetch_result(result))
+
+        if refs and not fetch_results:
+            failures.append("no DB CDN media URLs were fetched")
+
+    return refs, fetch_results, failures
+
+
+def _print_ref(ref: DbMediaRef) -> None:
+    print(
+        "db_media_cdn_ref "
+        f"source={ref.source} "
+        f"object_id={ref.object_id} "
+        f"field={ref.field} "
+        f"provider={ref.storage_provider or '-'} "
+        f"url={ref.url or '-'}"
+    )
+
+
+def _print_fetch(result: CdnFetchResult) -> None:
+    print(
+        "db_media_cdn_fetch "
+        f"status={result.status} "
+        f"content_type={result.content_type or '-'} "
+        f"content_length={result.content_length or '-'} "
+        f"cache_control={result.cache_control or '-'} "
+        f"cf_cache_status={result.cf_cache_status or '-'} "
+        f"url={result.url}"
+    )
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check DB-backed media CDN URLs.")
+    parser.add_argument("--expected-cdn-base", default="https://cdn.mvn.by")
+    parser.add_argument("--min-db-cdn-urls", type=int, default=3)
+    parser.add_argument("--max-rows-per-source", type=int, default=20)
+    parser.add_argument("--order-scan-limit", type=int, default=200)
+    parser.add_argument("--max-fetches", type=int, default=10)
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--skip-fetch", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        refs, fetch_results, failures = await check_db_media_cdn(
+            expected_cdn_base=args.expected_cdn_base,
+            min_db_cdn_urls=args.min_db_cdn_urls,
+            max_rows_per_source=max(1, args.max_rows_per_source),
+            order_scan_limit=max(1, args.order_scan_limit),
+            max_fetches=max(1, args.max_fetches),
+            timeout=args.timeout,
+            skip_fetch=args.skip_fetch,
+        )
+    except Exception as exc:
+        print(f"db_media_cdn_status=error error_type={type(exc).__name__} error={exc}", file=sys.stderr)
+        return 1
+
+    for ref in refs:
+        _print_ref(ref)
+    for result in fetch_results:
+        _print_fetch(result)
+
+    if failures:
+        for failure in failures:
+            print(f"db_media_cdn_failure={failure}", file=sys.stderr)
+        return 1
+
+    print(
+        "db_media_cdn_status=passed "
+        f"db_media_refs={len(refs)} "
+        f"cdn_urls_checked={len(fetch_results)}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(async_main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_media_cdn_db_urls.py
+++ b/tests/unit/test_media_cdn_db_urls.py
@@ -1,0 +1,108 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts/check_media_cdn_db_urls.py"
+SPEC = importlib.util.spec_from_file_location("check_media_cdn_db_urls", MODULE_PATH)
+check_media_cdn_db_urls = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = check_media_cdn_db_urls
+SPEC.loader.exec_module(check_media_cdn_db_urls)
+
+
+def test_refs_from_order_meta_extracts_nested_object_storage_entries_only():
+    refs = check_media_cdn_db_urls.refs_from_order_meta(
+        121,
+        {
+            "telegram_attachments": [
+                {"file_id": "legacy-only"},
+                {
+                    "storage_provider": "r2",
+                    "url": "https://cdn.mvn.by/orders/121/telegram/photo/hash.jpg",
+                    "raw_text": "must not be printed by checker",
+                },
+            ],
+            "repair": {
+                "nameplate_recognitions": [
+                    {
+                        "storage_provider": "local",
+                        "url": "/media/orders/121/local.jpg",
+                    },
+                    {
+                        "storage_provider": "s3_compatible",
+                        "url": "https://cdn.mvn.by/orders/121/telegram/photo/other.jpg",
+                    },
+                ]
+            },
+        },
+    )
+
+    assert [(ref.source, ref.object_id, ref.storage_provider, ref.url) for ref in refs] == [
+        (
+            "order_technical_meta",
+            "121",
+            "r2",
+            "https://cdn.mvn.by/orders/121/telegram/photo/hash.jpg",
+        ),
+        (
+            "order_technical_meta",
+            "121",
+            "s3_compatible",
+            "https://cdn.mvn.by/orders/121/telegram/photo/other.jpg",
+        ),
+    ]
+    assert refs[0].field == "$.telegram_attachments[1]"
+
+
+def test_validate_db_media_refs_requires_public_cdn_url_for_object_storage():
+    refs = [
+        check_media_cdn_db_urls.DbMediaRef(
+            source="product_image_variant",
+            object_id="1",
+            field="original",
+            storage_provider="r2",
+            url="https://cdn.mvn.by/products/variants/original/hash.webp",
+        ),
+        check_media_cdn_db_urls.DbMediaRef(
+            source="media_asset",
+            object_id="2",
+            field="original",
+            storage_provider="r2",
+            url=None,
+        ),
+        check_media_cdn_db_urls.DbMediaRef(
+            source="order_technical_meta",
+            object_id="121",
+            field="$.telegram_attachments[0]",
+            storage_provider="r2",
+            url="https://example.test/orders/121/file.jpg",
+        ),
+    ]
+
+    failures = check_media_cdn_db_urls.validate_db_media_refs(
+        refs,
+        expected_cdn_base="https://cdn.mvn.by",
+        min_db_cdn_urls=2,
+    )
+
+    assert any("provider=r2 is missing public URL" in failure for failure in failures)
+    assert any("url does not use https://cdn.mvn.by" in failure for failure in failures)
+    assert any("only 1 DB CDN media urls found; expected at least 2" in failure for failure in failures)
+
+
+def test_unique_db_cdn_urls_deduplicates_and_ignores_non_cdn_refs():
+    refs = [
+        check_media_cdn_db_urls.DbMediaRef("product_image_variant", "1", "original", "r2", "https://cdn.mvn.by/a.webp"),
+        check_media_cdn_db_urls.DbMediaRef("product_image_variant", "2", "card", "r2", "https://cdn.mvn.by/a.webp"),
+        check_media_cdn_db_urls.DbMediaRef("media_asset", "3", "original", "r2", "https://cdn.mvn.by/b.webp"),
+        check_media_cdn_db_urls.DbMediaRef("media_asset", "4", "original", "r2", "https://example.test/c.webp"),
+        check_media_cdn_db_urls.DbMediaRef("media_asset", "5", "original", "r2", None),
+    ]
+
+    urls = check_media_cdn_db_urls.unique_db_cdn_urls(
+        refs,
+        expected_cdn_base="https://cdn.mvn.by",
+    )
+
+    assert urls == ["https://cdn.mvn.by/a.webp", "https://cdn.mvn.by/b.webp"]

--- a/tests/unit/test_media_cdn_workflow.py
+++ b/tests/unit/test_media_cdn_workflow.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, step_name: str) -> dict:
+    return next(step for step in workflow["jobs"]["check"]["steps"] if step.get("name") == step_name)
+
+
+def test_media_cdn_workflow_keeps_public_and_db_backed_checks():
+    workflow = _workflow(".github/workflows/check-media-cdn.yml")
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    public_step = _step(workflow, "Run media CDN check")
+    ssh_step = _step(workflow, "Setup API SSH Key")
+    db_step = _step(workflow, "Run DB-backed media CDN check")
+    summary_step = _step(workflow, "Write Summary")
+    artifact_step = _step(workflow, "Upload media CDN log")
+
+    assert dispatch_inputs["min_db_cdn_urls"]["default"] == "3"
+    assert "scripts/check_media_cdn_public.py" in public_step["run"]
+    assert "secrets.SSH_HOST_API" in ssh_step["env"]["SSH_HOST_API"]
+    assert "secrets.SSH_USER_API" in ssh_step["env"]["SSH_USER_API"]
+    assert "secrets.SSH_KEY" in ssh_step["env"]["SSH_KEY"]
+    assert "scripts/check_media_cdn_db_urls.py" in db_step["run"]
+    assert "--min-db-cdn-urls" in db_step["run"]
+    assert "tee -a media-cdn-check.log" in db_step["run"]
+    assert "min_db_cdn_urls:" in summary_step["run"]
+    assert artifact_step["if"] == "always()"
+    assert artifact_step["with"]["path"] == "media-cdn-check.log"


### PR DESCRIPTION
## Summary
- add a read-only DB-backed media CDN checker for object-storage rows
- extend the scheduled Media CDN workflow to check production DB media references via SSH/app container
- cover the checker and workflow wiring with unit tests
- document that the monitor covers product variants, media library assets, and order/bot attachments

## Tests
- pytest tests/unit/test_media_cdn_public_check.py tests/unit/test_media_cdn_db_urls.py tests/unit/test_media_cdn_workflow.py -q
- python3 YAML parse check for .github/workflows/check-media-cdn.yml
- python3 -m py_compile scripts/check_media_cdn_db_urls.py scripts/check_media_cdn_public.py
- git diff --check