### PR TITLE
Add API HA readiness rollup audit

### DIFF
--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -1,0 +1,98 @@
+name: API HA Readiness Audit
+
+on:
+  schedule:
+    - cron: "11 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail unless Cloudflare LB strict audit and PITR are fully enabled"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  HA_READINESS_STRICT: ${{ github.event_name == 'workflow_dispatch' && inputs.strict || vars.API_HA_READINESS_STRICT || 'false' }}
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup API SSH Key
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/ha_readiness_key
+          chmod 600 ~/.ssh/ha_readiness_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Run API HA readiness audit
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+          API_STANDBY_COMPOSE_FILE: ${{ vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.reserve.yml' }}
+          API_PRIMARY_ORIGIN: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
+          API_STANDBY_ORIGIN: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
+          POSTGRES_PITR_REQUIRED: ${{ vars.POSTGRES_PITR_REQUIRED || 'false' }}
+          EXPECTED_CDN_BASE: https://cdn.mvn.by
+          MIN_DB_CDN_URLS: "3"
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_LB_READ_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ~/.ssh/ha_readiness_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          export PRIMARY_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+          export STANDBY_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export PRIMARY_ORIGIN="${API_PRIMARY_ORIGIN}"
+          export STANDBY_ORIGIN="${API_STANDBY_ORIGIN}"
+          export PRIMARY_PROJECT_DIR="${API_PROJECT_DIR}"
+          export PRIMARY_COMPOSE_FILE="${API_COMPOSE_FILE}"
+          export STANDBY_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          export STANDBY_COMPOSE_FILE="${API_STANDBY_COMPOSE_FILE}"
+          bash scripts/ha/check_api_ha_readiness.sh | tee api-ha-readiness.log
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## API HA Readiness Audit"
+            echo "- strict: ${HA_READINESS_STRICT}"
+            echo "- primary_origin: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}"
+            echo "- standby_origin: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
+            echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
+            echo "- standby_project_dir: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}"
+            echo "- log_artifact: api-ha-readiness-log-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload HA readiness log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-ha-readiness-log-${{ github.run_id }}
+          path: api-ha-readiness.log
+          if-no-files-found: warn

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -108,11 +108,24 @@ GitHub health check:
 gh workflow run check-api-vps-health.yml --repo mvnby/air-api --ref main -f mode=ssh
 ```
 
+Whole-system HA readiness audit:
+
+```bash
+gh workflow run check-api-ha-readiness.yml --repo mvnby/air-api --ref main
+```
+
+The audit fails on core readiness, replication, and media CDN problems. Until
+Cloudflare read-only credentials and PostgreSQL PITR are fully enabled, it
+reports those two items as soft blockers. Run with `strict=true` only after
+`CLOUDFLARE_LB_CONFIG_REQUIRED=true` and `POSTGRES_PITR_REQUIRED=true` are
+intended to be enforced.
+
 Scheduled monitors:
 
 | Workflow | Schedule | Purpose |
 | --- | --- | --- |
 | `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups, media storage config |
+| `check-api-ha-readiness.yml` | every 6 hours | whole-system HA readiness rollup; core checks fail, Cloudflare/PITR are soft blockers until strict |
 | `check-api-ha-invariants.yml` | every 30 minutes | public/primary ready and standby fenced |
 | `check-cloudflare-lb-config.yml` | every 6 hours | Cloudflare LB pool order, fallback, host header, and monitor config |
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+HA_READINESS_STRICT="${HA_READINESS_STRICT:-false}"
+
+API_HOST="${API_HOST:-api.mvn.by}"
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-https://${API_HOST}}"
+PRIMARY_ORIGIN="${PRIMARY_ORIGIN:-185.250.45.54}"
+STANDBY_ORIGIN="${STANDBY_ORIGIN:-193.47.42.213}"
+
+PRIMARY_SSH="${PRIMARY_SSH:-mvn-api}"
+STANDBY_SSH="${STANDBY_SSH:-zakup}"
+PRIMARY_PROJECT_DIR="${PRIMARY_PROJECT_DIR:-${API_PROJECT_DIR:-/opt/air-api}}"
+PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE:-${API_COMPOSE_FILE:-docker-compose.prod.yml}}"
+STANDBY_PROJECT_DIR="${STANDBY_PROJECT_DIR:-${API_STANDBY_PROJECT_DIR:-/opt/mvn-reserve}}"
+STANDBY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE:-${API_STANDBY_COMPOSE_FILE:-docker-compose.reserve.yml}}"
+
+EXPECTED_CDN_BASE="${EXPECTED_CDN_BASE:-https://cdn.mvn.by}"
+MIN_DB_CDN_URLS="${MIN_DB_CDN_URLS:-3}"
+
+CHECK_ACTIVE_PASSIVE="${CHECK_ACTIVE_PASSIVE:-true}"
+CHECK_POSTGRES_REPLICATION="${CHECK_POSTGRES_REPLICATION:-true}"
+CHECK_MEDIA_CDN_DB="${CHECK_MEDIA_CDN_DB:-true}"
+CHECK_POSTGRES_PITR="${CHECK_POSTGRES_PITR:-true}"
+CHECK_CLOUDFLARE_LB="${CHECK_CLOUDFLARE_LB:-true}"
+
+failures=0
+warnings=0
+soft_blockers=0
+
+log() {
+  local level="$1"
+  shift
+  printf '[ha-readiness][%s] %s\n' "${level}" "$*"
+}
+
+is_true() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+quote_remote() {
+  printf '%q' "$1"
+}
+
+fail() {
+  failures=$((failures + 1))
+  log fail "$*"
+}
+
+warn() {
+  warnings=$((warnings + 1))
+  log warn "$*"
+}
+
+soft_blocker() {
+  if is_true "${HA_READINESS_STRICT}"; then
+    fail "$*"
+  else
+    soft_blockers=$((soft_blockers + 1))
+    log soft-blocker "$*"
+  fi
+}
+
+run_required() {
+  local name="$1"
+  shift
+  log start "${name}"
+  if "$@"; then
+    log ok "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+run_required_shell() {
+  local name="$1"
+  shift
+  log start "${name}"
+  if bash -lc "$*"; then
+    log ok "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+run_active_passive() {
+  API_HOST="${API_HOST}" \
+    PUBLIC_BASE_URL="${PUBLIC_BASE_URL}" \
+    PRIMARY_ORIGIN="${PRIMARY_ORIGIN}" \
+    STANDBY_ORIGIN="${STANDBY_ORIGIN}" \
+    PRIMARY_ROLE=primary \
+    STANDBY_ROLE=standby \
+    bash scripts/ha/check_active_passive.sh
+}
+
+run_postgres_replication() {
+  PRIMARY_SSH="${PRIMARY_SSH}" \
+    STANDBY_SSH="${STANDBY_SSH}" \
+    PRIMARY_PROJECT_DIR="${PRIMARY_PROJECT_DIR}" \
+    PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE}" \
+    STANDBY_PROJECT_DIR="${STANDBY_PROJECT_DIR}" \
+    STANDBY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE}" \
+    bash scripts/ha/check_postgres_replication.sh
+}
+
+run_media_cdn_db() {
+  local remote_cmd
+  remote_cmd="cd $(quote_remote "${PRIMARY_PROJECT_DIR}") && docker compose -f $(quote_remote "${PRIMARY_COMPOSE_FILE}") exec -T app python3 scripts/check_media_cdn_db_urls.py --expected-cdn-base $(quote_remote "${EXPECTED_CDN_BASE}") --min-db-cdn-urls $(quote_remote "${MIN_DB_CDN_URLS}") --max-fetches 10"
+  # shellcheck disable=SC2086
+  ssh ${SSH_OPTS:-} "${PRIMARY_SSH}" "${remote_cmd}"
+}
+
+run_postgres_pitr() {
+  local pitr_required="${POSTGRES_PITR_REQUIRED:-false}"
+  if is_true "${HA_READINESS_STRICT}"; then
+    pitr_required=true
+  elif ! is_true "${pitr_required}"; then
+    soft_blocker "POSTGRES_PITR_REQUIRED is not true; PITR is monitored in soft mode only"
+  fi
+
+  local remote_cmd
+  remote_cmd="PROJECT_DIR=$(quote_remote "${PRIMARY_PROJECT_DIR}") COMPOSE_FILE=$(quote_remote "${PRIMARY_COMPOSE_FILE}") PITR_REQUIRED=$(quote_remote "${pitr_required}") /usr/local/sbin/mvn-postgres-pitr-status"
+  # shellcheck disable=SC2086
+  ssh ${SSH_OPTS:-} "${PRIMARY_SSH}" "${remote_cmd}"
+}
+
+run_cloudflare_lb() {
+  local missing=()
+  [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || missing+=("CLOUDFLARE_API_TOKEN")
+  [[ -n "${CLOUDFLARE_ZONE_ID:-}" ]] || missing+=("CLOUDFLARE_ZONE_ID")
+  [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || missing+=("CLOUDFLARE_ACCOUNT_ID")
+  if (( ${#missing[@]} > 0 )); then
+    soft_blocker "Cloudflare LB config audit missing credentials: ${missing[*]}"
+  fi
+
+  if is_true "${HA_READINESS_STRICT}"; then
+    export CF_LB_SKIP_IF_MISSING_CREDENTIALS=false
+  else
+    export CF_LB_SKIP_IF_MISSING_CREDENTIALS=true
+  fi
+
+  CF_LB_HOSTNAME="${CF_LB_HOSTNAME:-${API_HOST}}" \
+    CF_LB_PRIMARY_ORIGIN="${CF_LB_PRIMARY_ORIGIN:-${PRIMARY_ORIGIN}}" \
+    CF_LB_STANDBY_ORIGIN="${CF_LB_STANDBY_ORIGIN:-${STANDBY_ORIGIN}}" \
+    CF_LB_HOST_HEADER="${CF_LB_HOST_HEADER:-${API_HOST}}" \
+    CF_LB_MONITOR_PATH="${CF_LB_MONITOR_PATH:-/api/ready}" \
+    CF_LB_MONITOR_METHOD="${CF_LB_MONITOR_METHOD:-GET}" \
+    CF_LB_MONITOR_EXPECTED_CODE="${CF_LB_MONITOR_EXPECTED_CODE:-200}" \
+    CF_LB_REQUIRE_ADAPTIVE_FAILOVER="${CF_LB_REQUIRE_ADAPTIVE_FAILOVER:-true}" \
+    CF_LB_REQUIRE_SESSION_AFFINITY_OFF="${CF_LB_REQUIRE_SESSION_AFFINITY_OFF:-true}" \
+    python3 scripts/ha/check_cloudflare_lb_config.py
+}
+
+log info "strict=${HA_READINESS_STRICT} primary=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN} primary_ssh=${PRIMARY_SSH} standby_ssh=${STANDBY_SSH}"
+
+if is_true "${CHECK_ACTIVE_PASSIVE}"; then
+  run_required "active_passive_invariant" run_active_passive
+else
+  warn "active/passive check skipped"
+fi
+
+if is_true "${CHECK_POSTGRES_REPLICATION}"; then
+  run_required "postgres_replication" run_postgres_replication
+else
+  warn "PostgreSQL replication check skipped"
+fi
+
+if is_true "${CHECK_MEDIA_CDN_DB}"; then
+  run_required "db_backed_media_cdn" run_media_cdn_db
+else
+  warn "DB-backed media CDN check skipped"
+fi
+
+if is_true "${CHECK_POSTGRES_PITR}"; then
+  run_required "postgres_pitr_status" run_postgres_pitr
+else
+  warn "PostgreSQL PITR check skipped"
+fi
+
+if is_true "${CHECK_CLOUDFLARE_LB}"; then
+  run_required "cloudflare_lb_config" run_cloudflare_lb
+else
+  warn "Cloudflare LB config check skipped"
+fi
+
+if (( failures > 0 )); then
+  log summary "status=failed failures=${failures} warnings=${warnings} soft_blockers=${soft_blockers}"
+  exit 1
+fi
+
+log summary "status=passed failures=0 warnings=${warnings} soft_blockers=${soft_blockers}"

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -1,0 +1,46 @@
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, step_name: str) -> dict:
+    return next(step for step in workflow["jobs"]["audit"]["steps"] if step.get("name") == step_name)
+
+
+def test_ha_readiness_script_has_valid_bash_syntax():
+    script = REPO_ROOT / "scripts/ha/check_api_ha_readiness.sh"
+
+    result = subprocess.run(["bash", "-n", str(script)], text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
+    workflow = _workflow(".github/workflows/check-api-ha-readiness.yml")
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    ssh_step = _step(workflow, "Setup API SSH Key")
+    audit_step = _step(workflow, "Run API HA readiness audit")
+    summary_step = _step(workflow, "Write Summary")
+    artifact_step = _step(workflow, "Upload HA readiness log")
+
+    assert dispatch_inputs["strict"]["default"] == "false"
+    assert "API_HA_READINESS_STRICT" in workflow["env"]["HA_READINESS_STRICT"]
+    assert "secrets.SSH_HOST_API" in ssh_step["env"]["SSH_HOST_API"]
+    assert "secrets.SSH_KEY" in ssh_step["env"]["SSH_KEY"]
+    assert "CLOUDFLARE_LB_READ_TOKEN" in audit_step["env"]["CLOUDFLARE_API_TOKEN"]
+    assert "POSTGRES_PITR_REQUIRED" in audit_step["env"]
+    assert "scripts/ha/check_api_ha_readiness.sh" in audit_step["run"]
+    assert "PRIMARY_SSH" in audit_step["run"]
+    assert "STANDBY_SSH" in audit_step["run"]
+    assert "api-ha-readiness.log" in audit_step["run"]
+    assert "strict:" in summary_step["run"]
+    assert artifact_step["if"] == "always()"
+    assert artifact_step["with"]["path"] == "api-ha-readiness.log"


### PR DESCRIPTION
## Summary
- add a whole-system API HA readiness audit workflow
- aggregate active/passive, PostgreSQL replication, DB-backed media CDN, PITR, and Cloudflare LB checks
- keep PITR and Cloudflare as soft blockers in non-strict mode until external credentials are enabled
- document the new rollup monitor in the HA runbook

## Tests
- pytest tests/unit/test_ha_readiness_workflow.py -q
- python3 YAML parse check for check-api-ha-readiness.yml
- bash -n scripts/ha/check_api_ha_readiness.sh
- git diff --check
- local non-strict HA readiness audit