### PR TITLE
Avoid Cloudflare challenge in HA GitHub checks

### DIFF
--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -38,6 +38,7 @@ jobs:
           STANDBY_ORIGIN: ${{ github.event.inputs.standby_origin || vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
           PRIMARY_ROLE: primary
           STANDBY_ROLE: standby
+          CHECK_PUBLIC_READY: "false"
         run: bash scripts/ha/check_active_passive.sh | tee api-ha-invariant.log
 
       - name: Upload HA invariant log

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -60,6 +60,7 @@ jobs:
           POSTGRES_PITR_REQUIRED: ${{ vars.POSTGRES_PITR_REQUIRED || 'false' }}
           EXPECTED_CDN_BASE: https://cdn.mvn.by
           MIN_DB_CDN_URLS: "3"
+          CHECK_PUBLIC_READY: "false"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_LB_READ_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -125,8 +125,8 @@ Scheduled monitors:
 | Workflow | Schedule | Purpose |
 | --- | --- | --- |
 | `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups, media storage config |
-| `check-api-ha-readiness.yml` | every 6 hours | whole-system HA readiness rollup; core checks fail, Cloudflare/PITR are soft blockers until strict |
-| `check-api-ha-invariants.yml` | every 30 minutes | public/primary ready and standby fenced |
+| `check-api-ha-readiness.yml` | every 6 hours | whole-system HA readiness rollup; direct-origin core checks fail, Cloudflare/PITR are soft blockers until strict |
+| `check-api-ha-invariants.yml` | every 30 minutes | direct primary ready and standby fenced; public Cloudflare routing is covered by the LB monitor/config checks |
 | `check-cloudflare-lb-config.yml` | every 6 hours | Cloudflare LB pool order, fallback, host header, and monitor config |
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
 | `check-postgres-pitr.yml` | every 6 hours | PITR archive/timer/backlog and remote R2 freshness |

--- a/scripts/ha/check_active_passive.sh
+++ b/scripts/ha/check_active_passive.sh
@@ -7,6 +7,7 @@ PRIMARY_ORIGIN="${PRIMARY_ORIGIN:-185.250.45.54}"
 STANDBY_ORIGIN="${STANDBY_ORIGIN:-193.47.42.213}"
 PRIMARY_ROLE="${PRIMARY_ROLE:-primary}"
 STANDBY_ROLE="${STANDBY_ROLE:-standby}"
+CHECK_PUBLIC_READY="${CHECK_PUBLIC_READY:-true}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
 
@@ -31,6 +32,13 @@ curl_json() {
     -w '%{http_code}' \
     "$@" \
     "${url}"
+}
+
+is_true() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 validate_payload() {
@@ -72,14 +80,18 @@ public_file="${TMP_DIR}/public-ready.json"
 primary_file="${TMP_DIR}/primary-ready.json"
 standby_file="${TMP_DIR}/standby-ready.json"
 
-public_code="$(curl_json "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}")"
-printf '\n'
-if [[ "${public_code}" != "200" ]]; then
-  log "public /api/ready expected HTTP 200, got ${public_code}"
-  cat "${public_file}" || true
-  exit 1
+if is_true "${CHECK_PUBLIC_READY}"; then
+  public_code="$(curl_json "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}")"
+  printf '\n'
+  if [[ "${public_code}" != "200" ]]; then
+    log "public /api/ready expected HTTP 200, got ${public_code}"
+    cat "${public_file}" || true
+    exit 1
+  fi
+  validate_payload "public" "${public_file}" "${PRIMARY_ROLE}" ready
+else
+  log "public ready check skipped"
 fi
-validate_payload "public" "${public_file}" "${PRIMARY_ROLE}" ready
 
 primary_code="$(curl_json "primary direct ready" "https://${API_HOST}/api/ready" "${primary_file}" --resolve "${API_HOST}:443:${PRIMARY_ORIGIN}")"
 printf '\n'

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -97,6 +97,7 @@ run_active_passive() {
     STANDBY_ORIGIN="${STANDBY_ORIGIN}" \
     PRIMARY_ROLE=primary \
     STANDBY_ROLE=standby \
+    CHECK_PUBLIC_READY="${CHECK_PUBLIC_READY:-false}" \
     bash scripts/ha/check_active_passive.sh
 }
 

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -37,6 +37,7 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert "secrets.SSH_KEY" in ssh_step["env"]["SSH_KEY"]
     assert "CLOUDFLARE_LB_READ_TOKEN" in audit_step["env"]["CLOUDFLARE_API_TOKEN"]
     assert "POSTGRES_PITR_REQUIRED" in audit_step["env"]
+    assert audit_step["env"]["CHECK_PUBLIC_READY"] == "false"
     assert "scripts/ha/check_api_ha_readiness.sh" in audit_step["run"]
     assert "PRIMARY_SSH" in audit_step["run"]
     assert "STANDBY_SSH" in audit_step["run"]
@@ -44,3 +45,11 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert "strict:" in summary_step["run"]
     assert artifact_step["if"] == "always()"
     assert artifact_step["with"]["path"] == "api-ha-readiness.log"
+
+
+def test_ha_invariant_workflow_skips_public_cloudflare_challenge_from_runner():
+    workflow = _workflow(".github/workflows/check-api-ha-invariants.yml")
+    check_step = next(step for step in workflow["jobs"]["check"]["steps"] if step.get("name") == "Run active-passive invariant check")
+
+    assert check_step["env"]["CHECK_PUBLIC_READY"] == "false"
+    assert "scripts/ha/check_active_passive.sh" in check_step["run"]


### PR DESCRIPTION
## Summary
- make the public /api/ready probe optional in the active-passive HA script
- disable that public Cloudflare probe from GitHub HA workflows so Managed Challenge does not create false negatives
- keep direct-origin primary/standby checks, replication, CDN media, PITR, and Cloudflare config audit in the readiness rollup

## Validation
- pytest tests/unit/test_ha_readiness_workflow.py -q
- bash -n scripts/ha/check_active_passive.sh && bash -n scripts/ha/check_api_ha_readiness.sh
- YAML parse for HA readiness/invariant workflows
- CHECK_PUBLIC_READY=false bash scripts/ha/check_api_ha_readiness.sh
