### PR TITLE
Add HA external prerequisites check

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -59,6 +59,7 @@ unreviewed host-local compose edits:
 | PostgreSQL PITR env/bootstrap | `scripts/ha/configure_postgres_pitr_env.py`, `scripts/ha/bootstrap_postgres_pitr.sh` |
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
+| External strict-mode prerequisite check | `scripts/ha/check_ha_external_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
 
@@ -119,6 +120,18 @@ Cloudflare read-only credentials and PostgreSQL PITR are fully enabled, it
 reports those two items as soft blockers. Run with `strict=true` only after
 `CLOUDFLARE_LB_CONFIG_REQUIRED=true` and `POSTGRES_PITR_REQUIRED=true` are
 intended to be enforced.
+
+External strict-mode prerequisite check:
+
+```bash
+python3 scripts/ha/check_ha_external_prerequisites.py --repo mvnby/air-api
+python3 scripts/ha/check_ha_external_prerequisites.py --repo mvnby/air-api --require-strict
+```
+
+This check uses `gh` metadata only. It lists missing GitHub variables/secrets
+without printing secret values. It cannot read host-local private PITR R2
+credentials; after those are installed, verify them on the primary with
+`ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'`.
 
 Scheduled monitors:
 

--- a/scripts/ha/check_ha_external_prerequisites.py
+++ b/scripts/ha/check_ha_external_prerequisites.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Check GitHub-side external prerequisites for MVN API HA strict mode.
+
+This script intentionally checks only metadata: variable names/values and secret
+names. It never reads or prints secret values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+
+DEFAULT_REPO = "mvnby/air-api"
+
+REQUIRED_SECRETS = {
+    "CLOUDFLARE_LB_READ_TOKEN": "Cloudflare read-only token for Load Balancer config audit",
+}
+
+REQUIRED_VARIABLES = {
+    "API_HA_READINESS_STRICT": "Controls whether the rollup HA audit treats soft blockers as failures",
+    "CLOUDFLARE_ACCOUNT_ID": "Cloudflare account id for Load Balancer pools/monitors",
+    "CLOUDFLARE_LB_CONFIG_REQUIRED": "Controls whether the Cloudflare LB audit is strict",
+    "CLOUDFLARE_ZONE_ID": "Cloudflare zone id for api.mvn.by load balancer lookup",
+    "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS": "Maximum accepted private PITR basebackup age",
+    "POSTGRES_PITR_MAX_WAL_AGE_MINUTES": "Maximum accepted private PITR WAL age",
+    "POSTGRES_PITR_REQUIRED": "Controls whether PITR archive/timer/remote checks are strict",
+}
+
+STRICT_TRUE_VARIABLES = (
+    "API_HA_READINESS_STRICT",
+    "CLOUDFLARE_LB_CONFIG_REQUIRED",
+    "POSTGRES_PITR_REQUIRED",
+)
+
+
+@dataclass(frozen=True)
+class GithubMetadata:
+    variables: dict[str, str]
+    secrets: set[str]
+
+
+def _run_gh_json(args: Sequence[str]) -> object:
+    result = subprocess.run(
+        ["gh", *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "gh command failed"
+        raise RuntimeError(message)
+    return json.loads(result.stdout or "[]")
+
+
+def load_github_metadata(repo: str) -> GithubMetadata:
+    raw_vars = _run_gh_json(["variable", "list", "--repo", repo, "--json", "name,value"])
+    raw_secrets = _run_gh_json(["secret", "list", "--repo", repo, "--json", "name"])
+    if not isinstance(raw_vars, list) or not isinstance(raw_secrets, list):
+        raise RuntimeError("unexpected gh JSON response")
+
+    variables = {
+        str(item.get("name")): str(item.get("value") or "")
+        for item in raw_vars
+        if isinstance(item, dict) and item.get("name")
+    }
+    secrets = {
+        str(item.get("name"))
+        for item in raw_secrets
+        if isinstance(item, dict) and item.get("name")
+    }
+    return GithubMetadata(variables=variables, secrets=secrets)
+
+
+def is_true(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def check_metadata(metadata: GithubMetadata, *, require_strict: bool) -> tuple[list[str], list[str], list[str]]:
+    ok: list[str] = []
+    warnings: list[str] = []
+    failures: list[str] = []
+
+    for name, description in sorted(REQUIRED_SECRETS.items()):
+        if name in metadata.secrets:
+            ok.append(f"secret present: {name}")
+        else:
+            failures.append(f"missing GitHub secret {name}: {description}")
+
+    for name, description in sorted(REQUIRED_VARIABLES.items()):
+        value = metadata.variables.get(name)
+        if value:
+            ok.append(f"variable present: {name}")
+        else:
+            failures.append(f"missing GitHub variable {name}: {description}")
+
+    for name in STRICT_TRUE_VARIABLES:
+        value = metadata.variables.get(name)
+        if value is None:
+            continue
+        if is_true(value):
+            ok.append(f"strict variable enabled: {name}")
+        elif require_strict:
+            failures.append(f"{name} must be true before strict HA mode")
+        else:
+            warnings.append(f"{name} is not true yet")
+
+    warnings.append(
+        "private PITR R2 credentials are host-local; verify with "
+        "`ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'` "
+        "after bucket credentials are installed"
+    )
+    return ok, warnings, failures
+
+
+def print_report(*, repo: str, ok: Sequence[str], warnings: Sequence[str], failures: Sequence[str]) -> None:
+    print(f"[ha-external][info] repo={repo}")
+    for line in ok:
+        print(f"[ha-external][ok] {line}")
+    for line in warnings:
+        print(f"[ha-external][warn] {line}")
+    for line in failures:
+        print(f"[ha-external][fail] {line}")
+    status = "failed" if failures else "passed"
+    print(
+        f"[ha-external][summary] status={status} "
+        f"failures={len(failures)} warnings={len(warnings)}"
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check GitHub vars/secrets needed before MVN API HA strict mode."
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO,
+        help=f"GitHub repository in owner/name form. Default: {DEFAULT_REPO}",
+    )
+    parser.add_argument(
+        "--require-strict",
+        action="store_true",
+        help="Fail unless strict-mode variables are already true.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        metadata = load_github_metadata(args.repo)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        print(f"[ha-external][fail] {exc}", file=sys.stderr)
+        return 2
+
+    ok, warnings, failures = check_metadata(metadata, require_strict=args.require_strict)
+    print_report(repo=args.repo, ok=ok, warnings=warnings, failures=failures)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ha_external_prerequisites.py
+++ b/tests/unit/test_ha_external_prerequisites.py
@@ -1,0 +1,87 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ha/check_ha_external_prerequisites.py"
+
+
+spec = importlib.util.spec_from_file_location("check_ha_external_prerequisites", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+def _metadata(*, variables: dict[str, str] | None = None, secrets: set[str] | None = None):
+    return module.GithubMetadata(variables=variables or {}, secrets=secrets or set())
+
+
+def test_external_prerequisites_report_missing_cloudflare_secret_and_vars():
+    ok, warnings, failures = module.check_metadata(
+        _metadata(
+            variables={
+                "API_HA_READINESS_STRICT": "false",
+                "CLOUDFLARE_LB_CONFIG_REQUIRED": "false",
+                "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS": "30",
+                "POSTGRES_PITR_MAX_WAL_AGE_MINUTES": "180",
+                "POSTGRES_PITR_REQUIRED": "false",
+            },
+            secrets=set(),
+        ),
+        require_strict=False,
+    )
+
+    assert any("missing GitHub secret CLOUDFLARE_LB_READ_TOKEN" in item for item in failures)
+    assert any("missing GitHub variable CLOUDFLARE_ACCOUNT_ID" in item for item in failures)
+    assert any("missing GitHub variable CLOUDFLARE_ZONE_ID" in item for item in failures)
+    assert any("POSTGRES_PITR_REQUIRED is not true yet" in item for item in warnings)
+    assert any("variable present: POSTGRES_PITR_MAX_WAL_AGE_MINUTES" in item for item in ok)
+
+
+def test_external_prerequisites_require_strict_fails_when_flags_are_false():
+    ok, warnings, failures = module.check_metadata(
+        _metadata(
+            variables={
+                "API_HA_READINESS_STRICT": "false",
+                "CLOUDFLARE_ACCOUNT_ID": "account",
+                "CLOUDFLARE_LB_CONFIG_REQUIRED": "false",
+                "CLOUDFLARE_ZONE_ID": "zone",
+                "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS": "30",
+                "POSTGRES_PITR_MAX_WAL_AGE_MINUTES": "180",
+                "POSTGRES_PITR_REQUIRED": "false",
+            },
+            secrets={"CLOUDFLARE_LB_READ_TOKEN"},
+        ),
+        require_strict=True,
+    )
+
+    assert any("API_HA_READINESS_STRICT must be true" in item for item in failures)
+    assert any("CLOUDFLARE_LB_CONFIG_REQUIRED must be true" in item for item in failures)
+    assert any("POSTGRES_PITR_REQUIRED must be true" in item for item in failures)
+    assert any("secret present: CLOUDFLARE_LB_READ_TOKEN" in item for item in ok)
+    assert any("private PITR R2 credentials are host-local" in item for item in warnings)
+
+
+def test_external_prerequisites_pass_when_all_metadata_is_ready():
+    ok, warnings, failures = module.check_metadata(
+        _metadata(
+            variables={
+                "API_HA_READINESS_STRICT": "true",
+                "CLOUDFLARE_ACCOUNT_ID": "account",
+                "CLOUDFLARE_LB_CONFIG_REQUIRED": "true",
+                "CLOUDFLARE_ZONE_ID": "zone",
+                "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS": "30",
+                "POSTGRES_PITR_MAX_WAL_AGE_MINUTES": "180",
+                "POSTGRES_PITR_REQUIRED": "true",
+            },
+            secrets={"CLOUDFLARE_LB_READ_TOKEN"},
+        ),
+        require_strict=True,
+    )
+
+    assert not failures
+    assert any("strict variable enabled: API_HA_READINESS_STRICT" in item for item in ok)
+    assert any("strict variable enabled: POSTGRES_PITR_REQUIRED" in item for item in ok)
+    assert any("private PITR R2 credentials are host-local" in item for item in warnings)


### PR DESCRIPTION
## Summary
- add a GitHub metadata check for HA strict-mode prerequisites without printing secret values
- cover missing, strict, and ready states with unit tests
- document the command in the API HA runbook

## Validation
- pytest tests/unit/test_ha_external_prerequisites.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_postgres_pitr_workflows.py -q
- python3 -m py_compile scripts/ha/check_ha_external_prerequisites.py
- scripts/ha/check_ha_external_prerequisites.py --repo mvnby/air-api
- scripts/ha/check_ha_external_prerequisites.py --repo mvnby/air-api --require-strict
- git diff --check
