### PR TITLE
Add Cloudflare LB prerequisite helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -60,6 +60,7 @@ unreviewed host-local compose edits:
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | External strict-mode prerequisite check | `scripts/ha/check_ha_external_prerequisites.py` |
+| Cloudflare LB GitHub prerequisite apply helper | `scripts/ha/apply_cloudflare_lb_github_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
 
@@ -132,6 +133,38 @@ This check uses `gh` metadata only. It lists missing GitHub variables/secrets
 without printing secret values. It cannot read host-local private PITR R2
 credentials; after those are installed, verify them on the primary with
 `ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'`.
+
+After creating the Cloudflare LB read-only token and finding the zone/account
+ids, apply them to GitHub without pasting secrets into command history:
+
+```bash
+printf 'Cloudflare LB token: '
+stty -echo
+IFS= read -r CLOUDFLARE_LB_READ_TOKEN
+stty echo
+printf '\n'
+export CLOUDFLARE_LB_READ_TOKEN
+export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
+export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
+python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api
+unset CLOUDFLARE_LB_READ_TOKEN
+```
+
+After the required Cloudflare LB workflow passes and you want scheduled checks
+to fail on drift, repeat with:
+
+```bash
+printf 'Cloudflare LB token: '
+stty -echo
+IFS= read -r CLOUDFLARE_LB_READ_TOKEN
+stty echo
+printf '\n'
+export CLOUDFLARE_LB_READ_TOKEN
+export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
+export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
+python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --mark-required
+unset CLOUDFLARE_LB_READ_TOKEN
+```
 
 Scheduled monitors:
 
@@ -451,13 +484,14 @@ If the dashboard presents granular permission groups instead of roles, choose
 read/list-only permissions for those same Load Balancing resources. Do not grant
 edit permissions for this audit token.
 
-GitHub scheduled audit:
+GitHub scheduled audit fallback, if the helper above is not available:
 
 ```bash
 gh secret set CLOUDFLARE_LB_READ_TOKEN --repo mvnby/air-api
 gh variable set CLOUDFLARE_ZONE_ID --repo mvnby/air-api --body <zone-id>
 gh variable set CLOUDFLARE_ACCOUNT_ID --repo mvnby/air-api --body <account-id>
 gh workflow run check-cloudflare-lb-config.yml --repo mvnby/air-api --ref main -f required=true
+# Set this only after the required workflow is green.
 gh variable set CLOUDFLARE_LB_CONFIG_REQUIRED --repo mvnby/air-api --body true
 ```
 

--- a/scripts/ha/apply_cloudflare_lb_github_prerequisites.py
+++ b/scripts/ha/apply_cloudflare_lb_github_prerequisites.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Apply Cloudflare Load Balancer audit prerequisites to GitHub.
+
+The Cloudflare API token is intentionally passed to `gh secret set` through
+stdin, not as a command-line argument, so it does not appear in process args.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+DEFAULT_REPO = "mvnby/air-api"
+DEFAULT_REF = "main"
+WORKFLOW = "check-cloudflare-lb-config.yml"
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+
+
+def log(stage: str, message: str) -> None:
+    print(f"[ha-cloudflare-setup][{stage}] {message}")
+
+
+def _run_subprocess(args: Sequence[str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_checked(args: Sequence[str], *, stdin: str | None = None, runner: Runner | None = None) -> str:
+    actual_runner = runner or _run_subprocess
+    result = actual_runner(args, stdin)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(output or f"command failed: {' '.join(args)}")
+    return result.stdout.strip()
+
+
+def env_value(name: str) -> str:
+    return str(os.environ.get(name) or "").strip()
+
+
+def collect_inputs(*, token_env: str, zone_id_env: str, account_id_env: str) -> tuple[str, str, str]:
+    values = (
+        env_value(token_env),
+        env_value(zone_id_env),
+        env_value(account_id_env),
+    )
+    missing = [
+        env_name
+        for env_name, value in zip((token_env, zone_id_env, account_id_env), values, strict=True)
+        if not value
+    ]
+    if missing:
+        raise RuntimeError("missing required environment variables: " + ", ".join(missing))
+    return values
+
+
+def set_secret(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
+    run_checked(["gh", "secret", "set", name, "--repo", repo], stdin=f"{value}\n", runner=runner)
+    log("ok", f"GitHub secret set: {name}")
+
+
+def set_variable(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
+    run_checked(["gh", "variable", "set", name, "--repo", repo], stdin=f"{value}\n", runner=runner)
+    log("ok", f"GitHub variable set: {name}")
+
+
+def run_external_prereq_check(repo: str, *, runner: Runner | None = None) -> None:
+    script = Path(__file__).with_name("check_ha_external_prerequisites.py")
+    output = run_checked([sys.executable, str(script), "--repo", repo], runner=runner)
+    if output:
+        print(output)
+
+
+def parse_run_id(output: str) -> str:
+    match = re.search(r"/actions/runs/([0-9]+)", output)
+    if not match:
+        raise RuntimeError(f"could not parse GitHub Actions run id from: {output!r}")
+    return match.group(1)
+
+
+def run_cloudflare_required_workflow(
+    *,
+    repo: str,
+    ref: str,
+    wait: bool,
+    runner: Runner | None = None,
+) -> str:
+    output = run_checked(
+        [
+            "gh",
+            "workflow",
+            "run",
+            WORKFLOW,
+            "--repo",
+            repo,
+            "--ref",
+            ref,
+            "-f",
+            "required=true",
+        ],
+        runner=runner,
+    )
+    run_id = parse_run_id(output)
+    log("ok", f"started Cloudflare LB required audit: {output}")
+    if wait:
+        run_checked(
+            ["gh", "run", "watch", run_id, "--repo", repo, "--exit-status", "--interval", "10"],
+            runner=runner,
+        )
+        log("ok", f"Cloudflare LB required audit passed: {run_id}")
+    return run_id
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Set GitHub Cloudflare LB audit prerequisites and run the required audit."
+    )
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO)
+    parser.add_argument("--ref", default=DEFAULT_REF)
+    parser.add_argument("--token-env", default="CLOUDFLARE_LB_READ_TOKEN")
+    parser.add_argument("--zone-id-env", default="CLOUDFLARE_ZONE_ID")
+    parser.add_argument("--account-id-env", default="CLOUDFLARE_ACCOUNT_ID")
+    parser.add_argument(
+        "--mark-required",
+        action="store_true",
+        help="Set CLOUDFLARE_LB_CONFIG_REQUIRED=true after the required audit passes.",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Start the required workflow but do not wait for it to finish.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate local inputs and print intended actions without writing GitHub metadata.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        token, zone_id, account_id = collect_inputs(
+            token_env=args.token_env,
+            zone_id_env=args.zone_id_env,
+            account_id_env=args.account_id_env,
+        )
+        log("info", f"repo={args.repo} ref={args.ref}")
+        log("info", f"using token from ${args.token_env}; value will not be printed")
+        if args.mark_required and args.no_wait:
+            raise RuntimeError("--mark-required requires waiting for the required audit to pass")
+
+        if args.dry_run:
+            log("dry-run", "would set GitHub secret CLOUDFLARE_LB_READ_TOKEN")
+            log("dry-run", "would set GitHub variables CLOUDFLARE_ZONE_ID and CLOUDFLARE_ACCOUNT_ID")
+            log("dry-run", f"would run {WORKFLOW} with required=true")
+            if args.mark_required:
+                log("dry-run", "would set CLOUDFLARE_LB_CONFIG_REQUIRED=true after audit success")
+            return 0
+
+        set_secret(args.repo, "CLOUDFLARE_LB_READ_TOKEN", token)
+        set_variable(args.repo, "CLOUDFLARE_ZONE_ID", zone_id)
+        set_variable(args.repo, "CLOUDFLARE_ACCOUNT_ID", account_id)
+        run_external_prereq_check(args.repo)
+        run_cloudflare_required_workflow(repo=args.repo, ref=args.ref, wait=not args.no_wait)
+
+        if args.mark_required:
+            set_variable(args.repo, "CLOUDFLARE_LB_CONFIG_REQUIRED", "true")
+            run_external_prereq_check(args.repo)
+        return 0
+    except RuntimeError as exc:
+        log("fail", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
+++ b/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ha/apply_cloudflare_lb_github_prerequisites.py"
+
+
+spec = importlib.util.spec_from_file_location("apply_cloudflare_lb_github_prerequisites", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class FakeCompleted:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_set_secret_uses_stdin_not_command_args():
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    module.set_secret("mvnby/air-api", "CLOUDFLARE_LB_READ_TOKEN", "super-secret", runner=fake_runner)
+
+    args, stdin = calls[0]
+    assert args == ["gh", "secret", "set", "CLOUDFLARE_LB_READ_TOKEN", "--repo", "mvnby/air-api"]
+    assert stdin == "super-secret\n"
+    assert "super-secret" not in args
+
+
+def test_set_variable_uses_stdin():
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    module.set_variable("mvnby/air-api", "CLOUDFLARE_ZONE_ID", "zone-id", runner=fake_runner)
+
+    assert calls == [(["gh", "variable", "set", "CLOUDFLARE_ZONE_ID", "--repo", "mvnby/air-api"], "zone-id\n")]
+
+
+def test_parse_run_id_from_workflow_url():
+    assert (
+        module.parse_run_id("https://github.com/mvnby/air-api/actions/runs/28636799268")
+        == "28636799268"
+    )
+
+
+def test_collect_inputs_reports_missing_env_names_without_values(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_LB_READ_TOKEN", "token")
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+
+    try:
+        module.collect_inputs(
+            token_env="CLOUDFLARE_LB_READ_TOKEN",
+            zone_id_env="CLOUDFLARE_ZONE_ID",
+            account_id_env="CLOUDFLARE_ACCOUNT_ID",
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("collect_inputs should fail")
+
+    assert "CLOUDFLARE_ZONE_ID" in message
+    assert "CLOUDFLARE_ACCOUNT_ID" in message
+    assert "token" not in message
+
+
+def test_main_rejects_mark_required_without_wait_before_writes(monkeypatch, capsys):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    monkeypatch.setenv("CLOUDFLARE_LB_READ_TOKEN", "token")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--mark-required", "--no-wait"]) == 1
+
+    assert calls == []
+    assert "--mark-required requires waiting" in capsys.readouterr().out
+
+
+def test_main_sets_metadata_then_runs_required_audit(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        if list(args[:3]) == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="https://github.com/mvnby/air-api/actions/runs/28636799268\n")
+        return FakeCompleted()
+
+    monkeypatch.setenv("CLOUDFLARE_LB_READ_TOKEN", "token")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api"]) == 0
+
+    command_names = [call[0][:3] for call in calls]
+    assert ["gh", "secret", "set"] in command_names
+    assert ["gh", "variable", "set"] in command_names
+    assert ["gh", "workflow", "run"] in command_names
+    assert ["gh", "run", "watch"] in command_names
+    assert all("token" not in args for args, _stdin in calls)


### PR DESCRIPTION
## Summary
- add a helper that safely writes Cloudflare LB audit GitHub secret/vars and runs the required audit before enabling strict drift checks
- document zsh-safe hidden token input in the HA runbook
- cover secret stdin handling, invalid flag combinations, and workflow triggering with unit tests

## Tests
- python3 -m py_compile scripts/ha/apply_cloudflare_lb_github_prerequisites.py scripts/ha/check_ha_external_prerequisites.py
- pytest tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_ha_external_prerequisites.py -q
- pytest tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_external_prerequisites.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_postgres_pitr_workflows.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py -q
- git diff --cached --check