### PR TITLE
Add PostgreSQL PITR primary prerequisite helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -57,6 +57,7 @@ unreviewed host-local compose edits:
 | PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
 | PostgreSQL PITR restore helpers | `scripts/ha/restore_postgres_pitr_from_s3.py`, `scripts/ha/restore_postgres_pitr_drill.sh`, `.github/workflows/postgres-pitr-restore-drill.yml` |
 | PostgreSQL PITR env/bootstrap | `scripts/ha/configure_postgres_pitr_env.py`, `scripts/ha/bootstrap_postgres_pitr.sh` |
+| PostgreSQL PITR primary prerequisite apply helper | `scripts/ha/apply_postgres_pitr_primary_prerequisites.py` |
 | PostgreSQL PITR monitoring | `scripts/ha/check_postgres_pitr_status.sh`, `scripts/ha/check_postgres_pitr_remote.py`, `.github/workflows/check-postgres-pitr.yml` |
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | External strict-mode prerequisite check | `scripts/ha/check_ha_external_prerequisites.py` |
@@ -267,22 +268,31 @@ tar -czf - \
 # Copy deploy/ha/mvn-api/docker-compose.primary.yml through CI.
 gh workflow run deploy.yml --repo mvnby/air-api --ref main -f deploy_frontend=false
 
-# Put the private R2 credentials in a temporary root-only file on the primary.
-# Do not paste these values in tickets, PRs, or chat.
-ssh mvn-api 'umask 077; cat > /root/mvn-postgres-pitr.env' <<'EOF'
-POSTGRES_PITR_CLUSTER=mvn-api
-POSTGRES_PITR_S3_BUCKET=<private-r2-bucket>
-POSTGRES_PITR_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
-POSTGRES_PITR_S3_REGION=auto
-POSTGRES_PITR_S3_ACCESS_KEY_ID=<private-r2-token-access-key>
-POSTGRES_PITR_S3_SECRET_ACCESS_KEY=<private-r2-token-secret>
-POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr
-EOF
+# Put the private R2 credentials in the local shell environment or let the
+# helper prompt for the missing access-key values. It uploads a temporary
+# root-only env file to the primary, removes it after the remote phase, and
+# never prints access keys.
+export POSTGRES_PITR_CLUSTER=mvn-api
+export POSTGRES_PITR_S3_BUCKET=<private-r2-bucket>
+export POSTGRES_PITR_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+export POSTGRES_PITR_S3_REGION=auto
+export POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr
 
-# Validate credentials, write PITR env with archive mode still off, upload a
-# physical basebackup, and stage archive_mode=on for the next DB recreate.
-ssh mvn-api 'ENV_INPUT_FILE=/root/mvn-postgres-pitr.env /usr/local/sbin/mvn-postgres-pitr-bootstrap bootstrap-before-maintenance'
-ssh mvn-api 'rm -f /root/mvn-postgres-pitr.env'
+# First verify the local input shape without touching the primary.
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --dry-run
+
+# Then upload the temporary env file and run the remote preflight. This does not
+# write the production .env, upload a basebackup, or recreate the database.
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --phase preflight
+
+# Finally validate credentials, write PITR env with archive mode still off,
+# upload a physical basebackup, and stage archive_mode=on for the next DB
+# recreate. This still does not recreate the database.
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --phase bootstrap-before-maintenance
+
+unset POSTGRES_PITR_CLUSTER POSTGRES_PITR_S3_BUCKET POSTGRES_PITR_S3_ENDPOINT_URL
+unset POSTGRES_PITR_S3_REGION POSTGRES_PITR_S3_ACCESS_KEY_ID
+unset POSTGRES_PITR_S3_SECRET_ACCESS_KEY POSTGRES_PITR_S3_KEY_PREFIX
 
 # In a short maintenance window, recreate db so archive_mode=on and the
 # /postgres-wal-archive mount become active. The helper also resets historical

--- a/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
+++ b/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Apply PostgreSQL PITR primary prerequisites without printing secrets.
+
+This helper collects private R2/S3 PITR settings locally, uploads a temporary
+root-only env file to the current primary over SSH, runs a safe pre-maintenance
+bootstrap phase, and removes the temporary env file from the host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+
+DEFAULT_PRIMARY_HOST = "mvn-api"
+DEFAULT_PROJECT_DIR = "/opt/air-api"
+DEFAULT_COMPOSE_FILE = "docker-compose.prod.yml"
+DEFAULT_REMOTE_ENV_FILE = "/root/mvn-postgres-pitr.env"
+DEFAULT_BOOTSTRAP_HELPER = "/usr/local/sbin/mvn-postgres-pitr-bootstrap"
+
+BUCKET_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$")
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class PitrInput:
+    cluster: str
+    bucket: str
+    endpoint_url: str
+    region: str
+    access_key_id: str
+    secret_access_key: str
+    key_prefix: str
+
+
+def log(stage: str, message: str) -> None:
+    print(f"[ha-pitr-setup][{stage}] {message}")
+
+
+def _run_subprocess(args: Sequence[str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_checked(args: Sequence[str], *, stdin: str | None = None, runner: Runner | None = None) -> str:
+    actual_runner = runner or _run_subprocess
+    result = actual_runner(args, stdin)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(output or f"command failed: {' '.join(args)}")
+    output = result.stdout.strip()
+    if output:
+        print(output)
+    return output
+
+
+def _clean(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _env(name: str, environ: Mapping[str, str]) -> str:
+    return _clean(environ.get(name))
+
+
+def _prompt(name: str, *, secret: bool, no_prompt: bool) -> str:
+    if no_prompt:
+        return ""
+    if not sys.stdin.isatty():
+        return ""
+    if secret:
+        return getpass.getpass(f"{name}: ").strip()
+    return input(f"{name}: ").strip()
+
+
+def _value(
+    *,
+    environ: Mapping[str, str],
+    name: str,
+    default: str = "",
+    secret: bool = False,
+    no_prompt: bool,
+) -> str:
+    return _env(name, environ) or default or _prompt(name, secret=secret, no_prompt=no_prompt)
+
+
+def collect_inputs(
+    *,
+    environ: Mapping[str, str] | None = None,
+    no_prompt: bool = False,
+) -> PitrInput:
+    source = environ or os.environ
+    config = PitrInput(
+        cluster=_value(
+            environ=source,
+            name="POSTGRES_PITR_CLUSTER",
+            default="mvn-api",
+            no_prompt=no_prompt,
+        ).strip("/"),
+        bucket=_value(environ=source, name="POSTGRES_PITR_S3_BUCKET", no_prompt=no_prompt),
+        endpoint_url=_value(environ=source, name="POSTGRES_PITR_S3_ENDPOINT_URL", no_prompt=no_prompt),
+        region=_value(
+            environ=source,
+            name="POSTGRES_PITR_S3_REGION",
+            default="auto",
+            no_prompt=no_prompt,
+        ),
+        access_key_id=_value(
+            environ=source,
+            name="POSTGRES_PITR_S3_ACCESS_KEY_ID",
+            secret=True,
+            no_prompt=no_prompt,
+        ),
+        secret_access_key=_value(
+            environ=source,
+            name="POSTGRES_PITR_S3_SECRET_ACCESS_KEY",
+            secret=True,
+            no_prompt=no_prompt,
+        ),
+        key_prefix=_value(
+            environ=source,
+            name="POSTGRES_PITR_S3_KEY_PREFIX",
+            default="postgres/pitr",
+            no_prompt=no_prompt,
+        ).strip("/"),
+    )
+    validate_input(config)
+    return config
+
+
+def validate_input(config: PitrInput) -> None:
+    missing = [
+        name
+        for name, value in (
+            ("POSTGRES_PITR_CLUSTER", config.cluster),
+            ("POSTGRES_PITR_S3_BUCKET", config.bucket),
+            ("POSTGRES_PITR_S3_ENDPOINT_URL", config.endpoint_url),
+            ("POSTGRES_PITR_S3_ACCESS_KEY_ID", config.access_key_id),
+            ("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", config.secret_access_key),
+            ("POSTGRES_PITR_S3_KEY_PREFIX", config.key_prefix),
+        )
+        if not value
+    ]
+    if missing:
+        raise RuntimeError("missing required PITR settings: " + ", ".join(missing))
+
+    if not BUCKET_RE.match(config.bucket):
+        raise RuntimeError(
+            "POSTGRES_PITR_S3_BUCKET must be an R2/S3 bucket name with lowercase letters, numbers, and hyphens"
+        )
+    if not config.endpoint_url.startswith("https://") or ".r2.cloudflarestorage.com" not in config.endpoint_url:
+        raise RuntimeError(
+            "POSTGRES_PITR_S3_ENDPOINT_URL must look like https://<account-id>.r2.cloudflarestorage.com"
+        )
+    if ".r2.dev" in config.endpoint_url or "cdn.mvn.by" in config.endpoint_url:
+        raise RuntimeError("PITR endpoint must use the private R2 S3 API endpoint, not a public CDN URL")
+
+    for name, value in (
+        ("POSTGRES_PITR_CLUSTER", config.cluster),
+        ("POSTGRES_PITR_S3_BUCKET", config.bucket),
+        ("POSTGRES_PITR_S3_ENDPOINT_URL", config.endpoint_url),
+        ("POSTGRES_PITR_S3_REGION", config.region),
+        ("POSTGRES_PITR_S3_ACCESS_KEY_ID", config.access_key_id),
+        ("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", config.secret_access_key),
+        ("POSTGRES_PITR_S3_KEY_PREFIX", config.key_prefix),
+    ):
+        if "\n" in value or "\r" in value:
+            raise RuntimeError(f"{name} must be a single-line value")
+        if value != value.strip() or any(ch.isspace() for ch in value) or "#" in value or "'" in value or '"' in value:
+            raise RuntimeError(f"{name} must not contain whitespace, quotes, or #")
+
+
+def render_env(config: PitrInput, *, redact: bool = False) -> str:
+    access_key_id = "redacted" if redact else config.access_key_id
+    secret_access_key = "redacted" if redact else config.secret_access_key
+    return "\n".join(
+        [
+            f"POSTGRES_PITR_CLUSTER={config.cluster}",
+            f"POSTGRES_PITR_S3_BUCKET={config.bucket}",
+            f"POSTGRES_PITR_S3_ENDPOINT_URL={config.endpoint_url}",
+            f"POSTGRES_PITR_S3_REGION={config.region}",
+            f"POSTGRES_PITR_S3_ACCESS_KEY_ID={access_key_id}",
+            f"POSTGRES_PITR_S3_SECRET_ACCESS_KEY={secret_access_key}",
+            f"POSTGRES_PITR_S3_KEY_PREFIX={config.key_prefix}",
+            "",
+        ]
+    )
+
+
+def upload_remote_env(
+    *,
+    ssh_host: str,
+    remote_env_file: str,
+    env_text: str,
+    runner: Runner | None = None,
+) -> None:
+    remote_file = shlex.quote(remote_env_file)
+    run_checked(
+        ["ssh", ssh_host, f"umask 077; cat > {remote_file}; chmod 600 {remote_file}"],
+        stdin=env_text,
+        runner=runner,
+    )
+    log("ok", f"temporary PITR env uploaded to {ssh_host}:{remote_env_file}")
+
+
+def run_remote_phase(
+    *,
+    ssh_host: str,
+    remote_env_file: str,
+    bootstrap_helper: str,
+    project_dir: str,
+    compose_file: str,
+    phase: str,
+    runner: Runner | None = None,
+) -> None:
+    remote_file = shlex.quote(remote_env_file)
+    command = " ".join(
+        [
+            f"PROJECT_DIR={shlex.quote(project_dir)}",
+            f"COMPOSE_FILE={shlex.quote(compose_file)}",
+            f"ENV_INPUT_FILE={remote_file}",
+            shlex.quote(bootstrap_helper),
+            shlex.quote(phase),
+            ";",
+            "status=$?",
+            ";",
+            "rm -f",
+            remote_file,
+            ";",
+            "exit ${status}",
+        ]
+    )
+    run_checked(["ssh", ssh_host, command], runner=runner)
+    log("ok", f"remote PITR phase passed: {phase}")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare current PostgreSQL primary for private R2/S3 PITR without printing secrets."
+    )
+    parser.add_argument("--ssh-host", default=DEFAULT_PRIMARY_HOST)
+    parser.add_argument("--project-dir", default=DEFAULT_PROJECT_DIR)
+    parser.add_argument("--compose-file", default=DEFAULT_COMPOSE_FILE)
+    parser.add_argument("--remote-env-file", default=DEFAULT_REMOTE_ENV_FILE)
+    parser.add_argument("--bootstrap-helper", default=DEFAULT_BOOTSTRAP_HELPER)
+    parser.add_argument(
+        "--phase",
+        choices=("preflight", "bootstrap-before-maintenance"),
+        default="preflight",
+        help="Use preflight first. bootstrap-before-maintenance writes PITR env and uploads the first basebackup.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--no-prompt",
+        action="store_true",
+        help="Do not prompt for missing PITR values; fail instead.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        config = collect_inputs(no_prompt=args.no_prompt)
+        log("info", f"ssh_host={args.ssh_host} project_dir={args.project_dir} compose_file={args.compose_file}")
+        log("info", f"phase={args.phase}")
+        log("info", "PITR R2 access key values will not be printed")
+
+        if args.dry_run:
+            log("dry-run", "would upload this redacted env to the primary:")
+            print(render_env(config, redact=True).rstrip())
+            log("dry-run", f"would run {args.bootstrap_helper} {args.phase} on {args.ssh_host}")
+            return 0
+
+        env_text = render_env(config)
+        upload_remote_env(
+            ssh_host=args.ssh_host,
+            remote_env_file=args.remote_env_file,
+            env_text=env_text,
+        )
+        run_remote_phase(
+            ssh_host=args.ssh_host,
+            remote_env_file=args.remote_env_file,
+            bootstrap_helper=args.bootstrap_helper,
+            project_dir=args.project_dir,
+            compose_file=args.compose_file,
+            phase=args.phase,
+        )
+        return 0
+    except RuntimeError as exc:
+        log("fail", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_apply_postgres_pitr_primary_prerequisites.py
+++ b/tests/unit/test_apply_postgres_pitr_primary_prerequisites.py
@@ -1,0 +1,167 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ha/apply_postgres_pitr_primary_prerequisites.py"
+
+
+spec = importlib.util.spec_from_file_location("apply_postgres_pitr_primary_prerequisites", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class FakeCompleted:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _env(**overrides):
+    values = {
+        "POSTGRES_PITR_CLUSTER": "mvn-api",
+        "POSTGRES_PITR_S3_BUCKET": "mvn-postgres-pitr",
+        "POSTGRES_PITR_S3_ENDPOINT_URL": "https://account-id.r2.cloudflarestorage.com",
+        "POSTGRES_PITR_S3_REGION": "auto",
+        "POSTGRES_PITR_S3_ACCESS_KEY_ID": "access-key-id",
+        "POSTGRES_PITR_S3_SECRET_ACCESS_KEY": "super-secret-key",
+        "POSTGRES_PITR_S3_KEY_PREFIX": "postgres/pitr",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_render_env_redacts_access_keys():
+    config = module.collect_inputs(environ=_env(), no_prompt=True)
+
+    rendered = module.render_env(config, redact=True)
+
+    assert "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr" in rendered
+    assert "access-key-id" not in rendered
+    assert "super-secret-key" not in rendered
+    assert "POSTGRES_PITR_S3_ACCESS_KEY_ID=redacted" in rendered
+    assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=redacted" in rendered
+
+
+def test_upload_remote_env_passes_secret_only_via_stdin():
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    config = module.collect_inputs(environ=_env(), no_prompt=True)
+    env_text = module.render_env(config)
+
+    module.upload_remote_env(
+        ssh_host="mvn-api",
+        remote_env_file="/root/mvn-postgres-pitr.env",
+        env_text=env_text,
+        runner=fake_runner,
+    )
+
+    args, stdin = calls[0]
+    assert args == [
+        "ssh",
+        "mvn-api",
+        "umask 077; cat > /root/mvn-postgres-pitr.env; chmod 600 /root/mvn-postgres-pitr.env",
+    ]
+    assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=super-secret-key" in stdin
+    assert all("super-secret-key" not in arg for arg in args)
+
+
+def test_run_remote_phase_removes_temporary_env_file():
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    module.run_remote_phase(
+        ssh_host="mvn-api",
+        remote_env_file="/root/mvn-postgres-pitr.env",
+        bootstrap_helper="/usr/local/sbin/mvn-postgres-pitr-bootstrap",
+        project_dir="/opt/air-api",
+        compose_file="docker-compose.prod.yml",
+        phase="preflight",
+        runner=fake_runner,
+    )
+
+    args, stdin = calls[0]
+    assert stdin is None
+    assert args[:2] == ["ssh", "mvn-api"]
+    assert "ENV_INPUT_FILE=/root/mvn-postgres-pitr.env" in args[2]
+    assert "rm -f /root/mvn-postgres-pitr.env" in args[2]
+    assert "/usr/local/sbin/mvn-postgres-pitr-bootstrap preflight" in args[2]
+
+
+def test_collect_inputs_reports_missing_names_without_secret_values():
+    try:
+        module.collect_inputs(
+            environ=_env(POSTGRES_PITR_S3_BUCKET="", POSTGRES_PITR_S3_SECRET_ACCESS_KEY="super-secret-key"),
+            no_prompt=True,
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("collect_inputs should fail")
+
+    assert "POSTGRES_PITR_S3_BUCKET" in message
+    assert "super-secret-key" not in message
+
+
+def test_collect_inputs_rejects_public_endpoint():
+    try:
+        module.collect_inputs(
+            environ=_env(POSTGRES_PITR_S3_ENDPOINT_URL="https://cdn.mvn.by"),
+            no_prompt=True,
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("collect_inputs should fail")
+
+    assert "r2.cloudflarestorage.com" in message
+    assert "super-secret-key" not in message
+
+
+def test_dry_run_prints_redacted_env(monkeypatch, capsys):
+    monkeypatch.setenv("POSTGRES_PITR_CLUSTER", "mvn-api")
+    monkeypatch.setenv("POSTGRES_PITR_S3_BUCKET", "mvn-postgres-pitr")
+    monkeypatch.setenv("POSTGRES_PITR_S3_ENDPOINT_URL", "https://account-id.r2.cloudflarestorage.com")
+    monkeypatch.setenv("POSTGRES_PITR_S3_REGION", "auto")
+    monkeypatch.setenv("POSTGRES_PITR_S3_ACCESS_KEY_ID", "access-key-id")
+    monkeypatch.setenv("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", "super-secret-key")
+    monkeypatch.setenv("POSTGRES_PITR_S3_KEY_PREFIX", "postgres/pitr")
+
+    assert module.main(["--dry-run", "--no-prompt"]) == 0
+
+    output = capsys.readouterr().out
+    assert "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr" in output
+    assert "access-key-id" not in output
+    assert "super-secret-key" not in output
+    assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=redacted" in output
+
+
+def test_main_runs_upload_and_preflight_with_monkeypatched_subprocess(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    for name, value in _env().items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--no-prompt", "--phase", "preflight"]) == 0
+
+    assert len(calls) == 2
+    assert calls[0][0][:2] == ["ssh", "mvn-api"]
+    assert "super-secret-key" in calls[0][1]
+    assert all("super-secret-key" not in arg for args, _stdin in calls for arg in args)
+    assert "preflight" in calls[1][0][2]


### PR DESCRIPTION
## Summary
- add a local helper that safely uploads temporary PITR R2 credentials to the current primary over SSH without printing access keys
- keep PITR activation split into dry-run, preflight, and explicit bootstrap-before-maintenance before any DB recreate
- update the HA runbook to use the helper instead of manual heredoc secret pasting

## Tests
- python3 -m py_compile scripts/ha/apply_postgres_pitr_primary_prerequisites.py scripts/ha/configure_postgres_pitr_env.py scripts/ha/apply_cloudflare_lb_github_prerequisites.py
- pytest tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py -q
- pytest tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_external_prerequisites.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_workflows.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py -q
- git diff --check
- git diff --cached --check