### PR TITLE
Add HA monitor Telegram alerts

### DIFF
--- a/.github/actions/notify-ha-failure/action.yml
+++ b/.github/actions/notify-ha-failure/action.yml
@@ -1,0 +1,81 @@
+name: Notify HA Failure
+description: Send an optional Telegram alert for failed MVN HA monitor workflows.
+
+inputs:
+  bot-token:
+    description: Telegram bot token used only for this notification.
+    required: false
+    default: ""
+  chat-id:
+    description: Telegram chat id for HA alerts.
+    required: false
+    default: ""
+  thread-id:
+    description: Optional Telegram forum topic/thread id.
+    required: false
+    default: ""
+  title:
+    description: Short alert title.
+    required: true
+  details:
+    description: Optional one-line context, usually the uploaded artifact name.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Send Telegram alert
+      shell: bash
+      env:
+        BOT_TOKEN: ${{ inputs.bot-token }}
+        CHAT_ID: ${{ inputs.chat-id }}
+        THREAD_ID: ${{ inputs.thread-id }}
+        TITLE: ${{ inputs.title }}
+        DETAILS: ${{ inputs.details }}
+      run: |
+        set -euo pipefail
+        if [ -z "${BOT_TOKEN}" ] || [ -z "${CHAT_ID}" ]; then
+          echo "HA alert skipped: HA_ALERT_TELEGRAM_BOT_TOKEN or HA_ALERT_TELEGRAM_CHAT_ID is not configured."
+          exit 0
+        fi
+
+        payload_file="$(mktemp)"
+        python3 - <<'PY' > "${payload_file}"
+        import json
+        import os
+
+        run_url = (
+            f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/"
+            f"{os.environ.get('GITHUB_REPOSITORY', '')}/actions/runs/"
+            f"{os.environ.get('GITHUB_RUN_ID', '')}"
+        )
+        lines = [
+            os.environ.get("TITLE", "MVN HA monitor failed"),
+            f"Workflow: {os.environ.get('GITHUB_WORKFLOW', '')}",
+            f"Branch: {os.environ.get('GITHUB_REF_NAME', '')}",
+            f"Run: {run_url}",
+        ]
+        details = os.environ.get("DETAILS", "").strip()
+        if details:
+            lines.append(details)
+
+        payload = {
+            "chat_id": os.environ["CHAT_ID"],
+            "text": "\n".join(lines),
+            "disable_web_page_preview": True,
+        }
+        thread_id = os.environ.get("THREAD_ID", "").strip()
+        if thread_id:
+            payload["message_thread_id"] = thread_id
+        print(json.dumps(payload, ensure_ascii=True))
+        PY
+
+        if ! curl --fail --silent --show-error \
+          --request POST \
+          --header "Content-Type: application/json" \
+          --data @"${payload_file}" \
+          "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" >/dev/null; then
+          echo "::warning::Failed to send HA Telegram alert"
+        fi
+        rm -f "${payload_file}"

--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -16,6 +16,9 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup API SSH Key
         env:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
@@ -54,3 +57,13 @@ jobs:
           name: api-restore-drill-log-${{ github.run_id }}
           path: api-restore-drill.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN API restore drill failed"
+          details: "Artifact: api-restore-drill-log-${{ github.run_id }}"

--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -48,3 +48,13 @@ jobs:
           name: api-ha-invariant-log-${{ github.run_id }}
           path: api-ha-invariant.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN API HA invariant check failed"
+          details: "Artifact: api-ha-invariant-log-${{ github.run_id }}"

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -97,3 +97,13 @@ jobs:
           name: api-ha-readiness-log-${{ github.run_id }}
           path: api-ha-readiness.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN API HA readiness audit failed"
+          details: "Artifact: api-ha-readiness-log-${{ github.run_id }}"

--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -103,3 +103,13 @@ jobs:
           name: api-vps-health-log-${{ github.run_id }}
           path: api-vps-health.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN API VPS health check failed"
+          details: "Artifact: api-vps-health-log-${{ github.run_id }}"

--- a/.github/workflows/check-cloudflare-lb-config.yml
+++ b/.github/workflows/check-cloudflare-lb-config.yml
@@ -86,3 +86,13 @@ jobs:
           name: cloudflare-lb-config-log-${{ github.run_id }}
           path: cloudflare-lb-config.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN Cloudflare LB config check failed"
+          details: "Artifact: cloudflare-lb-config-log-${{ github.run_id }}"

--- a/.github/workflows/check-media-cdn.yml
+++ b/.github/workflows/check-media-cdn.yml
@@ -119,3 +119,13 @@ jobs:
           name: media-cdn-check-log-${{ github.run_id }}
           path: media-cdn-check.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN media CDN check failed"
+          details: "Artifact: media-cdn-check-log-${{ github.run_id }}"

--- a/.github/workflows/check-postgres-pitr.yml
+++ b/.github/workflows/check-postgres-pitr.yml
@@ -98,3 +98,13 @@ jobs:
           name: postgres-pitr-check-log-${{ github.run_id }}
           path: postgres-pitr-check.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN PostgreSQL PITR check failed"
+          details: "Artifact: postgres-pitr-check-log-${{ github.run_id }}"

--- a/.github/workflows/check-postgres-replication.yml
+++ b/.github/workflows/check-postgres-replication.yml
@@ -86,3 +86,13 @@ jobs:
           name: postgres-replication-check-log-${{ github.run_id }}
           path: postgres-replication-check.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN PostgreSQL replication check failed"
+          details: "Artifact: postgres-replication-check-log-${{ github.run_id }}"

--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -129,3 +129,13 @@ jobs:
           name: postgres-pitr-restore-drill-log-${{ github.run_id }}
           path: postgres-pitr-restore-drill.log
           if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN PostgreSQL PITR restore drill failed"
+          details: "Artifact: postgres-pitr-restore-drill-log-${{ github.run_id }}"

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -181,6 +181,22 @@ Scheduled monitors:
 | `postgres-pitr-restore-drill.yml` | daily when `POSTGRES_PITR_REQUIRED=true` | disposable physical restore from PITR basebackup + WAL |
 | `check-media-cdn.yml` | every 6 hours | public product images and DB-backed object-storage media use `cdn.mvn.by`; sampled CDN objects are cacheable |
 
+Owner-visible alerting:
+
+All HA monitor workflows call `.github/actions/notify-ha-failure` on failure
+after the log artifact upload step. Without the secrets below, the notifier
+prints a skip message and does not fail the workflow:
+
+```bash
+gh secret set HA_ALERT_TELEGRAM_BOT_TOKEN --repo mvnby/air-api
+gh secret set HA_ALERT_TELEGRAM_CHAT_ID --repo mvnby/air-api
+# Optional, only for Telegram forum topics:
+gh secret set HA_ALERT_TELEGRAM_THREAD_ID --repo mvnby/air-api
+```
+
+Use a dedicated Telegram bot or a tightly scoped internal alert chat. Do not
+reuse the customer-facing bot token for infrastructure alerts.
+
 ## PostgreSQL PITR
 
 Streaming replication protects us from a dead primary host. PITR protects us
@@ -741,5 +757,5 @@ gh workflow run api-restore-drill.yml --repo mvnby/air-api --ref main
 
 ## Next Improvements
 
-- Add owner-visible alerts from GitHub Actions or Cloudflare to Telegram/email
-  beyond the default GitHub failed-workflow notification path.
+- Add Cloudflare-native origin health alerts if GitHub Actions alerting is not
+  fast enough for operational needs.

--- a/scripts/ha/check_ha_external_prerequisites.py
+++ b/scripts/ha/check_ha_external_prerequisites.py
@@ -22,6 +22,11 @@ REQUIRED_SECRETS = {
     "CLOUDFLARE_LB_READ_TOKEN": "Cloudflare read-only token for Load Balancer config audit",
 }
 
+OPTIONAL_SECRETS = {
+    "HA_ALERT_TELEGRAM_BOT_TOKEN": "Telegram bot token for owner-visible HA failure alerts",
+    "HA_ALERT_TELEGRAM_CHAT_ID": "Telegram chat id for owner-visible HA failure alerts",
+}
+
 REQUIRED_VARIABLES = {
     "API_HA_READINESS_STRICT": "Controls whether the rollup HA audit treats soft blockers as failures",
     "CLOUDFLARE_ACCOUNT_ID": "Cloudflare account id for Load Balancer pools/monitors",
@@ -91,6 +96,12 @@ def check_metadata(metadata: GithubMetadata, *, require_strict: bool) -> tuple[l
             ok.append(f"secret present: {name}")
         else:
             failures.append(f"missing GitHub secret {name}: {description}")
+
+    for name, description in sorted(OPTIONAL_SECRETS.items()):
+        if name in metadata.secrets:
+            ok.append(f"optional secret present: {name}")
+        else:
+            warnings.append(f"missing optional GitHub secret {name}: {description}")
 
     for name, description in sorted(REQUIRED_VARIABLES.items()):
         value = metadata.variables.get(name)

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ACTION_PATH = REPO_ROOT / ".github/actions/notify-ha-failure/action.yml"
+
+ALERTED_WORKFLOWS = [
+    (".github/workflows/api-restore-drill.yml", "restore-drill"),
+    (".github/workflows/check-api-ha-invariants.yml", "check"),
+    (".github/workflows/check-api-ha-readiness.yml", "audit"),
+    (".github/workflows/check-api-vps-health.yml", "check"),
+    (".github/workflows/check-cloudflare-lb-config.yml", "check"),
+    (".github/workflows/check-media-cdn.yml", "check"),
+    (".github/workflows/check-postgres-pitr.yml", "check"),
+    (".github/workflows/check-postgres-replication.yml", "check"),
+    (".github/workflows/postgres-pitr-restore-drill.yml", "pitr-restore-drill"),
+]
+
+
+def _yaml(path: Path) -> dict:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, job_name: str, step_name: str) -> dict:
+    return next(step for step in workflow["jobs"][job_name]["steps"] if step.get("name") == step_name)
+
+
+def test_notify_ha_failure_action_skips_when_telegram_secrets_are_absent():
+    action = _yaml(ACTION_PATH)
+    step = action["runs"]["steps"][0]
+    run = step["run"]
+
+    assert action["runs"]["using"] == "composite"
+    assert "HA_ALERT_TELEGRAM_BOT_TOKEN or HA_ALERT_TELEGRAM_CHAT_ID is not configured" in run
+    assert "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" in run
+    assert "GITHUB_RUN_ID" in run
+    assert "disable_web_page_preview" in run
+
+
+def test_ha_monitor_workflows_notify_on_failure_after_artifact_upload():
+    for workflow_path, job_name in ALERTED_WORKFLOWS:
+        workflow = _yaml(REPO_ROOT / workflow_path)
+        steps = workflow["jobs"][job_name]["steps"]
+        notify_step = _step(workflow, job_name, "Notify HA failure")
+        notify_index = steps.index(notify_step)
+        artifact_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == "actions/upload-artifact@v7"
+        ]
+
+        assert artifact_indexes, workflow_path
+        assert notify_index > max(artifact_indexes), workflow_path
+        assert notify_step["if"] == "failure()"
+        assert notify_step["uses"] == "./.github/actions/notify-ha-failure"
+        assert "HA_ALERT_TELEGRAM_BOT_TOKEN" in notify_step["with"]["bot-token"]
+        assert "HA_ALERT_TELEGRAM_CHAT_ID" in notify_step["with"]["chat-id"]
+        assert "HA_ALERT_TELEGRAM_THREAD_ID" in notify_step["with"]["thread-id"]
+        assert "Artifact:" in notify_step["with"]["details"]
+
+
+def test_restore_drill_checks_out_repo_before_local_alert_action():
+    workflow = _yaml(REPO_ROOT / ".github/workflows/api-restore-drill.yml")
+    steps = workflow["jobs"]["restore-drill"]["steps"]
+
+    assert steps[0]["name"] == "Checkout"
+    assert steps[0]["uses"] == "actions/checkout@v6"

--- a/tests/unit/test_ha_external_prerequisites.py
+++ b/tests/unit/test_ha_external_prerequisites.py
@@ -36,6 +36,8 @@ def test_external_prerequisites_report_missing_cloudflare_secret_and_vars():
     assert any("missing GitHub secret CLOUDFLARE_LB_READ_TOKEN" in item for item in failures)
     assert any("missing GitHub variable CLOUDFLARE_ACCOUNT_ID" in item for item in failures)
     assert any("missing GitHub variable CLOUDFLARE_ZONE_ID" in item for item in failures)
+    assert any("missing optional GitHub secret HA_ALERT_TELEGRAM_BOT_TOKEN" in item for item in warnings)
+    assert any("missing optional GitHub secret HA_ALERT_TELEGRAM_CHAT_ID" in item for item in warnings)
     assert any("POSTGRES_PITR_REQUIRED is not true yet" in item for item in warnings)
     assert any("variable present: POSTGRES_PITR_MAX_WAL_AGE_MINUTES" in item for item in ok)
 
@@ -76,12 +78,13 @@ def test_external_prerequisites_pass_when_all_metadata_is_ready():
                 "POSTGRES_PITR_MAX_WAL_AGE_MINUTES": "180",
                 "POSTGRES_PITR_REQUIRED": "true",
             },
-            secrets={"CLOUDFLARE_LB_READ_TOKEN"},
+            secrets={"CLOUDFLARE_LB_READ_TOKEN", "HA_ALERT_TELEGRAM_BOT_TOKEN", "HA_ALERT_TELEGRAM_CHAT_ID"},
         ),
         require_strict=True,
     )
 
     assert not failures
+    assert any("optional secret present: HA_ALERT_TELEGRAM_BOT_TOKEN" in item for item in ok)
     assert any("strict variable enabled: API_HA_READINESS_STRICT" in item for item in ok)
     assert any("strict variable enabled: POSTGRES_PITR_REQUIRED" in item for item in ok)
     assert any("private PITR R2 credentials are host-local" in item for item in warnings)


### PR DESCRIPTION
## Summary
- add an optional Telegram notifier composite action for HA monitor workflow failures
- wire failure alerts into HA/readiness/replication/PITR/CDN scheduled checks after log artifact upload
- document required alert secrets and report missing alert secrets as optional HA prerequisite warnings

## Tests
- pytest tests/unit/test_ha_alert_workflows.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_external_prerequisites.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_workflows.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_media_cdn_workflow.py -q
- python3 -m py_compile scripts/ha/check_ha_external_prerequisites.py
- YAML parse for .github/workflows and .github/actions
- bash -n scripts/ha/check_api_ha_readiness.sh scripts/ha/check_active_passive.sh scripts/ha/check_postgres_replication.sh scripts/ha/check_postgres_pitr_status.sh scripts/ha/restore_drill_latest_db.sh scripts/ha/restore_postgres_pitr_drill.sh
- git diff --check