### PR TITLE
Add HA strict activation helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -62,6 +62,7 @@ unreviewed host-local compose edits:
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | Cloudflare LB primary switch helper | `scripts/ha/switch_cloudflare_lb_primary.py` |
 | External strict-mode prerequisite check | `scripts/ha/check_ha_external_prerequisites.py` |
+| Strict-mode activation helper | `scripts/ha/enable_ha_strict_mode.py` |
 | Cloudflare LB GitHub prerequisite apply helper | `scripts/ha/apply_cloudflare_lb_github_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
@@ -167,6 +168,20 @@ export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
 python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --mark-required
 unset CLOUDFLARE_LB_READ_TOKEN
 ```
+
+After Cloudflare LB credentials are in GitHub and PostgreSQL PITR has passed
+`mvn-postgres-pitr-bootstrap verify`, use the strict-mode activation helper
+instead of setting strict variables by hand:
+
+```bash
+python3 scripts/ha/enable_ha_strict_mode.py --repo mvnby/air-api --dry-run
+python3 scripts/ha/enable_ha_strict_mode.py --repo mvnby/air-api
+```
+
+The helper waits for the required Cloudflare LB config audit, PITR status
+check, PITR restore drill, and strict HA readiness audit. It sets
+`CLOUDFLARE_LB_CONFIG_REQUIRED=true`, `POSTGRES_PITR_REQUIRED=true`, and
+`API_HA_READINESS_STRICT=true` only after those proof workflows pass.
 
 Scheduled monitors:
 

--- a/scripts/ha/enable_ha_strict_mode.py
+++ b/scripts/ha/enable_ha_strict_mode.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Enable MVN API HA strict mode only after proof workflows pass.
+
+The helper intentionally sets GitHub strict-mode variables only after the
+Cloudflare LB audit, PostgreSQL PITR freshness check, PITR restore drill, and
+strict HA readiness audit have all passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+DEFAULT_REPO = "mvnby/air-api"
+DEFAULT_REF = "main"
+
+STRICT_VARIABLES = (
+    "CLOUDFLARE_LB_CONFIG_REQUIRED",
+    "POSTGRES_PITR_REQUIRED",
+    "API_HA_READINESS_STRICT",
+)
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class WorkflowProof:
+    workflow: str
+    description: str
+    fields: Mapping[str, str]
+
+
+PROOF_WORKFLOWS = (
+    WorkflowProof(
+        workflow="check-cloudflare-lb-config.yml",
+        description="Cloudflare Load Balancer required config audit",
+        fields={"required": "true"},
+    ),
+    WorkflowProof(
+        workflow="check-postgres-pitr.yml",
+        description="PostgreSQL PITR required freshness/status check",
+        fields={"required": "true"},
+    ),
+    WorkflowProof(
+        workflow="postgres-pitr-restore-drill.yml",
+        description="PostgreSQL PITR physical restore drill",
+        fields={"required": "true"},
+    ),
+    WorkflowProof(
+        workflow="check-api-ha-readiness.yml",
+        description="whole-system HA readiness audit in strict mode",
+        fields={"strict": "true"},
+    ),
+)
+
+
+def log(stage: str, message: str) -> None:
+    print(f"[ha-strict-enable][{stage}] {message}")
+
+
+def _run_subprocess(args: Sequence[str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_checked(
+    args: Sequence[str],
+    *,
+    stdin: str | None = None,
+    runner: Runner | None = None,
+    print_stdout: bool = True,
+) -> str:
+    actual_runner = runner or _run_subprocess
+    result = actual_runner(args, stdin)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(output or f"command failed: {' '.join(args)}")
+    output = result.stdout.strip()
+    if print_stdout and output:
+        print(output)
+    return output
+
+
+def parse_run_id(output: str) -> str | None:
+    match = re.search(r"/actions/runs/([0-9]+)", output)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_github_time(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def find_recent_workflow_run_id(
+    *,
+    repo: str,
+    ref: str,
+    workflow: str,
+    started_after: datetime,
+    runner: Runner | None = None,
+) -> str:
+    output = run_checked(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            workflow,
+            "--branch",
+            ref,
+            "--event",
+            "workflow_dispatch",
+            "--json",
+            "databaseId,createdAt,url",
+            "--limit",
+            "10",
+        ],
+        runner=runner,
+        print_stdout=False,
+    )
+    try:
+        runs = json.loads(output or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"could not parse gh run list output for {workflow}: {output!r}") from exc
+
+    candidates: list[tuple[datetime, str]] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        created_at = parse_github_time(str(run.get("createdAt") or ""))
+        run_id = str(run.get("databaseId") or "")
+        if created_at and run_id and created_at >= started_after:
+            candidates.append((created_at, run_id))
+
+    if not candidates:
+        raise RuntimeError(
+            f"could not find a recent workflow_dispatch run for {workflow}; "
+            "rerun or inspect GitHub Actions manually"
+        )
+
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def trigger_and_wait_workflow(
+    proof: WorkflowProof,
+    *,
+    repo: str,
+    ref: str,
+    runner: Runner | None = None,
+) -> str:
+    log("start", proof.description)
+    started_after = datetime.now(timezone.utc) - timedelta(seconds=10)
+    args = ["gh", "workflow", "run", proof.workflow, "--repo", repo, "--ref", ref]
+    for key, value in proof.fields.items():
+        args.extend(["-f", f"{key}={value}"])
+
+    output = run_checked(args, runner=runner)
+    run_id = parse_run_id(output)
+    if not run_id:
+        run_id = find_recent_workflow_run_id(
+            repo=repo,
+            ref=ref,
+            workflow=proof.workflow,
+            started_after=started_after,
+            runner=runner,
+        )
+
+    run_checked(
+        ["gh", "run", "watch", run_id, "--repo", repo, "--exit-status", "--interval", "10"],
+        runner=runner,
+    )
+    log("ok", f"{proof.workflow} passed: {run_id}")
+    return run_id
+
+
+def set_variable(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
+    run_checked(["gh", "variable", "set", name, "--repo", repo], stdin=f"{value}\n", runner=runner)
+    log("ok", f"GitHub variable set: {name}={value}")
+
+
+def run_external_prereq_check(repo: str, *, require_strict: bool, runner: Runner | None = None) -> None:
+    script = Path(__file__).with_name("check_ha_external_prerequisites.py")
+    args = [sys.executable, str(script), "--repo", repo]
+    if require_strict:
+        args.append("--require-strict")
+    run_checked(args, runner=runner)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run MVN HA proof workflows and enable GitHub strict-mode variables only after they pass."
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--ref", default=DEFAULT_REF)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the proof sequence and variables that would be set without running workflows.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        log("info", f"repo={args.repo} ref={args.ref}")
+        if args.dry_run:
+            log("dry-run", "would verify non-strict external prerequisites")
+            for proof in PROOF_WORKFLOWS:
+                fields = " ".join(f"{key}={value}" for key, value in proof.fields.items())
+                log("dry-run", f"would run and wait for {proof.workflow} {fields}")
+            for name in STRICT_VARIABLES:
+                log("dry-run", f"would set GitHub variable {name}=true")
+            log("dry-run", "would verify strict external prerequisites")
+            return 0
+
+        run_external_prereq_check(args.repo, require_strict=False)
+        for proof in PROOF_WORKFLOWS:
+            trigger_and_wait_workflow(proof, repo=args.repo, ref=args.ref)
+
+        for name in STRICT_VARIABLES:
+            set_variable(args.repo, name, "true")
+
+        run_external_prereq_check(args.repo, require_strict=True)
+        log("ok", "strict HA mode is enabled")
+        return 0
+    except RuntimeError as exc:
+        log("fail", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_enable_ha_strict_mode.py
+++ b/tests/unit/test_enable_ha_strict_mode.py
@@ -1,0 +1,137 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ha/enable_ha_strict_mode.py"
+
+
+spec = importlib.util.spec_from_file_location("enable_ha_strict_mode", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class FakeCompleted:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_dry_run_does_not_call_subprocess(monkeypatch, capsys):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--dry-run"]) == 0
+
+    assert calls == []
+    output = capsys.readouterr().out
+    assert "would run and wait for check-cloudflare-lb-config.yml required=true" in output
+    assert "would set GitHub variable API_HA_READINESS_STRICT=true" in output
+
+
+def test_main_runs_proofs_before_enabling_strict_variables(monkeypatch):
+    calls = []
+    run_id = 28640000000
+
+    def fake_runner(args, stdin):
+        nonlocal run_id
+        args = list(args)
+        calls.append((args, stdin))
+        if args[:3] == ["gh", "workflow", "run"]:
+            run_id += 1
+            return FakeCompleted(stdout=f"https://github.com/mvnby/air-api/actions/runs/{run_id}\n")
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api"]) == 0
+
+    workflow_calls = [args for args, _stdin in calls if args[:3] == ["gh", "workflow", "run"]]
+    variable_calls = [args for args, _stdin in calls if args[:3] == ["gh", "variable", "set"]]
+    first_variable_index = next(index for index, call in enumerate(calls) if call[0][:3] == ["gh", "variable", "set"])
+    last_watch_index = max(index for index, call in enumerate(calls) if call[0][:3] == ["gh", "run", "watch"])
+
+    assert [call[3] for call in workflow_calls] == [
+        "check-cloudflare-lb-config.yml",
+        "check-postgres-pitr.yml",
+        "postgres-pitr-restore-drill.yml",
+        "check-api-ha-readiness.yml",
+    ]
+    assert ["-f", "strict=true"] in [
+        workflow_calls[-1][index : index + 2] for index in range(len(workflow_calls[-1]) - 1)
+    ]
+    assert last_watch_index < first_variable_index
+    assert [call[3] for call in variable_calls] == [
+        "CLOUDFLARE_LB_CONFIG_REQUIRED",
+        "POSTGRES_PITR_REQUIRED",
+        "API_HA_READINESS_STRICT",
+    ]
+    assert all(stdin == "true\n" for _args, stdin in calls if _args[:3] == ["gh", "variable", "set"])
+    assert calls[-1][0][-1] == "--require-strict"
+
+
+def test_workflow_output_without_url_falls_back_to_recent_run_list(monkeypatch):
+    calls = []
+    real_datetime = module.datetime
+
+    def fake_runner(args, stdin):
+        args = list(args)
+        calls.append((args, stdin))
+        if args[:3] == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="Created workflow_dispatch event\n")
+        if args[:3] == ["gh", "run", "list"]:
+            return FakeCompleted(
+                stdout='[{"databaseId":28639999999,"createdAt":"2026-07-03T05:08:21Z",'
+                '"url":"https://github.com/mvnby/air-api/actions/runs/28639999999"}]'
+            )
+        return FakeCompleted()
+
+    class FrozenDatetime:
+        @staticmethod
+        def now(_tz):
+            return real_datetime(2026, 7, 3, 5, 8, 22, tzinfo=module.timezone.utc)
+
+        @staticmethod
+        def fromisoformat(value):
+            return real_datetime.fromisoformat(value)
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+    monkeypatch.setattr(module, "datetime", FrozenDatetime)
+
+    run_id = module.trigger_and_wait_workflow(
+        module.PROOF_WORKFLOWS[0],
+        repo="mvnby/air-api",
+        ref="main",
+    )
+
+    assert run_id == "28639999999"
+    assert any(args[:3] == ["gh", "run", "list"] for args, _stdin in calls)
+    assert any(args[:3] == ["gh", "run", "watch"] and args[3] == "28639999999" for args, _stdin in calls)
+
+
+def test_failed_proof_does_not_enable_strict_variables(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        args = list(args)
+        calls.append((args, stdin))
+        if args[:3] == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="https://github.com/mvnby/air-api/actions/runs/28636799268\n")
+        if args[:3] == ["gh", "run", "watch"] and args[3] == "28636799268":
+            return FakeCompleted(stderr="workflow failed", returncode=1)
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api"]) == 1
+
+    assert not any(args[:3] == ["gh", "variable", "set"] for args, _stdin in calls)


### PR DESCRIPTION
## Summary
- add a safe HA strict-mode activation helper that runs proof workflows before setting strict GitHub variables
- cover workflow URL parsing, fallback run lookup, dry-run behavior, and failure-before-variable-write safety
- document the strict activation path in the API HA runbook

## Tests
- pytest tests/unit/test_enable_ha_strict_mode.py tests/unit/test_ha_alert_workflows.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_external_prerequisites.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_workflows.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_media_cdn_workflow.py -q
- python3 -m py_compile scripts/ha/enable_ha_strict_mode.py
- python3 scripts/ha/enable_ha_strict_mode.py --repo mvnby/air-api --dry-run
- git diff --check