### PR TITLE
Add GitHub API routing switch helper

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -53,6 +53,7 @@ unreviewed host-local compose edits:
 | `zakup` as standby | `deploy/ha/zakup/docker-compose.standby.yml` |
 | Active-passive invariant check | `scripts/ha/check_active_passive.sh` |
 | Local standby promotion helper | `scripts/ha/promote_local_standby.sh` |
+| GitHub Actions primary switch helper | `scripts/ha/switch_github_api_primary.py` |
 | Disposable DB restore drill | `scripts/ha/restore_drill_latest_db.sh` |
 | PostgreSQL PITR WAL/basebackup upload | `scripts/ha/upload_postgres_pitr_to_s3.py`, `scripts/ha/upload_postgres_pitr_wal.sh`, `scripts/ha/create_postgres_pitr_basebackup.sh` |
 | PostgreSQL PITR restore helpers | `scripts/ha/restore_postgres_pitr_from_s3.py`, `scripts/ha/restore_postgres_pitr_drill.sh`, `.github/workflows/postgres-pitr-restore-drill.yml` |
@@ -409,10 +410,12 @@ keeps proving that basebackups plus archived WAL can actually be restored.
 
 ## GitHub Actions Routing
 
-Current production variables must match the active primary:
+Current production GitHub secret/variables must match the active primary:
 
 ```text
 SSH_HOST_API=185.250.45.54
+API_PRIMARY_ORIGIN=185.250.45.54
+API_STANDBY_ORIGIN=193.47.42.213
 API_PROJECT_DIR=/opt/air-api
 API_COMPOSE_FILE=docker-compose.prod.yml
 API_COMPOSE_SOURCE_FILE=deploy/ha/mvn-api/docker-compose.primary.yml
@@ -432,6 +435,24 @@ API_STANDBY_COPY_COMPOSE=true
 API_STANDBY_COMPOSE_SOURCE_FILE=deploy/ha/zakup/docker-compose.standby.yml
 API_STANDBY_HEALTH_URL=http://localhost:18000/api/health
 ```
+
+Use the helper to switch these GitHub secret/variables after a real promotion
+or planned failback. It prints a dry-run plan by default:
+
+```bash
+# Normal routing: mvn-api primary, zakup standby.
+python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary mvn-api
+python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary mvn-api --confirm
+
+# After zakup has actually been promoted.
+python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary zakup
+python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary zakup --confirm
+```
+
+The helper updates the `SSH_HOST_API` GitHub secret plus the repo variables
+used by deploy, smoke checks, replication checks, standby image deploy, and
+Cloudflare origin audits. Run it only after the database role has been changed;
+it does not promote PostgreSQL and does not switch Cloudflare traffic.
 
 If an emergency requires manual host-local compose edits, set
 `API_COPY_COMPOSE=false` and/or `API_STANDBY_COPY_COMPOSE=false` temporarily.
@@ -667,9 +688,8 @@ The manual steps below are the same procedure expanded for review.
    `zakup` the current primary:
 
    ```bash
-   gh variable set API_PRIMARY_ORIGIN --repo mvnby/air-api --body 193.47.42.213
-   gh variable set API_STANDBY_ORIGIN --repo mvnby/air-api --body 185.250.45.54
-   gh variable set API_STANDBY_HOST --repo mvnby/air-api --body 185.250.45.54
+   python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary zakup
+   python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary zakup --confirm
 
    printf 'Cloudflare LB write token: '
    stty -echo
@@ -692,10 +712,12 @@ The manual steps below are the same procedure expanded for review.
 9. Do not restart `mvn-api` as primary. Rebuild it as standby from the promoted
    database.
 
-GitHub Actions variables after `zakup` promotion:
+GitHub Actions secret/variables after `zakup` promotion:
 
 ```text
 SSH_HOST_API=193.47.42.213
+API_PRIMARY_ORIGIN=193.47.42.213
+API_STANDBY_ORIGIN=185.250.45.54
 API_PROJECT_DIR=/opt/mvn-reserve
 API_COMPOSE_FILE=docker-compose.reserve.yml
 API_COMPOSE_SOURCE_FILE=deploy/ha/zakup/docker-compose.primary.yml
@@ -705,6 +727,9 @@ API_READY_URL=http://localhost:18000/api/ready
 API_LOCAL_HEALTH_URL=http://127.0.0.1:18000/api/health
 API_TUNNEL_REMOTE_PORT=18000
 API_DEPLOY_SERVICES=app bot
+API_SMOKE_COMPOSE_SERVICE_CHECKS=app bot db
+API_COMPOSE_SERVICE_CHECKS=app bot db
+API_BOT_EXPECT_ENABLED=true
 API_STANDBY_HOST=185.250.45.54
 API_STANDBY_PROJECT_DIR=/opt/air-api
 API_STANDBY_COMPOSE_FILE=docker-compose.prod.yml

--- a/scripts/ha/switch_github_api_primary.py
+++ b/scripts/ha/switch_github_api_primary.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Switch GitHub Actions API primary/standby routing variables.
+
+Use this after a real PostgreSQL promotion/failback decision. By default the
+helper prints the exact GitHub secret/variable writes and does not modify
+anything. Pass --confirm to apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+
+DEFAULT_REPO = "mvnby/air-api"
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class ApiHostProfile:
+    name: str
+    origin: str
+    project_dir: str
+    compose_file: str
+    primary_compose_source: str
+    standby_compose_source: str
+    local_port: int
+
+    @property
+    def base_url(self) -> str:
+        return f"http://localhost:{self.local_port}"
+
+    @property
+    def local_health_url(self) -> str:
+        return f"http://127.0.0.1:{self.local_port}/api/health"
+
+    @property
+    def ready_url(self) -> str:
+        return f"http://localhost:{self.local_port}/api/ready"
+
+    @property
+    def health_url(self) -> str:
+        return f"http://localhost:{self.local_port}/api/health"
+
+
+HOSTS = {
+    "mvn-api": ApiHostProfile(
+        name="mvn-api",
+        origin="185.250.45.54",
+        project_dir="/opt/air-api",
+        compose_file="docker-compose.prod.yml",
+        primary_compose_source="deploy/ha/mvn-api/docker-compose.primary.yml",
+        standby_compose_source="deploy/ha/mvn-api/docker-compose.standby.yml",
+        local_port=8000,
+    ),
+    "zakup": ApiHostProfile(
+        name="zakup",
+        origin="193.47.42.213",
+        project_dir="/opt/mvn-reserve",
+        compose_file="docker-compose.reserve.yml",
+        primary_compose_source="deploy/ha/zakup/docker-compose.primary.yml",
+        standby_compose_source="deploy/ha/zakup/docker-compose.standby.yml",
+        local_port=18000,
+    ),
+}
+
+
+def log(stage: str, message: str) -> None:
+    print(f"[github-api-primary][{stage}] {message}")
+
+
+def _run_subprocess(args: Sequence[str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_checked(args: Sequence[str], *, stdin: str | None = None, runner: Runner | None = None) -> str:
+    actual_runner = runner or _run_subprocess
+    result = actual_runner(args, stdin)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(output or f"command failed: {' '.join(args)}")
+    return result.stdout.strip()
+
+
+def opposite_host(name: str) -> str:
+    if name == "mvn-api":
+        return "zakup"
+    if name == "zakup":
+        return "mvn-api"
+    raise RuntimeError(f"unknown API host profile: {name}")
+
+
+def build_routing(primary_name: str) -> tuple[str, Mapping[str, str]]:
+    primary = HOSTS[primary_name]
+    standby = HOSTS[opposite_host(primary_name)]
+    variables = {
+        "API_PRIMARY_ORIGIN": primary.origin,
+        "API_STANDBY_ORIGIN": standby.origin,
+        "API_PROJECT_DIR": primary.project_dir,
+        "API_COMPOSE_FILE": primary.compose_file,
+        "API_COMPOSE_SOURCE_FILE": primary.primary_compose_source,
+        "API_COPY_COMPOSE": "true",
+        "API_BASE_URL": primary.base_url,
+        "API_READY_URL": primary.ready_url,
+        "API_LOCAL_HEALTH_URL": primary.local_health_url,
+        "API_TUNNEL_REMOTE_PORT": str(primary.local_port),
+        "API_DEPLOY_SERVICES": "app bot",
+        "API_SMOKE_COMPOSE_SERVICE_CHECKS": "app bot db",
+        "API_COMPOSE_SERVICE_CHECKS": "app bot db",
+        "API_BOT_EXPECT_ENABLED": "true",
+        "API_STANDBY_HOST": standby.origin,
+        "API_STANDBY_PROJECT_DIR": standby.project_dir,
+        "API_STANDBY_COMPOSE_FILE": standby.compose_file,
+        "API_STANDBY_COPY_COMPOSE": "true",
+        "API_STANDBY_COMPOSE_SOURCE_FILE": standby.standby_compose_source,
+        "API_STANDBY_HEALTH_URL": standby.health_url,
+    }
+    return primary.origin, variables
+
+
+def set_secret(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
+    run_checked(["gh", "secret", "set", name, "--repo", repo], stdin=f"{value}\n", runner=runner)
+    log("ok", f"GitHub secret set: {name}")
+
+
+def set_variable(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
+    run_checked(["gh", "variable", "set", name, "--repo", repo], stdin=f"{value}\n", runner=runner)
+    log("ok", f"GitHub variable set: {name}={value}")
+
+
+def print_plan(primary_name: str, ssh_host_api: str, variables: Mapping[str, str]) -> None:
+    standby_name = opposite_host(primary_name)
+    log("plan", f"primary={primary_name} standby={standby_name}")
+    log("plan", f"secret SSH_HOST_API={ssh_host_api}")
+    for name in sorted(variables):
+        log("plan", f"variable {name}={variables[name]}")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Switch GitHub Actions API deploy/check routing between mvn-api and zakup."
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--primary",
+        choices=sorted(HOSTS),
+        required=True,
+        help="Host that is already promoted and should receive primary deploys/checks.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Apply the printed GitHub secret/variable changes.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        ssh_host_api, variables = build_routing(args.primary)
+        log("info", f"repo={args.repo}")
+        print_plan(args.primary, ssh_host_api, variables)
+        if not args.confirm:
+            log("dry-run", "no changes applied; rerun with --confirm after reviewing the plan")
+            return 0
+
+        set_secret(args.repo, "SSH_HOST_API", ssh_host_api)
+        for name in sorted(variables):
+            set_variable(args.repo, name, variables[name])
+        log("ok", "GitHub API routing updated")
+        return 0
+    except RuntimeError as exc:
+        log("fail", str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_switch_github_api_primary.py
+++ b/tests/unit/test_switch_github_api_primary.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ha/switch_github_api_primary.py"
+
+
+spec = importlib.util.spec_from_file_location("switch_github_api_primary", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class FakeCompleted:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_build_routing_for_normal_mvn_api_primary():
+    ssh_host, variables = module.build_routing("mvn-api")
+
+    assert ssh_host == "185.250.45.54"
+    assert variables["API_PRIMARY_ORIGIN"] == "185.250.45.54"
+    assert variables["API_STANDBY_ORIGIN"] == "193.47.42.213"
+    assert variables["API_PROJECT_DIR"] == "/opt/air-api"
+    assert variables["API_COMPOSE_FILE"] == "docker-compose.prod.yml"
+    assert variables["API_COMPOSE_SOURCE_FILE"] == "deploy/ha/mvn-api/docker-compose.primary.yml"
+    assert variables["API_BASE_URL"] == "http://localhost:8000"
+    assert variables["API_READY_URL"] == "http://localhost:8000/api/ready"
+    assert variables["API_STANDBY_HOST"] == "193.47.42.213"
+    assert variables["API_STANDBY_PROJECT_DIR"] == "/opt/mvn-reserve"
+    assert variables["API_STANDBY_COMPOSE_SOURCE_FILE"] == "deploy/ha/zakup/docker-compose.standby.yml"
+    assert variables["API_STANDBY_HEALTH_URL"] == "http://localhost:18000/api/health"
+    assert variables["API_COPY_COMPOSE"] == "true"
+    assert variables["API_STANDBY_COPY_COMPOSE"] == "true"
+
+
+def test_build_routing_for_promoted_zakup_primary():
+    ssh_host, variables = module.build_routing("zakup")
+
+    assert ssh_host == "193.47.42.213"
+    assert variables["API_PRIMARY_ORIGIN"] == "193.47.42.213"
+    assert variables["API_STANDBY_ORIGIN"] == "185.250.45.54"
+    assert variables["API_PROJECT_DIR"] == "/opt/mvn-reserve"
+    assert variables["API_COMPOSE_FILE"] == "docker-compose.reserve.yml"
+    assert variables["API_COMPOSE_SOURCE_FILE"] == "deploy/ha/zakup/docker-compose.primary.yml"
+    assert variables["API_BASE_URL"] == "http://localhost:18000"
+    assert variables["API_READY_URL"] == "http://localhost:18000/api/ready"
+    assert variables["API_STANDBY_HOST"] == "185.250.45.54"
+    assert variables["API_STANDBY_PROJECT_DIR"] == "/opt/air-api"
+    assert variables["API_STANDBY_COMPOSE_SOURCE_FILE"] == "deploy/ha/mvn-api/docker-compose.standby.yml"
+    assert variables["API_STANDBY_HEALTH_URL"] == "http://localhost:8000/api/health"
+
+
+def test_dry_run_prints_plan_without_writes(monkeypatch, capsys):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--primary", "zakup"]) == 0
+
+    assert calls == []
+    output = capsys.readouterr().out
+    assert "primary=zakup standby=mvn-api" in output
+    assert "secret SSH_HOST_API=193.47.42.213" in output
+    assert "variable API_COMPOSE_SOURCE_FILE=deploy/ha/zakup/docker-compose.primary.yml" in output
+    assert "no changes applied" in output
+
+
+def test_confirm_sets_secret_then_variables_without_values_in_args(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--primary", "zakup", "--confirm"]) == 0
+
+    secret_call = calls[0]
+    assert secret_call == (
+        ["gh", "secret", "set", "SSH_HOST_API", "--repo", "mvnby/air-api"],
+        "193.47.42.213\n",
+    )
+    variable_calls = [call for call in calls if call[0][:3] == ["gh", "variable", "set"]]
+    variable_names = [args[3] for args, _stdin in variable_calls]
+
+    assert "API_PROJECT_DIR" in variable_names
+    assert "API_STANDBY_HOST" in variable_names
+    assert "API_PRIMARY_ORIGIN" in variable_names
+    assert all("193.47.42.213" not in args for args, _stdin in calls)
+    assert any(args[3] == "API_PROJECT_DIR" and stdin == "/opt/mvn-reserve\n" for args, stdin in variable_calls)
+
+
+def test_confirm_stops_on_secret_write_failure(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        if list(args[:3]) == ["gh", "secret", "set"]:
+            return FakeCompleted(stderr="denied", returncode=1)
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--primary", "mvn-api", "--confirm"]) == 1
+
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- add a dry-run-first helper for switching GitHub Actions API primary/standby routing after promotion or failback
- update the HA runbook to use the helper and document that SSH_HOST_API is a secret while API routing uses repo variables
- cover normal mvn-api primary, promoted zakup primary, dry-run behavior, and secret/variable write safety

## Tests
- pytest tests/unit/test_switch_github_api_primary.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_promote_local_standby_script.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_external_prerequisites.py -q
- pytest tests/unit/test_switch_github_api_primary.py tests/unit/test_enable_ha_strict_mode.py tests/unit/test_ha_alert_workflows.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_cloudflare_lb_config.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_external_prerequisites.py tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_workflows.py tests/unit/test_postgres_pitr_env_config.py tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_restore.py tests/unit/test_postgres_pitr_upload.py tests/unit/test_media_cdn_workflow.py tests/unit/test_promote_local_standby_script.py -q
- python3 -m py_compile scripts/ha/switch_github_api_primary.py
- python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary mvn-api
- python3 scripts/ha/switch_github_api_primary.py --repo mvnby/air-api --primary zakup
- git diff --check