### PR TITLE
Tighten media CDN source monitoring

### DIFF
--- a/.github/workflows/check-media-cdn.yml
+++ b/.github/workflows/check-media-cdn.yml
@@ -25,6 +25,11 @@ on:
         type: string
         required: false
         default: "3"
+      min_db_cdn_urls_by_source:
+        description: "Per-source DB CDN thresholds, comma-separated source=count"
+        type: string
+        required: false
+        default: "product_image_variant=1,media_asset=1,order_technical_meta=1"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -80,6 +85,7 @@ jobs:
           API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
           EXPECTED_CDN_BASE: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_cdn_base || 'https://cdn.mvn.by' }}
           MIN_DB_CDN_URLS: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls || '3' }}
+          MIN_DB_CDN_URLS_BY_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls_by_source || 'product_image_variant=1,media_asset=1,order_technical_meta=1' }}
         run: |
           set -euo pipefail
           SSH_OPTS="-i ~/.ssh/media_cdn_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
@@ -94,6 +100,7 @@ jobs:
               python3 scripts/check_media_cdn_db_urls.py \
                 --expected-cdn-base $(quote "${EXPECTED_CDN_BASE}") \
                 --min-db-cdn-urls $(quote "${MIN_DB_CDN_URLS}") \
+                --min-db-cdn-urls-by-source $(quote "${MIN_DB_CDN_URLS_BY_SOURCE}") \
                 --max-fetches 10" \
             2>&1 \
             | tee -a media-cdn-check.log
@@ -107,6 +114,7 @@ jobs:
             echo "- expected_cdn_base: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_cdn_base || 'https://cdn.mvn.by' }}"
             echo "- min_cdn_urls: ${{ github.event_name == 'workflow_dispatch' && inputs.min_cdn_urls || '3' }}"
             echo "- min_db_cdn_urls: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls || '3' }}"
+            echo "- min_db_cdn_urls_by_source: ${{ github.event_name == 'workflow_dispatch' && inputs.min_db_cdn_urls_by_source || 'product_image_variant=1,media_asset=1,order_technical_meta=1' }}"
             echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
             echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"
             echo "- log_artifact: media-cdn-check-log-${{ github.run_id }}"

--- a/docs/media-storage-r2.md
+++ b/docs/media-storage-r2.md
@@ -386,8 +386,10 @@ After the bounded smoke passes and the owner approves the full switch:
    failures during normal manager uploads/search attaches and variant
    generation.
 5. Keep the scheduled `check-media-cdn.yml` workflow green. It samples public
-   catalog image URLs and DB-backed object-storage rows from the API primary,
-   including product variants, media library assets, and order/bot attachments.
+   catalog image URLs and DB-backed object-storage rows from the API primary.
+   The DB-backed check now enforces at least one CDN URL from each active
+   runtime media source: product variants, media library assets, and order/bot
+   attachments.
 6. Spot-check new manager media rows daily during the first rollout window:
 
    ```sql

--- a/scripts/check_media_cdn_db_urls.py
+++ b/scripts/check_media_cdn_db_urls.py
@@ -91,10 +91,12 @@ def validate_db_media_refs(
     *,
     expected_cdn_base: str,
     min_db_cdn_urls: int,
+    min_db_cdn_urls_by_source: Mapping[str, int] | None = None,
 ) -> list[str]:
     failures: list[str] = []
     normalized_base = expected_cdn_base.rstrip("/")
     cdn_count = 0
+    cdn_count_by_source: dict[str, int] = {}
 
     for ref in refs:
         label = f"source={ref.source} object_id={ref.object_id} field={ref.field}"
@@ -113,11 +115,49 @@ def validate_db_media_refs(
             failures.append(f"{label} url does not use {normalized_base}: {ref.url}")
             continue
         cdn_count += 1
+        cdn_count_by_source[ref.source] = cdn_count_by_source.get(ref.source, 0) + 1
 
     if cdn_count < min_db_cdn_urls:
         failures.append(f"only {cdn_count} DB CDN media urls found; expected at least {min_db_cdn_urls}")
 
+    for source, minimum in (min_db_cdn_urls_by_source or {}).items():
+        actual = cdn_count_by_source.get(source, 0)
+        if actual < minimum:
+            failures.append(f"source {source} has {actual} DB CDN media urls; expected at least {minimum}")
+
     return failures
+
+
+def parse_min_db_cdn_urls_by_source(value: str | None) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for raw_item in (value or "").split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise ValueError(f"source threshold must look like source=count: {item}")
+        source, raw_minimum = (part.strip() for part in item.split("=", 1))
+        if not source:
+            raise ValueError(f"source threshold is missing source name: {item}")
+        try:
+            minimum = int(raw_minimum)
+        except ValueError as exc:
+            raise ValueError(f"source threshold count must be an integer: {item}") from exc
+        if minimum < 0:
+            raise ValueError(f"source threshold count must be >= 0: {item}")
+        result[source] = minimum
+    return result
+
+
+def summarize_refs_by_source(refs: list[DbMediaRef], *, expected_cdn_base: str) -> dict[str, dict[str, int]]:
+    normalized_base = expected_cdn_base.rstrip("/")
+    summary: dict[str, dict[str, int]] = {}
+    for ref in refs:
+        source_summary = summary.setdefault(ref.source, {"refs": 0, "cdn_urls": 0})
+        source_summary["refs"] += 1
+        if ref.url and ref.url.startswith(f"{normalized_base}/"):
+            source_summary["cdn_urls"] += 1
+    return summary
 
 
 def unique_db_cdn_urls(refs: list[DbMediaRef], *, expected_cdn_base: str) -> list[str]:
@@ -197,6 +237,7 @@ async def check_db_media_cdn(
     *,
     expected_cdn_base: str,
     min_db_cdn_urls: int,
+    min_db_cdn_urls_by_source: Mapping[str, int] | None,
     max_rows_per_source: int,
     order_scan_limit: int,
     max_fetches: int,
@@ -212,6 +253,7 @@ async def check_db_media_cdn(
         refs,
         expected_cdn_base=expected_cdn_base,
         min_db_cdn_urls=min_db_cdn_urls,
+        min_db_cdn_urls_by_source=min_db_cdn_urls_by_source,
     )
 
     fetch_results: list[CdnFetchResult] = []
@@ -257,10 +299,24 @@ def _print_fetch(result: CdnFetchResult) -> None:
     )
 
 
+def _print_source_summary(source: str, counts: Mapping[str, int]) -> None:
+    print(
+        "db_media_cdn_source "
+        f"source={source} "
+        f"refs={counts.get('refs', 0)} "
+        f"cdn_urls={counts.get('cdn_urls', 0)}"
+    )
+
+
 async def async_main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Check DB-backed media CDN URLs.")
     parser.add_argument("--expected-cdn-base", default="https://cdn.mvn.by")
     parser.add_argument("--min-db-cdn-urls", type=int, default=3)
+    parser.add_argument(
+        "--min-db-cdn-urls-by-source",
+        default="",
+        help="Comma-separated per-source thresholds, for example product_image_variant=1,media_asset=1.",
+    )
     parser.add_argument("--max-rows-per-source", type=int, default=20)
     parser.add_argument("--order-scan-limit", type=int, default=200)
     parser.add_argument("--max-fetches", type=int, default=10)
@@ -269,9 +325,11 @@ async def async_main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        min_db_cdn_urls_by_source = parse_min_db_cdn_urls_by_source(args.min_db_cdn_urls_by_source)
         refs, fetch_results, failures = await check_db_media_cdn(
             expected_cdn_base=args.expected_cdn_base,
             min_db_cdn_urls=args.min_db_cdn_urls,
+            min_db_cdn_urls_by_source=min_db_cdn_urls_by_source,
             max_rows_per_source=max(1, args.max_rows_per_source),
             order_scan_limit=max(1, args.order_scan_limit),
             max_fetches=max(1, args.max_fetches),
@@ -284,6 +342,8 @@ async def async_main(argv: list[str] | None = None) -> int:
 
     for ref in refs:
         _print_ref(ref)
+    for source, counts in sorted(summarize_refs_by_source(refs, expected_cdn_base=args.expected_cdn_base).items()):
+        _print_source_summary(source, counts)
     for result in fetch_results:
         _print_fetch(result)
 

--- a/tests/unit/test_media_cdn_db_urls.py
+++ b/tests/unit/test_media_cdn_db_urls.py
@@ -84,11 +84,97 @@ def test_validate_db_media_refs_requires_public_cdn_url_for_object_storage():
         refs,
         expected_cdn_base="https://cdn.mvn.by",
         min_db_cdn_urls=2,
+        min_db_cdn_urls_by_source=None,
     )
 
     assert any("provider=r2 is missing public URL" in failure for failure in failures)
     assert any("url does not use https://cdn.mvn.by" in failure for failure in failures)
     assert any("only 1 DB CDN media urls found; expected at least 2" in failure for failure in failures)
+
+
+def test_validate_db_media_refs_enforces_per_source_thresholds():
+    refs = [
+        check_media_cdn_db_urls.DbMediaRef(
+            source="product_image_variant",
+            object_id="1",
+            field="original",
+            storage_provider="r2",
+            url="https://cdn.mvn.by/products/variants/original/hash.webp",
+        ),
+        check_media_cdn_db_urls.DbMediaRef(
+            source="order_technical_meta",
+            object_id="121",
+            field="$.telegram_attachments[0]",
+            storage_provider="r2",
+            url="https://cdn.mvn.by/orders/121/file.jpg",
+        ),
+    ]
+
+    failures = check_media_cdn_db_urls.validate_db_media_refs(
+        refs,
+        expected_cdn_base="https://cdn.mvn.by",
+        min_db_cdn_urls=1,
+        min_db_cdn_urls_by_source={
+            "product_image_variant": 1,
+            "media_asset": 1,
+            "order_technical_meta": 1,
+        },
+    )
+
+    assert "source media_asset has 0 DB CDN media urls; expected at least 1" in failures
+    assert not any("source product_image_variant" in failure for failure in failures)
+    assert not any("source order_technical_meta" in failure for failure in failures)
+
+
+def test_parse_min_db_cdn_urls_by_source_rejects_bad_thresholds():
+    assert check_media_cdn_db_urls.parse_min_db_cdn_urls_by_source(
+        "product_image_variant=1, media_asset=2"
+    ) == {
+        "product_image_variant": 1,
+        "media_asset": 2,
+    }
+
+    for value in ("product_image_variant", "=1", "media_asset=nope", "order_technical_meta=-1"):
+        try:
+            check_media_cdn_db_urls.parse_min_db_cdn_urls_by_source(value)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected ValueError for {value!r}")
+
+
+def test_summarize_refs_by_source_counts_refs_and_cdn_urls():
+    refs = [
+        check_media_cdn_db_urls.DbMediaRef(
+            "product_image_variant",
+            "1",
+            "original",
+            "r2",
+            "https://cdn.mvn.by/a.webp",
+        ),
+        check_media_cdn_db_urls.DbMediaRef(
+            "product_image_variant",
+            "2",
+            "card",
+            "r2",
+            "https://example.test/a.webp",
+        ),
+        check_media_cdn_db_urls.DbMediaRef(
+            "media_asset",
+            "3",
+            "original",
+            "r2",
+            "https://cdn.mvn.by/b.webp",
+        ),
+    ]
+
+    assert check_media_cdn_db_urls.summarize_refs_by_source(
+        refs,
+        expected_cdn_base="https://cdn.mvn.by",
+    ) == {
+        "product_image_variant": {"refs": 2, "cdn_urls": 1},
+        "media_asset": {"refs": 1, "cdn_urls": 1},
+    }
 
 
 def test_unique_db_cdn_urls_deduplicates_and_ignores_non_cdn_refs():

--- a/tests/unit/test_media_cdn_workflow.py
+++ b/tests/unit/test_media_cdn_workflow.py
@@ -22,15 +22,24 @@ def test_media_cdn_workflow_keeps_public_and_db_backed_checks():
     db_step = _step(workflow, "Run DB-backed media CDN check")
     summary_step = _step(workflow, "Write Summary")
     artifact_step = _step(workflow, "Upload media CDN log")
+    expected_source_thresholds = "product_image_variant=1,media_asset=1,order_technical_meta=1"
 
     assert dispatch_inputs["min_db_cdn_urls"]["default"] == "3"
+    assert dispatch_inputs["min_db_cdn_urls_by_source"]["default"] == expected_source_thresholds
     assert "scripts/check_media_cdn_public.py" in public_step["run"]
     assert "secrets.SSH_HOST_API" in ssh_step["env"]["SSH_HOST_API"]
     assert "secrets.SSH_USER_API" in ssh_step["env"]["SSH_USER_API"]
     assert "secrets.SSH_KEY" in ssh_step["env"]["SSH_KEY"]
     assert "scripts/check_media_cdn_db_urls.py" in db_step["run"]
     assert "--min-db-cdn-urls" in db_step["run"]
+    assert "--min-db-cdn-urls-by-source" in db_step["run"]
+    assert (
+        db_step["env"]["MIN_DB_CDN_URLS_BY_SOURCE"]
+        == "${{ github.event_name == 'workflow_dispatch' && "
+        f"inputs.min_db_cdn_urls_by_source || '{expected_source_thresholds}' }}}}"
+    )
     assert "tee -a media-cdn-check.log" in db_step["run"]
     assert "min_db_cdn_urls:" in summary_step["run"]
+    assert "min_db_cdn_urls_by_source:" in summary_step["run"]
     assert artifact_step["if"] == "always()"
     assert artifact_step["with"]["path"] == "media-cdn-check.log"


### PR DESCRIPTION
## Summary
- add per-source DB CDN thresholds to the media CDN checker
- require scheduled media CDN checks to cover product variants, media library assets, and order/bot attachments
- print per-source CDN summaries and document the stricter monitor

## Verification
- pytest tests/unit/test_media_cdn_db_urls.py tests/unit/test_media_cdn_workflow.py tests/unit/test_media_storage_config_check.py -q
- pytest tests/unit/test_media_cdn_public_check.py tests/unit/test_media_cdn_db_urls.py tests/unit/test_media_cdn_workflow.py tests/unit/test_media_storage_config_check.py tests/unit/test_media_storage_service.py tests/unit/test_bot_order_attachment_service.py tests/unit/test_bot_repair_nameplate_service.py tests/unit/test_media_library_service.py -q
- python3 -m py_compile scripts/check_media_cdn_db_urls.py
- git diff --check
- live primary temp run: product_image_variant=20, media_asset=2, order_technical_meta=2; CDN fetches returned 200 with immutable cache headers