### PR TITLE
Check active-passive invariants after standby deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -433,6 +433,8 @@ jobs:
       API_STANDBY_COPY_COMPOSE: ${{ vars.API_STANDBY_COPY_COMPOSE || 'false' }}
       API_STANDBY_COMPOSE_SOURCE_FILE: ${{ vars.API_STANDBY_COMPOSE_SOURCE_FILE || vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.prod.yml' }}
       API_STANDBY_HEALTH_URL: ${{ vars.API_STANDBY_HEALTH_URL || 'http://localhost:8000/api/health' }}
+      API_PRIMARY_ORIGIN: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
+      API_STANDBY_ORIGIN: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
 
     steps:
       - name: Checkout
@@ -494,6 +496,15 @@ jobs:
             docker compose -f '${API_STANDBY_COMPOSE_FILE}' logs --tail=120 app; \
             exit 1"
 
+      - name: Post-Standby Active-Passive Invariant Check
+        id: standby_active_passive
+        run: |
+          set -euo pipefail
+          CHECK_PUBLIC_READY=false \
+          PRIMARY_ORIGIN="${API_PRIMARY_ORIGIN}" \
+          STANDBY_ORIGIN="${API_STANDBY_ORIGIN}" \
+          bash scripts/ha/check_active_passive.sh 2>&1 | tee standby_active_passive.log
+
       - name: Prune Unused Standby Docker Images
         id: prune_standby_images
         run: |
@@ -510,6 +521,7 @@ jobs:
         with:
           name: standby-deploy-logs-${{ github.run_id }}
           path: |
+            standby_active_passive.log
             standby_docker_prune.log
           if-no-files-found: warn
 
@@ -525,7 +537,13 @@ jobs:
             echo "- standby_compose_source_file: ${API_STANDBY_COMPOSE_SOURCE_FILE}"
             echo "- backend_image: ghcr.io/${GITHUB_REPOSITORY,,}/backend:${GITHUB_SHA}"
             echo "- health_url: ${API_STANDBY_HEALTH_URL}"
+            echo "- primary_origin: ${API_PRIMARY_ORIGIN}"
+            echo "- standby_origin: ${API_STANDBY_ORIGIN}"
+            echo "- active_passive_status: ${{ steps.standby_active_passive.outcome }}"
             echo "- docker_prune_status: ${{ steps.prune_standby_images.outcome }}"
+            if [ -f standby_active_passive.log ]; then
+              echo "- active_passive_log: collected"
+            fi
             if [ -f standby_docker_prune.log ]; then
               echo "- docker_prune_log: collected"
             fi

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -473,6 +473,9 @@ Expected deploy behavior:
 
 - primary `mvn-api`: recreate `app` and `bot`;
 - standby `zakup`: recreate only `app`, then stop `bot`;
+- after standby deploy: run the active-passive invariant check with public
+  Cloudflare readiness skipped, proving the direct primary origin is ready and
+  writable while the direct standby origin remains fenced;
 - both API hosts: prune unused Docker images after successful deploy; this does
   not remove volumes or images used by running containers;
 - frontend deploy is skipped unless explicitly requested.

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(job: dict, step_name: str) -> dict:
+    return next(step for step in job["steps"] if step.get("name") == step_name)
+
+
+def test_deploy_workflow_checks_active_passive_after_standby_deploy():
+    workflow = _workflow(".github/workflows/deploy.yml")
+    standby_job = workflow["jobs"]["deploy-api-standby"]
+    step_names = [step.get("name") for step in standby_job["steps"]]
+    invariant_step = _step(standby_job, "Post-Standby Active-Passive Invariant Check")
+    artifact_step = _step(standby_job, "Upload Standby Deploy Logs")
+    summary_step = _step(standby_job, "Standby Deploy Summary")
+
+    assert standby_job["env"]["API_PRIMARY_ORIGIN"] == "${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}"
+    assert standby_job["env"]["API_STANDBY_ORIGIN"] == "${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
+    assert step_names.index("Deploy standby API app image") < step_names.index(
+        "Post-Standby Active-Passive Invariant Check"
+    )
+    assert step_names.index("Post-Standby Active-Passive Invariant Check") < step_names.index(
+        "Prune Unused Standby Docker Images"
+    )
+    assert invariant_step["id"] == "standby_active_passive"
+    assert "CHECK_PUBLIC_READY=false" in invariant_step["run"]
+    assert 'PRIMARY_ORIGIN="${API_PRIMARY_ORIGIN}"' in invariant_step["run"]
+    assert 'STANDBY_ORIGIN="${API_STANDBY_ORIGIN}"' in invariant_step["run"]
+    assert "scripts/ha/check_active_passive.sh" in invariant_step["run"]
+    assert "standby_active_passive.log" in invariant_step["run"]
+    assert "standby_active_passive.log" in artifact_step["with"]["path"]
+    assert "active_passive_status:" in summary_step["run"]
+    assert "active_passive_log: collected" in summary_step["run"]


### PR DESCRIPTION
## Summary
- add a post-standby active-passive invariant gate to the production deploy workflow
- persist the invariant log in standby deploy artifacts and summary
- document that deploy now proves primary readiness/writability and standby fencing

## Verification
- pytest tests/unit/test_deploy_workflow.py tests/unit/test_ha_readiness_workflow.py -q
- pytest tests/unit/test_deploy_workflow.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_switch_github_api_primary.py tests/unit/test_promote_local_standby_script.py tests/unit/test_ha_alert_workflows.py -q
- bash -n scripts/ha/check_active_passive.sh
- git diff --check
- live invariant: CHECK_PUBLIC_READY=false PRIMARY_ORIGIN=185.250.45.54 STANDBY_ORIGIN=193.47.42.213 bash scripts/ha/check_active_passive.sh