### PR TITLE
Add scheduled HA status report

### DIFF
--- a/.github/workflows/report-ha-status.yml
+++ b/.github/workflows/report-ha-status.yml
@@ -1,0 +1,96 @@
+name: API HA Status Report
+
+on:
+  schedule:
+    - cron: "17 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      require_strict:
+        description: "Fail on external strict-mode blockers"
+        type: boolean
+        required: false
+        default: false
+      skip_live:
+        description: "Skip direct-origin active/passive curl check"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  HA_STATUS_REQUIRE_STRICT: ${{ github.event_name == 'workflow_dispatch' && inputs.require_strict || 'false' }}
+  HA_STATUS_SKIP_LIVE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_live || 'false' }}
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run HA status report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HA_EXTERNAL_METADATA_SOURCE: env
+          API_PRIMARY_ORIGIN: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
+          API_STANDBY_ORIGIN: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
+          API_HA_READINESS_STRICT: ${{ vars.API_HA_READINESS_STRICT || 'false' }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_LB_CONFIG_REQUIRED: ${{ vars.CLOUDFLARE_LB_CONFIG_REQUIRED || 'false' }}
+          CLOUDFLARE_LB_READ_TOKEN: ${{ secrets.CLOUDFLARE_LB_READ_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          HA_ALERT_TELEGRAM_BOT_TOKEN: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          HA_ALERT_TELEGRAM_CHAT_ID: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS: ${{ vars.POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS || '30' }}
+          POSTGRES_PITR_MAX_WAL_AGE_MINUTES: ${{ vars.POSTGRES_PITR_MAX_WAL_AGE_MINUTES || '180' }}
+          POSTGRES_PITR_REQUIRED: ${{ vars.POSTGRES_PITR_REQUIRED || 'false' }}
+        run: |
+          set -euo pipefail
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --branch "${GITHUB_REF_NAME:-main}"
+            --primary-origin "${API_PRIMARY_ORIGIN}"
+            --standby-origin "${API_STANDBY_ORIGIN}"
+          )
+          if [ "${HA_STATUS_REQUIRE_STRICT}" = "true" ]; then
+            args+=(--require-strict)
+          fi
+          if [ "${HA_STATUS_SKIP_LIVE}" = "true" ]; then
+            args+=(--skip-live)
+          fi
+          python3 scripts/ha/report_ha_status.py "${args[@]}" 2>&1 | tee ha-status-report.log
+
+      - name: Write Summary
+        if: always()
+        run: |
+          {
+            echo "## API HA Status Report"
+            echo "- require_strict: ${HA_STATUS_REQUIRE_STRICT}"
+            echo "- skip_live: ${HA_STATUS_SKIP_LIVE}"
+            echo "- primary_origin: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}"
+            echo "- standby_origin: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
+            echo "- log_artifact: ha-status-report-log-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload HA status report log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ha-status-report-log-${{ github.run_id }}
+          path: ha-status-report.log
+          if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN API HA status report failed"
+          details: "Artifact: ha-status-report-log-${{ github.run_id }}"

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -63,7 +63,7 @@ unreviewed host-local compose edits:
 | PostgreSQL PITR systemd units | `deploy/ha/systemd/mvn-postgres-wal-upload.*`, `deploy/ha/systemd/mvn-postgres-basebackup.*` |
 | Cloudflare LB primary switch helper | `scripts/ha/switch_cloudflare_lb_primary.py` |
 | External strict-mode prerequisite check | `scripts/ha/check_ha_external_prerequisites.py` |
-| Operator HA status report | `scripts/ha/report_ha_status.py` |
+| Operator HA status report | `scripts/ha/report_ha_status.py`, `.github/workflows/report-ha-status.yml` |
 | Strict-mode activation helper | `scripts/ha/enable_ha_strict_mode.py` |
 | Cloudflare LB GitHub prerequisite apply helper | `scripts/ha/apply_cloudflare_lb_github_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
@@ -201,6 +201,7 @@ Scheduled monitors:
 
 | Workflow | Schedule | Purpose |
 | --- | --- | --- |
+| `report-ha-status.yml` | every 2 hours | operator rollup over deploys, monitors, external prerequisites, and direct active/passive state |
 | `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups, media storage config |
 | `check-api-ha-readiness.yml` | every 6 hours | whole-system HA readiness rollup; direct-origin core checks fail, Cloudflare/PITR are soft blockers until strict |
 | `check-api-ha-invariants.yml` | every 30 minutes | direct primary ready and standby fenced; public Cloudflare routing is covered by the LB monitor/config checks |

--- a/scripts/ha/check_ha_external_prerequisites.py
+++ b/scripts/ha/check_ha_external_prerequisites.py
@@ -82,6 +82,34 @@ def load_github_metadata(repo: str) -> GithubMetadata:
     return GithubMetadata(variables=variables, secrets=secrets)
 
 
+def load_env_metadata() -> GithubMetadata:
+    """Load prerequisite metadata from process env without printing secrets.
+
+    GitHub Actions' default token can run workflows and read workflow history,
+    but it is not a good fit for listing repository secret metadata. Scheduled
+    HA reports pass the relevant secret names as env vars and this loader only
+    records whether each value is non-empty.
+    """
+
+    variables = {
+        name: os.getenv(name, "").strip()
+        for name in REQUIRED_VARIABLES
+        if os.getenv(name, "").strip()
+    }
+    secret_names = set(REQUIRED_SECRETS) | set(OPTIONAL_SECRETS)
+    secrets = {name for name in secret_names if os.getenv(name, "").strip()}
+    return GithubMetadata(variables=variables, secrets=secrets)
+
+
+def load_metadata(*, repo: str, source: str | None = None) -> GithubMetadata:
+    metadata_source = (source or os.getenv("HA_EXTERNAL_METADATA_SOURCE") or "github").strip().lower()
+    if metadata_source == "github":
+        return load_github_metadata(repo)
+    if metadata_source == "env":
+        return load_env_metadata()
+    raise RuntimeError("HA_EXTERNAL_METADATA_SOURCE must be 'github' or 'env'")
+
+
 def is_true(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
@@ -158,13 +186,19 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         action="store_true",
         help="Fail unless strict-mode variables are already true.",
     )
+    parser.add_argument(
+        "--metadata-source",
+        choices=("github", "env"),
+        default=os.environ.get("HA_EXTERNAL_METADATA_SOURCE") or "github",
+        help="Where to read prerequisite metadata from. Default: github.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
-        metadata = load_github_metadata(args.repo)
+        metadata = load_metadata(repo=args.repo, source=args.metadata_source)
     except (RuntimeError, json.JSONDecodeError) as exc:
         print(f"[ha-external][fail] {exc}", file=sys.stderr)
         return 2

--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -28,7 +28,7 @@ if str(SCRIPT_DIR) not in sys.path:
 
 from check_ha_external_prerequisites import (  # noqa: E402
     check_metadata,
-    load_github_metadata,
+    load_metadata,
 )
 
 
@@ -280,7 +280,7 @@ def run_live_active_passive(
 
 
 def external_prereq_result(*, repo: str, require_strict: bool) -> ReportResult:
-    metadata = load_github_metadata(repo)
+    metadata = load_metadata(repo=repo)
     ok, warnings, failures = check_metadata(metadata, require_strict=require_strict)
     if require_strict:
         return ReportResult(ok=list(ok), warnings=list(warnings), blockers=[], failures=list(failures))

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -16,6 +16,7 @@ ALERTED_WORKFLOWS = [
     (".github/workflows/check-postgres-pitr.yml", "check"),
     (".github/workflows/check-postgres-replication.yml", "check"),
     (".github/workflows/postgres-pitr-restore-drill.yml", "pitr-restore-drill"),
+    (".github/workflows/report-ha-status.yml", "report"),
 ]
 
 

--- a/tests/unit/test_ha_external_prerequisites.py
+++ b/tests/unit/test_ha_external_prerequisites.py
@@ -88,3 +88,20 @@ def test_external_prerequisites_pass_when_all_metadata_is_ready():
     assert any("strict variable enabled: API_HA_READINESS_STRICT" in item for item in ok)
     assert any("strict variable enabled: POSTGRES_PITR_REQUIRED" in item for item in ok)
     assert any("private PITR R2 credentials are host-local" in item for item in warnings)
+
+
+def test_env_metadata_loader_records_presence_without_secret_values(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_LB_READ_TOKEN", "secret-token")
+    monkeypatch.setenv("HA_ALERT_TELEGRAM_BOT_TOKEN", "telegram-token")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("POSTGRES_PITR_REQUIRED", "false")
+    monkeypatch.setenv("POSTGRES_PITR_MAX_WAL_AGE_MINUTES", "180")
+
+    metadata = module.load_metadata(repo="mvnby/air-api", source="env")
+
+    assert metadata.secrets == {"CLOUDFLARE_LB_READ_TOKEN", "HA_ALERT_TELEGRAM_BOT_TOKEN"}
+    assert metadata.variables["CLOUDFLARE_ACCOUNT_ID"] == "account"
+    assert metadata.variables["CLOUDFLARE_ZONE_ID"] == "zone"
+    assert metadata.variables["POSTGRES_PITR_REQUIRED"] == "false"
+    assert "secret-token" not in metadata.secrets

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -73,14 +73,14 @@ def test_evaluate_workflows_flags_missing_failed_and_stale_runs():
 
 
 def test_external_prereq_failures_are_blockers_until_require_strict(monkeypatch):
-    def fake_load_metadata(repo: str):
+    def fake_load_metadata(*, repo: str):
         assert repo == "mvnby/air-api"
         return object()
 
     def fake_check_metadata(metadata: object, *, require_strict: bool):
         return ["var present"], ["optional missing"], ["missing cloudflare token"]
 
-    monkeypatch.setattr(report_ha_status, "load_github_metadata", fake_load_metadata)
+    monkeypatch.setattr(report_ha_status, "load_metadata", fake_load_metadata)
     monkeypatch.setattr(report_ha_status, "check_metadata", fake_check_metadata)
 
     soft = report_ha_status.external_prereq_result(repo="mvnby/air-api", require_strict=False)

--- a/tests/unit/test_ha_status_report_workflow.py
+++ b/tests/unit/test_ha_status_report_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(workflow: dict, step_name: str) -> dict:
+    return next(step for step in workflow["jobs"]["report"]["steps"] if step.get("name") == step_name)
+
+
+def test_ha_status_report_workflow_runs_scheduled_operator_rollup():
+    workflow = _workflow(".github/workflows/report-ha-status.yml")
+
+    assert workflow["name"] == "API HA Status Report"
+    assert workflow["on"]["schedule"][0]["cron"] == "17 */2 * * *"
+    assert "require_strict" in workflow["on"]["workflow_dispatch"]["inputs"]
+    assert "skip_live" in workflow["on"]["workflow_dispatch"]["inputs"]
+
+    job = workflow["jobs"]["report"]
+    assert job["permissions"]["actions"] == "read"
+    assert job["permissions"]["contents"] == "read"
+
+    report_step = _step(workflow, "Run HA status report")
+    env = report_step["env"]
+    run = report_step["run"]
+    assert env["GH_TOKEN"] == "${{ github.token }}"
+    assert env["HA_EXTERNAL_METADATA_SOURCE"] == "env"
+    assert "secrets.CLOUDFLARE_LB_READ_TOKEN" in env["CLOUDFLARE_LB_READ_TOKEN"]
+    assert "vars.CLOUDFLARE_ACCOUNT_ID" in env["CLOUDFLARE_ACCOUNT_ID"]
+    assert "vars.POSTGRES_PITR_REQUIRED" in env["POSTGRES_PITR_REQUIRED"]
+    assert "scripts/ha/report_ha_status.py" in run
+    assert "--require-strict" in run
+    assert "--skip-live" in run
+    assert "tee ha-status-report.log" in run
+
+    artifact_step = _step(workflow, "Upload HA status report log")
+    assert artifact_step["uses"] == "actions/upload-artifact@v7"
+    assert artifact_step["with"]["path"] == "ha-status-report.log"


### PR DESCRIPTION
## Summary
- add a scheduled/manual API HA Status Report workflow that runs the operator rollup every 2 hours
- let external prerequisite checks read presence-only metadata from env for GitHub Actions without listing repo secrets
- document the scheduled report and cover workflow/env-source wiring with tests

## Tests
- pytest tests/unit/test_ha_external_prerequisites.py tests/unit/test_ha_status_report.py tests/unit/test_ha_status_report_workflow.py tests/unit/test_ha_alert_workflows.py -q
- python3 -m py_compile scripts/ha/check_ha_external_prerequisites.py scripts/ha/report_ha_status.py
- git diff --check
- HA_EXTERNAL_METADATA_SOURCE=env API_HA_READINESS_STRICT=false CLOUDFLARE_LB_CONFIG_REQUIRED=false POSTGRES_PITR_REQUIRED=false POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS=30 POSTGRES_PITR_MAX_WAL_AGE_MINUTES=180 python3 scripts/ha/report_ha_status.py --repo mvnby/air-api --skip-live