### PR TITLE
Add HA status next steps

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -149,7 +149,9 @@ python3 scripts/ha/report_ha_status.py --repo mvnby/air-api --require-strict
 The default report checks recent GitHub deploy/monitor runs, lists external
 strict-mode blockers as attention items, and runs the direct-origin
 active-passive invariant. Use `--require-strict` before enabling strict mode;
-in that mode missing Cloudflare/PITR prerequisites become hard failures.
+in that mode missing Cloudflare/PITR prerequisites become hard failures. Treat
+`[ha-status][next-step]` lines as the immediate operator checklist; they are
+derived from the current blockers and failures without printing secret values.
 
 After creating the Cloudflare LB read-only token and finding the zone/account
 ids, apply them to GitHub without pasting secrets into command history:

--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -300,6 +300,62 @@ def combine_results(results: Sequence[ReportResult]) -> ReportResult:
     return ReportResult(ok=ok, warnings=warnings, blockers=blockers, failures=failures)
 
 
+def next_steps_for(result: ReportResult) -> list[str]:
+    messages = [*result.failures, *result.blockers, *result.warnings]
+    joined = "\n".join(messages)
+    next_steps: list[str] = []
+
+    def add_once(message: str) -> None:
+        if message not in next_steps:
+            next_steps.append(message)
+
+    if result.failures:
+        add_once("inspect failed workflow URLs/artifacts before changing API routing or database roles")
+
+    if any(
+        key in joined
+        for key in (
+            "CLOUDFLARE_LB_READ_TOKEN",
+            "CLOUDFLARE_ACCOUNT_ID",
+            "CLOUDFLARE_ZONE_ID",
+        )
+    ):
+        add_once(
+            "create the Cloudflare LB read-only token and zone/account ids, then run "
+            "`python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api`"
+        )
+
+    if "private PITR R2 credentials are host-local" in joined:
+        add_once(
+            "install private PostgreSQL PITR R2 credentials on the primary, then run "
+            "`ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'`"
+        )
+
+    if "POSTGRES_PITR_REQUIRED is not true yet" in joined:
+        add_once("run one required PostgreSQL PITR freshness check and physical restore drill before enabling PITR strict mode")
+
+    if any(
+        key in joined
+        for key in (
+            "API_HA_READINESS_STRICT is not true yet",
+            "CLOUDFLARE_LB_CONFIG_REQUIRED is not true yet",
+            "POSTGRES_PITR_REQUIRED is not true yet",
+        )
+    ):
+        add_once(
+            "after Cloudflare LB and PITR proofs pass, enable strict mode with "
+            "`python3 scripts/ha/enable_ha_strict_mode.py --repo mvnby/air-api`"
+        )
+
+    if "HA_ALERT_TELEGRAM_BOT_TOKEN" in joined or "HA_ALERT_TELEGRAM_CHAT_ID" in joined:
+        add_once("set HA_ALERT_TELEGRAM_BOT_TOKEN and HA_ALERT_TELEGRAM_CHAT_ID to receive owner-visible HA alerts")
+
+    if "live active/passive check skipped" in joined:
+        add_once("rerun without --skip-live before failover, promotion, or strict-mode changes")
+
+    return next_steps
+
+
 def print_result(prefix: str, result: ReportResult) -> None:
     for line in result.ok:
         log(f"{prefix}-ok", line)
@@ -370,6 +426,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"status={combined.status} ok={len(combined.ok)} warnings={len(combined.warnings)} "
         f"blockers={len(combined.blockers)} failures={len(combined.failures)}",
     )
+    for step in next_steps_for(combined):
+        log("next-step", step)
     return 1 if combined.failures else 0
 
 

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -114,3 +114,42 @@ def test_run_live_active_passive_maps_exit_codes():
     assert ok.status == "passed"
     assert failed.status == "failed"
     assert "active/passive direct-origin invariant failed" in failed.failures[0]
+
+
+def test_next_steps_explain_external_blockers_without_secret_values():
+    result = report_ha_status.ReportResult(
+        ok=[],
+        warnings=[
+            "missing optional GitHub secret HA_ALERT_TELEGRAM_BOT_TOKEN",
+            "POSTGRES_PITR_REQUIRED is not true yet",
+            "private PITR R2 credentials are host-local; verify with `ssh mvn-api`",
+        ],
+        blockers=[
+            "missing GitHub secret CLOUDFLARE_LB_READ_TOKEN",
+            "missing GitHub variable CLOUDFLARE_ACCOUNT_ID",
+            "missing GitHub variable CLOUDFLARE_ZONE_ID",
+        ],
+        failures=[],
+    )
+
+    steps = report_ha_status.next_steps_for(result)
+
+    assert any("apply_cloudflare_lb_github_prerequisites.py" in step for step in steps)
+    assert any("mvn-postgres-pitr-bootstrap verify" in step for step in steps)
+    assert any("enable_ha_strict_mode.py" in step for step in steps)
+    assert any("HA_ALERT_TELEGRAM_BOT_TOKEN" in step for step in steps)
+    assert not any("secret-token" in step for step in steps)
+
+
+def test_next_steps_prioritize_failed_workflows_and_live_skip():
+    result = report_ha_status.ReportResult(
+        ok=[],
+        warnings=["live active/passive check skipped"],
+        blockers=[],
+        failures=["Media CDN Check: latest run concluded failure (url=https://github.test/run)"],
+    )
+
+    steps = report_ha_status.next_steps_for(result)
+
+    assert steps[0] == "inspect failed workflow URLs/artifacts before changing API routing or database roles"
+    assert any("rerun without --skip-live" in step for step in steps)


### PR DESCRIPTION
## Summary
- add operator next-step recommendations to the HA status report based on current failures/blockers/warnings
- cover Cloudflare, PITR, strict-mode, Telegram alert, failed workflow, and live-skip recommendations with unit tests
- document next-step lines as the immediate HA operator checklist

## Tests
- pytest tests/unit/test_ha_status_report.py tests/unit/test_ha_status_report_workflow.py tests/unit/test_ha_external_prerequisites.py -q
- python3 -m py_compile scripts/ha/report_ha_status.py
- git diff --check
- python3 scripts/ha/report_ha_status.py --repo mvnby/air-api