### PR TITLE
Include HA status workflow in rollup

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -146,12 +146,13 @@ python3 scripts/ha/report_ha_status.py --repo mvnby/air-api
 python3 scripts/ha/report_ha_status.py --repo mvnby/air-api --require-strict
 ```
 
-The default report checks recent GitHub deploy/monitor runs, lists external
-strict-mode blockers as attention items, and runs the direct-origin
-active-passive invariant. Use `--require-strict` before enabling strict mode;
-in that mode missing Cloudflare/PITR prerequisites become hard failures. Treat
-`[ha-status][next-step]` lines as the immediate operator checklist; they are
-derived from the current blockers and failures without printing secret values.
+The default report checks recent GitHub deploy/monitor runs, including its own
+scheduled workflow, lists external strict-mode blockers as attention items, and
+runs the direct-origin active-passive invariant. Use `--require-strict` before
+enabling strict mode; in that mode missing Cloudflare/PITR prerequisites become
+hard failures. Treat `[ha-status][next-step]` lines as the immediate operator
+checklist; they are derived from the current blockers and failures without
+printing secret values.
 
 After creating the Cloudflare LB read-only token and finding the zone/account
 ids, apply them to GitHub without pasting secrets into command history:

--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -75,6 +75,7 @@ class ReportResult:
 EXPECTED_WORKFLOWS = (
     ExpectedWorkflow("Deploy to Production 🚀"),
     ExpectedWorkflow("CI (Test & Lint)"),
+    ExpectedWorkflow("API HA Status Report", max_age_hours=3),
     ExpectedWorkflow("API HA Invariant Check", max_age_hours=8),
     ExpectedWorkflow("API HA Readiness Audit", max_age_hours=8),
     ExpectedWorkflow("API VPS Health Check", max_age_hours=8),
@@ -171,7 +172,11 @@ def load_workflow_runs(
 def latest_runs_by_workflow(runs: Sequence[WorkflowRun]) -> dict[str, WorkflowRun]:
     latest: dict[str, WorkflowRun] = {}
     for run in runs:
-        if run.workflow_name not in latest:
+        current = latest.get(run.workflow_name)
+        if current is None:
+            latest[run.workflow_name] = run
+            continue
+        if current.status != "completed" and run.status == "completed":
             latest[run.workflow_name] = run
     return latest
 

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -12,11 +12,17 @@ sys.modules[SPEC.name] = report_ha_status
 SPEC.loader.exec_module(report_ha_status)
 
 
-def _run(name: str, *, created_at: str = "2026-07-03T07:00:00Z", conclusion: str = "success") -> dict:
+def _run(
+    name: str,
+    *,
+    created_at: str = "2026-07-03T07:00:00Z",
+    status: str = "completed",
+    conclusion: str = "success",
+) -> dict:
     return {
         "workflowName": name,
         "displayTitle": name,
-        "status": "completed",
+        "status": status,
         "conclusion": conclusion,
         "createdAt": created_at,
         "url": f"https://github.test/{name}",
@@ -70,6 +76,31 @@ def test_evaluate_workflows_flags_missing_failed_and_stale_runs():
     assert any("Media CDN Check: latest success is stale" in warning for warning in result.warnings)
     assert any("PostgreSQL Replication Check: latest run concluded failure" in failure for failure in result.failures)
     assert any("workflow missing from recent run list: API HA Invariant Check" in warning for warning in result.warnings)
+
+
+def test_latest_runs_prefers_latest_completed_run_over_current_in_progress():
+    current = report_ha_status.parse_workflow_run(
+        _run(
+            "API HA Status Report",
+            created_at="2026-07-03T08:00:00Z",
+            status="in_progress",
+            conclusion="",
+        )
+    )
+    previous = report_ha_status.parse_workflow_run(
+        _run("API HA Status Report", created_at="2026-07-03T07:00:00Z")
+    )
+
+    latest = report_ha_status.latest_runs_by_workflow([current, previous])
+
+    assert latest["API HA Status Report"] == previous
+
+
+def test_default_expected_workflows_include_status_report_self_check():
+    assert any(
+        workflow.name == "API HA Status Report" and workflow.max_age_hours == 3
+        for workflow in report_ha_status.EXPECTED_WORKFLOWS
+    )
 
 
 def test_external_prereq_failures_are_blockers_until_require_strict(monkeypatch):


### PR DESCRIPTION
## Summary
- include the API HA Status Report workflow in the operator rollup freshness checks
- prefer the latest completed run when a newer run is still in progress, avoiding self-noise from the report workflow
- document that the rollup checks its own scheduled workflow

## Tests
- pytest tests/unit/test_ha_status_report.py tests/unit/test_ha_status_report_workflow.py -q
- python3 -m py_compile scripts/ha/report_ha_status.py
- git diff --check
- python3 scripts/ha/report_ha_status.py --repo mvnby/air-api