### PR TITLE
Harden HA strict prerequisite helpers

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -155,35 +155,29 @@ checklist; they are derived from the current blockers and failures without
 printing secret values.
 
 After creating the Cloudflare LB read-only token and finding the zone/account
-ids, apply them to GitHub without pasting secrets into command history:
+ids, put them in local `.env` as:
 
 ```bash
-printf 'Cloudflare LB token: '
-stty -echo
-IFS= read -r CLOUDFLARE_LB_READ_TOKEN
-stty echo
-printf '\n'
-export CLOUDFLARE_LB_READ_TOKEN
-export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
-export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
-python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api
-unset CLOUDFLARE_LB_READ_TOKEN
+CLOUDFLARE_API_TOKEN_LB_AUDIT=<read-only Cloudflare token>
+CLOUDFLARE_ZONE_ID=<mvn.by zone id>
+CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
 ```
+
+Then apply them to GitHub without printing secret values:
+
+```bash
+python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --env-file .env
+```
+
+The helper also accepts `CLOUDFLARE_LB_READ_TOKEN` for the local input token,
+but always stores the GitHub Actions secret under the canonical
+`CLOUDFLARE_LB_READ_TOKEN` name.
 
 After the required Cloudflare LB workflow passes and you want scheduled checks
 to fail on drift, repeat with:
 
 ```bash
-printf 'Cloudflare LB token: '
-stty -echo
-IFS= read -r CLOUDFLARE_LB_READ_TOKEN
-stty echo
-printf '\n'
-export CLOUDFLARE_LB_READ_TOKEN
-export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
-export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
-python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --mark-required
-unset CLOUDFLARE_LB_READ_TOKEN
+python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --env-file .env --mark-required
 ```
 
 After Cloudflare LB credentials are in GitHub and PostgreSQL PITR has passed
@@ -198,7 +192,10 @@ python3 scripts/ha/enable_ha_strict_mode.py --repo mvnby/air-api
 The helper waits for the required Cloudflare LB config audit, PITR status
 check, PITR restore drill, and strict HA readiness audit. It sets
 `CLOUDFLARE_LB_CONFIG_REQUIRED=true`, `POSTGRES_PITR_REQUIRED=true`, and
-`API_HA_READINESS_STRICT=true` only after those proof workflows pass.
+`API_HA_READINESS_STRICT=true` only after those proof workflows pass, then runs
+the final `report_ha_status.py --require-strict` rollup so the same command
+proves GitHub workflows, external prerequisites, and the live active/passive
+invariant after strict mode is enabled.
 
 Scheduled monitors:
 

--- a/scripts/ha/apply_cloudflare_lb_github_prerequisites.py
+++ b/scripts/ha/apply_cloudflare_lb_github_prerequisites.py
@@ -8,17 +8,22 @@ stdin, not as a command-line argument, so it does not appear in process args.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Sequence
 
 
 DEFAULT_REPO = "mvnby/air-api"
 DEFAULT_REF = "main"
 WORKFLOW = "check-cloudflare-lb-config.yml"
+DEFAULT_TOKEN_ENV = "CLOUDFLARE_LB_READ_TOKEN"
+TOKEN_FALLBACK_ENVS = ("CLOUDFLARE_API_TOKEN_LB_AUDIT",)
 
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 
@@ -50,20 +55,76 @@ def env_value(name: str) -> str:
     return str(os.environ.get(name) or "").strip()
 
 
-def collect_inputs(*, token_env: str, zone_id_env: str, account_id_env: str) -> tuple[str, str, str]:
-    values = (
-        env_value(token_env),
-        env_value(zone_id_env),
-        env_value(account_id_env),
-    )
-    missing = [
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        return None
+    key, raw_value = line.split("=", 1)
+    key = key.strip().removeprefix("export ").strip()
+    if not key or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+        return None
+    raw_value = raw_value.strip()
+    if raw_value and raw_value[0] in {"'", '"'}:
+        try:
+            parts = shlex.split(f"{key}={raw_value}", posix=True)
+        except ValueError:
+            parts = []
+        if parts and "=" in parts[0]:
+            return key, parts[0].split("=", 1)[1]
+    if " #" in raw_value:
+        raw_value = raw_value.split(" #", 1)[0].rstrip()
+    return key, raw_value
+
+
+def load_env_file(path: Path, *, allowed_names: set[str]) -> None:
+    if not path.exists():
+        raise RuntimeError(f"env file not found: {path}")
+    loaded = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key not in allowed_names:
+            continue
+        if key not in os.environ:
+            os.environ[key] = value
+            loaded += 1
+    log("ok", f"loaded env file: {path} keys={loaded}")
+
+
+def _first_env_value(names: Sequence[str]) -> tuple[str, str]:
+    for name in names:
+        value = env_value(name)
+        if value:
+            return value, name
+    return "", names[0] if names else ""
+
+
+def collect_inputs(
+    *,
+    token_env: str,
+    zone_id_env: str,
+    account_id_env: str,
+    token_fallback_envs: Sequence[str] = TOKEN_FALLBACK_ENVS,
+) -> tuple[str, str, str, str]:
+    token, token_source = _first_env_value((token_env, *token_fallback_envs))
+    zone_id = env_value(zone_id_env)
+    account_id = env_value(account_id_env)
+    token_label = token_env
+    if token_fallback_envs:
+        token_label = f"{token_env} (or {'/'.join(token_fallback_envs)})"
+    missing = []
+    if not token:
+        missing.append(token_label)
+    missing.extend(
         env_name
-        for env_name, value in zip((token_env, zone_id_env, account_id_env), values, strict=True)
+        for env_name, value in ((zone_id_env, zone_id), (account_id_env, account_id))
         if not value
-    ]
+    )
     if missing:
         raise RuntimeError("missing required environment variables: " + ", ".join(missing))
-    return values
+    return token, zone_id, account_id, token_source
 
 
 def set_secret(repo: str, name: str, value: str, *, runner: Runner | None = None) -> None:
@@ -90,6 +151,72 @@ def parse_run_id(output: str) -> str:
     return match.group(1)
 
 
+def parse_run_id_optional(output: str) -> str | None:
+    match = re.search(r"/actions/runs/([0-9]+)", output)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_github_time(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def find_recent_workflow_run_id(
+    *,
+    repo: str,
+    ref: str,
+    workflow: str,
+    started_after: datetime,
+    runner: Runner | None = None,
+) -> str:
+    output = run_checked(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            workflow,
+            "--branch",
+            ref,
+            "--event",
+            "workflow_dispatch",
+            "--json",
+            "databaseId,createdAt,url",
+            "--limit",
+            "10",
+        ],
+        runner=runner,
+    )
+    try:
+        runs = json.loads(output or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"could not parse gh run list output for {workflow}: {output!r}") from exc
+
+    candidates: list[tuple[datetime, str]] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        created_at = parse_github_time(str(run.get("createdAt") or ""))
+        run_id = str(run.get("databaseId") or "")
+        if created_at and run_id and created_at >= started_after:
+            candidates.append((created_at, run_id))
+
+    if not candidates:
+        raise RuntimeError(
+            f"could not find a recent workflow_dispatch run for {workflow}; "
+            "rerun or inspect GitHub Actions manually"
+        )
+
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
 def run_cloudflare_required_workflow(
     *,
     repo: str,
@@ -97,6 +224,7 @@ def run_cloudflare_required_workflow(
     wait: bool,
     runner: Runner | None = None,
 ) -> str:
+    started_after = datetime.now(timezone.utc) - timedelta(seconds=10)
     output = run_checked(
         [
             "gh",
@@ -112,7 +240,15 @@ def run_cloudflare_required_workflow(
         ],
         runner=runner,
     )
-    run_id = parse_run_id(output)
+    run_id = parse_run_id_optional(output)
+    if not run_id:
+        run_id = find_recent_workflow_run_id(
+            repo=repo,
+            ref=ref,
+            workflow=WORKFLOW,
+            started_after=started_after,
+            runner=runner,
+        )
     log("ok", f"started Cloudflare LB required audit: {output}")
     if wait:
         run_checked(
@@ -129,9 +265,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO)
     parser.add_argument("--ref", default=DEFAULT_REF)
-    parser.add_argument("--token-env", default="CLOUDFLARE_LB_READ_TOKEN")
+    parser.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
     parser.add_argument("--zone-id-env", default="CLOUDFLARE_ZONE_ID")
     parser.add_argument("--account-id-env", default="CLOUDFLARE_ACCOUNT_ID")
+    parser.add_argument(
+        "--env-file",
+        default=os.environ.get("HA_ENV_FILE") or "",
+        help="Optional dotenv-style file to load before reading Cloudflare inputs.",
+    )
     parser.add_argument(
         "--mark-required",
         action="store_true",
@@ -153,13 +294,23 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
-        token, zone_id, account_id = collect_inputs(
+        if args.env_file:
+            load_env_file(
+                Path(args.env_file),
+                allowed_names={
+                    args.token_env,
+                    *TOKEN_FALLBACK_ENVS,
+                    args.zone_id_env,
+                    args.account_id_env,
+                },
+            )
+        token, zone_id, account_id, token_source = collect_inputs(
             token_env=args.token_env,
             zone_id_env=args.zone_id_env,
             account_id_env=args.account_id_env,
         )
         log("info", f"repo={args.repo} ref={args.ref}")
-        log("info", f"using token from ${args.token_env}; value will not be printed")
+        log("info", f"using token from ${token_source}; value will not be printed")
         if args.mark_required and args.no_wait:
             raise RuntimeError("--mark-required requires waiting for the required audit to pass")
 

--- a/scripts/ha/enable_ha_strict_mode.py
+++ b/scripts/ha/enable_ha_strict_mode.py
@@ -206,6 +206,19 @@ def run_external_prereq_check(repo: str, *, require_strict: bool, runner: Runner
     run_checked(args, runner=runner)
 
 
+def run_final_status_report(
+    *,
+    repo: str,
+    ref: str,
+    runner: Runner | None = None,
+) -> None:
+    script = Path(__file__).with_name("report_ha_status.py")
+    run_checked(
+        [sys.executable, str(script), "--repo", repo, "--branch", ref, "--require-strict"],
+        runner=runner,
+    )
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run MVN HA proof workflows and enable GitHub strict-mode variables only after they pass."
@@ -232,6 +245,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             for name in STRICT_VARIABLES:
                 log("dry-run", f"would set GitHub variable {name}=true")
             log("dry-run", "would verify strict external prerequisites")
+            log("dry-run", "would run final HA status report with --require-strict")
             return 0
 
         run_external_prereq_check(args.repo, require_strict=False)
@@ -242,6 +256,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             set_variable(args.repo, name, "true")
 
         run_external_prereq_check(args.repo, require_strict=True)
+        run_final_status_report(repo=args.repo, ref=args.ref)
         log("ok", "strict HA mode is enabled")
         return 0
     except RuntimeError as exc:

--- a/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
+++ b/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
@@ -55,6 +55,34 @@ def test_parse_run_id_from_workflow_url():
     )
 
 
+def test_load_env_file_sets_missing_values_without_overriding(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "CLOUDFLARE_API_TOKEN_LB_AUDIT=from-file",
+                "CLOUDFLARE_ACCOUNT_ID='account-from-file'",
+                "CLOUDFLARE_ZONE_ID=zone-from-file # comment",
+                "GH_TOKEN=stale-github-token",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "existing-account")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    module.load_env_file(
+        env_file,
+        allowed_names={"CLOUDFLARE_API_TOKEN_LB_AUDIT", "CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_ZONE_ID"},
+    )
+
+    assert module.env_value("CLOUDFLARE_API_TOKEN_LB_AUDIT") == "from-file"
+    assert module.env_value("CLOUDFLARE_ACCOUNT_ID") == "existing-account"
+    assert module.env_value("CLOUDFLARE_ZONE_ID") == "zone-from-file"
+    assert module.env_value("GH_TOKEN") == ""
+
+
 def test_collect_inputs_reports_missing_env_names_without_values(monkeypatch):
     monkeypatch.setenv("CLOUDFLARE_LB_READ_TOKEN", "token")
     monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
@@ -74,6 +102,24 @@ def test_collect_inputs_reports_missing_env_names_without_values(monkeypatch):
     assert "CLOUDFLARE_ZONE_ID" in message
     assert "CLOUDFLARE_ACCOUNT_ID" in message
     assert "token" not in message
+
+
+def test_collect_inputs_accepts_audit_token_alias(monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_LB_READ_TOKEN", raising=False)
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN_LB_AUDIT", "audit-token")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+
+    token, zone_id, account_id, token_source = module.collect_inputs(
+        token_env="CLOUDFLARE_LB_READ_TOKEN",
+        zone_id_env="CLOUDFLARE_ZONE_ID",
+        account_id_env="CLOUDFLARE_ACCOUNT_ID",
+    )
+
+    assert token == "audit-token"
+    assert token_source == "CLOUDFLARE_API_TOKEN_LB_AUDIT"
+    assert zone_id == "zone"
+    assert account_id == "account"
 
 
 def test_main_rejects_mark_required_without_wait_before_writes(monkeypatch, capsys):
@@ -116,3 +162,99 @@ def test_main_sets_metadata_then_runs_required_audit(monkeypatch):
     assert ["gh", "workflow", "run"] in command_names
     assert ["gh", "run", "watch"] in command_names
     assert all("token" not in args for args, _stdin in calls)
+
+
+def test_main_writes_canonical_secret_from_audit_token_alias(monkeypatch):
+    calls = []
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        if list(args[:3]) == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="https://github.com/mvnby/air-api/actions/runs/28636799268\n")
+        return FakeCompleted()
+
+    monkeypatch.delenv("CLOUDFLARE_LB_READ_TOKEN", raising=False)
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN_LB_AUDIT", "audit-token")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api"]) == 0
+
+    assert (
+        ["gh", "secret", "set", "CLOUDFLARE_LB_READ_TOKEN", "--repo", "mvnby/air-api"],
+        "audit-token\n",
+    ) in calls
+    assert all("audit-token" not in args for args, _stdin in calls)
+
+
+def test_main_can_load_project_env_file(tmp_path, monkeypatch):
+    calls = []
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "CLOUDFLARE_API_TOKEN_LB_AUDIT=audit-token",
+                "CLOUDFLARE_ZONE_ID=zone",
+                "CLOUDFLARE_ACCOUNT_ID=account",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        if list(args[:3]) == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="https://github.com/mvnby/air-api/actions/runs/28636799268\n")
+        return FakeCompleted()
+
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN_LB_AUDIT", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api", "--env-file", str(env_file)]) == 0
+
+    assert (
+        ["gh", "secret", "set", "CLOUDFLARE_LB_READ_TOKEN", "--repo", "mvnby/air-api"],
+        "audit-token\n",
+    ) in calls
+
+
+def test_workflow_output_without_url_falls_back_to_recent_run_list(monkeypatch):
+    calls = []
+    real_datetime = module.datetime
+
+    def fake_runner(args, stdin):
+        args = list(args)
+        calls.append((args, stdin))
+        if args[:3] == ["gh", "workflow", "run"]:
+            return FakeCompleted(stdout="Created workflow_dispatch event\n")
+        if args[:3] == ["gh", "run", "list"]:
+            return FakeCompleted(
+                stdout='[{"databaseId":28639999999,"createdAt":"2026-07-03T05:08:21Z",'
+                '"url":"https://github.com/mvnby/air-api/actions/runs/28639999999"}]'
+            )
+        return FakeCompleted()
+
+    class FrozenDatetime:
+        @staticmethod
+        def now(_tz):
+            return real_datetime(2026, 7, 3, 5, 8, 22, tzinfo=module.timezone.utc)
+
+        @staticmethod
+        def fromisoformat(value):
+            return real_datetime.fromisoformat(value)
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+    monkeypatch.setattr(module, "datetime", FrozenDatetime)
+
+    run_id = module.run_cloudflare_required_workflow(
+        repo="mvnby/air-api",
+        ref="main",
+        wait=True,
+    )
+
+    assert run_id == "28639999999"
+    assert any(args[:3] == ["gh", "run", "list"] for args, _stdin in calls)
+    assert any(args[:3] == ["gh", "run", "watch"] and args[3] == "28639999999" for args, _stdin in calls)

--- a/tests/unit/test_enable_ha_strict_mode.py
+++ b/tests/unit/test_enable_ha_strict_mode.py
@@ -36,6 +36,7 @@ def test_dry_run_does_not_call_subprocess(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "would run and wait for check-cloudflare-lb-config.yml required=true" in output
     assert "would set GitHub variable API_HA_READINESS_STRICT=true" in output
+    assert "would run final HA status report with --require-strict" in output
 
 
 def test_main_runs_proofs_before_enabling_strict_variables(monkeypatch):
@@ -59,6 +60,16 @@ def test_main_runs_proofs_before_enabling_strict_variables(monkeypatch):
     variable_calls = [args for args, _stdin in calls if args[:3] == ["gh", "variable", "set"]]
     first_variable_index = next(index for index, call in enumerate(calls) if call[0][:3] == ["gh", "variable", "set"])
     last_watch_index = max(index for index, call in enumerate(calls) if call[0][:3] == ["gh", "run", "watch"])
+    strict_external_index = next(
+        index
+        for index, call in enumerate(calls)
+        if call[0][-1] == "--require-strict" and "check_ha_external_prerequisites.py" in call[0][1]
+    )
+    final_report_index = next(
+        index
+        for index, call in enumerate(calls)
+        if call[0][-1] == "--require-strict" and "report_ha_status.py" in call[0][1]
+    )
 
     assert [call[3] for call in workflow_calls] == [
         "check-cloudflare-lb-config.yml",
@@ -76,7 +87,9 @@ def test_main_runs_proofs_before_enabling_strict_variables(monkeypatch):
         "API_HA_READINESS_STRICT",
     ]
     assert all(stdin == "true\n" for _args, stdin in calls if _args[:3] == ["gh", "variable", "set"])
+    assert last_watch_index < first_variable_index < strict_external_index < final_report_index
     assert calls[-1][0][-1] == "--require-strict"
+    assert "report_ha_status.py" in calls[-1][0][1]
 
 
 def test_workflow_output_without_url_falls_back_to_recent_run_list(monkeypatch):
@@ -135,3 +148,26 @@ def test_failed_proof_does_not_enable_strict_variables(monkeypatch):
     assert module.main(["--repo", "mvnby/air-api"]) == 1
 
     assert not any(args[:3] == ["gh", "variable", "set"] for args, _stdin in calls)
+
+
+def test_failed_final_status_report_keeps_strict_helper_failed(monkeypatch, capsys):
+    calls = []
+    run_id = 28640000000
+
+    def fake_runner(args, stdin):
+        nonlocal run_id
+        args = list(args)
+        calls.append((args, stdin))
+        if args[:3] == ["gh", "workflow", "run"]:
+            run_id += 1
+            return FakeCompleted(stdout=f"https://github.com/mvnby/air-api/actions/runs/{run_id}\n")
+        if "report_ha_status.py" in args[1]:
+            return FakeCompleted(stderr="strict report failed", returncode=1)
+        return FakeCompleted()
+
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--repo", "mvnby/air-api"]) == 1
+
+    assert any(args[:3] == ["gh", "variable", "set"] for args, _stdin in calls)
+    assert "strict report failed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- let the Cloudflare LB prerequisite helper safely read only the required Cloudflare keys from a local .env file
- accept the local CLOUDFLARE_API_TOKEN_LB_AUDIT alias while still writing the canonical GitHub secret CLOUDFLARE_LB_READ_TOKEN
- make Cloudflare workflow dispatch robust when gh does not return a run URL
- run the final strict HA status rollup from the strict-mode activation helper
- update the HA runbook for the .env-based flow

## Tests
- pytest tests/unit/test_apply_cloudflare_lb_github_prerequisites.py tests/unit/test_enable_ha_strict_mode.py tests/unit/test_ha_status_report.py -q
- python3 -m py_compile scripts/ha/apply_cloudflare_lb_github_prerequisites.py scripts/ha/enable_ha_strict_mode.py scripts/ha/report_ha_status.py
- git diff --check

## Current external state
- GitHub Cloudflare secret/vars are now present
- Required Cloudflare LB audit is still blocked by Cloudflare 403 on zone load balancers until the audit token gets Zone / Load Balancers / Read for mvn.by