### PR TITLE
Harden PITR env loading and basebackup

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -319,31 +319,22 @@ tar -czf - \
 # Copy deploy/ha/mvn-api/docker-compose.primary.yml through CI.
 gh workflow run deploy.yml --repo mvnby/air-api --ref main -f deploy_frontend=false
 
-# Put the private R2 credentials in the local shell environment or let the
-# helper prompt for the missing access-key values. It uploads a temporary
+# Put the private R2 credentials in local `.env` using the names above. The
+# helper loads only `POSTGRES_PITR_*` keys from that file, uploads a temporary
 # root-only env file to the primary, removes it after the remote phase, and
 # never prints access keys.
-export POSTGRES_PITR_CLUSTER=mvn-api
-export POSTGRES_PITR_S3_BUCKET=<private-r2-bucket>
-export POSTGRES_PITR_S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
-export POSTGRES_PITR_S3_REGION=auto
-export POSTGRES_PITR_S3_KEY_PREFIX=postgres/pitr
 
 # First verify the local input shape without touching the primary.
-python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --dry-run
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --env-file .env --dry-run --no-prompt
 
 # Then upload the temporary env file and run the remote preflight. This does not
 # write the production .env, upload a basebackup, or recreate the database.
-python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --phase preflight
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --env-file .env --phase preflight --no-prompt
 
 # Finally validate credentials, write PITR env with archive mode still off,
 # upload a physical basebackup, and stage archive_mode=on for the next DB
 # recreate. This still does not recreate the database.
-python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --phase bootstrap-before-maintenance
-
-unset POSTGRES_PITR_CLUSTER POSTGRES_PITR_S3_BUCKET POSTGRES_PITR_S3_ENDPOINT_URL
-unset POSTGRES_PITR_S3_REGION POSTGRES_PITR_S3_ACCESS_KEY_ID
-unset POSTGRES_PITR_S3_SECRET_ACCESS_KEY POSTGRES_PITR_S3_KEY_PREFIX
+python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --env-file .env --phase bootstrap-before-maintenance --no-prompt
 
 # In a short maintenance window, recreate db so archive_mode=on and the
 # /postgres-wal-archive mount become active. The helper also resets historical

--- a/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
+++ b/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
@@ -16,6 +16,7 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 
@@ -26,6 +27,15 @@ DEFAULT_REMOTE_ENV_FILE = "/root/mvn-postgres-pitr.env"
 DEFAULT_BOOTSTRAP_HELPER = "/usr/local/sbin/mvn-postgres-pitr-bootstrap"
 
 BUCKET_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$")
+PITR_ENV_NAMES = {
+    "POSTGRES_PITR_CLUSTER",
+    "POSTGRES_PITR_S3_BUCKET",
+    "POSTGRES_PITR_S3_ENDPOINT_URL",
+    "POSTGRES_PITR_S3_REGION",
+    "POSTGRES_PITR_S3_ACCESS_KEY_ID",
+    "POSTGRES_PITR_S3_SECRET_ACCESS_KEY",
+    "POSTGRES_PITR_S3_KEY_PREFIX",
+}
 
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 
@@ -73,6 +83,44 @@ def _clean(value: object | None) -> str:
 
 def _env(name: str, environ: Mapping[str, str]) -> str:
     return _clean(environ.get(name))
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        return None
+    key, raw_value = line.split("=", 1)
+    key = key.strip().removeprefix("export ").strip()
+    if not key or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+        return None
+    raw_value = raw_value.strip()
+    if raw_value and raw_value[0] in {"'", '"'}:
+        try:
+            parts = shlex.split(f"{key}={raw_value}", posix=True)
+        except ValueError:
+            parts = []
+        if parts and "=" in parts[0]:
+            return key, parts[0].split("=", 1)[1]
+    if " #" in raw_value:
+        raw_value = raw_value.split(" #", 1)[0].rstrip()
+    return key, raw_value
+
+
+def load_env_file(path: Path, *, allowed_names: set[str] = PITR_ENV_NAMES) -> None:
+    if not path.exists():
+        raise RuntimeError(f"env file not found: {path}")
+    loaded = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key not in allowed_names:
+            continue
+        if key not in os.environ:
+            os.environ[key] = value
+            loaded += 1
+    log("ok", f"loaded env file: {path} keys={loaded}")
 
 
 def _prompt(name: str, *, secret: bool, no_prompt: bool) -> str:
@@ -256,6 +304,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument("--remote-env-file", default=DEFAULT_REMOTE_ENV_FILE)
     parser.add_argument("--bootstrap-helper", default=DEFAULT_BOOTSTRAP_HELPER)
     parser.add_argument(
+        "--env-file",
+        default=os.environ.get("HA_ENV_FILE") or "",
+        help="Optional dotenv-style file to load before reading PITR inputs.",
+    )
+    parser.add_argument(
         "--phase",
         choices=("preflight", "bootstrap-before-maintenance"),
         default="preflight",
@@ -273,6 +326,8 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
+        if args.env_file:
+            load_env_file(Path(args.env_file))
         config = collect_inputs(no_prompt=args.no_prompt)
         log("info", f"ssh_host={args.ssh_host} project_dir={args.project_dir} compose_file={args.compose_file}")
         log("info", f"phase={args.phase}")

--- a/scripts/ha/create_postgres_pitr_basebackup.sh
+++ b/scripts/ha/create_postgres_pitr_basebackup.sh
@@ -42,13 +42,6 @@ if ! "${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc 'psql -U "$POSTGRES_USER" -d
   exit 1
 fi
 
-network="$(docker inspect -f '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' "${db_container}" | head -n 1)"
-db_ip="$(docker inspect -f '{{range $_, $network := .NetworkSettings.Networks}}{{println $network.IPAddress}}{{end}}' "${db_container}" | head -n 1)"
-if [[ -z "${network}" || -z "${db_ip}" ]]; then
-  echo "Could not detect Docker network/IP for ${DB_SERVICE}." >&2
-  exit 1
-fi
-
 backup_id="$(date -u +%Y%m%dT%H%M%SZ)"
 backup_dir="${BACKUP_ROOT}/${backup_id}"
 mkdir -p "${backup_dir}"
@@ -61,11 +54,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-log "Creating physical pg_basebackup ${backup_id} from ${db_ip} on ${network}..."
+# Join the DB container network namespace so Postgres sees this as localhost.
+# The default pg_hba.conf allows local replication without opening replication
+# to the whole Docker bridge network.
+log "Creating physical pg_basebackup ${backup_id} through ${DB_SERVICE} localhost network namespace..."
 docker run --rm \
-  --network "${network}" \
+  --network "container:${db_container}" \
   -e PGPASSWORD="${POSTGRES_PASSWORD}" \
-  -e PGHOST="${db_ip}" \
+  -e PGHOST="127.0.0.1" \
   -e PGUSER="${POSTGRES_USER}" \
   -e PGLABEL="mvn-pitr-${backup_id}" \
   -v "${backup_dir}:/backup" \

--- a/tests/unit/test_apply_postgres_pitr_primary_prerequisites.py
+++ b/tests/unit/test_apply_postgres_pitr_primary_prerequisites.py
@@ -47,6 +47,38 @@ def test_render_env_redacts_access_keys():
     assert "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=redacted" in rendered
 
 
+def test_load_env_file_loads_only_pitr_keys_without_overriding(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr",
+                "POSTGRES_PITR_S3_ENDPOINT_URL='https://account-id.r2.cloudflarestorage.com'",
+                "POSTGRES_PITR_S3_ACCESS_KEY_ID=access-key-id",
+                "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=super-secret-key",
+                "GH_TOKEN=stale-github-token",
+                "CLOUDFLARE_API_TOKEN_LB_AUDIT=cloudflare-token",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POSTGRES_PITR_S3_BUCKET", "existing-bucket")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN_LB_AUDIT", raising=False)
+
+    module.load_env_file(env_file)
+
+    assert module._env("POSTGRES_PITR_S3_BUCKET", module.os.environ) == "existing-bucket"
+    assert (
+        module._env("POSTGRES_PITR_S3_ENDPOINT_URL", module.os.environ)
+        == "https://account-id.r2.cloudflarestorage.com"
+    )
+    assert module._env("POSTGRES_PITR_S3_SECRET_ACCESS_KEY", module.os.environ) == "super-secret-key"
+    assert module._env("GH_TOKEN", module.os.environ) == ""
+    assert module._env("CLOUDFLARE_API_TOKEN_LB_AUDIT", module.os.environ) == ""
+
+
 def test_upload_remote_env_passes_secret_only_via_stdin():
     calls = []
 
@@ -165,3 +197,26 @@ def test_main_runs_upload_and_preflight_with_monkeypatched_subprocess(monkeypatc
     assert "super-secret-key" in calls[0][1]
     assert all("super-secret-key" not in arg for args, _stdin in calls for arg in args)
     assert "preflight" in calls[1][0][2]
+
+
+def test_main_can_load_project_env_file(tmp_path, monkeypatch):
+    calls = []
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(f"{name}={value}" for name, value in _env().items()),
+        encoding="utf-8",
+    )
+
+    def fake_runner(args, stdin):
+        calls.append((list(args), stdin))
+        return FakeCompleted()
+
+    for name in _env():
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(module, "_run_subprocess", fake_runner)
+
+    assert module.main(["--no-prompt", "--phase", "preflight", "--env-file", str(env_file)]) == 0
+
+    assert len(calls) == 2
+    assert "super-secret-key" in calls[0][1]
+    assert all("super-secret-key" not in arg for args, _stdin in calls for arg in args)

--- a/tests/unit/test_postgres_pitr_basebackup_script.py
+++ b/tests/unit/test_postgres_pitr_basebackup_script.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/ha/create_postgres_pitr_basebackup.sh"
+
+
+def test_basebackup_uses_db_container_network_namespace():
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    assert '--network "container:${db_container}"' in script
+    assert '-e PGHOST="127.0.0.1"' in script
+    assert '--network "${network}"' not in script
+    assert 'docker inspect -f' not in script


### PR DESCRIPTION
## Summary
- let the PITR primary prerequisite helper safely load only POSTGRES_PITR_* keys from local .env
- update the physical basebackup helper to run through the DB container network namespace, so Postgres sees localhost replication instead of a Docker bridge peer
- document the .env-based PITR operator flow
- add tests for whitelisted env loading and basebackup network behavior

## Tests
- pytest tests/unit/test_apply_postgres_pitr_primary_prerequisites.py tests/unit/test_postgres_pitr_basebackup_script.py -q
- bash -n scripts/ha/create_postgres_pitr_basebackup.sh scripts/ha/bootstrap_postgres_pitr.sh scripts/ha/install_postgres_pitr_units.sh
- python3 -m py_compile scripts/ha/apply_postgres_pitr_primary_prerequisites.py
- git diff --check

## Runtime proof
- apply_postgres_pitr_primary_prerequisites.py --env-file .env --phase preflight --no-prompt passed on mvn-api
- apply_postgres_pitr_primary_prerequisites.py --env-file .env --phase bootstrap-before-maintenance --no-prompt uploaded basebackup 20260703T095140Z to R2 and staged archive env; db recreate/archive activation is still pending manual maintenance confirmation
