### PR TITLE
Reduce HA prerequisite warning noise

### DIFF
--- a/scripts/ha/check_ha_external_prerequisites.py
+++ b/scripts/ha/check_ha_external_prerequisites.py
@@ -25,6 +25,9 @@ REQUIRED_SECRETS = {
 OPTIONAL_SECRETS = {
     "HA_ALERT_TELEGRAM_BOT_TOKEN": "Telegram bot token for owner-visible HA failure alerts",
     "HA_ALERT_TELEGRAM_CHAT_ID": "Telegram chat id for owner-visible HA failure alerts",
+}
+
+INFO_SECRETS = {
     "HA_ALERT_TELEGRAM_THREAD_ID": "Optional Telegram forum topic id for owner-visible HA failure alerts",
 }
 
@@ -97,7 +100,7 @@ def load_env_metadata() -> GithubMetadata:
         for name in REQUIRED_VARIABLES
         if os.getenv(name, "").strip()
     }
-    secret_names = set(REQUIRED_SECRETS) | set(OPTIONAL_SECRETS)
+    secret_names = set(REQUIRED_SECRETS) | set(OPTIONAL_SECRETS) | set(INFO_SECRETS)
     secrets = {name for name in secret_names if os.getenv(name, "").strip()}
     return GithubMetadata(variables=variables, secrets=secrets)
 
@@ -132,6 +135,10 @@ def check_metadata(metadata: GithubMetadata, *, require_strict: bool) -> tuple[l
         else:
             warnings.append(f"missing optional GitHub secret {name}: {description}")
 
+    for name in sorted(INFO_SECRETS):
+        if name in metadata.secrets:
+            ok.append(f"optional secret present: {name}")
+
     for name, description in sorted(REQUIRED_VARIABLES.items()):
         value = metadata.variables.get(name)
         if value:
@@ -150,11 +157,14 @@ def check_metadata(metadata: GithubMetadata, *, require_strict: bool) -> tuple[l
         else:
             warnings.append(f"{name} is not true yet")
 
-    warnings.append(
-        "private PITR R2 credentials are host-local; verify with "
-        "`ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'` "
-        "after bucket credentials are installed"
-    )
+    if is_true(metadata.variables.get("POSTGRES_PITR_REQUIRED")):
+        ok.append("private PITR R2 credentials are host-local and strict PITR checks are enabled")
+    else:
+        warnings.append(
+            "private PITR R2 credentials are host-local; verify with "
+            "`ssh mvn-api '/usr/local/sbin/mvn-postgres-pitr-bootstrap verify'` "
+            "after bucket credentials are installed"
+        )
     return ok, warnings, failures
 
 

--- a/tests/unit/test_ha_external_prerequisites.py
+++ b/tests/unit/test_ha_external_prerequisites.py
@@ -38,7 +38,7 @@ def test_external_prerequisites_report_missing_cloudflare_secret_and_vars():
     assert any("missing GitHub variable CLOUDFLARE_ZONE_ID" in item for item in failures)
     assert any("missing optional GitHub secret HA_ALERT_TELEGRAM_BOT_TOKEN" in item for item in warnings)
     assert any("missing optional GitHub secret HA_ALERT_TELEGRAM_CHAT_ID" in item for item in warnings)
-    assert any("missing optional GitHub secret HA_ALERT_TELEGRAM_THREAD_ID" in item for item in warnings)
+    assert not any("HA_ALERT_TELEGRAM_THREAD_ID" in item for item in warnings)
     assert any("POSTGRES_PITR_REQUIRED is not true yet" in item for item in warnings)
     assert any("variable present: POSTGRES_PITR_MAX_WAL_AGE_MINUTES" in item for item in ok)
 
@@ -91,9 +91,11 @@ def test_external_prerequisites_pass_when_all_metadata_is_ready():
 
     assert not failures
     assert any("optional secret present: HA_ALERT_TELEGRAM_BOT_TOKEN" in item for item in ok)
+    assert any("optional secret present: HA_ALERT_TELEGRAM_THREAD_ID" in item for item in ok)
     assert any("strict variable enabled: API_HA_READINESS_STRICT" in item for item in ok)
     assert any("strict variable enabled: POSTGRES_PITR_REQUIRED" in item for item in ok)
-    assert any("private PITR R2 credentials are host-local" in item for item in warnings)
+    assert any("strict PITR checks are enabled" in item for item in ok)
+    assert not any("private PITR R2 credentials are host-local" in item for item in warnings)
 
 
 def test_env_metadata_loader_records_presence_without_secret_values(monkeypatch):

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -152,7 +152,6 @@ def test_next_steps_explain_external_blockers_without_secret_values():
         ok=[],
         warnings=[
             "missing optional GitHub secret HA_ALERT_TELEGRAM_BOT_TOKEN",
-            "missing optional GitHub secret HA_ALERT_TELEGRAM_THREAD_ID",
             "POSTGRES_PITR_REQUIRED is not true yet",
             "private PITR R2 credentials are host-local; verify with `ssh mvn-api`",
         ],
@@ -170,7 +169,7 @@ def test_next_steps_explain_external_blockers_without_secret_values():
     assert any("mvn-postgres-pitr-bootstrap verify" in step for step in steps)
     assert any("enable_ha_strict_mode.py" in step for step in steps)
     assert any("HA_ALERT_TELEGRAM_BOT_TOKEN" in step for step in steps)
-    assert any("HA_ALERT_TELEGRAM_THREAD_ID" in step for step in steps)
+    assert any("optionally HA_ALERT_TELEGRAM_THREAD_ID" in step for step in steps)
     assert not any("secret-token" in step for step in steps)
 
 


### PR DESCRIPTION
## Summary
- stop warning on missing HA_ALERT_TELEGRAM_THREAD_ID when bot/chat alerts are configured
- treat host-local PITR credentials as OK once POSTGRES_PITR_REQUIRED is enabled
- keep PITR verification next-steps only before strict PITR is enabled

## Tests
- pytest tests/unit/test_ha_external_prerequisites.py tests/unit/test_ha_status_report.py -q
- python3 -m py_compile scripts/ha/check_ha_external_prerequisites.py scripts/ha/report_ha_status.py
- git diff --check

## Runtime context
- PITR strict status and PITR restore drill now pass
- Cloudflare LB audit remains blocked by Cloudflare token zone Load Balancers read permission