### PR TITLE
Clarify Cloudflare HA status next step

### DIFF
--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -317,6 +317,14 @@ def next_steps_for(result: ReportResult) -> list[str]:
     if result.failures:
         add_once("inspect failed workflow URLs/artifacts before changing API routing or database roles")
 
+    if "Cloudflare LB Config Check" in joined:
+        add_once(
+            "fix the Cloudflare LB read token permissions: grant `Zone / Load Balancers / Read` "
+            "for the `mvn.by` zone and `Account / Load Balancing: Monitors and Pools / Read` "
+            "for the account, update local `.env` if the token changed, then run "
+            "`python3 scripts/ha/apply_cloudflare_lb_github_prerequisites.py --repo mvnby/air-api --env-file .env`"
+        )
+
     if any(
         key in joined
         for key in (

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -185,3 +185,21 @@ def test_next_steps_prioritize_failed_workflows_and_live_skip():
 
     assert steps[0] == "inspect failed workflow URLs/artifacts before changing API routing or database roles"
     assert any("rerun without --skip-live" in step for step in steps)
+
+
+def test_next_steps_explain_failed_cloudflare_lb_config_check():
+    result = report_ha_status.ReportResult(
+        ok=[],
+        warnings=[],
+        blockers=[],
+        failures=[
+            "Cloudflare LB Config Check: latest run concluded failure (url=https://github.test/run)",
+        ],
+    )
+
+    steps = report_ha_status.next_steps_for(result)
+
+    assert any("Zone / Load Balancers / Read" in step for step in steps)
+    assert any("Account / Load Balancing: Monitors and Pools / Read" in step for step in steps)
+    assert any("apply_cloudflare_lb_github_prerequisites.py" in step for step in steps)
+    assert not any("secret-token" in step for step in steps)


### PR DESCRIPTION
## Summary
- add a targeted HA status next-step when the Cloudflare LB config workflow is failing
- include the exact read-only token permissions needed for the current blocker
- cover the new operator guidance with a unit test

## Tests
- pytest tests/unit/test_ha_status_report.py tests/unit/test_ha_external_prerequisites.py -q