### PR TITLE
Polish HA status diagnostics

### DIFF
--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -75,7 +75,6 @@ class ReportResult:
 EXPECTED_WORKFLOWS = (
     ExpectedWorkflow("Deploy to Production 🚀"),
     ExpectedWorkflow("CI (Test & Lint)"),
-    ExpectedWorkflow("API HA Status Report", max_age_hours=3),
     ExpectedWorkflow("API HA Invariant Check", max_age_hours=8),
     ExpectedWorkflow("API HA Readiness Audit", max_age_hours=8),
     ExpectedWorkflow("API VPS Health Check", max_age_hours=8),

--- a/scripts/ha/switch_cloudflare_lb_primary.py
+++ b/scripts/ha/switch_cloudflare_lb_primary.py
@@ -100,7 +100,7 @@ def _api_patch(path: str, token: str, payload: dict[str, Any]) -> dict[str, Any]
             response_payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
-        raise AuditFailure(f"Cloudflare API HTTP {exc.code} for {path}: {body}") from exc
+        raise AuditFailure(_format_cloudflare_patch_error(path, exc.code, body)) from exc
     except urllib.error.URLError as exc:
         raise AuditFailure(f"Cloudflare API request failed for {path}: {exc}") from exc
 
@@ -111,6 +111,18 @@ def _api_patch(path: str, token: str, payload: dict[str, Any]) -> dict[str, Any]
     if not isinstance(result, dict):
         raise AuditFailure(f"Cloudflare API result is not an object for {path}")
     return result
+
+
+def _format_cloudflare_patch_error(path: str, status_code: int, body: str) -> str:
+    message = f"Cloudflare API HTTP {status_code} for {path}: {body}"
+    if status_code in {401, 403} and path.startswith("/zones/") and "/load_balancers/" in path:
+        message += (
+            " Required token permission for applying this switch: "
+            "Zone / Load Balancers / Edit scoped to the mvn.by zone. "
+            "The read-only audit token can inspect this configuration but cannot patch "
+            "default_pools or fallback_pool."
+        )
+    return message
 
 
 def _desired_default_pools(

--- a/tests/unit/test_ha_status_report.py
+++ b/tests/unit/test_ha_status_report.py
@@ -96,11 +96,8 @@ def test_latest_runs_prefers_latest_completed_run_over_current_in_progress():
     assert latest["API HA Status Report"] == previous
 
 
-def test_default_expected_workflows_include_status_report_self_check():
-    assert any(
-        workflow.name == "API HA Status Report" and workflow.max_age_hours == 3
-        for workflow in report_ha_status.EXPECTED_WORKFLOWS
-    )
+def test_default_expected_workflows_do_not_self_check_status_report():
+    assert all(workflow.name != "API HA Status Report" for workflow in report_ha_status.EXPECTED_WORKFLOWS)
 
 
 def test_external_prereq_failures_are_blockers_until_require_strict(monkeypatch):

--- a/tests/unit/test_switch_cloudflare_lb_primary.py
+++ b/tests/unit/test_switch_cloudflare_lb_primary.py
@@ -236,3 +236,16 @@ def test_main_with_confirm_patches_minimal_payload(monkeypatch):
         "secret-token",
         {"default_pools": ["pool-standby", "pool-primary"], "fallback_pool": "pool-standby"},
     )
+
+
+def test_cloudflare_patch_403_explains_write_permission():
+    message = module._format_cloudflare_patch_error(
+        "/zones/zone/load_balancers/lb-api",
+        403,
+        '{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}',
+    )
+
+    assert "Authentication error" in message
+    assert "Zone / Load Balancers / Edit" in message
+    assert "default_pools" in message
+    assert "fallback_pool" in message


### PR DESCRIPTION
## Summary
- add a specific permission hint when the Cloudflare LB switch helper gets 401/403 on PATCH
- avoid API HA Status Report self-check recursion on an older failed status-report run
- cover both HA diagnostics paths with unit tests

## Tests
- pytest tests/unit/test_ha_status_report.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_cloudflare_lb_config.py -q
- python3 scripts/ha/report_ha_status.py --repo mvnby/air-api --require-strict