### PR TITLE
Clarify Cloudflare HA token handling

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -530,22 +530,25 @@ important than order and fallback.
 Repo-tracked Cloudflare config audit:
 
 ```bash
-python3 scripts/ha/check_cloudflare_lb_config.py
+python3 scripts/ha/check_cloudflare_lb_config.py --env-file .env
 ```
 
 Required environment:
 
 ```text
-CLOUDFLARE_API_TOKEN=<read-only token>
+CLOUDFLARE_API_TOKEN_LB_AUDIT=<read-only token>
 CLOUDFLARE_ZONE_ID=<mvn.by zone id>
 CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
 ```
 
-This is a normal Cloudflare API token, separate from R2 S3 credentials. Create a
-custom read-only token from the Cloudflare API Tokens screen and scope it to the
-`mvn.by` zone/account. Current Cloudflare role naming exposes the relevant
-account-scoped role as **Load Balancing Account Read**, which reads Load
-Balancers, Monitors, Monitor Groups, Pools, and Health Checks.
+The audit helper also accepts `CLOUDFLARE_LB_READ_TOKEN` and, for compatibility
+with GitHub workflow env mapping, `CLOUDFLARE_API_TOKEN`. Locally prefer
+`CLOUDFLARE_API_TOKEN_LB_AUDIT` so an old generic Cloudflare token cannot be
+picked accidentally. This is a normal Cloudflare API token, separate from R2 S3
+credentials. Create a custom read-only token from the Cloudflare API Tokens
+screen and scope it to the `mvn.by` zone/account. Current Cloudflare role naming
+exposes the relevant account-scoped role as **Load Balancing Account Read**,
+which reads Load Balancers, Monitors, Monitor Groups, Pools, and Health Checks.
 
 The audit calls these read-only endpoints, so the token must be able to read:
 
@@ -567,10 +570,10 @@ membership. Always run it without `--confirm` first:
 ```bash
 printf 'Cloudflare LB write token: '
 stty -echo
-IFS= read -r CLOUDFLARE_API_TOKEN
+IFS= read -r CLOUDFLARE_LB_WRITE_TOKEN
 stty echo
 printf '\n'
-export CLOUDFLARE_API_TOKEN
+export CLOUDFLARE_LB_WRITE_TOKEN
 export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
 export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
 
@@ -585,7 +588,7 @@ python3 scripts/ha/switch_cloudflare_lb_primary.py \
   --passive-origin 193.47.42.213 \
   --confirm
 
-unset CLOUDFLARE_API_TOKEN
+unset CLOUDFLARE_LB_WRITE_TOKEN
 ```
 
 After the switch is applied and the required Cloudflare LB audit passes, revoke
@@ -598,10 +601,10 @@ After a `zakup` promotion, reverse the origins:
 ```bash
 printf 'Cloudflare LB write token: '
 stty -echo
-IFS= read -r CLOUDFLARE_API_TOKEN
+IFS= read -r CLOUDFLARE_LB_WRITE_TOKEN
 stty echo
 printf '\n'
-export CLOUDFLARE_API_TOKEN
+export CLOUDFLARE_LB_WRITE_TOKEN
 export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
 export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
 
@@ -613,7 +616,7 @@ python3 scripts/ha/switch_cloudflare_lb_primary.py \
   --passive-origin 185.250.45.54 \
   --confirm
 
-unset CLOUDFLARE_API_TOKEN
+unset CLOUDFLARE_LB_WRITE_TOKEN
 ```
 
 GitHub scheduled audit fallback, if the helper above is not available:
@@ -722,10 +725,10 @@ The manual steps below are the same procedure expanded for review.
 
    printf 'Cloudflare LB write token: '
    stty -echo
-   IFS= read -r CLOUDFLARE_API_TOKEN
+   IFS= read -r CLOUDFLARE_LB_WRITE_TOKEN
    stty echo
    printf '\n'
-   export CLOUDFLARE_API_TOKEN
+   export CLOUDFLARE_LB_WRITE_TOKEN
    export CLOUDFLARE_ZONE_ID=<mvn.by zone id>
    export CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
    python3 scripts/ha/switch_cloudflare_lb_primary.py \
@@ -735,7 +738,7 @@ The manual steps below are the same procedure expanded for review.
      --active-origin 193.47.42.213 \
      --passive-origin 185.250.45.54 \
      --confirm
-   unset CLOUDFLARE_API_TOKEN
+   unset CLOUDFLARE_LB_WRITE_TOKEN
    ```
 
    After the switch is verified, revoke/delete that write token. Keep

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -134,7 +134,8 @@ run_postgres_pitr() {
 
 run_cloudflare_lb() {
   local missing=()
-  [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || missing+=("CLOUDFLARE_API_TOKEN")
+  local cloudflare_lb_token="${CLOUDFLARE_API_TOKEN_LB_AUDIT:-${CLOUDFLARE_LB_READ_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}}"
+  [[ -n "${cloudflare_lb_token}" ]] || missing+=("one of CLOUDFLARE_API_TOKEN_LB_AUDIT/CLOUDFLARE_LB_READ_TOKEN/CLOUDFLARE_API_TOKEN")
   [[ -n "${CLOUDFLARE_ZONE_ID:-}" ]] || missing+=("CLOUDFLARE_ZONE_ID")
   [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || missing+=("CLOUDFLARE_ACCOUNT_ID")
   if (( ${#missing[@]} > 0 )); then

--- a/scripts/ha/check_cloudflare_lb_config.py
+++ b/scripts/ha/check_cloudflare_lb_config.py
@@ -6,15 +6,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import shlex
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import Any, Mapping, Sequence
 
 
 API_BASE_URL = "https://api.cloudflare.com/client/v4"
+TOKEN_ENV_NAMES = ("CLOUDFLARE_API_TOKEN_LB_AUDIT", "CLOUDFLARE_LB_READ_TOKEN", "CLOUDFLARE_API_TOKEN")
+CREDENTIAL_ENV_NAMES = {*TOKEN_ENV_NAMES, "CLOUDFLARE_ZONE_ID", "CLOUDFLARE_ACCOUNT_ID"}
 
 
 class AuditFailure(Exception):
@@ -50,6 +55,74 @@ def _normalize_bool(value: str | bool | None, *, default: bool = False) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     raise argparse.ArgumentTypeError(f"expected boolean, got {value!r}")
+
+
+def _clean(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _env(name: str, environ: Mapping[str, str] | None = None) -> str:
+    source = os.environ if environ is None else environ
+    return _clean(source.get(name))
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        return None
+    key, raw_value = line.split("=", 1)
+    key = key.strip().removeprefix("export ").strip()
+    if not key or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+        return None
+    raw_value = raw_value.strip()
+    if raw_value and raw_value[0] in {"'", '"'}:
+        try:
+            parts = shlex.split(f"{key}={raw_value}", posix=True)
+        except ValueError:
+            parts = []
+        if parts and "=" in parts[0]:
+            return key, parts[0].split("=", 1)[1]
+    if " #" in raw_value:
+        raw_value = raw_value.split(" #", 1)[0].rstrip()
+    return key, raw_value
+
+
+def load_env_file(path: Path, *, allowed_names: set[str] = CREDENTIAL_ENV_NAMES) -> None:
+    if not path.exists():
+        raise AuditFailure(f"env file not found: {path}")
+    loaded = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key not in allowed_names:
+            continue
+        if key not in os.environ:
+            os.environ[key] = value
+            loaded += 1
+    _log("ok", f"loaded env file: {path} keys={loaded}")
+
+
+def _first_env_value(names: Sequence[str], environ: Mapping[str, str] | None = None) -> tuple[str, str]:
+    for name in names:
+        value = _env(name, environ)
+        if value:
+            return value, name
+    return "", names[0] if names else ""
+
+
+def collect_credentials(environ: Mapping[str, str] | None = None) -> tuple[str, str, str, str, list[str]]:
+    token, token_source = _first_env_value(TOKEN_ENV_NAMES, environ)
+    zone_id = _env("CLOUDFLARE_ZONE_ID", environ)
+    account_id = _env("CLOUDFLARE_ACCOUNT_ID", environ)
+    missing = []
+    if not token:
+        missing.append("one of " + "/".join(TOKEN_ENV_NAMES))
+    for name, value in (("CLOUDFLARE_ZONE_ID", zone_id), ("CLOUDFLARE_ACCOUNT_ID", account_id)):
+        if not value:
+            missing.append(name)
+    return token, token_source, zone_id, account_id, missing
 
 
 def _api_get(path: str, token: str, params: dict[str, str] | None = None) -> Any:
@@ -365,29 +438,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         default=_normalize_bool(os.getenv("CF_LB_SKIP_IF_MISSING_CREDENTIALS"), default=False),
     )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        help="Load Cloudflare audit credentials from a dotenv file without sourcing it as a shell script.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    token = os.getenv("CLOUDFLARE_API_TOKEN", "").strip()
-    zone_id = os.getenv("CLOUDFLARE_ZONE_ID", "").strip()
-    account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID", "").strip()
-    missing = [
-        name
-        for name, value in (
-            ("CLOUDFLARE_API_TOKEN", token),
-            ("CLOUDFLARE_ZONE_ID", zone_id),
-            ("CLOUDFLARE_ACCOUNT_ID", account_id),
-        )
-        if not value
-    ]
+    if args.env_file:
+        try:
+            load_env_file(args.env_file)
+        except AuditFailure as exc:
+            _log("fail", str(exc))
+            return 1
+
+    token, token_source, zone_id, account_id, missing = collect_credentials()
     if missing:
         message = "missing Cloudflare credentials: " + ", ".join(missing)
         if args.skip_if_missing_credentials:
             _log("skip", message)
             return 0
         raise SystemExit(message)
+    _log("info", f"using token from {token_source}")
 
     config = AuditConfig(
         hostname=args.hostname,

--- a/scripts/ha/switch_cloudflare_lb_primary.py
+++ b/scripts/ha/switch_cloudflare_lb_primary.py
@@ -26,6 +26,7 @@ from scripts.ha.check_cloudflare_lb_config import (  # noqa: E402
     AuditFailure,
     _find_lb,
     _find_pool_by_origin,
+    _first_env_value,
     _id,
     _name,
     _normalize_bool,
@@ -39,6 +40,7 @@ DEFAULT_PRIMARY_ORIGIN = "185.250.45.54"
 DEFAULT_STANDBY_ORIGIN = "193.47.42.213"
 DEFAULT_HOST_HEADER = "api.mvn.by"
 DEFAULT_MONITOR_PATH = "/api/ready"
+WRITE_TOKEN_ENV_NAMES = ("CLOUDFLARE_LB_WRITE_TOKEN", "CLOUDFLARE_API_TOKEN")
 
 
 @dataclass(frozen=True)
@@ -279,21 +281,19 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    token = _clean(os.getenv("CLOUDFLARE_API_TOKEN"))
+    token, token_source = _first_env_value(WRITE_TOKEN_ENV_NAMES)
     zone_id = _clean(os.getenv("CLOUDFLARE_ZONE_ID"))
     account_id = _clean(os.getenv("CLOUDFLARE_ACCOUNT_ID"))
-    missing = [
-        name
-        for name, value in (
-            ("CLOUDFLARE_API_TOKEN", token),
-            ("CLOUDFLARE_ZONE_ID", zone_id),
-            ("CLOUDFLARE_ACCOUNT_ID", account_id),
-        )
-        if not value
-    ]
+    missing = []
+    if not token:
+        missing.append("one of " + "/".join(WRITE_TOKEN_ENV_NAMES))
+    for name, value in (("CLOUDFLARE_ZONE_ID", zone_id), ("CLOUDFLARE_ACCOUNT_ID", account_id)):
+        if not value:
+            missing.append(name)
     if missing:
         log("fail", "missing Cloudflare credentials: " + ", ".join(missing))
         return 1
+    log("info", f"using token from {token_source}")
 
     config = SwitchConfig(
         hostname=args.hostname,

--- a/tests/unit/test_cloudflare_lb_config.py
+++ b/tests/unit/test_cloudflare_lb_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from scripts.ha.check_cloudflare_lb_config import (
@@ -5,6 +7,8 @@ from scripts.ha.check_cloudflare_lb_config import (
     AuditFailure,
     _format_cloudflare_http_error,
     audit_configuration,
+    collect_credentials,
+    load_env_file,
 )
 
 
@@ -155,3 +159,79 @@ def test_audit_configuration_rejects_monitor_path_drift():
             monitors=monitors,
             config=_config(),
         )
+
+
+def test_collect_credentials_prefers_lb_audit_token_over_generic_token():
+    token, token_source, zone_id, account_id, missing = collect_credentials(
+        {
+            "CLOUDFLARE_API_TOKEN_LB_AUDIT": "audit-token",
+            "CLOUDFLARE_LB_READ_TOKEN": "read-token",
+            "CLOUDFLARE_API_TOKEN": "old-generic-token",
+            "CLOUDFLARE_ZONE_ID": "zone",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+        }
+    )
+
+    assert token == "audit-token"
+    assert token_source == "CLOUDFLARE_API_TOKEN_LB_AUDIT"
+    assert zone_id == "zone"
+    assert account_id == "account"
+    assert missing == []
+
+
+def test_collect_credentials_falls_back_to_github_read_token():
+    token, token_source, _, _, missing = collect_credentials(
+        {
+            "CLOUDFLARE_LB_READ_TOKEN": "read-token",
+            "CLOUDFLARE_API_TOKEN": "old-generic-token",
+            "CLOUDFLARE_ZONE_ID": "zone",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+        }
+    )
+
+    assert token == "read-token"
+    assert token_source == "CLOUDFLARE_LB_READ_TOKEN"
+    assert missing == []
+
+
+def test_collect_credentials_reports_all_accepted_token_names_when_token_missing():
+    _, _, _, _, missing = collect_credentials(
+        {
+            "CLOUDFLARE_ZONE_ID": "zone",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+        }
+    )
+
+    assert missing == [
+        "one of CLOUDFLARE_API_TOKEN_LB_AUDIT/CLOUDFLARE_LB_READ_TOKEN/CLOUDFLARE_API_TOKEN"
+    ]
+
+
+def test_load_env_file_reads_only_cloudflare_credentials_without_sourcing(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "CLOUDFLARE_API_TOKEN_LB_AUDIT=audit-token",
+                "CLOUDFLARE_ZONE_ID=zone",
+                "CLOUDFLARE_ACCOUNT_ID=account",
+                "CLIENT_NAME=Дмитрий Иванов",
+                "CACHE_HEADER=max-age=31536000, immutable",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for name in (
+        "CLOUDFLARE_API_TOKEN_LB_AUDIT",
+        "CLOUDFLARE_ZONE_ID",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "CLIENT_NAME",
+        "CACHE_HEADER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    load_env_file(env_file)
+
+    assert collect_credentials()[0] == "audit-token"
+    assert "CLIENT_NAME" not in os.environ
+    assert "CACHE_HEADER" not in os.environ

--- a/tests/unit/test_switch_cloudflare_lb_primary.py
+++ b/tests/unit/test_switch_cloudflare_lb_primary.py
@@ -197,6 +197,25 @@ def test_main_without_confirm_prints_plan_but_does_not_patch(monkeypatch):
     assert calls[0][1]["token"] == "secret-token"
 
 
+def test_main_prefers_explicit_lb_write_token_over_generic_token(monkeypatch):
+    calls = []
+    load_balancers, pools, monitors = _fixtures()
+
+    def fake_fetch(**kwargs):
+        calls.append(("fetch", kwargs))
+        return load_balancers, pools, monitors
+
+    monkeypatch.setenv("CLOUDFLARE_LB_WRITE_TOKEN", "write-token")
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "old-generic-token")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account")
+    monkeypatch.setattr(module, "fetch_cloudflare_config", fake_fetch)
+
+    assert module.main(["--active-origin", "193.47.42.213", "--passive-origin", "185.250.45.54"]) == 0
+
+    assert calls[0][1]["token"] == "write-token"
+
+
 def test_main_with_confirm_patches_minimal_payload(monkeypatch):
     calls = []
     load_balancers, pools, monitors = _fixtures()


### PR DESCRIPTION
## Summary
- prefer the local Cloudflare LB audit token over the old generic token
- add --env-file support for the Cloudflare LB audit without shell-sourcing .env
- use a dedicated CLOUDFLARE_LB_WRITE_TOKEN name for manual LB switching

## Tests
- pytest tests/unit/test_cloudflare_lb_config.py tests/unit/test_switch_cloudflare_lb_primary.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_cloudflare_lb_workflow.py tests/unit/test_api_ha_runbook.py -q
- SSL_CERT_FILE=$(python3 -c 'import certifi; print(certifi.where())') python3 scripts/ha/check_cloudflare_lb_config.py --env-file .env
- python3 scripts/ha/report_ha_status.py --repo mvnby/air-api --require-strict