### PR TITLE
Harden active-passive readiness check

### DIFF
--- a/scripts/ha/check_active_passive.sh
+++ b/scripts/ha/check_active_passive.sh
@@ -10,6 +10,8 @@ STANDBY_ROLE="${STANDBY_ROLE:-standby}"
 CHECK_PUBLIC_READY="${CHECK_PUBLIC_READY:-true}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
+READY_RETRIES="${READY_RETRIES:-3}"
+READY_RETRY_SLEEP="${READY_RETRY_SLEEP:-5}"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
@@ -50,10 +52,14 @@ validate_payload() {
   python3 - "$label" "$file" "$expected_role" "$expected_ready" <<'PY'
 import json
 import sys
+from json import JSONDecodeError
 
 label, path, expected_role, expected_ready = sys.argv[1:5]
-with open(path, "r", encoding="utf-8") as fh:
-    payload = json.load(fh)
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+except (OSError, JSONDecodeError) as exc:
+    raise SystemExit(f"{label}: response is not valid readiness JSON: {exc}") from exc
 
 role = payload.get("app_role")
 if role != expected_role:
@@ -76,39 +82,87 @@ print(f"{label}: role={role} api={api_state} traffic={traffic}")
 PY
 }
 
+print_response_excerpt() {
+  local label="$1"
+  local file="$2"
+  if [[ ! -s "${file}" ]]; then
+    log "${label} response body is empty"
+    return
+  fi
+  log "${label} response body excerpt:"
+  head -c 500 "${file}" >&2 || true
+  printf '\n' >&2
+}
+
+check_ready_with_retries() {
+  local label="$1"
+  local url="$2"
+  local output_file="$3"
+  local expected_role="$4"
+  local expected_ready="$5"
+  shift 5
+
+  local attempt code
+  for attempt in $(seq 1 "${READY_RETRIES}"); do
+    if code="$(curl_json "${label}" "${url}" "${output_file}" "$@")"; then
+      printf '\n'
+    else
+      code="curl_failed"
+      printf '\n'
+    fi
+
+    if [[ "${expected_ready}" == "ready" ]]; then
+      if [[ "${code}" == "200" ]] && validate_payload "${label}" "${output_file}" "${expected_role}" ready; then
+        return 0
+      fi
+      log "${label} attempt ${attempt}/${READY_RETRIES} failed: expected HTTP 200 with ready JSON, got ${code}"
+    else
+      if [[ "${code}" == "200" ]]; then
+        log "${label} returned HTTP 200; split-brain risk"
+        print_response_excerpt "${label}" "${output_file}"
+        exit 1
+      fi
+      if validate_payload "${label}" "${output_file}" "${expected_role}" not_ready; then
+        return 0
+      fi
+      log "${label} attempt ${attempt}/${READY_RETRIES} failed: expected fenced standby JSON with non-200 HTTP, got ${code}"
+    fi
+
+    print_response_excerpt "${label}" "${output_file}"
+    if (( attempt < READY_RETRIES )); then
+      log "${label} retrying in ${READY_RETRY_SLEEP}s"
+      sleep "${READY_RETRY_SLEEP}"
+    fi
+  done
+
+  log "${label} failed after ${READY_RETRIES} attempts"
+  return 1
+}
+
 public_file="${TMP_DIR}/public-ready.json"
 primary_file="${TMP_DIR}/primary-ready.json"
 standby_file="${TMP_DIR}/standby-ready.json"
 
 if is_true "${CHECK_PUBLIC_READY}"; then
-  public_code="$(curl_json "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}")"
-  printf '\n'
-  if [[ "${public_code}" != "200" ]]; then
-    log "public /api/ready expected HTTP 200, got ${public_code}"
-    cat "${public_file}" || true
-    exit 1
-  fi
-  validate_payload "public" "${public_file}" "${PRIMARY_ROLE}" ready
+  check_ready_with_retries "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}" "${PRIMARY_ROLE}" ready
 else
   log "public ready check skipped"
 fi
 
-primary_code="$(curl_json "primary direct ready" "https://${API_HOST}/api/ready" "${primary_file}" --resolve "${API_HOST}:443:${PRIMARY_ORIGIN}")"
-printf '\n'
-if [[ "${primary_code}" != "200" ]]; then
-  log "primary direct /api/ready expected HTTP 200, got ${primary_code}"
-  cat "${primary_file}" || true
-  exit 1
-fi
-validate_payload "primary" "${primary_file}" "${PRIMARY_ROLE}" ready
+check_ready_with_retries \
+  "primary direct ready" \
+  "https://${API_HOST}/api/ready" \
+  "${primary_file}" \
+  "${PRIMARY_ROLE}" \
+  ready \
+  --resolve "${API_HOST}:443:${PRIMARY_ORIGIN}"
 
-standby_code="$(curl_json "standby direct ready" "https://${API_HOST}/api/ready" "${standby_file}" --resolve "${API_HOST}:443:${STANDBY_ORIGIN}")"
-printf '\n'
-if [[ "${standby_code}" == "200" ]]; then
-  log "standby direct /api/ready returned HTTP 200; split-brain risk"
-  cat "${standby_file}" || true
-  exit 1
-fi
-validate_payload "standby" "${standby_file}" "${STANDBY_ROLE}" not_ready
+check_ready_with_retries \
+  "standby direct ready" \
+  "https://${API_HOST}/api/ready" \
+  "${standby_file}" \
+  "${STANDBY_ROLE}" \
+  not_ready \
+  --resolve "${API_HOST}:443:${STANDBY_ORIGIN}"
 
 log "active-passive invariant passed: primary ready, standby fenced"

--- a/tests/unit/test_active_passive_script.py
+++ b/tests/unit/test_active_passive_script.py
@@ -1,0 +1,115 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/ha/check_active_passive.sh")
+
+
+def _write_fake_curl(tmp_path: Path, body: str) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_curl = bin_dir / "curl"
+    fake_curl.write_text(body, encoding="utf-8")
+    fake_curl.chmod(0o755)
+    return bin_dir
+
+
+def _run_check(tmp_path: Path, fake_curl_body: str) -> subprocess.CompletedProcess[str]:
+    bin_dir = _write_fake_curl(tmp_path, fake_curl_body)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "CHECK_PUBLIC_READY": "false",
+            "READY_RETRIES": "2",
+            "READY_RETRY_SLEEP": "0",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_active_passive_retries_transient_invalid_standby_response(tmp_path):
+    state_file = tmp_path / "standby-count"
+    fake_curl = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        output=""
+        args=("$@")
+        for ((i=0; i<$#; i++)); do
+          if [[ "${{args[$i]}}" == "-o" ]]; then
+            output="${{args[$((i + 1))]}}"
+          fi
+        done
+        joined=" $* "
+        if [[ "${{joined}}" == *"193.47.42.213"* ]]; then
+          count=0
+          if [[ -f "{state_file}" ]]; then
+            count="$(cat "{state_file}")"
+          fi
+          count=$((count + 1))
+          printf '%s' "${{count}}" > "{state_file}"
+          if (( count == 1 )); then
+            printf '<html>restarting</html>' > "${{output}}"
+            printf '503'
+            exit 0
+          fi
+          printf '{{"app_role":"standby","api":"not_ready","traffic":"disabled"}}' > "${{output}}"
+          printf '503'
+          exit 0
+        fi
+        printf '{{"status":"ok","app_role":"primary","api":"ready","traffic":"enabled","database":"online","database_writable":true}}' > "${{output}}"
+        printf '200'
+        """
+    )
+
+    result = _run_check(tmp_path, fake_curl)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "standby direct ready retrying" in result.stderr
+    assert state_file.read_text(encoding="utf-8") == "2"
+
+
+def test_active_passive_fails_immediately_when_standby_returns_http_200(tmp_path):
+    state_file = tmp_path / "standby-count"
+    fake_curl = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        output=""
+        args=("$@")
+        for ((i=0; i<$#; i++)); do
+          if [[ "${{args[$i]}}" == "-o" ]]; then
+            output="${{args[$((i + 1))]}}"
+          fi
+        done
+        joined=" $* "
+        if [[ "${{joined}}" == *"193.47.42.213"* ]]; then
+          count=0
+          if [[ -f "{state_file}" ]]; then
+            count="$(cat "{state_file}")"
+          fi
+          count=$((count + 1))
+          printf '%s' "${{count}}" > "{state_file}"
+          printf '{{"status":"ok","app_role":"standby","api":"ready","traffic":"enabled","database":"online","database_writable":true}}' > "${{output}}"
+          printf '200'
+          exit 0
+        fi
+        printf '{{"status":"ok","app_role":"primary","api":"ready","traffic":"enabled","database":"online","database_writable":true}}' > "${{output}}"
+        printf '200'
+        """
+    )
+
+    result = _run_check(tmp_path, fake_curl)
+
+    assert result.returncode == 1
+    assert "split-brain risk" in result.stderr
+    assert state_file.read_text(encoding="utf-8") == "1"


### PR DESCRIPTION
## Summary
- retry readiness probes for transient non-JSON/non-ready responses during deploy windows
- keep standby HTTP 200 as an immediate split-brain failure with no retry
- replace raw JSON parser tracebacks with clear response excerpts

## Context
The scheduled API HA readiness audit hit standby while it was being redeployed and failed on a transient non-JSON /api/ready response. Deploy's post-standby invariant passed immediately after, so this hardens the monitor without weakening split-brain detection.

## Tests
- pytest tests/unit/test_active_passive_script.py tests/unit/test_ha_status_report.py tests/unit/test_deploy_workflow.py tests/unit/test_ha_readiness_workflow.py -q
- bash -n scripts/ha/check_active_passive.sh
- bash scripts/ha/check_active_passive.sh
- local strict scripts/ha/check_api_ha_readiness.sh with Cloudflare audit token