### PR TITLE
[codex] Surface MDV media storage import failures

### DIFF
--- a/parsers/mdv_catalog.py
+++ b/parsers/mdv_catalog.py
@@ -131,6 +131,7 @@ class MdvCatalogParser(BaseParser):
             "main_image": self._absolute_url(item.get("PREVIEW_PICTURE") or item.get("DETAIL_PICTURE")),
             "images": images,
             "save_gallery": True,
+            "require_media_download": True,
             "categories": [],
             "specs": specs,
             "metrics": {

--- a/scripts/check_media_storage_config.py
+++ b/scripts/check_media_storage_config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,6 +23,7 @@ from services.media_storage_service import (
 
 OBJECT_STORAGE_PROVIDERS = {"r2", "s3", "s3_compatible"}
 SAMPLE_HASH = "a" * 64
+WRITE_PROBE_CONTENT = b"mvn-media-storage-write-probe\n"
 
 
 @dataclass(frozen=True)
@@ -106,6 +108,60 @@ def validate_checks(
     return failures
 
 
+async def run_write_probe() -> list[str]:
+    failures: list[str] = []
+    probes = [
+        (
+            "general_media",
+            get_general_media_storage(require_write=True).save_media(
+                content=WRITE_PROBE_CONTENT,
+                namespace="diagnostics/media-storage",
+                variant_type="probe",
+                extension="txt",
+                content_type="text/plain",
+            ),
+        ),
+        (
+            "product_variants",
+            get_product_media_storage(require_write=True).save_product_variant(
+                content=WRITE_PROBE_CONTENT,
+                variant_type="diagnostics",
+                extension="txt",
+            ),
+        ),
+        (
+            "product_originals",
+            get_product_original_source_storage().save_product_original(
+                content=WRITE_PROBE_CONTENT,
+                extension="txt",
+            ),
+        ),
+    ]
+    for label, awaitable in probes:
+        try:
+            stored = await awaitable
+        except Exception as exc:
+            failures.append(f"{label}: {type(exc).__name__}: {exc}")
+            print(
+                "media_storage_write_probe "
+                f"label={label} "
+                "status=failed "
+                f"error_type={type(exc).__name__} "
+                f"error={exc}",
+                file=sys.stderr,
+            )
+            continue
+        print(
+            "media_storage_write_probe "
+            f"label={label} "
+            "status=passed "
+            f"provider={stored.storage_provider} "
+            f"url={stored.url} "
+            f"path={stored.path}"
+        )
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate configured media storage providers and public target URLs."
@@ -119,6 +175,11 @@ def main(argv: list[str] | None = None) -> int:
         "--expected-public-base-url",
         default="",
         help="Optional expected public URL prefix, for example https://cdn.mvn.by.",
+    )
+    parser.add_argument(
+        "--write-probe",
+        action="store_true",
+        help="Also try writing one small diagnostic object through each storage adapter.",
     )
     args = parser.parse_args(argv)
 
@@ -149,6 +210,11 @@ def main(argv: list[str] | None = None) -> int:
         for failure in failures:
             print(f"media_storage_config_failure={failure}", file=sys.stderr)
         return 1
+
+    if args.write_probe:
+        write_failures = asyncio.run(run_write_probe())
+        if write_failures:
+            return 1
 
     print("media_storage_config_status=passed")
     return 0

--- a/services/import_media_service.py
+++ b/services/import_media_service.py
@@ -81,6 +81,7 @@ class ImportMediaService:
         *,
         source_url: str,
         source_storage: ProductOriginalSourceStorage | None = None,
+        raise_on_error: bool = False,
     ) -> Optional[str]:
         normalized_url = ImportMediaService.normalize_source_url(source_url)
         if not normalized_url:
@@ -96,6 +97,10 @@ class ImportMediaService:
             session.add(existing)
             return existing.local_url
 
+        def fail(message: str, exc: Exception | None = None) -> None:
+            if raise_on_error:
+                raise RuntimeError(message) from exc
+
         try:
             parts = urlsplit(normalized_url)
             verify_tls = not parts.netloc.endswith("mdv-aircond.ru")
@@ -108,6 +113,7 @@ class ImportMediaService:
                 response = await client.get(normalized_url)
         except Exception as exc:
             logger.warning("Import image download failed for %s: %s", normalized_url, exc)
+            fail(f"Import image download failed for {normalized_url}: {exc}", exc)
             return None
 
         if response.status_code != 200:
@@ -115,6 +121,10 @@ class ImportMediaService:
                 "Import image download failed for %s: status=%s",
                 normalized_url,
                 response.status_code,
+            )
+            fail(
+                f"Import image download failed for {normalized_url}: "
+                f"status={response.status_code}"
             )
             return None
 
@@ -125,6 +135,7 @@ class ImportMediaService:
             )
         except Exception as exc:
             logger.warning("Import image processing failed for %s: %s", normalized_url, exc)
+            fail(f"Import image processing failed for {normalized_url}: {exc}", exc)
             return None
 
         resolved_url = ImportMediaService.normalize_source_url(str(response.url))

--- a/services/importer_service.py
+++ b/services/importer_service.py
@@ -51,6 +51,17 @@ def _augment_auto_slugs_with_wifi_specs(auto_slugs: List[str], specs: dict) -> L
     return result
 
 
+def _should_replace_imported_main_image(existing_url: str | None) -> bool:
+    current = str(existing_url or "").strip()
+    if not current:
+        return True
+    if current.startswith("/media/") or current.startswith("media/"):
+        return False
+    if current.startswith("https://cdn.mvn.by/"):
+        return False
+    return current.startswith(("http://", "https://"))
+
+
 async def _normalize_import_price_to_byn(session, *, data: dict, source_url: str) -> None:
     """Convert source price to BYN if parser reports foreign currency."""
     raw_price = data.get("price")
@@ -334,10 +345,12 @@ class ImporterService:
             # Main Image
             main_image_url = data.get('main_image')
             local_main_image = None
+            require_media_download = bool(data.get("require_media_download"))
             if main_image_url:
                 local_main_image = await ImportMediaService.resolve_or_download(
                     session,
                     source_url=main_image_url,
+                    raise_on_error=require_media_download,
                 )
             
             # --- Gallery images ---
@@ -361,7 +374,7 @@ class ImporterService:
                 existing.source_url = canonical_source_url
                 if data.get("publish_on_update"):
                     existing.is_published = True
-                if local_main_image and not existing.main_image:
+                if local_main_image and _should_replace_imported_main_image(existing.main_image):
                     existing.main_image = local_main_image
 
                 # Preserve manual tags, but append newly inferred auto-tags.
@@ -426,6 +439,7 @@ class ImporterService:
                         local_path = await ImportMediaService.resolve_or_download(
                             session,
                             source_url=img_url,
+                            raise_on_error=require_media_download,
                         )
                         if local_path and local_path not in existing_gallery_urls:
                             pi = ProductImage(

--- a/tests/unit/test_import_media_service.py
+++ b/tests/unit/test_import_media_service.py
@@ -61,6 +61,16 @@ class _FakeOriginalSourceStorage:
         )
 
 
+class _FailingOriginalSourceStorage(_FakeOriginalSourceStorage):
+    async def save_product_original(
+        self,
+        *,
+        content: bytes,
+        extension: str = "webp",
+    ) -> StoredMediaObject:
+        raise RuntimeError("PutObject Unauthorized")
+
+
 @pytest.fixture
 async def sqlite_session(tmp_path: Path):
     db_path = tmp_path / "import_media_test.db"
@@ -216,3 +226,68 @@ async def test_import_media_service_writes_download_through_original_source_stor
         )
     ).scalar_one()
     assert cache_row.local_url == first
+
+
+@pytest.mark.asyncio
+async def test_import_media_service_can_raise_on_download_status(
+    sqlite_session,
+    monkeypatch,
+):
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            return _FakeResponse(
+                status_code=403,
+                content=b"",
+                url=url,
+            )
+
+    monkeypatch.setattr("services.import_media_service.httpx.AsyncClient", _FakeClient)
+
+    with pytest.raises(RuntimeError, match="status=403"):
+        await ImportMediaService.resolve_or_download(
+            sqlite_session,
+            source_url="https://example.com/forbidden.png",
+            raise_on_error=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_import_media_service_can_raise_on_storage_error(
+    sqlite_session,
+    monkeypatch,
+):
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            return _FakeResponse(
+                status_code=200,
+                content=_png_bytes((120, 80, 20)),
+                url=url,
+            )
+
+    monkeypatch.setattr("services.import_media_service.httpx.AsyncClient", _FakeClient)
+
+    with pytest.raises(RuntimeError, match="PutObject Unauthorized"):
+        await ImportMediaService.resolve_or_download(
+            sqlite_session,
+            source_url="https://example.com/r2-error.png",
+            source_storage=_FailingOriginalSourceStorage(),
+            raise_on_error=True,
+        )

--- a/tests/unit/test_importer_service_media_and_manuals.py
+++ b/tests/unit/test_importer_service_media_and_manuals.py
@@ -9,7 +9,7 @@ from sqlmodel import SQLModel
 from sqlmodel import select
 
 from models import ImportMediaCache, Product, ProductAttachment
-from services.importer_service import ImporterService
+from services.importer_service import ImporterService, _should_replace_imported_main_image
 
 
 def _png_bytes(color=(40, 80, 160)) -> bytes:
@@ -17,6 +17,16 @@ def _png_bytes(color=(40, 80, 160)) -> bytes:
     output = BytesIO()
     image.save(output, format="PNG")
     return output.getvalue()
+
+
+def test_importer_replaces_only_empty_or_remote_main_images():
+    assert _should_replace_imported_main_image(None) is True
+    assert _should_replace_imported_main_image("") is True
+    assert _should_replace_imported_main_image("https://mdv-aircond.ru/upload/source.png") is True
+    assert _should_replace_imported_main_image("https://example.com/source.png") is True
+    assert _should_replace_imported_main_image("/media/products/shared/source.webp") is False
+    assert _should_replace_imported_main_image("media/products/shared/source.webp") is False
+    assert _should_replace_imported_main_image("https://cdn.mvn.by/products/shared/source.webp") is False
 
 
 class _FakeResponse:
@@ -138,3 +148,58 @@ async def test_importer_saves_manuals_and_reuses_image_cache_on_update(sqlite_se
 
     cache_rows = (await sqlite_session.execute(select(ImportMediaCache))).scalars().all()
     assert len(cache_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_importer_propagates_required_media_errors(sqlite_session, monkeypatch):
+    calls = []
+
+    class _FakeParser:
+        async def parse(self, url):  # noqa: ARG002
+            return {
+                "title": "MDV Required Media",
+                "slug": "mdv-required-media",
+                "description": "Test description",
+                "price": 1234,
+                "area": 25,
+                "main_image": "https://mdv-aircond.ru/upload/required.png",
+                "images": [],
+                "save_gallery": True,
+                "require_media_download": True,
+                "categories": [],
+                "specs": {"brand": "MDV", "type": "сплит-система"},
+                "metrics": {"area": 25, "is_inverter": True, "power_cooling": 2.6},
+                "related_urls": [],
+            }
+
+    async def fake_resolve_or_download(*args, **kwargs):  # noqa: ARG001
+        calls.append(kwargs)
+        raise RuntimeError("PutObject Unauthorized")
+
+    monkeypatch.setattr(
+        "services.importer_service.async_session_maker",
+        lambda: _FakeSessionContext(sqlite_session),
+    )
+    monkeypatch.setattr(
+        "services.importer_service.ImportMediaService.resolve_or_download",
+        fake_resolve_or_download,
+    )
+
+    service = ImporterService()
+    service.get_parser = lambda url: _FakeParser()  # noqa: ARG005
+
+    with pytest.raises(RuntimeError, match="PutObject Unauthorized"):
+        await service.import_product(
+            "https://mdv-aircond.ru/catalog/test",
+            update_existing=False,
+            collect_related=False,
+        )
+
+    assert calls
+    assert calls[0]["raise_on_error"] is True
+    product = (
+        await sqlite_session.execute(
+            select(Product).where(Product.slug == "mdv-required-media")
+        )
+    ).scalar_one_or_none()
+    assert product is None

--- a/tests/unit/test_mdv_catalog_parser.py
+++ b/tests/unit/test_mdv_catalog_parser.py
@@ -144,6 +144,7 @@ async def test_mdv_catalog_parses_household_product_with_gallery_and_manuals(mon
     assert data["price"] == 46300
     assert data["price_currency"] == "RUB"
     assert data["main_image"] == "https://mdv-aircond.ru/upload/main-household.png"
+    assert data["require_media_download"] is True
     assert data["images"] == [
         "https://mdv-aircond.ru/upload/gallery-a.png",
         "https://mdv-aircond.ru/upload/gallery-b.png",


### PR DESCRIPTION
## Summary
- make MDV imports require media downloads so R2/storage failures surface as job errors instead of silent products without images
- preserve local/CDN main images on update, but replace empty or external main images with downloaded copies
- add an optional media storage write probe for diagnosing R2 PutObject permissions

## RCA
Production MDV images download from `mdv-aircond.ru` successfully, but every R2 `PutObject` currently returns `Unauthorized`. The previous importer swallowed that and still counted products as successful, leaving `main_image` empty and no `import_media_cache` rows.

## Tests
- `python3 -m py_compile services/import_media_service.py services/importer_service.py parsers/mdv_catalog.py scripts/check_media_storage_config.py`
- `pytest tests/unit/test_import_media_service.py tests/unit/test_importer_service_media_and_manuals.py tests/unit/test_mdv_catalog_parser.py -q`

## Prod follow-up
After deploy and R2 credentials/permissions are fixed, rerun the MDV import. Existing MDV products with empty or external main images will receive downloaded media; local/CDN images will be preserved.