### PR TITLE
[codex] Fix MDV RAC multi component mapping

### DIFF
--- a/services/supplier_match_service.py
+++ b/services/supplier_match_service.py
@@ -486,14 +486,22 @@ def _product_catalog_category(product: dict[str, Any]) -> str | None:
     title = _normalize_text(product.get("title"))
     combined = f"{system_type} {indoor_type} {title}"
 
-    if "полупром" in combined or any(
-        marker in combined for marker in ("кассет", "каналь", "колонн", "напольно", "потолоч")
-    ):
-        return "semi"
     if "мульти" in combined:
         return "multi"
     if any(marker in system_type for marker in _INDOOR_MARKERS + _OUTDOOR_MARKERS):
         return "multi"
+    component_title = (
+        "блок" in title
+        and any(marker in title for marker in _INDOOR_MARKERS + _OUTDOOR_MARKERS)
+        and "сплит" not in title
+        and "система" not in title
+    )
+    if component_title:
+        return "multi"
+    if "полупром" in combined or any(
+        marker in combined for marker in ("кассет", "каналь", "колонн", "напольно", "потолоч")
+    ):
+        return "semi"
     if "сплит" in system_type:
         return "household"
     return None

--- a/tests/unit/test_supplier_mapping_v2.py
+++ b/tests/unit/test_supplier_mapping_v2.py
@@ -4,6 +4,8 @@ from models.product import Product
 from models.supplier import Supplier, SupplierOffer, SupplierPriceSource
 from services.supplier_mapping_service import SupplierCatalogService
 from services.supplier_match_service import (
+    _product_catalog_category,
+    _score_candidate,
     build_offer_match_profile,
     normalize_offer_title_for_search,
     suggest_products_for_offer,
@@ -64,6 +66,76 @@ def test_build_offer_match_profile_extracts_model_tokens(raw, expected_tokens, e
         assert token in profile.indoor_model_tokens
     for token in expected_outdoor:
         assert token in profile.outdoor_model_tokens
+
+
+def test_product_catalog_category_keeps_multi_component_blocks_after_sanitized_specs():
+    assert (
+        _product_catalog_category(
+            {
+                "title": "Внутренний кассетный блок MDV MDCAC4I-12HRFN8",
+                "specs": {"type": "внутренний блок", "indoor_type": "кассетный"},
+            }
+        )
+        == "multi"
+    )
+    assert (
+        _product_catalog_category(
+            {
+                "title": "Наружный блок MDV MD2O-18HFN8",
+                "specs": {"type": "наружный блок"},
+            }
+        )
+        == "multi"
+    )
+    assert (
+        _product_catalog_category(
+            {
+                "title": "MDV Инверторные кассетные сплит-системы MDCAC4I-12HRFN8/MDOU3-12HN1-L",
+                "specs": {"type": "полупромышленный кондиционер", "indoor_type": "кассетный"},
+            }
+        )
+        == "semi"
+    )
+
+
+def test_mdv_rac_component_score_prefers_multi_block_over_semi_shape():
+    offer_profile = build_offer_match_profile("Внутренний блок MDCAC4I-12HRFN8")
+
+    multi_candidate = _score_candidate(
+        offer_profile=offer_profile,
+        product={
+            "id": 1,
+            "title": "Внутренний кассетный блок MDV MDCAC4I MDCAC4I-12HRFN8",
+            "price": 1000,
+            "specs": {
+                "type": "внутренний блок",
+                "indoor_type": "кассетный",
+                "model_indoor": "MDCAC4I-12HRFN8",
+            },
+        },
+        offer_catalog_categories={"multi"},
+        offer_rrc=1000,
+    )
+    semi_candidate = _score_candidate(
+        offer_profile=offer_profile,
+        product={
+            "id": 2,
+            "title": "MDV Инверторные кассетные сплит-системы MDCAC4I-12HRFN8/MDOU3-12HN1-L",
+            "price": 1000,
+            "specs": {
+                "type": "полупромышленный кондиционер",
+                "indoor_type": "кассетный",
+                "model_indoor": "MDCAC4I-12HRFN8",
+                "model_outdoor": "MDOU3-12HN1-L",
+            },
+        },
+        offer_catalog_categories={"multi"},
+        offer_rrc=1000,
+    )
+
+    assert multi_candidate["score_breakdown"]["catalog_context"] == 18
+    assert semi_candidate["score_breakdown"]["catalog_mismatch"] == -34
+    assert multi_candidate["score"] - semi_candidate["score"] >= 50
 
 
 @pytest.mark.asyncio
@@ -202,3 +274,79 @@ async def test_mdv_rac_context_prefers_household_system_over_multi_component(db)
     assert result["candidates"][0]["score_breakdown"]["catalog_context"] == 18
     multi_candidate = next(item for item in result["candidates"] if item["product_id"] == multi_indoor.id)
     assert multi_candidate["score_breakdown"]["catalog_mismatch"] == -34
+
+
+@pytest.mark.asyncio
+async def test_mdv_rac_component_context_prefers_multi_component_over_semi_shape(db):
+    supplier = Supplier(name="Биоконд", code="biokond", priority=1)
+    db.add(supplier)
+    await db.commit()
+    await db.refresh(supplier)
+
+    source = SupplierPriceSource(
+        supplier_id=supplier.id,
+        sheet_name="MDV RAC",
+        col_title="C",
+        col_wholesale="F",
+        col_wholesale_currency="USD",
+        col_rrc_byn="G",
+        col_qty="H",
+    )
+    db.add(source)
+    await db.commit()
+    await db.refresh(source)
+
+    multi_indoor = Product(
+        title="Внутренний кассетный блок MDV MDCAC4I MDCAC4I-12HRFN8",
+        slug="mdv-multi-cassette-indoor-12",
+        price=1000,
+        specs={
+            "__mdv_catalog": "multi",
+            "type": "внутренний блок",
+            "indoor_type": "кассетный",
+            "model_indoor": "MDCAC4I-12HRFN8",
+        },
+    )
+    semi_system = Product(
+        title="MDV Инверторные кассетные сплит-системы MDCAC4I-12HRFN8/MDOU3-12HN1-L",
+        slug="mdv-semi-cassette-system-12",
+        price=1000,
+        specs={
+            "type": "полупромышленный кондиционер",
+            "indoor_type": "кассетный",
+            "model_indoor": "MDCAC4I-12HRFN8",
+            "model_outdoor": "MDOU3-12HN1-L",
+        },
+    )
+    db.add_all([multi_indoor, semi_system])
+    await db.commit()
+    await db.refresh(multi_indoor)
+    await db.refresh(semi_system)
+
+    offer = SupplierOffer(
+        supplier_id=supplier.id,
+        source_id=source.id,
+        external_id="MDCAC4I-12HRFN8",
+        title_raw="Внутренний блок MDCAC4I-12HRFN8",
+        title_normalized="внутренний блок mdcac4i-12hrfn8",
+        model_tokens=["MDCAC4I-12HRFN8"],
+        indoor_model_tokens=["MDCAC4I-12HRFN8"],
+        rrc_byn=1000,
+        is_active=True,
+    )
+    db.add(offer)
+    await db.commit()
+    await db.refresh(offer)
+
+    result = await suggest_products_for_offer(
+        db,
+        title_raw=offer.title_raw,
+        offer=offer,
+        limit=5,
+    )
+
+    assert result["auto_eligible"] is True
+    assert result["candidates"][0]["product_id"] == multi_indoor.id
+    assert result["candidates"][0]["score_breakdown"]["catalog_context"] == 18
+    semi_candidate = next(item for item in result["candidates"] if item["product_id"] == semi_system.id)
+    assert semi_candidate["score_breakdown"]["catalog_mismatch"] == -34


### PR DESCRIPTION
## What changed
- Treat MDV RAC rows with `внутренний блок` / `наружный блок` as multi-split component context before cassette/duct/semi shape heuristics.
- Keep full semi systems classified as semi.
- Add regression coverage for sanitized MDV specs where `__mdv_catalog` is not present in search payloads.

## Why
Biocond `MDV RAC` now includes multi-split indoor/outdoor blocks. After product specs are sanitized, a multi component like `Внутренний кассетный блок` could be scored as semi because `кассетный` was checked before the component role.

## Checks
- `python3 -m py_compile services/supplier_match_service.py tests/unit/test_supplier_mapping_v2.py`
- `pytest tests/unit/test_supplier_mapping_v2.py -q -k "product_catalog or component_score or build_offer or normalize_offer"`

Full local DB-backed test file could not run because local test Postgres on `localhost:5433` is not available in this environment; CI should run it with the test database.
