### PR TITLE
[codex] Structure repair defect act drafts

### DIFF
--- a/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
+++ b/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
@@ -14,6 +14,9 @@ export type ManagerRepairActAiDraftPayload = {
     customer_complaint?: (string | null);
     complaint_official?: (string | null);
     likely_diagnosis?: (string | null);
+    diagnostic_notes?: (string | null);
+    refrigerant_type?: (string | null);
+    refrigerant_amount?: (string | null);
     extra_context?: (string | null);
     current_meta?: Record<string, any>;
 };

--- a/manager_frontend/src/client/models/ManagerRepairActAiDraftResponse.ts
+++ b/manager_frontend/src/client/models/ManagerRepairActAiDraftResponse.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ManagerRepairActAiDraftResponse = {
-    repair_meta?: Record<string, string>;
+    repair_meta?: Record<string, any>;
     provider?: string;
     model: string;
     prompt_version?: string;

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -29,6 +29,20 @@ import type {
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
 import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
+import {
+  CUSTOMER_APPROVAL_STATUS_OPTIONS,
+  EQUIPMENT_EVENT_OPTIONS,
+  PARTS_STATUS_OPTIONS,
+  REFRIGERANT_PRICING_MODE_OPTIONS,
+  REPAIR_AI_DEFECT_TYPES,
+  REPAIR_CHOICE_OPTIONS,
+  REPAIR_WORKFLOW_STATUS_OPTIONS,
+  emptyRepairMeta,
+  labeledOptionsWithCurrent,
+  normalizeRepairMeta,
+  selectOptionsWithCurrent,
+  type RepairMeta,
+} from './repair-meta';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
@@ -90,242 +104,12 @@ type ProductLine = {
 };
 type ServiceLine = { service_id?: number | null; title: string; quantity: number; price: number; cost: number };
 type OrderWorkflowType = 'sales_installation' | 'service_work' | 'maintenance' | 'repair';
-type RepairMeta = {
-  repair_status: string;
-  customer_approval_status: string;
-  customer_approval_note: string;
-  parts_status: string;
-  parts_note: string;
-  repair_completion_note: string;
-  customer_complaint: string;
-  complaint_official: string;
-  complaint_text?: string;
-  likely_diagnosis: string;
-  equipment_name: string;
-  equipment_brand: string;
-  equipment_model: string;
-  equipment_power: string;
-  equipment_serial_number: string;
-  equipment_inventory_number: string;
-  equipment_commissioning_date: string;
-  technical_condition: string;
-  startup_check_result: string;
-  compressor_check_result: string;
-  measurement_result: string;
-  diagnostic_result: string;
-  further_use_assessment: string;
-  operation_restrictions: string;
-  technical_conclusion: string;
-  repair_feasibility: string;
-  recommended_decision: string;
-  repair_recommendation: string;
-  repair_possible: string;
-  refrigerant_type: string;
-  refrigerant_amount: string;
-  refrigerant_pricing_mode: string;
-  repair_not_viable: string;
-  repair_not_viable_reason: string;
-};
-type RepairAiDefectType = {
-  value: string;
-  label: string;
-  hint: string;
-};
 
 const WORKFLOW_OPTIONS: Array<{ value: OrderWorkflowType; label: string; hint: string; icon: string }> = [
   { value: 'sales_installation', label: 'Продажа + монтаж', hint: 'товары, КП, монтаж', icon: 'shopping_cart' },
   { value: 'service_work', label: 'Работы', hint: 'монтаж, демонтаж, трассы', icon: 'construction' },
   { value: 'maintenance', label: 'Обслуживание', hint: 'ТО и сервисные договоры', icon: 'ac_unit' },
   { value: 'repair', label: 'Ремонт', hint: 'диагностика и дефектный акт', icon: 'build_circle' },
-];
-
-const REPAIR_WORKFLOW_STATUS_OPTIONS = [
-  { value: 'new', label: 'Новая' },
-  { value: 'scheduled', label: 'Запланирован' },
-  { value: 'diagnostic_in_progress', label: 'Диагностика идет' },
-  { value: 'awaiting_diagnostic_result', label: 'Ждем диагностику' },
-  { value: 'awaiting_customer_approval', label: 'На согласовании' },
-  { value: 'approved_for_repair', label: 'Ремонт согласован' },
-  { value: 'repair_in_progress', label: 'Ремонт идет' },
-  { value: 'awaiting_parts', label: 'Ждем запчасти' },
-  { value: 'completed', label: 'Завершен' },
-  { value: 'not_repairable', label: 'Не ремонтируется' },
-  { value: 'cancelled', label: 'Отменен' },
-];
-const REPAIR_WORKFLOW_STATUS_VALUES = new Set(REPAIR_WORKFLOW_STATUS_OPTIONS.map((item) => item.value));
-
-const CUSTOMER_APPROVAL_STATUS_OPTIONS = [
-  { value: '', label: 'Не указано' },
-  { value: 'pending', label: 'Ожидает согласования' },
-  { value: 'approved', label: 'Согласовано' },
-  { value: 'rejected', label: 'Отказано' },
-];
-
-const PARTS_STATUS_OPTIONS = [
-  { value: '', label: 'Не указано' },
-  { value: 'not_required', label: 'Не требуются' },
-  { value: 'awaiting', label: 'Ожидаются' },
-  { value: 'ordered', label: 'Заказаны' },
-  { value: 'received', label: 'Получены' },
-  { value: 'installed', label: 'Установлены' },
-];
-
-const emptyRepairMeta = (): RepairMeta => ({
-  repair_status: '',
-  customer_approval_status: '',
-  customer_approval_note: '',
-  parts_status: '',
-  parts_note: '',
-  repair_completion_note: '',
-  customer_complaint: '',
-  complaint_official: '',
-  likely_diagnosis: '',
-  equipment_name: '',
-  equipment_brand: '',
-  equipment_model: '',
-  equipment_power: '',
-  equipment_serial_number: '',
-  equipment_inventory_number: '',
-  equipment_commissioning_date: '',
-  technical_condition: '',
-  startup_check_result: '',
-  compressor_check_result: '',
-  measurement_result: '',
-  diagnostic_result: '',
-  further_use_assessment: '',
-  operation_restrictions: '',
-  technical_conclusion: '',
-  repair_feasibility: '',
-  recommended_decision: '',
-  repair_recommendation: '',
-  repair_possible: '',
-  refrigerant_type: '',
-  refrigerant_amount: '',
-  refrigerant_pricing_mode: '',
-  repair_not_viable: '',
-  repair_not_viable_reason: '',
-});
-
-const REPAIR_CHOICE_OPTIONS = ['', 'Да', 'Нет'];
-const REFRIGERANT_PRICING_MODE_OPTIONS = [
-  'по фактической массе',
-  'включен в стоимость ремонта',
-  'отдельной строкой сметы',
-  'не требуется',
-];
-const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
-  { value: 'diagnostic', label: 'Диагностика' },
-  { value: 'repair', label: 'Ремонт' },
-  { value: 'maintenance', label: 'Обслуживание' },
-  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
-  { value: 'leak', label: 'Утечка' },
-  { value: 'recommendation', label: 'Рекомендация' },
-  { value: 'not_repairable', label: 'Не ремонтируется' },
-  { value: 'other', label: 'Другое' },
-];
-
-const textValue = (value: unknown) => String(value ?? '').trim();
-
-const normalizeRepairWorkflowStatus = (value: unknown) => {
-  const raw = textValue(value);
-  const normalized = raw.toLowerCase().replace(/-/g, '_').split(/\s+/).filter(Boolean).join('_');
-  return REPAIR_WORKFLOW_STATUS_VALUES.has(normalized) ? normalized : '';
-};
-
-const choiceText = (value: unknown) => {
-  if (typeof value === 'boolean') return value ? 'Да' : 'Нет';
-  return textValue(value);
-};
-
-const isExplicitNegativeRepairText = (value: unknown) => {
-  const text = textValue(value).toLowerCase();
-  if (!text) return false;
-  return [
-    'невозмож',
-    'не возмож',
-    'нецелесообраз',
-    'не целесообраз',
-    'нерентаб',
-    'не рентаб',
-    'списан',
-    'списани',
-    'вывести из эксплуатации',
-  ].some((marker) => text.includes(marker));
-};
-
-const normalizeRepairMeta = (
-  raw: Partial<RepairMeta> | Record<string, any> | null | undefined,
-  options: { defaultRepairStatus?: boolean } = {},
-): RepairMeta => {
-  const meta = { ...emptyRepairMeta(), ...((raw || {}) as Partial<RepairMeta>) };
-  meta.repair_status = normalizeRepairWorkflowStatus(meta.repair_status) || (options.defaultRepairStatus ? 'new' : '');
-  meta.customer_approval_status = textValue(meta.customer_approval_status);
-  meta.customer_approval_note = textValue(meta.customer_approval_note);
-  meta.parts_status = textValue(meta.parts_status);
-  meta.parts_note = textValue(meta.parts_note);
-  meta.repair_completion_note = textValue(meta.repair_completion_note);
-  if (!textValue(meta.customer_complaint)) {
-    meta.customer_complaint = textValue(meta.complaint_official) || textValue(meta.complaint_text);
-  }
-  if (!textValue(meta.diagnostic_result)) {
-    meta.diagnostic_result = textValue(meta.measurement_result);
-  }
-  if (!textValue(meta.repair_recommendation)) {
-    meta.repair_recommendation = textValue(meta.recommended_decision) || textValue(meta.technical_conclusion);
-  }
-  meta.repair_possible = choiceText(meta.repair_possible);
-  meta.repair_not_viable = choiceText(meta.repair_not_viable);
-  const legacyFeasibility = textValue(meta.repair_feasibility);
-  if (legacyFeasibility && isExplicitNegativeRepairText(legacyFeasibility)) {
-    if (!textValue(meta.repair_not_viable)) meta.repair_not_viable = 'Да';
-    if (!textValue(meta.repair_not_viable_reason)) meta.repair_not_viable_reason = legacyFeasibility;
-  }
-  return meta;
-};
-
-const selectOptionsWithCurrent = (baseOptions: string[], current: unknown) => {
-  const currentValue = textValue(current);
-  if (!currentValue || baseOptions.includes(currentValue)) return baseOptions;
-  return [...baseOptions, currentValue];
-};
-
-const labeledOptionsWithCurrent = (baseOptions: Array<{ value: string; label: string }>, current: unknown) => {
-  const currentValue = textValue(current);
-  if (!currentValue || baseOptions.some((item) => item.value === currentValue)) return baseOptions;
-  return [...baseOptions, { value: currentValue, label: currentValue }];
-};
-
-const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
-  {
-    value: 'multiple_heat_exchanger_defects',
-    label: 'Множественные дефекты теплообменника',
-    hint: 'коррозия, загрязнение, механические повреждения, нарушение теплообмена',
-  },
-  {
-    value: 'compressor_winding_breakdown',
-    label: 'Пробой обмотки компрессора',
-    hint: 'электрическая неисправность компрессора, срабатывание защиты',
-  },
-  {
-    value: 'refrigerant_leak',
-    label: 'Утечка хладагента',
-    hint: 'падение производительности, обмерзание, требуется поиск и устранение утечки',
-  },
-  {
-    value: 'control_board_failure',
-    label: 'Неисправность платы управления',
-    hint: 'ошибки управления, нестабильная работа, отсутствие запуска',
-  },
-  {
-    value: 'fan_motor_failure',
-    label: 'Неисправность двигателя вентилятора',
-    hint: 'шум, отсутствие вращения, перегрев, ошибка вентилятора',
-  },
-  {
-    value: 'drainage_failure',
-    label: 'Нарушение отвода конденсата',
-    hint: 'протечка воды, засор или неправильный уклон дренажа',
-  },
 ];
 
 const serviceKindLabels: Record<string, string> = {
@@ -1105,11 +889,28 @@ const filteredRepairComplaintPresets = computed(() => {
 const selectedRepairAiDefect = computed(() => (
   REPAIR_AI_DEFECT_TYPES.find((item) => item.value === repairAiDefectType.value) || REPAIR_AI_DEFECT_TYPES[0]
 ));
+const repairStructuredJson = computed(() => {
+  const payload = {
+    structured_diagnosis: repairMeta.value.structured_diagnosis || {},
+    defect_act_blocks: repairMeta.value.defect_act_blocks || {},
+    risks: repairMeta.value.risks || [],
+    recommended_actions: repairMeta.value.recommended_actions || [],
+  };
+  return JSON.stringify(payload, null, 2);
+});
 const repairPossibleOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_possible));
 const repairNotViableOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_not_viable));
 const customerApprovalStatusOptions = computed(() => labeledOptionsWithCurrent(CUSTOMER_APPROVAL_STATUS_OPTIONS, repairMeta.value.customer_approval_status));
 const partsStatusOptions = computed(() => labeledOptionsWithCurrent(PARTS_STATUS_OPTIONS, repairMeta.value.parts_status));
-const buildRepairMetaPayload = () => normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: isRepairWorkflow.value });
+watch(repairAiDefectType, (value) => {
+  if (isRepairWorkflow.value) {
+    repairMeta.value.fault_type = value;
+  }
+});
+const buildRepairMetaPayload = () => normalizeRepairMeta({
+  ...repairMeta.value,
+  fault_type: repairMeta.value.fault_type || repairAiDefectType.value,
+}, { defaultRepairStatus: isRepairWorkflow.value });
 const documentSectionSummary = computed(() => {
   const contractText = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : 'без договора');
   return `${orderDocuments.value.length} док. · ${contractText}`;
@@ -1577,6 +1378,14 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   repairMeta.value = normalizeRepairMeta(((order as any).repair_meta || {}) as Partial<RepairMeta>, {
     defaultRepairStatus: workflowType.value === 'repair',
   });
+  if (workflowType.value === 'repair') {
+    const savedFaultType = repairMeta.value.fault_type || (repairMeta.value.structured_diagnosis || {}).fault_type;
+    if (savedFaultType && REPAIR_AI_DEFECT_TYPES.some((item) => item.value === savedFaultType)) {
+      repairAiDefectType.value = savedFaultType;
+    } else {
+      repairMeta.value.fault_type = repairAiDefectType.value;
+    }
+  }
   repairComplaintSearch.value = '';
   if (workflowType.value === 'repair' && !repairComplaintPresets.value.length) {
     void loadRepairComplaintPresets();
@@ -2147,7 +1956,10 @@ const generateRepairAiDraft = async () => {
       customer_complaint: repairMeta.value.customer_complaint,
       complaint_official: repairMeta.value.complaint_official,
       likely_diagnosis: repairMeta.value.likely_diagnosis,
-      extra_context: repairAiExtraContext.value || defect.hint,
+      diagnostic_notes: repairMeta.value.diagnostic_notes,
+      refrigerant_type: repairMeta.value.refrigerant_type,
+      refrigerant_amount: repairMeta.value.refrigerant_amount,
+      extra_context: repairMeta.value.diagnostic_notes || repairAiExtraContext.value || defect.hint,
       current_meta: repairMeta.value as any,
     });
     repairMeta.value = normalizeRepairMeta({ ...repairMeta.value, ...((response.repair_meta || {}) as Partial<RepairMeta>) });
@@ -3025,22 +2837,12 @@ watch(
           </div>
           <div class="md:col-span-2 rounded-xl border border-violet-100 bg-violet-50/60 p-3">
             <div class="mb-2 flex flex-col gap-2 lg:flex-row lg:items-end">
-              <label class="field-label flex-1">
-                Базовая неисправность
-                <select v-model="repairAiDefectType" class="field-input bg-white">
-                  <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="item.value" :value="item.value">
-                    {{ item.label }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label flex-[1.2]">
-                Детали диагностики
-                <input
-                  v-model="repairAiExtraContext"
-                  class="field-input bg-white"
-                  placeholder="Например: наружный блок не стартует, запах гари, сильная коррозия..."
-                />
-              </label>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-semibold text-violet-950">AI-черновик по выбранной неисправности</p>
+                <p class="mt-1 truncate text-xs text-violet-700/80">
+                  {{ selectedRepairAiDefect?.label || 'Базовая неисправность не выбрана' }}
+                </p>
+              </div>
               <button
                 type="button"
                 class="btn-mini h-[42px] justify-center whitespace-nowrap bg-violet-600 hover:bg-violet-700"
@@ -3066,12 +2868,12 @@ watch(
               </div>
             </div>
           </div>
-          <div class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <div class="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-sm font-semibold text-slate-900">Статусы ремонта</p>
-              <p class="text-xs text-slate-600">Этап ремонта; CRM/Kanban статус заказа отдельно.</p>
-            </div>
-            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+              Статусы, согласование и запчасти
+              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairWorkflowStatusLabel || 'не указано' }}</span>
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               <label class="field-label">
                 Этап ремонта
                 <select v-model="repairMeta.repair_status" class="field-input bg-white">
@@ -3121,7 +2923,7 @@ watch(
                 />
               </label>
             </div>
-          </div>
+          </details>
           <label class="field-label md:col-span-2">
             Жалоба клиента
             <textarea
@@ -3131,19 +2933,19 @@ watch(
             />
           </label>
           <label class="field-label">
-            Формулировка для акта
-            <textarea
-              v-model="repairMeta.complaint_official"
-              class="field-input min-h-[72px]"
-              placeholder="Официальная формулировка жалобы"
-            />
+            Базовая неисправность
+            <select v-model="repairAiDefectType" class="field-input">
+              <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="`main-${item.value}`" :value="item.value">
+                {{ item.label }}
+              </option>
+            </select>
           </label>
-          <label class="field-label">
-            Вероятный диагноз
+          <label class="field-label md:col-span-2">
+            Детали диагностики / заметки инженера
             <textarea
-              v-model="repairMeta.likely_diagnosis"
+              v-model="repairMeta.diagnostic_notes"
               class="field-input min-h-[72px]"
-              placeholder="Предварительная причина неисправности"
+              placeholder="Что увидел инженер: симптомы, проверки, ограничения, важные нюансы"
             />
           </label>
           <label class="field-label">
@@ -3160,6 +2962,14 @@ watch(
               v-model="repairMeta.repair_recommendation"
               class="field-input min-h-[88px]"
               placeholder="Что сделать: устранить утечку, заменить узел, дозаправить..."
+            />
+          </label>
+          <label class="field-label md:col-span-2">
+            Формулировка для сметы ремонта
+            <textarea
+              v-model="repairMeta.repair_estimate_text"
+              class="field-input min-h-[72px]"
+              placeholder="Короткая строка работ для сметы"
             />
           </label>
           <label class="field-label">
@@ -3207,6 +3017,12 @@ watch(
             />
           </label>
 
+          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+              Оборудование и паспортные данные
+              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairMeta.equipment_model || repairMeta.equipment_name || 'не заполнено' }}</span>
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2">
           <label class="field-label">
             Оборудование
             <input v-model="repairMeta.equipment_name" class="field-input" placeholder="Кондиционер настенный" />
@@ -3348,7 +3164,34 @@ watch(
               </div>
             </div>
           </div>
+            </div>
+          </details>
 
+          <details class="md:col-span-2 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-amber-900">
+              Экспертный режим: JSON и ручные override-поля
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2">
+              <label class="field-label md:col-span-2">
+                Структурированные выводы AI
+                <textarea :value="repairStructuredJson" readonly class="field-input min-h-[180px] font-mono text-xs" />
+              </label>
+              <label class="field-label">
+                Формулировка для акта
+                <textarea
+                  v-model="repairMeta.complaint_official"
+                  class="field-input min-h-[72px]"
+                  placeholder="Override официальной формулировки жалобы"
+                />
+              </label>
+              <label class="field-label">
+                Вероятный диагноз
+                <textarea
+                  v-model="repairMeta.likely_diagnosis"
+                  class="field-input min-h-[72px]"
+                  placeholder="Override предварительной причины"
+                />
+              </label>
           <label class="field-label">
             Техническое состояние
             <textarea v-model="repairMeta.technical_condition" class="field-input min-h-[80px]" placeholder="Общее состояние, износ, загрязнение, следы вмешательства..." />
@@ -3385,6 +3228,8 @@ watch(
             Техническое заключение
             <textarea v-model="repairMeta.technical_conclusion" class="field-input min-h-[96px]" placeholder="Итоговый вывод для дефектного акта" />
           </label>
+            </div>
+          </details>
         </div>
       </OrderDrawerSection>
 

--- a/manager_frontend/src/components/orders/repair-meta.ts
+++ b/manager_frontend/src/components/orders/repair-meta.ts
@@ -1,0 +1,268 @@
+import type { EquipmentServiceEventType } from '../../client';
+
+export type RepairMeta = {
+  repair_status: string;
+  customer_approval_status: string;
+  customer_approval_note: string;
+  parts_status: string;
+  parts_note: string;
+  repair_completion_note: string;
+  customer_complaint: string;
+  complaint_official: string;
+  complaint_text?: string;
+  likely_diagnosis: string;
+  fault_type: string;
+  fault_location: string;
+  operation_status: string;
+  diagnostic_notes: string;
+  equipment_name: string;
+  equipment_brand: string;
+  equipment_model: string;
+  equipment_power: string;
+  equipment_serial_number: string;
+  equipment_inventory_number: string;
+  equipment_commissioning_date: string;
+  technical_condition: string;
+  startup_check_result: string;
+  compressor_check_result: string;
+  measurement_result: string;
+  diagnostic_result: string;
+  further_use_assessment: string;
+  operation_restrictions: string;
+  technical_conclusion: string;
+  repair_feasibility: string;
+  recommended_decision: string;
+  repair_recommendation: string;
+  repair_possible: string;
+  refrigerant_type: string;
+  refrigerant_amount: string;
+  refrigerant_pricing_mode: string;
+  repair_not_viable: string;
+  repair_not_viable_reason: string;
+  repair_estimate_text: string;
+  risks?: string[];
+  recommended_actions?: string[];
+  hidden_defects_possible?: boolean;
+  structured_diagnosis?: Record<string, any>;
+  defect_act_blocks?: Record<string, string>;
+};
+
+export type RepairAiDefectType = {
+  value: string;
+  label: string;
+  hint: string;
+};
+
+export const REPAIR_WORKFLOW_STATUS_OPTIONS = [
+  { value: 'new', label: 'Новая' },
+  { value: 'scheduled', label: 'Запланирован' },
+  { value: 'diagnostic_in_progress', label: 'Диагностика идет' },
+  { value: 'awaiting_diagnostic_result', label: 'Ждем диагностику' },
+  { value: 'awaiting_customer_approval', label: 'На согласовании' },
+  { value: 'approved_for_repair', label: 'Ремонт согласован' },
+  { value: 'repair_in_progress', label: 'Ремонт идет' },
+  { value: 'awaiting_parts', label: 'Ждем запчасти' },
+  { value: 'completed', label: 'Завершен' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'cancelled', label: 'Отменен' },
+];
+const REPAIR_WORKFLOW_STATUS_VALUES = new Set(REPAIR_WORKFLOW_STATUS_OPTIONS.map((item) => item.value));
+
+export const CUSTOMER_APPROVAL_STATUS_OPTIONS = [
+  { value: '', label: 'Не указано' },
+  { value: 'pending', label: 'Ожидает согласования' },
+  { value: 'approved', label: 'Согласовано' },
+  { value: 'rejected', label: 'Отказано' },
+];
+
+export const PARTS_STATUS_OPTIONS = [
+  { value: '', label: 'Не указано' },
+  { value: 'not_required', label: 'Не требуются' },
+  { value: 'awaiting', label: 'Ожидаются' },
+  { value: 'ordered', label: 'Заказаны' },
+  { value: 'received', label: 'Получены' },
+  { value: 'installed', label: 'Установлены' },
+];
+
+export const emptyRepairMeta = (): RepairMeta => ({
+  repair_status: '',
+  customer_approval_status: '',
+  customer_approval_note: '',
+  parts_status: '',
+  parts_note: '',
+  repair_completion_note: '',
+  customer_complaint: '',
+  complaint_official: '',
+  likely_diagnosis: '',
+  fault_type: '',
+  fault_location: '',
+  operation_status: '',
+  diagnostic_notes: '',
+  equipment_name: '',
+  equipment_brand: '',
+  equipment_model: '',
+  equipment_power: '',
+  equipment_serial_number: '',
+  equipment_inventory_number: '',
+  equipment_commissioning_date: '',
+  technical_condition: '',
+  startup_check_result: '',
+  compressor_check_result: '',
+  measurement_result: '',
+  diagnostic_result: '',
+  further_use_assessment: '',
+  operation_restrictions: '',
+  technical_conclusion: '',
+  repair_feasibility: '',
+  recommended_decision: '',
+  repair_recommendation: '',
+  repair_possible: '',
+  refrigerant_type: '',
+  refrigerant_amount: '',
+  refrigerant_pricing_mode: '',
+  repair_not_viable: '',
+  repair_not_viable_reason: '',
+  repair_estimate_text: '',
+  risks: [],
+  recommended_actions: [],
+  hidden_defects_possible: false,
+  structured_diagnosis: {},
+  defect_act_blocks: {},
+});
+
+export const REPAIR_CHOICE_OPTIONS = ['', 'Да', 'Нет'];
+export const REFRIGERANT_PRICING_MODE_OPTIONS = [
+  'по фактической массе',
+  'включен в стоимость ремонта',
+  'отдельной строкой сметы',
+  'не требуется',
+];
+export const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
+  { value: 'diagnostic', label: 'Диагностика' },
+  { value: 'repair', label: 'Ремонт' },
+  { value: 'maintenance', label: 'Обслуживание' },
+  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
+  { value: 'leak', label: 'Утечка' },
+  { value: 'recommendation', label: 'Рекомендация' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'other', label: 'Другое' },
+];
+
+export const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
+  {
+    value: 'refrigerant_leak',
+    label: 'Утечка хладагента',
+    hint: 'падение производительности, обмерзание, требуется поиск и устранение утечки',
+  },
+  {
+    value: 'drainage_failure',
+    label: 'Нарушение отвода конденсата',
+    hint: 'протечка воды, засор или неправильный уклон дренажа',
+  },
+  {
+    value: 'control_board_failure',
+    label: 'Неисправность платы управления',
+    hint: 'ошибки управления, нестабильная работа, отсутствие запуска',
+  },
+  {
+    value: 'fan_motor_failure',
+    label: 'Неисправность двигателя вентилятора',
+    hint: 'шум, отсутствие вращения, перегрев, ошибка вентилятора',
+  },
+  {
+    value: 'compressor_failure',
+    label: 'Неисправность компрессора',
+    hint: 'электрическая или механическая неисправность компрессора, срабатывание защиты',
+  },
+  {
+    value: 'heat_exchanger_damage',
+    label: 'Повреждение теплообменника',
+    hint: 'коррозия, механические повреждения, нарушение теплообмена',
+  },
+  {
+    value: 'contamination',
+    label: 'Загрязнение оборудования',
+    hint: 'загрязнение теплообменника, фильтров или внутренних узлов',
+  },
+  {
+    value: 'poor_installation',
+    label: 'Нарушение монтажа',
+    hint: 'ошибки трассы, дренажа, подключения или установки блоков',
+  },
+  {
+    value: 'unknown_fault',
+    label: 'Требуется уточнение',
+    hint: 'причина не подтверждена, нужна дополнительная диагностика',
+  },
+];
+
+export const textValue = (value: unknown) => String(value ?? '').trim();
+
+const normalizeRepairWorkflowStatus = (value: unknown) => {
+  const raw = textValue(value);
+  const normalized = raw.toLowerCase().replace(/-/g, '_').split(/\s+/).filter(Boolean).join('_');
+  return REPAIR_WORKFLOW_STATUS_VALUES.has(normalized) ? normalized : '';
+};
+
+const choiceText = (value: unknown) => {
+  if (typeof value === 'boolean') return value ? 'Да' : 'Нет';
+  return textValue(value);
+};
+
+const isExplicitNegativeRepairText = (value: unknown) => {
+  const text = textValue(value).toLowerCase();
+  if (!text) return false;
+  return [
+    'невозмож',
+    'не возмож',
+    'нецелесообраз',
+    'не целесообраз',
+    'нерентаб',
+    'не рентаб',
+    'списан',
+    'списани',
+    'вывести из эксплуатации',
+  ].some((marker) => text.includes(marker));
+};
+
+export const normalizeRepairMeta = (
+  raw: Partial<RepairMeta> | Record<string, any> | null | undefined,
+  options: { defaultRepairStatus?: boolean } = {},
+): RepairMeta => {
+  const meta = { ...emptyRepairMeta(), ...((raw || {}) as Partial<RepairMeta>) };
+  meta.repair_status = normalizeRepairWorkflowStatus(meta.repair_status) || (options.defaultRepairStatus ? 'new' : '');
+  meta.customer_approval_status = textValue(meta.customer_approval_status);
+  meta.customer_approval_note = textValue(meta.customer_approval_note);
+  meta.parts_status = textValue(meta.parts_status);
+  meta.parts_note = textValue(meta.parts_note);
+  meta.repair_completion_note = textValue(meta.repair_completion_note);
+  if (!textValue(meta.customer_complaint)) {
+    meta.customer_complaint = textValue(meta.complaint_official) || textValue(meta.complaint_text);
+  }
+  if (!textValue(meta.diagnostic_result)) {
+    meta.diagnostic_result = textValue(meta.measurement_result);
+  }
+  if (!textValue(meta.repair_recommendation)) {
+    meta.repair_recommendation = textValue(meta.recommended_decision) || textValue(meta.technical_conclusion);
+  }
+  meta.repair_possible = choiceText(meta.repair_possible);
+  meta.repair_not_viable = choiceText(meta.repair_not_viable);
+  const legacyFeasibility = textValue(meta.repair_feasibility);
+  if (legacyFeasibility && isExplicitNegativeRepairText(legacyFeasibility)) {
+    if (!textValue(meta.repair_not_viable)) meta.repair_not_viable = 'Да';
+    if (!textValue(meta.repair_not_viable_reason)) meta.repair_not_viable_reason = legacyFeasibility;
+  }
+  return meta;
+};
+
+export const selectOptionsWithCurrent = (baseOptions: string[], current: unknown) => {
+  const currentValue = textValue(current);
+  if (!currentValue || baseOptions.includes(currentValue)) return baseOptions;
+  return [...baseOptions, currentValue];
+};
+
+export const labeledOptionsWithCurrent = (baseOptions: Array<{ value: string; label: string }>, current: unknown) => {
+  const currentValue = textValue(current);
+  if (!currentValue || baseOptions.some((item) => item.value === currentValue)) return baseOptions;
+  return [...baseOptions, { value: currentValue, label: currentValue }];
+};

--- a/openapi.json
+++ b/openapi.json
@@ -29724,6 +29724,39 @@
             ],
             "title": "Likely Diagnosis"
           },
+          "diagnostic_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diagnostic Notes"
+          },
+          "refrigerant_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refrigerant Type"
+          },
+          "refrigerant_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refrigerant Amount"
+          },
           "extra_context": {
             "anyOf": [
               {
@@ -29750,9 +29783,7 @@
       "ManagerRepairActAiDraftResponse": {
         "properties": {
           "repair_meta": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Repair Meta"
           },
@@ -29768,7 +29799,7 @@
           "prompt_version": {
             "type": "string",
             "title": "Prompt Version",
-            "default": "defect_act_v1"
+            "default": "defect_act_v2"
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -3525,15 +3525,18 @@ class ManagerRepairActAiDraftPayload(BaseModel):
     customer_complaint: Optional[str] = None
     complaint_official: Optional[str] = None
     likely_diagnosis: Optional[str] = None
+    diagnostic_notes: Optional[str] = None
+    refrigerant_type: Optional[str] = None
+    refrigerant_amount: Optional[str] = None
     extra_context: Optional[str] = None
     current_meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ManagerRepairActAiDraftResponse(BaseModel):
-    repair_meta: Dict[str, str] = Field(default_factory=dict)
+    repair_meta: Dict[str, Any] = Field(default_factory=dict)
     provider: str = "deepseek"
     model: str
-    prompt_version: str = "defect_act_v1"
+    prompt_version: str = "defect_act_v2"
 
 
 # --- SERVICE ESTIMATES ---

--- a/services/defect_act_ai_service.py
+++ b/services/defect_act_ai_service.py
@@ -6,15 +6,25 @@ import httpx
 
 from core.config import settings
 from schemas import ManagerRepairActAiDraftPayload
+from services.repair_defect_template_service import RepairDefectTemplateService
 
 
 class DefectActAIService:
-    """Builds repair defect-act field drafts through an LLM."""
+    """Builds structured repair diagnostics through an LLM and local templates."""
 
     ALLOWED_REPAIR_META_KEYS = {
+        "fault_type",
+        "fault_location",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "structured_diagnosis",
+        "defect_act_blocks",
+        "hidden_defects_possible",
         "customer_complaint",
         "complaint_official",
         "likely_diagnosis",
+        "diagnostic_notes",
         "equipment_name",
         "equipment_brand",
         "equipment_model",
@@ -36,9 +46,43 @@ class DefectActAIService:
         "refrigerant_pricing_mode",
         "repair_not_viable",
         "repair_not_viable_reason",
+        "repair_estimate_text",
         "inspection_work_done",
     }
-
+    ALLOWED_STRUCTURED_KEYS = {
+        "fault_type",
+        "fault_location",
+        "repairable",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "refrigerant",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "hidden_defects_possible",
+    }
+    STRUCTURED_RESPONSE_KEYS = {
+        "fault_type",
+        "fault_location",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "structured_diagnosis",
+        "defect_act_blocks",
+        "hidden_defects_possible",
+    }
+    PRIMARY_RESPONSE_KEYS = {
+        "likely_diagnosis",
+        "diagnostic_notes",
+        "diagnostic_result",
+        "repair_recommendation",
+        "repair_possible",
+        "repair_not_viable",
+        "repair_not_viable_reason",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "repair_estimate_text",
+    }
     @staticmethod
     def _clean_text(value: Any, *, max_length: int = 1200) -> str:
         text = str(value or "").strip()
@@ -47,12 +91,33 @@ class DefectActAIService:
         return text[:max_length].strip()
 
     @staticmethod
-    def _clean_meta(raw_meta: Any) -> Dict[str, str]:
+    def _clean_meta(raw_meta: Any) -> Dict[str, Any]:
         if not isinstance(raw_meta, dict):
             return {}
-        cleaned: Dict[str, str] = {}
+        cleaned: Dict[str, Any] = {}
         for key, value in raw_meta.items():
             if key not in DefectActAIService.ALLOWED_REPAIR_META_KEYS:
+                continue
+            if isinstance(value, dict):
+                nested = {
+                    str(nested_key): nested_value
+                    for nested_key, nested_value in value.items()
+                    if isinstance(nested_value, (str, int, float, bool, list, dict)) or nested_value is None
+                }
+                if nested:
+                    cleaned[key] = nested
+                continue
+            if isinstance(value, list):
+                items = [
+                    DefectActAIService._clean_text(item, max_length=160)
+                    for item in value
+                    if DefectActAIService._clean_text(item, max_length=160)
+                ]
+                if items:
+                    cleaned[key] = items
+                continue
+            if isinstance(value, bool):
+                cleaned[key] = value
                 continue
             text = DefectActAIService._clean_text(value)
             if text:
@@ -60,8 +125,35 @@ class DefectActAIService:
         return cleaned
 
     @staticmethod
+    def _clean_structured(raw: Any, payload: ManagerRepairActAiDraftPayload) -> Dict[str, Any]:
+        if not isinstance(raw, dict):
+            raw = {}
+        nested = raw.get("structured_diagnosis")
+        if isinstance(nested, dict):
+            raw = {**raw, **nested}
+        cleaned: Dict[str, Any] = {}
+        for key in DefectActAIService.ALLOWED_STRUCTURED_KEYS:
+            value = raw.get(key)
+            if isinstance(value, list):
+                cleaned[key] = [
+                    DefectActAIService._clean_text(item, max_length=120)
+                    for item in value
+                    if DefectActAIService._clean_text(item, max_length=120)
+                ]
+            elif isinstance(value, bool):
+                cleaned[key] = value
+            elif value is not None:
+                text = DefectActAIService._clean_text(value, max_length=200)
+                if text:
+                    cleaned[key] = text
+        if not cleaned.get("fault_type"):
+            cleaned["fault_type"] = payload.defect_type
+        return cleaned
+
+    @staticmethod
     def build_prompt(payload: ManagerRepairActAiDraftPayload) -> str:
         current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        fault_types = ", ".join(sorted(RepairDefectTemplateService.TEMPLATES.keys()))
         inputs = {
             "defect_type": payload.defect_type,
             "defect_label": payload.defect_label,
@@ -74,6 +166,9 @@ class DefectActAIService:
             "customer_complaint": payload.customer_complaint,
             "complaint_official": payload.complaint_official,
             "likely_diagnosis": payload.likely_diagnosis,
+            "diagnostic_notes": payload.diagnostic_notes,
+            "refrigerant_type": payload.refrigerant_type,
+            "refrigerant_amount": payload.refrigerant_amount,
             "extra_context": payload.extra_context,
             "current_meta": current_meta,
         }
@@ -97,50 +192,40 @@ class DefectActAIService:
         )
         mode_rules = assumptions_rules if payload.allow_assumptions else strict_rules
         existing_rules = (
-            "- Если в current_meta уже есть осмысленное значение, можно улучшить его стиль: "
-            "исправить терминологию, сделать формулировку официальной, раскрыть мысль до уровня дефектного акта.\n"
-            "- При улучшении заполненных полей строго сохраняй фактический смысл. Не добавляй новые факты, работы, "
-            "числовые измерения, даты, серийные или инвентарные номера, которых нет во входных данных.\n"
+            "- Используй current_meta как контекст: уточняй fault_type, risks и recommended_actions по уже заполненным данным.\n"
+            "- Не возвращай готовые текстовые поля дефектного акта и не переписывай ручные override-поля.\n"
+            "- Строго сохраняй фактический смысл. Не добавляй новые факты, работы, числовые измерения, даты, "
+            "серийные или инвентарные номера, которых нет во входных данных.\n"
         ) if payload.polish_existing else (
-            "- Если в current_meta уже есть осмысленное значение, не переписывай это поле и не возвращай его в ответе.\n"
-            "- Заполняй только пустые или явно неполные поля, опираясь на входные данные.\n"
+            "- Если в current_meta уже есть осмысленное значение, учитывай его как контекст, но не возвращай замену этого поля.\n"
+            "- Возвращай только структурированные выводы по диагностике и не трогай заполненные ручные поля.\n"
         )
 
         return (
-            "Ты инженер по ремонту систем кондиционирования и составляешь текстовые поля "
-            "для дефектного акта на русском языке.\n\n"
-            "Нужно заполнить значения для Google Docs-плейсхолдеров дефектного акта. "
-            "Пиши официально, по-деловому, без маркетинга и без разговорных формулировок.\n\n"
+            "Ты инженер по ремонту систем кондиционирования. Нужно определить структурированные выводы "
+            "по диагностике, а не писать готовый дефектный акт.\n\n"
+            "Документ и смета будут собраны отдельными шаблонами. Не дублируй одну мысль разными словами "
+            "и не возвращай длинные документные формулировки.\n\n"
             "Правила:\n"
             "- Верни только JSON-объект без markdown.\n"
             f"{mode_rules}"
             f"{existing_rules}"
-            "- Итог должен быть пригоден для дефектного акта, но не должен обещать невозможное без диагностики.\n\n"
-            "Разрешенные ключи JSON:\n"
-            + ", ".join(sorted(DefectActAIService.ALLOWED_REPAIR_META_KEYS))
-            + "\n\n"
-            "Смысл ключей:\n"
-            "customer_complaint - простая жалоба клиента; "
-            "complaint_official - официальная формулировка жалобы для акта; "
-            "likely_diagnosis - вероятная причина; "
-            "technical_condition - техническое состояние оборудования; "
-            "startup_check_result - результат проверки запуска; "
-            "compressor_check_result - проверка компрессора; "
-            "measurement_result - результаты диагностики/замеров без выдуманных чисел; "
-            "diagnostic_result - канонический результат диагностики; "
-            "further_use_assessment - возможность дальнейшей эксплуатации; "
-            "operation_restrictions - ограничения эксплуатации; "
-            "technical_conclusion - итоговое техническое заключение; "
-            "repair_feasibility - целесообразность ремонта; "
-            "recommended_decision - рекомендованное решение; "
-            "repair_recommendation - каноническая рекомендация по ремонту; "
-            "repair_possible - возможен ли ремонт; "
-            "refrigerant_type - тип хладагента; "
-            "refrigerant_amount - объем хладагента; "
-            "refrigerant_pricing_mode - способ расчета хладагента; "
-            "repair_not_viable - ремонт невозможен или нецелесообразен; "
-            "repair_not_viable_reason - причина невозможности или нецелесообразности ремонта; "
-            "inspection_work_done - выполненные диагностические действия.\n\n"
+            "- Итог должен быть пригоден для выбора шаблона, но не должен обещать невозможное без диагностики.\n\n"
+            "Разрешенные fault_type:\n"
+            f"{fault_types}\n\n"
+            "Верни JSON в такой структуре:\n"
+            "{\n"
+            '  "fault_type": "refrigerant_leak",\n'
+            '  "fault_location": "flare_connections",\n'
+            '  "repairable": true,\n'
+            '  "operation_status": "limited",\n'
+            '  "risks": ["compressor_damage"],\n'
+            '  "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],\n'
+            '  "refrigerant": "R410A",\n'
+            '  "refrigerant_amount": "790 g",\n'
+            '  "hidden_defects_possible": true\n'
+            "}\n\n"
+            "Если данных недостаточно, используй fault_type=unknown_fault и operation_status=unknown.\n\n"
             "Входные данные:\n"
             f"{json.dumps(inputs, ensure_ascii=False, indent=2)}"
         )
@@ -206,19 +291,31 @@ class DefectActAIService:
             raise ValueError("AI response has unexpected format") from exc
 
     @staticmethod
-    async def generate_repair_meta(payload: ManagerRepairActAiDraftPayload) -> Dict[str, str]:
+    async def generate_repair_meta(payload: ManagerRepairActAiDraftPayload) -> Dict[str, Any]:
         prompt = DefectActAIService.build_prompt(payload)
         content = await DefectActAIService._request_completion(prompt)
         parsed = DefectActAIService._extract_json_object(content)
-        meta = DefectActAIService._clean_meta(parsed)
+        structured = DefectActAIService._clean_structured(parsed, payload)
+        current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        meta = RepairDefectTemplateService.build_meta_from_structured(
+            raw=structured,
+            current_meta=current_meta,
+            fallback_fault_type=payload.defect_type,
+            diagnostic_notes=payload.diagnostic_notes or payload.extra_context,
+        )
+        response_keys = DefectActAIService.STRUCTURED_RESPONSE_KEYS | DefectActAIService.PRIMARY_RESPONSE_KEYS
         if payload.polish_existing:
-            return meta
+            return {
+                key: value
+                for key, value in meta.items()
+                if key in response_keys
+            }
 
-        existing_meta = DefectActAIService._clean_meta(payload.current_meta or {})
         return {
             key: value
             for key, value in meta.items()
-            if not existing_meta.get(key)
+            if key in DefectActAIService.STRUCTURED_RESPONSE_KEYS
+            or (key in DefectActAIService.PRIMARY_RESPONSE_KEYS and not current_meta.get(key))
         }
 
     @staticmethod

--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -3,6 +3,7 @@ from typing import Any, List, Optional
 from sqlmodel import select
 from services.google_service import get_google_service
 from services.documents.base import BaseDocumentStrategy, TEMPLATES, DOC_NAMES
+from services.repair_defect_template_service import RepairDefectTemplateService
 from models import CustomerContract, CustomerEquipment, EquipmentComponent, OrderDocument
 
 class GoogleDocStrategy(BaseDocumentStrategy):
@@ -179,6 +180,11 @@ class DefectActStrategy(GoogleDocStrategy):
             return repair_meta.get(key)
         return meta.get(key)
 
+    def _repair_meta(self) -> dict[str, Any]:
+        meta = self.order.technical_meta if self.order and isinstance(self.order.technical_meta, dict) else {}
+        repair_meta = meta.get("repair") if isinstance(meta.get("repair"), dict) else {}
+        return repair_meta
+
     def _repair_possible_text(self, default: str = "") -> str:
         canonical = self._meta_value("repair_possible")
         bool_text = self._bool_text(canonical)
@@ -252,14 +258,11 @@ class DefectActStrategy(GoogleDocStrategy):
             detailed_name = " ".join(part for part in [equipment_brand, equipment_model, equipment_power] if part)
             if detailed_name:
                 equipment_name = detailed_name
+        generated_repair_meta = RepairDefectTemplateService.build_document_fields(self._repair_meta())
         technical_condition = self._first_text(
-            self._meta_text(
-                "technical_condition",
-                "defect_technical_condition",
-                "complaint_official",
-                "customer_complaint",
-                "complaint_text",
-            ),
+            self._meta_text("technical_condition", "defect_technical_condition"),
+            generated_repair_meta.get("technical_condition"),
+            self._meta_text("complaint_official", "customer_complaint", "complaint_text"),
             getattr(self.order, "measurement_result", None) if self.order else None,
             default="_________________",
         )
@@ -302,7 +305,7 @@ class DefectActStrategy(GoogleDocStrategy):
                 "{{inspection_work_done}}": self._meta_text(
                     "inspection_work_done",
                     "diagnostic_work_done",
-                    default="_________________",
+                    default=generated_repair_meta.get("inspection_work_done") or "_________________",
                 ),
                 "{{startup_check_result}}": self._meta_text(
                     "startup_check_result",
@@ -311,47 +314,52 @@ class DefectActStrategy(GoogleDocStrategy):
                 ),
                 "{{compressor_check_result}}": self._meta_text("compressor_check_result", default="_________________"),
                 "{{measurement_result}}": self._meta_text(
-                    "diagnostic_result",
                     "measurement_result",
+                    "inspection_work_done",
                     "defect_measurement_result",
                     "diagnostic_measurement_result",
-                    default=(getattr(self.order, "measurement_result", None) if self.order else None) or "_________________",
+                    default=generated_repair_meta.get("measurement_result")
+                    or self._meta_text("diagnostic_result")
+                    or (getattr(self.order, "measurement_result", None) if self.order else None)
+                    or "_________________",
                 ),
                 "{{diagnostic_result}}": self._meta_text(
                     "diagnostic_result",
                     "measurement_result",
                     "defect_measurement_result",
                     "diagnostic_measurement_result",
-                    default=(getattr(self.order, "measurement_result", None) if self.order else None) or "_________________",
+                    default=(
+                        getattr(self.order, "measurement_result", None) if self.order else None
+                    ) or generated_repair_meta.get("diagnostic_result") or "_________________",
                 ),
                 "{{further_use_assessment}}": self._meta_text(
                     "further_use_assessment",
                     "operation_assessment",
-                    default="_________________",
+                    default=generated_repair_meta.get("further_use_assessment") or "_________________",
                 ),
                 "{{operation_restrictions}}": self._meta_text(
                     "operation_restrictions",
                     "use_restrictions",
-                    default="_________________",
+                    default=generated_repair_meta.get("operation_restrictions") or "_________________",
                 ),
                 "{{technical_conclusion}}": self._meta_text(
                     "technical_conclusion",
                     "defect_conclusion",
                     "repair_recommendation",
                     "recommended_decision",
-                    default="_________________",
+                    default=generated_repair_meta.get("technical_conclusion") or "_________________",
                 ),
                 "{{repair_feasibility}}": self._meta_text(
                     "repair_feasibility",
                     "repair_feasibility_text",
-                    default=self._repair_possible_text(default="_________________"),
+                    default=generated_repair_meta.get("repair_feasibility") or self._repair_possible_text(default="_________________"),
                 ),
                 "{{recommended_decision}}": self._meta_text(
                     "recommended_decision",
                     "defect_recommendation",
                     "repair_recommendation",
                     "technical_conclusion",
-                    default="_________________",
+                    default=generated_repair_meta.get("recommended_decision") or "_________________",
                 ),
                 "{{repair_recommendation}}": self._meta_text(
                     "repair_recommendation",
@@ -359,9 +367,11 @@ class DefectActStrategy(GoogleDocStrategy):
                     "defect_recommendation",
                     "technical_conclusion",
                     "defect_conclusion",
-                    default="_________________",
+                    default=generated_repair_meta.get("repair_recommendation") or "_________________",
                 ),
-                "{{repair_possible}}": self._repair_possible_text(default="_________________"),
+                "{{repair_possible}}": self._repair_possible_text(
+                    default=generated_repair_meta.get("repair_possible") or "_________________"
+                ),
                 "{{repair_status}}": self._meta_text("repair_status", default="_________________"),
                 "{{customer_approval_status}}": self._meta_text(
                     "customer_approval_status",
@@ -371,8 +381,14 @@ class DefectActStrategy(GoogleDocStrategy):
                 "{{parts_status}}": self._meta_text("parts_status", default="_________________"),
                 "{{parts_note}}": self._meta_text("parts_note", default="_________________"),
                 "{{repair_completion_note}}": self._meta_text("repair_completion_note", default="_________________"),
-                "{{refrigerant_type}}": self._meta_text("refrigerant_type", default="_________________"),
-                "{{refrigerant_amount}}": self._meta_text("refrigerant_amount", default="_________________"),
+                "{{refrigerant_type}}": self._meta_text(
+                    "refrigerant_type",
+                    default=generated_repair_meta.get("refrigerant_type") or "_________________",
+                ),
+                "{{refrigerant_amount}}": self._meta_text(
+                    "refrigerant_amount",
+                    default=generated_repair_meta.get("refrigerant_amount") or "_________________",
+                ),
                 "{{refrigerant_pricing_mode}}": self._meta_text("refrigerant_pricing_mode", default="_________________"),
                 "{{repair_not_viable}}": self._repair_not_viable_text(default="_________________"),
                 "{{repair_not_viable_reason}}": self._repair_not_viable_reason_text(default="_________________"),

--- a/services/repair_defect_template_service.py
+++ b/services/repair_defect_template_service.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class RepairDefectTemplateService:
+    """Templates for structured repair diagnostics and defect-act wording."""
+
+    FAULT_ALIASES = {
+        "multiple_heat_exchanger_defects": "heat_exchanger_damage",
+        "compressor_winding_breakdown": "compressor_failure",
+    }
+
+    DEFAULT_ACTIONS = {
+        "restore_circuit_tightness": "восстановить герметичность холодильного контура",
+        "replace_faulty_flare_connections": "заменить или переподключить неисправные вальцовочные соединения",
+        "vacuuming": "выполнить вакуумирование",
+        "full_refrigerant_charge": "заправить хладагентом согласно спецификации производителя",
+        "clean_drainage": "прочистить дренажную систему",
+        "restore_drainage_slope": "восстановить корректный уклон дренажа",
+        "replace_control_board": "заменить плату управления",
+        "replace_fan_motor": "заменить двигатель вентилятора",
+        "replace_compressor": "заменить компрессор",
+        "replace_heat_exchanger": "заменить теплообменник",
+        "deep_cleaning": "выполнить глубокую очистку оборудования",
+        "correct_installation": "устранить нарушения монтажа",
+        "additional_diagnostics": "выполнить дополнительную диагностику",
+    }
+
+    RISK_TEXTS = {
+        "compressor_damage": "повреждение компрессора",
+        "water_leak": "протечка конденсата",
+        "electrical_damage": "повреждение электрических компонентов",
+        "overheating": "перегрев узлов оборудования",
+        "repeated_failure": "повторное возникновение неисправности",
+        "low_efficiency": "снижение эффективности работы оборудования",
+    }
+
+    TEMPLATES: dict[str, dict[str, Any]] = {
+        "refrigerant_leak": {
+            "label": "Утечка хладагента",
+            "diagnosis_text": "Выявлены признаки утечки хладагента. Давление хладагента ниже нормативного значения.",
+            "operation_text": "Эксплуатация оборудования допускается только с ограничениями до проведения ремонта.",
+            "risk_text": "Дальнейшая эксплуатация при недостатке хладагента может привести к повреждению компрессора.",
+            "repair_text": "Рекомендуется восстановить герметичность холодильного контура, устранить место утечки, выполнить вакуумирование и заправку хладагентом согласно спецификации производителя.",
+            "estimate_text": "Устранение утечки хладагента с восстановлением герметичности холодильного контура и заправкой хладагентом согласно спецификации производителя.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["compressor_damage"],
+            "recommended_actions": [
+                "restore_circuit_tightness",
+                "replace_faulty_flare_connections",
+                "vacuuming",
+                "full_refrigerant_charge",
+            ],
+        },
+        "drainage_failure": {
+            "label": "Нарушение отвода конденсата",
+            "diagnosis_text": "Выявлено нарушение отвода конденсата из внутреннего блока.",
+            "operation_text": "Эксплуатация допускается после устранения причины протечки конденсата.",
+            "risk_text": "Дальнейшая эксплуатация может привести к протечке воды и повреждению отделки или оборудования.",
+            "repair_text": "Рекомендуется прочистить дренажную систему, проверить уклон и восстановить штатный отвод конденсата.",
+            "estimate_text": "Восстановление отвода конденсата с прочисткой дренажной системы и проверкой уклона.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["water_leak", "repeated_failure"],
+            "recommended_actions": ["clean_drainage", "restore_drainage_slope"],
+        },
+        "control_board_failure": {
+            "label": "Неисправность платы управления",
+            "diagnosis_text": "Выявлены признаки неисправности платы управления или цепей управления оборудованием.",
+            "operation_text": "Эксплуатация оборудования до ремонта не рекомендуется.",
+            "risk_text": "Дальнейшая эксплуатация может привести к нестабильной работе и повреждению электрических компонентов.",
+            "repair_text": "Рекомендуется выполнить проверку цепей управления и заменить неисправную плату управления.",
+            "estimate_text": "Диагностика цепей управления и замена неисправной платы управления.",
+            "operation_status": "not_allowed",
+            "repairable": True,
+            "risks": ["electrical_damage", "repeated_failure"],
+            "recommended_actions": ["replace_control_board"],
+        },
+        "fan_motor_failure": {
+            "label": "Неисправность двигателя вентилятора",
+            "diagnosis_text": "Выявлены признаки неисправности двигателя вентилятора или узла вентилятора.",
+            "operation_text": "Эксплуатация оборудования до устранения неисправности не рекомендуется.",
+            "risk_text": "Дальнейшая эксплуатация может привести к перегреву и повторному повреждению узлов оборудования.",
+            "repair_text": "Рекомендуется заменить неисправный двигатель вентилятора и проверить работу оборудования под нагрузкой.",
+            "estimate_text": "Замена двигателя вентилятора с проверкой работы оборудования.",
+            "operation_status": "not_allowed",
+            "repairable": True,
+            "risks": ["overheating", "repeated_failure"],
+            "recommended_actions": ["replace_fan_motor"],
+        },
+        "compressor_failure": {
+            "label": "Неисправность компрессора",
+            "diagnosis_text": "Выявлены признаки неисправности компрессора.",
+            "operation_text": "Эксплуатация оборудования не допускается до устранения неисправности.",
+            "risk_text": "Дальнейшая эксплуатация может привести к повреждению холодильного контура и электрических компонентов.",
+            "repair_text": "Рекомендуется оценить целесообразность замены компрессора с учетом стоимости ремонта и состояния оборудования.",
+            "estimate_text": "Диагностика холодильного контура и замена компрессора при экономической целесообразности ремонта.",
+            "operation_status": "not_allowed",
+            "repairable": False,
+            "risks": ["electrical_damage", "repeated_failure"],
+            "recommended_actions": ["replace_compressor"],
+        },
+        "heat_exchanger_damage": {
+            "label": "Повреждение теплообменника",
+            "diagnosis_text": "Выявлены признаки повреждения или сильного износа теплообменника.",
+            "operation_text": "Эксплуатация допускается только после оценки герметичности и состояния теплообменника.",
+            "risk_text": "Дальнейшая эксплуатация может привести к утечке хладагента и снижению эффективности оборудования.",
+            "repair_text": "Рекомендуется оценить возможность замены теплообменника или целесообразность замены оборудования.",
+            "estimate_text": "Диагностика теплообменника и замена поврежденного узла при целесообразности ремонта.",
+            "operation_status": "limited",
+            "repairable": False,
+            "risks": ["low_efficiency", "compressor_damage"],
+            "recommended_actions": ["replace_heat_exchanger"],
+        },
+        "contamination": {
+            "label": "Загрязнение оборудования",
+            "diagnosis_text": "Выявлено загрязнение теплообменников, фильтров или внутренних узлов оборудования.",
+            "operation_text": "Эксплуатация возможна после сервисной очистки оборудования.",
+            "risk_text": "Дальнейшая эксплуатация загрязненного оборудования снижает эффективность и повышает нагрузку на узлы.",
+            "repair_text": "Рекомендуется выполнить глубокую очистку оборудования и повторную проверку рабочих режимов.",
+            "estimate_text": "Глубокая очистка оборудования с повторной проверкой рабочих режимов.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["low_efficiency", "overheating"],
+            "recommended_actions": ["deep_cleaning"],
+        },
+        "poor_installation": {
+            "label": "Нарушение монтажа",
+            "diagnosis_text": "Выявлены признаки нарушения требований монтажа оборудования.",
+            "operation_text": "Эксплуатация допускается только после устранения выявленных нарушений.",
+            "risk_text": "Дальнейшая эксплуатация может привести к повторным неисправностям и повреждению оборудования.",
+            "repair_text": "Рекомендуется устранить нарушения монтажа и выполнить контрольную проверку работы оборудования.",
+            "estimate_text": "Устранение нарушений монтажа с контрольной проверкой работы оборудования.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["repeated_failure", "compressor_damage"],
+            "recommended_actions": ["correct_installation"],
+        },
+        "unknown_fault": {
+            "label": "Неисправность требует уточнения",
+            "diagnosis_text": "Неисправность оборудования требует дополнительной инструментальной диагностики.",
+            "operation_text": "Эксплуатация до уточнения причины неисправности не рекомендуется.",
+            "risk_text": "Без уточнения причины неисправности возможны повторные отказы и повреждение узлов оборудования.",
+            "repair_text": "Рекомендуется выполнить дополнительную диагностику и согласовать ремонт после уточнения причины неисправности.",
+            "estimate_text": "Дополнительная диагностика оборудования с последующим согласованием ремонта.",
+            "operation_status": "unknown",
+            "repairable": True,
+            "risks": ["repeated_failure"],
+            "recommended_actions": ["additional_diagnostics"],
+        },
+    }
+
+    @classmethod
+    def normalize_fault_type(cls, value: Any) -> str:
+        raw = str(value or "").strip()
+        raw = cls.FAULT_ALIASES.get(raw, raw)
+        return raw if raw in cls.TEMPLATES else "unknown_fault"
+
+    @staticmethod
+    def _clean_text(value: Any, max_length: int = 1200) -> str:
+        return " ".join(str(value or "").replace("\xa0", " ").split())[:max_length].strip()
+
+    @classmethod
+    def _list(cls, value: Any, fallback: list[str]) -> list[str]:
+        if isinstance(value, list):
+            items = [cls._clean_text(item, 120) for item in value]
+            return [item for item in items if item]
+        if isinstance(value, str) and value.strip():
+            return [cls._clean_text(part, 120) for part in value.split(",") if cls._clean_text(part, 120)]
+        return list(fallback)
+
+    @staticmethod
+    def _bool(value: Any, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        text = str(value or "").strip().lower()
+        if text in {"true", "1", "yes", "да"}:
+            return True
+        if text in {"false", "0", "no", "нет"}:
+            return False
+        return default
+
+    @classmethod
+    def build_structured_findings(cls, raw: dict[str, Any] | None, current_meta: dict[str, Any] | None = None) -> dict[str, Any]:
+        raw = raw if isinstance(raw, dict) else {}
+        current_meta = current_meta if isinstance(current_meta, dict) else {}
+        fault_type = cls.normalize_fault_type(raw.get("fault_type") or current_meta.get("fault_type") or current_meta.get("likely_diagnosis"))
+        template = cls.TEMPLATES[fault_type]
+        return {
+            "fault_type": fault_type,
+            "fault_location": cls._clean_text(raw.get("fault_location") or current_meta.get("fault_location"), 160),
+            "repairable": cls._bool(raw.get("repairable"), bool(template["repairable"])),
+            "operation_status": cls._clean_text(raw.get("operation_status") or template["operation_status"], 80),
+            "risks": cls._list(raw.get("risks"), template["risks"]),
+            "recommended_actions": cls._list(raw.get("recommended_actions"), template["recommended_actions"]),
+            "refrigerant": cls._clean_text(
+                raw.get("refrigerant") or raw.get("refrigerant_type") or current_meta.get("refrigerant_type"),
+                80,
+            ),
+            "refrigerant_amount": cls._clean_text(
+                raw.get("refrigerant_amount") or current_meta.get("refrigerant_amount"),
+                80,
+            ),
+            "hidden_defects_possible": cls._bool(raw.get("hidden_defects_possible"), True),
+        }
+
+    @classmethod
+    def render_repair_meta(
+        cls,
+        *,
+        structured: dict[str, Any],
+        current_meta: dict[str, Any] | None = None,
+        diagnostic_notes: Any = None,
+    ) -> dict[str, Any]:
+        current_meta = current_meta if isinstance(current_meta, dict) else {}
+        fault_type = cls.normalize_fault_type(structured.get("fault_type"))
+        template = cls.TEMPLATES[fault_type]
+        structured = deepcopy(structured)
+        structured["fault_type"] = fault_type
+
+        risks_text = cls._risks_text(structured.get("risks") or template["risks"])
+        actions_text = cls._actions_text(structured.get("recommended_actions") or template["recommended_actions"])
+        diagnosis_text = cls._clean_text(current_meta.get("diagnostic_result") or template["diagnosis_text"])
+        repair_text = cls._clean_text(current_meta.get("repair_recommendation") or template["repair_text"])
+        if actions_text and actions_text.lower() not in repair_text.lower():
+            repair_text = f"{repair_text} Основные работы: {actions_text}."
+        notes = cls._clean_text(diagnostic_notes or current_meta.get("diagnostic_notes") or current_meta.get("measurement_result"), 900)
+
+        hidden_tail = ""
+        if structured.get("hidden_defects_possible"):
+            hidden_tail = (
+                " В процессе ремонта могут быть выявлены дополнительные неисправности, "
+                "не определяемые при первичном обследовании и требующие отдельного согласования."
+            )
+
+        blocks = {
+            "technical_condition": f"Неисправное. {diagnosis_text}",
+            "inspection": " ".join(
+                part for part in [
+                    "Проверена работоспособность оборудования.",
+                    notes,
+                    diagnosis_text,
+                    "Точный объем дефекта уточняется в ходе ремонтных работ с применением специализированного оборудования."
+                    if structured.get("hidden_defects_possible")
+                    else "",
+                ] if part
+            ),
+            "operation": " ".join(part for part in [template["operation_text"], template["risk_text"], risks_text] if part),
+            "conclusion": f"{repair_text}{hidden_tail}",
+        }
+
+        return {
+            "fault_type": fault_type,
+            "fault_location": structured.get("fault_location") or "",
+            "operation_status": structured.get("operation_status") or "",
+            "risks": structured.get("risks") or [],
+            "recommended_actions": structured.get("recommended_actions") or [],
+            "hidden_defects_possible": bool(structured.get("hidden_defects_possible")),
+            "structured_diagnosis": structured,
+            "defect_act_blocks": blocks,
+            "likely_diagnosis": template["label"],
+            "diagnostic_result": diagnosis_text,
+            "diagnostic_notes": notes,
+            "inspection_work_done": blocks["inspection"],
+            "technical_condition": blocks["technical_condition"],
+            "measurement_result": blocks["inspection"],
+            "further_use_assessment": template["operation_text"],
+            "operation_restrictions": " ".join(part for part in [template["risk_text"], risks_text] if part),
+            "repair_recommendation": repair_text,
+            "technical_conclusion": blocks["conclusion"],
+            "recommended_decision": repair_text,
+            "repair_feasibility": "Ремонт возможен." if structured.get("repairable") else "Ремонт невозможен или экономически нецелесообразен.",
+            "repair_possible": "Да" if structured.get("repairable") else "Нет",
+            "repair_not_viable": "Нет" if structured.get("repairable") else "Да",
+            "repair_not_viable_reason": "" if structured.get("repairable") else "Ремонт требует отдельной оценки экономической целесообразности.",
+            "refrigerant_type": structured.get("refrigerant") or "",
+            "refrigerant_amount": structured.get("refrigerant_amount") or "",
+            "repair_estimate_text": template["estimate_text"],
+        }
+
+    @classmethod
+    def build_meta_from_structured(
+        cls,
+        *,
+        raw: dict[str, Any] | None,
+        current_meta: dict[str, Any] | None = None,
+        fallback_fault_type: Any = None,
+        diagnostic_notes: Any = None,
+    ) -> dict[str, Any]:
+        raw = raw if isinstance(raw, dict) else {}
+        if fallback_fault_type and not raw.get("fault_type"):
+            raw = {**raw, "fault_type": fallback_fault_type}
+        structured = cls.build_structured_findings(raw, current_meta)
+        return cls.render_repair_meta(
+            structured=structured,
+            current_meta=current_meta,
+            diagnostic_notes=diagnostic_notes,
+        )
+
+    @classmethod
+    def build_document_fields(cls, repair_meta: dict[str, Any] | None) -> dict[str, Any]:
+        repair_meta = repair_meta if isinstance(repair_meta, dict) else {}
+        structured = repair_meta.get("structured_diagnosis") if isinstance(repair_meta.get("structured_diagnosis"), dict) else {}
+        if not structured and repair_meta.get("fault_type"):
+            structured = {"fault_type": repair_meta.get("fault_type")}
+        if not structured:
+            return {}
+        return cls.build_meta_from_structured(
+            raw=structured,
+            current_meta=repair_meta,
+            fallback_fault_type=repair_meta.get("fault_type"),
+            diagnostic_notes=repair_meta.get("diagnostic_notes") or repair_meta.get("measurement_result"),
+        )
+
+    @classmethod
+    def _risks_text(cls, risks: Any) -> str:
+        labels = [cls.RISK_TEXTS.get(str(item), str(item)) for item in cls._list(risks, [])]
+        if not labels:
+            return ""
+        return "Основные риски: " + ", ".join(labels) + "."
+
+    @classmethod
+    def _actions_text(cls, actions: Any) -> str:
+        labels = [cls.DEFAULT_ACTIONS.get(str(item), str(item)) for item in cls._list(actions, [])]
+        return ", ".join(labels)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -508,12 +508,16 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
         captured["prompt"] = prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "technical_condition": "Теплообменник имеет множественные дефекты, загрязнение и следы коррозии.",
-                    "technical_conclusion": "Эксплуатация оборудования без ремонта не рекомендуется.",
-                    "recommended_decision": "Рассмотреть замену теплообменника или оборудования в сборе.",
-                    "unknown_key": "must be ignored",
-                }
+                "fault_type": "refrigerant_leak",
+                "fault_location": "flare_connections",
+                "repairable": True,
+                "operation_status": "limited",
+                "risks": ["compressor_damage"],
+                "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
+                "refrigerant": "R410A",
+                "refrigerant_amount": "790 g",
+                "hidden_defects_possible": True,
+                "unknown_key": "must be ignored",
             },
             ensure_ascii=False,
         )
@@ -524,9 +528,10 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
 
     headers = await _auth_headers(async_client)
     payload = {
-        "defect_type": "multiple_heat_exchanger_defects",
-        "defect_label": "Множественные дефекты теплообменника",
+        "defect_type": "refrigerant_leak",
+        "defect_label": "Утечка хладагента",
         "equipment_model": "Daikin FTXB25C",
+        "diagnostic_notes": "Обмерзает внутренний блок, давление ниже нормы.",
         "current_meta": {"customer_complaint": "Плохо холодит"},
     }
     response = await async_client.post("/api/manager/repair-complaints/ai-draft", json=payload, headers=headers)
@@ -534,12 +539,18 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["provider"] == "deepseek"
-    assert data["prompt_version"] == "defect_act_v1"
-    assert data["repair_meta"]["technical_condition"].startswith("Теплообменник")
-    assert data["repair_meta"]["technical_conclusion"] == "Эксплуатация оборудования без ремонта не рекомендуется."
+    assert data["prompt_version"] == "defect_act_v2"
+    assert data["repair_meta"]["fault_type"] == "refrigerant_leak"
+    assert data["repair_meta"]["structured_diagnosis"]["fault_location"] == "flare_connections"
+    assert data["repair_meta"]["diagnostic_result"].startswith("Выявлены признаки утечки")
+    assert data["repair_meta"]["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
+    assert data["repair_meta"]["repair_estimate_text"].startswith("Устранение утечки хладагента")
+    assert "technical_condition" not in data["repair_meta"]
+    assert "technical_conclusion" not in data["repair_meta"]
     assert "unknown_key" not in data["repair_meta"]
-    assert "Множественные дефекты теплообменника" in captured["prompt"]
+    assert "Утечка хладагента" in captured["prompt"]
     assert "Daikin FTXB25C" in captured["prompt"]
+    assert "готовый дефектный акт" in captured["prompt"]
 
 
 @pytest.mark.asyncio
@@ -2502,6 +2513,65 @@ async def test_manager_order_generate_defect_act_placeholders(async_client, db, 
     assert replacements["{{repair_not_viable}}"] == "Да"
     assert replacements["{{repair_not_viable_reason}}"] == "Стоимость ремонта сопоставима с заменой оборудования."
     assert replacements["{{additional_conditions}}"] == "Работы выполнять после согласования с администратором."
+
+
+@pytest.mark.asyncio
+async def test_manager_order_generate_defect_act_from_structured_repair_meta(async_client, db, monkeypatch):
+    customer = Customer(name='ООО "Структура"', phone="+375297777700", type=CustomerType.company)
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEW_LEAD,
+        technical_meta={
+            "repair": {
+                "customer_complaint": "Плохо охлаждает",
+                "fault_type": "refrigerant_leak",
+                "diagnostic_notes": "Обмерзает теплообменник внутреннего блока.",
+                "structured_diagnosis": {
+                    "fault_type": "refrigerant_leak",
+                    "fault_location": "flare_connections",
+                    "repairable": True,
+                    "operation_status": "limited",
+                    "risks": ["compressor_damage"],
+                    "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
+                    "refrigerant": "R410A",
+                    "refrigerant_amount": "790 g",
+                    "hidden_defects_possible": True,
+                },
+            },
+        },
+    )
+    db.add_all([customer, order])
+    await db.commit()
+    await db.refresh(order)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            return {"file_id": "fake-defect-act", "edit_url": "https://docs.google.com/document/d/fake-defect-act/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            captured["replacements"] = replacements
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/defect_act?contract_date=2026-05-14T00:00:00",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    replacements = captured["replacements"]
+    assert replacements["{{technical_condition}}"].startswith("Неисправное. Выявлены признаки утечки хладагента")
+    assert "Обмерзает теплообменник" in replacements["{{measurement_result}}"]
+    assert "Эксплуатация оборудования допускается только с ограничениями" in replacements["{{further_use_assessment}}"]
+    assert "повреждение компрессора" in replacements["{{operation_restrictions}}"]
+    assert "восстановить герметичность холодильного контура" in replacements["{{technical_conclusion}}"]
+    assert replacements["{{repair_possible}}"] == "Да"
+    assert replacements["{{refrigerant_type}}"] == "R410A"
+    assert replacements["{{refrigerant_amount}}"] == "790 g"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_defect_act_ai_service.py
+++ b/tests/unit/test_defect_act_ai_service.py
@@ -7,15 +7,18 @@ from services.defect_act_ai_service import DefectActAIService
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_polishes_existing_fields_by_default(monkeypatch):
+async def test_defect_act_ai_returns_structured_template_meta(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
         assert '"polish_existing": true' in prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "measurement_result": "Измерения показали пробой обмотки компрессора на корпус.",
-                    "technical_conclusion": "Компрессор неисправен, дальнейшая эксплуатация оборудования запрещена.",
-                }
+                "fault_type": "compressor_failure",
+                "repairable": False,
+                "operation_status": "not_allowed",
+                "risks": ["electrical_damage"],
+                "recommended_actions": ["replace_compressor"],
+                "hidden_defects_possible": True,
+                "technical_conclusion": "AI must not write expert override fields.",
             },
             ensure_ascii=False,
         )
@@ -28,25 +31,32 @@ async def test_defect_act_ai_polishes_existing_fields_by_default(monkeypatch):
             polish_existing=True,
             current_meta={
                 "measurement_result": "замерили токи, пробивает на корпус",
-                "technical_conclusion": "",
+                "technical_conclusion": "ручное заключение инженера",
             },
         )
     )
 
-    assert result["measurement_result"].startswith("Измерения показали")
-    assert result["technical_conclusion"].startswith("Компрессор неисправен")
+    assert result["fault_type"] == "compressor_failure"
+    assert result["structured_diagnosis"]["repairable"] is False
+    assert result["diagnostic_result"].startswith("Выявлены признаки неисправности компрессора")
+    assert result["repair_recommendation"].startswith("Рекомендуется оценить целесообразность")
+    assert result["repair_possible"] == "Нет"
+    assert "measurement_result" not in result
+    assert "technical_conclusion" not in result
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_can_leave_existing_fields_untouched(monkeypatch):
+async def test_defect_act_ai_leaves_existing_primary_fields_untouched_when_requested(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
         assert '"polish_existing": false' in prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "measurement_result": "AI tried to rewrite existing value",
-                    "technical_conclusion": "Компрессор неисправен.",
-                }
+                "fault_type": "refrigerant_leak",
+                "fault_location": "flare_connections",
+                "repairable": True,
+                "operation_status": "limited",
+                "risks": ["compressor_damage"],
+                "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
             },
             ensure_ascii=False,
         )
@@ -55,41 +65,35 @@ async def test_defect_act_ai_can_leave_existing_fields_untouched(monkeypatch):
 
     result = await DefectActAIService.generate_repair_meta(
         ManagerRepairActAiDraftPayload(
-            defect_type="compressor_winding_breakdown",
+            defect_type="refrigerant_leak",
             polish_existing=False,
             current_meta={
-                "measurement_result": "замерили токи, пробивает на корпус",
-                "technical_conclusion": "",
+                "diagnostic_result": "Уже заполненная диагностика инженера.",
+                "repair_recommendation": "",
             },
         )
     )
 
-    assert "measurement_result" not in result
-    assert result["technical_conclusion"] == "Компрессор неисправен."
+    assert result["fault_type"] == "refrigerant_leak"
+    assert result["structured_diagnosis"]["fault_location"] == "flare_connections"
+    assert "diagnostic_result" not in result
+    assert result["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_sanitization_keeps_content_keys_and_drops_workflow_keys(monkeypatch):
+async def test_defect_act_ai_sanitization_keeps_structured_keys_and_drops_workflow_keys(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
-        assert "diagnostic_result" in prompt
-        assert "repair_recommendation" in prompt
+        assert "diagnostic_notes" in prompt
+        assert "repair_recommendation" not in prompt.split("Верни JSON в такой структуре:", 1)[1]
         return json.dumps(
             {
                 "repair_meta": {
-                    "diagnostic_result": "Диагностика выявила недостаток хладагента.",
-                    "repair_recommendation": "Проверить контур на утечку и дозаправить.",
-                    "repair_possible": "Да",
+                    "fault_type": "refrigerant_leak",
+                    "refrigerant": "R32",
+                    "refrigerant_amount": "0,35 кг",
                     "repair_status": "awaiting_customer_approval",
                     "customer_approval_status": "pending",
-                    "customer_approval_note": "Ожидается письменное согласование клиента.",
                     "parts_status": "awaiting",
-                    "parts_note": "Датчик температуры требуется заказать.",
-                    "repair_completion_note": "Завершение возможно после поставки запчастей.",
-                    "refrigerant_type": "R32",
-                    "refrigerant_amount": "0,35 кг",
-                    "refrigerant_pricing_mode": "по фактической массе",
-                    "repair_not_viable": "Нет",
-                    "repair_not_viable_reason": "Критических повреждений не выявлено.",
                     "unknown_key": "must be dropped",
                 }
             },
@@ -106,18 +110,13 @@ async def test_defect_act_ai_sanitization_keeps_content_keys_and_drops_workflow_
         )
     )
 
-    assert result["diagnostic_result"] == "Диагностика выявила недостаток хладагента."
-    assert result["repair_recommendation"] == "Проверить контур на утечку и дозаправить."
+    assert result["fault_type"] == "refrigerant_leak"
+    assert result["diagnostic_result"].startswith("Выявлены признаки утечки хладагента")
+    assert result["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
     assert result["repair_possible"] == "Да"
     assert result["refrigerant_type"] == "R32"
     assert result["refrigerant_amount"] == "0,35 кг"
-    assert result["refrigerant_pricing_mode"] == "по фактической массе"
-    assert result["repair_not_viable"] == "Нет"
-    assert result["repair_not_viable_reason"] == "Критических повреждений не выявлено."
     assert "repair_status" not in result
     assert "customer_approval_status" not in result
-    assert "customer_approval_note" not in result
     assert "parts_status" not in result
-    assert "parts_note" not in result
-    assert "repair_completion_note" not in result
     assert "unknown_key" not in result


### PR DESCRIPTION
## Что изменилось
- Перевел AI-черновик ремонта на структурированный JSON: fault_type, repairable, risks, recommended_actions, refrigerant и т.д.
- Добавил библиотеку шаблонов типовых неисправностей для дефектного акта и сметы.
- Сократил основную карточку ремонта: первичные поля остались на поверхности, статусы/оборудование/экспертные override-поля спрятаны в раскрываемые блоки.
- Дефектный акт теперь может собирать техническое состояние, обследование, эксплуатацию и заключение из структуры + шаблонов.
- Вынес repair meta/справочники из OrderEditDrawer в отдельный frontend helper, чтобы не раздувать drawer дальше.

## Проверки
- `python3 -m py_compile services/repair_defect_template_service.py services/defect_act_ai_service.py services/documents/standard.py schemas.py`
- `pytest tests/unit/test_defect_act_ai_service.py tests/unit/test_document_service_base_documents.py -q`
- `PATH="/Users/maksimkorotov/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/vue-tsc -b && PATH="/Users/maksimkorotov/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/vite build` in `manager_frontend/`
- `git diff --check`

## Локальные ограничения
- Scoped integration test `pytest tests/integration/test_manager_orders_api.py -q -k "repair_act_ai_draft or defect_act_from_structured_repair_meta"` не дошел до кода: локальный Postgres `localhost:5433` недоступен, Docker daemon тоже не запущен.
- Полный `pytest tests/unit -q` имеет те же DB setup errors и два unrelated env-secret failures в HA/Cloudflare/PITR tests из-за локальных переменных окружения.
