### PR TITLE
Add structured repair diagnostic intake

### DIFF
--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -20,6 +20,7 @@ export type { BankStatementImportResponse } from './models/BankStatementImportRe
 export type { Body_attach_manager_doc_file } from './models/Body_attach_manager_doc_file';
 export type { Body_bulk_upload_local_images } from './models/Body_bulk_upload_local_images';
 export type { Body_complete_media_worker_job } from './models/Body_complete_media_worker_job';
+export type { Body_create_repair_diagnostic_lead } from './models/Body_create_repair_diagnostic_lead';
 export type { Body_import_manager_bank_statement } from './models/Body_import_manager_bank_statement';
 export type { Body_login_access_token } from './models/Body_login_access_token';
 export type { Body_recognize_manager_customer_requisites } from './models/Body_recognize_manager_customer_requisites';
@@ -325,6 +326,7 @@ export type { ProductSeriesResponse } from './models/ProductSeriesResponse';
 export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';
 export type { PublicBrandResponse } from './models/PublicBrandResponse';
+export type { RepairDiagnosticLeadResponse } from './models/RepairDiagnosticLeadResponse';
 export type { ServiceResponse } from './models/ServiceResponse';
 export type { SpecRegistryItemResponse } from './models/SpecRegistryItemResponse';
 export type { SpecRegistryResponse } from './models/SpecRegistryResponse';

--- a/manager_frontend/src/client/models/Body_create_repair_diagnostic_lead.ts
+++ b/manager_frontend/src/client/models/Body_create_repair_diagnostic_lead.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_create_repair_diagnostic_lead = {
+    payload: string;
+    nameplate?: (Array<Blob> | null);
+    indoor_unit?: (Array<Blob> | null);
+    outdoor_unit?: (Array<Blob> | null);
+    error_display?: (Array<Blob> | null);
+    leak_place?: (Array<Blob> | null);
+};
+

--- a/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
+++ b/manager_frontend/src/client/models/ManagerRepairActAiDraftPayload.ts
@@ -14,6 +14,9 @@ export type ManagerRepairActAiDraftPayload = {
     customer_complaint?: (string | null);
     complaint_official?: (string | null);
     likely_diagnosis?: (string | null);
+    diagnostic_notes?: (string | null);
+    refrigerant_type?: (string | null);
+    refrigerant_amount?: (string | null);
     extra_context?: (string | null);
     current_meta?: Record<string, any>;
 };

--- a/manager_frontend/src/client/models/ManagerRepairActAiDraftResponse.ts
+++ b/manager_frontend/src/client/models/ManagerRepairActAiDraftResponse.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type ManagerRepairActAiDraftResponse = {
-    repair_meta?: Record<string, string>;
+    repair_meta?: Record<string, any>;
     provider?: string;
     model: string;
     prompt_version?: string;

--- a/manager_frontend/src/client/models/RepairDiagnosticLeadResponse.ts
+++ b/manager_frontend/src/client/models/RepairDiagnosticLeadResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type RepairDiagnosticLeadResponse = {
+    order_id: number;
+    status: string;
+    created_at: string;
+    ai_pre_diagnosis_status?: string;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { AddressSuggestResponse } from '../models/AddressSuggestResponse';
 import type { ArticleResponse } from '../models/ArticleResponse';
+import type { Body_create_repair_diagnostic_lead } from '../models/Body_create_repair_diagnostic_lead';
 import type { CatalogResponse } from '../models/CatalogResponse';
 import type { CatalogRevisionResponse } from '../models/CatalogRevisionResponse';
 import type { FiltersConfigResponse } from '../models/FiltersConfigResponse';
@@ -14,6 +15,7 @@ import type { ProductAvailabilityLeadResponse } from '../models/ProductAvailabil
 import type { ProductResponse } from '../models/ProductResponse';
 import type { ProductSeriesNavigationResponse } from '../models/ProductSeriesNavigationResponse';
 import type { PublicBrandResponse } from '../models/PublicBrandResponse';
+import type { RepairDiagnosticLeadResponse } from '../models/RepairDiagnosticLeadResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
 import type { SpecRegistryResponse } from '../models/SpecRegistryResponse';
 import type { SpecsKeysResponse } from '../models/SpecsKeysResponse';
@@ -272,6 +274,25 @@ export class ApiService {
             url: '/api/v1/leads/product-availability',
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Repair Diagnostic Lead
+     * @param formData
+     * @returns RepairDiagnosticLeadResponse Successful Response
+     * @throws ApiError
+     */
+    public static createRepairDiagnosticLead(
+        formData: Body_create_repair_diagnostic_lead,
+    ): CancelablePromise<RepairDiagnosticLeadResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/leads/repair-diagnostic',
+            formData: formData,
+            mediaType: 'multipart/form-data',
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -29,6 +29,20 @@ import type {
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
 import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
+import {
+  CUSTOMER_APPROVAL_STATUS_OPTIONS,
+  EQUIPMENT_EVENT_OPTIONS,
+  PARTS_STATUS_OPTIONS,
+  REFRIGERANT_PRICING_MODE_OPTIONS,
+  REPAIR_AI_DEFECT_TYPES,
+  REPAIR_CHOICE_OPTIONS,
+  REPAIR_WORKFLOW_STATUS_OPTIONS,
+  emptyRepairMeta,
+  labeledOptionsWithCurrent,
+  normalizeRepairMeta,
+  selectOptionsWithCurrent,
+  type RepairMeta,
+} from './repair-meta';
 import { fromLocalDateTimeInput, toLocalDateTimeInput } from '../../utils/datetime';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
@@ -90,242 +104,12 @@ type ProductLine = {
 };
 type ServiceLine = { service_id?: number | null; title: string; quantity: number; price: number; cost: number };
 type OrderWorkflowType = 'sales_installation' | 'service_work' | 'maintenance' | 'repair';
-type RepairMeta = {
-  repair_status: string;
-  customer_approval_status: string;
-  customer_approval_note: string;
-  parts_status: string;
-  parts_note: string;
-  repair_completion_note: string;
-  customer_complaint: string;
-  complaint_official: string;
-  complaint_text?: string;
-  likely_diagnosis: string;
-  equipment_name: string;
-  equipment_brand: string;
-  equipment_model: string;
-  equipment_power: string;
-  equipment_serial_number: string;
-  equipment_inventory_number: string;
-  equipment_commissioning_date: string;
-  technical_condition: string;
-  startup_check_result: string;
-  compressor_check_result: string;
-  measurement_result: string;
-  diagnostic_result: string;
-  further_use_assessment: string;
-  operation_restrictions: string;
-  technical_conclusion: string;
-  repair_feasibility: string;
-  recommended_decision: string;
-  repair_recommendation: string;
-  repair_possible: string;
-  refrigerant_type: string;
-  refrigerant_amount: string;
-  refrigerant_pricing_mode: string;
-  repair_not_viable: string;
-  repair_not_viable_reason: string;
-};
-type RepairAiDefectType = {
-  value: string;
-  label: string;
-  hint: string;
-};
 
 const WORKFLOW_OPTIONS: Array<{ value: OrderWorkflowType; label: string; hint: string; icon: string }> = [
   { value: 'sales_installation', label: 'Продажа + монтаж', hint: 'товары, КП, монтаж', icon: 'shopping_cart' },
   { value: 'service_work', label: 'Работы', hint: 'монтаж, демонтаж, трассы', icon: 'construction' },
   { value: 'maintenance', label: 'Обслуживание', hint: 'ТО и сервисные договоры', icon: 'ac_unit' },
   { value: 'repair', label: 'Ремонт', hint: 'диагностика и дефектный акт', icon: 'build_circle' },
-];
-
-const REPAIR_WORKFLOW_STATUS_OPTIONS = [
-  { value: 'new', label: 'Новая' },
-  { value: 'scheduled', label: 'Запланирован' },
-  { value: 'diagnostic_in_progress', label: 'Диагностика идет' },
-  { value: 'awaiting_diagnostic_result', label: 'Ждем диагностику' },
-  { value: 'awaiting_customer_approval', label: 'На согласовании' },
-  { value: 'approved_for_repair', label: 'Ремонт согласован' },
-  { value: 'repair_in_progress', label: 'Ремонт идет' },
-  { value: 'awaiting_parts', label: 'Ждем запчасти' },
-  { value: 'completed', label: 'Завершен' },
-  { value: 'not_repairable', label: 'Не ремонтируется' },
-  { value: 'cancelled', label: 'Отменен' },
-];
-const REPAIR_WORKFLOW_STATUS_VALUES = new Set(REPAIR_WORKFLOW_STATUS_OPTIONS.map((item) => item.value));
-
-const CUSTOMER_APPROVAL_STATUS_OPTIONS = [
-  { value: '', label: 'Не указано' },
-  { value: 'pending', label: 'Ожидает согласования' },
-  { value: 'approved', label: 'Согласовано' },
-  { value: 'rejected', label: 'Отказано' },
-];
-
-const PARTS_STATUS_OPTIONS = [
-  { value: '', label: 'Не указано' },
-  { value: 'not_required', label: 'Не требуются' },
-  { value: 'awaiting', label: 'Ожидаются' },
-  { value: 'ordered', label: 'Заказаны' },
-  { value: 'received', label: 'Получены' },
-  { value: 'installed', label: 'Установлены' },
-];
-
-const emptyRepairMeta = (): RepairMeta => ({
-  repair_status: '',
-  customer_approval_status: '',
-  customer_approval_note: '',
-  parts_status: '',
-  parts_note: '',
-  repair_completion_note: '',
-  customer_complaint: '',
-  complaint_official: '',
-  likely_diagnosis: '',
-  equipment_name: '',
-  equipment_brand: '',
-  equipment_model: '',
-  equipment_power: '',
-  equipment_serial_number: '',
-  equipment_inventory_number: '',
-  equipment_commissioning_date: '',
-  technical_condition: '',
-  startup_check_result: '',
-  compressor_check_result: '',
-  measurement_result: '',
-  diagnostic_result: '',
-  further_use_assessment: '',
-  operation_restrictions: '',
-  technical_conclusion: '',
-  repair_feasibility: '',
-  recommended_decision: '',
-  repair_recommendation: '',
-  repair_possible: '',
-  refrigerant_type: '',
-  refrigerant_amount: '',
-  refrigerant_pricing_mode: '',
-  repair_not_viable: '',
-  repair_not_viable_reason: '',
-});
-
-const REPAIR_CHOICE_OPTIONS = ['', 'Да', 'Нет'];
-const REFRIGERANT_PRICING_MODE_OPTIONS = [
-  'по фактической массе',
-  'включен в стоимость ремонта',
-  'отдельной строкой сметы',
-  'не требуется',
-];
-const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
-  { value: 'diagnostic', label: 'Диагностика' },
-  { value: 'repair', label: 'Ремонт' },
-  { value: 'maintenance', label: 'Обслуживание' },
-  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
-  { value: 'leak', label: 'Утечка' },
-  { value: 'recommendation', label: 'Рекомендация' },
-  { value: 'not_repairable', label: 'Не ремонтируется' },
-  { value: 'other', label: 'Другое' },
-];
-
-const textValue = (value: unknown) => String(value ?? '').trim();
-
-const normalizeRepairWorkflowStatus = (value: unknown) => {
-  const raw = textValue(value);
-  const normalized = raw.toLowerCase().replace(/-/g, '_').split(/\s+/).filter(Boolean).join('_');
-  return REPAIR_WORKFLOW_STATUS_VALUES.has(normalized) ? normalized : '';
-};
-
-const choiceText = (value: unknown) => {
-  if (typeof value === 'boolean') return value ? 'Да' : 'Нет';
-  return textValue(value);
-};
-
-const isExplicitNegativeRepairText = (value: unknown) => {
-  const text = textValue(value).toLowerCase();
-  if (!text) return false;
-  return [
-    'невозмож',
-    'не возмож',
-    'нецелесообраз',
-    'не целесообраз',
-    'нерентаб',
-    'не рентаб',
-    'списан',
-    'списани',
-    'вывести из эксплуатации',
-  ].some((marker) => text.includes(marker));
-};
-
-const normalizeRepairMeta = (
-  raw: Partial<RepairMeta> | Record<string, any> | null | undefined,
-  options: { defaultRepairStatus?: boolean } = {},
-): RepairMeta => {
-  const meta = { ...emptyRepairMeta(), ...((raw || {}) as Partial<RepairMeta>) };
-  meta.repair_status = normalizeRepairWorkflowStatus(meta.repair_status) || (options.defaultRepairStatus ? 'new' : '');
-  meta.customer_approval_status = textValue(meta.customer_approval_status);
-  meta.customer_approval_note = textValue(meta.customer_approval_note);
-  meta.parts_status = textValue(meta.parts_status);
-  meta.parts_note = textValue(meta.parts_note);
-  meta.repair_completion_note = textValue(meta.repair_completion_note);
-  if (!textValue(meta.customer_complaint)) {
-    meta.customer_complaint = textValue(meta.complaint_official) || textValue(meta.complaint_text);
-  }
-  if (!textValue(meta.diagnostic_result)) {
-    meta.diagnostic_result = textValue(meta.measurement_result);
-  }
-  if (!textValue(meta.repair_recommendation)) {
-    meta.repair_recommendation = textValue(meta.recommended_decision) || textValue(meta.technical_conclusion);
-  }
-  meta.repair_possible = choiceText(meta.repair_possible);
-  meta.repair_not_viable = choiceText(meta.repair_not_viable);
-  const legacyFeasibility = textValue(meta.repair_feasibility);
-  if (legacyFeasibility && isExplicitNegativeRepairText(legacyFeasibility)) {
-    if (!textValue(meta.repair_not_viable)) meta.repair_not_viable = 'Да';
-    if (!textValue(meta.repair_not_viable_reason)) meta.repair_not_viable_reason = legacyFeasibility;
-  }
-  return meta;
-};
-
-const selectOptionsWithCurrent = (baseOptions: string[], current: unknown) => {
-  const currentValue = textValue(current);
-  if (!currentValue || baseOptions.includes(currentValue)) return baseOptions;
-  return [...baseOptions, currentValue];
-};
-
-const labeledOptionsWithCurrent = (baseOptions: Array<{ value: string; label: string }>, current: unknown) => {
-  const currentValue = textValue(current);
-  if (!currentValue || baseOptions.some((item) => item.value === currentValue)) return baseOptions;
-  return [...baseOptions, { value: currentValue, label: currentValue }];
-};
-
-const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
-  {
-    value: 'multiple_heat_exchanger_defects',
-    label: 'Множественные дефекты теплообменника',
-    hint: 'коррозия, загрязнение, механические повреждения, нарушение теплообмена',
-  },
-  {
-    value: 'compressor_winding_breakdown',
-    label: 'Пробой обмотки компрессора',
-    hint: 'электрическая неисправность компрессора, срабатывание защиты',
-  },
-  {
-    value: 'refrigerant_leak',
-    label: 'Утечка хладагента',
-    hint: 'падение производительности, обмерзание, требуется поиск и устранение утечки',
-  },
-  {
-    value: 'control_board_failure',
-    label: 'Неисправность платы управления',
-    hint: 'ошибки управления, нестабильная работа, отсутствие запуска',
-  },
-  {
-    value: 'fan_motor_failure',
-    label: 'Неисправность двигателя вентилятора',
-    hint: 'шум, отсутствие вращения, перегрев, ошибка вентилятора',
-  },
-  {
-    value: 'drainage_failure',
-    label: 'Нарушение отвода конденсата',
-    hint: 'протечка воды, засор или неправильный уклон дренажа',
-  },
 ];
 
 const serviceKindLabels: Record<string, string> = {
@@ -1105,11 +889,28 @@ const filteredRepairComplaintPresets = computed(() => {
 const selectedRepairAiDefect = computed(() => (
   REPAIR_AI_DEFECT_TYPES.find((item) => item.value === repairAiDefectType.value) || REPAIR_AI_DEFECT_TYPES[0]
 ));
+const repairStructuredJson = computed(() => {
+  const payload = {
+    structured_diagnosis: repairMeta.value.structured_diagnosis || {},
+    defect_act_blocks: repairMeta.value.defect_act_blocks || {},
+    risks: repairMeta.value.risks || [],
+    recommended_actions: repairMeta.value.recommended_actions || [],
+  };
+  return JSON.stringify(payload, null, 2);
+});
 const repairPossibleOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_possible));
 const repairNotViableOptions = computed(() => selectOptionsWithCurrent(REPAIR_CHOICE_OPTIONS, repairMeta.value.repair_not_viable));
 const customerApprovalStatusOptions = computed(() => labeledOptionsWithCurrent(CUSTOMER_APPROVAL_STATUS_OPTIONS, repairMeta.value.customer_approval_status));
 const partsStatusOptions = computed(() => labeledOptionsWithCurrent(PARTS_STATUS_OPTIONS, repairMeta.value.parts_status));
-const buildRepairMetaPayload = () => normalizeRepairMeta(repairMeta.value, { defaultRepairStatus: isRepairWorkflow.value });
+watch(repairAiDefectType, (value) => {
+  if (isRepairWorkflow.value) {
+    repairMeta.value.fault_type = value;
+  }
+});
+const buildRepairMetaPayload = () => normalizeRepairMeta({
+  ...repairMeta.value,
+  fault_type: repairMeta.value.fault_type || repairAiDefectType.value,
+}, { defaultRepairStatus: isRepairWorkflow.value });
 const documentSectionSummary = computed(() => {
   const contractText = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : 'без договора');
   return `${orderDocuments.value.length} док. · ${contractText}`;
@@ -1577,6 +1378,14 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   repairMeta.value = normalizeRepairMeta(((order as any).repair_meta || {}) as Partial<RepairMeta>, {
     defaultRepairStatus: workflowType.value === 'repair',
   });
+  if (workflowType.value === 'repair') {
+    const savedFaultType = repairMeta.value.fault_type || (repairMeta.value.structured_diagnosis || {}).fault_type;
+    if (savedFaultType && REPAIR_AI_DEFECT_TYPES.some((item) => item.value === savedFaultType)) {
+      repairAiDefectType.value = savedFaultType;
+    } else {
+      repairMeta.value.fault_type = repairAiDefectType.value;
+    }
+  }
   repairComplaintSearch.value = '';
   if (workflowType.value === 'repair' && !repairComplaintPresets.value.length) {
     void loadRepairComplaintPresets();
@@ -2147,7 +1956,10 @@ const generateRepairAiDraft = async () => {
       customer_complaint: repairMeta.value.customer_complaint,
       complaint_official: repairMeta.value.complaint_official,
       likely_diagnosis: repairMeta.value.likely_diagnosis,
-      extra_context: repairAiExtraContext.value || defect.hint,
+      diagnostic_notes: repairMeta.value.diagnostic_notes,
+      refrigerant_type: repairMeta.value.refrigerant_type,
+      refrigerant_amount: repairMeta.value.refrigerant_amount,
+      extra_context: repairMeta.value.diagnostic_notes || repairAiExtraContext.value || defect.hint,
       current_meta: repairMeta.value as any,
     });
     repairMeta.value = normalizeRepairMeta({ ...repairMeta.value, ...((response.repair_meta || {}) as Partial<RepairMeta>) });
@@ -3025,22 +2837,12 @@ watch(
           </div>
           <div class="md:col-span-2 rounded-xl border border-violet-100 bg-violet-50/60 p-3">
             <div class="mb-2 flex flex-col gap-2 lg:flex-row lg:items-end">
-              <label class="field-label flex-1">
-                Базовая неисправность
-                <select v-model="repairAiDefectType" class="field-input bg-white">
-                  <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="item.value" :value="item.value">
-                    {{ item.label }}
-                  </option>
-                </select>
-              </label>
-              <label class="field-label flex-[1.2]">
-                Детали диагностики
-                <input
-                  v-model="repairAiExtraContext"
-                  class="field-input bg-white"
-                  placeholder="Например: наружный блок не стартует, запах гари, сильная коррозия..."
-                />
-              </label>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-semibold text-violet-950">AI-черновик по выбранной неисправности</p>
+                <p class="mt-1 truncate text-xs text-violet-700/80">
+                  {{ selectedRepairAiDefect?.label || 'Базовая неисправность не выбрана' }}
+                </p>
+              </div>
               <button
                 type="button"
                 class="btn-mini h-[42px] justify-center whitespace-nowrap bg-violet-600 hover:bg-violet-700"
@@ -3066,12 +2868,12 @@ watch(
               </div>
             </div>
           </div>
-          <div class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <div class="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-sm font-semibold text-slate-900">Статусы ремонта</p>
-              <p class="text-xs text-slate-600">Этап ремонта; CRM/Kanban статус заказа отдельно.</p>
-            </div>
-            <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+              Статусы, согласование и запчасти
+              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairWorkflowStatusLabel || 'не указано' }}</span>
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               <label class="field-label">
                 Этап ремонта
                 <select v-model="repairMeta.repair_status" class="field-input bg-white">
@@ -3121,7 +2923,7 @@ watch(
                 />
               </label>
             </div>
-          </div>
+          </details>
           <label class="field-label md:col-span-2">
             Жалоба клиента
             <textarea
@@ -3131,19 +2933,19 @@ watch(
             />
           </label>
           <label class="field-label">
-            Формулировка для акта
-            <textarea
-              v-model="repairMeta.complaint_official"
-              class="field-input min-h-[72px]"
-              placeholder="Официальная формулировка жалобы"
-            />
+            Базовая неисправность
+            <select v-model="repairAiDefectType" class="field-input">
+              <option v-for="item in REPAIR_AI_DEFECT_TYPES" :key="`main-${item.value}`" :value="item.value">
+                {{ item.label }}
+              </option>
+            </select>
           </label>
-          <label class="field-label">
-            Вероятный диагноз
+          <label class="field-label md:col-span-2">
+            Детали диагностики / заметки инженера
             <textarea
-              v-model="repairMeta.likely_diagnosis"
+              v-model="repairMeta.diagnostic_notes"
               class="field-input min-h-[72px]"
-              placeholder="Предварительная причина неисправности"
+              placeholder="Что увидел инженер: симптомы, проверки, ограничения, важные нюансы"
             />
           </label>
           <label class="field-label">
@@ -3160,6 +2962,14 @@ watch(
               v-model="repairMeta.repair_recommendation"
               class="field-input min-h-[88px]"
               placeholder="Что сделать: устранить утечку, заменить узел, дозаправить..."
+            />
+          </label>
+          <label class="field-label md:col-span-2">
+            Формулировка для сметы ремонта
+            <textarea
+              v-model="repairMeta.repair_estimate_text"
+              class="field-input min-h-[72px]"
+              placeholder="Короткая строка работ для сметы"
             />
           </label>
           <label class="field-label">
@@ -3207,6 +3017,12 @@ watch(
             />
           </label>
 
+          <details class="md:col-span-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900">
+              Оборудование и паспортные данные
+              <span class="ml-2 text-xs font-normal text-slate-500">{{ repairMeta.equipment_model || repairMeta.equipment_name || 'не заполнено' }}</span>
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2">
           <label class="field-label">
             Оборудование
             <input v-model="repairMeta.equipment_name" class="field-input" placeholder="Кондиционер настенный" />
@@ -3348,7 +3164,34 @@ watch(
               </div>
             </div>
           </div>
+            </div>
+          </details>
 
+          <details class="md:col-span-2 rounded-xl border border-amber-200 bg-amber-50/60 p-3">
+            <summary class="cursor-pointer select-none text-sm font-semibold text-amber-900">
+              Экспертный режим: JSON и ручные override-поля
+            </summary>
+            <div class="mt-3 grid gap-3 md:grid-cols-2">
+              <label class="field-label md:col-span-2">
+                Структурированные выводы AI
+                <textarea :value="repairStructuredJson" readonly class="field-input min-h-[180px] font-mono text-xs" />
+              </label>
+              <label class="field-label">
+                Формулировка для акта
+                <textarea
+                  v-model="repairMeta.complaint_official"
+                  class="field-input min-h-[72px]"
+                  placeholder="Override официальной формулировки жалобы"
+                />
+              </label>
+              <label class="field-label">
+                Вероятный диагноз
+                <textarea
+                  v-model="repairMeta.likely_diagnosis"
+                  class="field-input min-h-[72px]"
+                  placeholder="Override предварительной причины"
+                />
+              </label>
           <label class="field-label">
             Техническое состояние
             <textarea v-model="repairMeta.technical_condition" class="field-input min-h-[80px]" placeholder="Общее состояние, износ, загрязнение, следы вмешательства..." />
@@ -3385,6 +3228,8 @@ watch(
             Техническое заключение
             <textarea v-model="repairMeta.technical_conclusion" class="field-input min-h-[96px]" placeholder="Итоговый вывод для дефектного акта" />
           </label>
+            </div>
+          </details>
         </div>
       </OrderDrawerSection>
 

--- a/manager_frontend/src/components/orders/repair-meta.ts
+++ b/manager_frontend/src/components/orders/repair-meta.ts
@@ -1,0 +1,268 @@
+import type { EquipmentServiceEventType } from '../../client';
+
+export type RepairMeta = {
+  repair_status: string;
+  customer_approval_status: string;
+  customer_approval_note: string;
+  parts_status: string;
+  parts_note: string;
+  repair_completion_note: string;
+  customer_complaint: string;
+  complaint_official: string;
+  complaint_text?: string;
+  likely_diagnosis: string;
+  fault_type: string;
+  fault_location: string;
+  operation_status: string;
+  diagnostic_notes: string;
+  equipment_name: string;
+  equipment_brand: string;
+  equipment_model: string;
+  equipment_power: string;
+  equipment_serial_number: string;
+  equipment_inventory_number: string;
+  equipment_commissioning_date: string;
+  technical_condition: string;
+  startup_check_result: string;
+  compressor_check_result: string;
+  measurement_result: string;
+  diagnostic_result: string;
+  further_use_assessment: string;
+  operation_restrictions: string;
+  technical_conclusion: string;
+  repair_feasibility: string;
+  recommended_decision: string;
+  repair_recommendation: string;
+  repair_possible: string;
+  refrigerant_type: string;
+  refrigerant_amount: string;
+  refrigerant_pricing_mode: string;
+  repair_not_viable: string;
+  repair_not_viable_reason: string;
+  repair_estimate_text: string;
+  risks?: string[];
+  recommended_actions?: string[];
+  hidden_defects_possible?: boolean;
+  structured_diagnosis?: Record<string, any>;
+  defect_act_blocks?: Record<string, string>;
+};
+
+export type RepairAiDefectType = {
+  value: string;
+  label: string;
+  hint: string;
+};
+
+export const REPAIR_WORKFLOW_STATUS_OPTIONS = [
+  { value: 'new', label: 'Новая' },
+  { value: 'scheduled', label: 'Запланирован' },
+  { value: 'diagnostic_in_progress', label: 'Диагностика идет' },
+  { value: 'awaiting_diagnostic_result', label: 'Ждем диагностику' },
+  { value: 'awaiting_customer_approval', label: 'На согласовании' },
+  { value: 'approved_for_repair', label: 'Ремонт согласован' },
+  { value: 'repair_in_progress', label: 'Ремонт идет' },
+  { value: 'awaiting_parts', label: 'Ждем запчасти' },
+  { value: 'completed', label: 'Завершен' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'cancelled', label: 'Отменен' },
+];
+const REPAIR_WORKFLOW_STATUS_VALUES = new Set(REPAIR_WORKFLOW_STATUS_OPTIONS.map((item) => item.value));
+
+export const CUSTOMER_APPROVAL_STATUS_OPTIONS = [
+  { value: '', label: 'Не указано' },
+  { value: 'pending', label: 'Ожидает согласования' },
+  { value: 'approved', label: 'Согласовано' },
+  { value: 'rejected', label: 'Отказано' },
+];
+
+export const PARTS_STATUS_OPTIONS = [
+  { value: '', label: 'Не указано' },
+  { value: 'not_required', label: 'Не требуются' },
+  { value: 'awaiting', label: 'Ожидаются' },
+  { value: 'ordered', label: 'Заказаны' },
+  { value: 'received', label: 'Получены' },
+  { value: 'installed', label: 'Установлены' },
+];
+
+export const emptyRepairMeta = (): RepairMeta => ({
+  repair_status: '',
+  customer_approval_status: '',
+  customer_approval_note: '',
+  parts_status: '',
+  parts_note: '',
+  repair_completion_note: '',
+  customer_complaint: '',
+  complaint_official: '',
+  likely_diagnosis: '',
+  fault_type: '',
+  fault_location: '',
+  operation_status: '',
+  diagnostic_notes: '',
+  equipment_name: '',
+  equipment_brand: '',
+  equipment_model: '',
+  equipment_power: '',
+  equipment_serial_number: '',
+  equipment_inventory_number: '',
+  equipment_commissioning_date: '',
+  technical_condition: '',
+  startup_check_result: '',
+  compressor_check_result: '',
+  measurement_result: '',
+  diagnostic_result: '',
+  further_use_assessment: '',
+  operation_restrictions: '',
+  technical_conclusion: '',
+  repair_feasibility: '',
+  recommended_decision: '',
+  repair_recommendation: '',
+  repair_possible: '',
+  refrigerant_type: '',
+  refrigerant_amount: '',
+  refrigerant_pricing_mode: '',
+  repair_not_viable: '',
+  repair_not_viable_reason: '',
+  repair_estimate_text: '',
+  risks: [],
+  recommended_actions: [],
+  hidden_defects_possible: false,
+  structured_diagnosis: {},
+  defect_act_blocks: {},
+});
+
+export const REPAIR_CHOICE_OPTIONS = ['', 'Да', 'Нет'];
+export const REFRIGERANT_PRICING_MODE_OPTIONS = [
+  'по фактической массе',
+  'включен в стоимость ремонта',
+  'отдельной строкой сметы',
+  'не требуется',
+];
+export const EQUIPMENT_EVENT_OPTIONS: Array<{ value: EquipmentServiceEventType; label: string }> = [
+  { value: 'diagnostic', label: 'Диагностика' },
+  { value: 'repair', label: 'Ремонт' },
+  { value: 'maintenance', label: 'Обслуживание' },
+  { value: 'refrigerant_charge', label: 'Заправка хладагентом' },
+  { value: 'leak', label: 'Утечка' },
+  { value: 'recommendation', label: 'Рекомендация' },
+  { value: 'not_repairable', label: 'Не ремонтируется' },
+  { value: 'other', label: 'Другое' },
+];
+
+export const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
+  {
+    value: 'refrigerant_leak',
+    label: 'Утечка хладагента',
+    hint: 'падение производительности, обмерзание, требуется поиск и устранение утечки',
+  },
+  {
+    value: 'drainage_failure',
+    label: 'Нарушение отвода конденсата',
+    hint: 'протечка воды, засор или неправильный уклон дренажа',
+  },
+  {
+    value: 'control_board_failure',
+    label: 'Неисправность платы управления',
+    hint: 'ошибки управления, нестабильная работа, отсутствие запуска',
+  },
+  {
+    value: 'fan_motor_failure',
+    label: 'Неисправность двигателя вентилятора',
+    hint: 'шум, отсутствие вращения, перегрев, ошибка вентилятора',
+  },
+  {
+    value: 'compressor_failure',
+    label: 'Неисправность компрессора',
+    hint: 'электрическая или механическая неисправность компрессора, срабатывание защиты',
+  },
+  {
+    value: 'heat_exchanger_damage',
+    label: 'Повреждение теплообменника',
+    hint: 'коррозия, механические повреждения, нарушение теплообмена',
+  },
+  {
+    value: 'contamination',
+    label: 'Загрязнение оборудования',
+    hint: 'загрязнение теплообменника, фильтров или внутренних узлов',
+  },
+  {
+    value: 'poor_installation',
+    label: 'Нарушение монтажа',
+    hint: 'ошибки трассы, дренажа, подключения или установки блоков',
+  },
+  {
+    value: 'unknown_fault',
+    label: 'Требуется уточнение',
+    hint: 'причина не подтверждена, нужна дополнительная диагностика',
+  },
+];
+
+export const textValue = (value: unknown) => String(value ?? '').trim();
+
+const normalizeRepairWorkflowStatus = (value: unknown) => {
+  const raw = textValue(value);
+  const normalized = raw.toLowerCase().replace(/-/g, '_').split(/\s+/).filter(Boolean).join('_');
+  return REPAIR_WORKFLOW_STATUS_VALUES.has(normalized) ? normalized : '';
+};
+
+const choiceText = (value: unknown) => {
+  if (typeof value === 'boolean') return value ? 'Да' : 'Нет';
+  return textValue(value);
+};
+
+const isExplicitNegativeRepairText = (value: unknown) => {
+  const text = textValue(value).toLowerCase();
+  if (!text) return false;
+  return [
+    'невозмож',
+    'не возмож',
+    'нецелесообраз',
+    'не целесообраз',
+    'нерентаб',
+    'не рентаб',
+    'списан',
+    'списани',
+    'вывести из эксплуатации',
+  ].some((marker) => text.includes(marker));
+};
+
+export const normalizeRepairMeta = (
+  raw: Partial<RepairMeta> | Record<string, any> | null | undefined,
+  options: { defaultRepairStatus?: boolean } = {},
+): RepairMeta => {
+  const meta = { ...emptyRepairMeta(), ...((raw || {}) as Partial<RepairMeta>) };
+  meta.repair_status = normalizeRepairWorkflowStatus(meta.repair_status) || (options.defaultRepairStatus ? 'new' : '');
+  meta.customer_approval_status = textValue(meta.customer_approval_status);
+  meta.customer_approval_note = textValue(meta.customer_approval_note);
+  meta.parts_status = textValue(meta.parts_status);
+  meta.parts_note = textValue(meta.parts_note);
+  meta.repair_completion_note = textValue(meta.repair_completion_note);
+  if (!textValue(meta.customer_complaint)) {
+    meta.customer_complaint = textValue(meta.complaint_official) || textValue(meta.complaint_text);
+  }
+  if (!textValue(meta.diagnostic_result)) {
+    meta.diagnostic_result = textValue(meta.measurement_result);
+  }
+  if (!textValue(meta.repair_recommendation)) {
+    meta.repair_recommendation = textValue(meta.recommended_decision) || textValue(meta.technical_conclusion);
+  }
+  meta.repair_possible = choiceText(meta.repair_possible);
+  meta.repair_not_viable = choiceText(meta.repair_not_viable);
+  const legacyFeasibility = textValue(meta.repair_feasibility);
+  if (legacyFeasibility && isExplicitNegativeRepairText(legacyFeasibility)) {
+    if (!textValue(meta.repair_not_viable)) meta.repair_not_viable = 'Да';
+    if (!textValue(meta.repair_not_viable_reason)) meta.repair_not_viable_reason = legacyFeasibility;
+  }
+  return meta;
+};
+
+export const selectOptionsWithCurrent = (baseOptions: string[], current: unknown) => {
+  const currentValue = textValue(current);
+  if (!currentValue || baseOptions.includes(currentValue)) return baseOptions;
+  return [...baseOptions, currentValue];
+};
+
+export const labeledOptionsWithCurrent = (baseOptions: Array<{ value: string; label: string }>, current: unknown) => {
+  const currentValue = textValue(current);
+  if (!currentValue || baseOptions.some((item) => item.value === currentValue)) return baseOptions;
+  return [...baseOptions, { value: currentValue, label: currentValue }];
+};

--- a/openapi.json
+++ b/openapi.json
@@ -29724,6 +29724,39 @@
             ],
             "title": "Likely Diagnosis"
           },
+          "diagnostic_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diagnostic Notes"
+          },
+          "refrigerant_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refrigerant Type"
+          },
+          "refrigerant_amount": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refrigerant Amount"
+          },
           "extra_context": {
             "anyOf": [
               {
@@ -29750,9 +29783,7 @@
       "ManagerRepairActAiDraftResponse": {
         "properties": {
           "repair_meta": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Repair Meta"
           },
@@ -29768,7 +29799,7 @@
           "prompt_version": {
             "type": "string",
             "title": "Prompt Version",
-            "default": "defect_act_v1"
+            "default": "defect_act_v2"
           }
         },
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -636,6 +636,48 @@
         }
       }
     },
+    "/api/v1/leads/repair-diagnostic": {
+      "post": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Create Repair Diagnostic Lead",
+        "operationId": "create_repair_diagnostic_lead",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_repair_diagnostic_lead"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepairDiagnosticLeadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/orders": {
       "post": {
         "tags": [
@@ -15445,6 +15487,94 @@
           "file"
         ],
         "title": "Body_complete_media_worker_job"
+      },
+      "Body_create_repair_diagnostic_lead": {
+        "properties": {
+          "payload": {
+            "type": "string",
+            "title": "Payload"
+          },
+          "nameplate": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nameplate"
+          },
+          "indoor_unit": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Indoor Unit"
+          },
+          "outdoor_unit": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outdoor Unit"
+          },
+          "error_display": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Display"
+          },
+          "leak_place": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Leak Place"
+          }
+        },
+        "type": "object",
+        "required": [
+          "payload"
+        ],
+        "title": "Body_create_repair_diagnostic_lead"
       },
       "Body_import_manager_bank_statement": {
         "properties": {
@@ -36208,6 +36338,35 @@
           "sort_order"
         ],
         "title": "PublicBrandResponse"
+      },
+      "RepairDiagnosticLeadResponse": {
+        "properties": {
+          "order_id": {
+            "type": "integer",
+            "title": "Order Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "ai_pre_diagnosis_status": {
+            "type": "string",
+            "title": "Ai Pre Diagnosis Status",
+            "default": "pending"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_id",
+          "status",
+          "created_at"
+        ],
+        "title": "RepairDiagnosticLeadResponse"
       },
       "ServiceResponse": {
         "properties": {

--- a/routers/api_leads.py
+++ b/routers/api_leads.py
@@ -1,10 +1,18 @@
 """Public website lead capture endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from typing import List, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from core.config import settings
 from core.database import get_session
 from schemas import ProductAvailabilityLeadPayload, ProductAvailabilityLeadResponse
+from services.repair_diagnostic_service import (
+    RepairDiagnosticLeadResponse,
+    RepairDiagnosticService,
+)
 from services.website_lead_service import WebsiteLeadService
 
 router = APIRouter(tags=["api"])
@@ -23,3 +31,49 @@ async def create_product_availability_lead(
         return await WebsiteLeadService.create_product_availability_lead(session, payload)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post(
+    "/v1/leads/repair-diagnostic",
+    response_model=RepairDiagnosticLeadResponse,
+    operation_id="create_repair_diagnostic_lead",
+)
+async def create_repair_diagnostic_lead(
+    background_tasks: BackgroundTasks,
+    payload: str = Form(...),
+    nameplate: Optional[List[UploadFile]] = File(default=None),
+    indoor_unit: Optional[List[UploadFile]] = File(default=None),
+    outdoor_unit: Optional[List[UploadFile]] = File(default=None),
+    error_display: Optional[List[UploadFile]] = File(default=None),
+    leak_place: Optional[List[UploadFile]] = File(default=None),
+    session: AsyncSession = Depends(get_session),
+):
+    try:
+        parsed_payload = RepairDiagnosticService.parse_payload(payload)
+        uploads = await RepairDiagnosticService.collect_uploads(
+            {
+                "nameplate": nameplate,
+                "indoor_unit": indoor_unit,
+                "outdoor_unit": outdoor_unit,
+                "error_display": error_display,
+                "leak_place": leak_place,
+            }
+        )
+        response, nameplate_files = await RepairDiagnosticService.create_lead(
+            session,
+            payload=parsed_payload,
+            uploads=uploads,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if settings.ENVIRONMENT != "test":
+        background_tasks.add_task(
+            RepairDiagnosticService.run_ai_pre_diagnosis,
+            order_id=response.order_id,
+            payload_data=parsed_payload.model_dump(),
+            nameplate_files=nameplate_files,
+        )
+    return response

--- a/schemas.py
+++ b/schemas.py
@@ -3525,15 +3525,18 @@ class ManagerRepairActAiDraftPayload(BaseModel):
     customer_complaint: Optional[str] = None
     complaint_official: Optional[str] = None
     likely_diagnosis: Optional[str] = None
+    diagnostic_notes: Optional[str] = None
+    refrigerant_type: Optional[str] = None
+    refrigerant_amount: Optional[str] = None
     extra_context: Optional[str] = None
     current_meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ManagerRepairActAiDraftResponse(BaseModel):
-    repair_meta: Dict[str, str] = Field(default_factory=dict)
+    repair_meta: Dict[str, Any] = Field(default_factory=dict)
     provider: str = "deepseek"
     model: str
-    prompt_version: str = "defect_act_v1"
+    prompt_version: str = "defect_act_v2"
 
 
 # --- SERVICE ESTIMATES ---

--- a/services/defect_act_ai_service.py
+++ b/services/defect_act_ai_service.py
@@ -6,15 +6,25 @@ import httpx
 
 from core.config import settings
 from schemas import ManagerRepairActAiDraftPayload
+from services.repair_defect_template_service import RepairDefectTemplateService
 
 
 class DefectActAIService:
-    """Builds repair defect-act field drafts through an LLM."""
+    """Builds structured repair diagnostics through an LLM and local templates."""
 
     ALLOWED_REPAIR_META_KEYS = {
+        "fault_type",
+        "fault_location",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "structured_diagnosis",
+        "defect_act_blocks",
+        "hidden_defects_possible",
         "customer_complaint",
         "complaint_official",
         "likely_diagnosis",
+        "diagnostic_notes",
         "equipment_name",
         "equipment_brand",
         "equipment_model",
@@ -36,9 +46,43 @@ class DefectActAIService:
         "refrigerant_pricing_mode",
         "repair_not_viable",
         "repair_not_viable_reason",
+        "repair_estimate_text",
         "inspection_work_done",
     }
-
+    ALLOWED_STRUCTURED_KEYS = {
+        "fault_type",
+        "fault_location",
+        "repairable",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "refrigerant",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "hidden_defects_possible",
+    }
+    STRUCTURED_RESPONSE_KEYS = {
+        "fault_type",
+        "fault_location",
+        "operation_status",
+        "risks",
+        "recommended_actions",
+        "structured_diagnosis",
+        "defect_act_blocks",
+        "hidden_defects_possible",
+    }
+    PRIMARY_RESPONSE_KEYS = {
+        "likely_diagnosis",
+        "diagnostic_notes",
+        "diagnostic_result",
+        "repair_recommendation",
+        "repair_possible",
+        "repair_not_viable",
+        "repair_not_viable_reason",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "repair_estimate_text",
+    }
     @staticmethod
     def _clean_text(value: Any, *, max_length: int = 1200) -> str:
         text = str(value or "").strip()
@@ -47,12 +91,33 @@ class DefectActAIService:
         return text[:max_length].strip()
 
     @staticmethod
-    def _clean_meta(raw_meta: Any) -> Dict[str, str]:
+    def _clean_meta(raw_meta: Any) -> Dict[str, Any]:
         if not isinstance(raw_meta, dict):
             return {}
-        cleaned: Dict[str, str] = {}
+        cleaned: Dict[str, Any] = {}
         for key, value in raw_meta.items():
             if key not in DefectActAIService.ALLOWED_REPAIR_META_KEYS:
+                continue
+            if isinstance(value, dict):
+                nested = {
+                    str(nested_key): nested_value
+                    for nested_key, nested_value in value.items()
+                    if isinstance(nested_value, (str, int, float, bool, list, dict)) or nested_value is None
+                }
+                if nested:
+                    cleaned[key] = nested
+                continue
+            if isinstance(value, list):
+                items = [
+                    DefectActAIService._clean_text(item, max_length=160)
+                    for item in value
+                    if DefectActAIService._clean_text(item, max_length=160)
+                ]
+                if items:
+                    cleaned[key] = items
+                continue
+            if isinstance(value, bool):
+                cleaned[key] = value
                 continue
             text = DefectActAIService._clean_text(value)
             if text:
@@ -60,8 +125,35 @@ class DefectActAIService:
         return cleaned
 
     @staticmethod
+    def _clean_structured(raw: Any, payload: ManagerRepairActAiDraftPayload) -> Dict[str, Any]:
+        if not isinstance(raw, dict):
+            raw = {}
+        nested = raw.get("structured_diagnosis")
+        if isinstance(nested, dict):
+            raw = {**raw, **nested}
+        cleaned: Dict[str, Any] = {}
+        for key in DefectActAIService.ALLOWED_STRUCTURED_KEYS:
+            value = raw.get(key)
+            if isinstance(value, list):
+                cleaned[key] = [
+                    DefectActAIService._clean_text(item, max_length=120)
+                    for item in value
+                    if DefectActAIService._clean_text(item, max_length=120)
+                ]
+            elif isinstance(value, bool):
+                cleaned[key] = value
+            elif value is not None:
+                text = DefectActAIService._clean_text(value, max_length=200)
+                if text:
+                    cleaned[key] = text
+        if not cleaned.get("fault_type"):
+            cleaned["fault_type"] = payload.defect_type
+        return cleaned
+
+    @staticmethod
     def build_prompt(payload: ManagerRepairActAiDraftPayload) -> str:
         current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        fault_types = ", ".join(sorted(RepairDefectTemplateService.TEMPLATES.keys()))
         inputs = {
             "defect_type": payload.defect_type,
             "defect_label": payload.defect_label,
@@ -74,6 +166,9 @@ class DefectActAIService:
             "customer_complaint": payload.customer_complaint,
             "complaint_official": payload.complaint_official,
             "likely_diagnosis": payload.likely_diagnosis,
+            "diagnostic_notes": payload.diagnostic_notes,
+            "refrigerant_type": payload.refrigerant_type,
+            "refrigerant_amount": payload.refrigerant_amount,
             "extra_context": payload.extra_context,
             "current_meta": current_meta,
         }
@@ -97,50 +192,40 @@ class DefectActAIService:
         )
         mode_rules = assumptions_rules if payload.allow_assumptions else strict_rules
         existing_rules = (
-            "- Если в current_meta уже есть осмысленное значение, можно улучшить его стиль: "
-            "исправить терминологию, сделать формулировку официальной, раскрыть мысль до уровня дефектного акта.\n"
-            "- При улучшении заполненных полей строго сохраняй фактический смысл. Не добавляй новые факты, работы, "
-            "числовые измерения, даты, серийные или инвентарные номера, которых нет во входных данных.\n"
+            "- Используй current_meta как контекст: уточняй fault_type, risks и recommended_actions по уже заполненным данным.\n"
+            "- Не возвращай готовые текстовые поля дефектного акта и не переписывай ручные override-поля.\n"
+            "- Строго сохраняй фактический смысл. Не добавляй новые факты, работы, числовые измерения, даты, "
+            "серийные или инвентарные номера, которых нет во входных данных.\n"
         ) if payload.polish_existing else (
-            "- Если в current_meta уже есть осмысленное значение, не переписывай это поле и не возвращай его в ответе.\n"
-            "- Заполняй только пустые или явно неполные поля, опираясь на входные данные.\n"
+            "- Если в current_meta уже есть осмысленное значение, учитывай его как контекст, но не возвращай замену этого поля.\n"
+            "- Возвращай только структурированные выводы по диагностике и не трогай заполненные ручные поля.\n"
         )
 
         return (
-            "Ты инженер по ремонту систем кондиционирования и составляешь текстовые поля "
-            "для дефектного акта на русском языке.\n\n"
-            "Нужно заполнить значения для Google Docs-плейсхолдеров дефектного акта. "
-            "Пиши официально, по-деловому, без маркетинга и без разговорных формулировок.\n\n"
+            "Ты инженер по ремонту систем кондиционирования. Нужно определить структурированные выводы "
+            "по диагностике, а не писать готовый дефектный акт.\n\n"
+            "Документ и смета будут собраны отдельными шаблонами. Не дублируй одну мысль разными словами "
+            "и не возвращай длинные документные формулировки.\n\n"
             "Правила:\n"
             "- Верни только JSON-объект без markdown.\n"
             f"{mode_rules}"
             f"{existing_rules}"
-            "- Итог должен быть пригоден для дефектного акта, но не должен обещать невозможное без диагностики.\n\n"
-            "Разрешенные ключи JSON:\n"
-            + ", ".join(sorted(DefectActAIService.ALLOWED_REPAIR_META_KEYS))
-            + "\n\n"
-            "Смысл ключей:\n"
-            "customer_complaint - простая жалоба клиента; "
-            "complaint_official - официальная формулировка жалобы для акта; "
-            "likely_diagnosis - вероятная причина; "
-            "technical_condition - техническое состояние оборудования; "
-            "startup_check_result - результат проверки запуска; "
-            "compressor_check_result - проверка компрессора; "
-            "measurement_result - результаты диагностики/замеров без выдуманных чисел; "
-            "diagnostic_result - канонический результат диагностики; "
-            "further_use_assessment - возможность дальнейшей эксплуатации; "
-            "operation_restrictions - ограничения эксплуатации; "
-            "technical_conclusion - итоговое техническое заключение; "
-            "repair_feasibility - целесообразность ремонта; "
-            "recommended_decision - рекомендованное решение; "
-            "repair_recommendation - каноническая рекомендация по ремонту; "
-            "repair_possible - возможен ли ремонт; "
-            "refrigerant_type - тип хладагента; "
-            "refrigerant_amount - объем хладагента; "
-            "refrigerant_pricing_mode - способ расчета хладагента; "
-            "repair_not_viable - ремонт невозможен или нецелесообразен; "
-            "repair_not_viable_reason - причина невозможности или нецелесообразности ремонта; "
-            "inspection_work_done - выполненные диагностические действия.\n\n"
+            "- Итог должен быть пригоден для выбора шаблона, но не должен обещать невозможное без диагностики.\n\n"
+            "Разрешенные fault_type:\n"
+            f"{fault_types}\n\n"
+            "Верни JSON в такой структуре:\n"
+            "{\n"
+            '  "fault_type": "refrigerant_leak",\n'
+            '  "fault_location": "flare_connections",\n'
+            '  "repairable": true,\n'
+            '  "operation_status": "limited",\n'
+            '  "risks": ["compressor_damage"],\n'
+            '  "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],\n'
+            '  "refrigerant": "R410A",\n'
+            '  "refrigerant_amount": "790 g",\n'
+            '  "hidden_defects_possible": true\n'
+            "}\n\n"
+            "Если данных недостаточно, используй fault_type=unknown_fault и operation_status=unknown.\n\n"
             "Входные данные:\n"
             f"{json.dumps(inputs, ensure_ascii=False, indent=2)}"
         )
@@ -206,19 +291,31 @@ class DefectActAIService:
             raise ValueError("AI response has unexpected format") from exc
 
     @staticmethod
-    async def generate_repair_meta(payload: ManagerRepairActAiDraftPayload) -> Dict[str, str]:
+    async def generate_repair_meta(payload: ManagerRepairActAiDraftPayload) -> Dict[str, Any]:
         prompt = DefectActAIService.build_prompt(payload)
         content = await DefectActAIService._request_completion(prompt)
         parsed = DefectActAIService._extract_json_object(content)
-        meta = DefectActAIService._clean_meta(parsed)
+        structured = DefectActAIService._clean_structured(parsed, payload)
+        current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        meta = RepairDefectTemplateService.build_meta_from_structured(
+            raw=structured,
+            current_meta=current_meta,
+            fallback_fault_type=payload.defect_type,
+            diagnostic_notes=payload.diagnostic_notes or payload.extra_context,
+        )
+        response_keys = DefectActAIService.STRUCTURED_RESPONSE_KEYS | DefectActAIService.PRIMARY_RESPONSE_KEYS
         if payload.polish_existing:
-            return meta
+            return {
+                key: value
+                for key, value in meta.items()
+                if key in response_keys
+            }
 
-        existing_meta = DefectActAIService._clean_meta(payload.current_meta or {})
         return {
             key: value
             for key, value in meta.items()
-            if not existing_meta.get(key)
+            if key in DefectActAIService.STRUCTURED_RESPONSE_KEYS
+            or (key in DefectActAIService.PRIMARY_RESPONSE_KEYS and not current_meta.get(key))
         }
 
     @staticmethod

--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -3,6 +3,7 @@ from typing import Any, List, Optional
 from sqlmodel import select
 from services.google_service import get_google_service
 from services.documents.base import BaseDocumentStrategy, TEMPLATES, DOC_NAMES
+from services.repair_defect_template_service import RepairDefectTemplateService
 from models import CustomerContract, CustomerEquipment, EquipmentComponent, OrderDocument
 
 class GoogleDocStrategy(BaseDocumentStrategy):
@@ -179,6 +180,11 @@ class DefectActStrategy(GoogleDocStrategy):
             return repair_meta.get(key)
         return meta.get(key)
 
+    def _repair_meta(self) -> dict[str, Any]:
+        meta = self.order.technical_meta if self.order and isinstance(self.order.technical_meta, dict) else {}
+        repair_meta = meta.get("repair") if isinstance(meta.get("repair"), dict) else {}
+        return repair_meta
+
     def _repair_possible_text(self, default: str = "") -> str:
         canonical = self._meta_value("repair_possible")
         bool_text = self._bool_text(canonical)
@@ -252,14 +258,11 @@ class DefectActStrategy(GoogleDocStrategy):
             detailed_name = " ".join(part for part in [equipment_brand, equipment_model, equipment_power] if part)
             if detailed_name:
                 equipment_name = detailed_name
+        generated_repair_meta = RepairDefectTemplateService.build_document_fields(self._repair_meta())
         technical_condition = self._first_text(
-            self._meta_text(
-                "technical_condition",
-                "defect_technical_condition",
-                "complaint_official",
-                "customer_complaint",
-                "complaint_text",
-            ),
+            self._meta_text("technical_condition", "defect_technical_condition"),
+            generated_repair_meta.get("technical_condition"),
+            self._meta_text("complaint_official", "customer_complaint", "complaint_text"),
             getattr(self.order, "measurement_result", None) if self.order else None,
             default="_________________",
         )
@@ -302,7 +305,7 @@ class DefectActStrategy(GoogleDocStrategy):
                 "{{inspection_work_done}}": self._meta_text(
                     "inspection_work_done",
                     "diagnostic_work_done",
-                    default="_________________",
+                    default=generated_repair_meta.get("inspection_work_done") or "_________________",
                 ),
                 "{{startup_check_result}}": self._meta_text(
                     "startup_check_result",
@@ -311,47 +314,52 @@ class DefectActStrategy(GoogleDocStrategy):
                 ),
                 "{{compressor_check_result}}": self._meta_text("compressor_check_result", default="_________________"),
                 "{{measurement_result}}": self._meta_text(
-                    "diagnostic_result",
                     "measurement_result",
+                    "inspection_work_done",
                     "defect_measurement_result",
                     "diagnostic_measurement_result",
-                    default=(getattr(self.order, "measurement_result", None) if self.order else None) or "_________________",
+                    default=generated_repair_meta.get("measurement_result")
+                    or self._meta_text("diagnostic_result")
+                    or (getattr(self.order, "measurement_result", None) if self.order else None)
+                    or "_________________",
                 ),
                 "{{diagnostic_result}}": self._meta_text(
                     "diagnostic_result",
                     "measurement_result",
                     "defect_measurement_result",
                     "diagnostic_measurement_result",
-                    default=(getattr(self.order, "measurement_result", None) if self.order else None) or "_________________",
+                    default=(
+                        getattr(self.order, "measurement_result", None) if self.order else None
+                    ) or generated_repair_meta.get("diagnostic_result") or "_________________",
                 ),
                 "{{further_use_assessment}}": self._meta_text(
                     "further_use_assessment",
                     "operation_assessment",
-                    default="_________________",
+                    default=generated_repair_meta.get("further_use_assessment") or "_________________",
                 ),
                 "{{operation_restrictions}}": self._meta_text(
                     "operation_restrictions",
                     "use_restrictions",
-                    default="_________________",
+                    default=generated_repair_meta.get("operation_restrictions") or "_________________",
                 ),
                 "{{technical_conclusion}}": self._meta_text(
                     "technical_conclusion",
                     "defect_conclusion",
                     "repair_recommendation",
                     "recommended_decision",
-                    default="_________________",
+                    default=generated_repair_meta.get("technical_conclusion") or "_________________",
                 ),
                 "{{repair_feasibility}}": self._meta_text(
                     "repair_feasibility",
                     "repair_feasibility_text",
-                    default=self._repair_possible_text(default="_________________"),
+                    default=generated_repair_meta.get("repair_feasibility") or self._repair_possible_text(default="_________________"),
                 ),
                 "{{recommended_decision}}": self._meta_text(
                     "recommended_decision",
                     "defect_recommendation",
                     "repair_recommendation",
                     "technical_conclusion",
-                    default="_________________",
+                    default=generated_repair_meta.get("recommended_decision") or "_________________",
                 ),
                 "{{repair_recommendation}}": self._meta_text(
                     "repair_recommendation",
@@ -359,9 +367,11 @@ class DefectActStrategy(GoogleDocStrategy):
                     "defect_recommendation",
                     "technical_conclusion",
                     "defect_conclusion",
-                    default="_________________",
+                    default=generated_repair_meta.get("repair_recommendation") or "_________________",
                 ),
-                "{{repair_possible}}": self._repair_possible_text(default="_________________"),
+                "{{repair_possible}}": self._repair_possible_text(
+                    default=generated_repair_meta.get("repair_possible") or "_________________"
+                ),
                 "{{repair_status}}": self._meta_text("repair_status", default="_________________"),
                 "{{customer_approval_status}}": self._meta_text(
                     "customer_approval_status",
@@ -371,8 +381,14 @@ class DefectActStrategy(GoogleDocStrategy):
                 "{{parts_status}}": self._meta_text("parts_status", default="_________________"),
                 "{{parts_note}}": self._meta_text("parts_note", default="_________________"),
                 "{{repair_completion_note}}": self._meta_text("repair_completion_note", default="_________________"),
-                "{{refrigerant_type}}": self._meta_text("refrigerant_type", default="_________________"),
-                "{{refrigerant_amount}}": self._meta_text("refrigerant_amount", default="_________________"),
+                "{{refrigerant_type}}": self._meta_text(
+                    "refrigerant_type",
+                    default=generated_repair_meta.get("refrigerant_type") or "_________________",
+                ),
+                "{{refrigerant_amount}}": self._meta_text(
+                    "refrigerant_amount",
+                    default=generated_repair_meta.get("refrigerant_amount") or "_________________",
+                ),
                 "{{refrigerant_pricing_mode}}": self._meta_text("refrigerant_pricing_mode", default="_________________"),
                 "{{repair_not_viable}}": self._repair_not_viable_text(default="_________________"),
                 "{{repair_not_viable_reason}}": self._repair_not_viable_reason_text(default="_________________"),

--- a/services/repair_defect_template_service.py
+++ b/services/repair_defect_template_service.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class RepairDefectTemplateService:
+    """Templates for structured repair diagnostics and defect-act wording."""
+
+    FAULT_ALIASES = {
+        "multiple_heat_exchanger_defects": "heat_exchanger_damage",
+        "compressor_winding_breakdown": "compressor_failure",
+    }
+
+    DEFAULT_ACTIONS = {
+        "restore_circuit_tightness": "восстановить герметичность холодильного контура",
+        "replace_faulty_flare_connections": "заменить или переподключить неисправные вальцовочные соединения",
+        "vacuuming": "выполнить вакуумирование",
+        "full_refrigerant_charge": "заправить хладагентом согласно спецификации производителя",
+        "clean_drainage": "прочистить дренажную систему",
+        "restore_drainage_slope": "восстановить корректный уклон дренажа",
+        "replace_control_board": "заменить плату управления",
+        "replace_fan_motor": "заменить двигатель вентилятора",
+        "replace_compressor": "заменить компрессор",
+        "replace_heat_exchanger": "заменить теплообменник",
+        "deep_cleaning": "выполнить глубокую очистку оборудования",
+        "correct_installation": "устранить нарушения монтажа",
+        "additional_diagnostics": "выполнить дополнительную диагностику",
+    }
+
+    RISK_TEXTS = {
+        "compressor_damage": "повреждение компрессора",
+        "water_leak": "протечка конденсата",
+        "electrical_damage": "повреждение электрических компонентов",
+        "overheating": "перегрев узлов оборудования",
+        "repeated_failure": "повторное возникновение неисправности",
+        "low_efficiency": "снижение эффективности работы оборудования",
+    }
+
+    TEMPLATES: dict[str, dict[str, Any]] = {
+        "refrigerant_leak": {
+            "label": "Утечка хладагента",
+            "diagnosis_text": "Выявлены признаки утечки хладагента. Давление хладагента ниже нормативного значения.",
+            "operation_text": "Эксплуатация оборудования допускается только с ограничениями до проведения ремонта.",
+            "risk_text": "Дальнейшая эксплуатация при недостатке хладагента может привести к повреждению компрессора.",
+            "repair_text": "Рекомендуется восстановить герметичность холодильного контура, устранить место утечки, выполнить вакуумирование и заправку хладагентом согласно спецификации производителя.",
+            "estimate_text": "Устранение утечки хладагента с восстановлением герметичности холодильного контура и заправкой хладагентом согласно спецификации производителя.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["compressor_damage"],
+            "recommended_actions": [
+                "restore_circuit_tightness",
+                "replace_faulty_flare_connections",
+                "vacuuming",
+                "full_refrigerant_charge",
+            ],
+        },
+        "drainage_failure": {
+            "label": "Нарушение отвода конденсата",
+            "diagnosis_text": "Выявлено нарушение отвода конденсата из внутреннего блока.",
+            "operation_text": "Эксплуатация допускается после устранения причины протечки конденсата.",
+            "risk_text": "Дальнейшая эксплуатация может привести к протечке воды и повреждению отделки или оборудования.",
+            "repair_text": "Рекомендуется прочистить дренажную систему, проверить уклон и восстановить штатный отвод конденсата.",
+            "estimate_text": "Восстановление отвода конденсата с прочисткой дренажной системы и проверкой уклона.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["water_leak", "repeated_failure"],
+            "recommended_actions": ["clean_drainage", "restore_drainage_slope"],
+        },
+        "control_board_failure": {
+            "label": "Неисправность платы управления",
+            "diagnosis_text": "Выявлены признаки неисправности платы управления или цепей управления оборудованием.",
+            "operation_text": "Эксплуатация оборудования до ремонта не рекомендуется.",
+            "risk_text": "Дальнейшая эксплуатация может привести к нестабильной работе и повреждению электрических компонентов.",
+            "repair_text": "Рекомендуется выполнить проверку цепей управления и заменить неисправную плату управления.",
+            "estimate_text": "Диагностика цепей управления и замена неисправной платы управления.",
+            "operation_status": "not_allowed",
+            "repairable": True,
+            "risks": ["electrical_damage", "repeated_failure"],
+            "recommended_actions": ["replace_control_board"],
+        },
+        "fan_motor_failure": {
+            "label": "Неисправность двигателя вентилятора",
+            "diagnosis_text": "Выявлены признаки неисправности двигателя вентилятора или узла вентилятора.",
+            "operation_text": "Эксплуатация оборудования до устранения неисправности не рекомендуется.",
+            "risk_text": "Дальнейшая эксплуатация может привести к перегреву и повторному повреждению узлов оборудования.",
+            "repair_text": "Рекомендуется заменить неисправный двигатель вентилятора и проверить работу оборудования под нагрузкой.",
+            "estimate_text": "Замена двигателя вентилятора с проверкой работы оборудования.",
+            "operation_status": "not_allowed",
+            "repairable": True,
+            "risks": ["overheating", "repeated_failure"],
+            "recommended_actions": ["replace_fan_motor"],
+        },
+        "compressor_failure": {
+            "label": "Неисправность компрессора",
+            "diagnosis_text": "Выявлены признаки неисправности компрессора.",
+            "operation_text": "Эксплуатация оборудования не допускается до устранения неисправности.",
+            "risk_text": "Дальнейшая эксплуатация может привести к повреждению холодильного контура и электрических компонентов.",
+            "repair_text": "Рекомендуется оценить целесообразность замены компрессора с учетом стоимости ремонта и состояния оборудования.",
+            "estimate_text": "Диагностика холодильного контура и замена компрессора при экономической целесообразности ремонта.",
+            "operation_status": "not_allowed",
+            "repairable": False,
+            "risks": ["electrical_damage", "repeated_failure"],
+            "recommended_actions": ["replace_compressor"],
+        },
+        "heat_exchanger_damage": {
+            "label": "Повреждение теплообменника",
+            "diagnosis_text": "Выявлены признаки повреждения или сильного износа теплообменника.",
+            "operation_text": "Эксплуатация допускается только после оценки герметичности и состояния теплообменника.",
+            "risk_text": "Дальнейшая эксплуатация может привести к утечке хладагента и снижению эффективности оборудования.",
+            "repair_text": "Рекомендуется оценить возможность замены теплообменника или целесообразность замены оборудования.",
+            "estimate_text": "Диагностика теплообменника и замена поврежденного узла при целесообразности ремонта.",
+            "operation_status": "limited",
+            "repairable": False,
+            "risks": ["low_efficiency", "compressor_damage"],
+            "recommended_actions": ["replace_heat_exchanger"],
+        },
+        "contamination": {
+            "label": "Загрязнение оборудования",
+            "diagnosis_text": "Выявлено загрязнение теплообменников, фильтров или внутренних узлов оборудования.",
+            "operation_text": "Эксплуатация возможна после сервисной очистки оборудования.",
+            "risk_text": "Дальнейшая эксплуатация загрязненного оборудования снижает эффективность и повышает нагрузку на узлы.",
+            "repair_text": "Рекомендуется выполнить глубокую очистку оборудования и повторную проверку рабочих режимов.",
+            "estimate_text": "Глубокая очистка оборудования с повторной проверкой рабочих режимов.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["low_efficiency", "overheating"],
+            "recommended_actions": ["deep_cleaning"],
+        },
+        "poor_installation": {
+            "label": "Нарушение монтажа",
+            "diagnosis_text": "Выявлены признаки нарушения требований монтажа оборудования.",
+            "operation_text": "Эксплуатация допускается только после устранения выявленных нарушений.",
+            "risk_text": "Дальнейшая эксплуатация может привести к повторным неисправностям и повреждению оборудования.",
+            "repair_text": "Рекомендуется устранить нарушения монтажа и выполнить контрольную проверку работы оборудования.",
+            "estimate_text": "Устранение нарушений монтажа с контрольной проверкой работы оборудования.",
+            "operation_status": "limited",
+            "repairable": True,
+            "risks": ["repeated_failure", "compressor_damage"],
+            "recommended_actions": ["correct_installation"],
+        },
+        "unknown_fault": {
+            "label": "Неисправность требует уточнения",
+            "diagnosis_text": "Неисправность оборудования требует дополнительной инструментальной диагностики.",
+            "operation_text": "Эксплуатация до уточнения причины неисправности не рекомендуется.",
+            "risk_text": "Без уточнения причины неисправности возможны повторные отказы и повреждение узлов оборудования.",
+            "repair_text": "Рекомендуется выполнить дополнительную диагностику и согласовать ремонт после уточнения причины неисправности.",
+            "estimate_text": "Дополнительная диагностика оборудования с последующим согласованием ремонта.",
+            "operation_status": "unknown",
+            "repairable": True,
+            "risks": ["repeated_failure"],
+            "recommended_actions": ["additional_diagnostics"],
+        },
+    }
+
+    @classmethod
+    def normalize_fault_type(cls, value: Any) -> str:
+        raw = str(value or "").strip()
+        raw = cls.FAULT_ALIASES.get(raw, raw)
+        return raw if raw in cls.TEMPLATES else "unknown_fault"
+
+    @staticmethod
+    def _clean_text(value: Any, max_length: int = 1200) -> str:
+        return " ".join(str(value or "").replace("\xa0", " ").split())[:max_length].strip()
+
+    @classmethod
+    def _list(cls, value: Any, fallback: list[str]) -> list[str]:
+        if isinstance(value, list):
+            items = [cls._clean_text(item, 120) for item in value]
+            return [item for item in items if item]
+        if isinstance(value, str) and value.strip():
+            return [cls._clean_text(part, 120) for part in value.split(",") if cls._clean_text(part, 120)]
+        return list(fallback)
+
+    @staticmethod
+    def _bool(value: Any, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        text = str(value or "").strip().lower()
+        if text in {"true", "1", "yes", "да"}:
+            return True
+        if text in {"false", "0", "no", "нет"}:
+            return False
+        return default
+
+    @classmethod
+    def build_structured_findings(cls, raw: dict[str, Any] | None, current_meta: dict[str, Any] | None = None) -> dict[str, Any]:
+        raw = raw if isinstance(raw, dict) else {}
+        current_meta = current_meta if isinstance(current_meta, dict) else {}
+        fault_type = cls.normalize_fault_type(raw.get("fault_type") or current_meta.get("fault_type") or current_meta.get("likely_diagnosis"))
+        template = cls.TEMPLATES[fault_type]
+        return {
+            "fault_type": fault_type,
+            "fault_location": cls._clean_text(raw.get("fault_location") or current_meta.get("fault_location"), 160),
+            "repairable": cls._bool(raw.get("repairable"), bool(template["repairable"])),
+            "operation_status": cls._clean_text(raw.get("operation_status") or template["operation_status"], 80),
+            "risks": cls._list(raw.get("risks"), template["risks"]),
+            "recommended_actions": cls._list(raw.get("recommended_actions"), template["recommended_actions"]),
+            "refrigerant": cls._clean_text(
+                raw.get("refrigerant") or raw.get("refrigerant_type") or current_meta.get("refrigerant_type"),
+                80,
+            ),
+            "refrigerant_amount": cls._clean_text(
+                raw.get("refrigerant_amount") or current_meta.get("refrigerant_amount"),
+                80,
+            ),
+            "hidden_defects_possible": cls._bool(raw.get("hidden_defects_possible"), True),
+        }
+
+    @classmethod
+    def render_repair_meta(
+        cls,
+        *,
+        structured: dict[str, Any],
+        current_meta: dict[str, Any] | None = None,
+        diagnostic_notes: Any = None,
+    ) -> dict[str, Any]:
+        current_meta = current_meta if isinstance(current_meta, dict) else {}
+        fault_type = cls.normalize_fault_type(structured.get("fault_type"))
+        template = cls.TEMPLATES[fault_type]
+        structured = deepcopy(structured)
+        structured["fault_type"] = fault_type
+
+        risks_text = cls._risks_text(structured.get("risks") or template["risks"])
+        actions_text = cls._actions_text(structured.get("recommended_actions") or template["recommended_actions"])
+        diagnosis_text = cls._clean_text(current_meta.get("diagnostic_result") or template["diagnosis_text"])
+        repair_text = cls._clean_text(current_meta.get("repair_recommendation") or template["repair_text"])
+        if actions_text and actions_text.lower() not in repair_text.lower():
+            repair_text = f"{repair_text} Основные работы: {actions_text}."
+        notes = cls._clean_text(diagnostic_notes or current_meta.get("diagnostic_notes") or current_meta.get("measurement_result"), 900)
+
+        hidden_tail = ""
+        if structured.get("hidden_defects_possible"):
+            hidden_tail = (
+                " В процессе ремонта могут быть выявлены дополнительные неисправности, "
+                "не определяемые при первичном обследовании и требующие отдельного согласования."
+            )
+
+        blocks = {
+            "technical_condition": f"Неисправное. {diagnosis_text}",
+            "inspection": " ".join(
+                part for part in [
+                    "Проверена работоспособность оборудования.",
+                    notes,
+                    diagnosis_text,
+                    "Точный объем дефекта уточняется в ходе ремонтных работ с применением специализированного оборудования."
+                    if structured.get("hidden_defects_possible")
+                    else "",
+                ] if part
+            ),
+            "operation": " ".join(part for part in [template["operation_text"], template["risk_text"], risks_text] if part),
+            "conclusion": f"{repair_text}{hidden_tail}",
+        }
+
+        return {
+            "fault_type": fault_type,
+            "fault_location": structured.get("fault_location") or "",
+            "operation_status": structured.get("operation_status") or "",
+            "risks": structured.get("risks") or [],
+            "recommended_actions": structured.get("recommended_actions") or [],
+            "hidden_defects_possible": bool(structured.get("hidden_defects_possible")),
+            "structured_diagnosis": structured,
+            "defect_act_blocks": blocks,
+            "likely_diagnosis": template["label"],
+            "diagnostic_result": diagnosis_text,
+            "diagnostic_notes": notes,
+            "inspection_work_done": blocks["inspection"],
+            "technical_condition": blocks["technical_condition"],
+            "measurement_result": blocks["inspection"],
+            "further_use_assessment": template["operation_text"],
+            "operation_restrictions": " ".join(part for part in [template["risk_text"], risks_text] if part),
+            "repair_recommendation": repair_text,
+            "technical_conclusion": blocks["conclusion"],
+            "recommended_decision": repair_text,
+            "repair_feasibility": "Ремонт возможен." if structured.get("repairable") else "Ремонт невозможен или экономически нецелесообразен.",
+            "repair_possible": "Да" if structured.get("repairable") else "Нет",
+            "repair_not_viable": "Нет" if structured.get("repairable") else "Да",
+            "repair_not_viable_reason": "" if structured.get("repairable") else "Ремонт требует отдельной оценки экономической целесообразности.",
+            "refrigerant_type": structured.get("refrigerant") or "",
+            "refrigerant_amount": structured.get("refrigerant_amount") or "",
+            "repair_estimate_text": template["estimate_text"],
+        }
+
+    @classmethod
+    def build_meta_from_structured(
+        cls,
+        *,
+        raw: dict[str, Any] | None,
+        current_meta: dict[str, Any] | None = None,
+        fallback_fault_type: Any = None,
+        diagnostic_notes: Any = None,
+    ) -> dict[str, Any]:
+        raw = raw if isinstance(raw, dict) else {}
+        if fallback_fault_type and not raw.get("fault_type"):
+            raw = {**raw, "fault_type": fallback_fault_type}
+        structured = cls.build_structured_findings(raw, current_meta)
+        return cls.render_repair_meta(
+            structured=structured,
+            current_meta=current_meta,
+            diagnostic_notes=diagnostic_notes,
+        )
+
+    @classmethod
+    def build_document_fields(cls, repair_meta: dict[str, Any] | None) -> dict[str, Any]:
+        repair_meta = repair_meta if isinstance(repair_meta, dict) else {}
+        structured = repair_meta.get("structured_diagnosis") if isinstance(repair_meta.get("structured_diagnosis"), dict) else {}
+        if not structured and repair_meta.get("fault_type"):
+            structured = {"fault_type": repair_meta.get("fault_type")}
+        if not structured:
+            return {}
+        return cls.build_meta_from_structured(
+            raw=structured,
+            current_meta=repair_meta,
+            fallback_fault_type=repair_meta.get("fault_type"),
+            diagnostic_notes=repair_meta.get("diagnostic_notes") or repair_meta.get("measurement_result"),
+        )
+
+    @classmethod
+    def _risks_text(cls, risks: Any) -> str:
+        labels = [cls.RISK_TEXTS.get(str(item), str(item)) for item in cls._list(risks, [])]
+        if not labels:
+            return ""
+        return "Основные риски: " + ", ".join(labels) + "."
+
+    @classmethod
+    def _actions_text(cls, actions: Any) -> str:
+        labels = [cls.DEFAULT_ACTIONS.get(str(item), str(item)) for item in cls._list(actions, [])]
+        return ", ".join(labels)

--- a/services/repair_diagnostic_service.py
+++ b/services/repair_diagnostic_service.py
@@ -1,0 +1,598 @@
+"""Public repair diagnostic intake for website leads."""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+
+from core.database import async_session_maker
+from core.input_validation import validate_required_phone
+from models import LeadSource, Order, OrderStatus
+from schemas import ManagerRepairActAiDraftPayload
+from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.bot_service import BotService
+from services.defect_act_ai_service import DefectActAIService
+from services.general_media_storage_service import get_general_media_storage
+from services.order_service import OrderService
+from services.staff_user_service import StaffUserService
+
+logger = logging.getLogger(__name__)
+
+
+SYMPTOM_LABELS = {
+    "not_cooling": "Не охлаждает / слабо охлаждает",
+    "water_leak": "Течет вода из внутреннего блока",
+    "not_turning_on": "Не включается",
+    "turns_off": "Сам выключается",
+    "noise_vibration": "Шумит или вибрирует",
+    "bad_smell": "Появился неприятный запах",
+    "error_code": "На дисплее ошибка",
+    "other": "Другая проблема",
+}
+
+TIMING_LABELS = {
+    "immediately": "Сразу после включения",
+    "after_minutes": "Через несколько минут работы",
+    "after_hours": "Через несколько часов",
+    "constantly": "Постоянно",
+    "periodically": "Периодически",
+    "after_service": "После обслуживания / ремонта / переноса",
+    "unknown": "Не знаю",
+}
+
+CLIENT_CHECK_LABELS = {
+    "filters_cleaned": "Чистили фильтры",
+    "power_restarted": "Перезагружали питание",
+    "remote_batteries_changed": "Меняли батарейки в пульте",
+    "drainage_checked": "Проверяли дренаж",
+    "master_visited": "Уже приезжал мастер",
+    "nothing_checked": "Ничего не проверяли",
+}
+
+SYMPTOM_DETAIL_LABELS = {
+    "leak_timing": "Вода течет",
+    "recently_cleaned": "Кондиционер недавно чистили",
+    "drainage_exit": "Куда выведен дренаж",
+    "leak_place": "Где капает вода",
+    "indoor_fan_works": "Вентилятор внутреннего блока работает",
+    "outdoor_unit_starts": "Наружный блок запускается",
+    "freezing_seen": "Есть обмерзание",
+    "cooled_before": "Раньше охлаждал нормально",
+    "has_indication": "Есть индикация на блоке",
+    "remote_response": "Реагирует на пульт",
+    "power_checked": "Питание / автомат проверяли",
+    "voltage_surge": "Был скачок напряжения",
+    "error_code": "Код ошибки",
+}
+
+PHOTO_LABELS = {
+    "nameplate": "Фото шильдика кондиционера",
+    "indoor_unit": "Фото внутреннего блока целиком",
+    "outdoor_unit": "Фото наружного блока",
+    "error_display": "Фото ошибки на дисплее",
+    "leak_place": "Фото места протечки",
+}
+
+PHOTO_FIELDS = set(PHOTO_LABELS)
+ALLOWED_IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/webp"}
+MAX_PHOTO_BYTES = 10 * 1024 * 1024
+MAX_FILES_PER_FIELD = 5
+
+SYMPTOM_FAULT_TYPE = {
+    "not_cooling": "refrigerant_leak",
+    "water_leak": "drainage_failure",
+    "not_turning_on": "control_board_failure",
+    "turns_off": "control_board_failure",
+    "noise_vibration": "fan_motor_failure",
+    "bad_smell": "contamination",
+    "error_code": "unknown_fault",
+    "other": "unknown_fault",
+}
+
+PRELIMINARY_DIAGNOSIS_HINTS = {
+    "not_cooling": "Возможны загрязнение теплообменников, недостаток хладагента или нарушение работы наружного блока.",
+    "water_leak": "Возможны засор дренажа, неправильный уклон отвода конденсата или загрязнение внутреннего блока.",
+    "not_turning_on": "Возможны проблема питания, пульта, индикации или цепей управления.",
+    "turns_off": "Возможны перегрев, ошибка датчика, проблема питания или защитное отключение.",
+    "noise_vibration": "Возможны загрязнение, крепеж, вентилятор или вибрация блока.",
+    "bad_smell": "Возможны загрязнение фильтров, теплообменника или дренажной ванны.",
+    "error_code": "Код ошибки нужно расшифровать и проверить на месте.",
+    "other": "Причину нужно уточнить после диагностики на месте.",
+}
+
+
+class RepairDiagnosticContact(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    phone: str = Field(..., min_length=3, max_length=80)
+    address: Optional[str] = Field(default=None, max_length=300)
+
+    @field_validator("name", "address", mode="before")
+    @classmethod
+    def _clean_optional_text(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        return " ".join(str(value).split())
+
+    @field_validator("phone")
+    @classmethod
+    def _validate_phone(cls, value: str) -> str:
+        return validate_required_phone(value)
+
+
+class RepairDiagnosticLeadPayload(BaseModel):
+    scenario: str = "repair"
+    symptom: str
+    problem_timing: Optional[str] = None
+    symptom_details: Dict[str, Any] = Field(default_factory=dict)
+    client_checks: List[str] = Field(default_factory=list)
+    client_comment: Optional[str] = Field(default=None, max_length=2000)
+    contact: RepairDiagnosticContact
+
+    @field_validator("scenario")
+    @classmethod
+    def _validate_scenario(cls, value: str) -> str:
+        if value != "repair":
+            raise ValueError("scenario must be repair")
+        return value
+
+    @field_validator("symptom")
+    @classmethod
+    def _validate_symptom(cls, value: str) -> str:
+        if value not in SYMPTOM_LABELS:
+            allowed = ", ".join(SYMPTOM_LABELS)
+            raise ValueError(f"Invalid symptom. Allowed: {allowed}")
+        return value
+
+    @field_validator("problem_timing")
+    @classmethod
+    def _validate_timing(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        if value not in TIMING_LABELS:
+            allowed = ", ".join(TIMING_LABELS)
+            raise ValueError(f"Invalid problem_timing. Allowed: {allowed}")
+        return value
+
+    @field_validator("client_checks")
+    @classmethod
+    def _validate_checks(cls, value: List[str]) -> List[str]:
+        cleaned: List[str] = []
+        seen: set[str] = set()
+        for item in value or []:
+            if item not in CLIENT_CHECK_LABELS or item in seen:
+                continue
+            seen.add(item)
+            cleaned.append(item)
+        return cleaned
+
+    @field_validator("client_comment", mode="before")
+    @classmethod
+    def _clean_comment(cls, value: Any) -> Optional[str]:
+        text = " ".join(str(value or "").split())
+        return text or None
+
+
+class RepairDiagnosticLeadResponse(BaseModel):
+    order_id: int
+    status: str
+    created_at: datetime
+    ai_pre_diagnosis_status: str = "pending"
+
+
+@dataclass(frozen=True)
+class RepairDiagnosticIncomingFile:
+    filename: str
+    content_type: Optional[str]
+    content: bytes
+
+
+class RepairDiagnosticService:
+    """Creates repair order leads and stores preliminary diagnostic metadata."""
+
+    @staticmethod
+    def parse_payload(raw_payload: str) -> RepairDiagnosticLeadPayload:
+        try:
+            return RepairDiagnosticLeadPayload.model_validate_json(raw_payload)
+        except ValueError:
+            data = json.loads(raw_payload)
+            return RepairDiagnosticLeadPayload.model_validate(data)
+
+    @staticmethod
+    async def collect_uploads(raw_groups: Dict[str, Any]) -> Dict[str, List[RepairDiagnosticIncomingFile]]:
+        uploads: Dict[str, List[RepairDiagnosticIncomingFile]] = {field: [] for field in PHOTO_FIELDS}
+        for field, raw_files in raw_groups.items():
+            if field not in PHOTO_FIELDS:
+                continue
+            files = [file for file in (raw_files or []) if file is not None]
+            if len(files) > MAX_FILES_PER_FIELD:
+                raise ValueError(f"{PHOTO_LABELS[field]}: можно загрузить не больше {MAX_FILES_PER_FIELD} файлов")
+            for upload in files:
+                content = await upload.read()
+                content_type = _normalize_content_type(getattr(upload, "content_type", None))
+                filename = _clean_filename(getattr(upload, "filename", None), content_type)
+                _validate_photo(content=content, content_type=content_type, label=PHOTO_LABELS[field])
+                uploads[field].append(
+                    RepairDiagnosticIncomingFile(
+                        filename=filename,
+                        content_type=content_type,
+                        content=content,
+                    )
+                )
+        return uploads
+
+    @staticmethod
+    async def create_lead(
+        session,
+        *,
+        payload: RepairDiagnosticLeadPayload,
+        uploads: Dict[str, List[RepairDiagnosticIncomingFile]],
+    ) -> tuple[RepairDiagnosticLeadResponse, list[RepairDiagnosticIncomingFile]]:
+        comment = RepairDiagnosticService._build_order_comment(payload, uploads)
+        order = await OrderService.create_from_website(
+            session=session,
+            customer_name=payload.contact.name,
+            customer_phone=payload.contact.phone,
+            customer_email=None,
+            customer_address=payload.contact.address,
+            items=[],
+            lead_source=LeadSource.SITE,
+            initial_status=OrderStatus.NEW_LEAD,
+            comment=comment,
+        )
+
+        order.workflow_type = "repair"
+        order.title = f"Ремонт кондиционера: {SYMPTOM_LABELS[payload.symptom]}"
+        order.delivery_address = payload.contact.address
+
+        photos = await RepairDiagnosticService._store_uploads(order_id=int(order.id), uploads=uploads)
+        repair_meta = RepairDiagnosticService._build_repair_meta(payload, photos)
+        meta = dict(order.technical_meta or {}) if isinstance(order.technical_meta, dict) else {}
+        meta["service_type"] = "repair"
+        order.technical_meta = meta
+        OrderService._set_repair_meta(
+            order,
+            repair_meta,
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+        flag_modified(order, "technical_meta")
+
+        await OrderService._maybe_add_default_repair_diagnostic(session, order)
+        session.add(order)
+        await session.commit()
+        await session.refresh(order)
+
+        await RepairDiagnosticService._notify_admins(session, order, payload, photos)
+
+        response = RepairDiagnosticLeadResponse(
+            order_id=int(order.id or 0),
+            status=str(order.status.value if hasattr(order.status, "value") else order.status),
+            created_at=order.created_at,
+            ai_pre_diagnosis_status=repair_meta["ai_pre_diagnosis_status"],
+        )
+        nameplate_files = uploads.get("nameplate") or []
+        return response, nameplate_files[:1]
+
+    @staticmethod
+    async def run_ai_pre_diagnosis(
+        *,
+        order_id: int,
+        payload_data: Dict[str, Any],
+        nameplate_files: List[RepairDiagnosticIncomingFile],
+    ) -> None:
+        async with async_session_maker() as session:
+            result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+            order = result.scalars().first()
+            if not order:
+                return
+            payload = RepairDiagnosticLeadPayload.model_validate(payload_data)
+            repair_meta = OrderService._get_repair_meta(order)
+            try:
+                await RepairDiagnosticService._apply_nameplate_recognition(repair_meta, nameplate_files)
+                ai_meta = await RepairDiagnosticService._build_ai_meta(payload, repair_meta)
+                if ai_meta:
+                    repair_meta.update(ai_meta)
+                repair_meta["ai_pre_diagnosis_status"] = "completed"
+                repair_meta["ai_pre_diagnosis_updated_at"] = datetime.now().isoformat(timespec="seconds")
+            except ValueError as exc:
+                status = "skipped" if "TOKEN is not configured" in str(exc) else "failed"
+                repair_meta["ai_pre_diagnosis_status"] = status
+                repair_meta["ai_pre_diagnosis_error"] = str(exc)[:300]
+                logger.info("Repair pre-diagnosis %s for order %s: %s", status, order_id, exc)
+            except Exception as exc:  # pragma: no cover - defensive background guard
+                repair_meta["ai_pre_diagnosis_status"] = "failed"
+                repair_meta["ai_pre_diagnosis_error"] = str(exc)[:300]
+                logger.exception("Repair pre-diagnosis failed for order %s", order_id)
+
+            OrderService._set_repair_meta(
+                order,
+                repair_meta,
+                default_status=OrderService.REPAIR_DEFAULT_STATUS,
+            )
+            flag_modified(order, "technical_meta")
+            session.add(order)
+            await session.commit()
+
+    @staticmethod
+    async def _store_uploads(
+        *,
+        order_id: int,
+        uploads: Dict[str, List[RepairDiagnosticIncomingFile]],
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        storage = get_general_media_storage()
+        stored: Dict[str, List[Dict[str, Any]]] = {field: [] for field in PHOTO_FIELDS}
+        uploaded_at = datetime.now().isoformat(timespec="seconds")
+        for field, files in uploads.items():
+            for file in files:
+                extension = _extension_for_file(file.filename, file.content_type)
+                saved = await storage.save_media(
+                    content=file.content,
+                    namespace=f"orders/{order_id}/repair-diagnostic",
+                    variant_type=field,
+                    extension=extension,
+                    content_type=file.content_type,
+                )
+                stored[field].append(
+                    {
+                        "filename": file.filename,
+                        "content_type": file.content_type,
+                        "url": saved.url,
+                        "storage_provider": saved.storage_provider,
+                        "storage_path": saved.path,
+                        "content_hash": saved.content_hash,
+                        "size_bytes": saved.size_bytes,
+                        "uploaded_at": uploaded_at,
+                    }
+                )
+        return stored
+
+    @staticmethod
+    def _build_repair_meta(
+        payload: RepairDiagnosticLeadPayload,
+        photos: Dict[str, List[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        missing = RepairDiagnosticService._missing_data(payload, photos)
+        symptom_label = SYMPTOM_LABELS[payload.symptom]
+        return {
+            "scenario": "repair",
+            "repair_status": OrderService.REPAIR_DEFAULT_STATUS,
+            "symptom": payload.symptom,
+            "symptom_label": symptom_label,
+            "symptom_details": _clean_nested_dict(payload.symptom_details),
+            "problem_timing": payload.problem_timing,
+            "problem_timing_label": TIMING_LABELS.get(payload.problem_timing or "", ""),
+            "client_checks": payload.client_checks,
+            "client_checks_labels": [CLIENT_CHECK_LABELS[item] for item in payload.client_checks],
+            "photos": photos,
+            "client_comment": payload.client_comment or "",
+            "contact": payload.contact.model_dump(),
+            "ai_pre_diagnosis_status": "pending",
+            "missing_data": missing,
+            "customer_complaint": f"Клиент сообщил: {symptom_label}.",
+            "complaint_official": f"Со слов клиента: {symptom_label.lower()}.",
+            "likely_diagnosis": PRELIMINARY_DIAGNOSIS_HINTS[payload.symptom],
+            "preliminary_fault_type": SYMPTOM_FAULT_TYPE[payload.symptom],
+            "preliminary_note": (
+                "Предварительная оценка основана на ответах клиента. "
+                "Точная причина и стоимость ремонта определяются после диагностики на месте."
+            ),
+        }
+
+    @staticmethod
+    def _build_order_comment(
+        payload: RepairDiagnosticLeadPayload,
+        uploads: Dict[str, List[RepairDiagnosticIncomingFile]],
+    ) -> str:
+        lines = [
+            "Заявка на ремонт кондиционера с предварительной диагностикой.",
+            f"Что случилось: {SYMPTOM_LABELS[payload.symptom]}",
+        ]
+        if payload.problem_timing:
+            lines.append(f"Когда проявляется: {TIMING_LABELS[payload.problem_timing]}")
+        if payload.client_checks:
+            labels = [CLIENT_CHECK_LABELS[item] for item in payload.client_checks]
+            lines.append(f"Что уже проверяли: {', '.join(labels)}")
+        detail_lines = RepairDiagnosticService._format_details(payload.symptom_details)
+        if detail_lines:
+            lines.append("Уточнения:")
+            lines.extend(f"- {line}" for line in detail_lines)
+        photo_lines = [
+            f"{PHOTO_LABELS[field]}: {len(files)}"
+            for field, files in uploads.items()
+            if files
+        ]
+        if photo_lines:
+            lines.append(f"Фото: {', '.join(photo_lines)}")
+        if payload.client_comment:
+            lines.append(f"Комментарий клиента: {payload.client_comment}")
+        if payload.contact.address:
+            lines.append(f"Адрес/район: {payload.contact.address}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_details(details: Dict[str, Any]) -> List[str]:
+        result: List[str] = []
+        cleaned = _clean_nested_dict(details)
+        for key, value in cleaned.items():
+            label = SYMPTOM_DETAIL_LABELS.get(key, key)
+            result.append(f"{label}: {_stringify_detail(value)}")
+        return result
+
+    @staticmethod
+    def _missing_data(
+        payload: RepairDiagnosticLeadPayload,
+        photos: Dict[str, List[Dict[str, Any]]],
+    ) -> List[str]:
+        missing: List[str] = []
+        if not photos.get("nameplate"):
+            missing.append("Фото шильдика")
+        if not photos.get("indoor_unit"):
+            missing.append("Фото внутреннего блока целиком")
+        if payload.symptom == "water_leak" and not photos.get("leak_place"):
+            missing.append("Фото места протечки")
+        if payload.symptom == "error_code":
+            if not payload.symptom_details.get("error_code"):
+                missing.append("Код ошибки")
+            if not photos.get("error_display"):
+                missing.append("Фото ошибки на дисплее")
+        if not payload.contact.address:
+            missing.append("Адрес или район")
+        return missing
+
+    @staticmethod
+    async def _apply_nameplate_recognition(
+        repair_meta: Dict[str, Any],
+        nameplate_files: List[RepairDiagnosticIncomingFile],
+    ) -> None:
+        if not nameplate_files:
+            repair_meta["nameplate_recognition_status"] = "missing_photo"
+            return
+        file = nameplate_files[0]
+        try:
+            recognized = await BotRepairNameplateService.recognize_bytes(
+                content=file.content,
+                filename=file.filename,
+                mime_type=file.content_type,
+            )
+        except Exception as exc:
+            repair_meta["nameplate_recognition_status"] = "failed"
+            repair_meta["nameplate_recognition_error"] = str(exc)[:300]
+            return
+
+        extracted = recognized.get("extracted") if isinstance(recognized, dict) else {}
+        if not isinstance(extracted, dict):
+            extracted = {}
+        merge = BotRepairNameplateService.preview_merge(repair_meta, extracted)
+        if merge["applied"]:
+            repair_meta.update(merge["applied"])
+        repair_meta["nameplate_recognition_status"] = "recognized"
+        repair_meta["nameplate_recognition"] = {
+            "filename": file.filename,
+            "extracted": extracted,
+            "validation_flags": recognized.get("validation_flags") or {},
+            "applied_fields": list(merge["applied"].keys()),
+            "conflicts": merge["conflicts"],
+        }
+
+    @staticmethod
+    async def _build_ai_meta(
+        payload: RepairDiagnosticLeadPayload,
+        repair_meta: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        diagnostic_context = RepairDiagnosticService._build_order_comment(
+            payload,
+            {field: [] for field in PHOTO_FIELDS},
+        )
+        return await DefectActAIService.generate_repair_meta(
+            ManagerRepairActAiDraftPayload(
+                defect_type=SYMPTOM_FAULT_TYPE[payload.symptom],
+                defect_label=SYMPTOM_LABELS[payload.symptom],
+                allow_assumptions=False,
+                polish_existing=False,
+                equipment_name=repair_meta.get("equipment_name"),
+                equipment_brand=repair_meta.get("equipment_brand"),
+                equipment_model=repair_meta.get("equipment_model"),
+                equipment_power=repair_meta.get("equipment_power"),
+                customer_complaint=repair_meta.get("customer_complaint"),
+                complaint_official=repair_meta.get("complaint_official"),
+                likely_diagnosis=repair_meta.get("likely_diagnosis"),
+                extra_context=diagnostic_context,
+                current_meta=repair_meta,
+            )
+        )
+
+    @staticmethod
+    async def _notify_admins(
+        session,
+        order: Order,
+        payload: RepairDiagnosticLeadPayload,
+        photos: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        admin_ids = await StaffUserService.get_active_owner_admin_telegram_recipient_ids(session)
+        if not admin_ids:
+            return
+        photo_count = sum(len(items) for items in photos.values())
+        message_lines = [
+            f"<b>ЗАЯВКА НА РЕМОНТ С САЙТА #{order.id}</b>",
+            f"Клиент: {payload.contact.name}",
+            f"Телефон: {payload.contact.phone}",
+            f"Симптом: {SYMPTOM_LABELS[payload.symptom]}",
+        ]
+        if payload.contact.address:
+            message_lines.append(f"Адрес/район: {payload.contact.address}")
+        message_lines.append(f"Фото: {photo_count}")
+        admin_text = "\n".join(message_lines)
+        for admin_id in admin_ids:
+            try:
+                await BotService.send_message(admin_id, admin_text)
+            except Exception as exc:
+                logger.warning("Failed to notify admin %s about repair order %s: %s", admin_id, order.id, exc)
+
+
+def _normalize_content_type(value: Optional[str]) -> str:
+    return str(value or "").split(";")[0].strip().lower()
+
+
+def _clean_filename(filename: Optional[str], content_type: Optional[str]) -> str:
+    raw = str(filename or "").replace("\\", "/").split("/")[-1].strip()
+    if raw:
+        return raw[:160]
+    extension = _extension_for_file("", content_type)
+    return f"repair-photo.{extension}"
+
+
+def _extension_for_file(filename: str, content_type: Optional[str]) -> str:
+    lower = str(filename or "").lower()
+    if "." in lower:
+        extension = lower.rsplit(".", 1)[-1].strip()
+        if extension in {"jpg", "jpeg", "png", "webp"}:
+            return "jpg" if extension == "jpeg" else extension
+    guessed = mimetypes.guess_extension(content_type or "") or ".jpg"
+    return guessed.lower().lstrip(".").replace("jpeg", "jpg") or "jpg"
+
+
+def _validate_photo(*, content: bytes, content_type: str, label: str) -> None:
+    if not content:
+        raise ValueError(f"{label}: файл пустой")
+    if len(content) > MAX_PHOTO_BYTES:
+        raise ValueError(f"{label}: файл больше 10 МБ")
+    if content_type not in ALLOWED_IMAGE_MIME_TYPES:
+        raise ValueError(f"{label}: поддерживаются только JPG, PNG и WEBP")
+
+
+def _clean_nested_dict(raw: Any) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    cleaned: Dict[str, Any] = {}
+    for key, value in raw.items():
+        clean_key = " ".join(str(key or "").split())[:80]
+        if not clean_key or value is None:
+            continue
+        if isinstance(value, str):
+            text = " ".join(value.split())[:500]
+            if text:
+                cleaned[clean_key] = text
+        elif isinstance(value, bool):
+            cleaned[clean_key] = value
+        elif isinstance(value, (int, float)):
+            cleaned[clean_key] = value
+        elif isinstance(value, list):
+            items = [str(item).strip()[:160] for item in value if str(item).strip()]
+            if items:
+                cleaned[clean_key] = items[:20]
+    return cleaned
+
+
+def _stringify_detail(value: Any) -> str:
+    if isinstance(value, bool):
+        return "да" if value else "нет"
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    return str(value)

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -508,12 +508,16 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
         captured["prompt"] = prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "technical_condition": "Теплообменник имеет множественные дефекты, загрязнение и следы коррозии.",
-                    "technical_conclusion": "Эксплуатация оборудования без ремонта не рекомендуется.",
-                    "recommended_decision": "Рассмотреть замену теплообменника или оборудования в сборе.",
-                    "unknown_key": "must be ignored",
-                }
+                "fault_type": "refrigerant_leak",
+                "fault_location": "flare_connections",
+                "repairable": True,
+                "operation_status": "limited",
+                "risks": ["compressor_damage"],
+                "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
+                "refrigerant": "R410A",
+                "refrigerant_amount": "790 g",
+                "hidden_defects_possible": True,
+                "unknown_key": "must be ignored",
             },
             ensure_ascii=False,
         )
@@ -524,9 +528,10 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
 
     headers = await _auth_headers(async_client)
     payload = {
-        "defect_type": "multiple_heat_exchanger_defects",
-        "defect_label": "Множественные дефекты теплообменника",
+        "defect_type": "refrigerant_leak",
+        "defect_label": "Утечка хладагента",
         "equipment_model": "Daikin FTXB25C",
+        "diagnostic_notes": "Обмерзает внутренний блок, давление ниже нормы.",
         "current_meta": {"customer_complaint": "Плохо холодит"},
     }
     response = await async_client.post("/api/manager/repair-complaints/ai-draft", json=payload, headers=headers)
@@ -534,12 +539,18 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["provider"] == "deepseek"
-    assert data["prompt_version"] == "defect_act_v1"
-    assert data["repair_meta"]["technical_condition"].startswith("Теплообменник")
-    assert data["repair_meta"]["technical_conclusion"] == "Эксплуатация оборудования без ремонта не рекомендуется."
+    assert data["prompt_version"] == "defect_act_v2"
+    assert data["repair_meta"]["fault_type"] == "refrigerant_leak"
+    assert data["repair_meta"]["structured_diagnosis"]["fault_location"] == "flare_connections"
+    assert data["repair_meta"]["diagnostic_result"].startswith("Выявлены признаки утечки")
+    assert data["repair_meta"]["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
+    assert data["repair_meta"]["repair_estimate_text"].startswith("Устранение утечки хладагента")
+    assert "technical_condition" not in data["repair_meta"]
+    assert "technical_conclusion" not in data["repair_meta"]
     assert "unknown_key" not in data["repair_meta"]
-    assert "Множественные дефекты теплообменника" in captured["prompt"]
+    assert "Утечка хладагента" in captured["prompt"]
     assert "Daikin FTXB25C" in captured["prompt"]
+    assert "готовый дефектный акт" in captured["prompt"]
 
 
 @pytest.mark.asyncio
@@ -2502,6 +2513,65 @@ async def test_manager_order_generate_defect_act_placeholders(async_client, db, 
     assert replacements["{{repair_not_viable}}"] == "Да"
     assert replacements["{{repair_not_viable_reason}}"] == "Стоимость ремонта сопоставима с заменой оборудования."
     assert replacements["{{additional_conditions}}"] == "Работы выполнять после согласования с администратором."
+
+
+@pytest.mark.asyncio
+async def test_manager_order_generate_defect_act_from_structured_repair_meta(async_client, db, monkeypatch):
+    customer = Customer(name='ООО "Структура"', phone="+375297777700", type=CustomerType.company)
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.NEW_LEAD,
+        technical_meta={
+            "repair": {
+                "customer_complaint": "Плохо охлаждает",
+                "fault_type": "refrigerant_leak",
+                "diagnostic_notes": "Обмерзает теплообменник внутреннего блока.",
+                "structured_diagnosis": {
+                    "fault_type": "refrigerant_leak",
+                    "fault_location": "flare_connections",
+                    "repairable": True,
+                    "operation_status": "limited",
+                    "risks": ["compressor_damage"],
+                    "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
+                    "refrigerant": "R410A",
+                    "refrigerant_amount": "790 g",
+                    "hidden_defects_possible": True,
+                },
+            },
+        },
+    )
+    db.add_all([customer, order])
+    await db.commit()
+    await db.refresh(order)
+
+    captured = {}
+
+    class _FakeGoogleService:
+        def copy_template(self, template_id, title):
+            return {"file_id": "fake-defect-act", "edit_url": "https://docs.google.com/document/d/fake-defect-act/edit"}
+
+        def replace_placeholders(self, file_id, replacements):
+            captured["replacements"] = replacements
+
+    from services import document_service
+
+    monkeypatch.setattr(document_service, "get_google_service", lambda: _FakeGoogleService())
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/defect_act?contract_date=2026-05-14T00:00:00",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    replacements = captured["replacements"]
+    assert replacements["{{technical_condition}}"].startswith("Неисправное. Выявлены признаки утечки хладагента")
+    assert "Обмерзает теплообменник" in replacements["{{measurement_result}}"]
+    assert "Эксплуатация оборудования допускается только с ограничениями" in replacements["{{further_use_assessment}}"]
+    assert "повреждение компрессора" in replacements["{{operation_restrictions}}"]
+    assert "восстановить герметичность холодильного контура" in replacements["{{technical_conclusion}}"]
+    assert replacements["{{repair_possible}}"] == "Да"
+    assert replacements["{{refrigerant_type}}"] == "R410A"
+    assert replacements["{{refrigerant_amount}}"] == "790 g"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_repair_diagnostic_api.py
+++ b/tests/integration/test_repair_diagnostic_api.py
@@ -1,0 +1,86 @@
+import json
+
+import pytest
+
+from models import LeadSource, Order, OrderStatus
+from services.general_media_storage_service import StoredGeneralMediaObject
+
+
+class FakeRepairDiagnosticStorage:
+    provider_name = "local"
+
+    async def save_media(self, **kwargs):
+        variant_type = kwargs["variant_type"]
+        extension = kwargs["extension"]
+        return StoredGeneralMediaObject(
+            url=f"/media/orders/1/repair-diagnostic/{variant_type}/hash.{extension}",
+            content_hash="a" * 64,
+            storage_provider="local",
+            path=f"media/orders/1/repair-diagnostic/{variant_type}/hash.{extension}",
+            size_bytes=len(kwargs["content"]),
+        )
+
+
+@pytest.mark.asyncio
+async def test_public_repair_diagnostic_creates_structured_repair_order(async_client, db, monkeypatch):
+    monkeypatch.setattr(
+        "services.repair_diagnostic_service.get_general_media_storage",
+        lambda: FakeRepairDiagnosticStorage(),
+    )
+    payload = {
+        "scenario": "repair",
+        "symptom": "water_leak",
+        "problem_timing": "after_minutes",
+        "symptom_details": {
+            "leak_timing": "later",
+            "recently_cleaned": "no",
+            "drainage_exit": "unknown",
+            "leak_place": "body",
+        },
+        "client_checks": ["filters_cleaned", "drainage_checked"],
+        "client_comment": "Капает справа после 10 минут работы",
+        "contact": {
+            "name": "Иван",
+            "phone": "+375 (29) 111-22-33",
+            "address": "Витебск, Билево",
+        },
+    }
+
+    response = await async_client.post(
+        "/api/v1/leads/repair-diagnostic",
+        files=[
+            ("payload", (None, json.dumps(payload), "application/json")),
+            ("nameplate", ("nameplate.jpg", b"nameplate-content", "image/jpeg")),
+            ("indoor_unit", ("indoor.webp", b"indoor-content", "image/webp")),
+        ],
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "new_lead"
+    assert data["ai_pre_diagnosis_status"] == "pending"
+
+    order = await db.get(Order, data["order_id"])
+    assert order is not None
+    assert order.status == OrderStatus.NEW_LEAD
+    assert order.lead_source == LeadSource.SITE
+    assert order.workflow_type == "repair"
+    assert order.title == "Ремонт кондиционера: Течет вода из внутреннего блока"
+    assert "предварительной диагностикой" in order.comment
+
+    meta = order.technical_meta
+    assert meta["service_type"] == "repair"
+    repair_meta = meta["repair"]
+    assert repair_meta["scenario"] == "repair"
+    assert repair_meta["repair_status"] == "new"
+    assert repair_meta["symptom"] == "water_leak"
+    assert repair_meta["problem_timing"] == "after_minutes"
+    assert repair_meta["client_checks"] == ["filters_cleaned", "drainage_checked"]
+    assert repair_meta["symptom_details"]["drainage_exit"] == "unknown"
+    assert repair_meta["contact"]["address"] == "Витебск, Билево"
+    assert repair_meta["ai_pre_diagnosis_status"] == "pending"
+    assert repair_meta["photos"]["nameplate"][0]["url"].endswith("/nameplate/hash.jpg")
+    assert repair_meta["photos"]["indoor_unit"][0]["content_type"] == "image/webp"
+    assert "Фото шильдика" not in repair_meta["missing_data"]
+    assert "Фото внутреннего блока целиком" not in repair_meta["missing_data"]
+    assert "Фото места протечки" in repair_meta["missing_data"]

--- a/tests/unit/test_defect_act_ai_service.py
+++ b/tests/unit/test_defect_act_ai_service.py
@@ -7,15 +7,18 @@ from services.defect_act_ai_service import DefectActAIService
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_polishes_existing_fields_by_default(monkeypatch):
+async def test_defect_act_ai_returns_structured_template_meta(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
         assert '"polish_existing": true' in prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "measurement_result": "Измерения показали пробой обмотки компрессора на корпус.",
-                    "technical_conclusion": "Компрессор неисправен, дальнейшая эксплуатация оборудования запрещена.",
-                }
+                "fault_type": "compressor_failure",
+                "repairable": False,
+                "operation_status": "not_allowed",
+                "risks": ["electrical_damage"],
+                "recommended_actions": ["replace_compressor"],
+                "hidden_defects_possible": True,
+                "technical_conclusion": "AI must not write expert override fields.",
             },
             ensure_ascii=False,
         )
@@ -28,25 +31,32 @@ async def test_defect_act_ai_polishes_existing_fields_by_default(monkeypatch):
             polish_existing=True,
             current_meta={
                 "measurement_result": "замерили токи, пробивает на корпус",
-                "technical_conclusion": "",
+                "technical_conclusion": "ручное заключение инженера",
             },
         )
     )
 
-    assert result["measurement_result"].startswith("Измерения показали")
-    assert result["technical_conclusion"].startswith("Компрессор неисправен")
+    assert result["fault_type"] == "compressor_failure"
+    assert result["structured_diagnosis"]["repairable"] is False
+    assert result["diagnostic_result"].startswith("Выявлены признаки неисправности компрессора")
+    assert result["repair_recommendation"].startswith("Рекомендуется оценить целесообразность")
+    assert result["repair_possible"] == "Нет"
+    assert "measurement_result" not in result
+    assert "technical_conclusion" not in result
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_can_leave_existing_fields_untouched(monkeypatch):
+async def test_defect_act_ai_leaves_existing_primary_fields_untouched_when_requested(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
         assert '"polish_existing": false' in prompt
         return json.dumps(
             {
-                "repair_meta": {
-                    "measurement_result": "AI tried to rewrite existing value",
-                    "technical_conclusion": "Компрессор неисправен.",
-                }
+                "fault_type": "refrigerant_leak",
+                "fault_location": "flare_connections",
+                "repairable": True,
+                "operation_status": "limited",
+                "risks": ["compressor_damage"],
+                "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],
             },
             ensure_ascii=False,
         )
@@ -55,41 +65,35 @@ async def test_defect_act_ai_can_leave_existing_fields_untouched(monkeypatch):
 
     result = await DefectActAIService.generate_repair_meta(
         ManagerRepairActAiDraftPayload(
-            defect_type="compressor_winding_breakdown",
+            defect_type="refrigerant_leak",
             polish_existing=False,
             current_meta={
-                "measurement_result": "замерили токи, пробивает на корпус",
-                "technical_conclusion": "",
+                "diagnostic_result": "Уже заполненная диагностика инженера.",
+                "repair_recommendation": "",
             },
         )
     )
 
-    assert "measurement_result" not in result
-    assert result["technical_conclusion"] == "Компрессор неисправен."
+    assert result["fault_type"] == "refrigerant_leak"
+    assert result["structured_diagnosis"]["fault_location"] == "flare_connections"
+    assert "diagnostic_result" not in result
+    assert result["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
 
 
 @pytest.mark.asyncio
-async def test_defect_act_ai_sanitization_keeps_content_keys_and_drops_workflow_keys(monkeypatch):
+async def test_defect_act_ai_sanitization_keeps_structured_keys_and_drops_workflow_keys(monkeypatch):
     async def _fake_request_completion(prompt: str) -> str:
-        assert "diagnostic_result" in prompt
-        assert "repair_recommendation" in prompt
+        assert "diagnostic_notes" in prompt
+        assert "repair_recommendation" not in prompt.split("Верни JSON в такой структуре:", 1)[1]
         return json.dumps(
             {
                 "repair_meta": {
-                    "diagnostic_result": "Диагностика выявила недостаток хладагента.",
-                    "repair_recommendation": "Проверить контур на утечку и дозаправить.",
-                    "repair_possible": "Да",
+                    "fault_type": "refrigerant_leak",
+                    "refrigerant": "R32",
+                    "refrigerant_amount": "0,35 кг",
                     "repair_status": "awaiting_customer_approval",
                     "customer_approval_status": "pending",
-                    "customer_approval_note": "Ожидается письменное согласование клиента.",
                     "parts_status": "awaiting",
-                    "parts_note": "Датчик температуры требуется заказать.",
-                    "repair_completion_note": "Завершение возможно после поставки запчастей.",
-                    "refrigerant_type": "R32",
-                    "refrigerant_amount": "0,35 кг",
-                    "refrigerant_pricing_mode": "по фактической массе",
-                    "repair_not_viable": "Нет",
-                    "repair_not_viable_reason": "Критических повреждений не выявлено.",
                     "unknown_key": "must be dropped",
                 }
             },
@@ -106,18 +110,13 @@ async def test_defect_act_ai_sanitization_keeps_content_keys_and_drops_workflow_
         )
     )
 
-    assert result["diagnostic_result"] == "Диагностика выявила недостаток хладагента."
-    assert result["repair_recommendation"] == "Проверить контур на утечку и дозаправить."
+    assert result["fault_type"] == "refrigerant_leak"
+    assert result["diagnostic_result"].startswith("Выявлены признаки утечки хладагента")
+    assert result["repair_recommendation"].startswith("Рекомендуется восстановить герметичность")
     assert result["repair_possible"] == "Да"
     assert result["refrigerant_type"] == "R32"
     assert result["refrigerant_amount"] == "0,35 кг"
-    assert result["refrigerant_pricing_mode"] == "по фактической массе"
-    assert result["repair_not_viable"] == "Нет"
-    assert result["repair_not_viable_reason"] == "Критических повреждений не выявлено."
     assert "repair_status" not in result
     assert "customer_approval_status" not in result
-    assert "customer_approval_note" not in result
     assert "parts_status" not in result
-    assert "parts_note" not in result
-    assert "repair_completion_note" not in result
     assert "unknown_key" not in result

--- a/tests/unit/test_repair_diagnostic_service.py
+++ b/tests/unit/test_repair_diagnostic_service.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from models import LeadSource, Order, OrderStatus
+from services.general_media_storage_service import StoredGeneralMediaObject
+from services.repair_diagnostic_service import (
+    RepairDiagnosticIncomingFile,
+    RepairDiagnosticLeadPayload,
+    RepairDiagnosticService,
+)
+
+
+class FakeRepairDiagnosticStorage:
+    provider_name = "local"
+
+    async def save_media(self, **kwargs):
+        variant_type = kwargs["variant_type"]
+        extension = kwargs["extension"]
+        return StoredGeneralMediaObject(
+            url=f"/media/orders/42/repair-diagnostic/{variant_type}/hash.{extension}",
+            content_hash="c" * 64,
+            storage_provider="local",
+            path=f"media/orders/42/repair-diagnostic/{variant_type}/hash.{extension}",
+            size_bytes=len(kwargs["content"]),
+        )
+
+
+@pytest.fixture
+async def sqlite_repair_diagnostic_session(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'repair_diagnostic.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_repair_diagnostic_service_creates_repair_order_with_structured_meta(
+    sqlite_repair_diagnostic_session,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "services.repair_diagnostic_service.get_general_media_storage",
+        lambda: FakeRepairDiagnosticStorage(),
+    )
+    payload = RepairDiagnosticLeadPayload.model_validate(
+        {
+            "scenario": "repair",
+            "symptom": "not_cooling",
+            "problem_timing": "after_minutes",
+            "symptom_details": {
+                "indoor_fan_works": "yes",
+                "outdoor_unit_starts": "unknown",
+                "freezing_seen": "no",
+                "cooled_before": "yes",
+            },
+            "client_checks": ["filters_cleaned", "power_restarted"],
+            "client_comment": "Стал хуже холодить после жары",
+            "contact": {
+                "name": "Анна",
+                "phone": "+375291112233",
+                "address": "Витебск, центр",
+            },
+        }
+    )
+    uploads = {
+        "nameplate": [
+            RepairDiagnosticIncomingFile(
+                filename="nameplate.jpg",
+                content_type="image/jpeg",
+                content=b"nameplate-content",
+            )
+        ],
+        "indoor_unit": [
+            RepairDiagnosticIncomingFile(
+                filename="indoor.png",
+                content_type="image/png",
+                content=b"indoor-content",
+            )
+        ],
+    }
+
+    response, nameplate_files = await RepairDiagnosticService.create_lead(
+        sqlite_repair_diagnostic_session,
+        payload=payload,
+        uploads=uploads,
+    )
+
+    assert response.status == "new_lead"
+    assert response.ai_pre_diagnosis_status == "pending"
+    assert len(nameplate_files) == 1
+
+    order = await sqlite_repair_diagnostic_session.get(Order, response.order_id)
+    assert order is not None
+    assert order.status == OrderStatus.NEW_LEAD
+    assert order.lead_source == LeadSource.SITE
+    assert order.workflow_type == "repair"
+    assert order.delivery_address == "Витебск, центр"
+    assert order.title == "Ремонт кондиционера: Не охлаждает / слабо охлаждает"
+
+    meta = order.technical_meta
+    assert meta["service_type"] == "repair"
+    repair_meta = meta["repair"]
+    assert repair_meta["scenario"] == "repair"
+    assert repair_meta["symptom"] == "not_cooling"
+    assert repair_meta["symptom_details"]["outdoor_unit_starts"] == "unknown"
+    assert repair_meta["client_checks"] == ["filters_cleaned", "power_restarted"]
+    assert repair_meta["photos"]["nameplate"][0]["content_hash"] == "c" * 64
+    assert repair_meta["ai_pre_diagnosis_status"] == "pending"
+    assert repair_meta["preliminary_fault_type"] == "refrigerant_leak"
+    assert "Фото шильдика" not in repair_meta["missing_data"]

--- a/web/src/components/RepairDiagnosticForm.vue
+++ b/web/src/components/RepairDiagnosticForm.vue
@@ -1,0 +1,636 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { submitRepairDiagnostic } from '../utils/api';
+import { formatPhoneForDisplay, validateRequiredBelarusPhone } from '../utils/validation';
+import {
+  clientChecks,
+  conditionalQuestions,
+  photoFields,
+  symptoms,
+  timings,
+} from '../config/repairDiagnostic';
+
+const steps = [
+  'Что случилось',
+  'Когда проявляется',
+  'Что проверяли',
+  'Фото',
+  'Контакты',
+];
+
+const currentStep = ref(0);
+const isSubmitting = ref(false);
+const isSuccess = ref(false);
+const submitError = ref('');
+const createdOrderId = ref(null);
+const phoneInput = ref(null);
+const formRoot = ref(null);
+
+const form = ref({
+  symptom: '',
+  problemTiming: '',
+  symptomDetails: {},
+  clientChecks: [],
+  name: '',
+  phone: '',
+  address: '',
+  comment: '',
+});
+
+const photos = ref(
+  photoFields.reduce((acc, item) => {
+    acc[item.key] = [];
+    return acc;
+  }, {})
+);
+
+const activeQuestions = computed(() => conditionalQuestions[form.value.symptom] || []);
+
+onMounted(() => {
+  if (!phoneInput.value) return;
+  phoneInput.value.onfocus = () => {
+    if (!form.value.phone.trim()) form.value.phone = '+375 ';
+  };
+  phoneInput.value.onblur = () => {
+    form.value.phone = formatPhoneForDisplay(form.value.phone);
+  };
+});
+
+function selectSymptom(value) {
+  form.value.symptom = value;
+  form.value.symptomDetails = {};
+}
+
+function setDetail(key, value) {
+  form.value.symptomDetails = {
+    ...form.value.symptomDetails,
+    [key]: value,
+  };
+}
+
+function toggleCheck(value) {
+  const checks = new Set(form.value.clientChecks);
+  if (value === 'nothing_checked') {
+    form.value.clientChecks = checks.has(value) ? [] : [value];
+    return;
+  }
+  checks.delete('nothing_checked');
+  if (checks.has(value)) checks.delete(value);
+  else checks.add(value);
+  form.value.clientChecks = Array.from(checks);
+}
+
+function onFilesChange(key, event) {
+  photos.value[key] = Array.from(event.target.files || []).slice(0, 5);
+}
+
+function validateStep(index) {
+  submitError.value = '';
+  if (index === 0 && !form.value.symptom) {
+    submitError.value = 'Выберите, что случилось с кондиционером.';
+    return false;
+  }
+  if (index === 1 && !form.value.problemTiming) {
+    submitError.value = 'Выберите, когда проявляется проблема.';
+    return false;
+  }
+  if (index === 4) {
+    if (!form.value.name.trim()) {
+      submitError.value = 'Введите имя.';
+      return false;
+    }
+    form.value.phone = formatPhoneForDisplay(form.value.phone);
+    const phoneError = validateRequiredBelarusPhone(form.value.phone, true);
+    if (phoneError) {
+      submitError.value = phoneError;
+      return false;
+    }
+    if (!form.value.address.trim()) {
+      submitError.value = 'Укажите адрес или район.';
+      return false;
+    }
+  }
+  return true;
+}
+
+function scrollToDiagnosticStart() {
+  requestAnimationFrame(() => {
+    formRoot.value?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+}
+
+function nextStep() {
+  if (!validateStep(currentStep.value)) return;
+  currentStep.value = Math.min(currentStep.value + 1, steps.length - 1);
+  scrollToDiagnosticStart();
+}
+
+function previousStep() {
+  submitError.value = '';
+  currentStep.value = Math.max(currentStep.value - 1, 0);
+  scrollToDiagnosticStart();
+}
+
+function buildPayload() {
+  return {
+    scenario: 'repair',
+    symptom: form.value.symptom,
+    problem_timing: form.value.problemTiming,
+    symptom_details: form.value.symptomDetails,
+    client_checks: form.value.clientChecks,
+    client_comment: form.value.comment.trim(),
+    contact: {
+      name: form.value.name.trim(),
+      phone: form.value.phone.trim(),
+      address: form.value.address.trim(),
+    },
+  };
+}
+
+async function submitForm() {
+  for (let index = 0; index < steps.length; index += 1) {
+    if (!validateStep(index)) {
+      currentStep.value = index;
+      scrollToDiagnosticStart();
+      return;
+    }
+  }
+  isSubmitting.value = true;
+  submitError.value = '';
+  const result = await submitRepairDiagnostic(buildPayload(), photos.value);
+  isSubmitting.value = false;
+  if (!result) {
+    submitError.value = 'Не удалось отправить заявку. Попробуйте позже или позвоните нам.';
+    return;
+  }
+  createdOrderId.value = result.order_id;
+  isSuccess.value = true;
+}
+</script>
+
+<template>
+  <section ref="formRoot" class="repair-diagnostic" id="repair-diagnostic">
+    <div v-if="isSuccess" class="success-panel">
+      <span class="material-icons-round success-icon">check_circle</span>
+      <h3>Заявка принята.</h3>
+      <p>
+        Заявка принята. По вашим ответам мастер предварительно оценит возможную причину
+        неисправности. Точная причина и стоимость ремонта определяются после диагностики на месте.
+      </p>
+      <p v-if="createdOrderId" class="order-number">Номер заявки: {{ createdOrderId }}</p>
+    </div>
+
+    <div v-else>
+      <div class="diagnostic-intro">
+        <p class="eyebrow">Предварительная диагностика</p>
+        <h3>Поможем мастеру подготовиться до выезда</h3>
+        <p>
+          Ответьте на несколько вопросов, и мастер заранее поймет, с чем может быть связана
+          неисправность. Это не заменяет диагностику на месте, но помогает быстрее оценить
+          ситуацию, подготовить инструмент и ориентировочно понять сложность ремонта.
+        </p>
+      </div>
+
+      <div class="stepper" aria-label="Шаги диагностики">
+        <div
+          v-for="(step, index) in steps"
+          :key="step"
+          class="step-dot"
+          :class="{ active: currentStep === index, done: currentStep > index }"
+          :aria-current="currentStep === index ? 'step' : undefined"
+        >
+          <span>{{ index + 1 }}</span>
+          <b>{{ step }}</b>
+        </div>
+      </div>
+
+      <form class="diagnostic-form" @submit.prevent="submitForm">
+        <div v-if="currentStep === 0" class="step-panel">
+          <h4>Что случилось?</h4>
+          <div class="option-grid">
+            <button
+              v-for="item in symptoms"
+              :key="item.value"
+              type="button"
+              class="choice"
+              :class="{ selected: form.symptom === item.value }"
+              @click="selectSymptom(item.value)"
+            >
+              {{ item.label }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="currentStep === 1" class="step-panel">
+          <h4>Когда проявляется проблема?</h4>
+          <div class="option-grid compact">
+            <button
+              v-for="item in timings"
+              :key="item.value"
+              type="button"
+              class="choice"
+              :class="{ selected: form.problemTiming === item.value }"
+              @click="form.problemTiming = item.value"
+            >
+              {{ item.label }}
+            </button>
+          </div>
+
+          <div v-if="activeQuestions.length" class="conditional">
+            <h5>Уточним по выбранному симптому</h5>
+            <div v-for="question in activeQuestions" :key="question.key" class="question-row">
+              <label>{{ question.label }}</label>
+              <input
+                v-if="question.type === 'text'"
+                v-model="form.symptomDetails[question.key]"
+                type="text"
+                :placeholder="question.placeholder"
+              />
+              <div v-else class="segmented">
+                <button
+                  v-for="option in question.options"
+                  :key="option.value"
+                  type="button"
+                  class="segment"
+                  :class="{ selected: form.symptomDetails[question.key] === option.value }"
+                  @click="setDetail(question.key, option.value)"
+                >
+                  {{ option.label }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="currentStep === 2" class="step-panel">
+          <h4>Что уже проверяли?</h4>
+          <div class="option-grid compact">
+            <button
+              v-for="item in clientChecks"
+              :key="item.value"
+              type="button"
+              class="choice"
+              :class="{ selected: form.clientChecks.includes(item.value) }"
+              @click="toggleCheck(item.value)"
+            >
+              {{ item.label }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="currentStep === 3" class="step-panel">
+          <h4>Фото</h4>
+          <p class="step-note">
+            Особенно важно фото шильдика: по нему можно определить модель, хладагент и часть
+            технических параметров.
+          </p>
+          <div class="photo-list">
+            <label v-for="item in photoFields" :key="item.key" class="photo-field">
+              <span>
+                <b>{{ item.label }}</b>
+                <small v-if="item.hint">{{ item.hint }}</small>
+              </span>
+              <input
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                multiple
+                @change="onFilesChange(item.key, $event)"
+              />
+              <em v-if="photos[item.key].length">{{ photos[item.key].length }} файл(а)</em>
+            </label>
+          </div>
+        </div>
+
+        <div v-if="currentStep === 4" class="step-panel">
+          <h4>Контакты</h4>
+          <div class="field-grid">
+            <label>
+              <span>Имя</span>
+              <input v-model="form.name" type="text" autocomplete="name" required />
+            </label>
+            <label>
+              <span>Телефон</span>
+              <input
+                ref="phoneInput"
+                v-model="form.phone"
+                type="tel"
+                autocomplete="tel"
+                placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX"
+                required
+              />
+            </label>
+            <label class="wide">
+              <span>Адрес или район</span>
+              <input v-model="form.address" type="text" autocomplete="street-address" required />
+            </label>
+            <label class="wide">
+              <span>Комментарий</span>
+              <textarea
+                v-model="form.comment"
+                rows="4"
+                placeholder="Например: кондиционер висит над окном, наружный блок доступен с балкона"
+              ></textarea>
+            </label>
+          </div>
+          <p class="privacy">
+            Нажимая кнопку, вы соглашаетесь с
+            <a href="/privacy/">политикой обработки персональных данных</a>.
+          </p>
+        </div>
+
+        <p v-if="submitError" class="form-error">{{ submitError }}</p>
+
+        <div class="actions">
+          <button
+            v-if="currentStep > 0"
+            class="btn btn-outline"
+            type="button"
+            @click="previousStep"
+          >
+            Назад
+          </button>
+          <button
+            v-if="currentStep < steps.length - 1"
+            class="btn btn-primary"
+            type="button"
+            @click="nextStep"
+          >
+            Далее
+          </button>
+          <button
+            v-else
+            class="btn btn-primary"
+            type="submit"
+            :disabled="isSubmitting"
+          >
+            {{ isSubmitting ? 'Отправка...' : 'Отправить заявку' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.repair-diagnostic {
+  background: var(--panel-glass-bg);
+  border: 1px solid var(--panel-glass-border);
+  border-radius: 1rem;
+  box-shadow: var(--panel-glass-shadow);
+  margin: 2rem 0;
+  padding: 1.5rem;
+  scroll-margin-top: 6rem;
+}
+
+.diagnostic-intro {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  color: var(--primary);
+  font-weight: 800;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+h3,
+h4,
+h5,
+p {
+  margin: 0;
+}
+
+h3 {
+  font-size: 1.6rem;
+}
+
+h4 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.stepper {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.step-dot {
+  align-items: center;
+  background: var(--panel-pill-bg);
+  border: 1px solid var(--panel-chip-border);
+  border-radius: 0.75rem;
+  color: var(--text-muted);
+  display: flex;
+  gap: 0.5rem;
+  min-height: 3rem;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.step-dot span {
+  align-items: center;
+  background: var(--secondary);
+  border-radius: 999px;
+  color: var(--primary);
+  display: inline-flex;
+  flex: 0 0 1.6rem;
+  height: 1.6rem;
+  justify-content: center;
+  line-height: 1;
+}
+
+.step-dot b {
+  font-size: 0.8rem;
+  line-height: 1.15;
+}
+
+.step-dot.active,
+.step-dot.done {
+  border-color: var(--panel-chip-hover-border);
+  color: var(--text);
+}
+
+.step-dot.active span,
+.step-dot.done span {
+  background: var(--panel-active-gradient);
+  color: var(--panel-active-text);
+}
+
+.diagnostic-form,
+.step-panel,
+.conditional,
+.photo-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.option-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.option-grid.compact {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.choice,
+.segment {
+  background: var(--panel-chip-bg);
+  border: 1px solid var(--panel-chip-border);
+  border-radius: 0.75rem;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  min-height: 3.25rem;
+  padding: 0.8rem 1rem;
+  text-align: left;
+}
+
+.choice.selected,
+.segment.selected {
+  background: var(--panel-active-gradient);
+  border-color: transparent;
+  color: var(--panel-active-text);
+}
+
+.conditional {
+  border-top: 1px solid var(--border);
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+}
+
+.question-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.question-row label,
+.field-grid span,
+.photo-field b {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.segment {
+  min-height: 2.75rem;
+  text-align: center;
+}
+
+.step-note,
+.photo-field small,
+.privacy,
+.order-number {
+  color: var(--text-muted);
+}
+
+.photo-field {
+  align-items: center;
+  border: 1px solid var(--panel-input-border);
+  border-radius: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr);
+  padding: 1rem;
+}
+
+.photo-field span {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.photo-field input,
+.question-row input,
+.field-grid input,
+.field-grid textarea {
+  background: var(--panel-input-bg);
+  border: 1px solid var(--panel-input-border);
+  border-radius: 0.75rem;
+  color: var(--text);
+  font: inherit;
+  padding: 0.85rem 1rem;
+  width: 100%;
+}
+
+.photo-field em {
+  color: var(--success-text);
+  font-style: normal;
+  font-weight: 700;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-grid label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.field-grid .wide {
+  grid-column: 1 / -1;
+}
+
+.form-error {
+  background: var(--error-bg);
+  border: 1px solid var(--error-text);
+  border-radius: 0.75rem;
+  color: var(--error-text);
+  padding: 0.85rem 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.success-panel {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: start;
+}
+
+.success-icon {
+  color: var(--success-text);
+  font-size: 2.25rem;
+}
+
+@media (max-width: 760px) {
+  .repair-diagnostic {
+    padding: 1rem;
+  }
+
+  .stepper,
+  .option-grid,
+  .option-grid.compact,
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .step-dot {
+    min-height: 2.75rem;
+  }
+
+  .actions {
+    flex-direction: column-reverse;
+  }
+
+  .actions .btn {
+    width: 100%;
+  }
+}
+</style>

--- a/web/src/config/repairDiagnostic.js
+++ b/web/src/config/repairDiagnostic.js
@@ -1,0 +1,165 @@
+export const symptoms = [
+  { value: 'not_cooling', label: 'Не охлаждает / слабо охлаждает' },
+  { value: 'water_leak', label: 'Течет вода из внутреннего блока' },
+  { value: 'not_turning_on', label: 'Не включается' },
+  { value: 'turns_off', label: 'Сам выключается' },
+  { value: 'noise_vibration', label: 'Шумит или вибрирует' },
+  { value: 'bad_smell', label: 'Появился неприятный запах' },
+  { value: 'error_code', label: 'На дисплее ошибка' },
+  { value: 'other', label: 'Другая проблема' },
+];
+
+export const timings = [
+  { value: 'immediately', label: 'Сразу после включения' },
+  { value: 'after_minutes', label: 'Через несколько минут работы' },
+  { value: 'after_hours', label: 'Через несколько часов' },
+  { value: 'constantly', label: 'Постоянно' },
+  { value: 'periodically', label: 'Периодически' },
+  { value: 'after_service', label: 'После обслуживания / ремонта / переноса' },
+  { value: 'unknown', label: 'Не знаю' },
+];
+
+export const clientChecks = [
+  { value: 'filters_cleaned', label: 'Чистили фильтры' },
+  { value: 'power_restarted', label: 'Перезагружали питание' },
+  { value: 'remote_batteries_changed', label: 'Меняли батарейки в пульте' },
+  { value: 'drainage_checked', label: 'Проверяли дренаж' },
+  { value: 'master_visited', label: 'Уже приезжал мастер' },
+  { value: 'nothing_checked', label: 'Ничего не проверяли' },
+];
+
+export const conditionalQuestions = {
+  water_leak: [
+    {
+      key: 'leak_timing',
+      label: 'Вода течет сразу или через некоторое время?',
+      options: [
+        { value: 'immediately', label: 'Сразу' },
+        { value: 'later', label: 'Через некоторое время' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'recently_cleaned',
+      label: 'Кондиционер недавно чистили?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'drainage_exit',
+      label: 'Куда выведен дренаж?',
+      options: [
+        { value: 'street', label: 'На улицу' },
+        { value: 'sewer', label: 'В канализацию' },
+        { value: 'unknown', label: 'Неизвестно' },
+      ],
+    },
+    {
+      key: 'leak_place',
+      label: 'Где капает вода?',
+      options: [
+        { value: 'body', label: 'Из корпуса' },
+        { value: 'wall', label: 'По стене' },
+        { value: 'tube', label: 'Из трубки' },
+      ],
+    },
+  ],
+  not_cooling: [
+    {
+      key: 'indoor_fan_works',
+      label: 'Вентилятор внутреннего блока работает?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'outdoor_unit_starts',
+      label: 'Наружный блок запускается?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'freezing_seen',
+      label: 'Есть ли обмерзание трубок или внутреннего блока?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'cooled_before',
+      label: 'Кондиционер раньше охлаждал нормально?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+  ],
+  not_turning_on: [
+    {
+      key: 'has_indication',
+      label: 'Есть ли индикация на блоке?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'remote_response',
+      label: 'Реагирует ли на пульт?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+    {
+      key: 'power_checked',
+      label: 'Проверяли ли питание / автомат?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+      ],
+    },
+    {
+      key: 'voltage_surge',
+      label: 'Был ли скачок напряжения?',
+      options: [
+        { value: 'yes', label: 'Да' },
+        { value: 'no', label: 'Нет' },
+        { value: 'unknown', label: 'Не знаю' },
+      ],
+    },
+  ],
+  error_code: [
+    {
+      key: 'error_code',
+      label: 'Введите код ошибки',
+      type: 'text',
+      placeholder: 'Например E6, F0, P4',
+    },
+  ],
+};
+
+export const photoFields = [
+  {
+    key: 'nameplate',
+    label: 'Фото шильдика кондиционера',
+    hint: 'Особенно важно фото шильдика: по нему можно определить модель, хладагент и часть технических параметров.',
+  },
+  { key: 'indoor_unit', label: 'Фото внутреннего блока целиком' },
+  { key: 'outdoor_unit', label: 'Фото наружного блока, если доступен' },
+  { key: 'error_display', label: 'Фото ошибки на дисплее, если есть' },
+  { key: 'leak_place', label: 'Фото места протечки, если течет вода' },
+];

--- a/web/src/pages/services/repair.astro
+++ b/web/src/pages/services/repair.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import ContactForm from "../../components/ContactForm.vue";
+import RepairDiagnosticForm from "../../components/RepairDiagnosticForm.vue";
 
 export const prerender = true;
 ---
@@ -58,6 +58,8 @@ export const prerender = true;
                     <li>На дисплее появилась ошибка</li>
                 </ul>
 
+                <RepairDiagnosticForm client:visible />
+
                 <h3>Что проверяет мастер</h3>
                 <ul>
                     <li>Внутренний и наружный блоки</li>
@@ -85,7 +87,15 @@ export const prerender = true;
         </div>
 
         <div class="sidebar">
-            <ContactForm client:visible />
+            <div class="repair-sidebar-note glass">
+                <h3>Что подготовить</h3>
+                <p>
+                    Для предварительной оценки лучше приложить фото шильдика,
+                    внутреннего блока, ошибки на дисплее и места протечки, если
+                    течет вода.
+                </p>
+                <a class="btn btn-primary" href="#repair-diagnostic">Заполнить диагностику</a>
+            </div>
         </div>
     </section>
 </Layout>
@@ -129,7 +139,7 @@ export const prerender = true;
         gap: 0.75rem;
     }
     .feature-list .material-icons-round {
-        color: #10b981;
+        color: var(--success);
     }
 
     .article-content h3 {
@@ -145,6 +155,27 @@ export const prerender = true;
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+    }
+
+    .repair-sidebar-note {
+        position: sticky;
+        top: 6rem;
+        padding: 1.5rem;
+        border-radius: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .repair-sidebar-note h3 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        margin: 0;
+    }
+
+    .repair-sidebar-note p {
+        color: var(--text-muted);
+        margin: 0;
     }
 
     @media (max-width: 900px) {

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -521,6 +521,28 @@ export async function submitContactForm(formData) {
     }
 }
 
+export async function submitRepairDiagnostic(payload, photoFiles = {}) {
+    const url = `${API_V1}/leads/repair-diagnostic`;
+    const body = new FormData();
+    body.append('payload', JSON.stringify(payload));
+
+    Object.entries(photoFiles || {}).forEach(([field, files]) => {
+        Array.from(files || []).forEach((file) => {
+            if (file) body.append(field, file);
+        });
+    });
+
+    try {
+        return await fetchJson(url, {
+            method: 'POST',
+            body,
+        }, false);
+    } catch (e) {
+        console.error('[API] submitRepairDiagnostic failed:', e);
+        return null;
+    }
+}
+
 export async function submitProductAvailabilityLead(payload) {
     const url = `${API_V1}/leads/product-availability`;
     try {


### PR DESCRIPTION
## Summary
- add a public multipart repair diagnostic lead endpoint that creates CRM-visible `workflow_type="repair"` order leads
- store structured repair metadata, grouped photos, missing-data hints, and pending AI pre-diagnosis status in `technical_meta["repair"]`
- add post-submit AI/nameplate pre-processing hook for repair leads without making final diagnosis claims
- replace the generic repair-page contact form with a 5-step diagnostic Vue island and synced API helper
- sync OpenAPI and generated manager client models for the new endpoint

## Verification
- `pytest tests/unit/test_repair_diagnostic_service.py -q`
- `python3 -m compileall routers/api_leads.py services/repair_diagnostic_service.py tests/unit/test_repair_diagnostic_service.py tests/integration/test_repair_diagnostic_api.py`
- `bash scripts/audit_theme_hardcodes.sh`
- Browser QA on `http://127.0.0.1:4321/services/repair/`: desktop and 390px mobile, no horizontal overflow, conditional water-leak questions render, step change scrolls to the block start
- `astro build` reached Vite/client bundle generation, including `RepairDiagnosticForm`; full SSG failed because `http://localhost:8000/api/v1` is not running in this environment
- Integration test `tests/integration/test_repair_diagnostic_api.py` was added but not executed successfully here because test Postgres at `localhost:5433` is unavailable and Docker daemon is not running
