### PR TITLE
Seed LG24 product series content

### DIFF
--- a/parsers/lg24.py
+++ b/parsers/lg24.py
@@ -35,6 +35,7 @@ class Lg24Parser(BaseParser):
         "ARTCOOL Mirror",
         "Ultra Inverter R32",
         "Ultra Inverter",
+        "Smart Inverter",
         "Deluxe Pro",
         "EVO Max",
         "ECO Smart",

--- a/scripts/seed_lg24_series_content.py
+++ b/scripts/seed_lg24_series_content.py
@@ -1,0 +1,46 @@
+import argparse
+import asyncio
+import sys
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from services.lg24_series_content_service import seed_lg24_series_content
+
+
+async def run_seed(*, execute: bool, overwrite: bool) -> None:
+    db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(db_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session() as session:
+        result = await seed_lg24_series_content(
+            session,
+            execute=execute,
+            overwrite=overwrite,
+        )
+
+    await engine.dispose()
+
+    print(f"[{result['mode'].upper()}] updated={result['updated']} linked={result['linked']} missed={len(result['missed'])}")
+    for item in result["applied"]:
+        print(f"[update] {item}")
+    for item in result["kept"]:
+        print(f"[keep] {item}")
+    if result["missed"]:
+        print("[missed] " + ", ".join(result["missed"]))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed LG product series content from lg24.by")
+    parser.add_argument("--execute", action="store_true", help="Commit changes")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing series content")
+    args = parser.parse_args()
+    asyncio.run(run_seed(execute=args.execute, overwrite=args.overwrite))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/lg24_series_content_data.py
+++ b/services/lg24_series_content_data.py
@@ -1,0 +1,507 @@
+"""Static LG series and reusable feature seeds for lg24.by content import."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Lg24SeriesSeed:
+    title: str
+    source_url: str
+    match_slugs: tuple[str, ...]
+    tagline: str
+    short_description: str
+    description: str
+    fallback_features: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LgBrandFeatureSeed:
+    slug: str
+    title: str
+    text: str
+    icon: str
+    aliases: tuple[str, ...]
+    keywords: tuple[str, ...]
+
+
+SERIES_SEEDS: tuple[Lg24SeriesSeed, ...] = (
+    Lg24SeriesSeed(
+        title="Deluxe Pro",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/deluxe-pro/",
+        match_slugs=("deluxe-pro",),
+        tagline="Премиальная инверторная серия LG",
+        short_description="Тихая серия с Dual Inverter, контролем энергопотребления и управлением через LG ThinQ.",
+        description=(
+            "Deluxe Pro подходит для помещений, где важны высокая энергоэффективность, "
+            "низкий шум и аккуратный современный дизайн. По данным LG24, серия делает "
+            "упор на Dual Inverter, контроль потребления электроэнергии, чистый воздух "
+            "и Wi-Fi/голосовое управление через LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Контроль потребления электроэнергии",
+            "Чистый воздух и максимальный комфорт",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="EVO Max",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/evo_max/",
+        match_slugs=("evo-max", "evomax"),
+        tagline="Инвертор LG с расширенной очисткой воздуха",
+        short_description="Серия с Dual Inverter, Plasmaster Ionizer+, UVnano, Allergy Filter и Wi-Fi.",
+        description=(
+            "EVO Max — одна из наиболее насыщенных бытовых линеек LG на LG24: помимо "
+            "экономичной инверторной работы здесь заявлены ионизация Plasmaster Ionizer+, "
+            "UVnano, Allergy Filter, низкий шум и управление через приложение."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "UVnano",
+            "Allergy Filter",
+            "Экономия электроэнергии до 70%",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ECO Smart",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/eco-smart/",
+        match_slugs=("eco-smart",),
+        tagline="Практичная инверторная серия LG",
+        short_description="Инверторная серия с Allergy Filter, тихой работой и управлением LG SmartThinQ.",
+        description=(
+            "ECO Smart — массовая бытовая серия LG с понятным набором функций: "
+            "Dual Inverter, Allergy Filter, экономичная работа, низкий шум и управление "
+            "через Wi-Fi/голосовые сценарии LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Allergy Filter",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="LOOK Smart",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/look_smart/",
+        match_slugs=("look-smart", "look"),
+        tagline="Инвертор LG для базового комфорта",
+        short_description="Серия с Dual Inverter, Allergy Filter, быстрым охлаждением и эффективным нагревом.",
+        description=(
+            "LOOK Smart закрывает базовые бытовые задачи без лишней сложности: "
+            "экономичное охлаждение и обогрев, Allergy Filter, быстрый выход на режим "
+            "и низкий уровень шума."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Allergy Filter",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Быстрое охлаждение и эффективный нагрев",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ARTCOOL Gallery",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/artcool-gallery/",
+        match_slugs=("artcool-gallery",),
+        tagline="Дизайнерская серия с заменяемым изображением",
+        short_description="ARTCOOL Gallery совмещает инверторную работу LG и декоративную фронтальную панель.",
+        description=(
+            "ARTCOOL Gallery — дизайнерская серия LG: кондиционер работает как бытовая "
+            "сплит-система, но фронтальная панель используется как интерьерный объект "
+            "с возможностью смены изображения."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Ультратонкий дизайн со сменным изображением",
+            "Контроль потребления электроэнергии",
+            "Чистый воздух и максимальный комфорт",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ARTCOOL Gallery Special",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/artcool-gallery-special/",
+        match_slugs=("artcool-gallery-special",),
+        tagline="Специальная версия ARTCOOL Gallery",
+        short_description="Дизайнерская серия Gallery Special с инвертором LG и сменным изображением.",
+        description=(
+            "ARTCOOL Gallery Special развивает идею Gallery: серия рассчитана на "
+            "интерьеры, где внешний вид внутреннего блока так же важен, как охлаждение, "
+            "обогрев и управление через приложение."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Ультратонкий дизайн со сменным изображением",
+            "Контроль потребления электроэнергии",
+            "Чистый воздух и максимальный комфорт",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ARTCOOL Gallery Premium",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/artcool-gallery-premium/",
+        match_slugs=("artcool-gallery-premium",),
+        tagline="Премиальная версия ARTCOOL Gallery",
+        short_description="Интерьерная серия Gallery Premium с Dual Inverter и управлением LG ThinQ.",
+        description=(
+            "ARTCOOL Gallery Premium — верхняя дизайнерская линейка Gallery. На LG24 "
+            "для нее заявлены Dual Inverter, сменное изображение на передней панели, "
+            "контроль потребления, чистый воздух и SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Ультратонкий дизайн со сменным изображением",
+            "Контроль потребления электроэнергии",
+            "Чистый воздух и максимальный комфорт",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ARTCOOL Mirror",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/artcool-mirror/",
+        match_slugs=("artcool-mirror",),
+        tagline="Инвертор LG в зеркальном дизайне",
+        short_description="ARTCOOL Mirror сочетает зеркальную панель, Dual Inverter, ионизацию и Wi-Fi.",
+        description=(
+            "ARTCOOL Mirror — серия для интерьеров, где обычный белый внутренний блок "
+            "не подходит визуально. По данным LG24, линейка сочетает стильный дизайн, "
+            "Dual Inverter, Plasmaster Ionizer+, экономию энергии и SmartThinQ."
+        ),
+        fallback_features=(
+            "Стильный дизайн ARTCOOL",
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Objet Green",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/objet_green/",
+        match_slugs=("objet-green", "object-green"),
+        tagline="Цветная дизайнерская серия LG Objet",
+        short_description="Objet Green — дизайнерский инвертор LG с ионизацией, низким шумом и SmartThinQ.",
+        description=(
+            "Objet Green делает акцент на цвете и дизайне внутреннего блока, сохраняя "
+            "ключевые функции LG: Dual Inverter, Plasmaster Ionizer+, экономичную работу, "
+            "низкий шум и управление через LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Objet Beige",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/objet_beige/",
+        match_slugs=("objet-beige", "object-beige"),
+        tagline="Бежевая дизайнерская серия LG Objet",
+        short_description="Objet Beige — интерьерная серия LG с инвертором, ионизацией и SmartThinQ.",
+        description=(
+            "Objet Beige подходит для спокойных светлых интерьеров, где нужен не только "
+            "климат, но и аккуратное попадание блока в дизайн комнаты. На LG24 серия "
+            "описана через Dual Inverter, Plasmaster Ionizer+, экономию и SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="DUALCOOL Premium",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/dualcool-premium/",
+        match_slugs=("dualcool-premium", "dual-cool-premium"),
+        tagline="Премиальная бытовая серия LG DUALCOOL",
+        short_description="DUALCOOL Premium соединяет Dual Inverter, контроль энергии, чистый воздух и Wi-Fi.",
+        description=(
+            "DUALCOOL Premium — бытовая премиальная серия LG с акцентом на экономичный "
+            "инвертор, комфортный воздух, контроль потребления и управление через "
+            "LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Контроль потребления электроэнергии",
+            "Чистый воздух и максимальный комфорт",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="ECO",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/eco/",
+        match_slugs=("eco",),
+        tagline="Базовая инверторная серия LG",
+        short_description="ECO — простая серия LG с Allergy Filter, экономичной работой и быстрым выходом на режим.",
+        description=(
+            "ECO — базовая бытовая серия LG для стандартных помещений. В карточках LG24 "
+            "для нее выделены Dual Inverter, Allergy Filter, экономия электроэнергии, "
+            "низкий шум, быстрое охлаждение и эффективный нагрев."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Allergy Filter",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Быстрое охлаждение и эффективный нагрев",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="PuriCare",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/puricare/",
+        match_slugs=("puricare", "puri-care"),
+        tagline="LG с усиленным акцентом на качество воздуха",
+        short_description="PuriCare — инверторная серия с ионизацией, тихой работой и SmartThinQ.",
+        description=(
+            "PuriCare логично выделять покупателям, которым важны не только охлаждение "
+            "и обогрев, но и качество воздуха. На LG24 для серии заявлены Dual Inverter, "
+            "Plasmaster Ionizer+, экономия, низкий шум и SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="PROCOOL",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/procool/",
+        match_slugs=("procool", "pro-cool"),
+        tagline="Тихий инвертор LG с ионизацией",
+        short_description="PROCOOL сочетает Dual Inverter, Plasmaster Ionizer+, низкий шум и SmartThinQ.",
+        description=(
+            "PROCOOL — бытовая серия LG с низким уровнем шума и расширенной очисткой "
+            "воздуха. По LG24, серия включает Dual Inverter, Plasmaster Ionizer+, "
+            "экономию электроэнергии и управление через LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="EVOCOOL",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/evocool/",
+        match_slugs=("evocool", "evo-cool"),
+        tagline="Инвертор LG с ионизацией и Wi-Fi",
+        short_description="EVOCOOL — серия с Dual Inverter, Plasmaster Ionizer+, низким шумом и SmartThinQ.",
+        description=(
+            "EVOCOOL находится между базовыми и более насыщенными линейками LG: "
+            "в карточках LG24 заявлены Dual Inverter, Plasmaster Ionizer+, экономия "
+            "электроэнергии, низкий шум и управление через приложение."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Plasmaster Ionizer+",
+            "Экономия электроэнергии до 70%",
+            "Низкий уровень шума",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Smart Line",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/smart_line/",
+        match_slugs=("smart-line",),
+        tagline="Бытовая инверторная серия LG",
+        short_description="Smart Line — инвертор LG с экономичной работой, низким шумом и SmartThinQ.",
+        description=(
+            "Smart Line — спокойная бытовая серия LG для стандартных задач охлаждения "
+            "и обогрева. LG24 выделяет Dual Inverter, экономию электроэнергии, низкий "
+            "шум и Wi-Fi/голосовое управление через LG SmartThinQ."
+        ),
+        fallback_features=(
+            "Dual Inverter компрессор с 10-летней гарантией",
+            "Экономия электроэнергии до 70%",
+            "Бесшумная работа",
+            "Wi-Fi и голосовое управление LG SmartThinQ",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Ultra Inverter",
+        source_url="https://lg24.by/product/4-potochnyj-kassetnyj-tip-ultra-inverter-ct09r-uu09wr/",
+        match_slugs=("ultra-inverter",),
+        tagline="Коммерческая серия LG для кассетных, канальных и потолочных систем",
+        short_description="Ultra Inverter — коммерческие блоки LG с распределением воздуха, дренажным насосом и корейской сборкой.",
+        description=(
+            "Ultra Inverter закрывает коммерческие задачи: кассетные, канальные, "
+            "потолочные и колонные решения для офисов, торговых помещений и объектов "
+            "с требованием к равномерному воздухообмену."
+        ),
+        fallback_features=(
+            "Равномерное распределение воздуха",
+            "Индивидуальное управление створками",
+            "Встроенный дренажный насос",
+            "Упрощенный монтаж",
+            "Сделано в Южной Корее",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Ultra Inverter R32",
+        source_url="https://lg24.by/product/srednenapornyj-kanalnyj-tip-cm18r-cm18r/",
+        match_slugs=("ultra-inverter-r32",),
+        tagline="Коммерческая инверторная серия LG на R32",
+        short_description="Ultra Inverter R32 ориентирована на канальные и зональные коммерческие решения LG.",
+        description=(
+            "Ultra Inverter R32 — коммерческая линейка LG с хладагентом R32. В карточках "
+            "LG24 для канальных моделей выделены поддержание расчетного расхода воздуха, "
+            "зональное управление и возможность работы на несколько воздуховодов."
+        ),
+        fallback_features=(
+            "Поддержание расчетного расхода воздуха",
+            "Зональное управление",
+            "До 9 воздуховодов с одинаковыми параметрами",
+            "Дренажный насос опционально",
+            "Сделано в Южной Корее",
+        ),
+    ),
+    Lg24SeriesSeed(
+        title="Smart Inverter",
+        source_url="https://lg24.by/product/4-potochnyj-kassetnyj-tip-smart-inverter-ut18wc-uu18wc/",
+        match_slugs=("smart-inverter",),
+        tagline="Коммерческая инверторная серия LG",
+        short_description="Smart Inverter — коммерческие блоки LG с 4-сторонним распределением воздуха и удобным монтажом.",
+        description=(
+            "Smart Inverter — коммерческая серия LG для объектов, где важны равномерное "
+            "распределение воздуха, обслуживание с потолка и предсказуемый монтаж. "
+            "LG24 отдельно отмечает управление створками, 4-сторонний поток и дренажный насос."
+        ),
+        fallback_features=(
+            "Индивидуальное управление створками",
+            "Равномерное распределение воздуха в 4 стороны",
+            "Возможность установки на большой высоте",
+            "Упрощенный монтаж",
+            "Встроенный дренажный насос",
+        ),
+    ),
+)
+
+
+BRAND_FEATURE_SEEDS: tuple[LgBrandFeatureSeed, ...] = (
+    LgBrandFeatureSeed(
+        slug="dual-inverter",
+        title="Dual Inverter",
+        text="Инверторный компрессор LG быстрее выходит на режим, работает тише и экономит электроэнергию по сравнению с обычным компрессором.",
+        icon="settings_suggest",
+        aliases=("Dual Inverter компрессор", "Инверторный компрессор LG"),
+        keywords=("dual inverter", "инверторный компрессор", "10-летней гарантией"),
+    ),
+    LgBrandFeatureSeed(
+        slug="energy-control",
+        title="Active Energy Control",
+        text="Режимы контроля энергопотребления позволяют ограничивать расход электроэнергии и управлять эффективностью охлаждения.",
+        icon="energy_savings_leaf",
+        aliases=("Контроль потребления электроэнергии", "Active Energy Control"),
+        keywords=("active energy control", "контроль потребления", "экономия электроэнергии", "энергосбереж"),
+    ),
+    LgBrandFeatureSeed(
+        slug="lg-thinq",
+        title="LG ThinQ / SmartThinQ",
+        text="Wi-Fi и приложение LG ThinQ/SmartThinQ дают удаленное управление, мониторинг и голосовые сценарии.",
+        icon="wifi",
+        aliases=("SmartThinQ", "LG ThinQ", "Wi-Fi управление"),
+        keywords=("smartthinq", "lg thinq", "wi-fi", "wifi", "голосовое управление"),
+    ),
+    LgBrandFeatureSeed(
+        slug="allergy-filter",
+        title="Allergy Filter",
+        text="Фильтр Allergy Filter помогает задерживать аллергены и поддерживать более чистый воздух в помещении.",
+        icon="filter_alt",
+        aliases=("Аллергенный фильтр", "Allergy Filter"),
+        keywords=("allergy filter", "аллерген", "здоровый микроклимат"),
+    ),
+    LgBrandFeatureSeed(
+        slug="plasmaster-ionizer",
+        title="Plasmaster Ionizer+",
+        text="Ионизатор Plasmaster Ionizer+ используется LG для дополнительной обработки воздуха и снижения количества бактерий.",
+        icon="air",
+        aliases=("Ионизатор", "Plasmaster Ionizer+"),
+        keywords=("plasmaster", "ionizer", "ионизатор", "ионизации воздуха"),
+    ),
+    LgBrandFeatureSeed(
+        slug="uvnano",
+        title="UVnano",
+        text="UVnano использует УФ-лампу для обеззараживания внутренних элементов и дополнительной гигиены воздуха.",
+        icon="shield",
+        aliases=("UVnano", "УФ-лампа"),
+        keywords=("uvnano", "уф-ламп", "ультрафиолет"),
+    ),
+    LgBrandFeatureSeed(
+        slug="gold-fin",
+        title="Gold Fin",
+        text="Покрытие Gold Fin защищает теплообменник от коррозии и помогает продлить срок службы наружного блока.",
+        icon="shield",
+        aliases=("Gold Fin", "Голд Фин"),
+        keywords=("gold fin", "голд фин", "защищает теплообменник", "корроз"),
+    ),
+    LgBrandFeatureSeed(
+        slug="low-noise",
+        title="Низкий уровень шума",
+        text="Тихая работа внутреннего блока важна для спален, кабинетов и других помещений, где кондиционер работает долго.",
+        icon="volume_down",
+        aliases=("Бесшумная работа", "Низкий уровень шума"),
+        keywords=("бесшум", "низкий уровень шума", "19 дб", "21 дб", "22 дб"),
+    ),
+    LgBrandFeatureSeed(
+        slug="jet-cool",
+        title="Быстрое охлаждение",
+        text="Режим быстрого охлаждения ускоряет выход помещения на комфортную температуру после запуска кондиционера.",
+        icon="ac_unit",
+        aliases=("Jet Cool", "Быстрое охлаждение"),
+        keywords=("jet cool", "быстрое охлаждение", "охладить помещение"),
+    ),
+    LgBrandFeatureSeed(
+        slug="smart-diagnosis",
+        title="Умная диагностика",
+        text="Smart Diagnosis помогает быстрее определить неисправность и упростить обслуживание оборудования.",
+        icon="settings_suggest",
+        aliases=("Smart Diagnosis", "Умная диагностика"),
+        keywords=("smart diagnosis", "умная диагностика", "самодиагност"),
+    ),
+    LgBrandFeatureSeed(
+        slug="artcool-design",
+        title="ARTCOOL дизайн",
+        text="Дизайнерские внутренние блоки ARTCOOL и Objet легче вписываются в интерьер, чем стандартные белые корпуса.",
+        icon="auto_awesome",
+        aliases=("ARTCOOL", "Objet", "Сменное изображение"),
+        keywords=("artcool", "objet", "смены изображения", "ультратонкий дизайн", "стильный дизайн"),
+    ),
+    LgBrandFeatureSeed(
+        slug="four-way-airflow",
+        title="4-сторонний воздушный поток",
+        text="Кассетные блоки распределяют воздух в четыре стороны, что полезно для офисов, залов и коммерческих помещений.",
+        icon="waves",
+        aliases=("4-way airflow", "Распределение воздуха в 4 стороны"),
+        keywords=("4 стороны", "четыре стороны", "створк", "равномерное распределение воздуха"),
+    ),
+    LgBrandFeatureSeed(
+        slug="drain-pump",
+        title="Дренажный насос",
+        text="Встроенный или опциональный дренажный насос упрощает отвод конденсата в коммерческих системах.",
+        icon="water_drop",
+        aliases=("Дренажный насос",),
+        keywords=("дренажный насос",),
+    ),
+    LgBrandFeatureSeed(
+        slug="zone-control",
+        title="Зональное управление",
+        text="Канальные системы могут обслуживать несколько зон или воздуховодов с отдельной логикой распределения воздуха.",
+        icon="air",
+        aliases=("Зональный контроллер", "Зональное управление"),
+        keywords=("зональ", "9 воздуховод", "4-х помещ"),
+    ),
+)

--- a/services/lg24_series_content_service.py
+++ b/services/lg24_series_content_service.py
@@ -1,0 +1,362 @@
+"""Seed LG series content from lg24.by product/category pages."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Sequence
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+from slugify import slugify
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models import Brand, BrandFeature, ProductSeries, ProductSeriesFeatureLink
+from parsers.lg24 import Lg24Parser
+from services.catalog_revision_service import CatalogRevisionService
+from services.lg24_series_content_data import BRAND_FEATURE_SEEDS, SERIES_SEEDS, Lg24SeriesSeed
+
+
+def normalize_seed_slug(value: str) -> str:
+    return slugify(value or "", lowercase=True)
+
+
+def clean_text(value: Any) -> str:
+    text = str(value or "").replace("\xa0", " ")
+    text = re.sub(r"\s+", " ", text)
+    text = text.replace("СМОТРЕТЬ ВИДЕО ЦЕЛИКОМ", " ")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def text_matches_series(series: ProductSeries, seed: Lg24SeriesSeed) -> bool:
+    current = {
+        normalize_seed_slug(series.slug or ""),
+        normalize_seed_slug(series.title or ""),
+    }
+    candidates = {normalize_seed_slug(seed.title), *(normalize_seed_slug(item) for item in seed.match_slugs)}
+    return bool(current & candidates)
+
+
+def image_url_from_tag(img: Tag, current_url: str) -> str:
+    raw = img.get("data-large_image") or img.get("data-src") or img.get("src") or ""
+    url = Lg24Parser._to_abs_url(str(raw), current_url)
+    if not url or url.startswith("data:"):
+        return ""
+    return url
+
+
+def extract_short_features(soup: BeautifulSoup) -> list[str]:
+    container = soup.select_one(".woocommerce-product-details__short-description")
+    if not container:
+        return []
+
+    items: list[str] = []
+    seen: set[str] = set()
+    for li in container.select("li"):
+        text = clean_text(li.get_text(" ", strip=True))
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(text)
+    return items
+
+
+def extract_feature_blocks(soup: BeautifulSoup, *, max_blocks: int = 8) -> list[dict[str, str | None]]:
+    blocks: list[dict[str, str | None]] = []
+    started = False
+    excluded_titles = {"габаритные размеры", "отзывы", "добавить отзыв отменить ответ"}
+
+    for heading in soup.find_all(["h2", "h3"]):
+        title = clean_text(heading.get_text(" ", strip=True))
+        title_key = title.casefold()
+        if heading.name == "h2":
+            if "преимущества" in title_key:
+                started = True
+                continue
+            if started:
+                break
+        if not started or heading.name != "h3" or not title:
+            continue
+        if title_key in excluded_titles:
+            continue
+        if "отзыв" in title_key:
+            continue
+
+        text = ""
+        parent = heading.parent if isinstance(heading.parent, Tag) else heading
+        for sibling in parent.find_next_siblings():
+            if not isinstance(sibling, Tag):
+                continue
+            if sibling.find(["h2", "h3"]):
+                break
+            sibling_text = clean_text(sibling.get_text(" ", strip=True))
+            if sibling_text:
+                text = sibling_text
+                break
+
+        blocks.append(
+            {
+                "title": title,
+                "text": text or None,
+                "image_url": None,
+                "icon": None,
+                "footnote": None,
+            }
+        )
+        if len(blocks) >= max_blocks:
+            break
+    return blocks
+
+
+def extract_feature_gallery_images(soup: BeautifulSoup, current_url: str, *, limit: int = 8) -> list[str]:
+    images: list[str] = []
+    seen: set[str] = set()
+    started = False
+
+    for node in soup.find_all(["h2", "h3", "img"]):
+        if node.name in {"h2", "h3"}:
+            text = clean_text(node.get_text(" ", strip=True)).casefold()
+            if node.name == "h2" and "преимущества" in text:
+                started = True
+                continue
+            if node.name == "h2" and started:
+                break
+        if not started or node.name != "img":
+            continue
+        url = image_url_from_tag(node, current_url)
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        images.append(url)
+        if len(images) >= limit:
+            break
+    return images
+
+
+def detected_feature_slugs(text_chunks: Sequence[str]) -> list[str]:
+    haystack = " ".join(clean_text(chunk) for chunk in text_chunks if chunk).casefold()
+    slugs: list[str] = []
+    for feature in BRAND_FEATURE_SEEDS:
+        if any(keyword.casefold() in haystack for keyword in feature.keywords):
+            slugs.append(feature.slug)
+    return slugs
+
+
+async def fetch_series_page_content(client: httpx.AsyncClient, seed: Lg24SeriesSeed) -> tuple[list[str], list[dict[str, str | None]], list[str], str]:
+    parser = Lg24Parser()
+    source_url = seed.source_url
+    if Lg24Parser._is_category_url(source_url):
+        urls = await parser.get_import_urls(source_url)
+        source_url = urls[0] if urls else source_url
+
+    response = await client.get(source_url)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    return (
+        extract_short_features(soup),
+        extract_feature_blocks(soup),
+        extract_feature_gallery_images(soup, str(response.url)),
+        str(response.url),
+    )
+
+
+async def upsert_brand_features(
+    session: AsyncSession,
+    *,
+    brand_id: int,
+    execute: bool,
+    overwrite: bool,
+) -> dict[str, int]:
+    existing = (
+        await session.execute(select(BrandFeature).where(BrandFeature.brand_id == brand_id))
+    ).scalars().all()
+    by_slug = {feature.slug: feature for feature in existing}
+    ids: dict[str, int] = {}
+
+    for index, seed in enumerate(BRAND_FEATURE_SEEDS):
+        feature = by_slug.get(seed.slug)
+        if feature is None:
+            if not execute:
+                continue
+            feature = BrandFeature(
+                brand_id=brand_id,
+                slug=seed.slug,
+                title=seed.title,
+                text=seed.text,
+                icon=seed.icon,
+                aliases=list(seed.aliases),
+                sort_order=(index + 1) * 10,
+                is_published=True,
+            )
+            session.add(feature)
+            await session.flush()
+        elif overwrite:
+            feature.title = seed.title
+            feature.text = seed.text
+            feature.icon = seed.icon
+            feature.aliases = list(seed.aliases)
+            feature.sort_order = (index + 1) * 10
+            session.add(feature)
+
+        if feature.id is not None:
+            ids[seed.slug] = int(feature.id)
+
+    return ids
+
+
+async def sync_series_feature_links(
+    session: AsyncSession,
+    *,
+    series: ProductSeries,
+    feature_ids: Iterable[int],
+    execute: bool,
+) -> int:
+    normalized = [int(value) for value in dict.fromkeys(feature_ids) if value]
+    if not normalized or series.id is None:
+        return 0
+
+    existing = (
+        await session.execute(
+            select(ProductSeriesFeatureLink).where(ProductSeriesFeatureLink.series_id == series.id)
+        )
+    ).scalars().all()
+    existing_ids = {int(link.feature_id) for link in existing}
+    to_add = [feature_id for feature_id in normalized if feature_id not in existing_ids]
+    if not execute:
+        return len(to_add)
+
+    base_order = max((int(link.sort_order or 0) for link in existing), default=0)
+    for offset, feature_id in enumerate(to_add, start=1):
+        session.add(
+            ProductSeriesFeatureLink(
+                series_id=int(series.id),
+                feature_id=feature_id,
+                sort_order=base_order + offset * 10,
+            )
+        )
+    return len(to_add)
+
+
+def should_update_value(current: Any, *, overwrite: bool) -> bool:
+    if overwrite:
+        return True
+    if current is None:
+        return True
+    if isinstance(current, str):
+        return not current.strip()
+    if isinstance(current, list):
+        return not current
+    return False
+
+
+async def seed_lg24_series_content(
+    session: AsyncSession,
+    *,
+    execute: bool = False,
+    overwrite: bool = False,
+    seeds: Iterable[Lg24SeriesSeed] = SERIES_SEEDS,
+) -> dict[str, Any]:
+    brand = (await session.execute(select(Brand).where(Brand.slug == "lg"))).scalar_one_or_none()
+    if brand is None or brand.id is None:
+        return {"updated": 0, "linked": 0, "missed": ["LG brand not found"]}
+
+    series_rows = (
+        await session.execute(select(ProductSeries).where(ProductSeries.brand_id == brand.id))
+    ).scalars().all()
+    feature_ids = await upsert_brand_features(
+        session,
+        brand_id=int(brand.id),
+        execute=execute,
+        overwrite=overwrite,
+    )
+
+    updated = 0
+    linked = 0
+    missed: list[str] = []
+    kept: list[str] = []
+    applied: list[str] = []
+
+    async with httpx.AsyncClient(
+        headers=Lg24Parser._HEADERS,
+        follow_redirects=True,
+        timeout=20.0,
+    ) as client:
+        for seed in seeds:
+            matched = [series for series in series_rows if text_matches_series(series, seed)]
+            if not matched:
+                missed.append(seed.title)
+                continue
+
+            short_features, feature_blocks, gallery_images, resolved_source_url = await fetch_series_page_content(client, seed)
+            features = short_features or list(seed.fallback_features)
+            block_text = [
+                str(value)
+                for block in feature_blocks
+                for value in (block.get("title"), block.get("text"))
+                if value
+            ]
+            detected_slugs = detected_feature_slugs([*features, *block_text, seed.title, seed.description])
+            detected_ids = [feature_ids[slug] for slug in detected_slugs if slug in feature_ids]
+
+            for series in matched:
+                changed = False
+                if should_update_value(series.tagline, overwrite=overwrite):
+                    series.tagline = seed.tagline
+                    changed = True
+                if should_update_value(series.short_description, overwrite=overwrite):
+                    series.short_description = seed.short_description
+                    changed = True
+                if should_update_value(series.description, overwrite=overwrite):
+                    series.description = seed.description
+                    changed = True
+                if should_update_value(series.source_url, overwrite=overwrite):
+                    series.source_url = seed.source_url
+                    changed = True
+                if should_update_value(series.features, overwrite=overwrite):
+                    series.features = list(features)
+                    changed = True
+                if feature_blocks and should_update_value(series.feature_blocks, overwrite=overwrite):
+                    series.feature_blocks = feature_blocks
+                    changed = True
+                if gallery_images and should_update_value(series.gallery_images, overwrite=overwrite):
+                    series.gallery_images = gallery_images
+                    changed = True
+
+                linked += await sync_series_feature_links(
+                    session,
+                    series=series,
+                    feature_ids=detected_ids,
+                    execute=execute,
+                )
+
+                if changed:
+                    applied.append(f"{series.title} <- {seed.title} ({resolved_source_url})")
+                    updated += 1
+                    if execute:
+                        session.add(series)
+                else:
+                    kept.append(series.title)
+
+    if execute and (updated or linked):
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="lg24_series_content_seed",
+            brand_slugs=["lg"],
+        )
+    elif execute:
+        await session.commit()
+    else:
+        await session.rollback()
+
+    return {
+        "updated": updated,
+        "linked": linked,
+        "missed": missed,
+        "kept": kept,
+        "applied": applied,
+        "mode": "execute" if execute else "dry-run",
+    }

--- a/tests/unit/test_lg24_parser.py
+++ b/tests/unit/test_lg24_parser.py
@@ -170,6 +170,13 @@ def test_lg24_infers_series_from_breadcrumb_or_title():
         )
         == "Smart Line"
     )
+    assert (
+        Lg24Parser._infer_series_from_context(
+            "LG Smart Inverter UT18WC/UU18WC",
+            ["Главная", "Коммерческие кондиционеры", "Кассетный блок", "4-поточный кассетный тип Smart Inverter UT18WC/UU18WC"],
+        )
+        == "Smart Inverter"
+    )
 
 
 def test_lg24_infers_component_models_from_combined_model():

--- a/tests/unit/test_lg24_series_content_service.py
+++ b/tests/unit/test_lg24_series_content_service.py
@@ -1,0 +1,102 @@
+from bs4 import BeautifulSoup
+
+from models import ProductSeries
+from services.lg24_series_content_service import (
+    Lg24SeriesSeed,
+    detected_feature_slugs,
+    extract_feature_blocks,
+    extract_feature_gallery_images,
+    extract_short_features,
+    text_matches_series,
+)
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
+def test_extract_short_features_uses_feature_list_items_only():
+    soup = _soup(
+        """
+        <div class="woocommerce-product-details__short-description">
+          <ul class="feature-list">
+            <li>Dual Inverter компрессор</li>
+            <li>Wi-Fi и голосовое управление <img data-src="/wp-content/uploads/icon.jpg" /></li>
+            <li>Dual Inverter компрессор</li>
+          </ul>
+        </div>
+        """
+    )
+
+    assert extract_short_features(soup) == [
+        "Dual Inverter компрессор",
+        "Wi-Fi и голосовое управление",
+    ]
+
+
+def test_extract_feature_blocks_stops_before_next_page_section():
+    soup = _soup(
+        """
+        <h2>Преимущества</h2>
+        <div class="title"><h3>Gold Fin™</h3></div>
+        <div class="copy font-regular">Защита теплообменника от коррозии.</div>
+        <div class="title"><h3>Габаритные размеры</h3></div>
+        <h2>Оплата и доставка</h2>
+        <div class="title"><h3>Отзывы</h3></div>
+        """
+    )
+
+    assert extract_feature_blocks(soup) == [
+        {
+            "title": "Gold Fin™",
+            "text": "Защита теплообменника от коррозии.",
+            "image_url": None,
+            "icon": None,
+            "footnote": None,
+        }
+    ]
+
+
+def test_extract_feature_gallery_images_ignores_lazy_placeholders():
+    soup = _soup(
+        """
+        <h2>Преимущества</h2>
+        <img src="data:image/svg+xml,placeholder" />
+        <img data-src="/wp-content/uploads/feature.jpg" />
+        <h2>Отзывы</h2>
+        <img data-src="/wp-content/uploads/review.jpg" />
+        """
+    )
+
+    assert extract_feature_gallery_images(soup, "https://lg24.by/product/demo/") == [
+        "https://lg24.by/wp-content/uploads/feature.jpg"
+    ]
+
+
+def test_detected_feature_slugs_from_lg24_text():
+    slugs = detected_feature_slugs(
+        [
+            "Технология Dual Inverter компрессор с 10-летней гарантией",
+            "Технология UVnano уничтожает вирусы, плесень и бактерии с помощью УФ-лампы",
+            "Wi-Fi и голосовое управление, мониторинг с помощью приложения LG SmartThinQ",
+        ]
+    )
+
+    assert "dual-inverter" in slugs
+    assert "uvnano" in slugs
+    assert "lg-thinq" in slugs
+
+
+def test_text_matches_series_by_slug_alias():
+    seed = Lg24SeriesSeed(
+        title="EVO Max",
+        source_url="https://lg24.by/product-category/konditionery_dla_doma/evo_max/",
+        match_slugs=("evo-max", "evomax"),
+        tagline="",
+        short_description="",
+        description="",
+        fallback_features=(),
+    )
+
+    assert text_matches_series(ProductSeries(title="LG EVO Max", slug="evomax"), seed)
+    assert not text_matches_series(ProductSeries(title="LG ECO Smart", slug="eco-smart"), seed)


### PR DESCRIPTION
## Summary
- add LG24 series content seeder for LG brand series descriptions, short feature chips, feature blocks, gallery images, and reusable brand-feature links
- add curated LG24 series/feature seed data for household and commercial LG series
- teach LG24 parser to recognize the commercial Smart Inverter series

## Runbook
Dry-run inside the app container:
`docker compose exec app python3 scripts/seed_lg24_series_content.py`

Apply after reviewing dry-run:
`docker compose exec app python3 scripts/seed_lg24_series_content.py --execute`

Force-refresh existing filled fields only when needed:
`docker compose exec app python3 scripts/seed_lg24_series_content.py --execute --overwrite`

## Verification
- `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_lg24_parser.py tests/unit/test_lg24_series_content_service.py tests/unit/test_spec_normalizer_filters.py tests/unit/test_importer_service_media_and_manuals.py tests/unit/test_importer_service_related.py -q` -> 63 passed
- live-fetch smoke over all configured LG24 series sources -> 19/19 sources fetched successfully