### PR TITLE
Import LG24 series media into library

### DIFF
--- a/scripts/seed_lg24_series_content.py
+++ b/scripts/seed_lg24_series_content.py
@@ -11,7 +11,7 @@ from core.config import settings
 from services.lg24_series_content_service import seed_lg24_series_content
 
 
-async def run_seed(*, execute: bool, overwrite: bool) -> None:
+async def run_seed(*, execute: bool, overwrite: bool, import_media: bool) -> None:
     db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
     engine = create_async_engine(db_url)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -21,11 +21,23 @@ async def run_seed(*, execute: bool, overwrite: bool) -> None:
             session,
             execute=execute,
             overwrite=overwrite,
+            import_media=import_media,
         )
 
     await engine.dispose()
 
     print(f"[{result['mode'].upper()}] updated={result['updated']} linked={result['linked']} missed={len(result['missed'])}")
+    media = result.get("media") or {}
+    if media.get("enabled"):
+        print(
+            "[media] "
+            f"planned={media.get('planned', 0)} "
+            f"imported={media.get('imported', 0)} "
+            f"reused={media.get('reused', 0)} "
+            f"failed={len(media.get('failed') or [])}"
+        )
+        for item in media.get("failed") or []:
+            print(f"[media-failed] {item.get('url')}: {item.get('error')}")
     for item in result["applied"]:
         print(f"[update] {item}")
     for item in result["kept"]:
@@ -38,8 +50,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Seed LG product series content from lg24.by")
     parser.add_argument("--execute", action="store_true", help="Commit changes")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing series content")
+    parser.add_argument(
+        "--import-media",
+        action="store_true",
+        help="Download LG24 promo images into the media library and store local URLs",
+    )
     args = parser.parse_args()
-    asyncio.run(run_seed(execute=args.execute, overwrite=args.overwrite))
+    asyncio.run(run_seed(execute=args.execute, overwrite=args.overwrite, import_media=args.import_media))
 
 
 if __name__ == "__main__":

--- a/services/lg24_series_content_service.py
+++ b/services/lg24_series_content_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Any, Iterable, Sequence
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from bs4 import BeautifulSoup, Tag
@@ -11,10 +13,17 @@ from slugify import slugify
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models import Brand, BrandFeature, ProductSeries, ProductSeriesFeatureLink
+from models import Brand, BrandFeature, MediaAsset, ProductSeries, ProductSeriesFeatureLink
 from parsers.lg24 import Lg24Parser
 from services.catalog_revision_service import CatalogRevisionService
 from services.lg24_series_content_data import BRAND_FEATURE_SEEDS, SERIES_SEEDS, Lg24SeriesSeed
+from services.media_library_service import MediaLibraryService
+
+
+@dataclass(frozen=True)
+class ResolvedSeriesMedia:
+    url: str
+    created: bool
 
 
 def normalize_seed_slug(value: str) -> str:
@@ -46,6 +55,39 @@ def image_url_from_tag(img: Tag, current_url: str) -> str:
     return url
 
 
+def normalize_remote_media_url(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    parts = urlsplit(raw)
+    if not parts.scheme and not parts.netloc:
+        return raw
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+
+
+def first_image_url_from_tag(tag: Tag, current_url: str) -> str:
+    if tag.name == "img":
+        return image_url_from_tag(tag, current_url)
+    for img in tag.find_all("img"):
+        if not isinstance(img, Tag):
+            continue
+        url = image_url_from_tag(img, current_url)
+        if url:
+            return url
+    return ""
+
+
+def iter_feature_block_nodes(heading: Tag) -> Iterable[Tag]:
+    for node in heading.next_elements:
+        if node is heading:
+            continue
+        if not isinstance(node, Tag):
+            continue
+        if node.name in {"h2", "h3"}:
+            break
+        yield node
+
+
 def extract_short_features(soup: BeautifulSoup) -> list[str]:
     container = soup.select_one(".woocommerce-product-details__short-description")
     if not container:
@@ -65,7 +107,12 @@ def extract_short_features(soup: BeautifulSoup) -> list[str]:
     return items
 
 
-def extract_feature_blocks(soup: BeautifulSoup, *, max_blocks: int = 8) -> list[dict[str, str | None]]:
+def extract_feature_blocks(
+    soup: BeautifulSoup,
+    current_url: str = "",
+    *,
+    max_blocks: int = 8,
+) -> list[dict[str, str | None]]:
     blocks: list[dict[str, str | None]] = []
     started = False
     excluded_titles = {"габаритные размеры", "отзывы", "добавить отзыв отменить ответ"}
@@ -87,22 +134,24 @@ def extract_feature_blocks(soup: BeautifulSoup, *, max_blocks: int = 8) -> list[
             continue
 
         text = ""
-        parent = heading.parent if isinstance(heading.parent, Tag) else heading
-        for sibling in parent.find_next_siblings():
-            if not isinstance(sibling, Tag):
+        image_url = ""
+        for node in iter_feature_block_nodes(heading):
+            if node.find(["h2", "h3"]):
                 continue
-            if sibling.find(["h2", "h3"]):
-                break
-            sibling_text = clean_text(sibling.get_text(" ", strip=True))
-            if sibling_text:
-                text = sibling_text
+            if not text and node.name in {"p", "div", "li"}:
+                sibling_text = clean_text(node.get_text(" ", strip=True))
+                if sibling_text:
+                    text = sibling_text
+            if current_url and not image_url:
+                image_url = first_image_url_from_tag(node, current_url)
+            if text and image_url:
                 break
 
         blocks.append(
             {
                 "title": title,
                 "text": text or None,
-                "image_url": None,
+                "image_url": image_url or None,
                 "icon": None,
                 "footnote": None,
             }
@@ -158,10 +207,122 @@ async def fetch_series_page_content(client: httpx.AsyncClient, seed: Lg24SeriesS
     soup = BeautifulSoup(response.text, "html.parser")
     return (
         extract_short_features(soup),
-        extract_feature_blocks(soup),
+        extract_feature_blocks(soup, str(response.url)),
         extract_feature_gallery_images(soup, str(response.url)),
         str(response.url),
     )
+
+
+async def resolve_or_import_series_media(
+    session: AsyncSession,
+    *,
+    source_url: str,
+    title: str,
+    created_by: str | None = "lg24-series-seed",
+) -> ResolvedSeriesMedia | None:
+    normalized_url = normalize_remote_media_url(source_url)
+    if not normalized_url:
+        return None
+
+    existing = (
+        await session.execute(
+            select(MediaAsset)
+            .where(MediaAsset.original_url == normalized_url)
+            .order_by(MediaAsset.id.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing and existing.url:
+        return ResolvedSeriesMedia(url=existing.url, created=False)
+
+    content, filename = await MediaLibraryService._download_remote_image(normalized_url)
+    stored = await MediaLibraryService._store_image(content, variant_type="original")
+    asset = MediaAsset(
+        title=title or MediaLibraryService._title_from_filename(filename) or "LG feature",
+        alt_text=title or None,
+        kind="brand",
+        tags=MediaLibraryService._normalize_tags(["lg", "series", "feature", "promo"]),
+        variant_type="original",
+        url=stored.url,
+        original_url=normalized_url,
+        source_filename=filename,
+        mime_type=stored.mime_type,
+        storage_provider=stored.storage_provider,
+        processing_status="ready",
+        content_hash=stored.content_hash,
+        width=stored.width,
+        height=stored.height,
+        size_bytes=stored.size_bytes,
+        created_by=created_by,
+    )
+    session.add(asset)
+    await session.flush()
+    return ResolvedSeriesMedia(url=stored.url, created=True)
+
+
+def collect_feature_block_image_urls(feature_blocks: Sequence[dict[str, Any]]) -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+    for block in feature_blocks:
+        url = normalize_remote_media_url(str(block.get("image_url") or ""))
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+    return urls
+
+
+def remap_feature_block_image_urls(
+    feature_blocks: Sequence[dict[str, Any]],
+    media_map: dict[str, str],
+) -> list[dict[str, Any]]:
+    remapped: list[dict[str, Any]] = []
+    for block in feature_blocks:
+        next_block = dict(block)
+        source_url = normalize_remote_media_url(str(next_block.get("image_url") or ""))
+        if source_url and source_url in media_map:
+            next_block["image_url"] = media_map[source_url]
+        remapped.append(next_block)
+    return remapped
+
+
+async def import_series_media_urls(
+    session: AsyncSession,
+    *,
+    urls: Sequence[str],
+    execute: bool,
+    title_prefix: str,
+) -> dict[str, Any]:
+    unique_urls = [normalize_remote_media_url(url) for url in dict.fromkeys(urls) if normalize_remote_media_url(url)]
+    result: dict[str, Any] = {
+        "planned": len(unique_urls),
+        "imported": 0,
+        "reused": 0,
+        "failed": [],
+        "map": {},
+    }
+    if not execute:
+        return result
+
+    for index, source_url in enumerate(unique_urls, start=1):
+        try:
+            resolved = await resolve_or_import_series_media(
+                session,
+                source_url=source_url,
+                title=f"{title_prefix}: изображение {index}",
+            )
+        except Exception as exc:
+            result["failed"].append({"url": source_url, "error": str(exc)})
+            continue
+        if not resolved:
+            result["failed"].append({"url": source_url, "error": "empty media url"})
+            continue
+        result["map"][source_url] = resolved.url
+        if resolved.created:
+            result["imported"] += 1
+        else:
+            result["reused"] += 1
+    return result
 
 
 async def upsert_brand_features(
@@ -258,11 +419,26 @@ async def seed_lg24_series_content(
     *,
     execute: bool = False,
     overwrite: bool = False,
+    import_media: bool = False,
     seeds: Iterable[Lg24SeriesSeed] = SERIES_SEEDS,
 ) -> dict[str, Any]:
     brand = (await session.execute(select(Brand).where(Brand.slug == "lg"))).scalar_one_or_none()
     if brand is None or brand.id is None:
-        return {"updated": 0, "linked": 0, "missed": ["LG brand not found"]}
+        return {
+            "updated": 0,
+            "linked": 0,
+            "missed": ["LG brand not found"],
+            "kept": [],
+            "applied": [],
+            "media": {
+                "enabled": import_media,
+                "planned": 0,
+                "imported": 0,
+                "reused": 0,
+                "failed": [],
+            },
+            "mode": "execute" if execute else "dry-run",
+        }
 
     series_rows = (
         await session.execute(select(ProductSeries).where(ProductSeries.brand_id == brand.id))
@@ -279,6 +455,10 @@ async def seed_lg24_series_content(
     missed: list[str] = []
     kept: list[str] = []
     applied: list[str] = []
+    media_planned = 0
+    media_imported = 0
+    media_reused = 0
+    media_failed: list[dict[str, str]] = []
 
     async with httpx.AsyncClient(
         headers=Lg24Parser._HEADERS,
@@ -293,6 +473,30 @@ async def seed_lg24_series_content(
 
             short_features, feature_blocks, gallery_images, resolved_source_url = await fetch_series_page_content(client, seed)
             features = short_features or list(seed.fallback_features)
+            media_map: dict[str, str] = {}
+            if import_media:
+                media_urls = [
+                    *gallery_images,
+                    *collect_feature_block_image_urls(feature_blocks),
+                ]
+                media_result = await import_series_media_urls(
+                    session,
+                    urls=media_urls,
+                    execute=execute,
+                    title_prefix=f"LG {seed.title}",
+                )
+                media_planned += int(media_result["planned"])
+                media_imported += int(media_result["imported"])
+                media_reused += int(media_result["reused"])
+                media_failed.extend(media_result["failed"])
+                media_map = media_result["map"]
+                if execute and media_map:
+                    gallery_images = [
+                        media_map.get(normalize_remote_media_url(url), url)
+                        for url in gallery_images
+                    ]
+                    feature_blocks = remap_feature_block_image_urls(feature_blocks, media_map)
+
             block_text = [
                 str(value)
                 for block in feature_blocks
@@ -358,5 +562,12 @@ async def seed_lg24_series_content(
         "missed": missed,
         "kept": kept,
         "applied": applied,
+        "media": {
+            "enabled": import_media,
+            "planned": media_planned,
+            "imported": media_imported,
+            "reused": media_reused,
+            "failed": media_failed,
+        },
         "mode": "execute" if execute else "dry-run",
     }

--- a/services/media_library_service.py
+++ b/services/media_library_service.py
@@ -864,6 +864,7 @@ class MediaLibraryService:
                 select(func.count()).select_from(ProductSeries).where(ProductSeries.hero_image == url)
             )
         )
+        counts.append(await MediaLibraryService._series_json_usage_count(session, url))
         counts.append(
             await session.scalar(select(func.count()).select_from(ProductAttachment).where(ProductAttachment.url == url))
         )
@@ -979,21 +980,45 @@ class MediaLibraryService:
                 )
             )
 
-        series_rows = (
-            await session.execute(select(ProductSeries).where(ProductSeries.hero_image.is_not(None)))
-        ).scalars().all()
+        series_rows = (await session.execute(select(ProductSeries))).scalars().all()
         for series in series_rows:
-            if not series.hero_image:
-                continue
-            references.append(
-                ExistingMediaReference(
-                    url=series.hero_image,
-                    kind="brand",
-                    title=series.title or f"Product series #{series.id}",
-                    variant_type="hero",
-                    tags=("legacy", "series", "hero"),
+            if series.hero_image:
+                references.append(
+                    ExistingMediaReference(
+                        url=series.hero_image,
+                        kind="brand",
+                        title=series.title or f"Product series #{series.id}",
+                        variant_type="hero",
+                        tags=("legacy", "series", "hero"),
+                    )
                 )
-            )
+            for image_url in series.gallery_images or []:
+                if not image_url:
+                    continue
+                references.append(
+                    ExistingMediaReference(
+                        url=str(image_url),
+                        kind="brand",
+                        title=series.title or f"Product series #{series.id}",
+                        variant_type="gallery",
+                        tags=("legacy", "series", "gallery"),
+                    )
+                )
+            for block in series.feature_blocks or []:
+                if not isinstance(block, dict):
+                    continue
+                image_url = str(block.get("image_url") or "").strip()
+                if not image_url:
+                    continue
+                references.append(
+                    ExistingMediaReference(
+                        url=image_url,
+                        kind="brand",
+                        title=block.get("title") or series.title or f"Product series #{series.id}",
+                        variant_type="feature",
+                        tags=("legacy", "series", "feature"),
+                    )
+                )
 
         services = (await session.execute(select(Service).where(Service.image.is_not(None)))).scalars().all()
         for service in services:
@@ -1010,6 +1035,20 @@ class MediaLibraryService:
             )
 
         return [ref for ref in references if ref.url]
+
+    @staticmethod
+    async def _series_json_usage_count(session: AsyncSession, url: str) -> int:
+        if not url:
+            return 0
+
+        count = 0
+        series_rows = (await session.execute(select(ProductSeries))).scalars().all()
+        for series in series_rows:
+            count += sum(1 for image_url in series.gallery_images or [] if image_url == url)
+            for block in series.feature_blocks or []:
+                if isinstance(block, dict) and block.get("image_url") == url:
+                    count += 1
+        return count
 
     @staticmethod
     def _group_references_by_url(

--- a/tests/unit/test_lg24_series_content_service.py
+++ b/tests/unit/test_lg24_series_content_service.py
@@ -1,14 +1,38 @@
-from bs4 import BeautifulSoup
+from pathlib import Path
 
-from models import ProductSeries
+import pytest
+from bs4 import BeautifulSoup
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from models import MediaAsset, ProductSeries
 from services.lg24_series_content_service import (
     Lg24SeriesSeed,
+    collect_feature_block_image_urls,
     detected_feature_slugs,
     extract_feature_blocks,
     extract_feature_gallery_images,
     extract_short_features,
+    resolve_or_import_series_media,
+    remap_feature_block_image_urls,
     text_matches_series,
 )
+from services.media_library_service import StoredLibraryImage
+
+
+@pytest.fixture
+async def sqlite_session(tmp_path: Path):
+    db_path = tmp_path / "lg24_series_content.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session_factory = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
 
 
 def _soup(html: str) -> BeautifulSoup:
@@ -57,6 +81,25 @@ def test_extract_feature_blocks_stops_before_next_page_section():
     ]
 
 
+def test_extract_feature_blocks_attaches_first_image_before_next_heading():
+    soup = _soup(
+        """
+        <h2>Преимущества</h2>
+        <div class="title"><h3>Gold Fin™</h3></div>
+        <p>Защита теплообменника от коррозии.</p>
+        <p><img src="data:image/svg+xml,placeholder" data-src="/wp-content/uploads/gold-fin.jpg" /></p>
+        <div class="title"><h3>Бесшумная работа</h3></div>
+        <p><img src="/wp-content/uploads/silent.jpg" /></p>
+        <h2>Отзывы</h2>
+        """
+    )
+
+    blocks = extract_feature_blocks(soup, "https://lg24.by/product/demo/")
+
+    assert blocks[0]["image_url"] == "https://lg24.by/wp-content/uploads/gold-fin.jpg"
+    assert blocks[1]["image_url"] == "https://lg24.by/wp-content/uploads/silent.jpg"
+
+
 def test_extract_feature_gallery_images_ignores_lazy_placeholders():
     soup = _soup(
         """
@@ -100,3 +143,86 @@ def test_text_matches_series_by_slug_alias():
 
     assert text_matches_series(ProductSeries(title="LG EVO Max", slug="evomax"), seed)
     assert not text_matches_series(ProductSeries(title="LG ECO Smart", slug="eco-smart"), seed)
+
+
+def test_feature_block_media_url_collection_and_remap():
+    blocks = [
+        {"title": "A", "image_url": "https://lg24.by/a.jpg#frag"},
+        {"title": "B", "image_url": "https://lg24.by/a.jpg"},
+        {"title": "C", "image_url": "https://lg24.by/c.jpg"},
+        {"title": "D", "image_url": None},
+    ]
+
+    assert collect_feature_block_image_urls(blocks) == [
+        "https://lg24.by/a.jpg",
+        "https://lg24.by/c.jpg",
+    ]
+
+    remapped = remap_feature_block_image_urls(
+        blocks,
+        {
+            "https://lg24.by/a.jpg": "/media/library/original/a.webp",
+            "https://lg24.by/c.jpg": "/media/library/original/c.webp",
+        },
+    )
+
+    assert remapped[0]["image_url"] == "/media/library/original/a.webp"
+    assert remapped[1]["image_url"] == "/media/library/original/a.webp"
+    assert remapped[2]["image_url"] == "/media/library/original/c.webp"
+    assert remapped[3]["image_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_or_import_series_media_creates_and_reuses_asset(sqlite_session, monkeypatch):
+    calls = {"download": 0, "store": 0}
+
+    async def fake_download(url: str):
+        calls["download"] += 1
+        return b"image-content", "feature.jpg"
+
+    async def fake_store(content: bytes, *, variant_type: str):
+        calls["store"] += 1
+        assert content == b"image-content"
+        assert variant_type == "original"
+        return StoredLibraryImage(
+            url="/media/library/original/feature.webp",
+            path="media/library/original/feature.webp",
+            content_hash="hash",
+            width=1600,
+            height=900,
+            size_bytes=1234,
+        )
+
+    monkeypatch.setattr(
+        "services.lg24_series_content_service.MediaLibraryService._download_remote_image",
+        staticmethod(fake_download),
+    )
+    monkeypatch.setattr(
+        "services.lg24_series_content_service.MediaLibraryService._store_image",
+        staticmethod(fake_store),
+    )
+
+    first = await resolve_or_import_series_media(
+        sqlite_session,
+        source_url="https://lg24.by/wp-content/uploads/feature.jpg#fragment",
+        title="LG EVO Max: изображение 1",
+    )
+    second = await resolve_or_import_series_media(
+        sqlite_session,
+        source_url="https://lg24.by/wp-content/uploads/feature.jpg",
+        title="LG EVO Max: изображение 1",
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first.url == "/media/library/original/feature.webp"
+    assert first.created is True
+    assert second.url == first.url
+    assert second.created is False
+    assert calls == {"download": 1, "store": 1}
+
+    assets = (await sqlite_session.execute(select(MediaAsset))).scalars().all()
+    assert len(assets) == 1
+    assert assets[0].original_url == "https://lg24.by/wp-content/uploads/feature.jpg"
+    assert assets[0].kind == "brand"
+    assert assets[0].tags == ["lg", "series", "feature", "promo"]

--- a/tests/unit/test_media_library_service.py
+++ b/tests/unit/test_media_library_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 import models  # noqa: F401
-from models import MediaAsset, MediaProcessingJob, Product, ProductAttachment, ProductImage, Service
+from models import MediaAsset, MediaProcessingJob, Product, ProductAttachment, ProductImage, ProductSeries, Service
 from services.general_media_storage_service import StoredGeneralMediaObject
 from services import media_library_service
 from services.media_library_service import MediaLibraryService
@@ -580,11 +580,20 @@ async def test_usage_count_protects_service_images_and_product_attachments(
     monkeypatch.chdir(tmp_path)
     image_url = "/media/services/protected.png"
     attachment_url = "/media/products/manuals/manual.pdf"
+    series_gallery_url = "/media/library/original/series-gallery.webp"
+    series_feature_url = "/media/library/original/series-feature.webp"
     write_media_file(tmp_path / image_url.lstrip("/"))
     product = Product(title="Protected Product", slug="protected-product", price=100)
     service = Service(title="Protected Service", slug="protected-service", image=image_url)
+    series = ProductSeries(
+        title="Protected Series",
+        slug="protected-series",
+        gallery_images=[series_gallery_url],
+        feature_blocks=[{"title": "Feature", "image_url": series_feature_url}],
+    )
     sqlite_session.add(product)
     sqlite_session.add(service)
+    sqlite_session.add(series)
     await sqlite_session.flush()
     sqlite_session.add(
         ProductAttachment(
@@ -610,5 +619,7 @@ async def test_usage_count_protects_service_images_and_product_attachments(
 
     assert await MediaLibraryService._usage_count(sqlite_session, image_url) == 1
     assert await MediaLibraryService._usage_count(sqlite_session, attachment_url) == 1
+    assert await MediaLibraryService._usage_count(sqlite_session, series_gallery_url) == 1
+    assert await MediaLibraryService._usage_count(sqlite_session, series_feature_url) == 1
     with pytest.raises(ValueError, match="Media asset is used"):
         await MediaLibraryService.delete_asset(session=sqlite_session, asset_id=asset.id)


### PR DESCRIPTION
## Summary\n- add --import-media mode for LG24 series content seeding\n- import LG24 promo/feature images into the media library and replace external URLs with local/R2 URLs\n- track ProductSeries gallery and feature block image usage in media library references\n\n## Tests\n- SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_lg24_series_content_service.py tests/unit/test_media_library_service.py tests/unit/test_import_media_service.py tests/unit/test_lg24_parser.py -q\n- SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin python3 scripts/seed_lg24_series_content.py --help\n