### PR TITLE
Update existing LG24 media URLs on import

### DIFF
--- a/services/lg24_series_content_service.py
+++ b/services/lg24_series_content_service.py
@@ -414,6 +414,12 @@ def should_update_value(current: Any, *, overwrite: bool) -> bool:
     return False
 
 
+def should_update_media_value(current: Any, next_value: Any, *, overwrite: bool, import_media: bool) -> bool:
+    if should_update_value(current, overwrite=overwrite):
+        return True
+    return bool(import_media and next_value and current != next_value)
+
+
 async def seed_lg24_series_content(
     session: AsyncSession,
     *,
@@ -523,10 +529,20 @@ async def seed_lg24_series_content(
                 if should_update_value(series.features, overwrite=overwrite):
                     series.features = list(features)
                     changed = True
-                if feature_blocks and should_update_value(series.feature_blocks, overwrite=overwrite):
+                if feature_blocks and should_update_media_value(
+                    series.feature_blocks,
+                    feature_blocks,
+                    overwrite=overwrite,
+                    import_media=import_media,
+                ):
                     series.feature_blocks = feature_blocks
                     changed = True
-                if gallery_images and should_update_value(series.gallery_images, overwrite=overwrite):
+                if gallery_images and should_update_media_value(
+                    series.gallery_images,
+                    gallery_images,
+                    overwrite=overwrite,
+                    import_media=import_media,
+                ):
                     series.gallery_images = gallery_images
                     changed = True
 

--- a/tests/unit/test_lg24_series_content_service.py
+++ b/tests/unit/test_lg24_series_content_service.py
@@ -16,6 +16,7 @@ from services.lg24_series_content_service import (
     extract_short_features,
     resolve_or_import_series_media,
     remap_feature_block_image_urls,
+    should_update_media_value,
     text_matches_series,
 )
 from services.media_library_service import StoredLibraryImage
@@ -170,6 +171,27 @@ def test_feature_block_media_url_collection_and_remap():
     assert remapped[1]["image_url"] == "/media/library/original/a.webp"
     assert remapped[2]["image_url"] == "/media/library/original/c.webp"
     assert remapped[3]["image_url"] is None
+
+
+def test_import_media_updates_existing_external_media_values_without_overwrite():
+    assert should_update_media_value(
+        ["https://lg24.by/a.jpg"],
+        ["/media/library/original/a.webp"],
+        overwrite=False,
+        import_media=True,
+    )
+    assert not should_update_media_value(
+        ["/media/library/original/a.webp"],
+        ["/media/library/original/a.webp"],
+        overwrite=False,
+        import_media=True,
+    )
+    assert not should_update_media_value(
+        ["https://lg24.by/a.jpg"],
+        ["/media/library/original/a.webp"],
+        overwrite=False,
+        import_media=False,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- let --import-media refresh existing LG24 gallery/feature image URLs without requiring --overwrite\n- keep normal text/content overwrite behavior unchanged\n\n## Tests\n- python3 -m py_compile services/lg24_series_content_service.py\n- SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_lg24_series_content_service.py tests/unit/test_media_library_service.py -q\n