### PR TITLE
Map existing LG24 media during dry run

### DIFF
--- a/services/lg24_series_content_service.py
+++ b/services/lg24_series_content_service.py
@@ -224,16 +224,9 @@ async def resolve_or_import_series_media(
     if not normalized_url:
         return None
 
-    existing = (
-        await session.execute(
-            select(MediaAsset)
-            .where(MediaAsset.original_url == normalized_url)
-            .order_by(MediaAsset.id.asc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    if existing and existing.url:
-        return ResolvedSeriesMedia(url=existing.url, created=False)
+    existing = await find_imported_series_media(session, source_url=normalized_url)
+    if existing:
+        return existing
 
     content, filename = await MediaLibraryService._download_remote_image(normalized_url)
     stored = await MediaLibraryService._store_image(content, variant_type="original")
@@ -258,6 +251,28 @@ async def resolve_or_import_series_media(
     session.add(asset)
     await session.flush()
     return ResolvedSeriesMedia(url=stored.url, created=True)
+
+
+async def find_imported_series_media(
+    session: AsyncSession,
+    *,
+    source_url: str,
+) -> ResolvedSeriesMedia | None:
+    normalized_url = normalize_remote_media_url(source_url)
+    if not normalized_url:
+        return None
+
+    existing = (
+        await session.execute(
+            select(MediaAsset)
+            .where(MediaAsset.original_url == normalized_url)
+            .order_by(MediaAsset.id.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing and existing.url:
+        return ResolvedSeriesMedia(url=existing.url, created=False)
+    return None
 
 
 def collect_feature_block_image_urls(feature_blocks: Sequence[dict[str, Any]]) -> list[str]:
@@ -301,20 +316,22 @@ async def import_series_media_urls(
         "failed": [],
         "map": {},
     }
-    if not execute:
-        return result
-
     for index, source_url in enumerate(unique_urls, start=1):
         try:
-            resolved = await resolve_or_import_series_media(
-                session,
-                source_url=source_url,
-                title=f"{title_prefix}: изображение {index}",
-            )
+            if execute:
+                resolved = await resolve_or_import_series_media(
+                    session,
+                    source_url=source_url,
+                    title=f"{title_prefix}: изображение {index}",
+                )
+            else:
+                resolved = await find_imported_series_media(session, source_url=source_url)
         except Exception as exc:
             result["failed"].append({"url": source_url, "error": str(exc)})
             continue
         if not resolved:
+            if not execute:
+                continue
             result["failed"].append({"url": source_url, "error": "empty media url"})
             continue
         result["map"][source_url] = resolved.url

--- a/tests/unit/test_lg24_series_content_service.py
+++ b/tests/unit/test_lg24_series_content_service.py
@@ -14,6 +14,7 @@ from services.lg24_series_content_service import (
     extract_feature_blocks,
     extract_feature_gallery_images,
     extract_short_features,
+    import_series_media_urls,
     resolve_or_import_series_media,
     remap_feature_block_image_urls,
     should_update_media_value,
@@ -248,3 +249,38 @@ async def test_resolve_or_import_series_media_creates_and_reuses_asset(sqlite_se
     assert assets[0].original_url == "https://lg24.by/wp-content/uploads/feature.jpg"
     assert assets[0].kind == "brand"
     assert assets[0].tags == ["lg", "series", "feature", "promo"]
+
+
+@pytest.mark.asyncio
+async def test_import_series_media_urls_dry_run_maps_existing_assets(sqlite_session):
+    sqlite_session.add(
+        MediaAsset(
+            title="Existing LG promo",
+            kind="brand",
+            variant_type="original",
+            url="/media/library/original/existing.webp",
+            original_url="https://lg24.by/wp-content/uploads/existing.jpg",
+            mime_type="image/webp",
+            storage_provider="r2",
+            processing_status="ready",
+        )
+    )
+    await sqlite_session.flush()
+
+    result = await import_series_media_urls(
+        sqlite_session,
+        urls=[
+            "https://lg24.by/wp-content/uploads/existing.jpg",
+            "https://lg24.by/wp-content/uploads/new.jpg",
+        ],
+        execute=False,
+        title_prefix="LG Test",
+    )
+
+    assert result["planned"] == 2
+    assert result["imported"] == 0
+    assert result["reused"] == 1
+    assert result["failed"] == []
+    assert result["map"] == {
+        "https://lg24.by/wp-content/uploads/existing.jpg": "/media/library/original/existing.webp"
+    }


### PR DESCRIPTION
## Summary
- make LG24 `--import-media` dry-run reuse existing `MediaAsset.original_url` mappings
- keep missing media as planned-only in dry-run without downloads or failures

## Tests
- `python3 -m py_compile services/lg24_series_content_service.py`
- `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_lg24_series_content_service.py -q`
