### PR TITLE
Modernize brand landing pages

### DIFF
--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -325,6 +325,7 @@ export type { ProductSeriesNavigationResponse } from './models/ProductSeriesNavi
 export type { ProductSeriesResponse } from './models/ProductSeriesResponse';
 export type { ProductSiblingResponse } from './models/ProductSiblingResponse';
 export type { ProductUpdate } from './models/ProductUpdate';
+export type { PublicBrandDetailResponse } from './models/PublicBrandDetailResponse';
 export type { PublicBrandResponse } from './models/PublicBrandResponse';
 export type { RepairDiagnosticLeadResponse } from './models/RepairDiagnosticLeadResponse';
 export type { ServiceResponse } from './models/ServiceResponse';

--- a/manager_frontend/src/client/models/PublicBrandDetailResponse.ts
+++ b/manager_frontend/src/client/models/PublicBrandDetailResponse.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProductSeriesBrandFeatureResponse } from './ProductSeriesBrandFeatureResponse';
+export type PublicBrandDetailResponse = {
+    id: number;
+    title: string;
+    slug: string;
+    logo_url?: (string | null);
+    description?: (string | null);
+    products_count: number;
+    sort_order: number;
+    features?: Array<ProductSeriesBrandFeatureResponse>;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -14,6 +14,7 @@ import type { ProductAvailabilityLeadPayload } from '../models/ProductAvailabili
 import type { ProductAvailabilityLeadResponse } from '../models/ProductAvailabilityLeadResponse';
 import type { ProductResponse } from '../models/ProductResponse';
 import type { ProductSeriesNavigationResponse } from '../models/ProductSeriesNavigationResponse';
+import type { PublicBrandDetailResponse } from '../models/PublicBrandDetailResponse';
 import type { PublicBrandResponse } from '../models/PublicBrandResponse';
 import type { RepairDiagnosticLeadResponse } from '../models/RepairDiagnosticLeadResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
@@ -197,12 +198,12 @@ export class ApiService {
      * Get Public Brand
      * Get a published brand by slug if it has published products.
      * @param slug
-     * @returns PublicBrandResponse Successful Response
+     * @returns PublicBrandDetailResponse Successful Response
      * @throws ApiError
      */
     public static getPublicBrand(
         slug: string,
-    ): CancelablePromise<PublicBrandResponse> {
+    ): CancelablePromise<PublicBrandDetailResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/content/brands/{slug}',

--- a/openapi.json
+++ b/openapi.json
@@ -485,7 +485,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublicBrandResponse"
+                  "$ref": "#/components/schemas/PublicBrandDetailResponse"
                 }
               }
             }
@@ -36283,6 +36283,68 @@
         },
         "type": "object",
         "title": "ProductUpdate"
+      },
+      "PublicBrandDetailResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logo Url"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "products_count": {
+            "type": "integer",
+            "title": "Products Count"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order"
+          },
+          "features": {
+            "items": {
+              "$ref": "#/components/schemas/ProductSeriesBrandFeatureResponse"
+            },
+            "type": "array",
+            "title": "Features"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "products_count",
+          "sort_order"
+        ],
+        "title": "PublicBrandDetailResponse"
       },
       "PublicBrandResponse": {
         "properties": {

--- a/routers/api_content.py
+++ b/routers/api_content.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
 from core.database import get_session
-from schemas import ArticleResponse, PublicBrandResponse, ServiceResponse
+from schemas import ArticleResponse, PublicBrandDetailResponse, PublicBrandResponse, ServiceResponse
 from services.article_service import ArticleService
 from services.content_api_service import ContentApiService
 from services.installation_service import InstallationService
@@ -42,7 +42,7 @@ async def get_public_brands(session: AsyncSession = Depends(get_session)):
 
 @router.get(
     "/v1/content/brands/{slug}",
-    response_model=PublicBrandResponse,
+    response_model=PublicBrandDetailResponse,
     operation_id="get_public_brand",
 )
 async def get_public_brand(slug: str, session: AsyncSession = Depends(get_session)):

--- a/schemas.py
+++ b/schemas.py
@@ -438,6 +438,10 @@ class PublicBrandResponse(BaseModel):
     products_count: int
     sort_order: int
 
+
+class PublicBrandDetailResponse(PublicBrandResponse):
+    features: List[ProductSeriesBrandFeatureResponse] = Field(default_factory=list)
+
 # --- ORDERS ---
 
 class CalendarEventType(str, Enum):

--- a/services/content_api_service.py
+++ b/services/content_api_service.py
@@ -6,9 +6,10 @@ from bs4 import BeautifulSoup
 
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
-from models import Brand, GlobalConfig, Product, Service
+from models import Brand, BrandFeature, GlobalConfig, Product, Service
 
 
 class ContentApiService:
@@ -77,8 +78,42 @@ class ContentApiService:
         }
 
     @staticmethod
-    def _serialize_brand(brand: Brand, *, products_count: int) -> Dict[str, Any]:
+    def _serialize_brand_feature(feature: BrandFeature) -> Dict[str, Any]:
         return {
+            "id": feature.id,
+            "title": feature.title,
+            "slug": feature.slug,
+            "text": feature.text,
+            "image_url": feature.image_url,
+            "icon": feature.icon,
+            "footnote": feature.footnote,
+            "source_url": feature.source_url,
+            "aliases": feature.aliases or [],
+            "is_published": feature.is_published,
+            "sort_order": int(feature.sort_order or 0),
+        }
+
+    @staticmethod
+    def _serialize_brand_features(brand: Brand) -> List[Dict[str, Any]]:
+        features = list(getattr(brand, "__dict__", {}).get("feature_library") or [])
+        published = [feature for feature in features if getattr(feature, "is_published", False)]
+        published.sort(
+            key=lambda feature: (
+                int(getattr(feature, "sort_order", 0) or 0),
+                str(getattr(feature, "title", "") or "").casefold(),
+                int(getattr(feature, "id", 0) or 0),
+            )
+        )
+        return [ContentApiService._serialize_brand_feature(feature) for feature in published]
+
+    @staticmethod
+    def _serialize_brand(
+        brand: Brand,
+        *,
+        products_count: int,
+        include_features: bool = False,
+    ) -> Dict[str, Any]:
+        payload = {
             "id": brand.id,
             "title": brand.title,
             "slug": brand.slug,
@@ -87,6 +122,9 @@ class ContentApiService:
             "products_count": int(products_count or 0),
             "sort_order": brand.sort_order,
         }
+        if include_features:
+            payload["features"] = ContentApiService._serialize_brand_features(brand)
+        return payload
 
     @staticmethod
     async def get_active_services(session: AsyncSession) -> List[Dict[str, Any]]:
@@ -129,6 +167,7 @@ class ContentApiService:
     async def get_public_brand_by_slug(session: AsyncSession, slug: str) -> Dict[str, Any] | None:
         stmt = (
             select(Brand, func.count(Product.id).label("products_count"))
+            .options(selectinload(Brand.feature_library))
             .join(Product, Product.brand_id == Brand.id)
             .where(Brand.is_published == True)
             .where(Brand.slug == slug)
@@ -140,7 +179,7 @@ class ContentApiService:
         if row is None:
             return None
         brand, products_count = row
-        return ContentApiService._serialize_brand(brand, products_count=products_count)
+        return ContentApiService._serialize_brand(brand, products_count=products_count, include_features=True)
 
     @staticmethod
     async def get_global_config_map(session: AsyncSession) -> Dict[str, str]:

--- a/tests/integration/test_public_brands_api.py
+++ b/tests/integration/test_public_brands_api.py
@@ -1,7 +1,7 @@
 import pytest
 from httpx import AsyncClient
 
-from models import Brand, Product
+from models import Brand, BrandFeature, Product
 
 
 @pytest.mark.asyncio
@@ -22,6 +22,29 @@ async def test_public_brands_include_only_published_brands_with_published_produc
     empty = Brand(title="Empty", slug="empty", is_published=True, sort_order=30)
     db.add_all([tcl, mdv, hidden, empty])
     await db.flush()
+    db.add_all(
+        [
+            BrandFeature(
+                brand_id=tcl.id,
+                title="Fresh Air",
+                slug="fresh-air",
+                text="Фильтрация воздуха в бытовых сериях.",
+                image_url="/media/brands/tcl/fresh-air.webp",
+                icon="air",
+                footnote="Доступно не во всех моделях",
+                aliases=["filter"],
+                is_published=True,
+                sort_order=20,
+            ),
+            BrandFeature(
+                brand_id=tcl.id,
+                title="Draft feature",
+                slug="draft-feature",
+                is_published=False,
+                sort_order=10,
+            ),
+        ]
+    )
 
     db.add_all(
         [
@@ -79,7 +102,23 @@ async def test_public_brands_include_only_published_brands_with_published_produc
 
     detail_response = await async_client.get("/api/v1/content/brands/tcl")
     assert detail_response.status_code == 200, detail_response.text
-    assert detail_response.json()["products_count"] == 1
+    detail_payload = detail_response.json()
+    assert detail_payload["products_count"] == 1
+    assert detail_payload["features"] == [
+        {
+            "id": detail_payload["features"][0]["id"],
+            "title": "Fresh Air",
+            "slug": "fresh-air",
+            "text": "Фильтрация воздуха в бытовых сериях.",
+            "image_url": "/media/brands/tcl/fresh-air.webp",
+            "icon": "air",
+            "footnote": "Доступно не во всех моделях",
+            "source_url": None,
+            "aliases": ["filter"],
+            "is_published": True,
+            "sort_order": 20,
+        }
+    ]
 
     for slug in ("hidden", "empty", "missing"):
         missing_response = await async_client.get(f"/api/v1/content/brands/{slug}")

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "test:brands": "node tests/brand-markdown.test.mjs",
+    "test:brands": "node tests/brand-markdown.test.mjs && node tests/brand-series.test.mjs",
     "check-api": "node scripts/check-api.js",
     "audit:theme": "bash ../scripts/audit_theme_hardcodes.sh",
     "test:seo": "node scripts/test-seo-helpers.mjs",

--- a/web/src/components/brands/BrandFeatureStrip.astro
+++ b/web/src/components/brands/BrandFeatureStrip.astro
@@ -1,0 +1,50 @@
+---
+interface BrandFeature {
+    title: string;
+    text?: string | null;
+    image_url?: string | null;
+    icon?: string | null;
+}
+
+interface Props {
+    brandTitle: string;
+    features: BrandFeature[];
+    resolveImageUrl: (url: string) => string;
+}
+
+const { brandTitle, features, resolveImageUrl } = Astro.props as Props;
+---
+
+{features.length > 0 && (
+    <section class="brand-feature-strip" aria-labelledby="brand-features-title">
+        <div class="brand-section-head">
+            <p class="section-kicker">Почему {brandTitle}</p>
+            <h2 id="brand-features-title">Ключевые технологии и отличия</h2>
+        </div>
+        <div class="brand-feature-grid">
+            {features.slice(0, 6).map((feature) => {
+                const imageUrl = feature.image_url ? resolveImageUrl(feature.image_url) : "";
+                return (
+                    <article class={`brand-feature-card ${imageUrl ? "has-image" : ""}`}>
+                        {imageUrl ? (
+                            <img
+                                src={imageUrl}
+                                alt={feature.title}
+                                width="420"
+                                height="260"
+                                loading="lazy"
+                                decoding="async"
+                            />
+                        ) : (
+                            <span class="material-icons-round" aria-hidden="true">{feature.icon || "verified"}</span>
+                        )}
+                        <div>
+                            <h3>{feature.title}</h3>
+                            {feature.text && <p>{feature.text}</p>}
+                        </div>
+                    </article>
+                );
+            })}
+        </div>
+    </section>
+)}

--- a/web/src/components/brands/BrandHero.astro
+++ b/web/src/components/brands/BrandHero.astro
@@ -1,0 +1,86 @@
+---
+interface HeroFeature {
+    title: string;
+    icon?: string;
+}
+
+interface Props {
+    brandTitle: string;
+    h1: string;
+    introHtml: string;
+    productCountLabel: string;
+    logoUrl: string;
+    logoLabel: string;
+    initials: string;
+    heroImage: string;
+    fallbackFeatures: HeroFeature[];
+}
+
+const {
+    brandTitle,
+    h1,
+    introHtml,
+    productCountLabel,
+    logoUrl,
+    logoLabel,
+    initials,
+    heroImage,
+    fallbackFeatures,
+} = Astro.props as Props;
+---
+
+<section class="brand-hero" aria-labelledby="brand-hero-title">
+    <div class="brand-hero-copy">
+        <h1 id="brand-hero-title">{h1}</h1>
+        <div class="header-description brand-intro-markdown" set:html={introHtml} />
+        <div class="brand-hero-actions">
+            <a class="btn btn-primary" href="#brand-models">
+                <span class="material-icons-round" aria-hidden="true">grid_view</span>
+                Смотреть модели
+            </a>
+            <a class="btn btn-outline" href="/contacts/">
+                <span class="material-icons-round" aria-hidden="true">tune</span>
+                Подобрать {brandTitle}
+            </a>
+        </div>
+        <div class="brand-hero-meta" aria-label={`Кратко о бренде ${brandTitle}`}>
+            <span>{productCountLabel}</span>
+            <span>наличие и монтаж уточняем перед заказом</span>
+        </div>
+    </div>
+
+    <div class={`brand-hero-visual ${heroImage ? "has-image" : ""}`}>
+        {heroImage ? (
+            <img
+                src={heroImage}
+                alt={`Кондиционеры ${brandTitle}`}
+                width="720"
+                height="520"
+                loading="eager"
+                decoding="async"
+                fetchpriority="high"
+            />
+        ) : (
+            <div class="brand-logo-panel" aria-label={logoLabel}>
+                <div class="brand-logo-panel-mark">
+                    {logoUrl ? <img src={logoUrl} alt={brandTitle} width="160" height="90" /> : <span>{initials}</span>}
+                </div>
+                {fallbackFeatures.length > 0 && (
+                    <ul class="brand-logo-panel-features" aria-label={`Преимущества ${brandTitle}`}>
+                        {fallbackFeatures.slice(0, 3).map((feature) => (
+                            <li>
+                                <span class="material-icons-round" aria-hidden="true">{feature.icon || "check_circle"}</span>
+                                {feature.title}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        )}
+        {heroImage && logoUrl && (
+            <div class="brand-hero-logo-badge" aria-label={logoLabel}>
+                <img src={logoUrl} alt={brandTitle} width="112" height="64" />
+            </div>
+        )}
+    </div>
+</section>

--- a/web/src/components/brands/BrandSeriesCatalog.astro
+++ b/web/src/components/brands/BrandSeriesCatalog.astro
@@ -1,0 +1,127 @@
+---
+import ProductCard from "../ProductCard.astro";
+import { formatSeriesProductCount } from "../../utils/brand-series";
+import BrandSeriesFeatureBlocks from "./BrandSeriesFeatureBlocks.astro";
+
+interface Props {
+    brandTitle: string;
+    seriesGroupsByCatalog: any[];
+    productsWithoutSeriesByCatalog: any[];
+    resolveImageUrl: (url: string) => string;
+}
+
+const {
+    brandTitle,
+    seriesGroupsByCatalog,
+    productsWithoutSeriesByCatalog,
+    resolveImageUrl,
+} = Astro.props as Props;
+---
+
+<section id="brand-models" class="catalog-section brand-series-section" aria-labelledby="brand-products-title">
+    <div class="brand-section-head">
+        <p class="section-kicker">Каталог</p>
+        <h2 id="brand-products-title">Модели {brandTitle} по сериям</h2>
+    </div>
+    <div class="brand-series-list">
+        {seriesGroupsByCatalog.map((catalogGroup) => (
+            <section class="brand-catalog-group" aria-labelledby={`brand-catalog-${catalogGroup.key}`}>
+                <div class="brand-catalog-group-head">
+                    <h3 id={`brand-catalog-${catalogGroup.key}`}>{catalogGroup.title}</h3>
+                </div>
+                <div class="brand-catalog-group-list">
+                    {catalogGroup.series.map((group: any) => {
+                        const imageUrl = group.primaryImage ? resolveImageUrl(group.primaryImage) : "";
+                        return (
+                            <section id={group.anchorId} class="brand-series-group" aria-labelledby={`brand-series-${group.key}`}>
+                                <div class={`brand-series-summary ${imageUrl ? "has-media" : ""}`}>
+                                    {imageUrl && (
+                                        <a class="brand-series-media" href={`#${group.anchorId}`} aria-hidden="true" tabindex="-1">
+                                            <img
+                                                src={imageUrl}
+                                                alt={`Серия ${group.displayTitle}`}
+                                                width="640"
+                                                height="420"
+                                                loading="lazy"
+                                                decoding="async"
+                                            />
+                                        </a>
+                                    )}
+                                    <div class="brand-series-copy">
+                                        <div class="brand-series-title-row">
+                                            <div>
+                                                <p class="section-kicker">Серия</p>
+                                                <h4 id={`brand-series-${group.key}`}>{group.displayTitle}</h4>
+                                            </div>
+                                            <span>{formatSeriesProductCount(group.products.length)}</span>
+                                        </div>
+                                        {group.tagline && <p class="brand-series-tagline">{group.tagline}</p>}
+                                        {group.shortDescription || group.description ? (
+                                            <p>{group.shortDescription || group.description}</p>
+                                        ) : (
+                                            <p>{formatSeriesProductCount(group.products.length)} в каталоге {brandTitle}.</p>
+                                        )}
+                                        {group.distinctFeatures.length > 0 && (
+                                            <ul class="brand-series-features" aria-label={`Особенности серии ${group.displayTitle}`}>
+                                                {group.distinctFeatures.slice(0, 4).map((feature: string) => (
+                                                    <li>{feature}</li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                        <a class="brand-series-models-link" href={`#models-${group.anchorId}`}>
+                                            <span class="material-icons-round" aria-hidden="true">arrow_downward</span>
+                                            Смотреть модели серии
+                                        </a>
+                                    </div>
+                                </div>
+
+                                <BrandSeriesFeatureBlocks
+                                    blocks={group.visualFeatureBlocks}
+                                    seriesTitle={group.displayTitle}
+                                    resolveImageUrl={resolveImageUrl}
+                                />
+
+                                {group.footnotes.length > 0 && (
+                                    <ul class="brand-series-footnotes" aria-label={`Пояснения к серии ${group.displayTitle}`}>
+                                        {group.footnotes.slice(0, 3).map((footnote: string) => <li>{footnote}</li>)}
+                                    </ul>
+                                )}
+
+                                <div id={`models-${group.anchorId}`} class="catalog-grid series-products-grid">
+                                    {group.products.map((product: any) => (
+                                        <ProductCard
+                                            product={product}
+                                            variant="default"
+                                            showInstallation={true}
+                                            refreshProductOnMount={false}
+                                        />
+                                    ))}
+                                </div>
+                            </section>
+                        );
+                    })}
+                </div>
+            </section>
+        ))}
+        {productsWithoutSeriesByCatalog.map((catalogGroup) => (
+            <section class="brand-catalog-group" aria-labelledby={`brand-catalog-unsorted-${catalogGroup.key}`}>
+                <div class="brand-catalog-group-head">
+                    <h3 id={`brand-catalog-unsorted-${catalogGroup.key}`}>{catalogGroup.emptyTitle}</h3>
+                    <span>{formatSeriesProductCount(catalogGroup.products.length)}</span>
+                </div>
+                <div class="brand-series-group compact">
+                    <div class="catalog-grid series-products-grid">
+                        {catalogGroup.products.map((product: any) => (
+                            <ProductCard
+                                product={product}
+                                variant="default"
+                                showInstallation={true}
+                                refreshProductOnMount={false}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </section>
+        ))}
+    </div>
+</section>

--- a/web/src/components/brands/BrandSeriesFeatureBlocks.astro
+++ b/web/src/components/brands/BrandSeriesFeatureBlocks.astro
@@ -1,0 +1,73 @@
+---
+interface Props {
+    blocks: any[];
+    seriesTitle: string;
+    resolveImageUrl: (url: string) => string;
+}
+
+const { blocks, seriesTitle, resolveImageUrl } = Astro.props as Props;
+const visibleBlocks = blocks.slice(0, 3);
+const hiddenBlocks = blocks.slice(3);
+---
+
+{blocks.length > 0 && (
+    <div class="brand-series-visual-features" aria-label={`Особенности серии ${seriesTitle}`}>
+        <div class="brand-series-feature-grid">
+            {visibleBlocks.map((block) => {
+                const imageUrl = block.imageUrl ? resolveImageUrl(block.imageUrl) : "";
+                return (
+                    <article class={`brand-series-feature-card ${imageUrl ? "has-image" : ""}`}>
+                        {imageUrl ? (
+                            <img
+                                src={imageUrl}
+                                alt={block.title}
+                                width="520"
+                                height="320"
+                                loading="lazy"
+                                decoding="async"
+                            />
+                        ) : (
+                            <span class="material-icons-round" aria-hidden="true">{block.icon || "auto_awesome"}</span>
+                        )}
+                        <div>
+                            <h5>{block.title}</h5>
+                            {block.text && <p>{block.text}</p>}
+                            {block.footnote && <small>{block.footnote}</small>}
+                        </div>
+                    </article>
+                );
+            })}
+        </div>
+        {hiddenBlocks.length > 0 && (
+            <details class="brand-series-more-features">
+                <summary>Показать еще {hiddenBlocks.length}</summary>
+                <div class="brand-series-feature-grid">
+                    {hiddenBlocks.map((block) => {
+                        const imageUrl = block.imageUrl ? resolveImageUrl(block.imageUrl) : "";
+                        return (
+                            <article class={`brand-series-feature-card ${imageUrl ? "has-image" : ""}`}>
+                                {imageUrl ? (
+                                    <img
+                                        src={imageUrl}
+                                        alt={block.title}
+                                        width="520"
+                                        height="320"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                ) : (
+                                    <span class="material-icons-round" aria-hidden="true">{block.icon || "auto_awesome"}</span>
+                                )}
+                                <div>
+                                    <h5>{block.title}</h5>
+                                    {block.text && <p>{block.text}</p>}
+                                    {block.footnote && <small>{block.footnote}</small>}
+                                </div>
+                            </article>
+                        );
+                    })}
+                </div>
+            </details>
+        )}
+    </div>
+)}

--- a/web/src/components/brands/BrandSeriesNav.astro
+++ b/web/src/components/brands/BrandSeriesNav.astro
@@ -1,0 +1,39 @@
+---
+import { formatSeriesProductCount } from "../../utils/brand-series";
+
+interface Props {
+    brandTitle: string;
+    seriesGroupsByCatalog: any[];
+}
+
+const { brandTitle, seriesGroupsByCatalog } = Astro.props as Props;
+const totalSeries = seriesGroupsByCatalog.reduce((sum, group) => sum + (group.series?.length || 0), 0);
+---
+
+{totalSeries > 0 && (
+    <nav class="brand-series-nav" aria-labelledby="brand-series-nav-title">
+        <div class="brand-series-nav-head">
+            <div>
+                <p class="section-kicker" id="brand-series-nav-title">Серии {brandTitle}</p>
+                <p>Бытовые линейки идут первыми, мульти-сплит и полупромышленные модели отделены в свои группы.</p>
+            </div>
+        </div>
+        <div class="brand-series-nav-list">
+            {seriesGroupsByCatalog.map((catalogGroup) => (
+                <section class="brand-series-nav-group" aria-labelledby={`brand-series-nav-${catalogGroup.key}`}>
+                    <p class="brand-series-nav-group-title" id={`brand-series-nav-${catalogGroup.key}`}>
+                        {catalogGroup.navTitle}
+                    </p>
+                    <div class="brand-series-nav-chips">
+                        {catalogGroup.series.map((group: any) => (
+                            <a class="brand-series-chip" href={`#${group.anchorId}`}>
+                                <span>{group.displayTitle}</span>
+                                <small>{group.catalogGroup.shortLabel} · {formatSeriesProductCount(group.products.length)}</small>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            ))}
+        </div>
+    </nav>
+)}

--- a/web/src/pages/brands/[slug].astro
+++ b/web/src/pages/brands/[slug].astro
@@ -1,12 +1,13 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import CatalogApp from "../../components/CatalogApp.vue";
-import ProductCard from "../../components/ProductCard.astro";
-import {
-    buildBrandSeriesCatalog,
-    formatSeriesProductCount,
-} from "../../utils/brand-series";
+import BrandFeatureStrip from "../../components/brands/BrandFeatureStrip.astro";
+import BrandHero from "../../components/brands/BrandHero.astro";
+import BrandSeriesCatalog from "../../components/brands/BrandSeriesCatalog.astro";
+import BrandSeriesNav from "../../components/brands/BrandSeriesNav.astro";
+import { buildBrandSeriesCatalog } from "../../utils/brand-series";
 import "../../styles/brand-page.css";
+import "../../styles/brand-page-responsive.css";
 import {
     applyRuntimeFreshnessHeaders,
     createRuntimeFreshnessContext,
@@ -30,6 +31,16 @@ interface PublicBrand {
     slug: string;
     logo_url?: string | null;
     description?: string | null;
+    features?: Array<{
+        id?: number | null;
+        title: string;
+        slug?: string | null;
+        text?: string | null;
+        image_url?: string | null;
+        icon?: string | null;
+        footnote?: string | null;
+        sort_order?: number | null;
+    }>;
     products_count: number;
     sort_order: number;
 }
@@ -56,7 +67,19 @@ interface Product {
         short_description?: string | null;
         description?: string | null;
         hero_image?: string | null;
+        gallery_images?: string[] | null;
         features?: string[] | null;
+        brand_features?: Array<{
+            id?: number | null;
+            title?: string | null;
+            slug?: string | null;
+            text?: string | null;
+            image_url?: string | null;
+            icon?: string | null;
+            footnote?: string | null;
+            source_url?: string | null;
+            sort_order?: number | null;
+        }> | null;
         feature_blocks?: Array<{
             title?: string | null;
             text?: string | null;
@@ -64,6 +87,14 @@ interface Product {
             icon?: string | null;
             footnote?: string | null;
         }> | null;
+        content_blocks?: Array<{
+            kind?: string | null;
+            title?: string | null;
+            text?: string | null;
+            image_url?: string | null;
+            layout?: string | null;
+        }> | null;
+        footnotes?: string[] | null;
     } | null;
     badges?: Array<{ text: string; class?: string }>;
     tags?: Array<{
@@ -93,9 +124,8 @@ interface Props {
 const { brand: initialBrand } = Astro.props as Props;
 const runtimeFreshness = await createRuntimeFreshnessContext();
 const runtimeFreshnessOption = runtimeFreshness ? { runtimeFreshness } : undefined;
-const brand = runtimeFreshness
-    ? await getPublicBrandBySlug(Astro.params.slug || "", runtimeFreshnessOption)
-    : initialBrand || (await getPublicBrandBySlug(Astro.params.slug || ""));
+const brandSlug = Astro.params.slug || initialBrand?.slug || "";
+const brand = await getPublicBrandBySlug(brandSlug, runtimeFreshnessOption);
 if (!brand) {
     return createRuntimeNotFoundResponse(Astro.response, runtimeFreshness, {
         canonicalOrigin: Astro.url.origin,
@@ -136,6 +166,50 @@ const {
     seriesGroupsByCatalog,
     productsWithoutSeriesByCatalog,
 } = buildBrandSeriesCatalog(products, popularProducts, brand.title);
+const asText = (value: unknown) => String(value || "").trim();
+const normalizeFeatureKey = (value: string) => value.toLowerCase().replace(/ё/g, "е");
+const brandFeatureMap = new Map<string, NonNullable<PublicBrand["features"]>[number]>();
+for (const feature of brand.features || []) {
+    const title = asText(feature.title);
+    if (!title) continue;
+    brandFeatureMap.set(normalizeFeatureKey(feature.slug || title), { ...feature, title });
+}
+for (const group of seriesGroups) {
+    for (const feature of group.brandFeatures || []) {
+        const title = asText(feature.title);
+        if (!title) continue;
+        const key = normalizeFeatureKey(feature.slug || title);
+        if (!brandFeatureMap.has(key)) {
+            brandFeatureMap.set(key, {
+                title,
+                slug: feature.slug,
+                text: feature.text,
+                image_url: feature.imageUrl,
+                icon: feature.icon,
+                footnote: feature.footnote,
+                sort_order: feature.sortOrder,
+            });
+        }
+    }
+}
+if (brandFeatureMap.size === 0) {
+    for (const group of seriesGroups) {
+        for (const feature of group.distinctFeatures || []) {
+            const title = asText(feature);
+            const key = normalizeFeatureKey(title);
+            if (title && !brandFeatureMap.has(key)) {
+                brandFeatureMap.set(key, { title, icon: "check_circle" });
+            }
+            if (brandFeatureMap.size >= 6) break;
+        }
+        if (brandFeatureMap.size >= 6) break;
+    }
+}
+const brandFeatureHighlights = Array.from(brandFeatureMap.values())
+    .sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0) || a.title.localeCompare(b.title, "ru"))
+    .slice(0, 6);
+const heroImage = seriesGroups.find((group) => group.primaryImage)?.primaryImage || "";
+const resolvedHeroImage = heroImage ? resolveImageUrl(heroImage) : "";
 ---
 
 <Layout
@@ -154,20 +228,24 @@ const {
                 <span class="sep">/</span>
                 <span>{brand.title}</span>
             </div>
-            <div class="brand-hero">
-                <div class="brand-hero-copy">
-                    <h1 class="gradient-text">{h1}</h1>
-                    <div class="header-description brand-intro-markdown" set:html={brandIntroHtml} />
-                    <div class="brand-hero-meta">
-                        <span>{brandProductCount}</span>
-                        <span>наличие и монтаж уточняем перед заказом</span>
-                    </div>
-                </div>
-                <div class="brand-logo-panel" aria-label={brandLogoLabel}>
-                    {logoUrl ? <img src={logoUrl} alt={brand.title} /> : <span>{brandInitials}</span>}
-                </div>
-            </div>
+            <BrandHero
+                brandTitle={brand.title}
+                h1={h1}
+                introHtml={brandIntroHtml}
+                productCountLabel={brandProductCount}
+                logoUrl={logoUrl}
+                logoLabel={brandLogoLabel}
+                initials={brandInitials}
+                heroImage={resolvedHeroImage}
+                fallbackFeatures={brandFeatureHighlights}
+            />
         </header>
+
+        <BrandFeatureStrip
+            brandTitle={brand.title}
+            features={brandFeatureHighlights}
+            resolveImageUrl={resolveImageUrl}
+        />
 
         <CatalogApp
             client:idle
@@ -182,132 +260,16 @@ const {
             initialBrands={filtersConfig?.brands || []}
         >
             <div class="catalog-static-content">
-                {
-                    seriesGroups.length > 0 && (
-                        <nav class="brand-series-nav" aria-labelledby="brand-series-nav-title">
-                            <div class="brand-series-nav-head">
-                                <div>
-                                    <p class="section-kicker" id="brand-series-nav-title">Серии {brand.title}</p>
-                                    <p>Сначала бытовые линейки, затем мульти-сплит и полупромышленные модели.</p>
-                                </div>
-                            </div>
-                            <div class="brand-series-nav-list">
-                                {seriesGroupsByCatalog.map((catalogGroup) => (
-                                    <section class="brand-series-nav-group" aria-labelledby={`brand-series-nav-${catalogGroup.key}`}>
-                                        <p class="brand-series-nav-group-title" id={`brand-series-nav-${catalogGroup.key}`}>
-                                            {catalogGroup.navTitle}
-                                        </p>
-                                        <div class="brand-series-nav-chips">
-                                            {catalogGroup.series.map((group) => (
-                                                <a class="brand-series-chip" href={`#${group.anchorId}`}>
-                                                    <span>{group.displayTitle}</span>
-                                                    <small>{group.catalogGroup.shortLabel} · {formatSeriesProductCount(group.products.length)}</small>
-                                                </a>
-                                            ))}
-                                        </div>
-                                    </section>
-                                ))}
-                            </div>
-                        </nav>
-                    )
-                }
+                <BrandSeriesNav brandTitle={brand.title} seriesGroupsByCatalog={seriesGroupsByCatalog} />
 
                 {
                     seriesSourceProducts.length > 0 ? (
-                        <section class="catalog-section brand-series-section" aria-labelledby="brand-products-title">
-                            <div class="catalog-section-head">
-                                <h2 id="brand-products-title">Модели {brand.title} по сериям</h2>
-                            </div>
-                            <div class="brand-series-list">
-                                {seriesGroupsByCatalog.map((catalogGroup) => (
-                                    <section class="brand-catalog-group" aria-labelledby={`brand-catalog-${catalogGroup.key}`}>
-                                        <div class="brand-catalog-group-head">
-                                            <h3 id={`brand-catalog-${catalogGroup.key}`}>{catalogGroup.title}</h3>
-                                        </div>
-                                        <div class="brand-catalog-group-list">
-                                            {catalogGroup.series.map((group) => (
-                                                <section id={group.anchorId} class="brand-series-group" aria-labelledby={`brand-series-${group.key}`}>
-                                                    <div class={`brand-series-head brand-products-group-head ${group.heroImage ? "has-thumb" : ""}`}>
-                                                        {group.heroImage && (
-                                                            <img
-                                                                class="brand-series-thumb"
-                                                                src={resolveImageUrl(group.heroImage)}
-                                                                alt={`Серия ${group.displayTitle}`}
-                                                                loading="lazy"
-                                                            />
-                                                        )}
-                                                        <div class="brand-series-copy">
-                                                            <div class="brand-series-title-row">
-                                                                <div>
-                                                                    <p class="section-kicker">Серия</p>
-                                                                    <h4 id={`brand-series-${group.key}`}>{group.displayTitle}</h4>
-                                                                </div>
-                                                                <span>{formatSeriesProductCount(group.products.length)}</span>
-                                                            </div>
-                                                            {group.tagline && (
-                                                                <p class="brand-series-tagline">{group.tagline}</p>
-                                                            )}
-                                                            {group.shortDescription || group.description ? (
-                                                                <p>{group.shortDescription || group.description}</p>
-                                                            ) : (
-                                                                <p>{formatSeriesProductCount(group.products.length)} в каталоге {brand.title}.</p>
-                                                            )}
-                                                            {group.distinctFeatures.length > 0 && (
-                                                                <ul class="brand-series-features" aria-label={`Особенности серии ${group.displayTitle}`}>
-                                                                    {group.distinctFeatures.map((feature) => (
-                                                                        <li>{feature}</li>
-                                                                    ))}
-                                                                </ul>
-                                                            )}
-                                                            {group.featureBlocks.length > 0 && (
-                                                                <div class="brand-series-feature-blocks" aria-label={`Преимущества серии ${group.displayTitle}`}>
-                                                                    {group.featureBlocks.slice(0, 3).map((block) => (
-                                                                        <article class="brand-series-feature-block">
-                                                                            <strong>{block.title}</strong>
-                                                                            {block.text && <span>{block.text}</span>}
-                                                                        </article>
-                                                                    ))}
-                                                                </div>
-                                                            )}
-                                                        </div>
-                                                    </div>
-                                                    <div class="catalog-grid series-products-grid">
-                                                        {group.products.map((product) => (
-                                                            <ProductCard
-                                                                product={product}
-                                                                variant="default"
-                                                                showInstallation={true}
-                                                                refreshProductOnMount={false}
-                                                            />
-                                                        ))}
-                                                    </div>
-                                                </section>
-                                            ))}
-                                        </div>
-                                    </section>
-                                ))}
-                                {productsWithoutSeriesByCatalog.map((catalogGroup) => (
-                                    <section class="brand-catalog-group" aria-labelledby={`brand-catalog-unsorted-${catalogGroup.key}`}>
-                                        <div class="brand-catalog-group-head">
-                                            <h3 id={`brand-catalog-unsorted-${catalogGroup.key}`}>{catalogGroup.emptyTitle}</h3>
-                                            <span>{formatSeriesProductCount(catalogGroup.products.length)}</span>
-                                        </div>
-                                        <div class="brand-series-group">
-                                            <div class="catalog-grid series-products-grid">
-                                                {catalogGroup.products.map((product) => (
-                                                    <ProductCard
-                                                        product={product}
-                                                        variant="default"
-                                                        showInstallation={true}
-                                                        refreshProductOnMount={false}
-                                                    />
-                                                ))}
-                                            </div>
-                                        </div>
-                                    </section>
-                                ))}
-                            </div>
-                        </section>
+                        <BrandSeriesCatalog
+                            brandTitle={brand.title}
+                            seriesGroupsByCatalog={seriesGroupsByCatalog}
+                            productsWithoutSeriesByCatalog={productsWithoutSeriesByCatalog}
+                            resolveImageUrl={resolveImageUrl}
+                        />
                     ) : (
                         <div class="empty-status card">
                             <span class="material-icons-round large">search_off</span>

--- a/web/src/styles/brand-page-responsive.css
+++ b/web/src/styles/brand-page-responsive.css
@@ -1,0 +1,135 @@
+@media (max-width: 1020px) {
+    .brand-hero {
+        grid-template-columns: 1fr;
+        min-height: 0;
+    }
+
+    .brand-hero-visual.has-image img {
+        min-height: 320px;
+        aspect-ratio: 16 / 9;
+    }
+
+    .brand-feature-grid,
+    .brand-series-feature-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .brand-series-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .brand-series-media img {
+        min-height: 240px;
+    }
+}
+
+@media (max-width: 720px) {
+    .brand-page {
+        padding: 1.25rem 1rem 2.5rem;
+    }
+
+    .brand-hero {
+        gap: 0.8rem;
+    }
+
+    .brand-hero-copy {
+        padding: 1.1rem;
+    }
+
+    .brand-hero h1 {
+        font-size: 1.95rem;
+        line-height: 1.08;
+    }
+
+    .header-description {
+        display: -webkit-box;
+        overflow: hidden;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        font-size: 0.94rem;
+    }
+
+    .brand-intro-markdown p:nth-of-type(n+2),
+    .brand-intro-markdown ul {
+        display: none;
+    }
+
+    .brand-hero-meta span:nth-child(n+2) {
+        display: none;
+    }
+
+    .brand-hero-actions {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .brand-hero-actions .btn {
+        width: 100%;
+    }
+
+    .brand-hero-visual.has-image img {
+        min-height: 150px;
+        max-height: 170px;
+    }
+
+    .brand-hero-logo-badge {
+        right: 0.75rem;
+        bottom: 0.75rem;
+        width: 110px;
+        min-height: 64px;
+    }
+
+    .brand-logo-panel {
+        padding: 1.1rem;
+    }
+
+    .brand-feature-grid,
+    .brand-series-feature-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .brand-feature-card,
+    .brand-feature-card.has-image {
+        grid-template-columns: 1fr;
+    }
+
+    .brand-feature-card.has-image img {
+        aspect-ratio: 16 / 10;
+    }
+
+    .brand-series-nav {
+        padding: 1rem;
+    }
+
+    .brand-series-chip {
+        min-width: 170px;
+    }
+
+    .brand-catalog-group-head,
+    .brand-series-title-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.6rem;
+    }
+
+    .brand-catalog-group-head > span,
+    .brand-series-title-row > span {
+        white-space: normal;
+    }
+
+    .brand-series-copy {
+        padding: 1rem;
+    }
+
+    .brand-series-media img {
+        min-height: 190px;
+    }
+
+    .brand-series-feature-card img {
+        aspect-ratio: 16 / 9;
+    }
+
+    .catalog-seo-block {
+        padding: 1rem;
+    }
+}

--- a/web/src/styles/brand-page.css
+++ b/web/src/styles/brand-page.css
@@ -1,22 +1,22 @@
 .brand-page {
-    padding: 2rem 1.5rem;
     max-width: 1400px;
     margin: 0 auto;
+    padding: 2rem 1.5rem 3rem;
 }
 
 .brand-header {
-    margin-bottom: 2rem;
+    margin-bottom: 1.3rem;
 }
 
 .breadcrumb {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
     font-weight: 500;
-    flex-wrap: wrap;
 }
 
 .breadcrumb a:hover {
@@ -29,23 +29,38 @@
 
 .brand-hero {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 180px;
-    gap: 1.5rem;
-    align-items: center;
+    grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+    gap: 1.4rem;
+    align-items: stretch;
+    min-height: 430px;
+}
+
+.brand-hero-copy {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    padding: 2rem;
+    border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
+    box-shadow: var(--panel-glass-shadow);
 }
 
 .brand-hero h1 {
-    font-size: clamp(2rem, 4vw, 3rem);
-    margin-bottom: 0.75rem;
+    max-width: 760px;
+    margin: 0;
+    color: var(--text);
+    font-size: 3rem;
     font-weight: 800;
-    line-height: 1.1;
+    line-height: 1.05;
 }
 
 .header-description {
-    max-width: 780px;
+    max-width: 760px;
+    margin: 1rem 0 0;
     color: var(--text-muted);
-    margin: 0;
-    line-height: 1.7;
+    line-height: 1.65;
 }
 
 .brand-intro-markdown p {
@@ -60,6 +75,7 @@
 .brand-intro-markdown ul {
     margin: 0.55rem 0 0.65rem;
     padding-left: 1.2rem;
+    list-style: disc;
 }
 
 .brand-intro-markdown li + li {
@@ -73,11 +89,20 @@
     text-underline-offset: 0.2em;
 }
 
+.brand-hero-actions,
 .brand-hero-meta {
     display: flex;
     flex-wrap: wrap;
     gap: 0.65rem;
-    margin-top: 1rem;
+    margin-top: 1.1rem;
+}
+
+.brand-hero-actions .btn {
+    border-radius: 8px;
+}
+
+.brand-hero-actions .material-icons-round {
+    font-size: 1.1rem;
 }
 
 .brand-hero-meta span {
@@ -85,33 +110,184 @@
     align-items: center;
     min-height: 34px;
     padding: 0.35rem 0.7rem;
+    border: 1px solid var(--panel-chip-border);
     border-radius: 8px;
     background: var(--panel-chip-bg);
-    border: 1px solid var(--panel-chip-border);
     color: var(--text);
     font-size: 0.9rem;
     font-weight: 700;
 }
 
-.brand-logo-panel {
-    min-height: 140px;
+.brand-hero-visual {
+    position: relative;
+    min-width: 0;
+    min-height: 100%;
+    border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
+    box-shadow: var(--panel-glass-shadow);
+    overflow: hidden;
+}
+
+.brand-hero-visual.has-image img {
+    width: 100%;
+    height: 100%;
+    min-height: 430px;
+    object-fit: cover;
+}
+
+.brand-hero-logo-badge {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--panel-glass-bg);
+    width: 128px;
+    min-height: 76px;
+    padding: 0.8rem;
     border: 1px solid var(--panel-glass-border);
     border-radius: 8px;
+    background: var(--panel-pill-bg);
     box-shadow: var(--panel-glass-shadow);
+}
+
+.brand-hero-logo-badge img,
+.brand-logo-panel-mark img {
+    width: 100%;
+    height: auto;
+    max-height: 64px;
+    object-fit: contain;
+}
+
+.brand-logo-panel {
+    display: grid;
+    align-content: center;
+    gap: 1rem;
+    min-height: 100%;
+    padding: 2rem;
     color: var(--primary);
+}
+
+.brand-logo-panel-mark {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 150px;
     font-family: "Space Grotesk", sans-serif;
-    font-size: 2rem;
+    font-size: 2.4rem;
     font-weight: 800;
 }
 
-.brand-logo-panel img {
-    max-width: 132px;
-    max-height: 78px;
-    object-fit: contain;
+.brand-logo-panel-features {
+    display: grid;
+    gap: 0.6rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.brand-logo-panel-features li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--panel-chip-border);
+    border-radius: 8px;
+    background: var(--panel-chip-bg);
+    color: var(--text);
+    font-weight: 700;
+}
+
+.brand-logo-panel-features .material-icons-round {
+    color: var(--primary);
+    font-size: 1.1rem;
+}
+
+.brand-section-head {
+    display: grid;
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+.brand-section-head h2,
+.catalog-seo-block h2 {
+    margin: 0;
+    color: var(--text);
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 1.55rem;
+    line-height: 1.2;
+}
+
+.section-kicker {
+    margin: 0;
+    color: var(--primary);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.brand-feature-strip {
+    margin: 0 0 1.4rem;
+}
+
+.brand-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.brand-feature-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.8rem;
+    align-items: start;
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
+    box-shadow: var(--panel-glass-shadow);
+}
+
+.brand-feature-card.has-image {
+    grid-template-columns: 110px minmax(0, 1fr);
+}
+
+.brand-feature-card > .material-icons-round {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border: 1px solid var(--panel-chip-border);
+    border-radius: 8px;
+    background: var(--panel-chip-bg);
+    color: var(--primary);
+    font-size: 1.35rem;
+}
+
+.brand-feature-card img {
+    width: 100%;
+    aspect-ratio: 11 / 8;
+    border-radius: 8px;
+    object-fit: cover;
+    background: var(--panel-chip-bg);
+}
+
+.brand-feature-card h3 {
+    margin: 0;
+    color: var(--text);
+    font-size: 1rem;
+    line-height: 1.25;
+}
+
+.brand-feature-card p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.5;
 }
 
 .catalog-static-content,
@@ -121,33 +297,8 @@
     gap: 1.4rem;
 }
 
-.catalog-section-head {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 1rem;
-}
-
-.catalog-section-head h2,
-.catalog-seo-block h2 {
-    margin: 0;
-    color: var(--text);
-    font-family: "Space Grotesk", sans-serif;
-    font-size: 1.35rem;
-    line-height: 1.2;
-}
-
-.section-kicker {
-    margin: 0 0 0.25rem;
-    color: var(--primary);
-    font-size: 0.78rem;
-    font-weight: 800;
-    letter-spacing: 0;
-    text-transform: uppercase;
-}
-
 .brand-series-nav {
-    padding: 1.2rem;
+    padding: 1.1rem;
     border: 1px solid var(--panel-glass-border);
     border-radius: 8px;
     background: var(--panel-glass-bg);
@@ -162,7 +313,7 @@
 }
 
 .brand-series-nav-head p:not(.section-kicker) {
-    margin: 0;
+    margin: 0.25rem 0 0;
     color: var(--text-muted);
     font-size: 0.92rem;
     line-height: 1.5;
@@ -199,9 +350,10 @@
 }
 
 .brand-series-chip {
-    min-width: clamp(168px, 18vw, 240px);
     display: grid;
     gap: 0.22rem;
+    min-width: 180px;
+    max-width: 260px;
     padding: 0.7rem 0.8rem;
     border: 1px solid var(--panel-chip-border);
     border-radius: 8px;
@@ -216,10 +368,10 @@
 }
 
 .brand-series-chip span {
+    overflow-wrap: anywhere;
     font-size: 0.9rem;
     font-weight: 800;
     line-height: 1.25;
-    overflow-wrap: anywhere;
 }
 
 .brand-series-chip small {
@@ -228,29 +380,14 @@
     font-weight: 700;
 }
 
-.brand-series-title-row > span,
-.brand-catalog-group-head > span {
-    display: inline-flex;
-    align-items: center;
-    min-height: 30px;
-    padding: 0.25rem 0.6rem;
-    border-radius: 8px;
-    background: var(--panel-chip-bg);
-    border: 1px solid var(--panel-chip-border);
-    color: var(--text-muted);
-    font-size: 0.82rem;
-    font-weight: 800;
-    white-space: nowrap;
-}
-
 .brand-series-list {
     display: grid;
-    gap: 2rem;
+    gap: 2.2rem;
 }
 
 .brand-catalog-group {
     display: grid;
-    gap: 1.25rem;
+    gap: 1.15rem;
 }
 
 .brand-catalog-group-head {
@@ -270,47 +407,78 @@
 .brand-catalog-group-head h3 {
     margin: 0;
     color: var(--text);
-    font-size: 1.22rem;
+    font-size: 1.28rem;
     line-height: 1.25;
+}
+
+.brand-catalog-group-head > span,
+.brand-series-title-row > span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    padding: 0.25rem 0.6rem;
+    border: 1px solid var(--panel-chip-border);
+    border-radius: 8px;
+    background: var(--panel-chip-bg);
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    font-weight: 800;
+    white-space: nowrap;
 }
 
 .brand-catalog-group-list {
     display: grid;
-    gap: 1.5rem;
+    gap: 2rem;
 }
 
 .brand-series-group {
     display: grid;
     gap: 1rem;
     min-width: 0;
-    padding: 1rem;
-    border: 1px solid var(--panel-glass-border);
-    border-radius: 8px;
-    background: rgba(var(--surface-rgb), 0.42);
     scroll-margin-top: 5.5rem;
 }
 
-.brand-series-head {
+.brand-series-group + .brand-series-group {
+    padding-top: 2rem;
+    border-top: 1px solid var(--panel-glass-border);
+}
+
+.brand-series-summary {
     display: grid;
-    grid-template-columns: 1fr;
-    align-items: start;
+    grid-template-columns: minmax(260px, 0.52fr) minmax(0, 1fr);
     gap: 1rem;
+    align-items: stretch;
+    min-width: 0;
 }
 
-.brand-series-head.has-thumb {
-    grid-template-columns: minmax(0, 132px) minmax(0, 1fr);
+.brand-series-summary:not(.has-media) {
+    grid-template-columns: 1fr;
 }
 
-.brand-series-thumb {
-    width: 100%;
-    max-height: 128px;
+.brand-series-media {
+    display: block;
+    min-width: 0;
+    border: 1px solid var(--panel-glass-border);
     border-radius: 8px;
-    object-fit: cover;
     background: var(--panel-chip-bg);
+    overflow: hidden;
+}
+
+.brand-series-media img {
+    width: 100%;
+    height: 100%;
+    min-height: 260px;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
 }
 
 .brand-series-copy {
     min-width: 0;
+    padding: 1.1rem;
+    border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
+    box-shadow: var(--panel-glass-shadow);
 }
 
 .brand-series-title-row {
@@ -320,23 +488,23 @@
     gap: 1rem;
 }
 
-.brand-series-head h4 {
+.brand-series-copy h4 {
     margin: 0;
     color: var(--text);
-    font-size: 1.16rem;
+    font-size: 1.25rem;
     line-height: 1.25;
     overflow-wrap: anywhere;
 }
 
-.brand-series-head p {
+.brand-series-copy p {
     max-width: 780px;
-    margin: 0.4rem 0 0;
+    margin: 0.45rem 0 0;
     color: var(--text-muted);
-    font-size: 0.94rem;
+    font-size: 0.95rem;
     line-height: 1.6;
 }
 
-.brand-series-head .brand-series-tagline {
+.brand-series-copy .brand-series-tagline {
     color: var(--text);
     font-weight: 750;
 }
@@ -345,7 +513,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.45rem;
-    margin: 0.7rem 0 0;
+    margin: 0.75rem 0 0;
     padding: 0;
     list-style: none;
 }
@@ -355,38 +523,130 @@
     align-items: center;
     min-height: 30px;
     padding: 0.25rem 0.6rem;
+    border: 1px solid var(--panel-chip-border);
     border-radius: 8px;
     background: var(--panel-chip-bg);
-    border: 1px solid var(--panel-chip-border);
     color: var(--text);
     font-size: 0.82rem;
     font-weight: 700;
 }
 
-.brand-series-feature-blocks {
-    display: grid;
-    gap: 0.55rem;
-    margin-top: 0.8rem;
+.brand-series-models-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.9rem;
+    color: var(--primary);
+    font-size: 0.9rem;
+    font-weight: 800;
 }
 
-.brand-series-feature-block {
+.brand-series-models-link .material-icons-round {
+    font-size: 1rem;
+}
+
+.brand-series-visual-features {
     display: grid;
-    gap: 0.2rem;
-    padding: 0.65rem 0.75rem;
+    gap: 0.75rem;
+}
+
+.brand-series-feature-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.brand-series-feature-card {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    min-width: 0;
     border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
+    box-shadow: var(--panel-glass-shadow);
+    overflow: hidden;
+}
+
+.brand-series-feature-card:not(.has-image) {
+    grid-template-rows: 54px 1fr;
+    padding-top: 1rem;
+}
+
+.brand-series-feature-card > .material-icons-round {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    margin-left: 1rem;
+    border: 1px solid var(--panel-chip-border);
+    border-radius: 8px;
+    background: var(--panel-chip-bg);
+    color: var(--primary);
+    font-size: 1.35rem;
+}
+
+.brand-series-feature-card img {
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
+    background: var(--panel-chip-bg);
+}
+
+.brand-series-feature-card div {
+    min-width: 0;
+    padding: 0.9rem 1rem 1rem;
+}
+
+.brand-series-feature-card h5 {
+    margin: 0;
+    color: var(--text);
+    font-size: 0.98rem;
+    line-height: 1.25;
+}
+
+.brand-series-feature-card p {
+    margin: 0.4rem 0 0;
+    color: var(--text-muted);
+    font-size: 0.88rem;
+    line-height: 1.5;
+}
+
+.brand-series-feature-card small {
+    display: block;
+    margin-top: 0.55rem;
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    line-height: 1.45;
+}
+
+.brand-series-more-features {
+    border: 1px solid var(--panel-chip-border);
     border-radius: 8px;
     background: var(--panel-chip-bg);
 }
 
-.brand-series-feature-block strong {
+.brand-series-more-features summary {
+    cursor: pointer;
+    padding: 0.75rem 0.9rem;
     color: var(--text);
-    font-size: 0.9rem;
+    font-weight: 800;
 }
 
-.brand-series-feature-block span {
+.brand-series-more-features .brand-series-feature-grid {
+    padding: 0 0.75rem 0.75rem;
+}
+
+.brand-series-footnotes {
+    display: grid;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0.75rem 0.9rem;
+    border-left: 3px solid var(--panel-chip-hover-border);
     color: var(--text-muted);
-    font-size: 0.84rem;
+    font-size: 0.78rem;
     line-height: 1.45;
+    list-style: none;
 }
 
 .catalog-grid {
@@ -400,24 +660,26 @@
 }
 
 .empty-status {
-    text-align: center;
-    padding: 4rem 1rem;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 0.75rem;
+    padding: 4rem 1rem;
+    text-align: center;
 }
 
 .large {
-    font-size: 4rem;
     color: var(--text-muted);
+    font-size: 4rem;
     opacity: 0.55;
 }
 
 .catalog-seo-block {
     margin-top: 2.2rem;
-    padding-top: 1.6rem;
-    border-top: 1px solid var(--panel-glass-border);
+    padding: 1.4rem;
+    border: 1px solid var(--panel-glass-border);
+    border-radius: 8px;
+    background: var(--panel-glass-bg);
     color: var(--text-muted);
 }
 
@@ -425,44 +687,4 @@
     max-width: 880px;
     margin: 0.75rem 0 0;
     line-height: 1.7;
-}
-
-@media (max-width: 720px) {
-    .brand-hero {
-        grid-template-columns: 1fr;
-    }
-
-    .brand-logo-panel {
-        min-height: 108px;
-        justify-content: flex-start;
-        padding: 1rem;
-    }
-
-    .catalog-section-head,
-    .brand-series-nav-head,
-    .brand-catalog-group-head {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.6rem;
-    }
-
-    .brand-series-head {
-        grid-template-columns: 1fr;
-        align-items: start;
-        gap: 0.6rem;
-    }
-
-    .brand-series-thumb {
-        max-height: 160px;
-    }
-
-    .brand-series-title-row {
-        flex-direction: column;
-        gap: 0.6rem;
-    }
-
-    .brand-series-title-row > span,
-    .brand-catalog-group-head > span {
-        white-space: normal;
-    }
 }

--- a/web/src/utils/brand-series.ts
+++ b/web/src/utils/brand-series.ts
@@ -10,7 +10,19 @@ export interface BrandSeriesProduct {
         short_description?: string | null;
         description?: string | null;
         hero_image?: string | null;
+        gallery_images?: string[] | null;
         features?: string[] | null;
+        brand_features?: Array<{
+            id?: number | null;
+            title?: string | null;
+            slug?: string | null;
+            text?: string | null;
+            image_url?: string | null;
+            icon?: string | null;
+            footnote?: string | null;
+            source_url?: string | null;
+            sort_order?: number | null;
+        }> | null;
         feature_blocks?: Array<{
             title?: string | null;
             text?: string | null;
@@ -18,6 +30,14 @@ export interface BrandSeriesProduct {
             icon?: string | null;
             footnote?: string | null;
         }> | null;
+        content_blocks?: Array<{
+            kind?: string | null;
+            title?: string | null;
+            text?: string | null;
+            image_url?: string | null;
+            layout?: string | null;
+        }> | null;
+        footnotes?: string[] | null;
     } | null;
     tags?: Array<{
         title?: string;
@@ -37,6 +57,25 @@ export interface BrandSeriesFeatureBlock {
     imageUrl: string;
     icon: string;
     footnote: string;
+}
+
+export interface BrandSeriesBrandFeature extends BrandSeriesFeatureBlock {
+    id: number | null;
+    slug: string;
+    sourceUrl: string;
+    sortOrder: number;
+}
+
+export interface BrandSeriesContentBlock {
+    kind: string;
+    title: string;
+    text: string;
+    imageUrl: string;
+    layout: string;
+}
+
+export interface BrandSeriesVisualBlock extends BrandSeriesFeatureBlock {
+    source: "feature_block" | "brand_feature" | "content_block";
 }
 
 const CATALOG_GROUP_DEFINITIONS = {
@@ -95,8 +134,14 @@ export interface BrandSeriesGroup<T extends BrandSeriesProduct> {
     shortDescription: string;
     description: string;
     heroImage: string;
+    galleryImages: string[];
     features: string[];
+    brandFeatures: BrandSeriesBrandFeature[];
     featureBlocks: BrandSeriesFeatureBlock[];
+    contentBlocks: BrandSeriesContentBlock[];
+    footnotes: string[];
+    primaryImage: string;
+    visualFeatureBlocks: BrandSeriesVisualBlock[];
     catalogGroupKey: CatalogGroupKey;
     products: T[];
     anchorId: string;
@@ -163,6 +208,14 @@ const normalizeSeriesFeatures = (value: unknown) =>
         ? value.map((item) => asText(item)).filter(Boolean)
         : [];
 
+const normalizeSeriesGalleryImages = (series: BrandSeriesProduct["series"]) => {
+    const images = [
+        asText(series?.hero_image),
+        ...(Array.isArray(series?.gallery_images) ? series.gallery_images.map((item) => asText(item)) : []),
+    ].filter(Boolean);
+    return [...new Set(images)];
+};
+
 const normalizeSeriesFeatureBlocks = (value: unknown): BrandSeriesFeatureBlock[] =>
     Array.isArray(value)
         ? value
@@ -181,6 +234,96 @@ const normalizeSeriesFeatureBlocks = (value: unknown): BrandSeriesFeatureBlock[]
             })
             .filter((item): item is BrandSeriesFeatureBlock => Boolean(item))
         : [];
+
+const normalizeSeriesBrandFeatures = (value: unknown): BrandSeriesBrandFeature[] =>
+    Array.isArray(value)
+        ? value
+            .map((item) => {
+                if (!item || typeof item !== "object") return null;
+                const feature = item as Record<string, unknown>;
+                const title = asText(feature.title);
+                if (!title) return null;
+                const sortOrder = Number(feature.sort_order);
+                return {
+                    id: typeof feature.id === "number" ? feature.id : null,
+                    title,
+                    slug: asText(feature.slug),
+                    text: asText(feature.text),
+                    imageUrl: asText(feature.image_url),
+                    icon: asText(feature.icon),
+                    footnote: asText(feature.footnote),
+                    sourceUrl: asText(feature.source_url),
+                    sortOrder: Number.isFinite(sortOrder) ? sortOrder : 0,
+                };
+            })
+            .filter((item): item is BrandSeriesBrandFeature => Boolean(item))
+            .sort((a, b) => a.sortOrder - b.sortOrder || a.title.localeCompare(b.title, "ru"))
+        : [];
+
+const normalizeSeriesContentBlocks = (value: unknown): BrandSeriesContentBlock[] =>
+    Array.isArray(value)
+        ? value
+            .map((item) => {
+                if (!item || typeof item !== "object") return null;
+                const block = item as Record<string, unknown>;
+                const title = asText(block.title);
+                const text = asText(block.text);
+                const imageUrl = asText(block.image_url);
+                if (!title && !text && !imageUrl) return null;
+                return {
+                    kind: asText(block.kind) || "text",
+                    title,
+                    text,
+                    imageUrl,
+                    layout: asText(block.layout) || "text_left",
+                };
+            })
+            .filter((item): item is BrandSeriesContentBlock => Boolean(item))
+        : [];
+
+const getPrimarySeriesImage = (group: {
+    galleryImages: string[];
+    featureBlocks: BrandSeriesFeatureBlock[];
+    brandFeatures: BrandSeriesBrandFeature[];
+    contentBlocks: BrandSeriesContentBlock[];
+}) =>
+    group.galleryImages[0]
+    || group.featureBlocks.find((block) => block.imageUrl)?.imageUrl
+    || group.brandFeatures.find((block) => block.imageUrl)?.imageUrl
+    || group.contentBlocks.find((block) => block.imageUrl)?.imageUrl
+    || "";
+
+const buildVisualFeatureBlocks = (group: {
+    featureBlocks: BrandSeriesFeatureBlock[];
+    brandFeatures: BrandSeriesBrandFeature[];
+    contentBlocks: BrandSeriesContentBlock[];
+}): BrandSeriesVisualBlock[] => {
+    const seen = new Set<string>();
+    const blocks: BrandSeriesVisualBlock[] = [];
+    const addBlock = (block: BrandSeriesFeatureBlock, source: BrandSeriesVisualBlock["source"]) => {
+        const key = normalizeText(`${block.title} ${block.text}`);
+        if (!block.title || seen.has(key)) return;
+        seen.add(key);
+        blocks.push({ ...block, source });
+    };
+
+    group.featureBlocks.forEach((block) => addBlock(block, "feature_block"));
+    group.brandFeatures.forEach((block) => addBlock(block, "brand_feature"));
+    group.contentBlocks.forEach((block) =>
+        addBlock(
+            {
+                title: block.title || "Особенность серии",
+                text: block.text,
+                imageUrl: block.imageUrl,
+                icon: "",
+                footnote: "",
+            },
+            "content_block",
+        ),
+    );
+
+    return blocks;
+};
 
 const getTagSlugs = (product: BrandSeriesProduct) =>
     (product.tags || []).map((tag) => normalizeText(tag.slug || tag.title));
@@ -367,6 +510,10 @@ export const buildBrandSeriesCatalog = <T extends BrandSeriesProduct>(
         }
 
         if (!seriesGroupsMap.has(key)) {
+            const galleryImages = normalizeSeriesGalleryImages(product.series);
+            const featureBlocks = normalizeSeriesFeatureBlocks(product.series?.feature_blocks);
+            const brandFeatures = normalizeSeriesBrandFeatures(product.series?.brand_features);
+            const contentBlocks = normalizeSeriesContentBlocks(product.series?.content_blocks);
             seriesGroupsMap.set(key, {
                 key,
                 title,
@@ -374,8 +521,14 @@ export const buildBrandSeriesCatalog = <T extends BrandSeriesProduct>(
                 shortDescription: asText(product.series?.short_description),
                 description: asText(product.series?.description),
                 heroImage: asText(product.series?.hero_image),
+                galleryImages,
                 features: normalizeSeriesFeatures(product.series?.features),
-                featureBlocks: normalizeSeriesFeatureBlocks(product.series?.feature_blocks),
+                brandFeatures,
+                featureBlocks,
+                contentBlocks,
+                footnotes: normalizeSeriesFeatures(product.series?.footnotes),
+                primaryImage: "",
+                visualFeatureBlocks: [],
                 catalogGroupKey: getProductCatalogGroupKey(product),
                 products: [],
             });
@@ -387,11 +540,23 @@ export const buildBrandSeriesCatalog = <T extends BrandSeriesProduct>(
             if (!group.shortDescription) group.shortDescription = asText(product.series?.short_description);
             if (!group.description) group.description = asText(product.series?.description);
             if (!group.heroImage) group.heroImage = asText(product.series?.hero_image);
+            if (group.galleryImages.length === 0) {
+                group.galleryImages = normalizeSeriesGalleryImages(product.series);
+            }
             if (group.features.length === 0) {
                 group.features = normalizeSeriesFeatures(product.series?.features);
             }
+            if (group.brandFeatures.length === 0) {
+                group.brandFeatures = normalizeSeriesBrandFeatures(product.series?.brand_features);
+            }
             if (group.featureBlocks.length === 0) {
                 group.featureBlocks = normalizeSeriesFeatureBlocks(product.series?.feature_blocks);
+            }
+            if (group.contentBlocks.length === 0) {
+                group.contentBlocks = normalizeSeriesContentBlocks(product.series?.content_blocks);
+            }
+            if (group.footnotes.length === 0) {
+                group.footnotes = normalizeSeriesFeatures(product.series?.footnotes);
             }
             group.products.push(product);
         }
@@ -404,14 +569,21 @@ export const buildBrandSeriesCatalog = <T extends BrandSeriesProduct>(
         return counts;
     }, new Map<string, number>());
     const getDistinctFeatures = getDistinctFeaturesFactory(rawSeriesGroups);
-    const seriesGroups = rawSeriesGroups.map((group, index) => ({
-        ...group,
-        anchorId: `series-${slugifySeriesFallback(group.key || group.title) || index + 1}`,
-        catalogGroup: catalogGroups[group.catalogGroupKey],
-        displayTitle: getDisplayTitle(group.title, group.products, seriesTitleCounts.get(normalizeText(group.title)) || 0),
-        distinctFeatures: getDistinctFeatures(group.features),
-        previewProducts: getSeriesPreviewProducts(group.products),
-    }));
+    const seriesGroups = rawSeriesGroups.map((group, index) => {
+        const normalizedGroup = {
+            ...group,
+            primaryImage: getPrimarySeriesImage(group),
+            visualFeatureBlocks: buildVisualFeatureBlocks(group),
+        };
+        return {
+            ...normalizedGroup,
+            anchorId: `series-${slugifySeriesFallback(group.key || group.title) || index + 1}`,
+            catalogGroup: catalogGroups[group.catalogGroupKey],
+            displayTitle: getDisplayTitle(group.title, group.products, seriesTitleCounts.get(normalizeText(group.title)) || 0),
+            distinctFeatures: getDistinctFeatures(group.features),
+            previewProducts: getSeriesPreviewProducts(group.products),
+        };
+    });
     const seriesGroupsByCatalog = catalogGroupList
         .map((catalogGroup) => ({
             ...catalogGroup,

--- a/web/tests/brand-series.test.mjs
+++ b/web/tests/brand-series.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import ts from "typescript";
+
+const sourceUrl = new URL("../src/utils/brand-series.ts", import.meta.url);
+const source = await readFile(sourceUrl, "utf8");
+const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+    },
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+const { buildBrandSeriesCatalog } = await import(moduleUrl);
+
+describe("brand series catalog", () => {
+    it("keeps rich series media and feature blocks structured", () => {
+        const products = [
+            {
+                title: "LG Eco 09",
+                slug: "lg-eco-09",
+                area: 25,
+                series: {
+                    title: "Eco Smart",
+                    slug: "eco-smart",
+                    tagline: "Практичная инверторная серия",
+                    short_description: "Для квартир и офисов.",
+                    hero_image: "/media/series/eco-hero.webp",
+                    gallery_images: ["/media/series/eco-gallery.webp"],
+                    features: ["Dual Inverter", "Wi-Fi"],
+                    brand_features: [
+                        {
+                            id: 2,
+                            title: "Gold Fin",
+                            slug: "gold-fin",
+                            text: "Защита теплообменника.",
+                            image_url: "/media/features/gold-fin.webp",
+                            icon: "shield",
+                            footnote: "Зависит от модели",
+                            sort_order: 20,
+                        },
+                    ],
+                    feature_blocks: [
+                        {
+                            title: "Dual Inverter",
+                            text: "Компрессор регулирует мощность.",
+                            image_url: "/media/features/dual-inverter.webp",
+                            icon: "speed",
+                            footnote: "Гарантия зависит от условий.",
+                        },
+                    ],
+                    content_blocks: [
+                        {
+                            kind: "image_text",
+                            title: "Тихая работа",
+                            text: "Подходит для спальни.",
+                            image_url: "/media/features/quiet.webp",
+                            layout: "text_right",
+                        },
+                    ],
+                    footnotes: ["Точные характеристики зависят от модели."],
+                },
+                specs: { type: "сплит-система" },
+                tags: [{ slug: "cat-household", is_public: true }],
+            },
+        ];
+
+        const catalog = buildBrandSeriesCatalog(products, products, "LG");
+        const group = catalog.seriesGroups[0];
+
+        assert.equal(group.primaryImage, "/media/series/eco-hero.webp");
+        assert.deepEqual(group.galleryImages, ["/media/series/eco-hero.webp", "/media/series/eco-gallery.webp"]);
+        assert.equal(group.brandFeatures[0].title, "Gold Fin");
+        assert.equal(group.featureBlocks[0].title, "Dual Inverter");
+        assert.equal(group.contentBlocks[0].title, "Тихая работа");
+        assert.deepEqual(group.footnotes, ["Точные характеристики зависят от модели."]);
+        assert.deepEqual(
+            group.visualFeatureBlocks.map((block) => [block.source, block.title]),
+            [
+                ["feature_block", "Dual Inverter"],
+                ["brand_feature", "Gold Fin"],
+                ["content_block", "Тихая работа"],
+            ],
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- Rework brand pages into reusable Astro sections: brand hero, feature strip, series navigation, rich series catalog, and separate visual feature blocks.
- Extend public brand detail payload with published brand features while keeping brand list responses lightweight.
- Preserve product cards/catalog flow and expand series mapping for gallery images, brand features, content blocks, footnotes, primary images, and visual blocks.
- Regenerate OpenAPI/manager client for the new public brand detail response.

## Verification
- `SECRET_KEY=test-secret ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_public_brands_api.py -q`
- `node tests/brand-markdown.test.mjs && node tests/brand-series.test.mjs` using bundled Node and existing web dependencies
- `bash scripts/audit_theme_hardcodes.sh`
- `git diff --check`
- `astro build` reached Vite/static entrypoint and client build successfully, then stopped during SSG because local API fetches failed: `http://app:8000/api/v1/catalog?limit=1000 -> fetch failed`, `http://localhost:8000/api/v1/catalog?limit=1000 -> API Error 500`
- Browser QA with mock rich brand payload: desktop rendered hero/features/series/product cards with no broken images or horizontal overflow; in-app browser became unstable on final mobile rerun, but mobile CSS was then tightened to clamp intro text and reduce hero media height.
