### PR TITLE
Fix Aircond parser for current product pages

### DIFF
--- a/parsers/aircond.py
+++ b/parsers/aircond.py
@@ -1,6 +1,7 @@
+import json
 import re
 from typing import Dict, Any, List
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -28,21 +29,128 @@ class AircondParser(BaseParser):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_spec_value(td_cell) -> str:
-        """Extract value from a <td> cell in the specs table.
+    def _clean_text(value: Any) -> str:
+        return re.sub(r"\s+", " ", str(value or "").replace("\xa0", " ")).strip()
 
-        Boolean rows use <p class="table__icon true"> / <p class="table__icon false">
-        instead of text.
-        """
-        true_icon = td_cell.find("p", class_="table__icon")
-        if true_icon:
-            css_classes = true_icon.get("class", [])
+    @classmethod
+    def _extract_boolean_icon_value(cls, cell) -> str | None:
+        table_icon = cell.find("p", class_="table__icon")
+        if table_icon:
+            css_classes = table_icon.get("class", [])
             if "true" in css_classes:
                 return "да"
             if "false" in css_classes:
                 return "нет"
 
-        return td_cell.get_text(" ", strip=True).replace("\xa0", " ")
+        svg = cell.find("svg")
+        if not svg:
+            return None
+
+        classes = svg.get("class") or []
+        if "lucide-check" in classes:
+            return "да"
+        if "lucide-x" in classes or "lucide-minus" in classes:
+            return "нет"
+        return None
+
+    @classmethod
+    def _extract_spec_value(cls, td_cell) -> str:
+        """Extract value from a <td> cell in the specs table.
+
+        Boolean rows use <p class="table__icon true"> / <p class="table__icon false">
+        instead of text.
+        """
+        icon_value = cls._extract_boolean_icon_value(td_cell)
+        if icon_value is not None:
+            return icon_value
+
+        return cls._clean_text(td_cell.get_text(" ", strip=True))
+
+    @classmethod
+    def _extract_specs(cls, soup: BeautifulSoup) -> Dict[str, str]:
+        specs: Dict[str, str] = {}
+
+        spec_table = soup.select_one(".product__specs table")
+        if spec_table:
+            for row in spec_table.find_all("tr"):
+                th = row.find("th")
+                td = row.find("td")
+                if not th or not td:
+                    continue
+                key = cls._clean_text(th.get_text(" ", strip=True)).rstrip(":")
+                value = cls._extract_spec_value(td)
+                if key and value:
+                    specs[key] = value
+
+        modern_section = cls._find_section_by_heading(soup, "характеристики")
+        if modern_section:
+            for row in modern_section.find_all("div"):
+                spans = row.find_all("span", recursive=False)
+                if len(spans) < 2:
+                    continue
+                key = cls._clean_text(spans[0].get_text(" ", strip=True)).rstrip(":")
+                value = cls._extract_spec_value(spans[1])
+                if key and value:
+                    specs[key] = value
+
+        return specs
+
+    @classmethod
+    def _find_section_by_heading(cls, soup: BeautifulSoup, heading: str):
+        target = heading.strip().lower()
+        for header in soup.find_all(["h2", "h3"]):
+            if cls._clean_text(header.get_text(" ", strip=True)).lower() == target:
+                return header.parent
+        return None
+
+    @staticmethod
+    def _iter_json_ld_objects(soup: BeautifulSoup):
+        def walk(value):
+            if isinstance(value, dict):
+                yield value
+                graph = value.get("@graph")
+                if isinstance(graph, list):
+                    for item in graph:
+                        yield from walk(item)
+            elif isinstance(value, list):
+                for item in value:
+                    yield from walk(item)
+
+        for script in soup.find_all("script", type="application/ld+json"):
+            raw = script.string or script.get_text()
+            if not raw:
+                continue
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            yield from walk(parsed)
+
+    @classmethod
+    def _extract_product_schema(cls, soup: BeautifulSoup) -> Dict[str, Any]:
+        for item in cls._iter_json_ld_objects(soup):
+            item_type = item.get("@type")
+            if item_type == "Product" or (
+                isinstance(item_type, list) and "Product" in item_type
+            ):
+                return item
+        return {}
+
+    @staticmethod
+    def _parse_price(raw: Any) -> int:
+        if raw is None:
+            return 0
+        if isinstance(raw, (int, float)):
+            return int(float(raw))
+
+        match = re.search(r"\d[\d\s\xa0]*(?:[,.]\d+)?", str(raw))
+        if not match:
+            return 0
+        value = match.group(0).replace(" ", "").replace("\xa0", "").replace(",", ".")
+        try:
+            return int(float(value))
+        except ValueError:
+            return 0
 
     # ------------------------------------------------------------------
     # Image extraction
@@ -50,24 +158,36 @@ class AircondParser(BaseParser):
 
     @classmethod
     def _collect_images(cls, soup: BeautifulSoup) -> List[str]:
-        """Collect high-quality webp/product images from the page.
-
-        Looks for <img> tags whose src contains '/media/' — these are
-        product/series photos hosted on aircond.by in webp format.
-        """
+        """Collect high-quality product images from old and current aircond.by markup."""
         seen: set[str] = set()
         result: List[str] = []
 
-        for img in soup.find_all("img"):
-            src = img.get("src") or img.get("data-src") or ""
-            if "/media/" not in src:
-                continue
-            # Make absolute if relative
-            if src.startswith("/"):
-                src = f"{cls.BASE_URL}{src}"
+        def add(src: str | None) -> None:
+            if not src:
+                return
+            src = urljoin(cls.BASE_URL, src)
+            if "/images/payment" in src or "/thumb-" in src:
+                return
+            if not (
+                "/media/" in src
+                or "/series/" in src
+                or urlparse(src).netloc == "cdn.aircond.by"
+            ):
+                return
             if src not in seen:
                 seen.add(src)
                 result.append(src)
+
+        product_schema = cls._extract_product_schema(soup)
+        schema_images = product_schema.get("image")
+        if isinstance(schema_images, str):
+            add(schema_images)
+        elif isinstance(schema_images, list):
+            for src in schema_images:
+                add(str(src))
+
+        for img in soup.find_all("img"):
+            add(img.get("src") or img.get("data-src"))
 
         return result
 
@@ -77,20 +197,94 @@ class AircondParser(BaseParser):
 
     @classmethod
     def _collect_related_urls(cls, soup: BeautifulSoup, current_url: str) -> List[str]:
-        """Extract hrefs from .series-products__link elements."""
+        """Extract related variant URLs from old and current product markup."""
         related: List[str] = []
+
+        current_absolute = current_url.rstrip("/")
+        current_path = urlparse(current_url).path.rstrip("/")
+
+        def add(href: str) -> None:
+            absolute = urljoin(current_url, href).split("#", 1)[0].split("?", 1)[0]
+            parsed = urlparse(absolute)
+            path = parsed.path.rstrip("/")
+            if absolute.rstrip("/") == current_absolute:
+                return
+            if path == "/split-sistemy" or not path.startswith("/split-sistemy/"):
+                return
+            if path == current_path:
+                return
+            if absolute not in related:
+                related.append(absolute)
+
         for link in soup.select("a.series-products__link"):
             href = link.get("href", "")
             if not href:
                 continue
-            # Make absolute
-            if href.startswith("/"):
-                href = f"{cls.BASE_URL}{href}"
-            elif not href.startswith("http"):
-                href = urljoin(current_url, href)
-            if href != current_url and href not in related:
-                related.append(href)
+            add(href)
+
+        for link in soup.find_all("a", href=True):
+            classes = link.get("class") or []
+            if "rounded-md" not in classes or "border" not in classes:
+                continue
+            add(link["href"])
+
         return related
+
+    @classmethod
+    def _extract_description(cls, soup: BeautifulSoup, product_schema: Dict[str, Any]) -> str:
+        descr_el = soup.select_one(".product__descr")
+        if descr_el:
+            return descr_el.get_text("\n", strip=True)
+
+        schema_description = product_schema.get("description")
+        if schema_description:
+            return cls._clean_text(schema_description)
+
+        description_section = cls._find_section_by_heading(soup, "описание")
+        if not description_section:
+            return ""
+        prose = description_section.find(
+            "div",
+            class_=lambda classes: classes and "prose" in str(classes).split(),
+        )
+        target = prose or description_section
+        return cls._clean_text(target.get_text(" ", strip=True).replace("Описание", "", 1))
+
+    @classmethod
+    def _build_metrics(cls, specs: Dict[str, str]) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {
+            "power_cooling": None,
+            "power_heating": None,
+            "area": 0,
+            "is_inverter": False,
+            "min_temp_heating": None,
+        }
+
+        for key, value in specs.items():
+            key_lower = key.lower()
+            value_lower = value.lower()
+            normalized_value = value.replace(",", ".")
+
+            if "обслуживаемая площадь" in key_lower or "площадь помещения" in key_lower:
+                m = re.search(r"(\d+)", value)
+                if m and not metrics["area"]:
+                    metrics["area"] = int(m.group(1))
+            elif "инвертор" in key_lower:
+                metrics["is_inverter"] = value_lower.startswith("да") or "инвертор" in value_lower
+            elif "мощность охлаждения" in key_lower:
+                m = re.search(r"([\d.]+)", normalized_value)
+                if m:
+                    metrics["power_cooling"] = float(m.group(1))
+            elif "мощность обогрева" in key_lower:
+                m = re.search(r"([\d.]+)", normalized_value)
+                if m:
+                    metrics["power_heating"] = float(m.group(1))
+            elif "минимальная температура" in key_lower or "рабочая температура при обогреве" in key_lower:
+                m = re.search(r"(-\d+)", value)
+                if m:
+                    metrics["min_temp_heating"] = int(m.group(1))
+
+        return metrics
 
     # ------------------------------------------------------------------
     # Slug from URL
@@ -124,76 +318,42 @@ class AircondParser(BaseParser):
                 )
 
         soup = BeautifulSoup(resp.text, "html.parser")
+        product_schema = self._extract_product_schema(soup)
 
         # --- Title ---
-        h1 = soup.select_one("h1.product__name")
-        title = h1.get_text(strip=True) if h1 else "Без названия"
+        h1 = soup.select_one("h1.product__name") or soup.select_one("h1.page-title") or soup.find("h1")
+        title = (
+            h1.get_text(strip=True)
+            if h1
+            else self._clean_text(product_schema.get("name") or "Без названия")
+        )
 
         # --- Price ---
         price = 0
         price_el = soup.select_one('.offer__price span[property="price"]')
         if price_el:
             raw = price_el.get("content") or price_el.get_text(strip=True)
-            try:
-                price = int(float(raw.replace(" ", "").replace("\xa0", "")))
-            except (ValueError, TypeError):
-                pass
+            price = self._parse_price(raw)
+        if not price:
+            offers = product_schema.get("offers") or {}
+            if isinstance(offers, list):
+                offers = offers[0] if offers else {}
+            if isinstance(offers, dict):
+                price = self._parse_price(offers.get("price"))
+        if not price:
+            fallback_price_el = soup.find(
+                "span",
+                class_=lambda classes: classes and "text-3xl" in str(classes).split(),
+            )
+            if fallback_price_el:
+                price = self._parse_price(fallback_price_el.get_text(" ", strip=True))
 
         # --- Description ---
-        descr_el = soup.select_one(".product__descr")
-        description = descr_el.get_text("\n", strip=True) if descr_el else ""
+        description = self._extract_description(soup, product_schema)
 
         # --- Specs ---
-        all_specs: Dict[str, str] = {}
-        target_specs: Dict[str, Any] = {
-            "power_cooling": None,
-            "power_heating": None,
-            "area": 0,
-            "is_inverter": False,
-            "min_temp_heating": None,
-        }
-
-        spec_table = soup.select_one(".product__specs table")
-        if spec_table:
-            for row in spec_table.find_all("tr"):
-                th = row.find("th")
-                td = row.find("td")
-                if not th or not td:
-                    continue
-                key = th.get_text(" ", strip=True).replace("\xa0", " ").rstrip(":")
-                value = self._extract_spec_value(td)
-
-                all_specs[key] = value
-
-                key_lower = key.lower()
-
-                # Area
-                if "обслуживаемая площадь" in key_lower or "площадь помещения" in key_lower:
-                    m = re.search(r"(\d+)", value)
-                    if m and not target_specs["area"]:
-                        target_specs["area"] = int(m.group(1))
-
-                # Inverter
-                elif "инверторн" in key_lower:
-                    target_specs["is_inverter"] = value.lower().startswith("да")
-
-                # Cooling power
-                elif "мощность охлаждения" in key_lower:
-                    m = re.search(r"([\d.]+)", value)
-                    if m:
-                        target_specs["power_cooling"] = float(m.group(1))
-
-                # Heating power
-                elif "мощность обогрева" in key_lower:
-                    m = re.search(r"([\d.]+)", value)
-                    if m:
-                        target_specs["power_heating"] = float(m.group(1))
-
-                # Min temperature (heating)
-                elif "минимальная температура" in key_lower or "рабочая температура при обогреве" in key_lower:
-                    m = re.search(r"(-\d+)", value)
-                    if m:
-                        target_specs["min_temp_heating"] = int(m.group(1))
+        all_specs = self._extract_specs(soup)
+        target_specs = self._build_metrics(all_specs)
 
         # --- Images ---
         images = self._collect_images(soup)

--- a/services/spec_registry.py
+++ b/services/spec_registry.py
@@ -105,7 +105,12 @@ SPEC_DEFINITIONS: Mapping[str, SpecDefinition] = {
     "model_indoor": _spec("model_indoor", "Модель внутреннего блока", SpecValueType.TEXT),
     "model_outdoor": _spec("model_outdoor", "Модель наружного блока", SpecValueType.TEXT),
     "sku": _spec("sku", "Артикул", SpecValueType.TEXT),
-    "release_year": _spec("release_year", "Дата выхода на рынок", SpecValueType.TEXT, aliases=("Дата выхода на рынок",)),
+    "release_year": _spec(
+        "release_year",
+        "Дата выхода на рынок",
+        SpecValueType.TEXT,
+        aliases=("Дата выхода на рынок", "Год модели"),
+    ),
     "inverter": _spec(
         "inverter",
         "Инвертор",
@@ -497,6 +502,7 @@ SPEC_DEFINITIONS = {
     ),
     "ionizer": _spec("ionizer", "Ионизатор", SpecValueType.BOOLEAN),
     "modes": _spec("modes", "Режимы работы", SpecValueType.TEXT),
+    "features": _spec("features", "Функции", SpecValueType.TEXT, aliases=("Функции", "Особенности")),
     "multi_max_total_pipe_length": _spec(
         "multi_max_total_pipe_length",
         "Максимальная суммарная длина магистрали",
@@ -743,6 +749,7 @@ REGISTRY_HELP_TEXTS: Mapping[str, tuple[str | None, str | None]] = {
     "drain_pipe_diameter": ("Диаметр дренажной трубы или патрубка.", None),
     "electrostatic_filter": ("Наличие электростатического фильтра.", None),
     "fan_speed": ("Наличие регулировки скорости вентилятора.", None),
+    "features": ("Список маркетинговых и технических функций из источника.", None),
     "fresh_air": ("Наличие функции или канала притока свежего воздуха.", None),
     "humidification": ("Наличие функции увлажнения воздуха.", None),
     "includes_indoor_unit": ("Признак, что внутренний блок входит в комплект поставки.", None),
@@ -1038,6 +1045,7 @@ REGISTRY_LEGACY_ALIASES_BY_KEY: Mapping[str, tuple[str, ...]] = {
         'Установка',
     ),
     'inverter': (
+        'Инвертор',
         'Тип системы',
         'Инверторная технология',
         'Инверторный',
@@ -1068,6 +1076,10 @@ REGISTRY_LEGACY_ALIASES_BY_KEY: Mapping[str, tuple[str, ...]] = {
     'modes': (
         'Режим работы',
         'Режимы работы',
+    ),
+    'features': (
+        'Функции',
+        'Особенности',
     ),
     'multi_compat_mode': (
         'multi_compat_mode',
@@ -1420,9 +1432,13 @@ def _aliases_for_key(key: str) -> list[str]:
 
 REGISTRY_DIMENSIONS_MAP: dict[str, tuple[str, str, str]] = {
     "Габариты внутреннего блока (ШхВхГ)": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Габариты внутреннего блока (Ш×В×Г)": ("width_indoor", "height_indoor", "depth_indoor"),
     "Габариты внутреннего блока (ШхВхГ), мм": ("width_indoor", "height_indoor", "depth_indoor"),
+    "Габариты внутреннего блока (Ш×В×Г), мм": ("width_indoor", "height_indoor", "depth_indoor"),
     "Габариты наружного блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты наружного блока (Ш×В×Г)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты наружного блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
+    "Габариты наружного блока (Ш×В×Г), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты внешнего блока (ШхВхГ)": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габариты внешнего блока (ШхВхГ), мм": ("width_outdoor", "height_outdoor", "depth_outdoor"),
     "Габаритные размеры внутреннего блока (ШxВxГ) мм": ("width_indoor", "height_indoor", "depth_indoor"),

--- a/tests/unit/test_aircond_parser.py
+++ b/tests/unit/test_aircond_parser.py
@@ -1,0 +1,146 @@
+import pytest
+
+from parsers.aircond import AircondParser
+from services.spec_normalizer import normalize_specs
+from services.spec_registry import REGISTRY_DIMENSIONS_MAP, REGISTRY_KEY_MAP
+
+
+AIRCOND_MODERN_PRODUCT_HTML = """
+<html>
+  <head>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Сплит-система TCL SaveIN AI Inverter Wi-Fi TAC-09CHSD/ZG11IHB",
+        "offers": {"@type": "Offer", "priceCurrency": "BYN", "price": 1850},
+        "image": [
+          "https://cdn.aircond.by/series/129/main.webp",
+          "https://cdn.aircond.by/series/129/side.webp"
+        ],
+        "description": "TCL SaveIN AI Inverter создает микроклимат в помещениях до 25 м²."
+      }
+    </script>
+  </head>
+  <body>
+    <h1 class="page-title lg:row-span-2">Сплит-система TCL SaveIN AI Inverter Wi-Fi TAC-09CHSD/ZG11IHB</h1>
+    <img src="https://cdn.aircond.by/series/129/thumb-main.webp" alt="thumb" />
+    <img src="https://cdn.aircond.by/series/129/main.webp" alt="main" />
+    <img src="/images/payment-methods.png" alt="payment" />
+    <a class="border-border rounded-md border px-3 py-1" href="/split-sistemy/tcl-savein-ai-inverter-tac-12chsdzg11ihb/">35 м²</a>
+    <a class="border-border rounded-md border px-3 py-1" href="/split-sistemy/tcl-savein-ai-inverter-wi-fi-tac-09chsdzg41ihb/">черный</a>
+
+    <section class="space-y-6 mb-6">
+      <h2 class="text-xl font-semibold md:text-2xl">Характеристики</h2>
+      <div>
+        <h3 class="mb-2 text-lg font-medium">Основные</h3>
+        <div class="space-y-0">
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Тип</span><span class="max-w-lg text-right font-medium"><span>сплит-система</span></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Бренд</span><span class="max-w-lg text-right font-medium"><span>TCL</span></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Год модели</span><span class="max-w-lg text-right font-medium"><span>2026</span></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Инвертор</span>
+            <span class="max-w-lg text-right font-medium"><svg class="lucide lucide-check size-4.5 text-emerald-500"></svg></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Wi-Fi</span>
+            <span class="max-w-lg text-right font-medium"><svg class="lucide lucide-check size-4.5 text-emerald-500"></svg></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Функции</span>
+            <span class="max-w-lg text-right font-medium"><span>T-AI Energy Saving, Coanda Airflow, самоочистка</span></span>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3 class="mb-2 text-lg font-medium">Производительность</h3>
+        <div class="space-y-0">
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Обслуживаемая площадь</span><span class="max-w-lg text-right font-medium"><span>25 м²</span></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Мощность охлаждения</span><span class="max-w-lg text-right font-medium"><span>2.62 кВт</span></span>
+          </div>
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Рабочая температура при обогреве</span><span class="max-w-lg text-right font-medium"><span>-20...+30 °C</span></span>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3 class="mb-2 text-lg font-medium">Габариты</h3>
+        <div class="space-y-0">
+          <div class="-mx-3 grid grid-cols-[1fr_auto] gap-3 border-b px-3 py-2.5 text-sm">
+            <span class="text-neutral-600">Габариты внутреннего блока (Ш×В×Г)</span><span class="max-w-lg text-right font-medium"><span>778 × 272 × 192 мм</span></span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </body>
+</html>
+"""
+
+
+class _FakeResponse:
+    status_code = 200
+    text = AIRCOND_MODERN_PRODUCT_HTML
+
+
+class _FakeClient:
+    def __init__(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url):  # noqa: ARG002
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_aircond_parser_handles_current_product_markup(monkeypatch):
+    monkeypatch.setattr("parsers.aircond.httpx.AsyncClient", _FakeClient)
+
+    data = await AircondParser().parse(
+        "https://aircond.by/split-sistemy/tcl-savein-ai-inverter-tac-09chsdzg11ihb/"
+    )
+
+    assert data["title"] == "Сплит-система TCL SaveIN AI Inverter Wi-Fi TAC-09CHSD/ZG11IHB"
+    assert data["price"] == 1850
+    assert data["main_image"] == "https://cdn.aircond.by/series/129/main.webp"
+    assert data["images"] == ["https://cdn.aircond.by/series/129/side.webp"]
+    assert data["related_urls"] == [
+        "https://aircond.by/split-sistemy/tcl-savein-ai-inverter-tac-12chsdzg11ihb/",
+        "https://aircond.by/split-sistemy/tcl-savein-ai-inverter-wi-fi-tac-09chsdzg41ihb/",
+    ]
+    assert data["specs"]["Инвертор"] == "да"
+    assert data["specs"]["Wi-Fi"] == "да"
+    assert data["metrics"]["power_cooling"] == 2.62
+    assert data["metrics"]["area"] == 25
+    assert data["metrics"]["min_temp_heating"] == -20
+
+    normalized = normalize_specs(data["specs"], title=data["title"], auto_tag_slugs=[])
+    unmapped = {
+        key: value
+        for key, value in data["specs"].items()
+        if key not in REGISTRY_KEY_MAP and key not in REGISTRY_DIMENSIONS_MAP and key not in normalized
+    }
+
+    assert unmapped == {}
+    assert normalized["release_year"] == "2026"
+    assert normalized["inverter"] is True
+    assert normalized["wifi_state"] == "builtin"
+    assert normalized["features"] == "T-AI Energy Saving, Coanda Airflow, самоочистка"
+    assert normalized["capacity_cooling_kw"] == "2.62"
+    assert normalized["temp_range_heat"] == "-20...+30 °C"
+    assert normalized["width_indoor"] == "778"
+    assert normalized["height_indoor"] == "272"
+    assert normalized["depth_indoor"] == "192"


### PR DESCRIPTION
## Summary
- update `AircondParser` for the current aircond.by Next/utility markup
- read product JSON-LD for title/price/description/images and keep old markup fallbacks
- extract modern specs rows, boolean icon values, full-size gallery images and variant links
- extend spec registry aliases for `Год модели`, `Инвертор`, `Функции`, and `Ш×В×Г` dimensions
- add unit coverage for the current aircond.by product layout

## Root Cause
The parser still targeted the old aircond.by classes (`product__name`, `.offer__price`, `.product__specs table`, `/media/` images). The current TCL SaveIN pages render with different markup, so dry-run returned `Без названия`, zero price, zero images and zero specs.

## Validation
- Live dry-run: `https://aircond.by/split-sistemy/tcl-savein-ai-inverter-tac-09chsdzg11ihb/`
  - title parsed
  - price `1850`
  - 28 raw specs
  - 7 full-size images
  - 4 related URLs from the page
  - no unmapped normalized keys after dimension-map handling
- Live series audit from related URLs: 6 TCL SaveIN pages checked, all with no unmapped keys
- `python3 -m py_compile parsers/aircond.py services/spec_registry.py`
- `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_aircond_parser.py tests/unit/test_spec_registry.py tests/unit/test_spec_normalizer_filters.py tests/unit/test_importer_service_wifi.py -q` -> 53 passed

## Local Caveat
Full local `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit -q` reached 731 passed but then failed in DB-backed test setup because local PostgreSQL on `localhost:5433` was unavailable. Docker daemon was also not reachable locally, so I could not run the CI-style docker pytest pass from this machine.
