### PR TITLE
Track static storefront rebuild status

### DIFF
--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -2,6 +2,11 @@ name: Turbo Rebuild Web ⚡
 
 on:
   workflow_dispatch:
+    inputs:
+      catalog_revision:
+        description: Catalog revision that should be marked published after deploy
+        required: false
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -147,3 +152,47 @@ jobs:
 
           echo "::error::Manual web rebuild failed after ${MAX_ATTEMPTS} attempts (${FAILURE_KIND})."
           exit 1
+
+      - name: Mark catalog static revision published
+        if: ${{ success() }}
+        env:
+          CATALOG_REVISION: ${{ inputs.catalog_revision }}
+          WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
+          WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
+            echo "No callback token configured; skipping API callback."
+            exit 0
+          fi
+
+          CATALOG_REVISION="${CATALOG_REVISION:-0}"
+          CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
+          if ! curl -fsS -X POST "${CALLBACK_URL}" \
+            -H "Content-Type: application/json" \
+            -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
+            --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"success\"}"; then
+            echo "::warning::Static revision was deployed, but API callback failed."
+          fi
+
+      - name: Mark catalog static rebuild failed
+        if: ${{ failure() }}
+        env:
+          CATALOG_REVISION: ${{ inputs.catalog_revision }}
+          WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
+          WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
+            echo "No callback token configured; skipping failure callback."
+            exit 0
+          fi
+
+          CATALOG_REVISION="${CATALOG_REVISION:-0}"
+          CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
+          if ! curl -fsS -X POST "${CALLBACK_URL}" \
+            -H "Content-Type: application/json" \
+            -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
+            --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"; then
+            echo "::warning::Static rebuild failed, and API failure callback also failed."
+          fi

--- a/core/config.py
+++ b/core/config.py
@@ -198,6 +198,7 @@ class Settings(BaseSettings):
     GITHUB_TOKEN: str = ""
     GITHUB_OWNER: str = "mvnby"
     GITHUB_REPO: str = "air-api"
+    WEB_REBUILD_CALLBACK_TOKEN: str = ""
 
     # Mail integration (Yandex Mail by default)
     MAIL_IMAP_HOST: str = "imap.yandex.ru"

--- a/crud/catalog_revision.py
+++ b/crud/catalog_revision.py
@@ -10,11 +10,26 @@ from models import GlobalConfig
 CATALOG_REVISION_KEY = "catalog_revision"
 CATALOG_REVISION_EPOCH = datetime(1970, 1, 1)
 CATALOG_REVISION_DESCRIPTION = "Monotonic public catalog revision for storefront cache freshness."
+CATALOG_STATIC_PUBLISHED_REVISION_KEY = "catalog_static_published_revision"
+CATALOG_STATIC_PUBLISHED_AT_KEY = "catalog_static_published_at"
+CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY = "catalog_static_rebuild_requested_revision"
+CATALOG_STATIC_REBUILD_REQUESTED_AT_KEY = "catalog_static_rebuild_requested_at"
+CATALOG_STATIC_REBUILD_LAST_ERROR_KEY = "catalog_static_rebuild_last_error"
 
 
 class CatalogRevisionSnapshot(NamedTuple):
     revision: int
     updated_at: datetime
+
+
+class CatalogStaticPublishSnapshot(NamedTuple):
+    current_revision: int
+    current_updated_at: datetime
+    published_revision: int
+    published_at: datetime | None
+    requested_revision: int
+    requested_at: datetime | None
+    last_error: str | None
 
 
 def _parse_revision(value: str | None) -> int:
@@ -24,12 +39,69 @@ def _parse_revision(value: str | None) -> int:
         return 0
 
 
+def _parse_datetime(value: str | None) -> datetime | None:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return None
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
 def _scope_description(scope: str) -> str:
     normalized_scope = str(scope or "catalog").strip() or "catalog"
     return f"{CATALOG_REVISION_DESCRIPTION} Last scope: {normalized_scope}."
 
 
+def _static_key_description(label: str) -> str:
+    return f"Static storefront rebuild state. {label}"
+
+
 class CatalogRevisionDAO:
+    @staticmethod
+    async def _get_global_config_map(
+        session: AsyncSession,
+        keys: Iterable[str],
+    ) -> dict[str, GlobalConfig]:
+        normalized_keys = tuple(dict.fromkeys(str(key) for key in keys))
+        if not normalized_keys:
+            return {}
+        rows = (
+            await session.execute(
+                select(GlobalConfig).where(GlobalConfig.key.in_(normalized_keys))
+            )
+        ).scalars().all()
+        return {row.key: row for row in rows}
+
+    @staticmethod
+    async def _upsert_global_config(
+        session: AsyncSession,
+        *,
+        key: str,
+        value: str,
+        description: str,
+        now: datetime,
+    ) -> GlobalConfig:
+        row = (
+            await session.execute(
+                select(GlobalConfig).where(GlobalConfig.key == key).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            row = GlobalConfig(
+                key=key,
+                value=value,
+                updated_at=now,
+                description=description,
+            )
+        else:
+            row.value = value
+            row.updated_at = now
+            row.description = description
+        session.add(row)
+        return row
+
     @staticmethod
     async def get_current(session: AsyncSession) -> CatalogRevisionSnapshot:
         row = (
@@ -78,3 +150,139 @@ class CatalogRevisionDAO:
             revision=revision,
             updated_at=row.updated_at or now,
         )
+
+    @staticmethod
+    async def get_static_publish_snapshot(session: AsyncSession) -> CatalogStaticPublishSnapshot:
+        current = await CatalogRevisionDAO.get_current(session)
+        rows = await CatalogRevisionDAO._get_global_config_map(
+            session,
+            (
+                CATALOG_STATIC_PUBLISHED_REVISION_KEY,
+                CATALOG_STATIC_PUBLISHED_AT_KEY,
+                CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY,
+                CATALOG_STATIC_REBUILD_REQUESTED_AT_KEY,
+                CATALOG_STATIC_REBUILD_LAST_ERROR_KEY,
+            ),
+        )
+
+        published_revision = _parse_revision(
+            rows.get(CATALOG_STATIC_PUBLISHED_REVISION_KEY).value
+            if rows.get(CATALOG_STATIC_PUBLISHED_REVISION_KEY)
+            else None
+        )
+        requested_revision = _parse_revision(
+            rows.get(CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY).value
+            if rows.get(CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY)
+            else None
+        )
+        last_error = (
+            rows[CATALOG_STATIC_REBUILD_LAST_ERROR_KEY].value.strip()
+            if rows.get(CATALOG_STATIC_REBUILD_LAST_ERROR_KEY)
+            and rows[CATALOG_STATIC_REBUILD_LAST_ERROR_KEY].value.strip()
+            else None
+        )
+
+        return CatalogStaticPublishSnapshot(
+            current_revision=current.revision,
+            current_updated_at=current.updated_at,
+            published_revision=published_revision,
+            published_at=_parse_datetime(
+                rows.get(CATALOG_STATIC_PUBLISHED_AT_KEY).value
+                if rows.get(CATALOG_STATIC_PUBLISHED_AT_KEY)
+                else None
+            ),
+            requested_revision=requested_revision,
+            requested_at=_parse_datetime(
+                rows.get(CATALOG_STATIC_REBUILD_REQUESTED_AT_KEY).value
+                if rows.get(CATALOG_STATIC_REBUILD_REQUESTED_AT_KEY)
+                else None
+            ),
+            last_error=last_error,
+        )
+
+    @staticmethod
+    async def mark_static_rebuild_requested(
+        session: AsyncSession,
+        *,
+        revision: int,
+    ) -> CatalogStaticPublishSnapshot:
+        now = datetime.now()
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY,
+            value=str(max(0, int(revision))),
+            description=_static_key_description("Last requested catalog revision."),
+            now=now,
+        )
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_REQUESTED_AT_KEY,
+            value=now.isoformat(),
+            description=_static_key_description("Last rebuild request timestamp."),
+            now=now,
+        )
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_LAST_ERROR_KEY,
+            value="",
+            description=_static_key_description("Last rebuild failure text."),
+            now=now,
+        )
+        await session.flush()
+        return await CatalogRevisionDAO.get_static_publish_snapshot(session)
+
+    @staticmethod
+    async def mark_static_rebuild_completed(
+        session: AsyncSession,
+        *,
+        revision: int,
+    ) -> CatalogStaticPublishSnapshot:
+        now = datetime.now()
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_PUBLISHED_REVISION_KEY,
+            value=str(max(0, int(revision))),
+            description=_static_key_description("Last successfully published catalog revision."),
+            now=now,
+        )
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_PUBLISHED_AT_KEY,
+            value=now.isoformat(),
+            description=_static_key_description("Last successful publish timestamp."),
+            now=now,
+        )
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_LAST_ERROR_KEY,
+            value="",
+            description=_static_key_description("Last rebuild failure text."),
+            now=now,
+        )
+        await session.flush()
+        return await CatalogRevisionDAO.get_static_publish_snapshot(session)
+
+    @staticmethod
+    async def mark_static_rebuild_failed(
+        session: AsyncSession,
+        *,
+        revision: int,
+        error: str,
+    ) -> CatalogStaticPublishSnapshot:
+        now = datetime.now()
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_REQUESTED_REVISION_KEY,
+            value=str(max(0, int(revision))),
+            description=_static_key_description("Last requested catalog revision."),
+            now=now,
+        )
+        await CatalogRevisionDAO._upsert_global_config(
+            session,
+            key=CATALOG_STATIC_REBUILD_LAST_ERROR_KEY,
+            value=str(error or "GitHub Actions rebuild failed")[:1000],
+            description=_static_key_description("Last rebuild failure text."),
+            now=now,
+        )
+        await session.flush()
+        return await CatalogRevisionDAO.get_static_publish_snapshot(session)

--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, nextTick, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import type { Component } from 'vue';
-import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, ChevronDown, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText, Image as ImageIcon, ShieldCheck, Truck, Mail } from 'lucide-vue-next';
+import { Package, ShoppingCart, Users, UserPlus, Zap, Loader2, Menu, X, Sun, Moon, Calendar, Home, Settings, Wallet, ChevronLeft, ChevronRight, ChevronDown, Tags, FileSpreadsheet, Link2, Award, Database, Calculator, ReceiptText, Image as ImageIcon, ShieldCheck, Truck, Mail, AlertTriangle } from 'lucide-vue-next';
 import { api } from './api';
 import { getApiErrorMessage } from './utils/api-errors';
 import type { TelegramLoginPayload } from './api';
@@ -37,6 +37,7 @@ const loginError = ref('');
 const telegramLoginLoading = ref(false);
 const telegramLoginContainer = ref<HTMLElement | null>(null);
 const rebuildLoading = ref(false);
+const webRebuildStatus = ref<WebRebuildStatus | null>(null);
 const isMobileNavOpen = ref(false);
 const isDesktopNavCollapsed = ref(false);
 const theme = ref<'light' | 'dark'>('light');
@@ -49,6 +50,19 @@ const THEME_STORAGE_KEY = 'manager_theme';
 const NAV_SECTIONS_STORAGE_KEY = 'manager_nav_sections_v1';
 const telegramLoginBotUsername = String(import.meta.env.VITE_TELEGRAM_LOGIN_BOT_USERNAME || '').trim();
 const telegramCallbackName = 'onTelegramManagerAuth';
+let webRebuildStatusInterval: ReturnType<typeof window.setInterval> | null = null;
+
+type WebRebuildStatus = {
+  current_revision: number;
+  current_revision_updated_at: string;
+  published_revision: number;
+  published_at?: string | null;
+  requested_revision?: number | null;
+  requested_at?: string | null;
+  needs_rebuild: boolean;
+  state: string;
+  last_error?: string | null;
+};
 
 type NavItem = {
   path: string;
@@ -218,6 +232,48 @@ const currentView = computed(() => {
   return 'products';
 });
 
+const webRebuildNeedsAttention = computed(() => Boolean(webRebuildStatus.value?.needs_rebuild));
+const webRebuildQueued = computed(() => webRebuildStatus.value?.state === 'queued');
+const webRebuildNoticeVisible = computed(() => (
+  webRebuildNeedsAttention.value || Boolean(webRebuildStatus.value?.last_error)
+));
+
+const webRebuildNoticeClass = computed(() => {
+  if (webRebuildQueued.value) return 'border-blue-200 bg-blue-50 text-blue-900';
+  if (webRebuildNeedsAttention.value || webRebuildStatus.value?.last_error) {
+    return 'border-amber-200 bg-amber-50 text-amber-900';
+  }
+  return 'border-gray-200 bg-gray-50 text-gray-700';
+});
+
+const webRebuildNoticeTitle = computed(() => {
+  if (webRebuildQueued.value) return 'Сборка запущена';
+  if (webRebuildNeedsAttention.value) return 'Сайт устарел';
+  return 'Статика актуальна';
+});
+
+const webRebuildNoticeText = computed(() => {
+  if (webRebuildQueued.value) {
+    return 'GitHub Actions собирает Astro. После deploy предупреждение снимется.';
+  }
+  if (webRebuildNeedsAttention.value) {
+    return 'Каталог изменился после последней публикации. Нужна пересборка сайта.';
+  }
+  return 'Опубликована текущая ревизия каталога.';
+});
+
+const rebuildButtonLabel = computed(() => {
+  if (rebuildLoading.value) return 'Сборка...';
+  if (webRebuildNeedsAttention.value) return 'Пересобрать сайт';
+  return 'Обновить сайт';
+});
+
+const rebuildButtonTitle = computed(() => {
+  if (!isDesktopNavCollapsed.value) return '';
+  if (webRebuildNeedsAttention.value) return 'Статика устарела - пересобрать сайт';
+  return 'Обновить сайт';
+});
+
 const onPopState = () => {
   currentLocation.value = `${window.location.pathname}${window.location.search}`;
 };
@@ -256,6 +312,14 @@ const setToast = (message: string, type: 'success' | 'error' = 'success') => {
   }, 3000);
 };
 
+const fetchWebRebuildStatus = async () => {
+  try {
+    webRebuildStatus.value = await api.getWebRebuildStatus() as WebRebuildStatus;
+  } catch {
+    // Non-critical status widget; the rebuild button reports its own errors.
+  }
+};
+
 const handleLogin = async () => {
   loginLoading.value = true;
   loginError.value = '';
@@ -265,6 +329,7 @@ const handleLogin = async () => {
     showLoginModal.value = false;
     loginPassword.value = '';
     void fetchLeadsCount();
+    void fetchWebRebuildStatus();
   } catch {
     loginError.value = 'Неверный логин или пароль';
   } finally {
@@ -280,6 +345,7 @@ const handleTelegramLogin = async (payload: TelegramLoginPayload) => {
     isAuthenticated.value = true;
     showLoginModal.value = false;
     void fetchLeadsCount();
+    void fetchWebRebuildStatus();
   } catch (err) {
     loginError.value = getApiErrorMessage(err) || 'Не удалось войти через Telegram';
   } finally {
@@ -313,7 +379,9 @@ const handleRebuild = async () => {
   rebuildLoading.value = true;
   try {
     const result = await api.rebuildWeb();
+    webRebuildStatus.value = result as WebRebuildStatus;
     setToast(String(result.message || 'Сборка запущена. Сайт обновится через пару минут.'));
+    void fetchWebRebuildStatus();
   } catch (err) {
     setToast(`Ошибка при запуске сборки: ${getApiErrorMessage(err)}`, 'error');
   } finally {
@@ -336,6 +404,7 @@ const checkAuth = async () => {
     isAuthenticated.value = true;
     // Fetch the badge count once authenticated
     void fetchLeadsCount();
+    void fetchWebRebuildStatus();
   } catch {
     isAuthenticated.value = false;
     showLoginModal.value = true;
@@ -355,11 +424,18 @@ onMounted(() => {
     navigate('/manager');
   }
   window.addEventListener('popstate', onPopState);
+  webRebuildStatusInterval = window.setInterval(() => {
+    if (isAuthenticated.value) void fetchWebRebuildStatus();
+  }, 60_000);
   checkAuth();
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener('popstate', onPopState);
+  if (webRebuildStatusInterval) {
+    window.clearInterval(webRebuildStatusInterval);
+    webRebuildStatusInterval = null;
+  }
   delete window[telegramCallbackName];
 });
 
@@ -565,21 +641,42 @@ watch(currentPath, () => {
       </nav>
 
       <div class="p-3 border-t border-gray-100 mt-auto">
+        <div
+          v-if="webRebuildNoticeVisible && !isDesktopNavCollapsed"
+          class="mb-2 rounded-lg border px-3 py-2 text-xs leading-snug"
+          :class="webRebuildNoticeClass"
+        >
+          <div class="flex items-center gap-2 font-semibold">
+            <Loader2 v-if="webRebuildQueued" class="h-4 w-4 animate-spin shrink-0" />
+            <AlertTriangle v-else class="h-4 w-4 shrink-0" />
+            <span>{{ webRebuildNoticeTitle }}</span>
+          </div>
+          <p class="mt-1">{{ webRebuildNoticeText }}</p>
+          <p v-if="webRebuildStatus?.last_error" class="mt-1 break-words text-red-700">
+            {{ webRebuildStatus.last_error }}
+          </p>
+        </div>
         <button
-          class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all"
+          class="relative w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all"
           :class="[
             rebuildLoading
               ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-              : 'bg-teal-600 text-white hover:bg-teal-700 shadow-sm hover:shadow-md',
+              : webRebuildNeedsAttention
+                ? 'bg-amber-500 text-white hover:bg-amber-600 shadow-sm hover:shadow-md'
+                : 'bg-teal-600 text-white hover:bg-teal-700 shadow-sm hover:shadow-md',
             isDesktopNavCollapsed ? 'justify-center' : ''
           ]"
           :disabled="rebuildLoading"
           @click="handleRebuild"
-          :title="isDesktopNavCollapsed ? 'Обновить сайт (Deploy)' : ''"
+          :title="rebuildButtonTitle"
         >
+          <span
+            v-if="isDesktopNavCollapsed && webRebuildNeedsAttention"
+            class="absolute right-1 top-1 h-2.5 w-2.5 rounded-full bg-amber-300 ring-2 ring-white"
+          />
           <Loader2 v-if="rebuildLoading" class="w-5 h-5 animate-spin shrink-0" />
           <Zap v-else class="w-5 h-5 shrink-0" />
-          <span v-if="!isDesktopNavCollapsed">{{ rebuildLoading ? 'Сборка...' : 'Обновить сайт' }}</span>
+          <span v-if="!isDesktopNavCollapsed">{{ rebuildButtonLabel }}</span>
         </button>
       </div>
     </aside>

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -1063,6 +1063,10 @@ export const api = {
         return await SystemService.triggerRebuildWebApiSystemRebuildWebPost();
     },
 
+    async getWebRebuildStatus() {
+        return await SystemService.getRebuildWebStatusApiSystemRebuildWebStatusGet();
+    },
+
     async importProducts(urls: string[], withRelated: boolean, updateExisting: boolean): Promise<{
         success_count: number;
         error_count: number;

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -390,6 +390,9 @@ export type { TagGroupResponse } from './models/TagGroupResponse';
 export type { TagResponse } from './models/TagResponse';
 export type { TelegramLoginPayload } from './models/TelegramLoginPayload';
 export type { ValidationError } from './models/ValidationError';
+export type { WebRebuildCompletePayload } from './models/WebRebuildCompletePayload';
+export type { WebRebuildStatusResponse } from './models/WebRebuildStatusResponse';
+export type { WebRebuildTriggerResponse } from './models/WebRebuildTriggerResponse';
 
 export { ApiService } from './services/ApiService';
 export { LoginService } from './services/LoginService';

--- a/manager_frontend/src/client/models/WebRebuildCompletePayload.ts
+++ b/manager_frontend/src/client/models/WebRebuildCompletePayload.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WebRebuildCompletePayload = {
+    catalog_revision: number;
+    status?: string;
+    error?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/WebRebuildStatusResponse.ts
+++ b/manager_frontend/src/client/models/WebRebuildStatusResponse.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WebRebuildStatusResponse = {
+    current_revision: number;
+    current_revision_updated_at: string;
+    published_revision: number;
+    published_at?: (string | null);
+    requested_revision?: (number | null);
+    requested_at?: (string | null);
+    needs_rebuild: boolean;
+    state: string;
+    last_error?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/WebRebuildTriggerResponse.ts
+++ b/manager_frontend/src/client/models/WebRebuildTriggerResponse.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WebRebuildTriggerResponse = {
+    current_revision: number;
+    current_revision_updated_at: string;
+    published_revision: number;
+    published_at?: (string | null);
+    requested_revision?: (number | null);
+    requested_at?: (string | null);
+    needs_rebuild: boolean;
+    state: string;
+    last_error?: (string | null);
+    message: string;
+};
+

--- a/manager_frontend/src/client/services/SystemService.ts
+++ b/manager_frontend/src/client/services/SystemService.ts
@@ -2,21 +2,61 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { WebRebuildCompletePayload } from '../models/WebRebuildCompletePayload';
+import type { WebRebuildStatusResponse } from '../models/WebRebuildStatusResponse';
+import type { WebRebuildTriggerResponse } from '../models/WebRebuildTriggerResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 export class SystemService {
     /**
+     * Get Rebuild Web Status
+     * Return whether the static Astro storefront is behind catalog data.
+     * @returns WebRebuildStatusResponse Successful Response
+     * @throws ApiError
+     */
+    public static getRebuildWebStatusApiSystemRebuildWebStatusGet(): CancelablePromise<WebRebuildStatusResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/system/rebuild-web/status',
+        });
+    }
+    /**
      * Trigger Rebuild Web
      * Trigger a turbo-rebuild of the frontend Astro site.
      * Accessible only by authenticated managers/admins.
-     * @returns any Successful Response
+     * @returns WebRebuildTriggerResponse Successful Response
      * @throws ApiError
      */
-    public static triggerRebuildWebApiSystemRebuildWebPost(): CancelablePromise<any> {
+    public static triggerRebuildWebApiSystemRebuildWebPost(): CancelablePromise<WebRebuildTriggerResponse> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/system/rebuild-web',
+        });
+    }
+    /**
+     * Complete Rebuild Web
+     * Callback for GitHub Actions after the static storefront deploy completes.
+     * @param requestBody
+     * @param xWebRebuildToken
+     * @returns WebRebuildStatusResponse Successful Response
+     * @throws ApiError
+     */
+    public static completeRebuildWebApiSystemRebuildWebCompletePost(
+        requestBody: WebRebuildCompletePayload,
+        xWebRebuildToken?: (string | null),
+    ): CancelablePromise<WebRebuildStatusResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/system/rebuild-web/complete',
+            headers: {
+                'X-Web-Rebuild-Token': xWebRebuildToken,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -16140,6 +16140,33 @@
         }
       }
     },
+    "/api/system/rebuild-web/status": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Get Rebuild Web Status",
+        "description": "Return whether the static Astro storefront is behind catalog data.",
+        "operationId": "get_rebuild_web_status_api_system_rebuild_web_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebRebuildStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/system/rebuild-web": {
       "post": {
         "tags": [
@@ -16153,7 +16180,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/WebRebuildTriggerResponse"
+                }
               }
             }
           }
@@ -16163,6 +16192,66 @@
             "OAuth2PasswordBearer": []
           }
         ]
+      }
+    },
+    "/api/system/rebuild-web/complete": {
+      "post": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Complete Rebuild Web",
+        "description": "Callback for GitHub Actions after the static storefront deploy completes.",
+        "operationId": "complete_rebuild_web_api_system_rebuild_web_complete_post",
+        "parameters": [
+          {
+            "name": "X-Web-Rebuild-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Web-Rebuild-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebRebuildCompletePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebRebuildStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -41815,6 +41904,200 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "WebRebuildCompletePayload": {
+        "properties": {
+          "catalog_revision": {
+            "type": "integer",
+            "title": "Catalog Revision"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "success"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "catalog_revision"
+        ],
+        "title": "WebRebuildCompletePayload"
+      },
+      "WebRebuildStatusResponse": {
+        "properties": {
+          "current_revision": {
+            "type": "integer",
+            "title": "Current Revision"
+          },
+          "current_revision_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Current Revision Updated At"
+          },
+          "published_revision": {
+            "type": "integer",
+            "title": "Published Revision"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
+          "requested_revision": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested Revision"
+          },
+          "requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested At"
+          },
+          "needs_rebuild": {
+            "type": "boolean",
+            "title": "Needs Rebuild"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "current_revision",
+          "current_revision_updated_at",
+          "published_revision",
+          "needs_rebuild",
+          "state"
+        ],
+        "title": "WebRebuildStatusResponse"
+      },
+      "WebRebuildTriggerResponse": {
+        "properties": {
+          "current_revision": {
+            "type": "integer",
+            "title": "Current Revision"
+          },
+          "current_revision_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Current Revision Updated At"
+          },
+          "published_revision": {
+            "type": "integer",
+            "title": "Published Revision"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published At"
+          },
+          "requested_revision": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested Revision"
+          },
+          "requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested At"
+          },
+          "needs_rebuild": {
+            "type": "boolean",
+            "title": "Needs Rebuild"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "current_revision",
+          "current_revision_updated_at",
+          "published_revision",
+          "needs_rebuild",
+          "state",
+          "message"
+        ],
+        "title": "WebRebuildTriggerResponse"
       }
     },
     "securitySchemes": {

--- a/routers/system.py
+++ b/routers/system.py
@@ -1,19 +1,52 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
+from core.database import get_session
 from core.security import get_current_username
+from schemas import (
+    WebRebuildCompletePayload,
+    WebRebuildStatusResponse,
+    WebRebuildTriggerResponse,
+)
+from services.catalog_revision_service import CatalogRevisionService
 from services.system_service import system_service
 from core.logger import logger
 
 router = APIRouter(prefix="/api/system", tags=["system"])
 
-@router.post("/rebuild-web")
-async def trigger_rebuild_web(username: str = Depends(get_current_username)):
+
+@router.get("/rebuild-web/status", response_model=WebRebuildStatusResponse)
+async def get_rebuild_web_status(
+    username: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    Return whether the static Astro storefront is behind catalog data.
+    """
+    logger.debug("User %s checked web rebuild status.", username)
+    return await CatalogRevisionService.get_static_rebuild_status(session)
+
+
+@router.post("/rebuild-web", response_model=WebRebuildTriggerResponse)
+async def trigger_rebuild_web(
+    username: str = Depends(get_current_username),
+    session: AsyncSession = Depends(get_session),
+):
     """
     Trigger a turbo-rebuild of the frontend Astro site.
     Accessible only by authenticated managers/admins.
     """
-    logger.info(f"User {username} triggered a web site rebuild.")
-    
-    result = await system_service.trigger_web_rebuild()
+    status = await CatalogRevisionService.get_static_rebuild_status(session)
+    current_revision = int(status["current_revision"])
+
+    logger.info(
+        "User %s triggered a web site rebuild for catalog revision %s.",
+        username,
+        current_revision,
+    )
+
+    result = await system_service.trigger_web_rebuild(catalog_revision=current_revision)
     
     if not result["success"]:
         # Handle specific known errors
@@ -22,10 +55,55 @@ async def trigger_rebuild_web(username: str = Depends(get_current_username)):
                 status_code=503, 
                 detail="GitHub integration not configured on server (.env missing GITHUB_TOKEN)"
             )
-        
+
+        details = result.get("details") or result.get("status_code") or result.get("error")
         raise HTTPException(
             status_code=500, 
-            detail=f"Failed to trigger rebuild: {result.get('error')}"
+            detail=f"Failed to trigger rebuild: {result.get('error')}. Details: {details}"
         )
-        
-    return {"message": "Rebuild triggered successfully. The site will be updated in ~2 minutes."}
+
+    status = await CatalogRevisionService.mark_static_rebuild_requested(
+        session,
+        current_revision,
+    )
+    await session.commit()
+
+    return {
+        **status,
+        "message": "Rebuild triggered successfully. The site will be updated in ~2 minutes.",
+    }
+
+
+@router.post("/rebuild-web/complete", response_model=WebRebuildStatusResponse)
+async def complete_rebuild_web(
+    payload: WebRebuildCompletePayload,
+    x_web_rebuild_token: str | None = Header(default=None, alias="X-Web-Rebuild-Token"),
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    Callback for GitHub Actions after the static storefront deploy completes.
+    """
+    if not settings.WEB_REBUILD_CALLBACK_TOKEN:
+        raise HTTPException(status_code=503, detail="Web rebuild callback token is not configured")
+    if x_web_rebuild_token != settings.WEB_REBUILD_CALLBACK_TOKEN:
+        raise HTTPException(status_code=403, detail="Invalid web rebuild callback token")
+
+    catalog_revision = max(0, int(payload.catalog_revision))
+    if catalog_revision == 0:
+        current = await CatalogRevisionService.get_current(session)
+        catalog_revision = int(current["revision"])
+
+    status_value = str(payload.status or "success").strip().lower()
+    if status_value == "success":
+        status = await CatalogRevisionService.mark_static_rebuild_completed(
+            session,
+            catalog_revision,
+        )
+    else:
+        status = await CatalogRevisionService.mark_static_rebuild_failed(
+            session,
+            catalog_revision,
+            payload.error or "GitHub Actions rebuild failed",
+        )
+    await session.commit()
+    return status

--- a/schemas.py
+++ b/schemas.py
@@ -346,6 +346,28 @@ class CatalogRevisionResponse(BaseModel):
     updated_at: datetime
 
 
+class WebRebuildStatusResponse(BaseModel):
+    current_revision: int
+    current_revision_updated_at: datetime
+    published_revision: int
+    published_at: Optional[datetime] = None
+    requested_revision: Optional[int] = None
+    requested_at: Optional[datetime] = None
+    needs_rebuild: bool
+    state: str
+    last_error: Optional[str] = None
+
+
+class WebRebuildTriggerResponse(WebRebuildStatusResponse):
+    message: str
+
+
+class WebRebuildCompletePayload(BaseModel):
+    catalog_revision: int
+    status: str = "success"
+    error: Optional[str] = None
+
+
 class BulkSpecUpdate(BaseModel):
     product_ids: List[int]
     specs: Dict[str, Any]  # Словарь характеристик для добавления/обновления

--- a/services/catalog_revision_service.py
+++ b/services/catalog_revision_service.py
@@ -26,6 +26,74 @@ class CatalogRevisionService:
         return CatalogRevisionService._serialize(row)
 
     @staticmethod
+    def _serialize_static_rebuild_status(row: Any) -> dict[str, Any]:
+        needs_rebuild = row.current_revision > row.published_revision
+        rebuild_requested_for_current = (
+            needs_rebuild
+            and row.requested_revision >= row.current_revision
+            and row.requested_at is not None
+            and row.last_error is None
+        )
+        if not needs_rebuild:
+            state = "fresh"
+        elif rebuild_requested_for_current:
+            state = "queued"
+        else:
+            state = "stale"
+
+        return {
+            "current_revision": row.current_revision,
+            "current_revision_updated_at": row.current_updated_at,
+            "published_revision": row.published_revision,
+            "published_at": row.published_at,
+            "requested_revision": row.requested_revision or None,
+            "requested_at": row.requested_at,
+            "needs_rebuild": needs_rebuild,
+            "state": state,
+            "last_error": row.last_error,
+        }
+
+    @staticmethod
+    async def get_static_rebuild_status(session: AsyncSession) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.get_static_publish_snapshot(session)
+        return CatalogRevisionService._serialize_static_rebuild_status(row)
+
+    @staticmethod
+    async def mark_static_rebuild_requested(
+        session: AsyncSession,
+        revision: int,
+    ) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.mark_static_rebuild_requested(
+            session,
+            revision=revision,
+        )
+        return CatalogRevisionService._serialize_static_rebuild_status(row)
+
+    @staticmethod
+    async def mark_static_rebuild_completed(
+        session: AsyncSession,
+        revision: int,
+    ) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.mark_static_rebuild_completed(
+            session,
+            revision=revision,
+        )
+        return CatalogRevisionService._serialize_static_rebuild_status(row)
+
+    @staticmethod
+    async def mark_static_rebuild_failed(
+        session: AsyncSession,
+        revision: int,
+        error: str,
+    ) -> dict[str, Any]:
+        row = await CatalogRevisionDAO.mark_static_rebuild_failed(
+            session,
+            revision=revision,
+            error=error,
+        )
+        return CatalogRevisionService._serialize_static_rebuild_status(row)
+
+    @staticmethod
     async def bump(
         session: AsyncSession,
         scope: str,

--- a/services/system_service.py
+++ b/services/system_service.py
@@ -4,7 +4,7 @@ from core.logger import logger
 
 class SystemService:
     @staticmethod
-    async def trigger_web_rebuild() -> dict:
+    async def trigger_web_rebuild(catalog_revision: int | None = None) -> dict:
         """
         Triggers the 'rebuild-web.yml' workflow in GitHub Actions.
         Requires GITHUB_TOKEN to be set in .env.
@@ -25,9 +25,11 @@ class SystemService:
             "X-GitHub-Api-Version": "2022-11-28",
         }
         
-        payload = {
-            "ref": "main" # Build from main branch
+        payload: dict[str, object] = {
+            "ref": "main"  # Build from main branch
         }
+        if catalog_revision is not None:
+            payload["inputs"] = {"catalog_revision": str(max(0, int(catalog_revision)))}
         
         async with httpx.AsyncClient() as client:
             try:
@@ -38,7 +40,10 @@ class SystemService:
                     logger.info("Successfully triggered rebuild-web workflow.")
                     return {"success": True}
                 else:
-                    error_data = response.json() if response.content else "No response body"
+                    try:
+                        error_data = response.json() if response.content else "No response body"
+                    except ValueError:
+                        error_data = response.text or "No response body"
                     logger.error(f"GitHub API Error ({response.status_code}): {error_data}")
                     return {
                         "success": False, 

--- a/tests/unit/test_catalog_revision.py
+++ b/tests/unit/test_catalog_revision.py
@@ -117,6 +117,51 @@ async def test_product_update_and_brand_update_bump_revision(sqlite_session):
 
 
 @pytest.mark.asyncio
+async def test_static_rebuild_status_tracks_catalog_publication(sqlite_session):
+    initial = await CatalogRevisionService.get_static_rebuild_status(sqlite_session)
+    assert initial["current_revision"] == 0
+    assert initial["published_revision"] == 0
+    assert initial["needs_rebuild"] is False
+    assert initial["state"] == "fresh"
+
+    bumped = await CatalogRevisionService.bump(sqlite_session, scope="test_catalog_change")
+    stale = await CatalogRevisionService.get_static_rebuild_status(sqlite_session)
+    assert stale["current_revision"] == bumped["revision"]
+    assert stale["published_revision"] == 0
+    assert stale["needs_rebuild"] is True
+    assert stale["state"] == "stale"
+
+    queued = await CatalogRevisionService.mark_static_rebuild_requested(
+        sqlite_session,
+        bumped["revision"],
+    )
+    assert queued["requested_revision"] == bumped["revision"]
+    assert queued["needs_rebuild"] is True
+    assert queued["state"] == "queued"
+
+    fresh = await CatalogRevisionService.mark_static_rebuild_completed(
+        sqlite_session,
+        bumped["revision"],
+    )
+    assert fresh["published_revision"] == bumped["revision"]
+    assert fresh["needs_rebuild"] is False
+    assert fresh["state"] == "fresh"
+
+    failed_revision = (
+        await CatalogRevisionService.bump(sqlite_session, scope="test_failed_rebuild")
+    )["revision"]
+    failed = await CatalogRevisionService.mark_static_rebuild_failed(
+        sqlite_session,
+        failed_revision,
+        "deploy failed",
+    )
+    assert failed["requested_revision"] == failed_revision
+    assert failed["last_error"] == "deploy failed"
+    assert failed["needs_rebuild"] is True
+    assert failed["state"] == "stale"
+
+
+@pytest.mark.asyncio
 async def test_product_update_rolls_back_when_revision_bump_fails(sqlite_session, monkeypatch):
     product = Product(
         title="Rollback Revision Product",

--- a/tests/unit/test_system_service.py
+++ b/tests/unit/test_system_service.py
@@ -1,0 +1,53 @@
+import pytest
+
+from services import system_service as system_service_module
+from services.system_service import SystemService
+
+
+@pytest.mark.asyncio
+async def test_trigger_web_rebuild_sends_catalog_revision_input(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyResponse:
+        status_code = 204
+        content = b""
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, headers, json, timeout):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+            captured["timeout"] = timeout
+            return DummyResponse()
+
+    monkeypatch.setattr(system_service_module.settings, "GITHUB_TOKEN", "token")
+    monkeypatch.setattr(system_service_module.settings, "GITHUB_OWNER", "owner")
+    monkeypatch.setattr(system_service_module.settings, "GITHUB_REPO", "repo")
+    monkeypatch.setattr(system_service_module.httpx, "AsyncClient", lambda: DummyAsyncClient())
+
+    result = await SystemService.trigger_web_rebuild(catalog_revision=17)
+
+    assert result == {"success": True}
+    assert captured["url"] == (
+        "https://api.github.com/repos/owner/repo/actions/workflows/rebuild-web.yml/dispatches"
+    )
+    assert captured["json"] == {
+        "ref": "main",
+        "inputs": {"catalog_revision": "17"},
+    }
+    assert captured["timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_trigger_web_rebuild_reports_missing_token(monkeypatch):
+    monkeypatch.setattr(system_service_module.settings, "GITHUB_TOKEN", "")
+
+    result = await SystemService.trigger_web_rebuild(catalog_revision=17)
+
+    assert result == {"success": False, "error": "GITHUB_TOKEN_MISSING"}


### PR DESCRIPTION
## Summary
- add backend status for static storefront freshness based on catalog revision
- make Manager show a rebuild-needed warning and keep the rebuild button wired to GitHub Actions
- pass catalog revision into rebuild-web workflow and add a callback to mark published/failed revisions

## Checks
- SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_catalog_revision.py tests/unit/test_system_service.py -q
- manager_frontend build via vue-tsc + vite with existing node_modules symlink
- git diff --check

## Notes
- Production needs WEB_REBUILD_CALLBACK_TOKEN set both in API env and GitHub Actions secrets for automatic status clearing after deploy.
- WEB_REBUILD_CALLBACK_URL is optional; workflow defaults to https://api.mvn.by/api/system/rebuild-web/complete.