### PR TITLE
Bypass Cloudflare for rebuild callback

### DIFF
--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -159,6 +159,7 @@ jobs:
           CATALOG_REVISION: ${{ inputs.catalog_revision }}
           WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
           WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
+          WEB_REBUILD_CALLBACK_RESOLVE_IP: ${{ vars.WEB_REBUILD_CALLBACK_RESOLVE_IP }}
         run: |
           set -euo pipefail
           if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
@@ -168,7 +169,21 @@ jobs:
 
           CATALOG_REVISION="${CATALOG_REVISION:-0}"
           CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
-          if ! curl -fsS -X POST "${CALLBACK_URL}" \
+          CURL_RESOLVE_ARGS=()
+          if [ -n "${WEB_REBUILD_CALLBACK_RESOLVE_IP:-}" ]; then
+            CALLBACK_HOST="$(python3 - <<'PY'
+import os
+from urllib.parse import urlparse
+
+print(urlparse(os.environ["CALLBACK_URL"]).hostname or "")
+PY
+)"
+            if [ -n "${CALLBACK_HOST}" ]; then
+              CURL_RESOLVE_ARGS=(--resolve "${CALLBACK_HOST}:443:${WEB_REBUILD_CALLBACK_RESOLVE_IP}")
+            fi
+          fi
+
+          if ! curl -fsS "${CURL_RESOLVE_ARGS[@]}" -X POST "${CALLBACK_URL}" \
             -H "Content-Type: application/json" \
             -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
             --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"success\"}"; then
@@ -181,6 +196,7 @@ jobs:
           CATALOG_REVISION: ${{ inputs.catalog_revision }}
           WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
           WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
+          WEB_REBUILD_CALLBACK_RESOLVE_IP: ${{ vars.WEB_REBUILD_CALLBACK_RESOLVE_IP }}
         run: |
           set -euo pipefail
           if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
@@ -190,7 +206,21 @@ jobs:
 
           CATALOG_REVISION="${CATALOG_REVISION:-0}"
           CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
-          if ! curl -fsS -X POST "${CALLBACK_URL}" \
+          CURL_RESOLVE_ARGS=()
+          if [ -n "${WEB_REBUILD_CALLBACK_RESOLVE_IP:-}" ]; then
+            CALLBACK_HOST="$(python3 - <<'PY'
+import os
+from urllib.parse import urlparse
+
+print(urlparse(os.environ["CALLBACK_URL"]).hostname or "")
+PY
+)"
+            if [ -n "${CALLBACK_HOST}" ]; then
+              CURL_RESOLVE_ARGS=(--resolve "${CALLBACK_HOST}:443:${WEB_REBUILD_CALLBACK_RESOLVE_IP}")
+            fi
+          fi
+
+          if ! curl -fsS "${CURL_RESOLVE_ARGS[@]}" -X POST "${CALLBACK_URL}" \
             -H "Content-Type: application/json" \
             -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
             --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"; then


### PR DESCRIPTION
## Summary
- make rebuild-web callback optionally use curl --resolve to reach the API origin directly
- keep the existing public callback URL as the default
- use WEB_REBUILD_CALLBACK_RESOLVE_IP repo variable for the origin IP

## Why
GitHub Actions could rebuild and deploy the static site, but the callback to https://api.mvn.by/api/system/rebuild-web/complete received 403 before reaching nginx/FastAPI. Direct origin resolution to api.mvn.by:443:185.250.45.54 returns 200 and avoids Cloudflare blocking the callback.

## Checks
- git diff --check
- manual direct-origin callback check returned HTTP 200
- GitHub variable WEB_REBUILD_CALLBACK_RESOLVE_IP set to 185.250.45.54