### PR TITLE
Deploy web atomically through Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,203 @@
+name: Deploy Web Release
+
+on:
+  workflow_call:
+    inputs:
+      deploy_sha:
+        description: Full immutable Git SHA to build and deploy
+        required: true
+        type: string
+    secrets:
+      CLOUDFLARE_API_TOKEN_PAGES:
+        required: true
+      SSH_KEY:
+        required: true
+      SSH_HOST_API:
+        required: true
+      SSH_USER_API:
+        required: true
+      SSH_HOST_WEB:
+        required: true
+      SSH_USER_WEB:
+        required: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  API_TUNNEL_LOCAL_PORT: ${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}
+  API_TUNNEL_REMOTE_PORT: ${{ vars.API_TUNNEL_REMOTE_PORT || '18080' }}
+  CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'mvn-by' }}
+
+jobs:
+  production-web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment: production-web
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Checkout immutable release
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Verify immutable release SHA
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          [[ "${DEPLOY_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::deploy_sha must be a full Git SHA"
+            exit 1
+          }
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "${checked_out_sha}" != "${DEPLOY_SHA}" ]; then
+            echo "::error::Checked out ${checked_out_sha}, expected ${DEPLOY_SHA}"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_HOST_WEB: ${{ secrets.SSH_HOST_WEB }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          : > ~/.ssh/known_hosts
+
+          for host in "${SSH_HOST_API}" "${SSH_HOST_WEB}"; do
+            scanned=false
+            for attempt in 1 2 3 4 5; do
+              if ssh-keyscan -T 10 -H "${host}" >> ~/.ssh/known_hosts 2>/dev/null; then
+                scanned=true
+                break
+              fi
+              sleep $((attempt * 3))
+            done
+            if [ "${scanned}" != "true" ]; then
+              echo "::error::Could not obtain SSH host key for ${host}"
+              exit 1
+            fi
+          done
+          sort -u -o ~/.ssh/known_hosts ~/.ssh/known_hosts
+
+      - name: Build Astro site from production API
+        working-directory: web
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          INTERNAL_API_URL: http://127.0.0.1:${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}/api/v1
+          PUBLIC_API_URL: https://api.mvn.by/api/v1
+          PUBLIC_GTM_ID: GTM-5CR6WBBC
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+        run: |
+          set -euo pipefail
+          ssh -f -N \
+            -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
+            -i ~/.ssh/deploy_key \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ExitOnForwardFailure=yes \
+            -o ConnectTimeout=20 \
+            "${SSH_USER_API}@${SSH_HOST_API}"
+          curl -fsS --retry 10 --retry-delay 3 \
+            "http://127.0.0.1:${API_TUNNEL_LOCAL_PORT}/api/v1/config" >/dev/null
+          npm run build
+          printf '{"sha":"%s"}\n' "${DEPLOY_SHA}" > dist/release.json
+
+      - name: Validate static release
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: python3 scripts/check_web_dist.py web/dist --expected-release "${DEPLOY_SHA}" | tee web_dist_check.log
+
+      - name: Deploy Cloudflare Pages canary
+        id: pages_canary
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PAGES }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          PAGES_COMMIT_SHA: ${{ inputs.deploy_sha }}
+          PAGES_DEPLOY_OUTPUT_FILE: /tmp/cloudflare-pages-canary.log
+        run: |
+          set -euo pipefail
+          export CLOUDFLARE_PAGES_BRANCH="candidate-${DEPLOY_SHA:0:12}"
+          bash scripts/deploy_cloudflare_pages.sh
+
+      - name: Deploy atomic VPS fallback
+        env:
+          WEB_HOST: ${{ secrets.SSH_HOST_WEB }}
+          WEB_USER: ${{ secrets.SSH_USER_WEB }}
+          WEB_ROOT: ${{ vars.WEB_ROOT || '/var/www/mvn.by' }}
+          WEB_RELEASE_ID: ${{ inputs.deploy_sha }}
+          SSH_KEY_PATH: /home/runner/.ssh/deploy_key
+        run: bash scripts/deploy_web_atomic.sh | tee web_vps_deploy.log
+
+      - name: Deploy Cloudflare Pages production
+        id: pages_production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PAGES }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_PAGES_BRANCH: ${{ vars.CLOUDFLARE_PAGES_PRODUCTION_BRANCH || 'main' }}
+          PAGES_COMMIT_SHA: ${{ inputs.deploy_sha }}
+          PAGES_DEPLOY_OUTPUT_FILE: /tmp/cloudflare-pages-production.log
+        run: bash scripts/deploy_cloudflare_pages.sh
+
+      - name: Smoke stable web endpoints
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          for base_url in "https://${CLOUDFLARE_PAGES_PROJECT}.pages.dev" "https://mvn.by"; do
+            curl -fsSL --retry 10 --retry-delay 3 "${base_url}/" >/dev/null
+            curl -fsSL --retry 10 --retry-delay 3 "${base_url}/catalog/" >/dev/null
+            release_sha="$(curl -fsSL --retry 10 --retry-delay 3 \
+              "${base_url}/release.json?sha=${DEPLOY_SHA}" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["sha"])')"
+            if [ "${release_sha}" != "${DEPLOY_SHA}" ]; then
+              echo "::error::${base_url} release ${release_sha} does not match ${DEPLOY_SHA}"
+              exit 1
+            fi
+          done
+
+      - name: Upload web release logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-release-${{ inputs.deploy_sha }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            web_dist_check.log
+            web_vps_deploy.log
+            /tmp/cloudflare-pages-canary.log
+            /tmp/cloudflare-pages-production.log
+
+      - name: Web release summary
+        if: ${{ always() }}
+        env:
+          CANARY_URL: ${{ steps.pages_canary.outputs.deployment_url }}
+          PRODUCTION_URL: ${{ steps.pages_production.outputs.deployment_url }}
+        run: |
+          {
+            echo "## Web Release"
+            echo "- immutable_sha: ${{ inputs.deploy_sha }}"
+            echo "- pages_canary: ${CANARY_URL:-not-created}"
+            echo "- vps_fallback: atomic release under /var/www/mvn.by/releases"
+            echo "- pages_production: ${PRODUCTION_URL:-not-created}"
+            echo "- public_hostname: https://mvn.by"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
           else
             after="${{ needs.release-gate.outputs.deploy_sha }}"
             if before="$(git rev-parse "${after}^" 2>/dev/null)"; then
-              if git diff --name-only "${before}" "${after}" | grep -E '^(web/|\.github/workflows/(deploy|rebuild-web|check-web-ssh)\.yml$)' >/dev/null; then
+              if git diff --name-only "${before}" "${after}" | grep -E '^(web/|\.github/workflows/(deploy|deploy-web|rebuild-web|check-web-ssh)\.yml$|scripts/(check_web_dist\.py|deploy_cloudflare_pages\.sh|deploy_web_atomic\.sh|promote_web_release\.sh)$)' >/dev/null; then
                 web_changed=true
                 reason="storefront-relevant files changed"
               fi
@@ -536,160 +536,18 @@ jobs:
       backend_image: ${{ needs.deploy-backend.outputs.backend_image }}
     secrets: inherit
 
-  # ======================================================
-  # 3. FRONTEND DEPLOYMENT (Static -> mvn-web)
-  # ======================================================
+  # Web release is isolated in one reusable workflow so automatic releases and
+  # manual catalog rebuilds use the same immutable artifact and promotion path.
   deploy-frontend:
     if: ${{ needs.detect-frontend-changes.outputs.web_changed == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: production-web
+    needs:
+      - deploy-backend
+      - detect-frontend-changes
+      - release-gate
     permissions:
       contents: read
       deployments: write
-    needs:
-      - deploy-backend # Wait for API to be ready
-      - detect-frontend-changes
-      - release-gate
-    
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.release-gate.outputs.deploy_sha }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install Dependencies
-        working-directory: ./web
-        run: npm ci
-
-      - name: Build Astro Site
-        working-directory: ./web
-        env:
-           # SSR Build: bypass public CDN/WAF checks via SSH tunnel to the API host.
-           API_TUNNEL_LOCAL_PORT: ${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}
-           API_TUNNEL_REMOTE_PORT: ${{ vars.API_TUNNEL_REMOTE_PORT || '18080' }}
-           INTERNAL_API_URL: http://127.0.0.1:${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}/api/v1
-           # Client-side: Use production API  
-           # CRITICAL: API Router prefix is /api, full path: https://api.mvn.by/api/v1
-           PUBLIC_API_URL: https://api.mvn.by/api/v1
-           # Google Tag Manager ID
-           PUBLIC_GTM_ID: GTM-5CR6WBBC
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
-          ssh -f -N \
-            -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
-            -i ~/.ssh/deploy_key \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ExitOnForwardFailure=yes \
-            -o ConnectTimeout=20 \
-            ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}
-          curl -fsS --retry 10 --retry-delay 3 "http://127.0.0.1:${API_TUNNEL_LOCAL_PORT}/api/v1/config" >/dev/null
-          npm run build
-
-      - name: Setup SSH Key for Web Server
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_WEB }} >> ~/.ssh/known_hosts || true
-
-      - name: Deploy to Web Server
-        run: |
-          set -euo pipefail
-
-          WEB_HOST="${{ secrets.SSH_HOST_WEB }}"
-          WEB_USER="${{ secrets.SSH_USER_WEB }}"
-          WEB_TARGET="${{ secrets.SSH_WEB_TARGET }}"
-          if [ -z "${WEB_TARGET}" ]; then
-            WEB_TARGET="/var/www/${{ secrets.SSH_USER_WEB }}/data/www/mvn.by/"
-          fi
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
-          MAX_ATTEMPTS=5
-          PORT_FAILURES=0
-          LOGIN_FAILURES=0
-          RSYNC_FAILURES=0
-
-          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
-            echo "🚀 Frontend deploy attempt ${attempt}/${MAX_ATTEMPTS}"
-
-            if nc -z -w 10 "${WEB_HOST}" 22; then
-              echo "✅ Web SSH port is reachable"
-            else
-              PORT_FAILURES=$((PORT_FAILURES + 1))
-              echo "::warning::Web SSH port 22 is not reachable before rsync attempt ${attempt}"
-            fi
-
-            if ssh ${SSH_OPTS} "${WEB_USER}@${WEB_HOST}" "true"; then
-              if rsync -avz --delete \
-                -e "ssh ${SSH_OPTS}" \
-                web/dist/ \
-                "${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"; then
-                echo "✅ Frontend deployment completed on attempt ${attempt}!"
-                {
-                  echo "## Frontend Deploy Summary"
-                  echo "- job: deploy-frontend"
-                  echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
-                  echo "- attempts_used: ${attempt}"
-                  echo "- status: success"
-                  echo "- backend_dependency: deploy-backend completed before frontend deploy"
-                  echo "- build_status: success"
-                  echo "- failure_kind: n/a"
-                  echo "- ssh_port_failures: ${PORT_FAILURES}"
-                  echo "- ssh_login_failures: ${LOGIN_FAILURES}"
-                  echo "- rsync_failures: ${RSYNC_FAILURES}"
-                } >> "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-
-              RSYNC_FAILURES=$((RSYNC_FAILURES + 1))
-              echo "::warning::rsync failed on attempt ${attempt}"
-            else
-              LOGIN_FAILURES=$((LOGIN_FAILURES + 1))
-              echo "::warning::SSH login preflight failed on attempt ${attempt}"
-            fi
-
-            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
-              sleep_seconds=$((attempt * 20))
-              echo "⏳ Waiting ${sleep_seconds}s before retry..."
-              sleep "${sleep_seconds}"
-            fi
-          done
-
-          if [ "${PORT_FAILURES}" -gt 0 ] || [ "${LOGIN_FAILURES}" -gt 0 ]; then
-            FAILURE_KIND="web_ssh_connectivity"
-          elif [ "${RSYNC_FAILURES}" -gt 0 ]; then
-            FAILURE_KIND="rsync_transfer"
-          else
-            FAILURE_KIND="unknown"
-          fi
-
-          {
-            echo "## Frontend Deploy Summary"
-            echo "- job: deploy-frontend"
-            echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
-            echo "- attempts_used: ${MAX_ATTEMPTS}"
-            echo "- status: failed"
-            echo "- backend_dependency: deploy-backend completed before frontend deploy"
-            echo "- build_status: success"
-            echo "- failure_kind: ${FAILURE_KIND}"
-            echo "- ssh_port_failures: ${PORT_FAILURES}"
-            echo "- ssh_login_failures: ${LOGIN_FAILURES}"
-            echo "- rsync_failures: ${RSYNC_FAILURES}"
-            echo "- next_step: run the manual Web SSH Connectivity Check workflow or choose a more reliable web deploy architecture"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          echo "::error::Frontend deployment failed after ${MAX_ATTEMPTS} attempts (${FAILURE_KIND}). Backend deploy/smoke already completed; this failure is scoped to the web deploy path."
-          exit 1
+    uses: ./.github/workflows/deploy-web.yml
+    with:
+      deploy_sha: ${{ needs.release-gate.outputs.deploy_sha }}
+    secrets: inherit

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -1,4 +1,4 @@
-name: Turbo Rebuild Web ⚡
+name: Turbo Rebuild Web
 
 on:
   workflow_dispatch:
@@ -8,157 +8,46 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  SSH_HOST_WEB: ${{ secrets.SSH_HOST_WEB }}
-  SSH_USER_WEB: ${{ secrets.SSH_USER_WEB }}
-  SSH_WEB_TARGET: ${{ secrets.SSH_WEB_TARGET }}
-  API_TUNNEL_LOCAL_PORT: ${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}
-  API_TUNNEL_REMOTE_PORT: ${{ vars.API_TUNNEL_REMOTE_PORT || '18080' }}
 
 jobs:
-  rebuild:
+  main-branch-guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install Dependencies
-        working-directory: ./web
-        run: npm ci
-
-      - name: Build Astro Site
-        working-directory: ./web
-        env:
-           # SSR Build: bypass public CDN/WAF checks via SSH tunnel to the API host.
-           INTERNAL_API_URL: http://127.0.0.1:${{ vars.API_TUNNEL_LOCAL_PORT || '18000' }}/api/v1
-           # Client-side: Use production API  
-           PUBLIC_API_URL: https://api.mvn.by/api/v1
-           # Google Tag Manager ID
-           PUBLIC_GTM_ID: GTM-5CR6WBBC
+      - name: Require main branch
         run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
-          ssh -f -N \
-            -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
-            -i ~/.ssh/deploy_key \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ExitOnForwardFailure=yes \
-            -o ConnectTimeout=20 \
-            ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}
-          curl -fsS --retry 10 --retry-delay 3 "http://127.0.0.1:${API_TUNNEL_LOCAL_PORT}/api/v1/config" >/dev/null
-          npm run build
-
-      - name: Setup SSH Key for Web Server
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -T 10 -H ${{ env.SSH_HOST_WEB }} >> ~/.ssh/known_hosts || true
-
-      - name: Deploy to Web Server
-        run: |
-          set -euo pipefail
-
-          WEB_HOST="${SSH_HOST_WEB}"
-          WEB_USER="${SSH_USER_WEB}"
-          WEB_TARGET="${SSH_WEB_TARGET}"
-          if [ -z "${WEB_TARGET}" ]; then
-            WEB_TARGET="/var/www/${SSH_USER_WEB}/data/www/mvn.by/"
-          fi
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2"
-          MAX_ATTEMPTS=5
-          PORT_FAILURES=0
-          LOGIN_FAILURES=0
-          RSYNC_FAILURES=0
-
-          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
-            echo "Frontend rebuild deploy attempt ${attempt}/${MAX_ATTEMPTS}"
-
-            if nc -z -w 10 "${WEB_HOST}" 22; then
-              echo "Web SSH port is reachable"
-            else
-              PORT_FAILURES=$((PORT_FAILURES + 1))
-              echo "::warning::Web SSH port 22 is not reachable before rsync attempt ${attempt}"
-            fi
-
-            if ssh ${SSH_OPTS} "${WEB_USER}@${WEB_HOST}" "true"; then
-              if rsync -avz --delete \
-                -e "ssh ${SSH_OPTS}" \
-                web/dist/ \
-                "${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"; then
-                echo "Manual web rebuild completed on attempt ${attempt}."
-                {
-                  echo "## Manual Web Rebuild Summary"
-                  echo "- job: rebuild-web"
-                  echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
-                  echo "- attempts_used: ${attempt}"
-                  echo "- status: success"
-                  echo "- build_status: success"
-                  echo "- failure_kind: n/a"
-                  echo "- ssh_port_failures: ${PORT_FAILURES}"
-                  echo "- ssh_login_failures: ${LOGIN_FAILURES}"
-                  echo "- rsync_failures: ${RSYNC_FAILURES}"
-                } >> "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-
-              RSYNC_FAILURES=$((RSYNC_FAILURES + 1))
-              echo "::warning::rsync failed on attempt ${attempt}"
-            else
-              LOGIN_FAILURES=$((LOGIN_FAILURES + 1))
-              echo "::warning::SSH login preflight failed on attempt ${attempt}"
-            fi
-
-            if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
-              sleep_seconds=$((attempt * 20))
-              echo "Waiting ${sleep_seconds}s before retry..."
-              sleep "${sleep_seconds}"
-            fi
-          done
-
-          if [ "${PORT_FAILURES}" -gt 0 ] || [ "${LOGIN_FAILURES}" -gt 0 ]; then
-            FAILURE_KIND="web_ssh_connectivity"
-          elif [ "${RSYNC_FAILURES}" -gt 0 ]; then
-            FAILURE_KIND="rsync_transfer"
-          else
-            FAILURE_KIND="unknown"
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Production web rebuilds are allowed only from main"
+            exit 1
           fi
 
-          {
-            echo "## Manual Web Rebuild Summary"
-            echo "- job: rebuild-web"
-            echo "- target: ${WEB_USER}@${WEB_HOST}:${WEB_TARGET}"
-            echo "- attempts_used: ${MAX_ATTEMPTS}"
-            echo "- status: failed"
-            echo "- build_status: success"
-            echo "- failure_kind: ${FAILURE_KIND}"
-            echo "- ssh_port_failures: ${PORT_FAILURES}"
-            echo "- ssh_login_failures: ${LOGIN_FAILURES}"
-            echo "- rsync_failures: ${RSYNC_FAILURES}"
-            echo "- next_step: run the manual Web SSH Connectivity Check workflow or choose a more reliable web deploy architecture"
-          } >> "$GITHUB_STEP_SUMMARY"
+  rebuild:
+    needs: main-branch-guard
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/deploy-web.yml
+    with:
+      deploy_sha: ${{ github.sha }}
+    secrets: inherit
 
-          echo "::error::Manual web rebuild failed after ${MAX_ATTEMPTS} attempts (${FAILURE_KIND})."
-          exit 1
-
-      - name: Mark catalog static revision published
-        if: ${{ success() }}
+  callback:
+    if: ${{ always() }}
+    needs:
+      - main-branch-guard
+      - rebuild
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report catalog rebuild result
         env:
           CATALOG_REVISION: ${{ inputs.catalog_revision }}
+          REBUILD_RESULT: ${{ needs.rebuild.result }}
+          GUARD_RESULT: ${{ needs.main-branch-guard.result }}
           WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
           WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
         run: |
@@ -168,33 +57,21 @@ jobs:
             exit 0
           fi
 
-          CATALOG_REVISION="${CATALOG_REVISION:-0}"
-          CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
-          if ! curl -fsS -X POST "${CALLBACK_URL}" \
-            -H "Content-Type: application/json" \
-            -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
-            --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"success\"}"; then
-            echo "::warning::Static revision was deployed, but API callback failed."
+          catalog_revision="${CATALOG_REVISION:-0}"
+          if [[ ! "${catalog_revision}" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Invalid catalog_revision; reporting revision 0"
+            catalog_revision=0
+          fi
+          callback_url="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
+          if [ "${GUARD_RESULT}" = "success" ] && [ "${REBUILD_RESULT}" = "success" ]; then
+            payload="{\"catalog_revision\":${catalog_revision},\"status\":\"success\"}"
+          else
+            payload="{\"catalog_revision\":${catalog_revision},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"
           fi
 
-      - name: Mark catalog static rebuild failed
-        if: ${{ failure() }}
-        env:
-          CATALOG_REVISION: ${{ inputs.catalog_revision }}
-          WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
-          WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
-            echo "No callback token configured; skipping failure callback."
-            exit 0
-          fi
-
-          CATALOG_REVISION="${CATALOG_REVISION:-0}"
-          CALLBACK_URL="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
-          if ! curl -fsS -X POST "${CALLBACK_URL}" \
+          if ! curl -fsS -X POST "${callback_url}" \
             -H "Content-Type: application/json" \
             -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
-            --data "{\"catalog_revision\":${CATALOG_REVISION},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"; then
-            echo "::warning::Static rebuild failed, and API failure callback also failed."
+            --data "${payload}"; then
+            echo "::warning::Web rebuild callback failed."
           fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,13 +16,14 @@
 - **User:** `deploy` for static deploys, `root` for server administration only
 - **IP:** `153.80.244.78`
 - **Hostname:** `www.mvn.by`
-- **Production path:** `/var/www/mvn.by/current`
+- **Production path:** `/var/www/mvn.by/live` (atomic symlink)
 - **Nginx site:** `/etc/nginx/sites-available/mvn.by`
-- **Role:** current public Astro storefront target for `mvn.by` and `www.mvn.by`.
+- **Role:** Astro storefront origin and independent fallback for Cloudflare Pages.
 
 Prepared server baseline:
 - Ubuntu 24.04 LTS
-- nginx serving `/var/www/mvn.by/current`
+- nginx serving `/var/www/mvn.by/live`, initially linked to the legacy
+  `/var/www/mvn.by/current` tree
 - UFW active with inbound `22/tcp`, `80/tcp`, and `443/tcp` allowed; other inbound traffic denied
 - `deploy` user with SSH key auth and write access to the static root
 - SSH password authentication disabled after root and deploy key login were verified
@@ -52,16 +53,16 @@ curl -I -H 'Host: mvn.by' http://153.80.244.78/
 curl -I --resolve mvn.by:443:153.80.244.78 https://mvn.by/
 ```
 
-Cloudflare DNS state after the 2026-06-05 cutover:
+Cloudflare DNS state before the Pages custom-domain cutover:
 
 ```text
 mvn.by      A 153.80.244.78 proxied
 www.mvn.by  A 153.80.244.78 proxied
 ```
 
-Rollback keeps using the legacy `mvn-web` server: restore the Cloudflare A records
-to `178.159.240.174`, restore the legacy web deploy secrets if needed, and run the
-manual web rebuild workflow.
+The current VPS remains the primary Pages rollback origin. Restore the Cloudflare
+A records to `153.80.244.78` and verify the retained atomic release before using
+the older `mvn-web` host at `178.159.240.174` as the last-resort fallback.
 
 ### API Server
 - **Host alias:** `mvn-api` for the original API VPS; `zakup` for the emergency API primary.
@@ -266,8 +267,8 @@ The workflow requires these env vars in the build step:
 ```yaml
 - name: Build Astro Site
   env:
-    # Static generation: Production API for prerendered pages
-    INTERNAL_API_URL: https://api.mvn.by/api/v1
+    # Static generation: stable private API listener through an SSH tunnel
+    INTERNAL_API_URL: http://127.0.0.1:18000/api/v1
     # Client-side: Production API
     PUBLIC_API_URL: https://api.mvn.by/api/v1
     # Google Tag Manager
@@ -287,7 +288,9 @@ The workflow requires these env vars in the build step:
 3. **deploy-api-standby:** Installs the same image on the fenced app-only standby
    through the `standby-api` environment.
 4. **deploy-frontend:** When web files changed (or manual rebuild was requested),
-   builds Astro and deploys through the `production-web` environment.
+   builds Astro once, validates the static artifact and release marker, deploys
+   a Cloudflare Pages canary, atomically promotes the same artifact on the VPS,
+   and finally promotes it to the Pages production branch.
 
 The three GitHub environments are deployment audit boundaries. They contain no
 new secrets by default; existing repository secrets remain the credential source.
@@ -333,33 +336,61 @@ ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh /tmp/rollback_backend.sh
   bash /tmp/rollback_backend.sh'
 ```
 
-### Web VPS Deploy Target
+### Web Release Safety
 
-The web workflows deploy to the current VPS when these GitHub secrets are set:
+Both automatic releases and `rebuild-web.yml` call
+`.github/workflows/deploy-web.yml`. They share the `production-release`
+concurrency group, so a catalog rebuild cannot race a normal production release.
+
+Required GitHub secrets:
 
 ```text
 SSH_HOST_WEB=153.80.244.78
 SSH_USER_WEB=deploy
-SSH_WEB_TARGET=/var/www/mvn.by/current/
+CLOUDFLARE_API_TOKEN_PAGES=<Cloudflare Pages Edit token>
 ```
 
-Legacy fallback values:
+Required GitHub variables:
 
 ```text
-SSH_HOST_WEB=178.159.240.174
-SSH_USER_WEB=user2154318
-SSH_WEB_TARGET=
+CLOUDFLARE_ACCOUNT_ID=<Cloudflare account id>
+CLOUDFLARE_PAGES_PROJECT=mvn-by
+WEB_ROOT=/var/www/mvn.by
 ```
 
-Post-cutover verification:
+`CLOUDFLARE_PAGES_PROJECT` and `WEB_ROOT` have the values above as safe
+defaults. The workflow never writes into the live document root. It uploads to
+`/var/www/mvn.by/releases/.<sha>.incoming`, validates the candidate, moves it to
+the immutable release directory, and atomically replaces the `live` symlink.
+The previous release remains present for rollback, and the newest five releases
+are retained.
 
-1. Confirm `check-web-ssh.yml` succeeds against `deploy@153.80.244.78`.
-2. Run `rebuild-web.yml` manually against the current VPS.
-3. Verify the origin by IP with Host header:
+The VPS nginx site must use `/var/www/mvn.by/live` as its root. One-time setup:
+
+```bash
+scp scripts/bootstrap_web_atomic_nginx.sh mvn:/tmp/
+ssh mvn 'chmod +x /tmp/bootstrap_web_atomic_nginx.sh && \
+  CONFIRM_WEB_NGINX_BOOTSTRAP=true bash /tmp/bootstrap_web_atomic_nginx.sh'
+```
+
+The bootstrap backs up the nginx site, validates nginx before reload, preserves
+the currently served files, and restores the previous config on error.
+
+Release verification:
+
+1. Confirm the workflow summary contains successful Pages canary, VPS, and Pages
+   production steps for the same full Git SHA.
+2. Verify the Pages production marker:
 
    ```bash
-   curl -I -H 'Host: mvn.by' http://153.80.244.78/
-   curl -fsS -H 'Host: mvn.by' http://153.80.244.78/catalog/ | head
+   curl -fsS https://mvn-by.pages.dev/release.json
+   ```
+
+3. Verify the VPS origin while bypassing public DNS:
+
+   ```bash
+   curl -fsS --resolve mvn.by:443:153.80.244.78 https://mvn.by/
+   curl -fsS --resolve mvn.by:443:153.80.244.78 https://mvn.by/catalog/
    ```
 
 4. Verify public Cloudflare paths:
@@ -370,8 +401,38 @@ Post-cutover verification:
    curl -I https://www.mvn.by/
    ```
 
-5. Roll back by restoring DNS and/or GitHub secrets to the legacy `mvn-web`
-   values and running the manual rebuild workflow.
+Manual VPS rollback does not rebuild anything. Point `live` at a retained
+release and verify the origin:
+
+```bash
+ssh mvn
+cd /var/www/mvn.by
+ls -1t releases
+ln -s /var/www/mvn.by/releases/<previous-sha> live.next
+python3 - <<'PY'
+import os
+os.replace('live.next', 'live')
+PY
+curl -fsS --resolve mvn.by:443:127.0.0.1 https://mvn.by/ >/dev/null
+```
+
+### Cloudflare Pages Cutover
+
+Do not replace the `mvn.by` DNS records before the first Pages production
+release is green. Cloudflare Pages must associate both custom domains with the
+project before DNS cutover:
+
+1. Open **Workers & Pages -> mvn-by -> Custom domains**.
+2. Add `mvn.by`, wait for it to become active, then add `www.mvn.by`.
+3. Confirm both certificates are active and the public `release.json` matches
+   the expected production SHA.
+4. Keep the VPS, atomic releases, and origin smoke checks as the independent
+   rollback path.
+
+For an apex domain in a Cloudflare-managed zone, use the Pages custom-domain
+flow and let Cloudflare create the required DNS record. Creating only a manual
+CNAME without associating the domain with Pages can route traffic to an
+unconfigured Pages origin.
 
 ### Storefront Media Proxy
 
@@ -412,15 +473,10 @@ curl -I https://mvn.by/media/library/crop/<file>.webp
 
 ### Web SSH Reliability
 
-`deploy-frontend` and the manual `rebuild-web.yml` workflow use bounded SSH port/login preflight checks before rsync. They retry 5 times with backoff and write a summary with separate `ssh_port_failures`, `ssh_login_failures`, `rsync_failures`, and `failure_kind` fields.
-
-If `deploy-backend` and backend smoke-check are green but `deploy-frontend` fails with `failure_kind: web_ssh_connectivity`, treat it as web-host SSH/network instability from GitHub-hosted runners, not an Astro/backend build failure.
-
-Use the manual **Web SSH Connectivity Check** workflow to probe `SSH_HOST_WEB` from GitHub Actions without building or deploying files. If the probe is flaky too, the next decision should be architectural rather than adding more retries:
-
-- move the static site to a managed static hosting/CDN deploy path;
-- move web hosting to infrastructure with stable SSH from GitHub Actions;
-- switch to a pull-based deploy where the web host fetches a release artifact instead of GitHub Actions opening inbound SSH to the host.
+The VPS is now a fallback target rather than the only copy of the storefront.
+Remote preparation and upload use bounded retries, but a failed VPS promotion
+stops the release before Pages production is changed. The existing **Web SSH
+Connectivity Check** workflow remains the direct network diagnostic.
 
 ## Manager Frontend Env Model
 

--- a/docs/web-runtime-freshness-runbook.md
+++ b/docs/web-runtime-freshness-runbook.md
@@ -1,5 +1,9 @@
 # Production Web Runtime Freshness Runbook
 
+> Historical design record. The current static release path uses Cloudflare
+> Pages plus atomic VPS releases; see `docs/deployment.md`. The SSR staging
+> sections below remain relevant only to a future runtime migration.
+
 Related issue: #471
 
 This is the production design and runbook for moving the storefront from a

--- a/scripts/bootstrap_web_atomic_nginx.sh
+++ b/scripts/bootstrap_web_atomic_nginx.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WEB_ROOT="${WEB_ROOT:-/var/www/mvn.by}"
+LEGACY_DIR="${WEB_LEGACY_DIR:-${WEB_ROOT}/current}"
+LIVE_LINK="${WEB_LIVE_LINK:-${WEB_ROOT}/live}"
+NGINX_SITE_FILE="${WEB_NGINX_SITE_FILE:-/etc/nginx/sites-available/mvn.by}"
+WEB_HOST="${WEB_HOST:-mvn.by}"
+CONFIRM="${CONFIRM_WEB_NGINX_BOOTSTRAP:-false}"
+
+created_live_link=false
+site_changed=false
+backup=""
+
+log() {
+  printf '[web-nginx][%s] %s\n' "$1" "$2"
+}
+
+rollback_on_error() {
+  local exit_code=$?
+  trap - ERR
+  set +e
+  if [[ "${site_changed}" == "true" && -n "${backup}" ]]; then
+    cp -a "${backup}" "${NGINX_SITE_FILE}"
+    nginx -t && systemctl reload nginx
+  fi
+  if [[ "${created_live_link}" == "true" ]]; then
+    rm -f "${LIVE_LINK}"
+  fi
+  exit "${exit_code}"
+}
+
+if [[ "${CONFIRM}" != "true" ]]; then
+  log error "set CONFIRM_WEB_NGINX_BOOTSTRAP=true to apply"
+  exit 1
+fi
+for command in nginx systemctl python3 curl; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+[[ -d "${LEGACY_DIR}" ]] || {
+  log error "legacy web directory is missing: ${LEGACY_DIR}"
+  exit 1
+}
+[[ -f "${NGINX_SITE_FILE}" ]] || {
+  log error "nginx site is missing: ${NGINX_SITE_FILE}"
+  exit 1
+}
+
+trap rollback_on_error ERR
+if [[ -e "${LIVE_LINK}" && ! -L "${LIVE_LINK}" ]]; then
+  log error "refusing to replace non-symlink ${LIVE_LINK}"
+  exit 1
+fi
+if [[ ! -L "${LIVE_LINK}" ]]; then
+  ln -s "${LEGACY_DIR}" "${LIVE_LINK}"
+  created_live_link=true
+fi
+[[ -f "${LIVE_LINK}/index.html" ]] || {
+  log error "live link does not resolve to a storefront index"
+  exit 1
+}
+
+legacy_root="root ${LEGACY_DIR};"
+live_root="root ${LIVE_LINK};"
+if grep -Fq "${legacy_root}" "${NGINX_SITE_FILE}"; then
+  backup="${NGINX_SITE_FILE}.pre-atomic-web-$(date -u +%Y%m%dT%H%M%SZ)"
+  cp -a "${NGINX_SITE_FILE}" "${backup}"
+  python3 - "${NGINX_SITE_FILE}" "${legacy_root}" "${live_root}" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+old = sys.argv[2]
+new = sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if old not in text:
+    raise SystemExit(f"legacy nginx root not found in {path}")
+updated = text.replace(old, new)
+tmp = path.with_name(f"{path.name}.tmp")
+tmp.write_text(updated, encoding="utf-8")
+os.chmod(tmp, stat.S_IMODE(path.stat().st_mode))
+os.replace(tmp, path)
+PY
+  site_changed=true
+elif ! grep -Fq "${live_root}" "${NGINX_SITE_FILE}"; then
+  log error "nginx site contains neither legacy nor managed live root"
+  exit 1
+fi
+
+nginx -t
+if [[ "${site_changed}" == "true" ]]; then
+  systemctl reload nginx
+fi
+curl -fsS --resolve "${WEB_HOST}:443:127.0.0.1" "https://${WEB_HOST}/" >/dev/null
+
+trap - ERR
+log "done" "nginx serves ${LIVE_LINK}; current content is unchanged"

--- a/scripts/check_web_dist.py
+++ b/scripts/check_web_dist.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate the built static storefront before any production promotion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+class AssetParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.references: set[str] = set()
+
+    def handle_starttag(self, _tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name in {"href", "src", "poster"} and value:
+                self.references.add(value)
+
+
+def local_asset_paths(html: str) -> set[str]:
+    parser = AssetParser()
+    parser.feed(html)
+    paths: set[str] = set()
+    for reference in parser.references:
+        parsed = urlsplit(reference)
+        if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):
+            continue
+        path = unquote(parsed.path).lstrip("/")
+        if path and Path(path).suffix:
+            paths.add(path)
+    return paths
+
+
+def validate_dist(dist: Path, expected_release: str | None = None) -> tuple[int, int]:
+    required_pages = ("index.html", "catalog/index.html")
+    for relative in required_pages:
+        path = dist / relative
+        if not path.is_file() or path.stat().st_size == 0:
+            raise RuntimeError(f"required page is missing or empty: {relative}")
+
+    if expected_release is not None:
+        release_path = dist / "release.json"
+        try:
+            release = json.loads(release_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            raise RuntimeError("release.json is missing or invalid") from exc
+        if release != {"sha": expected_release}:
+            raise RuntimeError("release.json does not match the expected release SHA")
+
+    html_files = sorted(dist.rglob("*.html"))
+    if len(html_files) < 10:
+        raise RuntimeError(f"static build has too few HTML pages: {len(html_files)}")
+
+    missing_assets: set[str] = set()
+    referenced_assets: set[str] = set()
+    same_origin_media: set[str] = set()
+    for html_path in html_files:
+        html = html_path.read_text(encoding="utf-8")
+        if "http://127.0.0.1" in html or "http://localhost" in html:
+            raise RuntimeError(f"local development URL leaked into {html_path.relative_to(dist)}")
+        for asset in local_asset_paths(html):
+            referenced_assets.add(asset)
+            if asset.startswith("media/"):
+                same_origin_media.add(asset)
+            if not (dist / asset).is_file():
+                missing_assets.add(asset)
+
+    if same_origin_media:
+        sample = ", ".join(sorted(same_origin_media)[:10])
+        raise RuntimeError(f"same-origin media paths are incompatible with Pages: {sample}")
+    if missing_assets:
+        sample = ", ".join(sorted(missing_assets)[:10])
+        raise RuntimeError(f"referenced static assets are missing: {sample}")
+    if not any(asset.startswith("_astro/") for asset in referenced_assets):
+        raise RuntimeError("build does not reference any _astro assets")
+
+    return len(html_files), len(referenced_assets)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist", type=Path)
+    parser.add_argument("--expected-release")
+    args = parser.parse_args()
+    try:
+        html_count, asset_count = validate_dist(args.dist.resolve(), args.expected_release)
+    except RuntimeError as exc:
+        print(f"web_dist_status=failed reason={exc}")
+        return 1
+    print(f"web_dist_status=passed html_pages={html_count} referenced_assets={asset_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy_cloudflare_pages.sh
+++ b/scripts/deploy_cloudflare_pages.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIST_DIR="${PAGES_DIST_DIR:-web/dist}"
+PROJECT_NAME="${CLOUDFLARE_PAGES_PROJECT:-mvn-by}"
+DEPLOY_BRANCH="${CLOUDFLARE_PAGES_BRANCH:-}"
+COMMIT_SHA="${PAGES_COMMIT_SHA:-}"
+WRANGLER_VERSION="${WRANGLER_VERSION:-4.110.0}"
+WRANGLER_BIN="${WRANGLER_BIN:-npx}"
+WRANGLER_RUNNER="${WRANGLER_RUNNER:-npx}"
+SMOKE_ATTEMPTS="${PAGES_SMOKE_ATTEMPTS:-20}"
+SMOKE_DELAY_SECONDS="${PAGES_SMOKE_DELAY_SECONDS:-3}"
+OUTPUT_FILE="${PAGES_DEPLOY_OUTPUT_FILE:-/tmp/cloudflare-pages-deploy.log}"
+
+log() {
+  printf '[pages-deploy][%s] %s\n' "$1" "$2"
+}
+
+[[ -n "${CLOUDFLARE_API_TOKEN:-}" ]] || {
+  log error "CLOUDFLARE_API_TOKEN is required"
+  exit 1
+}
+[[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || {
+  log error "CLOUDFLARE_ACCOUNT_ID is required"
+  exit 1
+}
+[[ "${PROJECT_NAME}" =~ ^[a-z0-9][a-z0-9-]{0,57}[a-z0-9]$ ]] || {
+  log error "invalid Cloudflare Pages project name: ${PROJECT_NAME}"
+  exit 1
+}
+[[ "${DEPLOY_BRANCH}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,80}$ ]] || {
+  log error "invalid Pages branch: ${DEPLOY_BRANCH}"
+  exit 1
+}
+[[ "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+  log error "PAGES_COMMIT_SHA must be a full Git SHA"
+  exit 1
+}
+[[ -s "${DIST_DIR}/index.html" ]] || {
+  log error "Pages dist is missing index.html: ${DIST_DIR}"
+  exit 1
+}
+python3 - "${DIST_DIR}/release.json" "${COMMIT_SHA}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+release = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if release != {"sha": sys.argv[2]}:
+    raise SystemExit("release.json does not match PAGES_COMMIT_SHA")
+PY
+for command in "${WRANGLER_BIN}" python3 curl; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+
+case "${WRANGLER_RUNNER}" in
+  npx) wrangler_command=("${WRANGLER_BIN}" --yes "wrangler@${WRANGLER_VERSION}") ;;
+  pnpm) wrangler_command=("${WRANGLER_BIN}" dlx "wrangler@${WRANGLER_VERSION}") ;;
+  *)
+    log error "WRANGLER_RUNNER must be npx or pnpm"
+    exit 1
+    ;;
+esac
+
+"${wrangler_command[@]}" pages deploy "${DIST_DIR}" \
+  --project-name "${PROJECT_NAME}" \
+  --branch "${DEPLOY_BRANCH}" \
+  --commit-hash "${COMMIT_SHA}" \
+  --commit-message "MVN ${COMMIT_SHA}" \
+  --commit-dirty=false \
+  2>&1 | tee "${OUTPUT_FILE}"
+
+deployment_url="$(python3 - "${OUTPUT_FILE}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+urls = re.findall(r"https://[a-zA-Z0-9.-]+\.pages\.dev", text)
+if not urls:
+    raise SystemExit("Wrangler output did not contain a pages.dev deployment URL")
+print(urls[-1].rstrip("."))
+PY
+)"
+
+for attempt in $(seq 1 "${SMOKE_ATTEMPTS}"); do
+  if curl -fsSL --retry 2 --retry-delay 1 "${deployment_url}/" >/dev/null \
+    && curl -fsSL --retry 2 --retry-delay 1 "${deployment_url}/catalog/" >/dev/null \
+    && remote_sha="$(curl -fsSL --retry 2 --retry-delay 1 \
+      "${deployment_url}/release.json?sha=${COMMIT_SHA}" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["sha"])')" \
+    && [[ "${remote_sha}" == "${COMMIT_SHA}" ]]; then
+    log smoke "deployment is ready on attempt ${attempt}: ${deployment_url}"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+      printf 'deployment_url=%s\n' "${deployment_url}" >> "${GITHUB_OUTPUT}"
+    fi
+    log "done" "Pages branch ${DEPLOY_BRANCH} deployed"
+    exit 0
+  fi
+  sleep "${SMOKE_DELAY_SECONDS}"
+done
+
+log error "Pages deployment failed smoke checks: ${deployment_url}"
+exit 1

--- a/scripts/deploy_web_atomic.sh
+++ b/scripts/deploy_web_atomic.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WEB_HOST="${WEB_HOST:-}"
+WEB_SITE_HOST="${WEB_SITE_HOST:-mvn.by}"
+WEB_USER="${WEB_USER:-deploy}"
+WEB_ROOT="${WEB_ROOT:-/var/www/mvn.by}"
+WEB_RELEASE_ID="${WEB_RELEASE_ID:-}"
+WEB_DIST_DIR="${WEB_DIST_DIR:-web/dist}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-${HOME}/.ssh/deploy_key}"
+KEEP_RELEASES="${WEB_KEEP_RELEASES:-5}"
+MAX_ATTEMPTS="${WEB_DEPLOY_MAX_ATTEMPTS:-3}"
+REMOTE_HELPER="${WEB_REMOTE_HELPER:-/tmp/promote_web_release.sh}"
+PROMOTE_HELPER_SOURCE="${WEB_PROMOTE_HELPER_SOURCE:-scripts/promote_web_release.sh}"
+
+log() {
+  printf '[web-deploy][%s] %s\n' "$1" "$2"
+}
+
+quote() {
+  printf '%q' "$1"
+}
+
+[[ -n "${WEB_HOST}" ]] || {
+  log error "WEB_HOST is required"
+  exit 1
+}
+[[ "${WEB_ROOT}" == /* && "${WEB_ROOT}" != "/" && "${WEB_ROOT}" != *".."* ]] || {
+  log error "WEB_ROOT must be a safe absolute path"
+  exit 1
+}
+[[ "${WEB_RELEASE_ID}" =~ ^[0-9a-f]{7,64}$ ]] || {
+  log error "WEB_RELEASE_ID must be a lowercase hex commit id"
+  exit 1
+}
+[[ -s "${WEB_DIST_DIR}/index.html" ]] || {
+  log error "built storefront is missing: ${WEB_DIST_DIR}/index.html"
+  exit 1
+}
+[[ -s "${WEB_DIST_DIR}/catalog/index.html" ]] || {
+  log error "built catalog is missing: ${WEB_DIST_DIR}/catalog/index.html"
+  exit 1
+}
+python3 - "${WEB_DIST_DIR}/release.json" "${WEB_RELEASE_ID}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+release = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if release != {"sha": sys.argv[2]}:
+    raise SystemExit("release.json does not match WEB_RELEASE_ID")
+PY
+[[ -f "${PROMOTE_HELPER_SOURCE}" ]] || {
+  log error "promotion helper is missing: ${PROMOTE_HELPER_SOURCE}"
+  exit 1
+}
+for command in ssh rsync; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+
+SSH_OPTS=(
+  -i "${SSH_KEY_PATH}"
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=yes
+  -o ConnectTimeout=15
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=3
+)
+target="${WEB_USER}@${WEB_HOST}"
+incoming="${WEB_ROOT}/releases/.${WEB_RELEASE_ID}.incoming"
+
+prepared=false
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  log prepare "attempt ${attempt}/${MAX_ATTEMPTS}"
+  # shellcheck disable=SC2029
+  if ssh "${SSH_OPTS[@]}" "${target}" \
+    "mkdir -p $(quote "${WEB_ROOT}/releases") && rm -rf $(quote "${incoming}") && mkdir -p $(quote "${incoming}")" \
+    && cat "${PROMOTE_HELPER_SOURCE}" | ssh "${SSH_OPTS[@]}" "${target}" \
+      "cat > $(quote "${REMOTE_HELPER}") && chmod 0755 $(quote "${REMOTE_HELPER}")"; then
+    prepared=true
+    break
+  fi
+  sleep $((attempt * 10))
+done
+[[ "${prepared}" == "true" ]] || {
+  log error "remote release preparation failed after ${MAX_ATTEMPTS} attempts"
+  exit 1
+}
+
+uploaded=false
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  log upload "attempt ${attempt}/${MAX_ATTEMPTS}"
+  if rsync -az --delete --delay-updates \
+    -e "ssh ${SSH_OPTS[*]}" \
+    "${WEB_DIST_DIR}/" \
+    "${target}:${incoming}/"; then
+    uploaded=true
+    break
+  fi
+  sleep $((attempt * 10))
+done
+[[ "${uploaded}" == "true" ]] || {
+  log error "rsync failed after ${MAX_ATTEMPTS} attempts"
+  exit 1
+}
+
+# shellcheck disable=SC2029
+ssh "${SSH_OPTS[@]}" "${target}" "\
+  WEB_ROOT=$(quote "${WEB_ROOT}") \
+  WEB_RELEASE_ID=$(quote "${WEB_RELEASE_ID}") \
+  WEB_KEEP_RELEASES=$(quote "${KEEP_RELEASES}") \
+  WEB_HOST=$(quote "${WEB_SITE_HOST}") \
+  WEB_DEPLOY_SUMMARY_FILE=/tmp/web_deploy_summary.txt \
+  bash $(quote "${REMOTE_HELPER}") && \
+  cat /tmp/web_deploy_summary.txt"
+log "done" "atomic VPS release ${WEB_RELEASE_ID} is active"

--- a/scripts/promote_web_release.sh
+++ b/scripts/promote_web_release.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WEB_ROOT="${WEB_ROOT:-/var/www/mvn.by}"
+RELEASE_ID="${WEB_RELEASE_ID:-}"
+KEEP_RELEASES="${WEB_KEEP_RELEASES:-5}"
+WEB_HOST="${WEB_HOST:-mvn.by}"
+LIVE_LINK="${WEB_LIVE_LINK:-${WEB_ROOT}/live}"
+RELEASES_DIR="${WEB_ROOT}/releases"
+INCOMING_DIR="${RELEASES_DIR}/.${RELEASE_ID}.incoming"
+RELEASE_DIR="${RELEASES_DIR}/${RELEASE_ID}"
+LOCK_FILE="${WEB_DEPLOY_LOCK_FILE:-${WEB_ROOT}/.deploy.lock}"
+SUMMARY_FILE="${WEB_DEPLOY_SUMMARY_FILE:-/tmp/web_deploy_summary.txt}"
+
+previous_target=""
+promoted=false
+
+log() {
+  printf '[web-promote][%s] %s\n' "$1" "$2"
+}
+
+atomic_link() {
+  local target="$1"
+  local next="${LIVE_LINK}.next.$$"
+  ln -s "${target}" "${next}"
+  python3 - "${next}" "${LIVE_LINK}" <<'PY'
+import os
+import sys
+
+os.replace(sys.argv[1], sys.argv[2])
+PY
+}
+
+rollback_on_error() {
+  local exit_code=$?
+  trap - ERR
+  set +e
+  if [[ "${promoted}" == "true" && -n "${previous_target}" ]]; then
+    atomic_link "${previous_target}"
+    log rollback "restored ${previous_target}"
+  fi
+  exit "${exit_code}"
+}
+
+[[ "${RELEASE_ID}" =~ ^[0-9a-f]{7,64}$ ]] || {
+  log error "WEB_RELEASE_ID must be a 7-64 character lowercase hex commit id"
+  exit 1
+}
+[[ "${KEEP_RELEASES}" =~ ^[1-9][0-9]*$ ]] || {
+  log error "WEB_KEEP_RELEASES must be a positive integer"
+  exit 1
+}
+[[ "${WEB_ROOT}" == /* && "${WEB_ROOT}" != "/" && "${WEB_ROOT}" != *".."* ]] || {
+  log error "WEB_ROOT must be a safe absolute path"
+  exit 1
+}
+for command in flock curl python3; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+[[ -L "${LIVE_LINK}" ]] || {
+  log error "atomic live symlink is missing: ${LIVE_LINK}"
+  exit 1
+}
+[[ -d "${INCOMING_DIR}" ]] || {
+  log error "incoming release is missing: ${INCOMING_DIR}"
+  exit 1
+}
+[[ -s "${INCOMING_DIR}/index.html" ]] || {
+  log error "incoming release has no index.html"
+  exit 1
+}
+[[ -s "${INCOMING_DIR}/catalog/index.html" ]] || {
+  log error "incoming release has no catalog/index.html"
+  exit 1
+}
+python3 - "${INCOMING_DIR}/release.json" "${RELEASE_ID}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+release = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if release != {"sha": sys.argv[2]}:
+    raise SystemExit("incoming release.json does not match WEB_RELEASE_ID")
+PY
+
+exec 9>"${LOCK_FILE}"
+flock -n 9 || {
+  log error "another web deployment holds ${LOCK_FILE}"
+  exit 1
+}
+: > "${SUMMARY_FILE}"
+trap rollback_on_error ERR
+
+previous_target="$(readlink "${LIVE_LINK}")"
+if [[ -d "${RELEASE_DIR}" ]]; then
+  rm -rf "${INCOMING_DIR}"
+else
+  mv "${INCOMING_DIR}" "${RELEASE_DIR}"
+fi
+printf '%s\n' "${RELEASE_ID}" > "${RELEASE_DIR}/.release-id"
+
+atomic_link "${RELEASE_DIR}"
+promoted=true
+curl -fsS --resolve "${WEB_HOST}:443:127.0.0.1" "https://${WEB_HOST}/" >/dev/null
+curl -fsS --resolve "${WEB_HOST}:443:127.0.0.1" "https://${WEB_HOST}/catalog/" >/dev/null
+
+active_target="$(readlink -f "${LIVE_LINK}")"
+if ! python3 - "${RELEASES_DIR}" "${active_target}" "${KEEP_RELEASES}" <<'PY'
+import re
+import shutil
+import sys
+from pathlib import Path
+
+releases = Path(sys.argv[1])
+active = Path(sys.argv[2]).resolve()
+keep = int(sys.argv[3])
+candidates = [
+    path
+    for path in releases.iterdir()
+    if path.is_dir() and re.fullmatch(r"[0-9a-f]{7,64}", path.name)
+]
+candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+for path in candidates[keep:]:
+    if path.resolve() != active:
+        shutil.rmtree(path)
+PY
+then
+  log warning "old release cleanup failed; active release is unchanged"
+fi
+
+trap - ERR
+{
+  echo "status=activated"
+  echo "release_id=${RELEASE_ID}"
+  echo "release_dir=${RELEASE_DIR}"
+  echo "previous_target=${previous_target}"
+  echo "active_target=${active_target}"
+} >> "${SUMMARY_FILE}"
+log "done" "activated ${RELEASE_ID}"

--- a/tests/unit/test_check_web_dist.py
+++ b/tests/unit/test_check_web_dist.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.check_web_dist import validate_dist
+
+
+def _dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "dist"
+    asset = dist / "_astro/app.123.js"
+    asset.parent.mkdir(parents=True)
+    asset.write_text("console.log('ok')", encoding="utf-8")
+    for index in range(10):
+        page = dist / ("index.html" if index == 0 else f"page-{index}/index.html")
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text('<html><script src="/_astro/app.123.js"></script></html>', encoding="utf-8")
+    catalog = dist / "catalog/index.html"
+    catalog.parent.mkdir(parents=True)
+    catalog.write_text('<html><script src="/_astro/app.123.js"></script></html>', encoding="utf-8")
+    return dist
+
+
+def test_validate_dist_accepts_complete_static_build(tmp_path):
+    html_count, asset_count = validate_dist(_dist(tmp_path))
+
+    assert html_count == 11
+    assert asset_count == 1
+
+
+def test_validate_dist_requires_matching_release_marker(tmp_path):
+    dist = _dist(tmp_path)
+    sha = "a" * 40
+    (dist / "release.json").write_text(json.dumps({"sha": sha}), encoding="utf-8")
+
+    validate_dist(dist, sha)
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        validate_dist(dist, "b" * 40)
+
+
+def test_validate_dist_rejects_missing_referenced_asset(tmp_path):
+    dist = _dist(tmp_path)
+    (dist / "_astro/app.123.js").unlink()
+
+    with pytest.raises(RuntimeError, match="referenced static assets are missing"):
+        validate_dist(dist)
+
+
+def test_validate_dist_rejects_localhost_leak(tmp_path):
+    dist = _dist(tmp_path)
+    (dist / "index.html").write_text("<html>http://localhost:8000</html>", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="development URL leaked"):
+        validate_dist(dist)
+
+
+def test_validate_dist_rejects_same_origin_media_dependency(tmp_path):
+    dist = _dist(tmp_path)
+    (dist / "index.html").write_text(
+        '<html><img src="/media/library/crop/hash.webp"></html>',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="incompatible with Pages"):
+        validate_dist(dist)

--- a/tests/unit/test_deploy_cloudflare_pages_script.py
+++ b/tests/unit/test_deploy_cloudflare_pages_script.py
@@ -1,0 +1,136 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/deploy_cloudflare_pages.sh"
+SHA = "b" * 40
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_pages_deploy_uses_pinned_wrangler_and_smokes_returned_url(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    _executable(
+        fake_bin / "fake-npx",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+printf 'Deployment complete! Take a peek over at https://abc123.mvn-by.pages.dev\n'
+""",
+    )
+    _executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+if [[ "$*" == *release.json* ]]; then
+  printf '{"sha":"%s"}\n' "$EXPECTED_SHA"
+fi
+""",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("index", encoding="utf-8")
+    (dist / "release.json").write_text(json.dumps({"sha": SHA}), encoding="utf-8")
+    github_output = tmp_path / "github-output"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "EXPECTED_SHA": SHA,
+            "CLOUDFLARE_API_TOKEN": "test-token",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+            "CLOUDFLARE_PAGES_PROJECT": "mvn-by",
+            "CLOUDFLARE_PAGES_BRANCH": "candidate-123",
+            "PAGES_COMMIT_SHA": SHA,
+            "PAGES_DIST_DIR": str(dist),
+            "WRANGLER_BIN": "fake-npx",
+            "PAGES_DEPLOY_OUTPUT_FILE": str(tmp_path / "deploy.log"),
+            "GITHUB_OUTPUT": str(github_output),
+        }
+    )
+
+    result = subprocess.run(["bash", str(SCRIPT)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    calls = command_log.read_text(encoding="utf-8")
+    assert "--yes wrangler@4.110.0 pages deploy" in calls
+    assert "--branch candidate-123" in calls
+    assert f"--commit-hash {SHA}" in calls
+    assert "https://abc123.mvn-by.pages.dev/" in calls
+    assert "deployment_url=https://abc123.mvn-by.pages.dev" in github_output.read_text(encoding="utf-8")
+
+
+def test_pages_deploy_rejects_mutable_commit_identifier(tmp_path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("index", encoding="utf-8")
+    (dist / "release.json").write_text(json.dumps({"sha": SHA}), encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "CLOUDFLARE_API_TOKEN": "test-token",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+            "CLOUDFLARE_PAGES_BRANCH": "main",
+            "PAGES_COMMIT_SHA": "main",
+            "PAGES_DIST_DIR": str(dist),
+        }
+    )
+
+    result = subprocess.run(["bash", str(SCRIPT)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 1
+    assert "full Git SHA" in result.stdout
+
+
+def test_pages_deploy_supports_pinned_pnpm_runner(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    _executable(
+        fake_bin / "fake-pnpm",
+        """#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+printf 'Deployment complete: https://pnpm123.mvn-by.pages.dev\n'
+""",
+    )
+    _executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+if [[ "$*" == *release.json* ]]; then
+  printf '{"sha":"%s"}\n' "$EXPECTED_SHA"
+fi
+""",
+    )
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("index", encoding="utf-8")
+    (dist / "release.json").write_text(json.dumps({"sha": SHA}), encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "EXPECTED_SHA": SHA,
+            "CLOUDFLARE_API_TOKEN": "test-token",
+            "CLOUDFLARE_ACCOUNT_ID": "account",
+            "CLOUDFLARE_PAGES_BRANCH": "candidate-pnpm",
+            "PAGES_COMMIT_SHA": SHA,
+            "PAGES_DIST_DIR": str(dist),
+            "WRANGLER_BIN": "fake-pnpm",
+            "WRANGLER_RUNNER": "pnpm",
+            "PAGES_DEPLOY_OUTPUT_FILE": str(tmp_path / "deploy.log"),
+        }
+    )
+
+    result = subprocess.run(["bash", str(SCRIPT)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "dlx wrangler@4.110.0 pages deploy" in command_log.read_text(encoding="utf-8")

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(job: dict, name: str) -> dict:
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+def test_reusable_web_release_promotes_one_immutable_artifact_in_safe_order():
+    workflow = _workflow(".github/workflows/deploy-web.yml")
+    job = workflow["jobs"]["production-web"]
+    names = [step.get("name") for step in job["steps"]]
+
+    assert workflow["on"]["workflow_call"]["inputs"]["deploy_sha"]["required"] == "true"
+    assert job["environment"] == "production-web"
+    assert _step(job, "Checkout immutable release")["with"]["ref"] == "${{ inputs.deploy_sha }}"
+    assert 'printf \'{"sha":"%s"}\\n\'' in _step(job, "Build Astro site from production API")["run"]
+    assert "--expected-release" in _step(job, "Validate static release")["run"]
+    assert names.index("Deploy Cloudflare Pages canary") < names.index("Deploy atomic VPS fallback")
+    assert names.index("Deploy atomic VPS fallback") < names.index("Deploy Cloudflare Pages production")
+    assert names.index("Deploy Cloudflare Pages production") < names.index("Smoke stable web endpoints")
+    assert _step(job, "Deploy Cloudflare Pages canary")["env"]["CLOUDFLARE_API_TOKEN"] == (
+        "${{ secrets.CLOUDFLARE_API_TOKEN_PAGES }}"
+    )
+    assert 'candidate-${DEPLOY_SHA:0:12}' in _step(job, "Deploy Cloudflare Pages canary")["run"]
+    assert "scripts/deploy_web_atomic.sh" in _step(job, "Deploy atomic VPS fallback")["run"]
+    assert '"${base_url}/release.json?sha=${DEPLOY_SHA}"' in _step(job, "Smoke stable web endpoints")["run"]
+
+
+def test_release_and_manual_rebuild_call_the_same_web_workflow():
+    deploy = _workflow(".github/workflows/deploy.yml")
+    rebuild = _workflow(".github/workflows/rebuild-web.yml")
+    automatic = deploy["jobs"]["deploy-frontend"]
+    manual = rebuild["jobs"]["rebuild"]
+
+    assert automatic["uses"] == "./.github/workflows/deploy-web.yml"
+    assert automatic["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
+    assert manual["uses"] == "./.github/workflows/deploy-web.yml"
+    assert manual["with"]["deploy_sha"] == "${{ github.sha }}"
+    assert manual["needs"] == "main-branch-guard"
+    assert rebuild["jobs"]["callback"]["if"] == "${{ always() }}"
+
+    workflow_text = "\n".join(
+        (REPO_ROOT / path).read_text(encoding="utf-8")
+        for path in (".github/workflows/deploy.yml", ".github/workflows/rebuild-web.yml")
+    )
+    assert "rsync -avz --delete" not in workflow_text

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -63,10 +63,7 @@ def test_deploy_runs_only_after_successful_ci_for_the_exact_sha():
 def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     workflow = _workflow(".github/workflows/deploy.yml")
     jobs = workflow["jobs"]
-    expected_environments = {
-        "deploy-backend": "production-api",
-        "deploy-frontend": "production-web",
-    }
+    expected_environments = {"deploy-backend": "production-api"}
 
     for job_name, environment in expected_environments.items():
         job = jobs[job_name]
@@ -84,6 +81,16 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert standby_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
     assert standby_call["with"]["backend_image"] == "${{ needs.deploy-backend.outputs.backend_image }}"
     assert standby_call["secrets"] == "inherit"
+
+    web_workflow = _workflow(".github/workflows/deploy-web.yml")
+    web_job = web_workflow["jobs"]["production-web"]
+    assert web_job["environment"] == "production-web"
+    web_checkout = next(step for step in web_job["steps"] if step.get("uses") == "actions/checkout@v6")
+    assert web_checkout["with"]["ref"] == "${{ inputs.deploy_sha }}"
+    web_call = jobs["deploy-frontend"]
+    assert web_call["uses"] == "./.github/workflows/deploy-web.yml"
+    assert web_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
+    assert web_call["secrets"] == "inherit"
 
     workflow_text = (REPO_ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     assert "backend:latest" not in workflow_text

--- a/tests/unit/test_web_atomic_deploy_scripts.py
+++ b/tests/unit/test_web_atomic_deploy_scripts.py
@@ -1,0 +1,164 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "scripts/bootstrap_web_atomic_nginx.sh"
+PROMOTE = REPO_ROOT / "scripts/promote_web_release.sh"
+DEPLOY = REPO_ROOT / "scripts/deploy_web_atomic.sh"
+RELEASE_ID = "a" * 40
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_bin(tmp_path: Path) -> tuple[Path, Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(
+        fake_bin / "nginx",
+        """#!/usr/bin/env bash
+printf 'nginx %s\n' "$*" >> "$COMMAND_LOG"
+[[ "${NGINX_FAIL:-false}" != "true" ]]
+""",
+    )
+    _executable(
+        fake_bin / "systemctl",
+        "#!/usr/bin/env bash\nprintf 'systemctl %s\n' \"$*\" >> \"$COMMAND_LOG\"\n",
+    )
+    _executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+[[ "${CURL_FAIL:-false}" != "true" ]]
+""",
+    )
+    return fake_bin, command_log
+
+
+def test_nginx_bootstrap_switches_to_live_symlink_without_changing_content(tmp_path):
+    fake_bin, command_log = _fake_bin(tmp_path)
+    web_root = tmp_path / "web"
+    current = web_root / "current"
+    current.mkdir(parents=True)
+    (current / "index.html").write_text("legacy", encoding="utf-8")
+    nginx_site = tmp_path / "mvn.by"
+    nginx_site.write_text(
+        f"server {{ root {current}; }}\nserver {{ root {current}; }}\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "WEB_ROOT": str(web_root),
+            "WEB_NGINX_SITE_FILE": str(nginx_site),
+            "CONFIRM_WEB_NGINX_BOOTSTRAP": "true",
+        }
+    )
+
+    result = subprocess.run(["bash", str(BOOTSTRAP)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    live = web_root / "live"
+    assert live.is_symlink()
+    assert live.resolve() == current
+    assert f"root {live};" in nginx_site.read_text(encoding="utf-8")
+    assert (live / "index.html").read_text(encoding="utf-8") == "legacy"
+    assert "systemctl reload nginx" in command_log.read_text(encoding="utf-8")
+
+
+def _release_environment(tmp_path: Path, *, curl_fail: bool = False) -> tuple[dict[str, str], Path]:
+    fake_bin, _ = _fake_bin(tmp_path)
+    web_root = tmp_path / "web"
+    current = web_root / "current"
+    incoming = web_root / "releases" / f".{RELEASE_ID}.incoming"
+    (incoming / "catalog").mkdir(parents=True)
+    current.mkdir(parents=True)
+    (current / "index.html").write_text("legacy", encoding="utf-8")
+    (incoming / "index.html").write_text("candidate", encoding="utf-8")
+    (incoming / "catalog/index.html").write_text("catalog", encoding="utf-8")
+    (incoming / "release.json").write_text(json.dumps({"sha": RELEASE_ID}), encoding="utf-8")
+    (web_root / "live").symlink_to(current)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(tmp_path / "commands.log"),
+            "WEB_ROOT": str(web_root),
+            "WEB_RELEASE_ID": RELEASE_ID,
+            "WEB_DEPLOY_SUMMARY_FILE": str(tmp_path / "summary.txt"),
+            "CURL_FAIL": "true" if curl_fail else "false",
+        }
+    )
+    return env, web_root
+
+
+def test_promote_release_atomically_updates_live_link(tmp_path):
+    env, web_root = _release_environment(tmp_path)
+
+    result = subprocess.run(["bash", str(PROMOTE)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    release = web_root / "releases" / RELEASE_ID
+    assert (web_root / "live").resolve() == release
+    assert (release / "index.html").read_text(encoding="utf-8") == "candidate"
+    assert (web_root / "current/index.html").read_text(encoding="utf-8") == "legacy"
+    assert "status=activated" in Path(env["WEB_DEPLOY_SUMMARY_FILE"]).read_text(encoding="utf-8")
+
+
+def test_promote_release_restores_previous_link_when_origin_smoke_fails(tmp_path):
+    env, web_root = _release_environment(tmp_path, curl_fail=True)
+    previous = (web_root / "live").resolve()
+
+    result = subprocess.run(["bash", str(PROMOTE)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode != 0
+    assert (web_root / "live").resolve() == previous
+    assert "restored" in result.stdout
+
+
+def test_local_deploy_uploads_only_to_incoming_release(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    command_log = tmp_path / "commands.log"
+    _executable(
+        fake_bin / "ssh",
+        "#!/usr/bin/env bash\nprintf 'ssh %s\n' \"$*\" >> \"$COMMAND_LOG\"\ncat >/dev/null || true\n",
+    )
+    _executable(
+        fake_bin / "rsync",
+        "#!/usr/bin/env bash\nprintf 'rsync %s\n' \"$*\" >> \"$COMMAND_LOG\"\n",
+    )
+    _executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+    dist = tmp_path / "dist"
+    (dist / "catalog").mkdir(parents=True)
+    (dist / "index.html").write_text("index", encoding="utf-8")
+    (dist / "catalog/index.html").write_text("catalog", encoding="utf-8")
+    (dist / "release.json").write_text(json.dumps({"sha": RELEASE_ID}), encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "WEB_HOST": "web.test",
+            "WEB_RELEASE_ID": RELEASE_ID,
+            "WEB_DIST_DIR": str(dist),
+            "WEB_PROMOTE_HELPER_SOURCE": str(PROMOTE),
+        }
+    )
+
+    result = subprocess.run(["bash", str(DEPLOY)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    rsync_call = next(line for line in command_log.read_text(encoding="utf-8").splitlines() if line.startswith("rsync "))
+    assert f"releases/.{RELEASE_ID}.incoming/" in rsync_call
+    assert "/current/" not in rsync_call
+    assert "/live/" not in rsync_call

--- a/web/src/content/blog/filtry-v-kondicionere-kakie-byvayut.mdx
+++ b/web/src/content/blog/filtry-v-kondicionere-kakie-byvayut.mdx
@@ -30,7 +30,7 @@ import AdditionalFilterOptions from '../../components/mdx/AdditionalFilterOption
 
 <figure>
   <img
-    src="/media/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp"
+    src="https://cdn.mvn.by/library/crop/aa250270b046686a61a0baa623a3ea133a7d44e549053c9881e9e85dc970bb21.webp"
     alt="Сетчатый фильтр грубой очистки во внутреннем блоке кондиционера"
     loading="lazy"
   />


### PR DESCRIPTION
## Summary
- build one immutable Astro artifact and validate its pages, assets, CDN-only media references, and release SHA
- deploy a Cloudflare Pages canary, atomically promote the same release on the VPS fallback, then promote Pages production
- reuse the release workflow for automatic deploys and manager-triggered rebuilds while preserving catalog callbacks
- document VPS/Pages rollback and migrate the last same-origin article asset to R2

## Safety
- no DNS/custom-domain change in this PR
- nginx already serves `/var/www/mvn.by/live`, currently linked to the unchanged `current` tree
- VPS uploads land in an incoming release directory; the live symlink changes only after validation and restores on failed origin smoke
- automatic and manual web releases share `production-release` concurrency

## Verification
- `20 passed` focused workflow/script tests
- ShellCheck passes for all new deployment scripts
- Actionlint passes for the new/rebuilt workflows
- real Astro build: 1058 pages, 1158 files, static artifact validation passed
- real Cloudflare Pages preview: `https://acfc7914.mvn-by.pages.dev`
- R2 article asset: HTTP 200, `image/webp`, immutable cache
