### PR TITLE
Fix Pages deployment runtime on Node 22

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -22,6 +22,7 @@ def test_reusable_web_release_promotes_one_immutable_artifact_in_safe_order():
     assert workflow["on"]["workflow_call"]["inputs"]["deploy_sha"]["required"] == "true"
     assert job["environment"] == "production-web"
     assert _step(job, "Checkout immutable release")["with"]["ref"] == "${{ inputs.deploy_sha }}"
+    assert _step(job, "Setup Node.js")["with"]["node-version"] == "22"
     assert 'printf \'{"sha":"%s"}\\n\'' in _step(job, "Build Astro site from production API")["run"]
     assert "--expected-release" in _step(job, "Validate static release")["run"]
     assert names.index("Deploy Cloudflare Pages canary") < names.index("Deploy atomic VPS fallback")


### PR DESCRIPTION
## Fix
- run the reusable web release on Node 22, required by pinned Wrangler 4.110.0
- lock the runtime requirement in the workflow unit test

The failed production run stopped at the Pages canary before VPS or Pages production promotion.

## Verification
- 8 focused workflow tests passed
- Actionlint passed