### PR TITLE
Prepare Patroni PostgreSQL quorum foundation

### DIFF
--- a/.github/workflows/patroni-failover-rehearsal.yml
+++ b/.github/workflows/patroni-failover-rehearsal.yml
@@ -1,0 +1,50 @@
+name: Patroni Failover Rehearsal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '35 3 * * 1'
+
+concurrency:
+  group: patroni-failover-rehearsal
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  rehearse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run isolated Patroni failover rehearsal
+        run: |
+          set -euo pipefail
+          PATRONI_REHEARSAL_TIMEOUT=150 \
+            bash scripts/ha/rehearse_patroni_failover.sh | tee patroni_rehearsal.log
+
+      - name: Upload rehearsal log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: patroni-failover-rehearsal-${{ github.run_id }}
+          path: patroni_rehearsal.log
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Rehearsal summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Patroni Failover Rehearsal'
+            echo '- run_id: ${{ github.run_id }}'
+            echo '- result: ${{ job.status }}'
+            echo '- topology: 3 isolated etcd members, 2 isolated PostgreSQL nodes'
+            echo '- production_data_touched: false'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-patroni-image.yml
+++ b/.github/workflows/publish-patroni-image.yml
@@ -1,0 +1,98 @@
+name: Publish Patroni Image
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-patroni-image
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      image: ${{ steps.image.outputs.reference }}
+
+    steps:
+      - name: Require tested main SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Patroni images may be published only from main"
+            exit 1
+          fi
+          count="$(
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow ci.yml \
+              --branch main \
+              --commit "${GITHUB_SHA}" \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq 'length'
+          )"
+          if [ "${count}" != "1" ]; then
+            echo "::error::No successful CI run found for ${GITHUB_SHA}"
+            exit 1
+          fi
+
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: tag
+        run: echo "tag=ghcr.io/${GITHUB_REPOSITORY,,}/patroni:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Patroni
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/ha/patroni/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tag.outputs.tag }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Resolve immutable image
+        id: image
+        run: |
+          set -euo pipefail
+          digest="${{ steps.build.outputs.digest }}"
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Invalid Patroni image digest: ${digest:-empty}"
+            exit 1
+          fi
+          reference="ghcr.io/${GITHUB_REPOSITORY,,}/patroni@${digest}"
+          echo "reference=${reference}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Patroni Image"
+            echo "- tested_sha: ${GITHUB_SHA}"
+            echo "- immutable_image: ${reference}"
+            echo "- production_deployed: false"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -1,0 +1,102 @@
+x-api-app: &api-app
+  image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+  restart: unless-stopped
+  depends_on:
+    db:
+      condition: service_healthy
+  env_file:
+    - .env
+    - .ha-app-role.env
+  environment:
+    DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+  volumes:
+    - ./media:/app/media
+    - ./postgres-wal-archive:/postgres-wal-archive
+    - ./model-cache/u2net:/root/.u2net
+    - ./token.json:/app/token.json
+    - ./client_secret.json:/app/client_secret.json
+    - ./credentials.json:/app/credentials.json
+    - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+
+services:
+  db:
+    image: ${PATRONI_IMAGE:?set immutable PATRONI_IMAGE in .env}
+    restart: unless-stopped
+    shm_size: 256mb
+    environment:
+      PATRONI_SCOPE: mvn-postgres
+      PATRONI_NAMESPACE: /mvn/
+      PATRONI_NAME: mvn-api
+      PATRONI_POSTGRESQL_CONNECT_ADDRESS: 10.77.0.2:5432
+      PATRONI_RESTAPI_CONNECT_ADDRESS: 10.77.0.2:8008
+      PATRONI_ETCD3_HOSTS: 10.77.0.1:2379,10.77.0.2:2379,10.77.0.3:2379
+      PATRONI_ETCD3_PROTOCOL: https
+      PATRONI_ETCD3_CACERT: /etc/etcd/pki/ca.crt
+      PATRONI_ETCD3_CERT: /etc/etcd/pki/node.crt
+      PATRONI_ETCD3_KEY: /etc/etcd/pki/node.key
+      PATRONI_ALLOW_BOOTSTRAP: "false"
+      PATRONI_SYNCHRONOUS_MODE: "true"
+      PATRONI_SYNCHRONOUS_MODE_STRICT: "false"
+      PATRONI_FAILSAFE_MODE: "true"
+      PATRONI_WATCHDOG_MODE: "off"
+      PATRONI_MAXIMUM_LAG_ON_FAILOVER: "1048576"
+      PATRONI_ARCHIVE_MODE: ${POSTGRES_PITR_ARCHIVE_MODE:-off}
+      PATRONI_ARCHIVE_TIMEOUT: ${POSTGRES_PITR_ARCHIVE_TIMEOUT:-300}
+      PATRONI_ARCHIVE_COMMAND: test ! -f /postgres-wal-archive/%f && cp %p /postgres-wal-archive/%f || test -f /postgres-wal-archive/%f
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-air_conditioners}
+      PATRONI_REPLICATION_USERNAME: ${PATRONI_REPLICATION_USERNAME:?set PATRONI_REPLICATION_USERNAME in .env}
+      PATRONI_REPLICATION_PASSWORD: ${PATRONI_REPLICATION_PASSWORD:?set PATRONI_REPLICATION_PASSWORD in .env}
+    ports:
+      - "127.0.0.1:5432:5432"
+      - "10.77.0.2:5432:5432"
+      - "127.0.0.1:8008:8008"
+      - "10.77.0.2:8008:8008"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./postgres-wal-archive:/postgres-wal-archive
+      - ./patroni-pki:/etc/etcd/pki:ro
+    healthcheck:
+      test: [CMD, curl, -fsS, http://127.0.0.1:8008/health]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 15s
+    mem_limit: ${MVN_PATRONI_DB_MEMORY:-512m}
+
+  app:
+    <<: *api-app
+    ports:
+      - "127.0.0.1:8000:8000"
+
+  app-blue:
+    <<: *api-app
+    profiles: [bluegreen]
+    ports:
+      - "127.0.0.1:18001:8000"
+
+  app-green:
+    <<: *api-app
+    profiles: [bluegreen]
+    ports:
+      - "127.0.0.1:18002:8000"
+
+  bot:
+    image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+      - .ha-bot-role.env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+    volumes:
+      - ./media:/app/media
+      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    command: python -m bot_app.main
+
+volumes:
+  postgres_data:

--- a/deploy/ha/patroni/Dockerfile
+++ b/deploy/ha/patroni/Dockerfile
@@ -1,0 +1,24 @@
+ARG POSTGRES_IMAGE=postgres:15.18-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f
+FROM ${POSTGRES_IMAGE}
+
+ARG PATRONI_VERSION=4.1.4
+
+RUN apk add --no-cache \
+      curl \
+      py3-pip \
+      py3-psycopg2 \
+      python3 \
+      su-exec \
+    && pip3 install --no-cache-dir --break-system-packages "patroni[etcd3]==${PATRONI_VERSION}" \
+    && patroni --version
+
+COPY deploy/ha/patroni/render_patroni_config.py /usr/local/bin/render-patroni-config
+COPY deploy/ha/patroni/patroni-entrypoint.sh /usr/local/bin/patroni-entrypoint
+
+RUN chmod 0755 /usr/local/bin/render-patroni-config /usr/local/bin/patroni-entrypoint \
+    && mkdir -p /etc/patroni /var/run/postgresql \
+    && chown postgres:postgres /etc/patroni /var/run/postgresql
+
+EXPOSE 5432 8008
+ENTRYPOINT ["/usr/local/bin/patroni-entrypoint"]
+CMD ["patroni", "/etc/patroni/patroni.yml"]

--- a/deploy/ha/patroni/mvn-patroni-role-agent.service
+++ b/deploy/ha/patroni/mvn-patroni-role-agent.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=MVN Patroni API role reconciler
+Wants=network-online.target mvn-etcd-quorum.service
+After=network-online.target docker.service mvn-etcd-quorum.service
+Requires=docker.service
+ConditionPathExists=/usr/local/sbin/mvn-patroni-role-agent
+ConditionPathExists=/etc/default/mvn-patroni-role-agent
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/mvn-patroni-role-agent
+ExecStart=/usr/bin/python3 /usr/local/sbin/mvn-patroni-role-agent
+Restart=always
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ha/patroni/patroni-entrypoint.sh
+++ b/deploy/ha/patroni/patroni-entrypoint.sh
@@ -7,7 +7,8 @@ ALLOW_BOOTSTRAP="${PATRONI_ALLOW_BOOTSTRAP:-false}"
 
 if [ "$(id -u)" = "0" ]; then
   mkdir -p "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
-  chown -R postgres:postgres "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
+  chown postgres:postgres "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
+  chmod 0700 "${PGDATA}"
 fi
 
 if [ ! -s "${PGDATA}/PG_VERSION" ] && [ "${ALLOW_BOOTSTRAP}" != "true" ]; then

--- a/deploy/ha/patroni/patroni-entrypoint.sh
+++ b/deploy/ha/patroni/patroni-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+PGDATA="${PATRONI_POSTGRESQL_DATA_DIR:-${PGDATA:-/var/lib/postgresql/data}}"
+CONFIG_FILE="${PATRONI_CONFIG_FILE:-/etc/patroni/patroni.yml}"
+ALLOW_BOOTSTRAP="${PATRONI_ALLOW_BOOTSTRAP:-false}"
+
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
+  chown -R postgres:postgres "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
+fi
+
+if [ ! -s "${PGDATA}/PG_VERSION" ] && [ "${ALLOW_BOOTSTRAP}" != "true" ]; then
+  echo "[patroni-entrypoint][error] PGDATA is empty and PATRONI_ALLOW_BOOTSTRAP is not true" >&2
+  exit 1
+fi
+
+render-patroni-config "${CONFIG_FILE}"
+chmod 0600 "${CONFIG_FILE}"
+if [ "$(id -u)" = "0" ]; then
+  chown postgres:postgres "${CONFIG_FILE}"
+  exec su-exec postgres "$@"
+fi
+exec "$@"

--- a/deploy/ha/patroni/rehearsal/docker-compose.yml
+++ b/deploy/ha/patroni/rehearsal/docker-compose.yml
@@ -1,0 +1,128 @@
+name: mvn_patroni_rehearsal
+
+x-etcd: &etcd
+  image: quay.io/coreos/etcd:v3.6.11@sha256:6ae247c7666ceec554c51ba1f9bc8dd2212f975370dbd65710c9ca0e36ae1fff
+  restart: unless-stopped
+  networks: [ha]
+  healthcheck:
+    test: [CMD, etcdctl, endpoint, health]
+    interval: 5s
+    timeout: 3s
+    retries: 20
+
+x-patroni: &patroni
+  image: mvn-patroni-rehearsal:local
+  build:
+    context: ../../../..
+    dockerfile: deploy/ha/patroni/Dockerfile
+  restart: unless-stopped
+  depends_on:
+    etcd1: {condition: service_healthy}
+    etcd2: {condition: service_healthy}
+    etcd3: {condition: service_healthy}
+  environment: &patroni-env
+    PATRONI_SCOPE: mvn-rehearsal
+    PATRONI_NAMESPACE: /mvn-rehearsal/
+    PATRONI_ETCD_HOSTS: etcd1:2379,etcd2:2379,etcd3:2379
+    PATRONI_ETCD_PROTOCOL: http
+    PATRONI_ALLOW_BOOTSTRAP: "true"
+    PATRONI_SYNCHRONOUS_MODE: "true"
+    PATRONI_SYNCHRONOUS_MODE_STRICT: "false"
+    PATRONI_FAILSAFE_MODE: "true"
+    PATRONI_WATCHDOG_MODE: "off"
+    PATRONI_TTL: "20"
+    PATRONI_LOOP_WAIT: "4"
+    PATRONI_RETRY_TIMEOUT: "8"
+    PATRONI_MAXIMUM_LAG_ON_FAILOVER: "1048576"
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: rehearsal-superuser-password
+    PATRONI_REPLICATION_USERNAME: replicator
+    PATRONI_REPLICATION_PASSWORD: rehearsal-replication-password
+  networks: [ha]
+  healthcheck:
+    test: [CMD, curl, -fsS, http://127.0.0.1:8008/health]
+    interval: 5s
+    timeout: 3s
+    retries: 30
+    start_period: 10s
+
+services:
+  etcd1:
+    <<: *etcd
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd1
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd1:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd1:2380
+      - --initial-cluster=etcd1=http://etcd1:2380,etcd2=http://etcd2:2380,etcd3=http://etcd3:2380
+      - --initial-cluster-token=mvn-patroni-rehearsal
+      - --initial-cluster-state=new
+    volumes: [etcd1_data:/etcd-data]
+
+  etcd2:
+    <<: *etcd
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd2
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd2:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd2:2380
+      - --initial-cluster=etcd1=http://etcd1:2380,etcd2=http://etcd2:2380,etcd3=http://etcd3:2380
+      - --initial-cluster-token=mvn-patroni-rehearsal
+      - --initial-cluster-state=new
+    volumes: [etcd2_data:/etcd-data]
+
+  etcd3:
+    <<: *etcd
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd3
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd3:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd3:2380
+      - --initial-cluster=etcd1=http://etcd1:2380,etcd2=http://etcd2:2380,etcd3=http://etcd3:2380
+      - --initial-cluster-token=mvn-patroni-rehearsal
+      - --initial-cluster-state=new
+    volumes: [etcd3_data:/etcd-data]
+
+  pg1:
+    <<: *patroni
+    environment:
+      <<: *patroni-env
+      PATRONI_NAME: pg1
+      PATRONI_POSTGRESQL_CONNECT_ADDRESS: pg1:5432
+      PATRONI_RESTAPI_CONNECT_ADDRESS: pg1:8008
+    ports:
+      - 127.0.0.1:55431:5432
+      - 127.0.0.1:18008:8008
+    volumes: [pg1_data:/var/lib/postgresql/data]
+
+  pg2:
+    <<: *patroni
+    environment:
+      <<: *patroni-env
+      PATRONI_NAME: pg2
+      PATRONI_POSTGRESQL_CONNECT_ADDRESS: pg2:5432
+      PATRONI_RESTAPI_CONNECT_ADDRESS: pg2:8008
+    ports:
+      - 127.0.0.1:55432:5432
+      - 127.0.0.1:18009:8008
+    volumes: [pg2_data:/var/lib/postgresql/data]
+
+networks:
+  ha:
+    driver: bridge
+
+volumes:
+  etcd1_data:
+  etcd2_data:
+  etcd3_data:
+  pg1_data:
+  pg2_data:

--- a/deploy/ha/patroni/rehearsal/docker-compose.yml
+++ b/deploy/ha/patroni/rehearsal/docker-compose.yml
@@ -25,8 +25,8 @@ x-patroni: &patroni
   environment: &patroni-env
     PATRONI_SCOPE: mvn-rehearsal
     PATRONI_NAMESPACE: /mvn-rehearsal/
-    PATRONI_ETCD_HOSTS: etcd1:2379,etcd2:2379,etcd3:2379
-    PATRONI_ETCD_PROTOCOL: http
+    PATRONI_ETCD3_HOSTS: etcd1:2379,etcd2:2379,etcd3:2379
+    PATRONI_ETCD3_PROTOCOL: http
     PATRONI_ALLOW_BOOTSTRAP: "true"
     PATRONI_SYNCHRONOUS_MODE: "true"
     PATRONI_SYNCHRONOUS_MODE_STRICT: "false"

--- a/deploy/ha/patroni/rehearsal/docker-compose.yml
+++ b/deploy/ha/patroni/rehearsal/docker-compose.yml
@@ -4,6 +4,8 @@ x-etcd: &etcd
   image: quay.io/coreos/etcd:v3.6.11@sha256:6ae247c7666ceec554c51ba1f9bc8dd2212f975370dbd65710c9ca0e36ae1fff
   restart: unless-stopped
   networks: [ha]
+  mem_limit: 96m
+  cpus: 0.12
   healthcheck:
     test: [CMD, etcdctl, endpoint, health]
     interval: 5s
@@ -39,6 +41,8 @@ x-patroni: &patroni
     PATRONI_REPLICATION_USERNAME: replicator
     PATRONI_REPLICATION_PASSWORD: rehearsal-replication-password
   networks: [ha]
+  mem_limit: 320m
+  cpus: 0.30
   healthcheck:
     test: [CMD, curl, -fsS, http://127.0.0.1:8008/health]
     interval: 5s

--- a/deploy/ha/patroni/render_patroni_config.py
+++ b/deploy/ha/patroni/render_patroni_config.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Render a validated Patroni YAML file from environment variables."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def required(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def boolean(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be true or false")
+
+
+def integer(name: str, default: int, *, minimum: int = 0) -> int:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return value
+
+
+def csv(name: str) -> list[str]:
+    values = [item.strip() for item in required(name).split(",") if item.strip()]
+    if not values:
+        raise ValueError(f"{name} must contain at least one value")
+    return values
+
+
+def render_config() -> dict[str, Any]:
+    scope = os.getenv("PATRONI_SCOPE", "mvn-postgres").strip() or "mvn-postgres"
+    name = required("PATRONI_NAME")
+    connect_address = required("PATRONI_POSTGRESQL_CONNECT_ADDRESS")
+    rest_connect_address = required("PATRONI_RESTAPI_CONNECT_ADDRESS")
+    etcd_protocol = os.getenv("PATRONI_ETCD_PROTOCOL", "https").strip().lower()
+    if etcd_protocol not in {"http", "https"}:
+        raise ValueError("PATRONI_ETCD_PROTOCOL must be http or https")
+
+    ttl = integer("PATRONI_TTL", 30, minimum=20)
+    loop_wait = integer("PATRONI_LOOP_WAIT", 10, minimum=1)
+    retry_timeout = integer("PATRONI_RETRY_TIMEOUT", 10, minimum=1)
+    if loop_wait + (2 * retry_timeout) > ttl:
+        raise ValueError("PATRONI_LOOP_WAIT + 2*PATRONI_RETRY_TIMEOUT must be <= PATRONI_TTL")
+
+    superuser = required("POSTGRES_USER")
+    superuser_password = required("POSTGRES_PASSWORD")
+    replication_user = os.getenv("PATRONI_REPLICATION_USERNAME", "mvn_replicator").strip()
+    replication_password = required("PATRONI_REPLICATION_PASSWORD")
+    data_dir = os.getenv("PATRONI_POSTGRESQL_DATA_DIR", "/var/lib/postgresql/data").strip()
+    pgpass = os.getenv("PATRONI_POSTGRESQL_PGPASS", "/tmp/pgpass").strip()
+
+    etcd3: dict[str, Any] = {
+        "hosts": csv("PATRONI_ETCD_HOSTS"),
+        "protocol": etcd_protocol,
+    }
+    if etcd_protocol == "https":
+        etcd3.update(
+            {
+                "cacert": required("PATRONI_ETCD_CACERT"),
+                "cert": required("PATRONI_ETCD_CERT"),
+                "key": required("PATRONI_ETCD_KEY"),
+            }
+        )
+
+    postgres_parameters: dict[str, Any] = {
+        "hot_standby": "on",
+        "max_connections": integer("PATRONI_MAX_CONNECTIONS", 100, minimum=20),
+        "max_replication_slots": integer("PATRONI_MAX_REPLICATION_SLOTS", 10, minimum=2),
+        "max_wal_senders": integer("PATRONI_MAX_WAL_SENDERS", 10, minimum=2),
+        "unix_socket_directories": "/var/run/postgresql",
+        "wal_keep_size": os.getenv("PATRONI_WAL_KEEP_SIZE", "512MB").strip(),
+        "wal_level": "replica",
+        "wal_log_hints": "on",
+    }
+    archive_mode = os.getenv("PATRONI_ARCHIVE_MODE", "off").strip().lower()
+    if archive_mode not in {"on", "off"}:
+        raise ValueError("PATRONI_ARCHIVE_MODE must be on or off")
+    postgres_parameters["archive_mode"] = archive_mode
+    if archive_mode == "on":
+        postgres_parameters["archive_timeout"] = integer(
+            "PATRONI_ARCHIVE_TIMEOUT", 300, minimum=1
+        )
+        postgres_parameters["archive_command"] = required("PATRONI_ARCHIVE_COMMAND")
+
+    watchdog_mode = os.getenv("PATRONI_WATCHDOG_MODE", "off").strip().lower()
+    if watchdog_mode not in {"off", "automatic", "required"}:
+        raise ValueError("PATRONI_WATCHDOG_MODE must be off, automatic, or required")
+
+    return {
+        "scope": scope,
+        "namespace": os.getenv("PATRONI_NAMESPACE", "/mvn/").strip() or "/mvn/",
+        "name": name,
+        "restapi": {
+            "listen": "0.0.0.0:8008",
+            "connect_address": rest_connect_address,
+        },
+        "etcd3": etcd3,
+        "bootstrap": {
+            "dcs": {
+                "ttl": ttl,
+                "loop_wait": loop_wait,
+                "retry_timeout": retry_timeout,
+                "maximum_lag_on_failover": integer(
+                    "PATRONI_MAXIMUM_LAG_ON_FAILOVER", 1_048_576, minimum=0
+                ),
+                "check_timeline": True,
+                "failsafe_mode": boolean("PATRONI_FAILSAFE_MODE", True),
+                "synchronous_mode": boolean("PATRONI_SYNCHRONOUS_MODE", True),
+                "synchronous_mode_strict": boolean("PATRONI_SYNCHRONOUS_MODE_STRICT", False),
+                "synchronous_node_count": 1,
+                "postgresql": {
+                    "use_pg_rewind": True,
+                    "use_slots": True,
+                    "parameters": postgres_parameters,
+                },
+            },
+            "initdb": [{"encoding": "UTF8"}, "data-checksums"],
+            "pg_hba": [
+                "local all all trust",
+                "host all all 127.0.0.1/32 scram-sha-256",
+                "host all all 172.16.0.0/12 scram-sha-256",
+                f"host replication {replication_user} 172.16.0.0/12 scram-sha-256",
+                f"host replication {replication_user} 10.77.0.0/24 scram-sha-256",
+                "host all all 10.77.0.0/24 scram-sha-256",
+            ],
+        },
+        "postgresql": {
+            "listen": "0.0.0.0:5432",
+            "connect_address": connect_address,
+            "data_dir": data_dir,
+            "bin_dir": "/usr/local/bin",
+            "pgpass": pgpass,
+            "authentication": {
+                "replication": {
+                    "username": replication_user,
+                    "password": replication_password,
+                },
+                "superuser": {
+                    "username": superuser,
+                    "password": superuser_password,
+                },
+            },
+            "parameters": {"password_encryption": "scram-sha-256"},
+        },
+        "watchdog": {
+            "mode": watchdog_mode,
+            "device": os.getenv("PATRONI_WATCHDOG_DEVICE", "/dev/watchdog").strip(),
+            "safety_margin": integer("PATRONI_WATCHDOG_SAFETY_MARGIN", 5, minimum=-1),
+        },
+        "tags": {
+            "nofailover": boolean("PATRONI_TAG_NOFAILOVER", False),
+            "noloadbalance": boolean("PATRONI_TAG_NOLOADBALANCE", False),
+            "clonefrom": boolean("PATRONI_TAG_CLONEFROM", False),
+            "nosync": boolean("PATRONI_TAG_NOSYNC", False),
+        },
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: render-patroni-config OUTPUT", file=sys.stderr)
+        return 2
+    try:
+        config = render_config()
+    except ValueError as exc:
+        print(f"patroni_config_status=failed reason={exc}", file=sys.stderr)
+        return 1
+    output = Path(sys.argv[1])
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    print(f"patroni_config_status=rendered path={output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/ha/patroni/render_patroni_config.py
+++ b/deploy/ha/patroni/render_patroni_config.py
@@ -53,9 +53,9 @@ def render_config() -> dict[str, Any]:
     name = required("PATRONI_NAME")
     connect_address = required("PATRONI_POSTGRESQL_CONNECT_ADDRESS")
     rest_connect_address = required("PATRONI_RESTAPI_CONNECT_ADDRESS")
-    etcd_protocol = os.getenv("PATRONI_ETCD_PROTOCOL", "https").strip().lower()
+    etcd_protocol = os.getenv("PATRONI_ETCD3_PROTOCOL", "https").strip().lower()
     if etcd_protocol not in {"http", "https"}:
-        raise ValueError("PATRONI_ETCD_PROTOCOL must be http or https")
+        raise ValueError("PATRONI_ETCD3_PROTOCOL must be http or https")
 
     ttl = integer("PATRONI_TTL", 30, minimum=20)
     loop_wait = integer("PATRONI_LOOP_WAIT", 10, minimum=1)
@@ -71,15 +71,15 @@ def render_config() -> dict[str, Any]:
     pgpass = os.getenv("PATRONI_POSTGRESQL_PGPASS", "/tmp/pgpass").strip()
 
     etcd3: dict[str, Any] = {
-        "hosts": csv("PATRONI_ETCD_HOSTS"),
+        "hosts": csv("PATRONI_ETCD3_HOSTS"),
         "protocol": etcd_protocol,
     }
     if etcd_protocol == "https":
         etcd3.update(
             {
-                "cacert": required("PATRONI_ETCD_CACERT"),
-                "cert": required("PATRONI_ETCD_CERT"),
-                "key": required("PATRONI_ETCD_KEY"),
+                "cacert": required("PATRONI_ETCD3_CACERT"),
+                "cert": required("PATRONI_ETCD3_CERT"),
+                "key": required("PATRONI_ETCD3_KEY"),
             }
         )
 

--- a/deploy/ha/patroni/role-agent.env.example
+++ b/deploy/ha/patroni/role-agent.env.example
@@ -1,13 +1,13 @@
 # mvn-api defaults. On zakup use:
 # HA_PROJECT_DIR=/opt/mvn-reserve
-# HA_COMPOSE_FILE=docker-compose.reserve.yml
-# HA_READY_URL=http://127.0.0.1:18000/api/ready
-# HA_APP_SERVICE=app
+# HA_COMPOSE_FILE=docker-compose.patroni.yml
+# HA_READY_URL=http://127.0.0.1:18080/api/ready
 HA_PROJECT_DIR=/opt/air-api
-HA_COMPOSE_FILE=docker-compose.prod.yml
+HA_COMPOSE_FILE=docker-compose.patroni.yml
 HA_PATRONI_URL=http://127.0.0.1:8008/patroni
 HA_READY_URL=http://127.0.0.1:18080/api/ready
 HA_APP_SERVICE=
+HA_PRIMARY_SYSTEMD_UNITS=mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer
 HA_ROLE_POLL_SECONDS=3
 HA_PROMOTION_DELAY_SECONDS=8
 HA_READY_ATTEMPTS=30

--- a/deploy/ha/patroni/role-agent.env.example
+++ b/deploy/ha/patroni/role-agent.env.example
@@ -1,0 +1,13 @@
+# mvn-api defaults. On zakup use:
+# HA_PROJECT_DIR=/opt/mvn-reserve
+# HA_COMPOSE_FILE=docker-compose.reserve.yml
+# HA_READY_URL=http://127.0.0.1:18000/api/ready
+# HA_APP_SERVICE=app
+HA_PROJECT_DIR=/opt/air-api
+HA_COMPOSE_FILE=docker-compose.prod.yml
+HA_PATRONI_URL=http://127.0.0.1:8008
+HA_READY_URL=http://127.0.0.1:18080/api/ready
+HA_APP_SERVICE=
+HA_ROLE_POLL_SECONDS=3
+HA_PROMOTION_DELAY_SECONDS=8
+HA_READY_ATTEMPTS=30

--- a/deploy/ha/patroni/role-agent.env.example
+++ b/deploy/ha/patroni/role-agent.env.example
@@ -5,7 +5,7 @@
 # HA_APP_SERVICE=app
 HA_PROJECT_DIR=/opt/air-api
 HA_COMPOSE_FILE=docker-compose.prod.yml
-HA_PATRONI_URL=http://127.0.0.1:8008
+HA_PATRONI_URL=http://127.0.0.1:8008/patroni
 HA_READY_URL=http://127.0.0.1:18080/api/ready
 HA_APP_SERVICE=
 HA_ROLE_POLL_SECONDS=3

--- a/deploy/ha/proxy/nginx.conf
+++ b/deploy/ha/proxy/nginx.conf
@@ -1,0 +1,27 @@
+user nginx;
+worker_processes 1;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 256;
+}
+
+http {
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log warn;
+    client_max_body_size 20m;
+    proxy_read_timeout 60s;
+
+    server {
+        listen 8000;
+        server_name _;
+
+        location / {
+            include /etc/nginx/conf.d/mvn-upstream.conf;
+            proxy_set_header Host api.mvn.by;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+        }
+    }
+}

--- a/deploy/ha/proxy/upstream.conf
+++ b/deploy/ha/proxy/upstream.conf
@@ -1,0 +1,1 @@
+proxy_pass http://app:8000;

--- a/deploy/ha/quorum/docker-compose.etcd.yml
+++ b/deploy/ha/quorum/docker-compose.etcd.yml
@@ -1,0 +1,55 @@
+name: mvn_quorum
+
+services:
+  etcd:
+    image: ${ETCD_IMAGE:-quay.io/coreos/etcd:v3.6.11@sha256:6ae247c7666ceec554c51ba1f9bc8dd2212f975370dbd65710c9ca0e36ae1fff}
+    container_name: mvn-etcd
+    restart: unless-stopped
+    network_mode: host
+    command:
+      - /usr/local/bin/etcd
+      - --name=${ETCD_NAME:?set ETCD_NAME}
+      - --data-dir=/etcd-data
+      - --listen-client-urls=https://127.0.0.1:2379,https://${ETCD_WG_IP:?set ETCD_WG_IP}:2379
+      - --advertise-client-urls=https://${ETCD_WG_IP:?set ETCD_WG_IP}:2379
+      - --listen-peer-urls=https://${ETCD_WG_IP:?set ETCD_WG_IP}:2380
+      - --initial-advertise-peer-urls=https://${ETCD_WG_IP:?set ETCD_WG_IP}:2380
+      - --initial-cluster=mvn-api=https://10.77.0.2:2380,zakup=https://10.77.0.1:2380,mvn-web=https://10.77.0.3:2380
+      - --initial-cluster-token=${ETCD_CLUSTER_TOKEN:-mvn-postgres-ha-v1}
+      - --initial-cluster-state=${ETCD_INITIAL_CLUSTER_STATE:-new}
+      - --cert-file=/etc/etcd/pki/node.crt
+      - --key-file=/etc/etcd/pki/node.key
+      - --client-cert-auth=true
+      - --trusted-ca-file=/etc/etcd/pki/ca.crt
+      - --peer-cert-file=/etc/etcd/pki/node.crt
+      - --peer-key-file=/etc/etcd/pki/node.key
+      - --peer-client-cert-auth=true
+      - --peer-trusted-ca-file=/etc/etcd/pki/ca.crt
+      - --auto-compaction-mode=periodic
+      - --auto-compaction-retention=1h
+      - --quota-backend-bytes=1073741824
+      - --snapshot-count=10000
+    environment:
+      ETCDCTL_API: "3"
+    volumes:
+      - ./data:/etcd-data
+      - ./pki:/etc/etcd/pki:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          etcdctl --endpoints=https://127.0.0.1:2379
+          --cacert=/etc/etcd/pki/ca.crt
+          --cert=/etc/etcd/pki/node.crt
+          --key=/etc/etcd/pki/node.key endpoint health
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: 20m
+        max-file: "5"
+    mem_limit: ${ETCD_MEMORY_LIMIT:-192m}
+    cpus: ${ETCD_CPU_LIMIT:-0.35}

--- a/deploy/ha/quorum/etcd.env.example
+++ b/deploy/ha/quorum/etcd.env.example
@@ -1,0 +1,10 @@
+# One file per host under /opt/mvn-quorum/.env.
+# mvn-api: ETCD_NAME=mvn-api, ETCD_WG_IP=10.77.0.2
+# zakup:   ETCD_NAME=zakup,   ETCD_WG_IP=10.77.0.1
+# mvn:     ETCD_NAME=mvn-web, ETCD_WG_IP=10.77.0.3
+ETCD_NAME=mvn-api
+ETCD_WG_IP=10.77.0.2
+ETCD_CLUSTER_TOKEN=mvn-postgres-ha-v1
+ETCD_INITIAL_CLUSTER_STATE=new
+ETCD_MEMORY_LIMIT=192m
+ETCD_CPU_LIMIT=0.35

--- a/deploy/ha/quorum/mvn-etcd-quorum.service
+++ b/deploy/ha/quorum/mvn-etcd-quorum.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=MVN three-node etcd quorum
+Wants=network-online.target
+After=network-online.target docker.service wg-quick@wg-mvn.service
+Requires=docker.service wg-quick@wg-mvn.service
+ConditionPathExists=/opt/mvn-quorum/docker-compose.etcd.yml
+ConditionPathExists=/opt/mvn-quorum/.env
+ConditionPathExists=/opt/mvn-quorum/pki/node.key
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/mvn-quorum
+ExecStart=/usr/bin/docker compose --env-file .env -f docker-compose.etcd.yml up -d --wait
+ExecReload=/usr/bin/docker compose --env-file .env -f docker-compose.etcd.yml up -d --wait
+ExecStop=/usr/bin/docker compose --env-file .env -f docker-compose.etcd.yml stop
+TimeoutStartSec=180
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -1,0 +1,136 @@
+name: mvn_reserve
+
+x-api-app: &api-app
+  image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+  restart: unless-stopped
+  depends_on:
+    db:
+      condition: service_healthy
+  env_file:
+    - ${MVN_RESERVE_ENV_FILE:-.env}
+    - .ha-app-role.env
+  environment:
+    ENVIRONMENT: production
+    DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+    BACKGROUND_REMOVAL_PROVIDER: noop
+    BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
+    BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
+    BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+  volumes:
+    - ./media:/app/media
+    - ./postgres-wal-archive:/postgres-wal-archive
+    - ./model-cache/u2net:/root/.u2net
+    - ./secrets/token.json:/app/token.json
+    - ./secrets/client_secret.json:/app/client_secret.json:ro
+    - ./secrets/credentials.json:/app/credentials.json:ro
+    - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+  mem_limit: ${MVN_RESERVE_APP_MEMORY:-520m}
+  networks: [reserve]
+
+services:
+  db:
+    image: ${PATRONI_IMAGE:?set immutable PATRONI_IMAGE in .env}
+    restart: unless-stopped
+    shm_size: 128mb
+    environment:
+      PATRONI_SCOPE: mvn-postgres
+      PATRONI_NAMESPACE: /mvn/
+      PATRONI_NAME: zakup
+      PATRONI_POSTGRESQL_CONNECT_ADDRESS: 10.77.0.1:5432
+      PATRONI_RESTAPI_CONNECT_ADDRESS: 10.77.0.1:8008
+      PATRONI_ETCD3_HOSTS: 10.77.0.1:2379,10.77.0.2:2379,10.77.0.3:2379
+      PATRONI_ETCD3_PROTOCOL: https
+      PATRONI_ETCD3_CACERT: /etc/etcd/pki/ca.crt
+      PATRONI_ETCD3_CERT: /etc/etcd/pki/node.crt
+      PATRONI_ETCD3_KEY: /etc/etcd/pki/node.key
+      PATRONI_ALLOW_BOOTSTRAP: "false"
+      PATRONI_SYNCHRONOUS_MODE: "true"
+      PATRONI_SYNCHRONOUS_MODE_STRICT: "false"
+      PATRONI_FAILSAFE_MODE: "true"
+      PATRONI_WATCHDOG_MODE: "off"
+      PATRONI_MAXIMUM_LAG_ON_FAILOVER: "1048576"
+      PATRONI_MAX_CONNECTIONS: "100"
+      PATRONI_ARCHIVE_MODE: ${POSTGRES_PITR_ARCHIVE_MODE:-off}
+      PATRONI_ARCHIVE_TIMEOUT: ${POSTGRES_PITR_ARCHIVE_TIMEOUT:-300}
+      PATRONI_ARCHIVE_COMMAND: test ! -f /postgres-wal-archive/%f && cp %p /postgres-wal-archive/%f || test -f /postgres-wal-archive/%f
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-air_conditioners}
+      PATRONI_REPLICATION_USERNAME: ${PATRONI_REPLICATION_USERNAME:?set PATRONI_REPLICATION_USERNAME in .env}
+      PATRONI_REPLICATION_PASSWORD: ${PATRONI_REPLICATION_PASSWORD:?set PATRONI_REPLICATION_PASSWORD in .env}
+    ports:
+      - "10.77.0.1:5432:5432"
+      - "127.0.0.1:8008:8008"
+      - "10.77.0.1:8008:8008"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./postgres-wal-archive:/postgres-wal-archive
+      - ./patroni-pki:/etc/etcd/pki:ro
+    healthcheck:
+      test: [CMD, curl, -fsS, http://127.0.0.1:8008/health]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 15s
+    mem_limit: ${MVN_RESERVE_DB_MEMORY:-320m}
+    networks: [reserve]
+
+  app:
+    <<: *api-app
+    ports:
+      - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
+
+  app-blue:
+    <<: *api-app
+    profiles: [bluegreen]
+    ports:
+      - "127.0.0.1:18001:8000"
+
+  app-green:
+    <<: *api-app
+    profiles: [bluegreen]
+    ports:
+      - "127.0.0.1:18002:8000"
+
+  bot:
+    image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+      - .ha-bot-role.env
+    environment:
+      ENVIRONMENT: production
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      BACKGROUND_REMOVAL_PROVIDER: noop
+    command: python -m bot_app.main
+    volumes:
+      - ./media:/app/media
+      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
+    mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
+    networks: [reserve]
+
+  api-proxy:
+    image: nginx:1.28.0-alpine@sha256:09ab424a8c788f8d0fe3a64429f6d19dfa526885c8609b748d0943a75dcb9f8c
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:18080:8000"
+    volumes:
+      - ./api-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./api-proxy/upstream.conf:/etc/nginx/conf.d/mvn-upstream.conf:ro
+    healthcheck:
+      test: [CMD, nginx, -t]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+    mem_limit: 48m
+    networks: [reserve]
+
+volumes:
+  postgres_data:
+
+networks:
+  reserve:
+    driver: bridge

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -69,6 +69,7 @@ unreviewed host-local compose edits:
 | Cloudflare LB GitHub prerequisite apply helper | `scripts/ha/apply_cloudflare_lb_github_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
+| PostgreSQL quorum preparation | `docs/postgres-quorum-runbook.md`, `deploy/ha/quorum/`, `scripts/ha/generate_etcd_pki.sh`, `scripts/ha/check_etcd_quorum.sh` |
 
 ## Daily Status Checks
 
@@ -866,5 +867,6 @@ gh workflow run api-restore-drill.yml --repo mvnby/air-api --ref main
 
 ## Next Improvements
 
-- Add Cloudflare-native origin health alerts if GitHub Actions alerting is not
-  fast enough for operational needs.
+- Complete the staged Patroni migration described in
+  `docs/postgres-quorum-runbook.md`; etcd installation alone must not be treated
+  as automatic PostgreSQL failover.

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -69,7 +69,7 @@ unreviewed host-local compose edits:
 | Cloudflare LB GitHub prerequisite apply helper | `scripts/ha/apply_cloudflare_lb_github_prerequisites.py` |
 | Status helpers | `scripts/ha/mvn-primary-status.sh`, `scripts/ha/mvn-standby-status.sh` |
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
-| PostgreSQL quorum preparation | `docs/postgres-quorum-runbook.md`, `deploy/ha/quorum/`, `scripts/ha/generate_etcd_pki.sh`, `scripts/ha/check_etcd_quorum.sh` |
+| PostgreSQL quorum preparation | `docs/postgres-quorum-runbook.md`, `deploy/ha/quorum/`, `deploy/ha/patroni/`, `scripts/ha/generate_etcd_pki.sh`, `scripts/ha/check_etcd_quorum.sh`, `scripts/ha/patroni_role_agent.py` |
 
 ## Daily Status Checks
 

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -34,6 +34,10 @@ networking so it can bind directly to each node's WireGuard address.
 - `deploy/ha/quorum/mvn-etcd-quorum.service`: boot ordering and lifecycle;
 - `scripts/ha/generate_etcd_pki.sh`: private CA and certificate generator;
 - `scripts/ha/check_etcd_quorum.sh`: member, leader, Raft lag, and health check.
+- `deploy/ha/patroni/`: pinned PostgreSQL/Patroni image, validated config renderer,
+  role-agent unit, and isolated rehearsal cluster;
+- `scripts/ha/rehearse_patroni_failover.sh`: disposable failover/rejoin drill;
+- `scripts/ha/patroni_role_agent.py`: local API/scheduler/bot role reconciler.
 
 ## PKI
 
@@ -133,3 +137,38 @@ blocking. When the synchronous replica is healthy, acknowledged transactions
 are present on both database hosts. If the replica is unavailable, the service
 may continue writing, but Patroni must refuse a loss-unsafe automatic promotion.
 PITR remains the final recovery layer.
+
+## Runtime Role Handoff
+
+Patroni controls only PostgreSQL. The role agent maps the local Patroni role to
+two non-secret env files consumed by the app and bot containers:
+
+```text
+.ha-app-role.env
+.ha-bot-role.env
+```
+
+On a replica, it stops the bot, disables scheduler/bootstrap, and keeps
+`API_READY_ENABLED=false`. On a stable primary, it waits for the promotion
+delay, recreates only the active API slot with scheduler enabled, requires
+writable `/api/ready=200`, and then starts the bot. It never runs `compose up`
+for `db` and shares the existing `.deploy.lock` with application releases.
+
+This ordering prevents Cloudflare from routing to a promoted database before
+the singleton processes have moved, and prevents two Telegram pollers from
+running intentionally. PostgreSQL read-only checks remain an independent fence
+on the former primary.
+
+Install the agent only during the Patroni migration window:
+
+```bash
+install -m 0755 scripts/ha/patroni_role_agent.py \
+  /usr/local/sbin/mvn-patroni-role-agent
+install -m 0644 deploy/ha/patroni/mvn-patroni-role-agent.service \
+  /etc/systemd/system/mvn-patroni-role-agent.service
+install -m 0600 deploy/ha/patroni/role-agent.env.example \
+  /etc/default/mvn-patroni-role-agent
+```
+
+Edit the non-secret host paths/ports in `/etc/default/mvn-patroni-role-agent`,
+run `--once`, verify the generated role files, and only then enable the unit.

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -40,6 +40,13 @@ networking so it can bind directly to each node's WireGuard address.
 - `scripts/ha/patroni_role_agent.py`: local API/scheduler/bot role reconciler.
 - `.github/workflows/patroni-failover-rehearsal.yml`: weekly isolated drill and
   retained diagnostic log.
+- `.github/workflows/publish-patroni-image.yml`: manual, CI-gated publication of
+  the production Patroni image with provenance, SBOM, and immutable digest.
+- `deploy/ha/mvn-api/docker-compose.patroni.yml` and
+  `deploy/ha/zakup/docker-compose.patroni.yml`: host-specific adoption compose
+  files. Normal API deploys must never recreate their `db` service.
+- `deploy/ha/proxy/`: the stable internal Nginx hop used only on `zakup`, so
+  belzakupki Caddy never needs to follow blue/green container names.
 
 ## PKI
 
@@ -140,6 +147,48 @@ are present on both database hosts. If the replica is unavailable, the service
 may continue writing, but Patroni must refuse a loss-unsafe automatic promotion.
 PITR remains the final recovery layer.
 
+## Immutable Patroni Image
+
+Publish only a CI-tested `main` revision:
+
+```bash
+gh workflow run publish-patroni-image.yml --ref main
+```
+
+Copy the resulting `ghcr.io/.../patroni@sha256:...` reference into the protected
+`.env` on both database hosts as `PATRONI_IMAGE`. Never use a mutable Patroni
+tag in production. Publishing the image does not restart or alter PostgreSQL.
+
+Before any Compose validation, both hosts must also have:
+
+```text
+PATRONI_REPLICATION_USERNAME=<existing replication role>
+PATRONI_REPLICATION_PASSWORD=<matching password>
+PATRONI_IMAGE=ghcr.io/.../patroni@sha256:...
+```
+
+The node certificate bundle belongs in `<project>/patroni-pki` with directory
+mode `0700`, key mode `0600`, and certificate mode `0644`. The CA private key
+must not be present on either server.
+
+## Reserve Proxy Gate
+
+`zakup` shares Caddy with belzakupki. Do not make release jobs rewrite that
+Caddyfile. Before the PostgreSQL window:
+
+1. Install `deploy/ha/proxy/nginx.conf` and `upstream.conf` under
+   `/opt/mvn-reserve/api-proxy`.
+2. Start only `api-proxy` from `docker-compose.patroni.yml`; do not start `db`.
+3. Verify `http://127.0.0.1:18080/api/health` reaches the existing fenced app.
+4. Back up `/opt/belzakupki/Caddyfile`, replace only the MVN upstream
+   `mvn_reserve-app-1:8000` with `mvn_reserve-api-proxy-1:8000`, run
+   `caddy validate`, reload Caddy, and smoke-check both MVN and maxikor.fun.
+5. Keep `upstream.conf` as runtime state. Normal releases switch it between
+   `app-blue:8000` and `app-green:8000`; they never edit the Caddyfile.
+
+Rollback for this gate is the single backed-up Caddyfile plus a validated Caddy
+reload. The existing app remains running throughout the gate.
+
 ## Runtime Role Handoff
 
 Patroni controls only PostgreSQL. The role agent maps the local Patroni role to
@@ -155,6 +204,12 @@ On a replica, it stops the bot, disables scheduler/bootstrap, and keeps
 delay, recreates only the active API slot with scheduler enabled, requires
 writable `/api/ready=200`, and then starts the bot. It never runs `compose up`
 for `db` and shares the existing `.deploy.lock` with application releases.
+
+The same role transition disables IMAP imports and Cloudflare purge on a
+replica. `mvn-postgres-wal-upload.timer` and
+`mvn-postgres-basebackup.timer` are stopped on a replica and started only after
+the promoted primary API becomes writable. Timer failures are visible in the
+agent log but do not hold customer traffic offline.
 
 This ordering prevents Cloudflare from routing to a promoted database before
 the singleton processes have moved, and prevents two Telegram pollers from
@@ -174,3 +229,33 @@ install -m 0600 deploy/ha/patroni/role-agent.env.example \
 
 Edit the non-secret host paths/ports in `/etc/default/mvn-patroni-role-agent`,
 run `--once`, verify the generated role files, and only then enable the unit.
+
+## Production Cutover
+
+The following steps require one approved 2-5 minute write window. Do not begin
+while a GitHub production release is running.
+
+1. Confirm etcd has three healthy members and no existing MVN Patroni DCS keys.
+2. Confirm PITR, both restore drills, physical replication lag, and the latest
+   API/Cloudflare report are green.
+3. Disable both PITR timers temporarily, stop the role agent if installed, and
+   create a deployment maintenance marker on both database hosts.
+4. Stop app, scheduler, and bot processes on both hosts; verify no new writes.
+5. Re-check zero replication lag, stop both PostgreSQL containers, and create a
+   compressed, checksummed PGDATA rollback copy on each host.
+6. Start only the current primary `db` with its Patroni compose. Require local
+   `/primary=200`, writable SQL, the expected system identifier, and one DCS
+   leader before continuing.
+7. Start only the reserve `db` with its Patroni compose. Require `/replica=200`,
+   streaming state, matching timeline/system identifier, zero replay lag, and
+   registration as the synchronous standby.
+8. Run the role agent once on both nodes. Require exactly one public
+   `/api/ready=200`, one bot, one scheduler, and PITR timers only on the primary.
+9. Enable the role-agent units, remove maintenance markers, then run an
+   operator-controlled switchover and switchback drill before declaring the
+   migration complete.
+
+If any gate before step 8 fails, stop both Patroni containers, restore the old
+compose files and PGDATA copies, start the former primary first, then restore
+physical replication. Do not delete rollback copies or Patroni DCS state until
+the old topology is verified; DCS cleanup is a separate, explicit retry step.

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -1,0 +1,135 @@
+# PostgreSQL Quorum Runbook
+
+This runbook defines the quorum layer required before PostgreSQL can move from
+manual active-passive promotion to Patroni-managed failover.
+
+The etcd layer does not promote PostgreSQL by itself. Installing etcd is safe
+while the current primary/standby setup remains active. Do not enable Patroni
+against production data until every migration gate in this document passes.
+
+## Topology
+
+| Member | SSH alias | WireGuard IP | etcd role | PostgreSQL role |
+| --- | --- | --- | --- | --- |
+| API VPS | `mvn-api` | `10.77.0.2` | voting member | primary or replica |
+| Reserve VPS | `zakup` | `10.77.0.1` | voting member | primary or replica |
+| Web VPS | `mvn` | `10.77.0.3` | voting witness | none initially |
+
+The three etcd members use Raft. Two reachable members are required to elect or
+retain a leader. Patroni will later use that leader lease to ensure that only
+one PostgreSQL node may accept writes.
+
+Only WireGuard addresses may listen on etcd ports:
+
+- `2379/tcp`: TLS client traffic from Patroni and operators;
+- `2380/tcp`: mutual-TLS peer traffic between etcd members.
+
+Do not publish these ports on a public interface. The Compose file uses host
+networking so it can bind directly to each node's WireGuard address.
+
+## Tracked Assets
+
+- `deploy/ha/quorum/docker-compose.etcd.yml`: digest-pinned etcd 3.6.11 service;
+- `deploy/ha/quorum/etcd.env.example`: per-node non-secret settings;
+- `deploy/ha/quorum/mvn-etcd-quorum.service`: boot ordering and lifecycle;
+- `scripts/ha/generate_etcd_pki.sh`: private CA and certificate generator;
+- `scripts/ha/check_etcd_quorum.sh`: member, leader, Raft lag, and health check.
+
+## PKI
+
+Generate the PKI only on an operator machine with an encrypted disk:
+
+```bash
+umask 077
+ETCD_PKI_OUTPUT_DIR="$HOME/.mvn/etcd-pki" \
+  bash scripts/ha/generate_etcd_pki.sh
+```
+
+The output has four distributable bundles:
+
+```text
+nodes/mvn-api/{ca.crt,node.crt,node.key}
+nodes/zakup/{ca.crt,node.crt,node.key}
+nodes/mvn-web/{ca.crt,node.crt,node.key}
+operator/{operator.crt,operator.key}
+```
+
+Never copy `ca-private/ca.key` to a server. Keep it offline after the three node
+certificates are installed. A lost node key can then be replaced without
+replacing the cluster CA.
+
+## Installation Gate
+
+Before installation:
+
+1. Back up `/etc/wireguard/wg-mvn.conf` on `mvn-api` and `zakup`.
+2. Add `mvn` as `10.77.0.3/32` to both existing peers and configure a full-mesh
+   `wg-mvn` interface on `mvn`.
+3. Allow UDP `51820` only between the three public server IPs.
+4. Verify all six directed WireGuard pings.
+5. Confirm public `2379/2380` are closed on every host.
+
+Install one node bundle and the tracked runtime under `/opt/mvn-quorum` on each
+host. The `.env` values are:
+
+```text
+mvn-api: ETCD_NAME=mvn-api ETCD_WG_IP=10.77.0.2
+zakup:   ETCD_NAME=zakup   ETCD_WG_IP=10.77.0.1
+mvn:     ETCD_NAME=mvn-web ETCD_WG_IP=10.77.0.3
+```
+
+Install the systemd unit as `/etc/systemd/system/mvn-etcd-quorum.service`, then
+start all three members within the same operation:
+
+```bash
+systemctl daemon-reload
+systemctl enable --now mvn-etcd-quorum.service
+```
+
+Run the cluster check from any member:
+
+```bash
+bash /opt/mvn-quorum/check_etcd_quorum.sh
+```
+
+Expected result:
+
+```text
+etcd_quorum_status=passed members=3 ... raft_lag=0 ...
+```
+
+## Quorum Drill
+
+The pre-Patroni drill is non-destructive to PostgreSQL:
+
+1. Stop one non-leader etcd member.
+2. Confirm the remaining two report three configured members, one leader, and
+   healthy reachable endpoints.
+3. Restart the member and wait until Raft lag returns below 100.
+4. Repeat with the current etcd leader and confirm a new leader is elected.
+5. Never stop two members together.
+
+Before Patroni adoption, stopping the entire etcd cluster has no effect on the
+current PostgreSQL primary. After Patroni adoption, quorum loss deliberately
+prevents automatic promotion and may fence the leader depending on the tested
+Patroni policy.
+
+## Patroni Migration Gates
+
+Production PostgreSQL may move under Patroni only after all of these are true:
+
+- disposable two-node Patroni failover and rejoin drill passes;
+- etcd survives each single-member failure;
+- PostgreSQL PITR and both restore workflows are green;
+- current physical replication lag is within the release threshold;
+- a fresh volume-level rollback copy exists on both database hosts;
+- Patroni configuration validation passes on the exact production image;
+- watchdog behavior is tested before `watchdog.mode=required` is enabled;
+- Cloudflare still observes exactly one `/api/ready=200` origin;
+- an operator approves a 2-5 minute write maintenance window.
+
+The initial production policy should use synchronous mode without strict write
+blocking. When the synchronous replica is healthy, acknowledged transactions
+are present on both database hosts. If the replica is unavailable, the service
+may continue writing, but Patroni must refuse a loss-unsafe automatic promotion.
+PITR remains the final recovery layer.

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -38,6 +38,8 @@ networking so it can bind directly to each node's WireGuard address.
   role-agent unit, and isolated rehearsal cluster;
 - `scripts/ha/rehearse_patroni_failover.sh`: disposable failover/rejoin drill;
 - `scripts/ha/patroni_role_agent.py`: local API/scheduler/bot role reconciler.
+- `.github/workflows/patroni-failover-rehearsal.yml`: weekly isolated drill and
+  retained diagnostic log.
 
 ## PKI
 

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -19,6 +19,9 @@ LEGACY_PORT="${API_LEGACY_PORT:-8000}"
 NGINX_SITE_FILE="${API_NGINX_SITE_FILE:-/etc/nginx/sites-available/air-api}"
 NGINX_UPSTREAM_FILE="${API_NGINX_UPSTREAM_FILE:-/etc/nginx/snippets/mvn-api-upstream.conf}"
 NGINX_INTERNAL_FILE="${API_NGINX_INTERNAL_FILE:-/etc/nginx/conf.d/mvn-api-internal.conf}"
+PROXY_MODE="${API_PROXY_MODE:-host_nginx}"
+PROXY_SERVICE="${API_PROXY_SERVICE:-api-proxy}"
+PROXY_CONFIG_FILE="${API_PROXY_CONFIG_FILE:-${PROJECT_DIR}/api-proxy/nginx.conf}"
 INTERNAL_PROXY_PORT="${API_INTERNAL_PROXY_PORT:-18080}"
 API_HOST="${API_HOST:-api.mvn.by}"
 PUBLIC_READY_URL="${API_PUBLIC_READY_URL:-https://${API_HOST}/api/ready}"
@@ -106,38 +109,88 @@ write_backend_image() {
   mv "${tmp}" "${ENV_FILE}"
 }
 
-write_upstream() {
-  local port="$1"
-  atomic_write_line "${NGINX_UPSTREAM_FILE}" "proxy_pass http://127.0.0.1:${port};" 644
+upstream_target_for_slot() {
+  local slot="$1"
+
+  case "${PROXY_MODE}" in
+    host_nginx)
+      printf '127.0.0.1:%s\n' "$(port_for_slot "${slot}")"
+      ;;
+    container_nginx)
+      printf '%s:8000\n' "$(service_for_slot "${slot}")"
+      ;;
+    *)
+      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
+      return 1
+      ;;
+  esac
 }
 
-parse_upstream_port() {
-  sed -nE 's/^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:([0-9]+);[[:space:]]*$/\1/p' \
-    "${NGINX_UPSTREAM_FILE}" | tail -n 1
+write_upstream() {
+  local slot="$1"
+  local target
+  target="$(upstream_target_for_slot "${slot}")"
+  atomic_write_line "${NGINX_UPSTREAM_FILE}" "proxy_pass http://${target};" 644
+}
+
+parse_upstream_slot() {
+  local target
+  target="$(
+    sed -nE 's/^[[:space:]]*proxy_pass[[:space:]]+http:\/\/([^;]+);[[:space:]]*$/\1/p' \
+      "${NGINX_UPSTREAM_FILE}" | tail -n 1
+  )"
+
+  case "${PROXY_MODE}" in
+    host_nginx)
+      [[ "${target}" =~ ^127\.0\.0\.1:([0-9]+)$ ]] || return 1
+      slot_for_port "${BASH_REMATCH[1]}"
+      ;;
+    container_nginx)
+      case "${target}" in
+        app:8000) printf 'legacy\n' ;;
+        app-blue:8000) printf 'blue\n' ;;
+        app-green:8000) printf 'green\n' ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
 }
 
 resolve_active_slot() {
   local include_line="include ${NGINX_UPSTREAM_FILE};"
   local configured_slot=""
-  local upstream_port=""
 
-  if grep -Fq "${include_line}" "${NGINX_SITE_FILE}"; then
-    [[ -f "${NGINX_UPSTREAM_FILE}" ]] || {
-      log error "managed nginx include exists but ${NGINX_UPSTREAM_FILE} is missing"
+  case "${PROXY_MODE}" in
+    host_nginx)
+      if grep -Fq "${include_line}" "${NGINX_SITE_FILE}"; then
+        [[ -f "${NGINX_UPSTREAM_FILE}" ]] || {
+          log error "managed nginx include exists but ${NGINX_UPSTREAM_FILE} is missing"
+          return 1
+        }
+        active_slot="$(parse_upstream_slot)" || {
+          log error "cannot parse active slot from ${NGINX_UPSTREAM_FILE}"
+          return 1
+        }
+      else
+        active_slot="legacy"
+      fi
+      ;;
+    container_nginx)
+      if [[ -f "${NGINX_UPSTREAM_FILE}" ]]; then
+        active_slot="$(parse_upstream_slot)" || {
+          log error "cannot parse active slot from ${NGINX_UPSTREAM_FILE}"
+          return 1
+        }
+      else
+        active_slot="legacy"
+      fi
+      ;;
+    *)
+      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
       return 1
-    }
-    upstream_port="$(parse_upstream_port)"
-    [[ -n "${upstream_port}" ]] || {
-      log error "cannot parse active port from ${NGINX_UPSTREAM_FILE}"
-      return 1
-    }
-    active_slot="$(slot_for_port "${upstream_port}")" || {
-      log error "nginx points to unmanaged API port ${upstream_port}"
-      return 1
-    }
-  else
-    active_slot="legacy"
-  fi
+      ;;
+  esac
 
   if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
     configured_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
@@ -166,7 +219,7 @@ ensure_managed_nginx_upstream() {
     return 0
   fi
 
-  write_upstream "${active_port}"
+  write_upstream "${active_slot}"
   backup="${NGINX_SITE_FILE}.pre-blue-green-$(date -u +%Y%m%dT%H%M%SZ)"
   cp -a "${NGINX_SITE_FILE}" "${backup}"
 
@@ -198,6 +251,52 @@ PY
   fi
   systemctl reload nginx
   log nginx "installed managed upstream include; legacy port remains active"
+}
+
+reload_proxy() {
+  case "${PROXY_MODE}" in
+    host_nginx)
+      nginx -t
+      systemctl reload nginx
+      ;;
+    container_nginx)
+      "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -t
+      "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -s reload
+      ;;
+    *)
+      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
+      return 1
+      ;;
+  esac
+}
+
+ensure_container_proxy() {
+  [[ -f "${PROXY_CONFIG_FILE}" ]] || {
+    log error "container proxy config is missing: ${PROXY_CONFIG_FILE}"
+    return 1
+  }
+  if [[ ! -f "${NGINX_UPSTREAM_FILE}" ]]; then
+    write_upstream "${active_slot}"
+  fi
+  "${COMPOSE[@]}" up -d --no-deps "${PROXY_SERVICE}"
+  reload_proxy
+  log nginx "container proxy ${PROXY_SERVICE} routes ${active_slot} through 127.0.0.1:${INTERNAL_PROXY_PORT}"
+}
+
+ensure_proxy() {
+  case "${PROXY_MODE}" in
+    host_nginx)
+      ensure_managed_nginx_upstream
+      ensure_internal_proxy
+      ;;
+    container_nginx)
+      ensure_container_proxy
+      ;;
+    *)
+      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
+      return 1
+      ;;
+  esac
 }
 
 ensure_internal_proxy() {
@@ -344,8 +443,8 @@ rollback_on_error() {
   fi
 
   if [[ "${nginx_switch_attempted}" == "true" && -f "${NGINX_UPSTREAM_FILE}" ]]; then
-    write_upstream "${active_port}"
-    nginx -t && systemctl reload nginx
+    write_upstream "${active_slot}"
+    reload_proxy
   fi
 
   if [[ "${bot_update_attempted}" == "true" ]] && is_immutable_image "${previous_image}"; then
@@ -370,7 +469,11 @@ rollback_on_error() {
   exit "${exit_code}"
 }
 
-for command in docker curl python3 nginx systemctl flock; do
+required_commands=(docker curl python3 flock)
+if [[ "${PROXY_MODE}" == "host_nginx" ]]; then
+  required_commands+=(nginx systemctl)
+fi
+for command in "${required_commands[@]}"; do
   command -v "${command}" >/dev/null 2>&1 || {
     log error "required command is missing: ${command}"
     exit 1
@@ -390,10 +493,15 @@ is_immutable_image "${BACKEND_IMAGE}" || {
   log error "compose file is missing: ${PROJECT_DIR}/${COMPOSE_FILE}"
   exit 1
 }
-[[ -f "${NGINX_SITE_FILE}" ]] || {
-  log error "nginx site is missing: ${NGINX_SITE_FILE}"
+if [[ "${PROXY_MODE}" == "host_nginx" ]]; then
+  [[ -f "${NGINX_SITE_FILE}" ]] || {
+    log error "nginx site is missing: ${NGINX_SITE_FILE}"
+    exit 1
+  }
+elif [[ "${PROXY_MODE}" != "container_nginx" ]]; then
+  log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
   exit 1
-}
+fi
 
 cd "${PROJECT_DIR}"
 if [[ "${DEPLOY_LOCK_ALREADY_HELD}" != "true" ]]; then
@@ -411,8 +519,7 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
 
 resolve_active_slot
-ensure_managed_nginx_upstream
-ensure_internal_proxy
+ensure_proxy
 previous_image="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
 is_immutable_image "${previous_image}" || {
   log error "current BACKEND_IMAGE in ${ENV_FILE} is not immutable"
@@ -478,9 +585,8 @@ bot_update_attempted=true
 wait_service_running bot
 
 nginx_switch_attempted=true
-write_upstream "${candidate_port}"
-nginx -t
-systemctl reload nginx
+write_upstream "${candidate_slot}"
+reload_proxy
 log switch "nginx now routes to ${candidate_slot} on ${candidate_port}"
 
 wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:443:127.0.0.1"

--- a/scripts/ha/check_etcd_quorum.sh
+++ b/scripts/ha/check_etcd_quorum.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER="${ETCD_CONTAINER:-mvn-etcd}"
+MAX_RAFT_LAG="${ETCD_MAX_RAFT_LAG:-100}"
+EXPECTED_MEMBERS="${ETCD_EXPECTED_MEMBERS:-3}"
+ENDPOINTS="${ETCD_ENDPOINTS:-https://10.77.0.2:2379,https://10.77.0.1:2379,https://10.77.0.3:2379}"
+PKI_DIR="${ETCD_PKI_DIR:-/etc/etcd/pki}"
+
+log() {
+  printf '[etcd-quorum][%s] %s\n' "$1" "$2"
+}
+
+for value in "${MAX_RAFT_LAG}" "${EXPECTED_MEMBERS}"; do
+  [[ "${value}" =~ ^[0-9]+$ ]] || {
+    log error "member and lag limits must be unsigned integers"
+    exit 1
+  }
+done
+docker inspect "${CONTAINER}" >/dev/null 2>&1 || {
+  log error "container is missing: ${CONTAINER}"
+  exit 1
+}
+
+status_json="$({
+  docker exec \
+    -e ETCDCTL_API=3 \
+    "${CONTAINER}" \
+    etcdctl \
+    --endpoints="${ENDPOINTS}" \
+    --cacert="${PKI_DIR}/ca.crt" \
+    --cert="${PKI_DIR}/node.crt" \
+    --key="${PKI_DIR}/node.key" \
+    endpoint status --cluster --write-out=json
+} 2>/dev/null)"
+
+python3 - "${EXPECTED_MEMBERS}" "${MAX_RAFT_LAG}" "${status_json}" <<'PY'
+import json
+import sys
+
+expected_members = int(sys.argv[1])
+max_raft_lag = int(sys.argv[2])
+payload = json.loads(sys.argv[3])
+if len(payload) != expected_members:
+    raise SystemExit(f"expected {expected_members} etcd members, got {len(payload)}")
+
+headers = [entry.get("Status", {}).get("header", {}) for entry in payload]
+cluster_ids = {header.get("cluster_id") for header in headers}
+if len(cluster_ids) != 1 or None in cluster_ids:
+    raise SystemExit(f"members disagree on cluster id: {cluster_ids}")
+
+leaders = {entry.get("Status", {}).get("leader") for entry in payload}
+if len(leaders) != 1 or 0 in leaders or None in leaders:
+    raise SystemExit(f"members disagree on leader: {leaders}")
+
+indexes = [int(entry.get("Status", {}).get("raftIndex", 0)) for entry in payload]
+if not all(indexes):
+    raise SystemExit(f"invalid raft indexes: {indexes}")
+lag = max(indexes) - min(indexes)
+if lag > max_raft_lag:
+    raise SystemExit(f"raft index lag {lag} exceeds {max_raft_lag}")
+
+versions = sorted({entry.get("Status", {}).get("version", "") for entry in payload})
+print(
+    "etcd_quorum_status=passed "
+    f"members={len(payload)} leader={next(iter(leaders))} "
+    f"raft_lag={lag} versions={','.join(versions)}"
+)
+PY
+
+docker exec \
+  -e ETCDCTL_API=3 \
+  "${CONTAINER}" \
+  etcdctl \
+  --endpoints="${ENDPOINTS}" \
+  --cacert="${PKI_DIR}/ca.crt" \
+  --cert="${PKI_DIR}/node.crt" \
+  --key="${PKI_DIR}/node.key" \
+  endpoint health --cluster >/dev/null
+
+log "done" "all ${EXPECTED_MEMBERS} members are healthy"

--- a/scripts/ha/generate_etcd_pki.sh
+++ b/scripts/ha/generate_etcd_pki.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${ETCD_PKI_OUTPUT_DIR:-}"
+FORCE="${ETCD_PKI_FORCE:-false}"
+VALID_DAYS="${ETCD_PKI_VALID_DAYS:-825}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ETCD_PKI_OUTPUT_DIR=/secure/path bash scripts/ha/generate_etcd_pki.sh
+
+Generates one private CA, three node certificates, and an operator certificate.
+The CA private key stays under ca-private/ and must never be copied to a server.
+Set ETCD_PKI_FORCE=true only to replace an uninstalled test PKI.
+USAGE
+}
+
+log() {
+  printf '[etcd-pki][%s] %s\n' "$1" "$2"
+}
+
+[[ "${1:-}" != "--help" && "${1:-}" != "-h" ]] || {
+  usage
+  exit 0
+}
+[[ -n "${OUTPUT_DIR}" ]] || {
+  log error "ETCD_PKI_OUTPUT_DIR is required"
+  exit 1
+}
+[[ "${VALID_DAYS}" =~ ^[1-9][0-9]*$ ]] || {
+  log error "ETCD_PKI_VALID_DAYS must be a positive integer"
+  exit 1
+}
+command -v openssl >/dev/null 2>&1 || {
+  log error "openssl is required"
+  exit 1
+}
+
+if [[ -e "${OUTPUT_DIR}" ]]; then
+  if [[ "${FORCE}" != "true" ]]; then
+    log error "output already exists; refusing to replace ${OUTPUT_DIR}"
+    exit 1
+  fi
+  [[ "${OUTPUT_DIR}" == /* && "${OUTPUT_DIR}" != "/" ]] || {
+    log error "refusing unsafe output path"
+    exit 1
+  }
+  rm -rf "${OUTPUT_DIR}"
+fi
+
+umask 077
+mkdir -p "${OUTPUT_DIR}/ca-private" "${OUTPUT_DIR}/nodes" "${OUTPUT_DIR}/operator"
+ca_key="${OUTPUT_DIR}/ca-private/ca.key"
+ca_cert="${OUTPUT_DIR}/ca.crt"
+
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out "${ca_key}" >/dev/null 2>&1
+openssl req -x509 -new -sha256 \
+  -key "${ca_key}" \
+  -out "${ca_cert}" \
+  -days "${VALID_DAYS}" \
+  -subj "/CN=MVN PostgreSQL HA etcd CA" >/dev/null 2>&1
+
+issue_certificate() {
+  local name="$1"
+  local output="$2"
+  local usage="$3"
+  local sans="${4:-}"
+  local config="${OUTPUT_DIR}/.${name}.cnf"
+  local csr="${OUTPUT_DIR}/.${name}.csr"
+
+  mkdir -p "${output}"
+  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out "${output}/node.key" >/dev/null 2>&1
+  {
+    echo '[req]'
+    echo 'distinguished_name = dn'
+    echo 'prompt = no'
+    echo 'req_extensions = req_ext'
+    echo '[dn]'
+    echo "CN = ${name}"
+    echo '[req_ext]'
+    echo "extendedKeyUsage = ${usage}"
+    if [[ -n "${sans}" ]]; then
+      echo "subjectAltName = ${sans}"
+    fi
+  } > "${config}"
+  openssl req -new -sha256 -key "${output}/node.key" -out "${csr}" -config "${config}" >/dev/null 2>&1
+  openssl x509 -req -sha256 \
+    -in "${csr}" \
+    -CA "${ca_cert}" \
+    -CAkey "${ca_key}" \
+    -CAcreateserial \
+    -out "${output}/node.crt" \
+    -days "${VALID_DAYS}" \
+    -copy_extensions copy >/dev/null 2>&1
+  cp "${ca_cert}" "${output}/ca.crt"
+  chmod 0600 "${output}/node.key"
+  chmod 0644 "${output}/node.crt" "${output}/ca.crt"
+  rm -f "${config}" "${csr}"
+  openssl verify -CAfile "${ca_cert}" "${output}/node.crt" >/dev/null
+}
+
+issue_certificate \
+  mvn-api \
+  "${OUTPUT_DIR}/nodes/mvn-api" \
+  serverAuth,clientAuth \
+  'IP:10.77.0.2,IP:127.0.0.1,DNS:mvn-api,DNS:api.mvn.by'
+issue_certificate \
+  zakup \
+  "${OUTPUT_DIR}/nodes/zakup" \
+  serverAuth,clientAuth \
+  'IP:10.77.0.1,IP:127.0.0.1,DNS:zakup,DNS:maxikor.fun'
+issue_certificate \
+  mvn-web \
+  "${OUTPUT_DIR}/nodes/mvn-web" \
+  serverAuth,clientAuth \
+  'IP:10.77.0.3,IP:127.0.0.1,DNS:mvn-web,DNS:www.mvn.by'
+issue_certificate operator "${OUTPUT_DIR}/operator" clientAuth
+
+mv "${OUTPUT_DIR}/operator/node.key" "${OUTPUT_DIR}/operator/operator.key"
+mv "${OUTPUT_DIR}/operator/node.crt" "${OUTPUT_DIR}/operator/operator.crt"
+rm -f "${OUTPUT_DIR}/operator/ca.crt" "${OUTPUT_DIR}/ca.srl"
+
+log "done" "generated CA, 3 node certificates, and operator certificate under ${OUTPUT_DIR}"

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Reconcile API, scheduler, and bot runtime state with the local Patroni role."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PRIMARY_ROLES = {"leader", "master", "primary"}
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    project_dir: Path
+    compose_file: str
+    patroni_url: str
+    ready_url: str
+    app_role_env: Path
+    bot_role_env: Path
+    state_file: Path
+    deploy_lock: Path
+    active_slot_file: Path
+    app_service: str
+    poll_seconds: int
+    promotion_delay_seconds: int
+    ready_attempts: int
+
+
+def _integer(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return value
+
+
+def load_config() -> AgentConfig:
+    project_dir = Path(os.getenv("HA_PROJECT_DIR", "/opt/air-api")).resolve()
+    compose_file = os.getenv("HA_COMPOSE_FILE", "docker-compose.prod.yml").strip()
+    return AgentConfig(
+        project_dir=project_dir,
+        compose_file=compose_file,
+        patroni_url=os.getenv("HA_PATRONI_URL", "http://127.0.0.1:8008").rstrip("/"),
+        ready_url=os.getenv("HA_READY_URL", "http://127.0.0.1:18080/api/ready"),
+        app_role_env=project_dir / ".ha-app-role.env",
+        bot_role_env=project_dir / ".ha-bot-role.env",
+        state_file=project_dir / ".ha-runtime-role",
+        deploy_lock=project_dir / ".deploy.lock",
+        active_slot_file=project_dir / ".active-api-slot",
+        app_service=os.getenv("HA_APP_SERVICE", "").strip(),
+        poll_seconds=_integer("HA_ROLE_POLL_SECONDS", 3),
+        promotion_delay_seconds=_integer("HA_PROMOTION_DELAY_SECONDS", 8, minimum=0),
+        ready_attempts=_integer("HA_READY_ATTEMPTS", 30),
+    )
+
+
+def fetch_patroni_role(url: str, *, timeout: float = 3.0) -> str:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if payload.get("state") != "running":
+        return "standby"
+    role = str(payload.get("role") or "").strip().lower()
+    return "primary" if role in PRIMARY_ROLES else "standby"
+
+
+def app_service(config: AgentConfig) -> str:
+    if config.app_service:
+        return config.app_service
+    try:
+        slot = config.active_slot_file.read_text(encoding="utf-8").strip().lower()
+    except FileNotFoundError:
+        slot = ""
+    if slot in {"blue", "green"}:
+        return f"app-{slot}"
+    return "app"
+
+
+def role_env(role: str, *, bot_process: bool) -> str:
+    primary = role == "primary"
+    values = {
+        "APP_ROLE": role,
+        "API_READY_ENABLED": "false" if bot_process else str(primary).lower(),
+        "BOT_ENABLED": str(primary and bot_process).lower(),
+        "DB_BOOTSTRAP_ENABLED": "false",
+        "SCHEDULER_ENABLED": str(primary and not bot_process).lower(),
+    }
+    return "".join(f"{name}={value}\n" for name, value in values.items())
+
+
+def _atomic_write(path: Path, content: str, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def _run_compose(config: AgentConfig, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = ["docker", "compose", "-f", config.compose_file, *args]
+    return subprocess.run(
+        command,
+        cwd=config.project_dir,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _runtime_matches(config: AgentConfig, role: str, service: str) -> bool:
+    result = _run_compose(config, "ps", "--status", "running", "--services", check=False)
+    if result.returncode != 0:
+        return False
+    running = set(result.stdout.splitlines())
+    if service not in running:
+        return False
+    return ("bot" in running) == (role == "primary")
+
+
+def _wait_ready(config: AgentConfig) -> None:
+    for _ in range(config.ready_attempts):
+        try:
+            with urllib.request.urlopen(config.ready_url, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if (
+                response.status == 200
+                and payload.get("api") == "ready"
+                and payload.get("database_writable") is True
+            ):
+                return
+        except (OSError, ValueError, urllib.error.URLError):
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"primary API did not become ready: {config.ready_url}")
+
+
+def reconcile(config: AgentConfig, role: str) -> bool:
+    desired_app = role_env(role, bot_process=False)
+    desired_bot = role_env(role, bot_process=True)
+    current_state = config.state_file.read_text(encoding="utf-8").strip() if config.state_file.exists() else ""
+    app_matches = config.app_role_env.exists() and config.app_role_env.read_text(encoding="utf-8") == desired_app
+    bot_matches = config.bot_role_env.exists() and config.bot_role_env.read_text(encoding="utf-8") == desired_bot
+    service = app_service(config)
+    if (
+        current_state == role
+        and app_matches
+        and bot_matches
+        and _runtime_matches(config, role, service)
+    ):
+        return False
+
+    config.deploy_lock.parent.mkdir(parents=True, exist_ok=True)
+    with config.deploy_lock.open("a+", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("patroni_role_agent_status=deferred reason=deployment_lock_busy", flush=True)
+            return False
+
+        if role == "primary" and config.promotion_delay_seconds:
+            time.sleep(config.promotion_delay_seconds)
+            if fetch_patroni_role(config.patroni_url) != "primary":
+                print("patroni_role_agent_status=deferred reason=primary_role_not_stable", flush=True)
+                return False
+
+        _atomic_write(config.app_role_env, desired_app)
+        _atomic_write(config.bot_role_env, desired_bot)
+        if role == "standby":
+            _run_compose(config, "stop", "bot", check=False)
+            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
+        else:
+            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
+            _wait_ready(config)
+            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", "bot")
+
+        _atomic_write(config.state_file, f"{role}\n")
+        print(f"patroni_role_agent_status=reconciled role={role} app_service={service}", flush=True)
+        return True
+
+
+def run(config: AgentConfig, *, once: bool) -> int:
+    while True:
+        try:
+            role = fetch_patroni_role(config.patroni_url)
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            role = "standby"
+            print(f"patroni_role_agent_status=warning patroni_unavailable={exc}", flush=True)
+        try:
+            reconcile(config, role)
+        except Exception as exc:
+            print(f"patroni_role_agent_status=failed role={role} error={exc}", flush=True)
+            if once:
+                return 1
+        if once:
+            return 0
+        time.sleep(config.poll_seconds)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+    try:
+        config = load_config()
+    except ValueError as exc:
+        print(f"patroni_role_agent_status=failed error={exc}")
+        return 2
+    return run(config, once=args.once)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -53,7 +53,7 @@ def load_config() -> AgentConfig:
     return AgentConfig(
         project_dir=project_dir,
         compose_file=compose_file,
-        patroni_url=os.getenv("HA_PATRONI_URL", "http://127.0.0.1:8008").rstrip("/"),
+        patroni_url=os.getenv("HA_PATRONI_URL", "http://127.0.0.1:8008/patroni").rstrip("/"),
         ready_url=os.getenv("HA_READY_URL", "http://127.0.0.1:18080/api/ready"),
         app_role_env=project_dir / ".ha-app-role.env",
         bot_role_env=project_dir / ".ha-bot-role.env",

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -31,6 +31,7 @@ class AgentConfig:
     deploy_lock: Path
     active_slot_file: Path
     app_service: str
+    primary_systemd_units: tuple[str, ...]
     poll_seconds: int
     promotion_delay_seconds: int
     ready_attempts: int
@@ -61,6 +62,7 @@ def load_config() -> AgentConfig:
         deploy_lock=project_dir / ".deploy.lock",
         active_slot_file=project_dir / ".active-api-slot",
         app_service=os.getenv("HA_APP_SERVICE", "").strip(),
+        primary_systemd_units=tuple(os.getenv("HA_PRIMARY_SYSTEMD_UNITS", "").split()),
         poll_seconds=_integer("HA_ROLE_POLL_SECONDS", 3),
         promotion_delay_seconds=_integer("HA_PROMOTION_DELAY_SECONDS", 8, minimum=0),
         ready_attempts=_integer("HA_READY_ATTEMPTS", 30),
@@ -97,6 +99,15 @@ def role_env(role: str, *, bot_process: bool) -> str:
         "DB_BOOTSTRAP_ENABLED": "false",
         "SCHEDULER_ENABLED": str(primary and not bot_process).lower(),
     }
+    if not primary:
+        values.update(
+            {
+                "MAIL_IMAP_AUTO_IMPORT_ENABLED": "false",
+                "MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED": "false",
+                "CLOUDFLARE_PURGE_ENABLED": "false",
+                "CLOUDFLARE_PURGE_DRY_RUN": "true",
+            }
+        )
     return "".join(f"{name}={value}\n" for name, value in values.items())
 
 
@@ -138,6 +149,38 @@ def _runtime_matches(config: AgentConfig, role: str, service: str) -> bool:
     return ("bot" in running) == (role == "primary")
 
 
+def _systemd_units_match(config: AgentConfig, role: str) -> bool:
+    expected_active = role == "primary"
+    for unit in config.primary_systemd_units:
+        result = subprocess.run(
+            ["systemctl", "is-active", "--quiet", unit],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if (result.returncode == 0) != expected_active:
+            return False
+    return True
+
+
+def _reconcile_primary_systemd_units(config: AgentConfig, role: str) -> None:
+    action = "start" if role == "primary" else "stop"
+    for unit in config.primary_systemd_units:
+        result = subprocess.run(
+            ["systemctl", action, unit],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout).strip().replace("\n", " ")
+            print(
+                f"patroni_role_agent_status=warning systemd_unit={unit} "
+                f"action={action} error={error or result.returncode}",
+                flush=True,
+            )
+
+
 def _wait_ready(config: AgentConfig) -> None:
     for _ in range(config.ready_attempts):
         try:
@@ -168,6 +211,8 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         and bot_matches
         and _runtime_matches(config, role, service)
     ):
+        if not _systemd_units_match(config, role):
+            _reconcile_primary_systemd_units(config, role)
         return False
 
     config.deploy_lock.parent.mkdir(parents=True, exist_ok=True)
@@ -187,12 +232,14 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         _atomic_write(config.app_role_env, desired_app)
         _atomic_write(config.bot_role_env, desired_bot)
         if role == "standby":
+            _reconcile_primary_systemd_units(config, role)
             _run_compose(config, "stop", "bot", check=False)
             _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
         else:
             _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
             _wait_ready(config)
             _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", "bot")
+            _reconcile_primary_systemd_units(config, role)
 
         _atomic_write(config.state_file, f"{role}\n")
         print(f"patroni_role_agent_status=reconciled role={role} app_service={service}", flush=True)

--- a/scripts/ha/rehearse_patroni_failover.sh
+++ b/scripts/ha/rehearse_patroni_failover.sh
@@ -20,7 +20,7 @@ trap cleanup EXIT
 role() {
   local service="$1"
   "${COMPOSE[@]}" exec -T "${service}" \
-    python3 -c 'import json,urllib.request; print(json.load(urllib.request.urlopen("http://127.0.0.1:8008", timeout=3))["role"])' \
+    python3 -c 'import json,urllib.request; print(json.load(urllib.request.urlopen("http://127.0.0.1:8008/patroni", timeout=3))["role"])' \
     2>/dev/null || true
 }
 
@@ -64,8 +64,9 @@ other_service() {
 sql() {
   local service="$1"
   local statement="$2"
-  "${COMPOSE[@]}" exec -T "${service}" \
+  "${COMPOSE[@]}" exec -T \
     -e "PGOPTIONS=-c statement_timeout=10000" \
+    "${service}" \
     psql -U postgres -d postgres -v ON_ERROR_STOP=1 -Atqc "${statement}"
 }
 
@@ -97,6 +98,16 @@ until [[ "$(sql "${replica}" "select value from ha_rehearsal where id=1" 2>/dev/
   }
   sleep 2
 done
+
+deadline=$((SECONDS + TIMEOUT))
+until [[ "$(sql "${leader}" "select sync_state from pg_stat_replication where application_name='${replica}' and state='streaming'" 2>/dev/null || true)" == "sync" ]]; do
+  (( SECONDS < deadline )) || {
+    log error "replica was not registered as synchronous"
+    exit 1
+  }
+  sleep 2
+done
+log check "synchronous standby=${replica}"
 
 log failover "stopping leader ${leader}"
 "${COMPOSE[@]}" stop "${leader}"

--- a/scripts/ha/rehearse_patroni_failover.sh
+++ b/scripts/ha/rehearse_patroni_failover.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="${PATRONI_REHEARSAL_COMPOSE_FILE:-deploy/ha/patroni/rehearsal/docker-compose.yml}"
+KEEP="${PATRONI_REHEARSAL_KEEP:-false}"
+TIMEOUT="${PATRONI_REHEARSAL_TIMEOUT:-120}"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+
+log() {
+  printf '[patroni-rehearsal][%s] %s\n' "$1" "$2"
+}
+
+cleanup() {
+  if [[ "${KEEP}" != "true" ]]; then
+    "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+role() {
+  local service="$1"
+  "${COMPOSE[@]}" exec -T "${service}" \
+    python3 -c 'import json,urllib.request; print(json.load(urllib.request.urlopen("http://127.0.0.1:8008", timeout=3))["role"])' \
+    2>/dev/null || true
+}
+
+wait_for_roles() {
+  local expected_leaders="$1"
+  local expected_replicas="$2"
+  local deadline=$((SECONDS + TIMEOUT))
+  while (( SECONDS < deadline )); do
+    local pg1_role pg2_role leaders=0 replicas=0
+    pg1_role="$(role pg1)"
+    pg2_role="$(role pg2)"
+    [[ "${pg1_role}" == "primary" || "${pg1_role}" == "leader" ]] && leaders=$((leaders + 1))
+    [[ "${pg2_role}" == "primary" || "${pg2_role}" == "leader" ]] && leaders=$((leaders + 1))
+    [[ "${pg1_role}" == "replica" ]] && replicas=$((replicas + 1))
+    [[ "${pg2_role}" == "replica" ]] && replicas=$((replicas + 1))
+    if [[ "${leaders}" == "${expected_leaders}" && "${replicas}" == "${expected_replicas}" ]]; then
+      printf '%s|%s\n' "${pg1_role}" "${pg2_role}"
+      return 0
+    fi
+    sleep 2
+  done
+  "${COMPOSE[@]}" ps
+  "${COMPOSE[@]}" logs --tail=120 pg1 pg2
+  return 1
+}
+
+leader_service() {
+  if [[ "$(role pg1)" == "primary" || "$(role pg1)" == "leader" ]]; then
+    echo pg1
+  elif [[ "$(role pg2)" == "primary" || "$(role pg2)" == "leader" ]]; then
+    echo pg2
+  else
+    return 1
+  fi
+}
+
+other_service() {
+  [[ "$1" == "pg1" ]] && echo pg2 || echo pg1
+}
+
+sql() {
+  local service="$1"
+  local statement="$2"
+  "${COMPOSE[@]}" exec -T "${service}" \
+    psql -U postgres -d postgres -v ON_ERROR_STOP=1 -Atqc "${statement}"
+}
+
+[[ "${TIMEOUT}" =~ ^[1-9][0-9]*$ ]] || {
+  log error "PATRONI_REHEARSAL_TIMEOUT must be a positive integer"
+  exit 1
+}
+command -v docker >/dev/null 2>&1 || {
+  log error "docker is required"
+  exit 1
+}
+
+log start "building isolated Patroni image"
+"${COMPOSE[@]}" build pg1
+log start "starting three etcd members and two PostgreSQL nodes"
+"${COMPOSE[@]}" up -d --wait
+wait_for_roles 1 1 >/dev/null
+
+leader="$(leader_service)"
+replica="$(other_service "${leader}")"
+log check "initial leader=${leader} replica=${replica}"
+sql "${leader}" "create table if not exists ha_rehearsal (id integer primary key, value text not null); insert into ha_rehearsal values (1, 'before-failover') on conflict (id) do update set value=excluded.value;"
+
+deadline=$((SECONDS + TIMEOUT))
+until [[ "$(sql "${replica}" "select value from ha_rehearsal where id=1" 2>/dev/null || true)" == "before-failover" ]]; do
+  (( SECONDS < deadline )) || {
+    log error "replica did not receive the rehearsal row"
+    exit 1
+  }
+  sleep 2
+done
+
+log failover "stopping leader ${leader}"
+"${COMPOSE[@]}" stop "${leader}"
+deadline=$((SECONDS + TIMEOUT))
+until [[ "$(role "${replica}")" == "primary" || "$(role "${replica}")" == "leader" ]]; do
+  (( SECONDS < deadline )) || {
+    log error "replica was not promoted"
+    exit 1
+  }
+  sleep 2
+done
+sql "${replica}" "select value from ha_rehearsal where id=1" | grep -Fx before-failover >/dev/null
+sql "${replica}" "insert into ha_rehearsal values (2, 'after-failover');"
+
+log rejoin "starting former leader ${leader}"
+"${COMPOSE[@]}" up -d "${leader}"
+wait_for_roles 1 1 >/dev/null
+deadline=$((SECONDS + TIMEOUT))
+until [[ "$(sql "${leader}" "select value from ha_rehearsal where id=2" 2>/dev/null || true)" == "after-failover" ]]; do
+  (( SECONDS < deadline )) || {
+    log error "former leader did not rejoin with the new timeline"
+    exit 1
+  }
+  sleep 2
+done
+
+log quorum "stopping one etcd member"
+"${COMPOSE[@]}" stop etcd3
+sleep 8
+[[ -n "$(leader_service)" ]] || {
+  log error "Patroni lost its leader after one etcd member stopped"
+  exit 1
+}
+
+log "done" "automatic failover, data continuity, rejoin, and one-member quorum loss passed"

--- a/scripts/ha/rehearse_patroni_failover.sh
+++ b/scripts/ha/rehearse_patroni_failover.sh
@@ -65,6 +65,7 @@ sql() {
   local service="$1"
   local statement="$2"
   "${COMPOSE[@]}" exec -T "${service}" \
+    -e "PGOPTIONS=-c statement_timeout=10000" \
     psql -U postgres -d postgres -v ON_ERROR_STOP=1 -Atqc "${statement}"
 }
 

--- a/tests/unit/test_blue_green_deploy_script.py
+++ b/tests/unit/test_blue_green_deploy_script.py
@@ -43,7 +43,7 @@ def _environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
 set -u
 printf 'docker %s\n' "$*" >> "$COMMAND_LOG"
 if [[ "$*" == *"ps --status running --services"* ]]; then
-  printf 'app\napp-blue\napp-green\nbot\n'
+  printf 'app\napp-blue\napp-green\nbot\napi-proxy\n'
 fi
 exit 0
 """,
@@ -183,6 +183,32 @@ def test_next_deploy_uses_green_and_stops_blue(tmp_path):
     assert "rm -f app-blue" in commands
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "green"
     assert "proxy_pass http://127.0.0.1:18002;" in upstream.read_text(encoding="utf-8")
+
+
+def test_container_proxy_switches_by_service_name_without_host_nginx(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    proxy_dir = project / "api-proxy"
+    proxy_dir.mkdir()
+    (proxy_dir / "nginx.conf").write_text("events {}\nhttp {}\n", encoding="utf-8")
+    upstream = proxy_dir / "upstream.conf"
+    upstream.write_text("proxy_pass http://app:8000;\n", encoding="utf-8")
+    env.update(
+        {
+            "API_PROXY_MODE": "container_nginx",
+            "API_PROXY_CONFIG_FILE": str(proxy_dir / "nginx.conf"),
+            "API_NGINX_UPSTREAM_FILE": str(upstream),
+        }
+    )
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert "up -d --no-deps api-proxy" in commands
+    assert "exec -T api-proxy nginx -t" in commands
+    assert "exec -T api-proxy nginx -s reload" in commands
+    assert "proxy_pass http://app-blue:8000;" in upstream.read_text(encoding="utf-8")
+    assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
 
 
 def test_failed_candidate_keeps_legacy_active(tmp_path):

--- a/tests/unit/test_etcd_quorum_assets.py
+++ b/tests/unit/test_etcd_quorum_assets.py
@@ -1,0 +1,117 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = REPO_ROOT / "deploy/ha/quorum/docker-compose.etcd.yml"
+UNIT = REPO_ROOT / "deploy/ha/quorum/mvn-etcd-quorum.service"
+GENERATE = REPO_ROOT / "scripts/ha/generate_etcd_pki.sh"
+CHECK = REPO_ROOT / "scripts/ha/check_etcd_quorum.sh"
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_etcd_compose_is_three_member_tls_only_and_digest_pinned():
+    payload = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    service = payload["services"]["etcd"]
+    text = COMPOSE.read_text(encoding="utf-8")
+
+    assert "@sha256:" in service["image"]
+    assert service["network_mode"] == "host"
+    assert "http://" not in text
+    assert "--client-cert-auth=true" in service["command"]
+    assert "--peer-client-cert-auth=true" in service["command"]
+    assert "mvn-api=https://10.77.0.2:2380" in text
+    assert "zakup=https://10.77.0.1:2380" in text
+    assert "mvn-web=https://10.77.0.3:2380" in text
+    assert service["mem_limit"] == "${ETCD_MEMORY_LIMIT:-192m}"
+    assert service["logging"]["options"]["max-file"] == "5"
+
+
+def test_etcd_systemd_unit_waits_for_wireguard_and_docker():
+    text = UNIT.read_text(encoding="utf-8")
+
+    assert "Requires=docker.service wg-quick@wg-mvn.service" in text
+    assert "ConditionPathExists=/opt/mvn-quorum/pki/node.key" in text
+    assert "docker compose --env-file .env -f docker-compose.etcd.yml up -d --wait" in text
+
+
+def test_pki_generator_creates_distinct_valid_certificates(tmp_path):
+    output = tmp_path / "pki"
+    env = os.environ.copy()
+    env["ETCD_PKI_OUTPUT_DIR"] = str(output)
+
+    result = subprocess.run(["bash", str(GENERATE)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    for node in ("mvn-api", "zakup", "mvn-web"):
+        node_dir = output / "nodes" / node
+        assert (node_dir / "ca.crt").is_file()
+        assert (node_dir / "node.crt").is_file()
+        assert (node_dir / "node.key").stat().st_mode & 0o777 == 0o600
+        verify = subprocess.run(
+            ["openssl", "verify", "-CAfile", str(output / "ca.crt"), str(node_dir / "node.crt")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert verify.returncode == 0, verify.stderr
+    assert (output / "operator/operator.crt").is_file()
+    assert (output / "operator/operator.key").is_file()
+    assert (output / "ca-private/ca.key").is_file()
+
+    duplicate = subprocess.run(
+        ["bash", str(GENERATE)], env=env, text=True, capture_output=True, check=False
+    )
+    assert duplicate.returncode == 1
+    assert "refusing to replace" in duplicate.stdout
+
+
+def test_quorum_check_requires_three_members_and_one_leader():
+    text = CHECK.read_text(encoding="utf-8")
+
+    assert "ETCD_EXPECTED_MEMBERS:-3" in text
+    assert "members disagree on leader" in text
+    assert "raft index lag" in text
+    assert "endpoint health --cluster" in text
+
+
+def test_quorum_check_accepts_consistent_healthy_cluster(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+if [[ "$1" == "inspect" ]]; then
+  exit 0
+fi
+if [[ "$*" == *"endpoint status"* ]]; then
+  cat <<'JSON'
+[
+  {"Endpoint":"https://10.77.0.1:2379","Status":{"header":{"cluster_id":7},"version":"3.6.11","leader":11,"raftIndex":100}},
+  {"Endpoint":"https://10.77.0.2:2379","Status":{"header":{"cluster_id":7},"version":"3.6.11","leader":11,"raftIndex":101}},
+  {"Endpoint":"https://10.77.0.3:2379","Status":{"header":{"cluster_id":7},"version":"3.6.11","leader":11,"raftIndex":101}}
+]
+JSON
+  exit 0
+fi
+if [[ "$*" == *"endpoint health"* ]]; then
+  exit 0
+fi
+exit 1
+""",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    result = subprocess.run(["bash", str(CHECK)], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "etcd_quorum_status=passed members=3" in result.stdout
+    assert "raft_lag=1" in result.stdout

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -11,6 +11,7 @@ DOCKERFILE = REPO_ROOT / "deploy/ha/patroni/Dockerfile"
 ENTRYPOINT = REPO_ROOT / "deploy/ha/patroni/patroni-entrypoint.sh"
 REHEARSAL_COMPOSE = REPO_ROOT / "deploy/ha/patroni/rehearsal/docker-compose.yml"
 REHEARSAL = REPO_ROOT / "scripts/ha/rehearse_patroni_failover.sh"
+REHEARSAL_WORKFLOW = REPO_ROOT / ".github/workflows/patroni-failover-rehearsal.yml"
 
 
 @pytest.fixture
@@ -83,3 +84,15 @@ def test_rehearsal_is_isolated_and_exercises_failover_and_rejoin():
     assert 'stop "${leader}"' in text
     assert "former leader did not rejoin" in text
     assert "stop etcd3" in text
+
+
+def test_rehearsal_workflow_is_scheduled_and_keeps_logs():
+    workflow = yaml.load(REHEARSAL_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    job = workflow["jobs"]["rehearse"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    assert "schedule" in workflow["on"]
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+    assert "rehearse_patroni_failover.sh" in steps["Run isolated Patroni failover rehearsal"]["run"]
+    assert steps["Upload rehearsal log"]["if"] == "${{ always() }}"
+    assert "production_data_touched: false" in steps["Rehearsal summary"]["run"]

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from deploy.ha.patroni.render_patroni_config import render_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "deploy/ha/patroni/Dockerfile"
+ENTRYPOINT = REPO_ROOT / "deploy/ha/patroni/patroni-entrypoint.sh"
+REHEARSAL_COMPOSE = REPO_ROOT / "deploy/ha/patroni/rehearsal/docker-compose.yml"
+REHEARSAL = REPO_ROOT / "scripts/ha/rehearse_patroni_failover.sh"
+
+
+@pytest.fixture
+def patroni_env(monkeypatch):
+    values = {
+        "PATRONI_NAME": "pg1",
+        "PATRONI_POSTGRESQL_CONNECT_ADDRESS": "10.77.0.2:5432",
+        "PATRONI_RESTAPI_CONNECT_ADDRESS": "10.77.0.2:8008",
+        "PATRONI_ETCD_HOSTS": "10.77.0.1:2379,10.77.0.2:2379,10.77.0.3:2379",
+        "PATRONI_ETCD_PROTOCOL": "https",
+        "PATRONI_ETCD_CACERT": "/etc/etcd/pki/ca.crt",
+        "PATRONI_ETCD_CERT": "/etc/etcd/pki/node.crt",
+        "PATRONI_ETCD_KEY": "/etc/etcd/pki/node.key",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "password: with spaces",
+        "PATRONI_REPLICATION_PASSWORD": "replication: secret",
+    }
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+    return values
+
+
+def test_renderer_builds_synchronous_tls_patroni_config(patroni_env):
+    config = render_config()
+
+    assert config["name"] == "pg1"
+    assert config["etcd3"]["protocol"] == "https"
+    assert len(config["etcd3"]["hosts"]) == 3
+    dcs = config["bootstrap"]["dcs"]
+    assert dcs["synchronous_mode"] is True
+    assert dcs["synchronous_mode_strict"] is False
+    assert dcs["failsafe_mode"] is True
+    assert dcs["postgresql"]["use_pg_rewind"] is True
+    assert config["postgresql"]["authentication"]["superuser"]["password"] == (
+        patroni_env["POSTGRES_PASSWORD"]
+    )
+    assert config["watchdog"]["mode"] == "off"
+
+
+def test_renderer_rejects_unsafe_timing_budget(patroni_env, monkeypatch):
+    monkeypatch.setenv("PATRONI_TTL", "20")
+    monkeypatch.setenv("PATRONI_LOOP_WAIT", "10")
+    monkeypatch.setenv("PATRONI_RETRY_TIMEOUT", "10")
+
+    with pytest.raises(ValueError, match="must be <="):
+        render_config()
+
+
+def test_patroni_image_and_entrypoint_are_versioned_and_adoption_safe():
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    entrypoint = ENTRYPOINT.read_text(encoding="utf-8")
+
+    assert "postgres:15.18-alpine@sha256:" in dockerfile
+    assert "PATRONI_VERSION=4.1.4" in dockerfile
+    assert '"patroni[etcd3]==${PATRONI_VERSION}"' in dockerfile
+    assert "PATRONI_ALLOW_BOOTSTRAP" in entrypoint
+    assert "PGDATA is empty" in entrypoint
+    assert "su-exec postgres" in entrypoint
+
+
+def test_rehearsal_is_isolated_and_exercises_failover_and_rejoin():
+    compose = yaml.safe_load(REHEARSAL_COMPOSE.read_text(encoding="utf-8"))
+    text = REHEARSAL.read_text(encoding="utf-8")
+
+    assert compose["name"] == "mvn_patroni_rehearsal"
+    assert {"etcd1", "etcd2", "etcd3", "pg1", "pg2"} <= set(compose["services"])
+    assert compose["services"]["pg1"]["ports"] == ["127.0.0.1:55431:5432", "127.0.0.1:18008:8008"]
+    assert compose["services"]["pg2"]["ports"] == ["127.0.0.1:55432:5432", "127.0.0.1:18009:8008"]
+    assert "down -v --remove-orphans" in text
+    assert 'stop "${leader}"' in text
+    assert "former leader did not rejoin" in text
+    assert "stop etcd3" in text

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -20,11 +20,11 @@ def patroni_env(monkeypatch):
         "PATRONI_NAME": "pg1",
         "PATRONI_POSTGRESQL_CONNECT_ADDRESS": "10.77.0.2:5432",
         "PATRONI_RESTAPI_CONNECT_ADDRESS": "10.77.0.2:8008",
-        "PATRONI_ETCD_HOSTS": "10.77.0.1:2379,10.77.0.2:2379,10.77.0.3:2379",
-        "PATRONI_ETCD_PROTOCOL": "https",
-        "PATRONI_ETCD_CACERT": "/etc/etcd/pki/ca.crt",
-        "PATRONI_ETCD_CERT": "/etc/etcd/pki/node.crt",
-        "PATRONI_ETCD_KEY": "/etc/etcd/pki/node.key",
+        "PATRONI_ETCD3_HOSTS": "10.77.0.1:2379,10.77.0.2:2379,10.77.0.3:2379",
+        "PATRONI_ETCD3_PROTOCOL": "https",
+        "PATRONI_ETCD3_CACERT": "/etc/etcd/pki/ca.crt",
+        "PATRONI_ETCD3_CERT": "/etc/etcd/pki/node.crt",
+        "PATRONI_ETCD3_KEY": "/etc/etcd/pki/node.key",
         "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "password: with spaces",
         "PATRONI_REPLICATION_PASSWORD": "replication: secret",
@@ -69,19 +69,28 @@ def test_patroni_image_and_entrypoint_are_versioned_and_adoption_safe():
     assert '"patroni[etcd3]==${PATRONI_VERSION}"' in dockerfile
     assert "PATRONI_ALLOW_BOOTSTRAP" in entrypoint
     assert "PGDATA is empty" in entrypoint
+    assert 'chmod 0700 "${PGDATA}"' in entrypoint
+    assert "chown -R" not in entrypoint
     assert "su-exec postgres" in entrypoint
 
 
 def test_rehearsal_is_isolated_and_exercises_failover_and_rejoin():
     compose = yaml.safe_load(REHEARSAL_COMPOSE.read_text(encoding="utf-8"))
+    compose_text = REHEARSAL_COMPOSE.read_text(encoding="utf-8")
     text = REHEARSAL.read_text(encoding="utf-8")
 
     assert compose["name"] == "mvn_patroni_rehearsal"
     assert {"etcd1", "etcd2", "etcd3", "pg1", "pg2"} <= set(compose["services"])
     assert compose["services"]["pg1"]["ports"] == ["127.0.0.1:55431:5432", "127.0.0.1:18008:8008"]
     assert compose["services"]["pg2"]["ports"] == ["127.0.0.1:55432:5432", "127.0.0.1:18009:8008"]
+    assert "PATRONI_ETCD3_HOSTS" in compose_text
+    assert "PATRONI_ETCD_HOSTS" not in compose_text
     assert "down -v --remove-orphans" in text
     assert 'stop "${leader}"' in text
+    assert "http://127.0.0.1:8008/patroni" in text
+    assert 'exec -T \\\n    -e "PGOPTIONS=' in text
+    assert "replica was not registered as synchronous" in text
+    assert "pg_stat_replication" in text
     assert "former leader did not rejoin" in text
     assert "stop etcd3" in text
 

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -12,6 +12,10 @@ ENTRYPOINT = REPO_ROOT / "deploy/ha/patroni/patroni-entrypoint.sh"
 REHEARSAL_COMPOSE = REPO_ROOT / "deploy/ha/patroni/rehearsal/docker-compose.yml"
 REHEARSAL = REPO_ROOT / "scripts/ha/rehearse_patroni_failover.sh"
 REHEARSAL_WORKFLOW = REPO_ROOT / ".github/workflows/patroni-failover-rehearsal.yml"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github/workflows/publish-patroni-image.yml"
+PRIMARY_COMPOSE = REPO_ROOT / "deploy/ha/mvn-api/docker-compose.patroni.yml"
+RESERVE_COMPOSE = REPO_ROOT / "deploy/ha/zakup/docker-compose.patroni.yml"
+PROXY_CONFIG = REPO_ROOT / "deploy/ha/proxy/nginx.conf"
 
 
 @pytest.fixture
@@ -105,3 +109,40 @@ def test_rehearsal_workflow_is_scheduled_and_keeps_logs():
     assert "rehearse_patroni_failover.sh" in steps["Run isolated Patroni failover rehearsal"]["run"]
     assert steps["Upload rehearsal log"]["if"] == "${{ always() }}"
     assert "production_data_touched: false" in steps["Rehearsal summary"]["run"]
+
+
+def test_production_patroni_composes_are_role_driven_and_private():
+    primary = yaml.safe_load(PRIMARY_COMPOSE.read_text(encoding="utf-8"))
+    reserve = yaml.safe_load(RESERVE_COMPOSE.read_text(encoding="utf-8"))
+
+    for compose, address in ((primary, "10.77.0.2"), (reserve, "10.77.0.1")):
+        db = compose["services"]["db"]
+        assert db["image"] == "${PATRONI_IMAGE:?set immutable PATRONI_IMAGE in .env}"
+        assert db["environment"]["PATRONI_ALLOW_BOOTSTRAP"] == "false"
+        assert db["environment"]["PATRONI_SYNCHRONOUS_MODE"] == "true"
+        assert db["environment"]["PATRONI_SYNCHRONOUS_MODE_STRICT"] == "false"
+        assert db["environment"]["PATRONI_ETCD3_PROTOCOL"] == "https"
+        assert f"{address}:5432:5432" in db["ports"]
+        assert f"{address}:8008:8008" in db["ports"]
+        assert "0.0.0.0:5432:5432" not in db["ports"]
+        assert compose["services"]["app-blue"]["env_file"][-1] == ".ha-app-role.env"
+        assert compose["services"]["bot"]["env_file"][-1] == ".ha-bot-role.env"
+
+    assert reserve["services"]["api-proxy"]["ports"] == ["127.0.0.1:18080:8000"]
+    assert "proxy_set_header Host api.mvn.by" in PROXY_CONFIG.read_text(encoding="utf-8")
+
+
+def test_patroni_image_publish_is_manual_sha_gated_and_digest_pinned():
+    workflow = yaml.load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    job = workflow["jobs"]["publish"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    assert "No successful CI run found" in steps["Require tested main SHA"]["run"]
+    assert steps["Checkout exact tested SHA"]["with"]["ref"] == "${{ github.sha }}"
+    build = steps["Build and push Patroni"]["with"]
+    assert build["file"] == "deploy/ha/patroni/Dockerfile"
+    assert build["platforms"] == "linux/amd64"
+    assert build["provenance"] == "mode=max"
+    assert build["sbom"] == "true"
+    assert "patroni@${digest}" in steps["Resolve immutable image"]["run"]

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -9,7 +9,7 @@ def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
     return AgentConfig(
         project_dir=tmp_path,
         compose_file="compose.yml",
-        patroni_url="http://127.0.0.1:8008",
+        patroni_url="http://127.0.0.1:8008/patroni",
         ready_url="http://127.0.0.1:18080/api/ready",
         app_role_env=tmp_path / ".ha-app-role.env",
         bot_role_env=tmp_path / ".ha-bot-role.env",

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -17,6 +17,7 @@ def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
         deploy_lock=tmp_path / ".deploy.lock",
         active_slot_file=tmp_path / ".active-api-slot",
         app_service=app_service_override,
+        primary_systemd_units=(),
         poll_seconds=3,
         promotion_delay_seconds=0,
         ready_attempts=2,
@@ -39,6 +40,9 @@ def test_role_env_opens_api_and_singleton_processes_only_on_primary():
     assert "SCHEDULER_ENABLED=false" in standby_app
     assert "BOT_ENABLED=false" in standby_bot
     assert "DB_BOOTSTRAP_ENABLED=false" in standby_app
+    assert "MAIL_IMAP_AUTO_IMPORT_ENABLED=false" in standby_app
+    assert "CLOUDFLARE_PURGE_ENABLED=false" in standby_app
+    assert "MAIL_IMAP_AUTO_IMPORT_ENABLED" not in primary_app
 
 
 def test_app_service_follows_blue_green_slot(tmp_path):
@@ -97,3 +101,35 @@ def test_reconcile_primary_waits_for_ready_before_starting_bot(tmp_path, monkeyp
     assert calls[-1] == ("up", "-d", "--no-deps", "--force-recreate", "bot")
     assert "SCHEDULER_ENABLED=true" in config.app_role_env.read_text(encoding="utf-8")
     assert "BOT_ENABLED=true" in config.bot_role_env.read_text(encoding="utf-8")
+
+
+def test_primary_only_systemd_units_follow_role_without_recreating_matching_runtime(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path, app_service_override="app")
+    config = AgentConfig(**{**config.__dict__, "primary_systemd_units": ("wal.timer",)})
+    config.app_role_env.write_text(role_env("primary", bot_process=False), encoding="utf-8")
+    config.bot_role_env.write_text(role_env("primary", bot_process=True), encoding="utf-8")
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    compose_calls: list[tuple[str, ...]] = []
+    systemctl_calls: list[tuple[str, ...]] = []
+
+    def fake_compose(_config, *args, check=True):
+        compose_calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="app\nbot\n")
+
+    def fake_run(command, **_kwargs):
+        systemctl_calls.append(tuple(command))
+        if command[1:3] == ["is-active", "--quiet"]:
+            return SimpleNamespace(returncode=3, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", fake_compose)
+    monkeypatch.setattr(patroni_role_agent.subprocess, "run", fake_run)
+
+    assert reconcile(config, "primary") is False
+    assert compose_calls == [("ps", "--status", "running", "--services")]
+    assert systemctl_calls == [
+        ("systemctl", "is-active", "--quiet", "wal.timer"),
+        ("systemctl", "start", "wal.timer"),
+    ]

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.ha import patroni_role_agent
+from scripts.ha.patroni_role_agent import AgentConfig, app_service, reconcile, role_env
+
+
+def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
+    return AgentConfig(
+        project_dir=tmp_path,
+        compose_file="compose.yml",
+        patroni_url="http://127.0.0.1:8008",
+        ready_url="http://127.0.0.1:18080/api/ready",
+        app_role_env=tmp_path / ".ha-app-role.env",
+        bot_role_env=tmp_path / ".ha-bot-role.env",
+        state_file=tmp_path / ".ha-runtime-role",
+        deploy_lock=tmp_path / ".deploy.lock",
+        active_slot_file=tmp_path / ".active-api-slot",
+        app_service=app_service_override,
+        poll_seconds=3,
+        promotion_delay_seconds=0,
+        ready_attempts=2,
+    )
+
+
+def test_role_env_opens_api_and_singleton_processes_only_on_primary():
+    primary_app = role_env("primary", bot_process=False)
+    primary_bot = role_env("primary", bot_process=True)
+    standby_app = role_env("standby", bot_process=False)
+    standby_bot = role_env("standby", bot_process=True)
+
+    assert "API_READY_ENABLED=true" in primary_app
+    assert "SCHEDULER_ENABLED=true" in primary_app
+    assert "BOT_ENABLED=false" in primary_app
+    assert "API_READY_ENABLED=false" in primary_bot
+    assert "SCHEDULER_ENABLED=false" in primary_bot
+    assert "BOT_ENABLED=true" in primary_bot
+    assert "API_READY_ENABLED=false" in standby_app
+    assert "SCHEDULER_ENABLED=false" in standby_app
+    assert "BOT_ENABLED=false" in standby_bot
+    assert "DB_BOOTSTRAP_ENABLED=false" in standby_app
+
+
+def test_app_service_follows_blue_green_slot(tmp_path):
+    config = _config(tmp_path)
+
+    assert app_service(config) == "app"
+    config.active_slot_file.write_text("blue\n", encoding="utf-8")
+    assert app_service(config) == "app-blue"
+    config.active_slot_file.write_text("green\n", encoding="utf-8")
+    assert app_service(config) == "app-green"
+
+
+def test_app_service_override_supports_in_place_standby(tmp_path):
+    assert app_service(_config(tmp_path, app_service_override="app")) == "app"
+
+
+def test_reconcile_standby_stops_bot_before_recreating_app(tmp_path, monkeypatch):
+    config = _config(tmp_path, app_service_override="app")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_compose(_config, *args, check=True):
+        calls.append(args)
+        if args[:3] == ("ps", "--status", "running"):
+            return SimpleNamespace(returncode=0, stdout="app\nbot\n")
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", fake_compose)
+
+    assert reconcile(config, "standby") is True
+    assert calls[-2] == ("stop", "bot")
+    assert calls[-1] == ("up", "-d", "--no-deps", "--force-recreate", "app")
+    assert "API_READY_ENABLED=false" in config.app_role_env.read_text(encoding="utf-8")
+    assert config.state_file.read_text(encoding="utf-8") == "standby\n"
+
+
+def test_reconcile_primary_waits_for_ready_before_starting_bot(tmp_path, monkeypatch):
+    config = _config(tmp_path, app_service_override="app")
+    calls: list[tuple[str, ...] | tuple[str]] = []
+
+    def fake_compose(_config, *args, check=True):
+        calls.append(args)
+        if args[:3] == ("ps", "--status", "running"):
+            return SimpleNamespace(returncode=0, stdout="app\n")
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", fake_compose)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_wait_ready",
+        lambda _config: calls.append(("wait-ready",)),
+    )
+
+    assert reconcile(config, "primary") is True
+    assert calls[-3] == ("up", "-d", "--no-deps", "--force-recreate", "app")
+    assert calls[-2] == ("wait-ready",)
+    assert calls[-1] == ("up", "-d", "--no-deps", "--force-recreate", "bot")
+    assert "SCHEDULER_ENABLED=true" in config.app_role_env.read_text(encoding="utf-8")
+    assert "BOT_ENABLED=true" in config.bot_role_env.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a TLS-only three-member etcd quorum topology and isolated Patroni failover rehearsal
- add immutable production Patroni image publishing plus host-specific adoption compose files
- add Patroni role reconciliation for API readiness, bot/scheduler/mail singletons, and PITR timers
- support a stable container Nginx proxy on zakup without coupling releases to belzakupki Caddy
- document guarded production cutover and rollback gates

## Safety
- no production PostgreSQL or etcd service is started by this PR
- existing API deploy remains in physical-replication mode
- Patroni publication is manual and requires a successful CI run for the exact main SHA
- production compose refuses empty PGDATA bootstrap and requires immutable image references

## Verification
- 29 focused unit tests passed
- isolated two-PostgreSQL/three-etcd rehearsal passed automatic failover, data continuity, rejoin, and one-member quorum loss
- ShellCheck, Python compilation, YAML/Compose validation, and git diff checks passed
