### PR TITLE
Wait for stable Cloudflare Pages alias

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -160,19 +160,42 @@ jobs:
       - name: Smoke stable web endpoints
         env:
           DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
         run: |
           set -euo pipefail
+          ssh \
+            -i ~/.ssh/deploy_key \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=20 \
+            "${SSH_USER_API}@${SSH_HOST_API}" \
+            "DEPLOY_SHA='${DEPLOY_SHA}' CLOUDFLARE_PAGES_PROJECT='${CLOUDFLARE_PAGES_PROJECT}' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          smoke_stable() {
+            local base_url="$1"
+            local release_sha=""
+            for attempt in $(seq 1 20); do
+              if curl -fsSL --max-time 20 --retry 2 --retry-delay 1 "${base_url}/" >/dev/null \
+                && curl -fsSL --max-time 20 --retry 2 --retry-delay 1 "${base_url}/catalog/" >/dev/null \
+                && release_sha="$(curl -fsSL --max-time 20 --retry 2 --retry-delay 1 \
+                  "${base_url}/release.json?sha=${DEPLOY_SHA}" \
+                  | python3 -c 'import json,sys; print(json.load(sys.stdin)["sha"])')" \
+                && [ "${release_sha}" = "${DEPLOY_SHA}" ]; then
+                echo "Stable release ${DEPLOY_SHA} confirmed at ${base_url} on attempt ${attempt}"
+                return 0
+              fi
+              sleep 3
+            done
+            echo "::error::${base_url} did not converge to release ${DEPLOY_SHA}; last=${release_sha:-unavailable}"
+            return 1
+          }
+
           for base_url in "https://${CLOUDFLARE_PAGES_PROJECT}.pages.dev" "https://mvn.by"; do
-            curl -fsSL --retry 10 --retry-delay 3 "${base_url}/" >/dev/null
-            curl -fsSL --retry 10 --retry-delay 3 "${base_url}/catalog/" >/dev/null
-            release_sha="$(curl -fsSL --retry 10 --retry-delay 3 \
-              "${base_url}/release.json?sha=${DEPLOY_SHA}" \
-              | python3 -c 'import json,sys; print(json.load(sys.stdin)["sha"])')"
-            if [ "${release_sha}" != "${DEPLOY_SHA}" ]; then
-              echo "::error::${base_url} release ${release_sha} does not match ${DEPLOY_SHA}"
-              exit 1
-            fi
+            smoke_stable "${base_url}"
           done
+          REMOTE
 
       - name: Upload web release logs
         if: ${{ always() }}

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -33,7 +33,13 @@ def test_reusable_web_release_promotes_one_immutable_artifact_in_safe_order():
     )
     assert 'candidate-${DEPLOY_SHA:0:12}' in _step(job, "Deploy Cloudflare Pages canary")["run"]
     assert "scripts/deploy_web_atomic.sh" in _step(job, "Deploy atomic VPS fallback")["run"]
-    assert '"${base_url}/release.json?sha=${DEPLOY_SHA}"' in _step(job, "Smoke stable web endpoints")["run"]
+    stable_smoke = _step(job, "Smoke stable web endpoints")["run"]
+    assert '"${base_url}/release.json?sha=${DEPLOY_SHA}"' in stable_smoke
+    assert "for attempt in $(seq 1 20)" in stable_smoke
+    assert 'sleep 3' in stable_smoke
+    assert "did not converge to release" in stable_smoke
+    assert '"${SSH_USER_API}@${SSH_HOST_API}"' in stable_smoke
+    assert "CLOUDFLARE_PAGES_PROJECT='${CLOUDFLARE_PAGES_PROJECT}' bash -s" in stable_smoke
 
 
 def test_release_and_manual_rebuild_call_the_same_web_workflow():


### PR DESCRIPTION
## Summary
- poll stable Pages/VPS hostnames until their immutable release marker converges
- keep the existing 60-second bound and fail with the last observed marker

## Context
The first production Pages deployment itself succeeded, as did the atomic VPS deploy. The final check raced the eventual update of `mvn-by.pages.dev` and failed before the stable alias exposed the new SHA.

## Verification
- 15 focused workflow/deploy tests passed
- workflow YAML and diff checks passed
- both `mvn-by.pages.dev` and the VPS currently serve `fc9e34174797faac547384cd7429b02e6d7924d7`
