### PR TITLE
Deploy API against the active Patroni primary

### DIFF
--- a/.github/workflows/deploy-api-patroni.yml
+++ b/.github/workflows/deploy-api-patroni.yml
@@ -1,0 +1,361 @@
+name: Deploy API with Patroni
+
+on:
+  workflow_call:
+    inputs:
+      deploy_sha:
+        description: Exact CI-tested commit to build and deploy
+        required: true
+        type: string
+    outputs:
+      backend_image:
+        description: Immutable backend image deployed to both nodes
+        value: ${{ jobs.build-backend.outputs.backend_image }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  build-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      backend_image: ${{ steps.image.outputs.reference }}
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Verify immutable release SHA
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          set -euo pipefail
+          [[ "${DEPLOY_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: manager_frontend/package-lock.json
+
+      - name: Build manager frontend
+        working-directory: manager_frontend
+        env:
+          WEBSITE_URL: https://mvn.by
+        run: |
+          npm ci
+          npm run build
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: tag
+        run: echo "tag=ghcr.io/${GITHUB_REPOSITORY,,}/backend:${{ inputs.deploy_sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push backend
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tag.outputs.tag }}
+          cache-from: type=gha,scope=patroni-backend
+          cache-to: type=gha,mode=max,scope=patroni-backend
+
+      - name: Resolve immutable backend image
+        id: image
+        run: |
+          set -euo pipefail
+          digest="${{ steps.build.outputs.digest }}"
+          [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::Invalid backend digest: ${digest:-empty}"
+            exit 1
+          }
+          reference="ghcr.io/${GITHUB_REPOSITORY,,}/backend@${digest}"
+          echo "reference=${reference}" >> "$GITHUB_OUTPUT"
+
+  probe-api-node:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production-api
+    permissions:
+      contents: read
+    outputs:
+      role: ${{ steps.probe.outputs.role }}
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Probe API node Patroni role
+        id: probe
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || secrets.SSH_HOST_API }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || secrets.SSH_USER_API || 'root' }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+        run: bash scripts/ha/run_patroni_node_remote.sh probe
+
+  probe-reserve-node:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: standby-api
+    permissions:
+      contents: read
+    outputs:
+      role: ${{ steps.probe.outputs.role }}
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Probe reserve node Patroni role
+        id: probe
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || vars.API_STANDBY_HOST }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || vars.API_STANDBY_USER || 'root' }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+        run: bash scripts/ha/run_patroni_node_remote.sh probe
+
+  validate-topology:
+    runs-on: ubuntu-latest
+    needs: [probe-api-node, probe-reserve-node]
+    outputs:
+      primary_node: ${{ steps.topology.outputs.primary_node }}
+
+    steps:
+      - name: Require exactly one Patroni primary
+        id: topology
+        env:
+          API_ROLE: ${{ needs.probe-api-node.outputs.role }}
+          RESERVE_ROLE: ${{ needs.probe-reserve-node.outputs.role }}
+        run: |
+          set -euo pipefail
+          if [ "${API_ROLE}" = "primary" ] && [ "${RESERVE_ROLE}" = "standby" ]; then
+            primary_node=api
+          elif [ "${API_ROLE}" = "standby" ] && [ "${RESERVE_ROLE}" = "primary" ]; then
+            primary_node=reserve
+          else
+            echo "::error::Unsafe Patroni topology: api=${API_ROLE} reserve=${RESERVE_ROLE}"
+            exit 1
+          fi
+          echo "primary_node=${primary_node}" >> "$GITHUB_OUTPUT"
+          echo "Patroni primary node: ${primary_node}"
+
+  migrate-api-node:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'api' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production-api
+    needs: [build-backend, validate-topology]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Run migrations on API primary
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || secrets.SSH_HOST_API }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || secrets.SSH_USER_API || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/air-api' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/mvn-api/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: host_nginx
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh migrate
+
+  migrate-reserve-node:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'reserve' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: standby-api
+    needs: [build-backend, validate-topology]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Run migrations on reserve primary
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || vars.API_STANDBY_HOST }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || vars.API_STANDBY_USER || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/mvn-reserve' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/zakup/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: container_nginx
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh migrate
+
+  deploy-replica-reserve:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'api' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: standby-api
+    needs: [build-backend, validate-topology, migrate-api-node]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Deploy fenced reserve replica
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || vars.API_STANDBY_HOST }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || vars.API_STANDBY_USER || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/mvn-reserve' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/zakup/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: container_nginx
+          API_EXPECTED_PATRONI_ROLE: standby
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+
+  deploy-replica-api:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'reserve' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production-api
+    needs: [build-backend, validate-topology, migrate-reserve-node]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Deploy fenced API replica
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || secrets.SSH_HOST_API }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || secrets.SSH_USER_API || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/air-api' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/mvn-api/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: host_nginx
+          API_EXPECTED_PATRONI_ROLE: standby
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+
+  deploy-primary-api:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'api' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production-api
+    needs: [build-backend, validate-topology, migrate-api-node, deploy-replica-reserve]
+    permissions:
+      contents: read
+      packages: read
+      deployments: write
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Blue-green deploy API primary
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || secrets.SSH_HOST_API }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || secrets.SSH_USER_API || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/air-api' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/mvn-api/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: host_nginx
+          API_EXPECTED_PATRONI_ROLE: primary
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+
+  deploy-primary-reserve:
+    if: ${{ needs.validate-topology.outputs.primary_node == 'reserve' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: standby-api
+    needs: [build-backend, validate-topology, migrate-reserve-node, deploy-replica-api]
+    permissions:
+      contents: read
+      packages: read
+      deployments: write
+
+    steps:
+      - name: Checkout exact tested SHA
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Blue-green deploy reserve primary
+        env:
+          API_NODE_HOST: ${{ vars.API_NODE_HOST || vars.API_STANDBY_HOST }}
+          API_NODE_USER: ${{ vars.API_NODE_USER || vars.API_STANDBY_USER || 'root' }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/mvn-reserve' }}
+          API_NODE_COMPOSE_SOURCE: deploy/ha/zakup/docker-compose.patroni.yml
+          API_NODE_PROXY_MODE: container_nginx
+          API_EXPECTED_PATRONI_ROLE: primary
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+
+  deployment-complete:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [validate-topology, deploy-primary-api, deploy-primary-reserve]
+
+    steps:
+      - name: Require the selected primary branch to succeed
+        env:
+          PRIMARY_NODE: ${{ needs.validate-topology.outputs.primary_node }}
+          API_RESULT: ${{ needs.deploy-primary-api.result }}
+          RESERVE_RESULT: ${{ needs.deploy-primary-reserve.result }}
+        run: |
+          set -euo pipefail
+          if [ "${PRIMARY_NODE}" = "api" ]; then
+            test "${API_RESULT}" = "success"
+            test "${RESERVE_RESULT}" = "skipped"
+          elif [ "${PRIMARY_NODE}" = "reserve" ]; then
+            test "${API_RESULT}" = "skipped"
+            test "${RESERVE_RESULT}" = "success"
+          else
+            echo "::error::No validated Patroni primary branch completed"
+            exit 1
+          fi
+          echo "Patroni-aware API release completed through ${PRIMARY_NODE}"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -107,14 +107,27 @@ jobs:
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
         run: |
           set -euo pipefail
-          ssh -f -N \
-            -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
-            -i ~/.ssh/deploy_key \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=yes \
-            -o ExitOnForwardFailure=yes \
-            -o ConnectTimeout=20 \
-            "${SSH_USER_API}@${SSH_HOST_API}"
+          tunnel_started=false
+          for attempt in 1 2 3 4 5; do
+            if ssh -f -N \
+              -L "${API_TUNNEL_LOCAL_PORT}:127.0.0.1:${API_TUNNEL_REMOTE_PORT}" \
+              -i ~/.ssh/deploy_key \
+              -o BatchMode=yes \
+              -o StrictHostKeyChecking=yes \
+              -o ExitOnForwardFailure=yes \
+              -o ConnectTimeout=20 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=3 \
+              "${SSH_USER_API}@${SSH_HOST_API}"; then
+              tunnel_started=true
+              break
+            fi
+            sleep $((attempt * 5))
+          done
+          if [ "${tunnel_started}" != "true" ]; then
+            echo "::error::Could not establish API SSH tunnel after 5 attempts"
+            exit 1
+          fi
           curl -fsS --retry 10 --retry-delay 3 \
             "http://127.0.0.1:${API_TUNNEL_LOCAL_PORT}/api/v1/config" >/dev/null
           npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,7 @@ jobs:
   # 1. BACKEND DEPLOYMENT (Docker -> mvn-api)
   # ======================================================
   deploy-backend:
+    if: ${{ vars.API_DB_HA_MODE != 'patroni' }}
     needs: release-gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -519,12 +520,63 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  deploy-backend-patroni:
+    if: ${{ vars.API_DB_HA_MODE == 'patroni' }}
+    needs: release-gate
+    permissions:
+      contents: read
+      deployments: write
+      packages: write
+    uses: ./.github/workflows/deploy-api-patroni.yml
+    with:
+      deploy_sha: ${{ needs.release-gate.outputs.deploy_sha }}
+    secrets: inherit
+
+  backend-release:
+    if: ${{ always() && needs.release-gate.result == 'success' }}
+    runs-on: ubuntu-latest
+    needs:
+      - release-gate
+      - deploy-backend
+      - deploy-backend-patroni
+    outputs:
+      backend_image: ${{ steps.resolve.outputs.backend_image }}
+      mode: ${{ steps.resolve.outputs.mode }}
+
+    steps:
+      - name: Require exactly one backend deployment path
+        id: resolve
+        env:
+          PHYSICAL_RESULT: ${{ needs.deploy-backend.result }}
+          PHYSICAL_IMAGE: ${{ needs.deploy-backend.outputs.backend_image }}
+          PATRONI_RESULT: ${{ needs.deploy-backend-patroni.result }}
+          PATRONI_IMAGE: ${{ needs.deploy-backend-patroni.outputs.backend_image }}
+        run: |
+          set -euo pipefail
+          if [ "${PHYSICAL_RESULT}" = "success" ] && [ "${PATRONI_RESULT}" = "skipped" ]; then
+            mode=physical
+            backend_image="${PHYSICAL_IMAGE}"
+          elif [ "${PHYSICAL_RESULT}" = "skipped" ] && [ "${PATRONI_RESULT}" = "success" ]; then
+            mode=patroni
+            backend_image="${PATRONI_IMAGE}"
+          else
+            echo "::error::Invalid backend paths: physical=${PHYSICAL_RESULT} patroni=${PATRONI_RESULT}"
+            exit 1
+          fi
+          [[ "${backend_image}" =~ @sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::Backend path did not produce an immutable digest"
+            exit 1
+          }
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+          echo "backend_image=${backend_image}" >> "$GITHUB_OUTPUT"
+          echo "Backend release mode: ${mode}"
+
   # Standby deployment is isolated in a reusable workflow so the main release
   # file remains an orchestration surface.
   deploy-api-standby:
-    if: ${{ vars.API_STANDBY_HOST != '' }}
+    if: ${{ needs.backend-release.outputs.mode == 'physical' && vars.API_STANDBY_HOST != '' }}
     needs:
-      - deploy-backend
+      - backend-release
       - release-gate
     permissions:
       contents: read
@@ -533,7 +585,7 @@ jobs:
     uses: ./.github/workflows/deploy-api-standby.yml
     with:
       deploy_sha: ${{ needs.release-gate.outputs.deploy_sha }}
-      backend_image: ${{ needs.deploy-backend.outputs.backend_image }}
+      backend_image: ${{ needs.backend-release.outputs.backend_image }}
     secrets: inherit
 
   # Web release is isolated in one reusable workflow so automatic releases and
@@ -541,7 +593,7 @@ jobs:
   deploy-frontend:
     if: ${{ needs.detect-frontend-changes.outputs.web_changed == 'true' }}
     needs:
-      - deploy-backend
+      - backend-release
       - detect-frontend-changes
       - release-gate
     permissions:

--- a/deploy/ha/patroni/render_patroni_config.py
+++ b/deploy/ha/patroni/render_patroni_config.py
@@ -41,6 +41,19 @@ def integer(name: str, default: int, *, minimum: int = 0) -> int:
     return value
 
 
+def seconds(name: str, default: int, *, minimum: int = 0) -> int:
+    raw = os.getenv(name, str(default)).strip().lower()
+    if raw.endswith("s"):
+        raw = raw[:-1].strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be integer seconds, optionally suffixed with s") from exc
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return value
+
+
 def csv(name: str) -> list[str]:
     values = [item.strip() for item in required(name).split(",") if item.strip()]
     if not values:
@@ -98,7 +111,7 @@ def render_config() -> dict[str, Any]:
         raise ValueError("PATRONI_ARCHIVE_MODE must be on or off")
     postgres_parameters["archive_mode"] = archive_mode
     if archive_mode == "on":
-        postgres_parameters["archive_timeout"] = integer(
+        postgres_parameters["archive_timeout"] = seconds(
             "PATRONI_ARCHIVE_TIMEOUT", 300, minimum=1
         )
         postgres_parameters["archive_command"] = required("PATRONI_ARCHIVE_COMMAND")

--- a/deploy/ha/quorum/docker-compose.etcd.yml
+++ b/deploy/ha/quorum/docker-compose.etcd.yml
@@ -29,19 +29,19 @@ services:
       - --auto-compaction-retention=1h
       - --quota-backend-bytes=1073741824
       - --snapshot-count=10000
-    environment:
-      ETCDCTL_API: "3"
     volumes:
       - ./data:/etcd-data
       - ./pki:/etc/etcd/pki:ro
     healthcheck:
       test:
-        - CMD-SHELL
-        - >-
-          etcdctl --endpoints=https://127.0.0.1:2379
-          --cacert=/etc/etcd/pki/ca.crt
-          --cert=/etc/etcd/pki/node.crt
-          --key=/etc/etcd/pki/node.key endpoint health
+        - CMD
+        - /usr/local/bin/etcdctl
+        - --endpoints=https://127.0.0.1:2379
+        - --cacert=/etc/etcd/pki/ca.crt
+        - --cert=/etc/etcd/pki/node.crt
+        - --key=/etc/etcd/pki/node.key
+        - endpoint
+        - health
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,8 +32,9 @@ Prepared server baseline:
 - Let's Encrypt certificate for `mvn.by` and `www.mvn.by` issued via Cloudflare DNS-01
 - certbot renewal hook reloads nginx after certificate renewal
 
-The production storefront is still static. The hybrid runtime/cache/freshness
-design for the new VPS is documented in
+The production storefront is static and served by Cloudflare Pages. The web
+VPS retains the same immutable artifacts as an independent origin rollback.
+The hybrid runtime/cache/freshness design for the new VPS is documented in
 [`web-runtime-freshness-runbook.md`](web-runtime-freshness-runbook.md). Do not
 switch public `mvn.by` to Astro runtime without following that runbook's
 staging, shadow, cutover, and rollback gates.
@@ -53,11 +54,11 @@ curl -I -H 'Host: mvn.by' http://153.80.244.78/
 curl -I --resolve mvn.by:443:153.80.244.78 https://mvn.by/
 ```
 
-Cloudflare DNS state before the Pages custom-domain cutover:
+Current Cloudflare DNS state after the Pages custom-domain cutover:
 
 ```text
-mvn.by      A 153.80.244.78 proxied
-www.mvn.by  A 153.80.244.78 proxied
+mvn.by      CNAME mvn-by.pages.dev proxied
+www.mvn.by  CNAME mvn-by.pages.dev proxied
 ```
 
 The current VPS remains the primary Pages rollback origin. Restore the Cloudflare
@@ -70,8 +71,10 @@ the older `mvn-web` host at `178.159.240.174` as the last-resort fallback.
 - **Original API IP:** `185.250.45.54`
 - **Emergency `zakup` IP:** `193.47.42.213`
 - **SSH Key:** `~/.ssh/id_ed25519`
-- **DNS:** `api.mvn.by` A-record must point to the current API primary.
-- **GitHub secret:** `SSH_HOST_API` must point to the current API primary.
+- **Routing:** `api.mvn.by` is managed by Cloudflare Load Balancing; `/api/ready`
+  controls which origin receives traffic.
+- **GitHub secret:** `SSH_HOST_API` identifies the physical-mode deployment host.
+  Patroni mode probes both protected deployment environments instead.
 - **Public entrypoint:** reverse proxy on `80/443`, proxying `api.mvn.by` to the current API app port.
 - **Health endpoint:** `/api/health`
 - **Load balancer readiness endpoint:** `/api/ready`
@@ -282,11 +285,12 @@ The workflow requires these env vars in the build step:
 
 1. **release-gate:** Resolves the tested `main` SHA and serializes production
    releases through the `production-release` concurrency group.
-2. **deploy-backend:** Publishes `backend:<commit-sha>`, deploys its resolved
-   `backend@sha256:<digest>` through the `production-api` environment, activates
-   it through the inactive blue-green slot, and runs smoke checks.
-3. **deploy-api-standby:** Installs the same image on the fenced app-only standby
-   through the `standby-api` environment.
+2. **backend deployment:** Publishes one immutable `backend@sha256:<digest>`.
+   Physical mode deploys `production-api` then the fenced standby. After the
+   guarded Patroni cutover, role-aware mode probes both nodes, migrates only on
+   the current primary, updates the fenced replica, then blue-greens the primary.
+3. **backend-release:** Requires exactly one physical or Patroni deployment path
+   to succeed before the web release may continue.
 4. **deploy-frontend:** When web files changed (or manual rebuild was requested),
    builds Astro once, validates the static artifact and release marker, deploys
    a Cloudflare Pages canary, atomically promotes the same artifact on the VPS,
@@ -418,16 +422,15 @@ curl -fsS --resolve mvn.by:443:127.0.0.1 https://mvn.by/ >/dev/null
 
 ### Cloudflare Pages Cutover
 
-Do not replace the `mvn.by` DNS records before the first Pages production
-release is green. Cloudflare Pages must associate both custom domains with the
-project before DNS cutover:
+The cutover is complete. Both custom domains are associated with `mvn-by`, have
+active Pages certificates, and point to `mvn-by.pages.dev`. For a future zone or
+project migration, preserve this order:
 
-1. Open **Workers & Pages -> mvn-by -> Custom domains**.
-2. Add `mvn.by`, wait for it to become active, then add `www.mvn.by`.
-3. Confirm both certificates are active and the public `release.json` matches
-   the expected production SHA.
-4. Keep the VPS, atomic releases, and origin smoke checks as the independent
-   rollback path.
+1. Produce a green Pages production release and matching atomic VPS release.
+2. Associate the custom domain with Pages before changing its DNS record.
+3. Change one hostname at a time, wait for `active`, and require exact-SHA smoke.
+4. Keep the VPS, DNS backup, atomic releases, and direct-origin checks as the
+   independent rollback path.
 
 For an apex domain in a Cloudflare-managed zone, use the Pages custom-domain
 flow and let Cloudflare create the required DNS record. Creating only a manual

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -259,3 +259,38 @@ If any gate before step 8 fails, stop both Patroni containers, restore the old
 compose files and PGDATA copies, start the former primary first, then restore
 physical replication. Do not delete rollback copies or Patroni DCS state until
 the old topology is verified; DCS cleanup is a separate, explicit retry step.
+
+## CI/CD Role Switch
+
+Keep repository variable `API_DB_HA_MODE` unset during preparation and the
+database cutover. The existing physical primary/standby release path remains
+active while it is unset.
+
+After Patroni, both role agents, the reserve proxy, and the switchover drill are
+green, define these environment variables:
+
+| Environment | `API_NODE_HOST` | `API_NODE_USER` | `API_NODE_PROJECT_DIR` |
+| --- | --- | --- | --- |
+| `production-api` | API VPS address | `root` | `/opt/air-api` |
+| `standby-api` | reserve VPS address | `root` | `/opt/mvn-reserve` |
+
+Both environments must retain `SSH_KEY` and `GHCR_PAT`. Then set the repository
+variable:
+
+```bash
+gh variable set API_DB_HA_MODE --body patroni
+```
+
+The next release will:
+
+1. build one immutable backend image from the exact CI-tested SHA;
+2. probe both local Patroni APIs and require exactly one primary;
+3. run migrations only on that primary while holding the deployment lock;
+4. update and smoke-check the fenced replica first;
+5. blue-green the current primary through its host-specific proxy;
+6. fail the release if the database role changes mid-operation.
+
+The Patroni deploy scripts never start, recreate, or pull `db`. For a full
+rollback to the former physical topology, restore PostgreSQL first under the
+cutover rollback procedure, then delete `API_DB_HA_MODE`; do not switch the
+variable while Patroni is still managing either database node.

--- a/docs/web-runtime-freshness-runbook.md
+++ b/docs/web-runtime-freshness-runbook.md
@@ -16,9 +16,10 @@ DNS, or VPS state by itself.
 
 Public production:
 
-- `mvn.by` and `www.mvn.by` are proxied through Cloudflare to the new web VPS
-  `153.80.244.78`.
-- nginx serves the public static Astro build from `/var/www/mvn.by/current`.
+- `mvn.by` and `www.mvn.by` are Cloudflare Pages custom domains for the static
+  Astro production branch.
+- nginx on `153.80.244.78` serves the matching atomic release from
+  `/var/www/mvn.by/live` as the independent rollback origin.
 - The legacy `mvn-web` host at `178.159.240.174` remains the static storefront
   reserve/fallback target.
 - API traffic stays separate at `https://api.mvn.by`.

--- a/scripts/ha/check_etcd_quorum.sh
+++ b/scripts/ha/check_etcd_quorum.sh
@@ -24,7 +24,6 @@ docker inspect "${CONTAINER}" >/dev/null 2>&1 || {
 
 status_json="$({
   docker exec \
-    -e ETCDCTL_API=3 \
     "${CONTAINER}" \
     etcdctl \
     --endpoints="${ENDPOINTS}" \
@@ -69,7 +68,6 @@ print(
 PY
 
 docker exec \
-  -e ETCDCTL_API=3 \
   "${CONTAINER}" \
   etcdctl \
   --endpoints="${ENDPOINTS}" \

--- a/scripts/ha/configure_patroni_image_env.sh
+++ b/scripts/ha/configure_patroni_image_env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${PATRONI_ENV_FILE:?set PATRONI_ENV_FILE}"
+
+IFS= read -r patroni_image
+[[ "${patroni_image}" =~ ^ghcr\.io/mvnby/air-api/patroni@sha256:[0-9a-f]{64}$ ]] || {
+  echo "PATRONI_IMAGE must be the immutable MVN Patroni GHCR digest" >&2
+  exit 1
+}
+[[ -f "${ENV_FILE}" ]] || {
+  echo "env file is missing: ${ENV_FILE}" >&2
+  exit 1
+}
+
+backup="${ENV_FILE}.bak-patroni-image-$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "${ENV_FILE}" "${backup}"
+temporary="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+trap 'rm -f "${temporary}"' EXIT
+grep -v '^PATRONI_IMAGE=' "${ENV_FILE}" > "${temporary}" || true
+printf 'PATRONI_IMAGE=%s\n' "${patroni_image}" >> "${temporary}"
+if ! chmod --reference="${ENV_FILE}" "${temporary}" 2>/dev/null; then
+  mode="$(stat -c '%a' "${ENV_FILE}" 2>/dev/null || stat -f '%Lp' "${ENV_FILE}")"
+  chmod "${mode}" "${temporary}"
+fi
+chown --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || true
+mv "${temporary}" "${ENV_FILE}"
+trap - EXIT
+
+echo "patroni_image_env=prepared backup=${backup}"

--- a/scripts/ha/configure_patroni_pitr_env.sh
+++ b/scripts/ha/configure_patroni_pitr_env.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ENV_FILE="${PATRONI_APP_ENV_FILE:?set PATRONI_APP_ENV_FILE}"
+PITR_ENV_FILE="${PATRONI_SYSTEMD_ENV_FILE:-/etc/mvn-postgres-pitr.env}"
+PROJECT_DIR="${PATRONI_PROJECT_DIR:?set PATRONI_PROJECT_DIR}"
+COMPOSE_FILE="${PATRONI_COMPOSE_FILE:-docker-compose.patroni.yml}"
+
+payload="$(mktemp)"
+temporary=""
+trap 'rm -f "${payload}" "${temporary}"' EXIT
+
+while IFS= read -r line; do
+  [[ -n "${line}" ]] || continue
+  key="${line%%=*}"
+  [[ "${line}" == *=* && "${key}" =~ ^POSTGRES_PITR_(ARCHIVE_MODE|ARCHIVE_TIMEOUT|CLUSTER|S3_[A-Z0-9_]+)$ ]] || {
+    echo "unsupported PITR env key: ${key}" >&2
+    exit 1
+  }
+  printf '%s\n' "${line}" >> "${payload}"
+done
+
+for required in \
+  POSTGRES_PITR_S3_ACCESS_KEY_ID \
+  POSTGRES_PITR_S3_SECRET_ACCESS_KEY \
+  POSTGRES_PITR_S3_BUCKET \
+  POSTGRES_PITR_S3_ENDPOINT_URL; do
+  grep -q "^${required}=" "${payload}" || {
+    echo "required PITR env key is missing: ${required}" >&2
+    exit 1
+  }
+done
+[[ -f "${APP_ENV_FILE}" ]] || {
+  echo "app env file is missing: ${APP_ENV_FILE}" >&2
+  exit 1
+}
+
+backup="${APP_ENV_FILE}.bak-patroni-pitr-$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "${APP_ENV_FILE}" "${backup}"
+temporary="$(mktemp "${APP_ENV_FILE}.tmp.XXXXXX")"
+grep -vE '^POSTGRES_PITR_(ARCHIVE_MODE|ARCHIVE_TIMEOUT|CLUSTER|S3_[A-Z0-9_]+)=' \
+  "${APP_ENV_FILE}" > "${temporary}" || true
+cat "${payload}" >> "${temporary}"
+if ! chmod --reference="${APP_ENV_FILE}" "${temporary}" 2>/dev/null; then
+  mode="$(stat -c '%a' "${APP_ENV_FILE}" 2>/dev/null || stat -f '%Lp' "${APP_ENV_FILE}")"
+  chmod "${mode}" "${temporary}"
+fi
+chown --reference="${APP_ENV_FILE}" "${temporary}" 2>/dev/null || true
+mv "${temporary}" "${APP_ENV_FILE}"
+temporary=""
+
+install -d -m 0755 "$(dirname "${PITR_ENV_FILE}")"
+if [[ -f "${PITR_ENV_FILE}" ]]; then
+  cp -a "${PITR_ENV_FILE}" "${PITR_ENV_FILE}.bak-patroni-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+temporary="$(mktemp "${PITR_ENV_FILE}.tmp.XXXXXX")"
+printf 'PROJECT_DIR=%s\nCOMPOSE_FILE=%s\n' "${PROJECT_DIR}" "${COMPOSE_FILE}" > "${temporary}"
+chmod 0600 "${temporary}"
+mv "${temporary}" "${PITR_ENV_FILE}"
+temporary=""
+
+echo "patroni_pitr_env=prepared app_backup=${backup}"

--- a/scripts/ha/configure_patroni_replication_env.sh
+++ b/scripts/ha/configure_patroni_replication_env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${PATRONI_ENV_FILE:?set PATRONI_ENV_FILE}"
+REPLICATION_USERNAME="${PATRONI_REPLICATION_USERNAME:-mvn_replicator}"
+
+IFS= read -r replication_password
+[[ "${#replication_password}" -ge 16 ]] || {
+  echo "replication password must contain at least 16 characters" >&2
+  exit 1
+}
+[[ -f "${ENV_FILE}" ]] || {
+  echo "env file is missing: ${ENV_FILE}" >&2
+  exit 1
+}
+
+backup="${ENV_FILE}.bak-patroni-$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "${ENV_FILE}" "${backup}"
+temporary="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+trap 'rm -f "${temporary}"' EXIT
+grep -vE '^PATRONI_REPLICATION_(USERNAME|PASSWORD)=' "${ENV_FILE}" > "${temporary}" || true
+printf 'PATRONI_REPLICATION_USERNAME=%s\n' "${REPLICATION_USERNAME}" >> "${temporary}"
+printf 'PATRONI_REPLICATION_PASSWORD=%s\n' "${replication_password}" >> "${temporary}"
+if ! chmod --reference="${ENV_FILE}" "${temporary}" 2>/dev/null; then
+  mode="$(stat -c '%a' "${ENV_FILE}" 2>/dev/null || stat -f '%Lp' "${ENV_FILE}")"
+  chmod "${mode}" "${temporary}"
+fi
+chown --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || true
+mv "${temporary}" "${ENV_FILE}"
+trap - EXIT
+
+echo "patroni_replication_env=prepared backup=${backup}"

--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.patroni.yml}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-}"
+EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
+READY_URL="${API_READY_URL:-http://127.0.0.1:18080/api/ready}"
+HEALTH_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}"
+BLUE_GREEN_SCRIPT="${API_BLUE_GREEN_SCRIPT:-/tmp/deploy_backend_blue_green.sh}"
+DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
+ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
+PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
+ENV_FILE="${PROJECT_DIR}/.env"
+HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
+
+previous_image=""
+active_service="app"
+env_updated=false
+TMP_DIR=""
+
+log() {
+  printf '[patroni-node-deploy][%s] %s\n' "$1" "$2"
+}
+
+local_role() {
+  curl -fsS --max-time 5 "${PATRONI_URL}" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("state") != "running":
+    raise SystemExit(1)
+role = str(payload.get("role") or "").lower()
+print("primary" if role in {"leader", "master", "primary"} else "standby")
+'
+}
+
+require_expected_role() {
+  local role
+  role="$(local_role)" || {
+    log error "local Patroni API is unavailable"
+    return 1
+  }
+  [[ "${role}" == "${EXPECTED_ROLE}" ]] || {
+    log error "role changed: expected=${EXPECTED_ROLE} actual=${role}"
+    return 1
+  }
+}
+
+resolve_active_service() {
+  local slot=""
+  if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
+    slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+    case "${slot}" in
+      blue|green) active_service="app-${slot}" ;;
+      *)
+        log error "invalid active API slot: ${slot}"
+        return 1
+        ;;
+    esac
+  fi
+}
+
+write_backend_image() {
+  local image="$1"
+  local temporary
+  touch "${ENV_FILE}"
+  temporary="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  grep -v '^BACKEND_IMAGE=' "${ENV_FILE}" > "${temporary}" || true
+  printf 'BACKEND_IMAGE=%s\n' "${image}" >> "${temporary}"
+  chmod --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || chmod 600 "${temporary}"
+  chown --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || true
+  mv "${temporary}" "${ENV_FILE}"
+}
+
+wait_fenced_standby() {
+  local health_file="${TMP_DIR}/health.json"
+  local ready_file="${TMP_DIR}/ready.json"
+  local ready_status=""
+
+  for attempt in $(seq 1 "${HEALTH_ATTEMPTS}"); do
+    ready_status="$(curl -sS --max-time 5 -o "${ready_file}" -w '%{http_code}' "${READY_URL}" || true)"
+    if curl -fsS --max-time 5 "${HEALTH_URL}" > "${health_file}" \
+      && [[ "${ready_status}" == "503" ]] \
+      && python3 - "${health_file}" "${ready_file}" <<'PY'
+import json
+import sys
+
+health = json.load(open(sys.argv[1], encoding="utf-8"))
+ready = json.load(open(sys.argv[2], encoding="utf-8"))
+if health.get("status") != "ok" or health.get("database") != "online":
+    raise SystemExit(1)
+if ready.get("api") != "not_ready" or ready.get("traffic") != "disabled":
+    raise SystemExit(1)
+PY
+    then
+      log smoke "standby is healthy and fenced on attempt ${attempt}"
+      return 0
+    fi
+    sleep 2
+  done
+  log error "standby did not become healthy and fenced"
+  return 1
+}
+
+rollback_standby() {
+  local exit_code=$?
+  trap - ERR
+  set +e
+  if [[ "${env_updated}" == "true" && "${previous_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
+    log rollback "restoring ${previous_image} on ${active_service}"
+    export BACKEND_IMAGE="${previous_image}"
+    write_backend_image "${previous_image}"
+    "${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
+  fi
+  "${COMPOSE[@]}" stop bot >/dev/null 2>&1 || true
+  exit "${exit_code}"
+}
+
+for command in docker curl python3 flock; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+[[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
+  log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
+  exit 1
+}
+[[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+  log error "BACKEND_IMAGE must be immutable"
+  exit 1
+}
+[[ ! -e "${MAINTENANCE_MARKER}" ]] || {
+  log error "Patroni maintenance marker exists: ${MAINTENANCE_MARKER}"
+  exit 1
+}
+[[ -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]] || {
+  log error "compose file is missing: ${PROJECT_DIR}/${COMPOSE_FILE}"
+  exit 1
+}
+
+cd "${PROJECT_DIR}"
+exec 9>"${DEPLOY_LOCK_FILE}"
+flock -n 9 || {
+  log error "another deployment holds ${DEPLOY_LOCK_FILE}"
+  exit 1
+}
+require_expected_role
+
+if [[ "${EXPECTED_ROLE}" == "primary" ]]; then
+  [[ -x "${BLUE_GREEN_SCRIPT}" ]] || {
+    log error "blue-green script is not executable: ${BLUE_GREEN_SCRIPT}"
+    exit 1
+  }
+  log primary "deploying through the inactive API slot"
+  API_DEPLOY_LOCK_ALREADY_HELD=true \
+    API_RUN_MIGRATIONS=false \
+    API_RUN_DEFAULTS=false \
+    bash "${BLUE_GREEN_SCRIPT}"
+  require_expected_role
+  log "done" "primary blue-green deployment completed"
+  exit 0
+fi
+
+resolve_active_service
+previous_image="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
+[[ "${previous_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+  log error "current BACKEND_IMAGE is not immutable"
+  exit 1
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
+export BACKEND_IMAGE
+if [[ -n "${GHCR_PAT:-}" ]]; then
+  printf '%s' "${GHCR_PAT}" | docker login ghcr.io -u "${GITHUB_ACTOR:-github-actions}" --password-stdin
+fi
+
+trap rollback_standby ERR
+log standby "updating fenced service ${active_service}"
+"${COMPOSE[@]}" pull "${active_service}" bot
+write_backend_image "${BACKEND_IMAGE}"
+env_updated=true
+"${COMPOSE[@]}" stop bot >/dev/null 2>&1 || true
+"${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
+require_expected_role
+wait_fenced_standby
+printf '%s\n' "${previous_image}" > "${PREVIOUS_IMAGE_FILE}"
+chmod 600 "${PREVIOUS_IMAGE_FILE}"
+trap - ERR
+log "done" "standby image updated without enabling traffic or singleton processes"

--- a/scripts/ha/run_patroni_migrations.sh
+++ b/scripts/ha/run_patroni_migrations.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.patroni.yml}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-}"
+MIGRATION_SERVICE="${API_MIGRATION_SERVICE:-app-blue}"
+PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
+DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
+RUN_DEFAULTS="${API_RUN_DEFAULTS:-true}"
+
+log() {
+  printf '[patroni-migrate][%s] %s\n' "$1" "$2"
+}
+
+local_role() {
+  curl -fsS --max-time 5 "${PATRONI_URL}" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("state") != "running":
+    raise SystemExit(1)
+role = str(payload.get("role") or "").lower()
+print("primary" if role in {"leader", "master", "primary"} else "standby")
+'
+}
+
+require_primary() {
+  local role
+  role="$(local_role)" || {
+    log error "local Patroni API is unavailable"
+    return 1
+  }
+  [[ "${role}" == "primary" ]] || {
+    log error "refusing migrations on local role=${role}"
+    return 1
+  }
+}
+
+for command in docker curl python3 flock; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+[[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+  log error "BACKEND_IMAGE must be immutable"
+  exit 1
+}
+[[ ! -e "${MAINTENANCE_MARKER}" ]] || {
+  log error "Patroni maintenance marker exists: ${MAINTENANCE_MARKER}"
+  exit 1
+}
+[[ -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]] || {
+  log error "compose file is missing: ${PROJECT_DIR}/${COMPOSE_FILE}"
+  exit 1
+}
+
+cd "${PROJECT_DIR}"
+exec 9>"${DEPLOY_LOCK_FILE}"
+flock -n 9 || {
+  log error "another deployment holds ${DEPLOY_LOCK_FILE}"
+  exit 1
+}
+
+require_primary
+export BACKEND_IMAGE
+COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
+if [[ -n "${GHCR_PAT:-}" ]]; then
+  printf '%s' "${GHCR_PAT}" | docker login ghcr.io -u "${GITHUB_ACTOR:-github-actions}" --password-stdin
+fi
+
+log pull "pulling migration image ${BACKEND_IMAGE}"
+"${COMPOSE[@]}" pull "${MIGRATION_SERVICE}"
+require_primary
+
+log migrate "running Alembic on the confirmed Patroni primary"
+"${COMPOSE[@]}" run -T --rm --no-deps "${MIGRATION_SERVICE}" alembic upgrade head
+if [[ "${RUN_DEFAULTS}" == "true" ]]; then
+  "${COMPOSE[@]}" run -T --rm --no-deps "${MIGRATION_SERVICE}" \
+    python3 scripts/ensure_global_config_defaults.py
+fi
+
+require_primary
+log "done" "migrations completed while the local node remained primary"

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Client-side values are shell-quoted deliberately before they enter SSH commands.
+# shellcheck disable=SC2029
+set -euo pipefail
+
+OPERATION="${1:-}"
+NODE_HOST="${API_NODE_HOST:-}"
+NODE_USER="${API_NODE_USER:-root}"
+PROJECT_DIR="${API_NODE_PROJECT_DIR:-}"
+COMPOSE_SOURCE="${API_NODE_COMPOSE_SOURCE:-}"
+PROXY_MODE="${API_NODE_PROXY_MODE:-host_nginx}"
+EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-}"
+SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-}"
+KEY_PATH="${RUNNER_TEMP:-/tmp}/mvn-patroni-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}.key"
+KNOWN_HOSTS_PATH="${KEY_PATH}.known_hosts"
+
+log() {
+  printf '[patroni-remote][%s] %s\n' "$1" "$2"
+}
+
+usage() {
+  echo "usage: run_patroni_node_remote.sh probe|migrate|deploy" >&2
+}
+
+quote() {
+  printf '%q' "$1"
+}
+
+[[ "${OPERATION}" == "probe" || "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]] || {
+  usage
+  exit 2
+}
+[[ -n "${NODE_HOST}" && -n "${NODE_USER}" ]] || {
+  log error "API_NODE_HOST and API_NODE_USER are required"
+  exit 1
+}
+[[ -n "${SSH_PRIVATE_KEY}" ]] || {
+  log error "SSH_PRIVATE_KEY is required"
+  exit 1
+}
+if [[ "${OPERATION}" != "probe" ]]; then
+  [[ -n "${PROJECT_DIR}" && -f "${COMPOSE_SOURCE}" ]] || {
+    log error "project directory and tracked compose source are required"
+    exit 1
+  }
+  [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    log error "BACKEND_IMAGE must be immutable"
+    exit 1
+  }
+fi
+if [[ "${OPERATION}" == "deploy" ]]; then
+  [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
+    log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
+    exit 1
+  }
+  [[ "${PROXY_MODE}" == "host_nginx" || "${PROXY_MODE}" == "container_nginx" ]] || {
+    log error "API_NODE_PROXY_MODE must be host_nginx or container_nginx"
+    exit 1
+  }
+fi
+
+for command in ssh scp ssh-keyscan; do
+  command -v "${command}" >/dev/null 2>&1 || {
+    log error "required command is missing: ${command}"
+    exit 1
+  }
+done
+
+trap 'rm -f "${KEY_PATH}" "${KNOWN_HOSTS_PATH}"' EXIT
+printf '%s\n' "${SSH_PRIVATE_KEY}" > "${KEY_PATH}"
+chmod 600 "${KEY_PATH}"
+: > "${KNOWN_HOSTS_PATH}"
+for attempt in 1 2 3 4 5; do
+  if ssh-keyscan -T 10 -H "${NODE_HOST}" >> "${KNOWN_HOSTS_PATH}" 2>/dev/null; then
+    break
+  fi
+  (( attempt < 5 )) || {
+    log error "could not obtain SSH host key for ${NODE_HOST}"
+    exit 1
+  }
+  sleep $((attempt * 2))
+done
+
+SSH_OPTS=(
+  -i "${KEY_PATH}"
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=yes
+  -o "UserKnownHostsFile=${KNOWN_HOSTS_PATH}"
+  -o ConnectTimeout=20
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=3
+)
+REMOTE="${NODE_USER}@${NODE_HOST}"
+
+if [[ "${OPERATION}" == "probe" ]]; then
+  role="$(ssh "${SSH_OPTS[@]}" "${REMOTE}" \
+    "curl -fsS --max-time 5 http://127.0.0.1:8008/patroni | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); print(\"primary\" if r in {\"leader\",\"master\",\"primary\"} else \"standby\")'")"
+  [[ "${role}" == "primary" || "${role}" == "standby" ]] || {
+    log error "invalid Patroni role from ${NODE_HOST}: ${role}"
+    exit 1
+  }
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'role=%s\n' "${role}" >> "${GITHUB_OUTPUT}"
+  fi
+  log probe "${NODE_HOST} role=${role}"
+  exit 0
+fi
+
+ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}")"
+scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
+  "${REMOTE}:${PROJECT_DIR}/docker-compose.patroni.yml"
+scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
+  scripts/ha/deploy_patroni_api_node.sh scripts/deploy_backend_blue_green.sh \
+  "${REMOTE}:/tmp/"
+
+if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
+  ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}/api-proxy")"
+  scp "${SSH_OPTS[@]}" deploy/ha/proxy/nginx.conf \
+    "${REMOTE}:${PROJECT_DIR}/api-proxy/nginx.conf"
+  if ! ssh "${SSH_OPTS[@]}" "${REMOTE}" "test -f $(quote "${PROJECT_DIR}/api-proxy/upstream.conf")"; then
+    scp "${SSH_OPTS[@]}" deploy/ha/proxy/upstream.conf \
+      "${REMOTE}:${PROJECT_DIR}/api-proxy/upstream.conf"
+  fi
+fi
+
+remote_script="/tmp/run_patroni_migrations.sh"
+if [[ "${OPERATION}" == "deploy" ]]; then
+  remote_script="/tmp/deploy_patroni_api_node.sh"
+fi
+
+proxy_env="API_PROXY_MODE=$(quote "${PROXY_MODE}")"
+if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
+  proxy_env+=" API_NGINX_UPSTREAM_FILE=$(quote "${PROJECT_DIR}/api-proxy/upstream.conf")"
+  proxy_env+=" API_PROXY_CONFIG_FILE=$(quote "${PROJECT_DIR}/api-proxy/nginx.conf")"
+  proxy_env+=" API_LEGACY_PORT=18000"
+fi
+
+log "${OPERATION}" "running ${OPERATION} on ${NODE_HOST}"
+printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
+  set -euo pipefail
+  IFS= read -r GHCR_PAT
+  export GHCR_PAT
+  chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh
+  API_PROJECT_DIR=$(quote "${PROJECT_DIR}") \
+  API_COMPOSE_FILE=docker-compose.patroni.yml \
+  API_EXPECTED_PATRONI_ROLE=$(quote "${EXPECTED_ROLE}") \
+  API_READY_URL=http://127.0.0.1:18080/api/ready \
+  API_HEALTH_URL=http://127.0.0.1:18080/api/health \
+  API_INTERNAL_PROXY_PORT=18080 \
+  API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
+  API_PUBLIC_READY_URL=https://api.mvn.by/api/ready \
+  BACKEND_IMAGE=$(quote "${BACKEND_IMAGE}") \
+  GITHUB_ACTOR=$(quote "${GITHUB_ACTOR:-github-actions}") \
+  ${proxy_env} \
+  bash $(quote "${remote_script}")
+"
+log "done" "${OPERATION} completed on ${NODE_HOST}"

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -23,7 +23,12 @@ def test_reusable_web_release_promotes_one_immutable_artifact_in_safe_order():
     assert job["environment"] == "production-web"
     assert _step(job, "Checkout immutable release")["with"]["ref"] == "${{ inputs.deploy_sha }}"
     assert _step(job, "Setup Node.js")["with"]["node-version"] == "22"
-    assert 'printf \'{"sha":"%s"}\\n\'' in _step(job, "Build Astro site from production API")["run"]
+    build_step = _step(job, "Build Astro site from production API")["run"]
+    assert 'printf \'{"sha":"%s"}\\n\'' in build_step
+    assert "for attempt in 1 2 3 4 5" in build_step
+    assert "sleep $((attempt * 5))" in build_step
+    assert "ServerAliveInterval=15" in build_step
+    assert "Could not establish API SSH tunnel after 5 attempts" in build_step
     assert "--expected-release" in _step(job, "Validate static release")["run"]
     assert names.index("Deploy Cloudflare Pages canary") < names.index("Deploy atomic VPS fallback")
     assert names.index("Deploy atomic VPS fallback") < names.index("Deploy Cloudflare Pages production")

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -79,7 +79,7 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     standby_call = jobs["deploy-api-standby"]
     assert standby_call["uses"] == "./.github/workflows/deploy-api-standby.yml"
     assert standby_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
-    assert standby_call["with"]["backend_image"] == "${{ needs.deploy-backend.outputs.backend_image }}"
+    assert standby_call["with"]["backend_image"] == "${{ needs.backend-release.outputs.backend_image }}"
     assert standby_call["secrets"] == "inherit"
 
     web_workflow = _workflow(".github/workflows/deploy-web.yml")
@@ -91,6 +91,7 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert web_call["uses"] == "./.github/workflows/deploy-web.yml"
     assert web_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
     assert web_call["secrets"] == "inherit"
+    assert "backend-release" in web_call["needs"]
 
     workflow_text = (REPO_ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     assert "backend:latest" not in workflow_text

--- a/tests/unit/test_etcd_quorum_assets.py
+++ b/tests/unit/test_etcd_quorum_assets.py
@@ -32,6 +32,10 @@ def test_etcd_compose_is_three_member_tls_only_and_digest_pinned():
     assert "mvn-web=https://10.77.0.3:2380" in text
     assert service["mem_limit"] == "${ETCD_MEMORY_LIMIT:-192m}"
     assert service["logging"]["options"]["max-file"] == "5"
+    assert service["healthcheck"]["test"][0] == "CMD"
+    assert service["healthcheck"]["test"][1] == "/usr/local/bin/etcdctl"
+    assert "CMD-SHELL" not in service["healthcheck"]["test"]
+    assert "ETCDCTL_API" not in text
 
 
 def test_etcd_systemd_unit_waits_for_wireguard_and_docker():
@@ -80,6 +84,7 @@ def test_quorum_check_requires_three_members_and_one_leader():
     assert "members disagree on leader" in text
     assert "raft index lag" in text
     assert "endpoint health --cluster" in text
+    assert "ETCDCTL_API" not in text
 
 
 def test_quorum_check_accepts_consistent_healthy_cluster(tmp_path):

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATE = REPO_ROOT / "scripts/ha/run_patroni_migrations.sh"
 DEPLOY = REPO_ROOT / "scripts/ha/deploy_patroni_api_node.sh"
+CONFIGURE_ENV = REPO_ROOT / "scripts/ha/configure_patroni_replication_env.sh"
 IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "4" * 64
 
 
@@ -65,3 +66,33 @@ def test_node_deploy_keeps_migrations_separate_and_has_role_and_maintenance_fenc
     assert "alembic upgrade head" not in text
     assert 'up -d --no-deps --force-recreate "${active_service}"' in text
     assert "up -d db" not in text
+
+
+def test_replication_env_updater_replaces_keys_atomically_and_preserves_mode(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "POSTGRES_USER=postgres\n"
+        "PATRONI_REPLICATION_USERNAME=old\n"
+        "PATRONI_REPLICATION_PASSWORD=${invalid}\n",
+        encoding="utf-8",
+    )
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        ["bash", str(CONFIGURE_ENV)],
+        env={**os.environ, "PATRONI_ENV_FILE": str(env_file)},
+        input="a-secure-replication-password\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    text = env_file.read_text(encoding="utf-8")
+    assert text.count("PATRONI_REPLICATION_USERNAME=") == 1
+    assert text.count("PATRONI_REPLICATION_PASSWORD=") == 1
+    assert "PATRONI_REPLICATION_USERNAME=mvn_replicator" in text
+    assert "PATRONI_REPLICATION_PASSWORD=a-secure-replication-password" in text
+    assert "${invalid}" not in text
+    assert env_file.stat().st_mode & 0o777 == 0o600
+    assert len(list(tmp_path.glob(".env.bak-patroni-*"))) == 1

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -7,6 +7,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MIGRATE = REPO_ROOT / "scripts/ha/run_patroni_migrations.sh"
 DEPLOY = REPO_ROOT / "scripts/ha/deploy_patroni_api_node.sh"
 CONFIGURE_ENV = REPO_ROOT / "scripts/ha/configure_patroni_replication_env.sh"
+CONFIGURE_PITR = REPO_ROOT / "scripts/ha/configure_patroni_pitr_env.sh"
 IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "4" * 64
 
 
@@ -96,3 +97,68 @@ def test_replication_env_updater_replaces_keys_atomically_and_preserves_mode(tmp
     assert "${invalid}" not in text
     assert env_file.stat().st_mode & 0o777 == 0o600
     assert len(list(tmp_path.glob(".env.bak-patroni-*"))) == 1
+
+
+def test_pitr_env_updater_allows_only_backup_keys_and_prepares_role_target(tmp_path):
+    app_env = tmp_path / ".env"
+    systemd_env = tmp_path / "mvn-postgres-pitr.env"
+    app_env.write_text(
+        "POSTGRES_USER=postgres\nPOSTGRES_PITR_S3_BUCKET=old\n",
+        encoding="utf-8",
+    )
+    app_env.chmod(0o600)
+    payload = (
+        "POSTGRES_PITR_ARCHIVE_MODE=on\n"
+        "POSTGRES_PITR_ARCHIVE_TIMEOUT=300\n"
+        "POSTGRES_PITR_CLUSTER=mvn\n"
+        "POSTGRES_PITR_S3_ACCESS_KEY_ID=key\n"
+        "POSTGRES_PITR_S3_SECRET_ACCESS_KEY=secret\n"
+        "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr\n"
+        "POSTGRES_PITR_S3_ENDPOINT_URL=https://example.invalid\n"
+        "POSTGRES_PITR_S3_KEY_PREFIX=postgres\n"
+        "POSTGRES_PITR_S3_REGION=auto\n"
+    )
+
+    result = subprocess.run(
+        ["bash", str(CONFIGURE_PITR)],
+        env={
+            **os.environ,
+            "PATRONI_APP_ENV_FILE": str(app_env),
+            "PATRONI_SYSTEMD_ENV_FILE": str(systemd_env),
+            "PATRONI_PROJECT_DIR": "/opt/mvn-reserve",
+        },
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    updated = app_env.read_text(encoding="utf-8")
+    assert updated.count("POSTGRES_PITR_S3_BUCKET=") == 1
+    assert "POSTGRES_PITR_S3_BUCKET=mvn-postgres-pitr" in updated
+    assert systemd_env.read_text(encoding="utf-8") == (
+        "PROJECT_DIR=/opt/mvn-reserve\nCOMPOSE_FILE=docker-compose.patroni.yml\n"
+    )
+    assert systemd_env.stat().st_mode & 0o777 == 0o600
+
+
+def test_pitr_env_updater_rejects_unrelated_keys(tmp_path):
+    app_env = tmp_path / ".env"
+    app_env.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(CONFIGURE_PITR)],
+        env={
+            **os.environ,
+            "PATRONI_APP_ENV_FILE": str(app_env),
+            "PATRONI_SYSTEMD_ENV_FILE": str(tmp_path / "pitr.env"),
+            "PATRONI_PROJECT_DIR": "/opt/mvn-reserve",
+        },
+        input="BOT_TOKEN=forbidden\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "unsupported PITR env key" in result.stderr

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATE = REPO_ROOT / "scripts/ha/run_patroni_migrations.sh"
+DEPLOY = REPO_ROOT / "scripts/ha/deploy_patroni_api_node.sh"
+IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "4" * 64
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_migration_script_requires_primary_and_never_manages_database_service(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\nprintf '{\"state\":\"running\",\"role\":\"primary\"}\\n'\n",
+    )
+    _executable(
+        fake_bin / "docker",
+        '#!/usr/bin/env bash\nprintf "docker %s\\n" "$*" >> "$COMMAND_LOG"\n',
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "compose.yml",
+            "BACKEND_IMAGE": IMAGE,
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(MIGRATE)], env=env, text=True, capture_output=True, check=False
+    )
+
+    assert result.returncode == 0, result.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert "pull app-blue" in commands
+    assert "run -T --rm --no-deps app-blue alembic upgrade head" in commands
+    assert "ensure_global_config_defaults.py" in commands
+    assert " up " not in commands
+    assert " db" not in commands
+
+
+def test_node_deploy_keeps_migrations_separate_and_has_role_and_maintenance_fences():
+    text = DEPLOY.read_text(encoding="utf-8")
+
+    assert "API_EXPECTED_PATRONI_ROLE must be primary or standby" in text
+    assert ".patroni-cutover-in-progress" in text
+    assert "API_RUN_MIGRATIONS=false" in text
+    assert '"${COMPOSE[@]}" stop bot' in text
+    assert "standby image updated without enabling traffic" in text
+    assert "alembic upgrade head" not in text
+    assert 'up -d --no-deps --force-recreate "${active_service}"' in text
+    assert "up -d db" not in text

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -8,7 +8,9 @@ MIGRATE = REPO_ROOT / "scripts/ha/run_patroni_migrations.sh"
 DEPLOY = REPO_ROOT / "scripts/ha/deploy_patroni_api_node.sh"
 CONFIGURE_ENV = REPO_ROOT / "scripts/ha/configure_patroni_replication_env.sh"
 CONFIGURE_PITR = REPO_ROOT / "scripts/ha/configure_patroni_pitr_env.sh"
+CONFIGURE_IMAGE = REPO_ROOT / "scripts/ha/configure_patroni_image_env.sh"
 IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "4" * 64
+PATRONI_IMAGE = "ghcr.io/mvnby/air-api/patroni@sha256:" + "5" * 64
 
 
 def _executable(path: Path, content: str) -> None:
@@ -97,6 +99,48 @@ def test_replication_env_updater_replaces_keys_atomically_and_preserves_mode(tmp
     assert "${invalid}" not in text
     assert env_file.stat().st_mode & 0o777 == 0o600
     assert len(list(tmp_path.glob(".env.bak-patroni-*"))) == 1
+
+
+def test_patroni_image_updater_requires_digest_and_preserves_env_file(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\nPATRONI_IMAGE=invalid\n", encoding="utf-8")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        ["bash", str(CONFIGURE_IMAGE)],
+        env={**os.environ, "PATRONI_ENV_FILE": str(env_file)},
+        input=f"{PATRONI_IMAGE}\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert env_file.read_text(encoding="utf-8").count("PATRONI_IMAGE=") == 1
+    assert f"PATRONI_IMAGE={PATRONI_IMAGE}" in env_file.read_text(encoding="utf-8")
+    assert env_file.stat().st_mode & 0o777 == 0o600
+    assert len(list(tmp_path.glob(".env.bak-patroni-image-*"))) == 1
+
+
+def test_patroni_image_updater_rejects_mutable_or_foreign_images(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+
+    for image in (
+        "ghcr.io/mvnby/air-api/patroni:latest",
+        "ghcr.io/other/air-api/patroni@sha256:" + "5" * 64,
+    ):
+        result = subprocess.run(
+            ["bash", str(CONFIGURE_IMAGE)],
+            env={**os.environ, "PATRONI_ENV_FILE": str(env_file)},
+            input=f"{image}\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        assert "immutable MVN Patroni GHCR digest" in result.stderr
 
 
 def test_pitr_env_updater_allows_only_backup_keys_and_prepares_role_target(tmp_path):

--- a/tests/unit/test_patroni_deploy_workflow.py
+++ b/tests/unit/test_patroni_deploy_workflow.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load((REPO_ROOT / path).read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(job: dict, name: str) -> dict:
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+def test_main_release_selects_exactly_one_physical_or_patroni_path():
+    jobs = _workflow(".github/workflows/deploy.yml")["jobs"]
+
+    assert jobs["deploy-backend"]["if"] == "${{ vars.API_DB_HA_MODE != 'patroni' }}"
+    patroni = jobs["deploy-backend-patroni"]
+    assert patroni["if"] == "${{ vars.API_DB_HA_MODE == 'patroni' }}"
+    assert patroni["uses"] == "./.github/workflows/deploy-api-patroni.yml"
+    assert patroni["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
+    gate = jobs["backend-release"]
+    gate_run = _step(gate, "Require exactly one backend deployment path")["run"]
+    assert {"release-gate", "deploy-backend", "deploy-backend-patroni"} == set(gate["needs"])
+    assert "physical=${PHYSICAL_RESULT} patroni=${PATRONI_RESULT}" in gate_run
+    assert "@sha256:[0-9a-f]{64}" in gate_run
+    assert "needs.backend-release.outputs.mode == 'physical'" in jobs["deploy-api-standby"]["if"]
+
+
+def test_patroni_workflow_builds_exact_sha_and_validates_single_primary():
+    workflow = _workflow(".github/workflows/deploy-api-patroni.yml")
+    jobs = workflow["jobs"]
+    build = jobs["build-backend"]
+    checkout = _step(build, "Checkout exact tested SHA")
+    image = _step(build, "Resolve immutable backend image")["run"]
+
+    assert checkout["with"]["ref"] == "${{ inputs.deploy_sha }}"
+    assert "backend@${digest}" in image
+    assert workflow["on"]["workflow_call"]["outputs"]["backend_image"]["value"] == (
+        "${{ jobs.build-backend.outputs.backend_image }}"
+    )
+    topology = _step(jobs["validate-topology"], "Require exactly one Patroni primary")["run"]
+    assert "api=${API_ROLE} reserve=${RESERVE_ROLE}" in topology
+    assert "primary_node=api" in topology
+    assert "primary_node=reserve" in topology
+
+
+def test_patroni_release_orders_migration_replica_then_primary():
+    jobs = _workflow(".github/workflows/deploy-api-patroni.yml")["jobs"]
+
+    assert jobs["migrate-api-node"]["environment"] == "production-api"
+    assert jobs["migrate-reserve-node"]["environment"] == "standby-api"
+    assert "migrate-api-node" in jobs["deploy-replica-reserve"]["needs"]
+    assert "deploy-replica-reserve" in jobs["deploy-primary-api"]["needs"]
+    assert "migrate-reserve-node" in jobs["deploy-replica-api"]["needs"]
+    assert "deploy-replica-api" in jobs["deploy-primary-reserve"]["needs"]
+
+    for job_name in (
+        "migrate-api-node",
+        "migrate-reserve-node",
+        "deploy-replica-reserve",
+        "deploy-replica-api",
+        "deploy-primary-api",
+        "deploy-primary-reserve",
+    ):
+        run = jobs[job_name]["steps"][-1]["run"]
+        assert "scripts/ha/run_patroni_node_remote.sh" in run
+
+    text = (REPO_ROOT / ".github/workflows/deploy-api-patroni.yml").read_text(encoding="utf-8")
+    assert "up -d db" not in text
+    assert "docker compose" not in text
+
+
+def test_patroni_deployment_completion_rejects_both_or_neither_branch():
+    jobs = _workflow(".github/workflows/deploy-api-patroni.yml")["jobs"]
+    complete = jobs["deployment-complete"]
+    run = _step(complete, "Require the selected primary branch to succeed")["run"]
+
+    assert complete["if"] == "${{ always() }}"
+    assert "test \"${API_RESULT}\" = \"success\"" in run
+    assert "test \"${RESERVE_RESULT}\" = \"success\"" in run
+    assert "No validated Patroni primary branch completed" in run

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -64,6 +64,26 @@ def test_renderer_rejects_unsafe_timing_budget(patroni_env, monkeypatch):
         render_config()
 
 
+def test_renderer_normalizes_postgres_archive_timeout_seconds(patroni_env, monkeypatch):
+    monkeypatch.setenv("PATRONI_ARCHIVE_MODE", "on")
+    monkeypatch.setenv("PATRONI_ARCHIVE_TIMEOUT", "300s")
+    monkeypatch.setenv("PATRONI_ARCHIVE_COMMAND", "cp %p /archive/%f")
+
+    config = render_config()
+
+    parameters = config["bootstrap"]["dcs"]["postgresql"]["parameters"]
+    assert parameters["archive_timeout"] == 300
+
+
+def test_renderer_rejects_non_second_archive_timeout(patroni_env, monkeypatch):
+    monkeypatch.setenv("PATRONI_ARCHIVE_MODE", "on")
+    monkeypatch.setenv("PATRONI_ARCHIVE_TIMEOUT", "5min")
+    monkeypatch.setenv("PATRONI_ARCHIVE_COMMAND", "cp %p /archive/%f")
+
+    with pytest.raises(ValueError, match="integer seconds"):
+        render_config()
+
+
 def test_patroni_image_and_entrypoint_are_versioned_and_adoption_safe():
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     entrypoint = ENTRYPOINT.read_text(encoding="utf-8")

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/ha/run_patroni_node_remote.sh"
+
+
+def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "probe|migrate|deploy" in text
+    assert "StrictHostKeyChecking=yes" in text
+    assert "UserKnownHostsFile=" in text
+    assert "docker-compose.patroni.yml" in text
+    assert "run_patroni_migrations.sh" in text
+    assert "deploy_patroni_api_node.sh" in text
+    assert "deploy_backend_blue_green.sh" in text
+    assert "API_PROXY_MODE=" in text
+    assert "upstream.conf" in text
+    assert "up -d db" not in text
+    assert "docker compose" not in text
+
+
+def test_remote_orchestrator_passes_token_over_stdin_not_command_line():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "IFS= read -r GHCR_PAT" in text
+    assert "export GHCR_PAT" in text
+    assert "GHCR_PAT='" not in text


### PR DESCRIPTION
## Summary
- add a feature-gated Patroni-aware API deployment workflow
- probe both database roles, migrate only the current primary, deploy the fenced replica first, then blue-green the primary
- add safe replication and PITR environment updaters plus production topology documentation

## Safety
- current physical deployment remains the default while `API_DB_HA_MODE` is unset
- the workflow never starts or stops PostgreSQL
- all deploys remain pinned to one immutable backend digest

## Verification
- `pytest -q tests/unit/test_deploy_workflow.py tests/unit/test_patroni_deploy_scripts.py tests/unit/test_patroni_deploy_workflow.py tests/unit/test_patroni_remote_script.py`
- `shellcheck scripts/ha/configure_patroni_pitr_env.sh scripts/ha/configure_patroni_replication_env.sh scripts/ha/deploy_patroni_api_node.sh scripts/ha/run_patroni_migrations.sh scripts/ha/run_patroni_node_remote.sh`
- `actionlint .github/workflows/deploy-api-patroni.yml .github/workflows/deploy.yml`