### PR TITLE
Close release orchestration and Patroni runtime gaps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,14 +121,25 @@ jobs:
             fi
           else
             after="${{ needs.release-gate.outputs.deploy_sha }}"
-            if before="$(git rev-parse "${after}^" 2>/dev/null)"; then
-              if git diff --name-only "${before}" "${after}" | grep -E '^(web/|\.github/workflows/(deploy|deploy-web|rebuild-web|check-web-ssh)\.yml$|scripts/(check_web_dist\.py|deploy_cloudflare_pages\.sh|deploy_web_atomic\.sh|promote_web_release\.sh)$)' >/dev/null; then
+            deployed_web_sha="$(
+              curl -fsS --retry 3 --retry-delay 2 \
+                -H 'Cache-Control: no-cache' \
+                "https://mvn.by/release.json?ci_run=${GITHUB_RUN_ID}" 2>/dev/null \
+                | jq -r '.sha // empty' 2>/dev/null \
+                || true
+            )"
+            if [[ "${deployed_web_sha}" =~ ^[0-9a-f]{40}$ ]] \
+              && git cat-file -e "${deployed_web_sha}^{commit}" 2>/dev/null \
+              && git merge-base --is-ancestor "${deployed_web_sha}" "${after}"; then
+              if git diff --name-only "${deployed_web_sha}" "${after}" | grep -E '^(web/|\.github/workflows/(deploy|deploy-web|rebuild-web|check-web-ssh)\.yml$|scripts/(check_web_dist\.py|deploy_cloudflare_pages\.sh|deploy_web_atomic\.sh|promote_web_release\.sh)$)' >/dev/null; then
                 web_changed=true
-                reason="storefront-relevant files changed"
+                reason="storefront-relevant files changed since deployed web SHA"
+              else
+                reason="no storefront-relevant changes since deployed web SHA"
               fi
             else
               web_changed=true
-              reason="release parent is unavailable; deploying frontend conservatively"
+              reason="deployed web SHA is unavailable or not an ancestor; deploying frontend conservatively"
             fi
           fi
 
@@ -574,7 +585,7 @@ jobs:
   # Standby deployment is isolated in a reusable workflow so the main release
   # file remains an orchestration surface.
   deploy-api-standby:
-    if: ${{ needs.backend-release.outputs.mode == 'physical' && vars.API_STANDBY_HOST != '' }}
+    if: ${{ always() && needs.backend-release.result == 'success' && needs.release-gate.result == 'success' && needs.backend-release.outputs.mode == 'physical' && vars.API_STANDBY_HOST != '' }}
     needs:
       - backend-release
       - release-gate
@@ -591,7 +602,7 @@ jobs:
   # Web release is isolated in one reusable workflow so automatic releases and
   # manual catalog rebuilds use the same immutable artifact and promotion path.
   deploy-frontend:
-    if: ${{ needs.detect-frontend-changes.outputs.web_changed == 'true' }}
+    if: ${{ always() && needs.backend-release.result == 'success' && needs.detect-frontend-changes.result == 'success' && needs.release-gate.result == 'success' && needs.detect-frontend-changes.outputs.web_changed == 'true' }}
     needs:
       - backend-release
       - detect-frontend-changes

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -50,6 +50,9 @@ jobs:
           GUARD_RESULT: ${{ needs.main-branch-guard.result }}
           WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
           WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
         run: |
           set -euo pipefail
           if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
@@ -69,9 +72,41 @@ jobs:
             payload="{\"catalog_revision\":${catalog_revision},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"
           fi
 
-          if ! curl -fsS -X POST "${callback_url}" \
-            -H "Content-Type: application/json" \
-            -H "X-Web-Rebuild-Token: ${WEB_REBUILD_CALLBACK_TOKEN}" \
-            --data "${payload}"; then
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          : > ~/.ssh/known_hosts
+          scanned=false
+          for attempt in 1 2 3 4 5; do
+            if ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts 2>/dev/null; then
+              scanned=true
+              break
+            fi
+            sleep $((attempt * 3))
+          done
+          if [ "${scanned}" != "true" ]; then
+            echo "::warning::Could not obtain API SSH host key for web rebuild callback."
+            exit 0
+          fi
+
+          callback_sent=false
+          for attempt in 1 2 3 4 5; do
+            if printf '%s\n%s\n%s\n' \
+              "${WEB_REBUILD_CALLBACK_TOKEN}" "${payload}" "${callback_url}" \
+              | ssh \
+                -i ~/.ssh/deploy_key \
+                -o BatchMode=yes \
+                -o StrictHostKeyChecking=yes \
+                -o ConnectTimeout=20 \
+                -o ServerAliveInterval=15 \
+                -o ServerAliveCountMax=3 \
+                "${SSH_USER_API}@${SSH_HOST_API}" \
+                'IFS= read -r callback_token; IFS= read -r payload; IFS= read -r callback_url; curl -fsS -X POST "${callback_url}" -H "Content-Type: application/json" -H "X-Web-Rebuild-Token: ${callback_token}" --data "${payload}"'; then
+              callback_sent=true
+              break
+            fi
+            sleep $((attempt * 5))
+          done
+          if [ "${callback_sent}" != "true" ]; then
             echo "::warning::Web rebuild callback failed."
           fi

--- a/deploy/ha/patroni/patroni-entrypoint.sh
+++ b/deploy/ha/patroni/patroni-entrypoint.sh
@@ -5,10 +5,41 @@ PGDATA="${PATRONI_POSTGRESQL_DATA_DIR:-${PGDATA:-/var/lib/postgresql/data}}"
 CONFIG_FILE="${PATRONI_CONFIG_FILE:-/etc/patroni/patroni.yml}"
 ALLOW_BOOTSTRAP="${PATRONI_ALLOW_BOOTSTRAP:-false}"
 
+prepare_etcd_tls() {
+  runtime_dir=/run/patroni-etcd-pki
+  ca_source="${PATRONI_ETCD3_CACERT:-}"
+  cert_source="${PATRONI_ETCD3_CERT:-}"
+  key_source="${PATRONI_ETCD3_KEY:-}"
+
+  for source in "${ca_source}" "${cert_source}" "${key_source}"; do
+    if [ ! -f "${source}" ]; then
+      echo "[patroni-entrypoint][error] etcd TLS file is missing: ${source:-<empty>}" >&2
+      exit 1
+    fi
+  done
+
+  mkdir -p "${runtime_dir}"
+  chmod 0700 "${runtime_dir}"
+  chown postgres:postgres "${runtime_dir}"
+  cp "${ca_source}" "${runtime_dir}/ca.crt"
+  cp "${cert_source}" "${runtime_dir}/node.crt"
+  cp "${key_source}" "${runtime_dir}/node.key"
+  chown postgres:postgres \
+    "${runtime_dir}/ca.crt" "${runtime_dir}/node.crt" "${runtime_dir}/node.key"
+  chmod 0400 \
+    "${runtime_dir}/ca.crt" "${runtime_dir}/node.crt" "${runtime_dir}/node.key"
+  export PATRONI_ETCD3_CACERT="${runtime_dir}/ca.crt"
+  export PATRONI_ETCD3_CERT="${runtime_dir}/node.crt"
+  export PATRONI_ETCD3_KEY="${runtime_dir}/node.key"
+}
+
 if [ "$(id -u)" = "0" ]; then
   mkdir -p "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
   chown postgres:postgres "${PGDATA}" "$(dirname "${CONFIG_FILE}")" /var/run/postgresql
   chmod 0700 "${PGDATA}"
+  if [ "${PATRONI_ETCD3_PROTOCOL:-https}" = "https" ]; then
+    prepare_etcd_tls
+  fi
 fi
 
 if [ ! -s "${PGDATA}/PG_VERSION" ] && [ "${ALLOW_BOOTSTRAP}" != "true" ]; then

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -59,6 +59,12 @@ def test_release_and_manual_rebuild_call_the_same_web_workflow():
     assert manual["with"]["deploy_sha"] == "${{ github.sha }}"
     assert manual["needs"] == "main-branch-guard"
     assert rebuild["jobs"]["callback"]["if"] == "${{ always() }}"
+    callback = _step(rebuild["jobs"]["callback"], "Report catalog rebuild result")["run"]
+    assert "for attempt in 1 2 3 4 5" in callback
+    assert 'printf \'%s\\n%s\\n%s\\n\'' in callback
+    assert "| ssh \\" in callback
+    assert '"${SSH_USER_API}@${SSH_HOST_API}"' in callback
+    assert "X-Web-Rebuild-Token: ${callback_token}" in callback
 
     workflow_text = "\n".join(
         (REPO_ROOT / path).read_text(encoding="utf-8")

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -78,6 +78,8 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert checkout["with"]["ref"] == "${{ inputs.deploy_sha }}"
     standby_call = jobs["deploy-api-standby"]
     assert standby_call["uses"] == "./.github/workflows/deploy-api-standby.yml"
+    assert "always()" in standby_call["if"]
+    assert "needs.backend-release.result == 'success'" in standby_call["if"]
     assert standby_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
     assert standby_call["with"]["backend_image"] == "${{ needs.backend-release.outputs.backend_image }}"
     assert standby_call["secrets"] == "inherit"
@@ -89,6 +91,8 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert web_checkout["with"]["ref"] == "${{ inputs.deploy_sha }}"
     web_call = jobs["deploy-frontend"]
     assert web_call["uses"] == "./.github/workflows/deploy-web.yml"
+    assert "always()" in web_call["if"]
+    assert "needs.backend-release.result == 'success'" in web_call["if"]
     assert web_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
     assert web_call["secrets"] == "inherit"
     assert "backend-release" in web_call["needs"]
@@ -100,6 +104,18 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert "tags: ghcr.io/${{ steps.prep.outputs.repo }}/backend:${{ needs.release-gate.outputs.deploy_sha }}" in workflow_text
     assert "BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}'" in workflow_text
     assert 'reference="ghcr.io/${{ steps.prep.outputs.repo }}/backend@${digest}"' in workflow_text
+
+
+def test_frontend_detection_compares_against_the_deployed_release_sha():
+    workflow = _workflow(".github/workflows/deploy.yml")
+    detect = _step(workflow["jobs"]["detect-frontend-changes"], "Detect storefront-relevant changes")[
+        "run"
+    ]
+
+    assert "https://mvn.by/release.json?ci_run=${GITHUB_RUN_ID}" in detect
+    assert 'git merge-base --is-ancestor "${deployed_web_sha}" "${after}"' in detect
+    assert 'git diff --name-only "${deployed_web_sha}" "${after}"' in detect
+    assert "deploying frontend conservatively" in detect
 
 
 def test_backend_release_is_scoped_and_has_guarded_rollback():

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -95,6 +95,10 @@ def test_patroni_image_and_entrypoint_are_versioned_and_adoption_safe():
     assert "PGDATA is empty" in entrypoint
     assert 'chmod 0700 "${PGDATA}"' in entrypoint
     assert "chown -R" not in entrypoint
+    assert "runtime_dir=/run/patroni-etcd-pki" in entrypoint
+    assert 'cp "${key_source}" "${runtime_dir}/node.key"' in entrypoint
+    assert "chmod 0400" in entrypoint
+    assert 'export PATRONI_ETCD3_KEY="${runtime_dir}/node.key"' in entrypoint
     assert "su-exec postgres" in entrypoint
 
 


### PR DESCRIPTION
## Summary
- stop skipped Patroni branches from suppressing physical standby and web jobs
- compare web changes against the actually deployed release SHA, with conservative fallback
- route rebuild callbacks through SSH to avoid Cloudflare blocking GitHub Azure egress
- copy root-only etcd TLS material into a private postgres-owned runtime directory before Patroni drops privileges

## Production evidence
- run 29119077504 produced `mode=physical` but skipped both downstream reusable jobs
- public web had remained on an older SHA after a prior failed web release
- direct GitHub callback returned Cloudflare 403; the SSH-routed production retry returned `state=fresh`
- exact image preflight showed `postgres_key_readable=no` for the host-mounted 0600 key

## Verification
- 18 focused tests passed
- entrypoint shellcheck passed
- actionlint passed (existing informational notices only)
- canonical web rebuild 29119840172 completed Pages, VPS, and stable smoke successfully