### PR TITLE
Add role-aware Patroni production monitoring

### DIFF
--- a/.github/workflows/check-postgres-pitr.yml
+++ b/.github/workflows/check-postgres-pitr.yml
@@ -40,6 +40,7 @@ jobs:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
         run: |
           set -euo pipefail
           if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
@@ -51,31 +52,86 @@ jobs:
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/postgres_pitr_key
           chmod 600 ~/.ssh/postgres_pitr_key
           ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
 
       - name: Run PostgreSQL PITR Check
         env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
           API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
           PITR_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && inputs.required || vars.POSTGRES_PITR_REQUIRED || 'false' }}
           PITR_MAX_WAL_AGE_MINUTES: ${{ github.event_name == 'workflow_dispatch' && inputs.max_wal_age_minutes || vars.POSTGRES_PITR_MAX_WAL_AGE_MINUTES || '180' }}
           PITR_MAX_BASEBACKUP_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_basebackup_age_hours || vars.POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS || '30' }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/postgres_pitr_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          SSH_OPTIONS=(
+            -i ~/.ssh/postgres_pitr_key
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+          export SSH_OPTS="${SSH_OPTIONS[*]}"
+          target_host="${SSH_HOST_API}"
+          target_user="${SSH_USER_API}"
+          target_project_dir="${API_PROJECT_DIR}"
+          target_compose_file="${API_COMPOSE_FILE}"
+          target_label=api
+
+          case "${API_DB_HA_MODE}" in
+            patroni)
+              export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+              export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+              primary_label="$(python3 scripts/ha/check_patroni_production.py --resolve-primary)"
+              case "${primary_label}" in
+                api)
+                  target_project_dir="${API_PROJECT_DIR}"
+                  ;;
+                reserve)
+                  target_host="${API_STANDBY_HOST}"
+                  target_user="${API_STANDBY_USER}"
+                  target_project_dir="${API_STANDBY_PROJECT_DIR}"
+                  target_label=reserve
+                  ;;
+                *)
+                  echo "::error::Unexpected Patroni primary label: ${primary_label:-empty}"
+                  exit 1
+                  ;;
+              esac
+              target_compose_file=docker-compose.patroni.yml
+              ;;
+            physical) ;;
+            *)
+              echo "::error::API_DB_HA_MODE must be physical or patroni"
+              exit 1
+              ;;
+          esac
+
+          quote() {
+            printf '%q' "$1"
+          }
+          remote_target="${target_user}@${target_host}"
           remote_script="/tmp/mvn-postgres-pitr-check-${GITHUB_RUN_ID}.sh"
-          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "cat > '${remote_script}' && chmod +x '${remote_script}'" \
-            < scripts/ha/check_postgres_pitr_status.sh | tee postgres-pitr-check.log
-          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
-            PROJECT_DIR='${API_PROJECT_DIR}' \
-            COMPOSE_FILE='${API_COMPOSE_FILE}' \
-            PITR_REQUIRED='${PITR_REQUIRED}' \
-            PITR_MAX_WAL_AGE_MINUTES='${PITR_MAX_WAL_AGE_MINUTES}' \
-            PITR_MAX_BASEBACKUP_AGE_HOURS='${PITR_MAX_BASEBACKUP_AGE_HOURS}' \
-            bash '${remote_script}'; \
+          echo "[postgres-pitr][info] selected_node=${target_label} ha_mode=${API_DB_HA_MODE}" | tee postgres-pitr-check.log
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "cat > $(quote "${remote_script}") && chmod +x $(quote "${remote_script}")" \
+            < scripts/ha/check_postgres_pitr_status.sh | tee -a postgres-pitr-check.log
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "\
+            PROJECT_DIR=$(quote "${target_project_dir}") \
+            COMPOSE_FILE=$(quote "${target_compose_file}") \
+            PITR_REQUIRED=$(quote "${PITR_REQUIRED}") \
+            PITR_MAX_WAL_AGE_MINUTES=$(quote "${PITR_MAX_WAL_AGE_MINUTES}") \
+            PITR_MAX_BASEBACKUP_AGE_HOURS=$(quote "${PITR_MAX_BASEBACKUP_AGE_HOURS}") \
+            bash $(quote "${remote_script}"); \
             status=\$?; \
-            rm -f '${remote_script}'; \
+            rm -f $(quote "${remote_script}"); \
             exit \${status}" | tee -a postgres-pitr-check.log
 
       - name: Write Summary
@@ -83,6 +139,7 @@ jobs:
         run: |
           {
             echo "## PostgreSQL PITR Check"
+            echo "- ha_mode: ${{ vars.API_DB_HA_MODE || 'physical' }}"
             echo "- pitr_required: ${{ github.event_name == 'workflow_dispatch' && inputs.required || vars.POSTGRES_PITR_REQUIRED || 'false' }}"
             echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
             echo "- api_compose_file: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}"

--- a/.github/workflows/check-postgres-replication.yml
+++ b/.github/workflows/check-postgres-replication.yml
@@ -2,14 +2,14 @@ name: PostgreSQL Replication Check
 
 on:
   schedule:
-    - cron: "17,47 * * * *"
+    - cron: "7,17,27,37,47,57 * * * *"
   workflow_dispatch:
     inputs:
       max_replay_lag_bytes:
         description: "Max allowed primary-to-standby replay lag in bytes"
         type: string
         required: false
-        default: "16777216"
+        default: "1048576"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -46,6 +46,7 @@ jobs:
 
       - name: Run PostgreSQL replication check
         env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
@@ -54,28 +55,50 @@ jobs:
           PRIMARY_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
           STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
           STANDBY_COMPOSE_FILE: ${{ vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.reserve.yml' }}
+          PATRONI_API_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/air-api' }}
+          PATRONI_RESERVE_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
           EXPECTED_SLOT: ${{ vars.POSTGRES_STANDBY_SLOT || 'zakup_standby' }}
           EXPECTED_PRIMARY_WG_IP: ${{ vars.POSTGRES_PRIMARY_WG_IP || '10.77.0.2' }}
           EXPECTED_STANDBY_WG_IP: ${{ vars.POSTGRES_STANDBY_WG_IP || '10.77.0.1' }}
-          MAX_REPLAY_LAG_BYTES: ${{ github.event_name == 'workflow_dispatch' && inputs.max_replay_lag_bytes || vars.POSTGRES_REPLICATION_MAX_LAG_BYTES || '16777216' }}
+          MAX_REPLAY_LAG_BYTES: ${{ github.event_name == 'workflow_dispatch' && inputs.max_replay_lag_bytes || vars.POSTGRES_REPLICATION_MAX_LAG_BYTES || '1048576' }}
         run: |
           set -euo pipefail
           export SSH_OPTS="-i ~/.ssh/postgres_replication_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          export PRIMARY_SSH="${SSH_USER_API}@${SSH_HOST_API}"
-          export STANDBY_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
-          bash scripts/ha/check_postgres_replication.sh | tee postgres-replication-check.log
+          case "${API_DB_HA_MODE}" in
+            patroni)
+              export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+              export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+              export API_NODE_PROJECT_DIR="${PATRONI_API_PROJECT_DIR}"
+              export RESERVE_NODE_PROJECT_DIR="${PATRONI_RESERVE_PROJECT_DIR}"
+              export API_NODE_COMPOSE_FILE=docker-compose.patroni.yml
+              export RESERVE_NODE_COMPOSE_FILE=docker-compose.patroni.yml
+              export API_NODE_WG_IP="${EXPECTED_PRIMARY_WG_IP}"
+              export RESERVE_NODE_WG_IP="${EXPECTED_STANDBY_WG_IP}"
+              python3 scripts/ha/check_patroni_production.py | tee postgres-replication-check.log
+              ;;
+            physical)
+              export PRIMARY_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+              export STANDBY_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+              bash scripts/ha/check_postgres_replication.sh | tee postgres-replication-check.log
+              ;;
+            *)
+              echo "::error::API_DB_HA_MODE must be physical or patroni"
+              exit 1
+              ;;
+          esac
 
       - name: Write Summary
         if: always()
         run: |
           {
             echo "## PostgreSQL Replication Check"
+            echo "- ha_mode: ${{ vars.API_DB_HA_MODE || 'physical' }}"
             echo "- primary_host: configured via SSH_HOST_API secret"
             echo "- standby_host: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}"
             echo "- primary_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
             echo "- standby_project_dir: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}"
             echo "- expected_slot: ${{ vars.POSTGRES_STANDBY_SLOT || 'zakup_standby' }}"
-            echo "- max_replay_lag_bytes: ${{ github.event_name == 'workflow_dispatch' && inputs.max_replay_lag_bytes || vars.POSTGRES_REPLICATION_MAX_LAG_BYTES || '16777216' }}"
+            echo "- max_replay_lag_bytes: ${{ github.event_name == 'workflow_dispatch' && inputs.max_replay_lag_bytes || vars.POSTGRES_REPLICATION_MAX_LAG_BYTES || '1048576' }}"
             echo "- log_artifact: postgres-replication-check-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -100,3 +100,5 @@ services:
 
 volumes:
   postgres_data:
+    name: air-api_postgres_data
+    external: true

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -130,6 +130,8 @@ services:
 
 volumes:
   postgres_data:
+    name: mvn_reserve_postgres_data
+    external: true
 
 networks:
   reserve:

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -1,5 +1,10 @@
 # API HA Runbook
 
+This document remains the rollback/reference runbook for the physical
+active-passive topology. Once repository variable `API_DB_HA_MODE=patroni`, use
+`docs/postgres-quorum-runbook.md` for database role changes and do not run the
+manual physical promotion helpers below against a Patroni-managed node.
+
 This runbook describes the current active-passive API setup for `api.mvn.by`.
 The system intentionally has one writable PostgreSQL primary and one warm
 standby. Do not make both origins public-writable.

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -171,6 +171,19 @@ The node certificate bundle belongs in `<project>/patroni-pki` with directory
 mode `0700`, key mode `0600`, and certificate mode `0644`. The CA private key
 must not be present on either server.
 
+Both production Patroni compose files declare the existing PGDATA volumes as
+external state:
+
+```text
+mvn-api: air-api_postgres_data
+zakup:   mvn_reserve_postgres_data
+```
+
+This makes `docker compose down -v` unable to delete production PGDATA. Confirm
+both volumes with `docker volume inspect` before staging the compose files. A
+new database host must create or restore the named external volume explicitly;
+Compose must fail closed instead of silently creating an empty database.
+
 ## Reserve Proxy Gate
 
 `zakup` shares Caddy with belzakupki. Do not make release jobs rewrite that
@@ -242,7 +255,9 @@ while a GitHub production release is running.
    create a deployment maintenance marker on both database hosts.
 4. Stop app, scheduler, and bot processes on both hosts; verify no new writes.
 5. Re-check zero replication lag, stop both PostgreSQL containers, and create a
-   compressed, checksummed PGDATA rollback copy on each host.
+   compressed, checksummed PGDATA rollback copy on each host. Verify the
+   external volume names are still `air-api_postgres_data` and
+   `mvn_reserve_postgres_data` before either Patroni container starts.
 6. Start only the current primary `db` with its Patroni compose. Require local
    `/primary=200`, writable SQL, the expected system identifier, and one DCS
    leader before continuing.
@@ -294,3 +309,37 @@ The Patroni deploy scripts never start, recreate, or pull `db`. For a full
 rollback to the former physical topology, restore PostgreSQL first under the
 cutover rollback procedure, then delete `API_DB_HA_MODE`; do not switch the
 variable while Patroni is still managing either database node.
+
+## Production Monitoring
+
+After `API_DB_HA_MODE=patroni`, the existing scheduled workflows become
+role-aware instead of treating the API VPS as a permanent primary:
+
+- `PostgreSQL Replication Check` runs every ten minutes and invokes
+  `scripts/ha/check_patroni_production.py`;
+- `PostgreSQL PITR Check` probes both Patroni REST APIs and executes the local
+  archive/timer/R2 freshness check on whichever node is currently primary;
+- both workflows retain the existing Telegram failure action and diagnostic
+  artifacts.
+
+The production checker requires all of these invariants at the same time:
+
+1. exactly one Patroni primary and one running replica;
+2. both DCS views identify the same leader and synchronous standby;
+3. matching PostgreSQL system identifiers, synchronous streaming, and replay
+   lag within `POSTGRES_REPLICATION_MAX_LAG_BYTES`;
+4. healthy three-member etcd quorum;
+5. active role agents, one bot, one traffic-enabled API, and the standby API
+   fenced with HTTP 503;
+6. PITR timers active only on the current primary.
+
+Manual operator check from a machine with both SSH aliases:
+
+```bash
+python3 scripts/ha/check_patroni_production.py
+```
+
+The first required scheduled runs must pass after the switchover and switchback
+drill. Keep `watchdog.mode=off` until a real fencing device is installed and a
+separate destructive-node rehearsal proves it; etcd quorum alone is not a
+substitute for watchdog fencing.

--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Verify the live two-node MVN Patroni cluster through SSH.
+
+The checker is role-aware: the API VPS and reserve VPS are node identities,
+not permanent PostgreSQL roles. It verifies DCS topology, PostgreSQL streaming
+and synchronous durability, API fencing, singleton bot/PITR ownership, and the
+three-member etcd quorum without reading database or infrastructure secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+PRIMARY_ROLES = {"leader", "master", "primary"}
+REPLICA_ROLES = {"replica", "standby"}
+CLUSTER_PRIMARY_ROLES = PRIMARY_ROLES
+CLUSTER_REPLICA_ROLES = {
+    "replica",
+    "standby",
+    "sync_standby",
+    "synchronous_standby",
+}
+PITR_TIMERS = (
+    "mvn-postgres-wal-upload.timer",
+    "mvn-postgres-basebackup.timer",
+)
+
+
+@dataclass(frozen=True)
+class NodeConfig:
+    label: str
+    patroni_name: str
+    ssh_target: str
+    project_dir: str
+    compose_file: str
+    wireguard_ip: str
+
+
+@dataclass(frozen=True)
+class CheckerConfig:
+    api: NodeConfig
+    reserve: NodeConfig
+    ssh_options: tuple[str, ...]
+    max_replay_lag_bytes: int
+    role_agent_unit: str
+    etcd_check_command: str
+    ready_url: str
+
+    @property
+    def nodes(self) -> tuple[NodeConfig, NodeConfig]:
+        return (self.api, self.reserve)
+
+
+@dataclass
+class Report:
+    ok: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+    def pass_check(self, message: str) -> None:
+        self.ok.append(message)
+
+    def fail(self, message: str) -> None:
+        self.failures.append(message)
+
+
+class SshRunner:
+    def __init__(self, options: Sequence[str]) -> None:
+        self.options = tuple(options)
+
+    def run(
+        self,
+        node: NodeConfig,
+        command: str,
+        *,
+        stdin: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["ssh", *self.options, node.ssh_target, command],
+            input=stdin,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if check and result.returncode != 0:
+            detail = (result.stderr or result.stdout or "remote command failed").strip()
+            raise RuntimeError(f"{node.label}: {detail}")
+        return result
+
+
+def _required_env(name: str, default: str = "") -> str:
+    value = os.getenv(name, default).strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def _unsigned_int(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an unsigned integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be an unsigned integer")
+    return value
+
+
+def load_config() -> CheckerConfig:
+    ssh_options = tuple(
+        shlex.split(
+            os.getenv(
+                "SSH_OPTS",
+                "-o BatchMode=yes -o StrictHostKeyChecking=yes "
+                "-o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3",
+            )
+        )
+    )
+    return CheckerConfig(
+        api=NodeConfig(
+            label="api",
+            patroni_name=os.getenv("API_NODE_PATRONI_NAME", "mvn-api").strip(),
+            ssh_target=_required_env("API_NODE_SSH", "mvn-api"),
+            project_dir=_required_env("API_NODE_PROJECT_DIR", "/opt/air-api"),
+            compose_file=_required_env("API_NODE_COMPOSE_FILE", "docker-compose.patroni.yml"),
+            wireguard_ip=_required_env("API_NODE_WG_IP", "10.77.0.2"),
+        ),
+        reserve=NodeConfig(
+            label="reserve",
+            patroni_name=os.getenv("RESERVE_NODE_PATRONI_NAME", "zakup").strip(),
+            ssh_target=_required_env("RESERVE_NODE_SSH", "zakup"),
+            project_dir=_required_env("RESERVE_NODE_PROJECT_DIR", "/opt/mvn-reserve"),
+            compose_file=_required_env(
+                "RESERVE_NODE_COMPOSE_FILE", "docker-compose.patroni.yml"
+            ),
+            wireguard_ip=_required_env("RESERVE_NODE_WG_IP", "10.77.0.1"),
+        ),
+        ssh_options=ssh_options,
+        max_replay_lag_bytes=_unsigned_int("MAX_REPLAY_LAG_BYTES", 1_048_576),
+        role_agent_unit=os.getenv(
+            "PATRONI_ROLE_AGENT_UNIT", "mvn-patroni-role-agent.service"
+        ).strip(),
+        etcd_check_command=os.getenv(
+            "ETCD_CHECK_COMMAND", "bash /opt/mvn-quorum/check_etcd_quorum.sh"
+        ).strip(),
+        ready_url=os.getenv(
+            "PATRONI_READY_URL", "http://127.0.0.1:18080/api/ready"
+        ).strip(),
+    )
+
+
+def role_from_patroni(payload: Mapping[str, Any]) -> str:
+    state = str(payload.get("state") or "").strip().lower()
+    role = str(payload.get("role") or "").strip().lower()
+    if state != "running":
+        raise ValueError(f"Patroni state is {state or '<empty>'}, expected running")
+    if role in PRIMARY_ROLES:
+        return "primary"
+    if role in REPLICA_ROLES:
+        return "standby"
+    raise ValueError(f"unsupported Patroni role: {role or '<empty>'}")
+
+
+def select_primary(
+    nodes: Sequence[NodeConfig], payloads: Mapping[str, Mapping[str, Any]]
+) -> tuple[NodeConfig, NodeConfig]:
+    roles: dict[str, str] = {}
+    for node in nodes:
+        payload = payloads[node.label]
+        patroni_metadata = payload.get("patroni")
+        nested_name = (
+            patroni_metadata.get("name") if isinstance(patroni_metadata, Mapping) else ""
+        )
+        actual_name = str(payload.get("name") or nested_name or "").strip()
+        if actual_name != node.patroni_name:
+            raise ValueError(
+                f"{node.label}: Patroni name is {actual_name or '<empty>'}, "
+                f"expected {node.patroni_name}"
+            )
+        if payload.get("pending_restart") is True:
+            raise ValueError(f"{node.label}: Patroni reports pending_restart")
+        if payload.get("pause") is True:
+            raise ValueError(f"{node.label}: Patroni cluster is paused")
+        if payload.get("cluster_unlocked") is True:
+            raise ValueError(f"{node.label}: Patroni cluster has no leader lock")
+        if payload.get("failsafe_mode_is_active") is True:
+            raise ValueError(f"{node.label}: Patroni DCS failsafe mode is active")
+        roles[node.label] = role_from_patroni(payload)
+
+    primaries = [node for node in nodes if roles[node.label] == "primary"]
+    standbys = [node for node in nodes if roles[node.label] == "standby"]
+    if len(primaries) != 1 or len(standbys) != 1:
+        rendered = " ".join(f"{label}={role}" for label, role in sorted(roles.items()))
+        raise ValueError(f"unsafe Patroni topology: {rendered}")
+    return primaries[0], standbys[0]
+
+
+def _json_remote(runner: SshRunner, node: NodeConfig, path: str) -> dict[str, Any]:
+    result = runner.run(
+        node,
+        f"curl -fsS --max-time 5 http://127.0.0.1:8008/{shlex.quote(path)}",
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{node.label}: invalid Patroni JSON from /{path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{node.label}: unexpected Patroni payload from /{path}")
+    return payload
+
+
+def probe_nodes(
+    config: CheckerConfig, runner: SshRunner
+) -> dict[str, dict[str, Any]]:
+    return {node.label: _json_remote(runner, node, "patroni") for node in config.nodes}
+
+
+def _compose_prefix(node: NodeConfig, *, profiles: bool = False) -> str:
+    command = ["docker", "compose", "-f", node.compose_file]
+    if profiles:
+        command.extend(["--profile", "bluegreen"])
+    return f"cd {shlex.quote(node.project_dir)} && {shlex.join(command)}"
+
+
+def _sql(runner: SshRunner, node: NodeConfig, statement: str) -> str:
+    psql = (
+        'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" '
+        '-d "${POSTGRES_DB:-air_conditioners}" -AtF "|"'
+    )
+    command = (
+        f"{_compose_prefix(node)} exec -T db sh -lc {shlex.quote(psql)}"
+    )
+    return runner.run(node, command, stdin=statement).stdout.strip()
+
+
+def _check_cluster_views(
+    config: CheckerConfig,
+    runner: SshRunner,
+    primary: NodeConfig,
+    standby: NodeConfig,
+    report: Report,
+) -> None:
+    initial_failure_count = len(report.failures)
+    expected_names = {node.patroni_name for node in config.nodes}
+    for source in config.nodes:
+        payload = _json_remote(runner, source, "cluster")
+        raw_members = payload.get("members")
+        if not isinstance(raw_members, list):
+            report.fail(f"{source.label}: /cluster has no member list")
+            continue
+        members = {
+            str(member.get("name") or ""): member
+            for member in raw_members
+            if isinstance(member, dict)
+        }
+        if set(members) != expected_names:
+            report.fail(
+                f"{source.label}: DCS members={sorted(members)} expected={sorted(expected_names)}"
+            )
+            continue
+
+        leader = members[primary.patroni_name]
+        replica = members[standby.patroni_name]
+        leader_role = str(leader.get("role") or "").lower()
+        replica_role = str(replica.get("role") or "").lower()
+        if leader_role not in CLUSTER_PRIMARY_ROLES:
+            report.fail(
+                f"{source.label}: DCS leader role={leader_role or '<empty>'}"
+            )
+        if replica_role not in CLUSTER_REPLICA_ROLES:
+            report.fail(
+                f"{source.label}: replica role={replica_role or '<empty>'}"
+            )
+        if str(leader.get("state") or "").lower() != "running":
+            report.fail(f"{source.label}: DCS leader is not running")
+        if str(replica.get("state") or "").lower() not in {"running", "streaming"}:
+            report.fail(f"{source.label}: DCS replica is not streaming")
+        if leader.get("pending_restart") is True or replica.get("pending_restart") is True:
+            report.fail(f"{source.label}: DCS member has pending_restart")
+
+        lag = replica.get("lag")
+        try:
+            lag_bytes = int(lag or 0)
+        except (TypeError, ValueError):
+            report.fail(f"{source.label}: replica lag is not numeric: {lag!r}")
+        else:
+            if lag_bytes > config.max_replay_lag_bytes:
+                report.fail(
+                    f"{source.label}: DCS lag {lag_bytes} exceeds "
+                    f"{config.max_replay_lag_bytes} bytes"
+                )
+
+        timelines = {member.get("timeline") for member in (leader, replica)}
+        timelines.discard(None)
+        if len(timelines) > 1:
+            report.fail(f"{source.label}: members disagree on timeline: {sorted(timelines)}")
+
+    sync_probe = runner.run(
+        standby,
+        "curl -fsS --max-time 5 http://127.0.0.1:8008/sync >/dev/null",
+        check=False,
+    )
+    if sync_probe.returncode != 0:
+        report.fail(f"{standby.label}: Patroni /sync endpoint is not healthy")
+
+    if len(report.failures) == initial_failure_count:
+        report.pass_check(
+            f"DCS topology has leader={primary.patroni_name} "
+            f"sync_standby={standby.patroni_name}"
+        )
+
+
+def _parse_rows(value: str, columns: int) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for line in value.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("|")
+        if len(parts) != columns:
+            raise ValueError(f"unexpected SQL row: {line!r}")
+        rows.append(parts)
+    return rows
+
+
+def _check_postgres(
+    config: CheckerConfig,
+    runner: SshRunner,
+    primary: NodeConfig,
+    standby: NodeConfig,
+    report: Report,
+) -> None:
+    initial_failure_count = len(report.failures)
+    primary_recovery = _sql(runner, primary, "select pg_is_in_recovery();")
+    standby_recovery = _sql(runner, standby, "select pg_is_in_recovery();")
+    if primary_recovery != "f":
+        report.fail(f"{primary.label}: PostgreSQL is not writable primary")
+    if standby_recovery != "t":
+        report.fail(f"{standby.label}: PostgreSQL is not in recovery")
+
+    system_id_sql = "select system_identifier from pg_control_system();"
+    primary_system_id = _sql(runner, primary, system_id_sql)
+    standby_system_id = _sql(runner, standby, system_id_sql)
+    if not primary_system_id or primary_system_id != standby_system_id:
+        report.fail(
+            f"PostgreSQL system identifiers differ: primary={primary_system_id or '<empty>'} "
+            f"standby={standby_system_id or '<empty>'}"
+        )
+
+    replication_sql = """
+select
+  coalesce(application_name, ''),
+  coalesce(client_addr::text, ''),
+  coalesce(state, ''),
+  coalesce(sync_state, ''),
+  coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)::bigint, -1)
+from pg_stat_replication
+order by application_name;
+"""
+    rows = _parse_rows(_sql(runner, primary, replication_sql), 5)
+    matching = [row for row in rows if row[0] == standby.patroni_name]
+    if len(matching) != 1:
+        report.fail(
+            f"{primary.label}: expected one replication row for {standby.patroni_name}, "
+            f"got {len(matching)}"
+        )
+    else:
+        application, client_addr, state, sync_state, lag_raw = matching[0]
+        if client_addr != standby.wireguard_ip:
+            report.fail(
+                f"{primary.label}: replica address={client_addr or '<empty>'}, "
+                f"expected {standby.wireguard_ip}"
+            )
+        if state != "streaming":
+            report.fail(f"{primary.label}: replication state={state or '<empty>'}")
+        if sync_state != "sync":
+            report.fail(f"{primary.label}: sync_state={sync_state or '<empty>'}")
+        try:
+            replay_lag = int(lag_raw)
+        except ValueError:
+            report.fail(f"{primary.label}: replay lag is not numeric: {lag_raw!r}")
+        else:
+            if replay_lag < 0 or replay_lag > config.max_replay_lag_bytes:
+                report.fail(
+                    f"{primary.label}: replay lag {replay_lag} exceeds "
+                    f"{config.max_replay_lag_bytes} bytes"
+                )
+
+    receiver_sql = """
+select
+  coalesce(status, ''),
+  coalesce(sender_host, ''),
+  coalesce(slot_name, ''),
+  coalesce(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())::bigint, 0)
+from pg_stat_wal_receiver;
+"""
+    receiver_rows = _parse_rows(_sql(runner, standby, receiver_sql), 4)
+    if len(receiver_rows) != 1:
+        report.fail(f"{standby.label}: expected one WAL receiver, got {len(receiver_rows)}")
+    else:
+        status, sender_host, slot_name, receive_replay_lag_raw = receiver_rows[0]
+        if status != "streaming":
+            report.fail(f"{standby.label}: WAL receiver status={status or '<empty>'}")
+        if sender_host != primary.wireguard_ip:
+            report.fail(
+                f"{standby.label}: WAL sender={sender_host or '<empty>'}, "
+                f"expected {primary.wireguard_ip}"
+            )
+        if not slot_name:
+            report.fail(f"{standby.label}: WAL receiver has no replication slot")
+        try:
+            receive_replay_lag = int(receive_replay_lag_raw)
+        except ValueError:
+            report.fail(
+                f"{standby.label}: receive/replay lag is not numeric: {receive_replay_lag_raw!r}"
+            )
+        else:
+            if receive_replay_lag < 0 or receive_replay_lag > config.max_replay_lag_bytes:
+                report.fail(
+                    f"{standby.label}: receive/replay lag {receive_replay_lag} exceeds "
+                    f"{config.max_replay_lag_bytes} bytes"
+                )
+
+    sync_names = _sql(runner, primary, "show synchronous_standby_names;")
+    if standby.patroni_name not in sync_names:
+        report.fail(
+            f"{primary.label}: synchronous_standby_names does not include "
+            f"{standby.patroni_name}"
+        )
+    if _sql(runner, primary, "show wal_log_hints;").lower() != "on":
+        report.fail(f"{primary.label}: wal_log_hints is not on")
+    if _sql(runner, primary, "show archive_mode;").lower() != "on":
+        report.fail(f"{primary.label}: archive_mode is not on")
+
+    if len(report.failures) == initial_failure_count:
+        report.pass_check(
+            f"PostgreSQL primary={primary.patroni_name} streams synchronously to "
+            f"{standby.patroni_name} with matching system identifier"
+        )
+
+
+def _unit_active(runner: SshRunner, node: NodeConfig, unit: str) -> bool:
+    return (
+        runner.run(
+            node,
+            f"systemctl is-active --quiet {shlex.quote(unit)}",
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _unit_enabled(runner: SshRunner, node: NodeConfig, unit: str) -> bool:
+    return (
+        runner.run(
+            node,
+            f"systemctl is-enabled --quiet {shlex.quote(unit)}",
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _ready_response(
+    runner: SshRunner, node: NodeConfig, ready_url: str
+) -> tuple[int, dict[str, Any]]:
+    command = f"curl -sS --max-time 5 -w '\\n%{{http_code}}' {shlex.quote(ready_url)}"
+    result = runner.run(node, command)
+    lines = result.stdout.rstrip().splitlines()
+    if len(lines) < 2:
+        raise RuntimeError(f"{node.label}: invalid readiness response")
+    try:
+        status = int(lines[-1])
+        payload = json.loads("\n".join(lines[:-1]))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{node.label}: invalid readiness response") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{node.label}: readiness payload is not an object")
+    return status, payload
+
+
+def _running_services(runner: SshRunner, node: NodeConfig) -> set[str]:
+    command = f"{_compose_prefix(node, profiles=True)} ps --status running --services"
+    return set(runner.run(node, command).stdout.split())
+
+
+def _role_env(runner: SshRunner, node: NodeConfig, filename: str) -> dict[str, str]:
+    path = f"{node.project_dir}/{filename}"
+    content = runner.run(node, f"cat {shlex.quote(path)}").stdout
+    values: dict[str, str] = {}
+    for line in content.splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        values[name.strip()] = value.strip()
+    return values
+
+
+def _check_runtime(
+    config: CheckerConfig,
+    runner: SshRunner,
+    primary: NodeConfig,
+    standby: NodeConfig,
+    report: Report,
+) -> None:
+    initial_failure_count = len(report.failures)
+    for node in config.nodes:
+        expected_role = "primary" if node == primary else "standby"
+        if not _unit_enabled(runner, node, config.role_agent_unit):
+            report.fail(f"{node.label}: Patroni role agent is not enabled")
+        if not _unit_active(runner, node, config.role_agent_unit):
+            report.fail(f"{node.label}: Patroni role agent is not active")
+
+        role_state = runner.run(
+            node,
+            f"cat {shlex.quote(node.project_dir + '/.ha-runtime-role')}",
+        ).stdout.strip()
+        if role_state != expected_role:
+            report.fail(
+                f"{node.label}: runtime role={role_state or '<empty>'}, expected {expected_role}"
+            )
+
+        app_env = _role_env(runner, node, ".ha-app-role.env")
+        bot_env = _role_env(runner, node, ".ha-bot-role.env")
+        expected_primary = node == primary
+        expected_app_values = {
+            "APP_ROLE": expected_role,
+            "API_READY_ENABLED": str(expected_primary).lower(),
+            "DB_BOOTSTRAP_ENABLED": "false",
+            "SCHEDULER_ENABLED": str(expected_primary).lower(),
+        }
+        expected_bot_values = {
+            "APP_ROLE": expected_role,
+            "API_READY_ENABLED": "false",
+            "BOT_ENABLED": str(expected_primary).lower(),
+            "DB_BOOTSTRAP_ENABLED": "false",
+            "SCHEDULER_ENABLED": "false",
+        }
+        for name, expected in expected_app_values.items():
+            if app_env.get(name) != expected:
+                report.fail(
+                    f"{node.label}: app role env {name}={app_env.get(name)!r}, expected {expected!r}"
+                )
+        for name, expected in expected_bot_values.items():
+            if bot_env.get(name) != expected:
+                report.fail(
+                    f"{node.label}: bot role env {name}={bot_env.get(name)!r}, expected {expected!r}"
+                )
+        if not expected_primary:
+            for name in (
+                "MAIL_IMAP_AUTO_IMPORT_ENABLED",
+                "MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED",
+                "CLOUDFLARE_PURGE_ENABLED",
+            ):
+                if app_env.get(name) != "false":
+                    report.fail(
+                        f"{node.label}: standby app role env {name} is not false"
+                    )
+
+        services = _running_services(runner, node)
+        app_services = services.intersection({"app", "app-blue", "app-green"})
+        if not app_services:
+            report.fail(f"{node.label}: no API app service is running")
+        bot_running = "bot" in services
+        if bot_running != (node == primary):
+            report.fail(
+                f"{node.label}: bot_running={str(bot_running).lower()} expected="
+                f"{str(node == primary).lower()}"
+            )
+
+        status, payload = _ready_response(runner, node, config.ready_url)
+        if node == primary:
+            if status != 200 or payload.get("api") != "ready" or payload.get("traffic") != "enabled":
+                report.fail(
+                    f"{node.label}: primary readiness is HTTP {status} "
+                    f"api={payload.get('api')} traffic={payload.get('traffic')}"
+                )
+        elif status != 503 or payload.get("api") != "not_ready" or payload.get("traffic") != "disabled":
+            report.fail(
+                f"{node.label}: standby fencing is HTTP {status} "
+                f"api={payload.get('api')} traffic={payload.get('traffic')}"
+            )
+
+        for timer in PITR_TIMERS:
+            active = _unit_active(runner, node, timer)
+            if active != (node == primary):
+                report.fail(
+                    f"{node.label}: {timer} active={str(active).lower()} "
+                    f"expected={str(node == primary).lower()}"
+                )
+
+    if len(report.failures) == initial_failure_count:
+        report.pass_check(
+            f"runtime ownership follows primary={primary.label}: one bot, one ready API, PITR timers fenced"
+        )
+
+
+def perform_checks(config: CheckerConfig, runner: SshRunner) -> Report:
+    report = Report()
+    payloads = probe_nodes(config, runner)
+    primary, standby = select_primary(config.nodes, payloads)
+    report.pass_check(
+        f"exactly one Patroni primary: {primary.label} ({primary.patroni_name})"
+    )
+
+    _check_cluster_views(config, runner, primary, standby, report)
+    _check_postgres(config, runner, primary, standby, report)
+    _check_runtime(config, runner, primary, standby, report)
+
+    etcd = runner.run(config.api, config.etcd_check_command, check=False)
+    if etcd.returncode == 0 and "etcd_quorum_status=passed members=3" in etcd.stdout:
+        report.pass_check("etcd quorum has three healthy members")
+    else:
+        detail = (etcd.stderr or etcd.stdout or "check failed").strip().replace("\n", " ")
+        report.fail(f"etcd quorum check failed: {detail}")
+    return report
+
+
+def _print_report(report: Report) -> None:
+    for message in report.ok:
+        print(f"[patroni-production][ok] {message}")
+    for message in report.failures:
+        print(f"[patroni-production][fail] {message}")
+    status = "failed" if report.failures else "passed"
+    print(
+        f"[patroni-production][summary] status={status} "
+        f"ok={len(report.ok)} failures={len(report.failures)}"
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--resolve-primary",
+        action="store_true",
+        help="Print only api or reserve after validating the two Patroni roles.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        config = load_config()
+        runner = SshRunner(config.ssh_options)
+        if args.resolve_primary:
+            primary, _ = select_primary(config.nodes, probe_nodes(config, runner))
+            print(primary.label)
+            return 0
+        report = perform_checks(config, runner)
+    except (RuntimeError, ValueError) as exc:
+        if args.resolve_primary:
+            print(f"could not resolve Patroni primary: {exc}", file=sys.stderr)
+        else:
+            print(f"[patroni-production][fail] {exc}")
+            print("[patroni-production][summary] status=failed ok=0 failures=1")
+        return 2
+
+    _print_report(report)
+    return 1 if report.failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_patroni_production_check.py
+++ b/tests/unit/test_patroni_production_check.py
@@ -1,0 +1,204 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ha.check_patroni_production import (
+    CheckerConfig,
+    NodeConfig,
+    Report,
+    _check_cluster_views,
+    _parse_rows,
+    role_from_patroni,
+    select_primary,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _nodes() -> tuple[NodeConfig, NodeConfig]:
+    return (
+        NodeConfig(
+            label="api",
+            patroni_name="mvn-api",
+            ssh_target="root@api",
+            project_dir="/opt/air-api",
+            compose_file="docker-compose.patroni.yml",
+            wireguard_ip="10.77.0.2",
+        ),
+        NodeConfig(
+            label="reserve",
+            patroni_name="zakup",
+            ssh_target="root@reserve",
+            project_dir="/opt/mvn-reserve",
+            compose_file="docker-compose.patroni.yml",
+            wireguard_ip="10.77.0.1",
+        ),
+    )
+
+
+def test_role_parser_requires_running_supported_role():
+    assert role_from_patroni({"state": "running", "role": "primary"}) == "primary"
+    assert role_from_patroni({"state": "running", "role": "replica"}) == "standby"
+
+    with pytest.raises(ValueError, match="expected running"):
+        role_from_patroni({"state": "stopped", "role": "replica"})
+    with pytest.raises(ValueError, match="unsupported Patroni role"):
+        role_from_patroni({"state": "running", "role": "unknown"})
+
+
+def test_primary_selection_accepts_nested_patroni_names():
+    api, reserve = _nodes()
+    primary, standby = select_primary(
+        (api, reserve),
+        {
+            "api": {
+                "state": "running",
+                "role": "primary",
+                "patroni": {"name": "mvn-api"},
+            },
+            "reserve": {
+                "state": "running",
+                "role": "replica",
+                "patroni": {"name": "zakup"},
+            },
+        },
+    )
+
+    assert primary == api
+    assert standby == reserve
+
+
+def test_primary_selection_rejects_split_brain_and_pending_restart():
+    api, reserve = _nodes()
+    both_primary = {
+        "api": {"state": "running", "role": "primary", "name": "mvn-api"},
+        "reserve": {"state": "running", "role": "primary", "name": "zakup"},
+    }
+    with pytest.raises(ValueError, match="unsafe Patroni topology"):
+        select_primary((api, reserve), both_primary)
+
+    pending_restart = {
+        "api": {
+            "state": "running",
+            "role": "primary",
+            "name": "mvn-api",
+            "pending_restart": True,
+        },
+        "reserve": {"state": "running", "role": "replica", "name": "zakup"},
+    }
+    with pytest.raises(ValueError, match="pending_restart"):
+        select_primary((api, reserve), pending_restart)
+
+    failsafe = {
+        "api": {
+            "state": "running",
+            "role": "primary",
+            "name": "mvn-api",
+            "failsafe_mode_is_active": True,
+        },
+        "reserve": {"state": "running", "role": "replica", "name": "zakup"},
+    }
+    with pytest.raises(ValueError, match="failsafe mode is active"):
+        select_primary((api, reserve), failsafe)
+
+
+def test_sql_row_parser_is_strict():
+    assert _parse_rows("zakup|10.77.0.1|streaming|sync|0\n", 5) == [
+        ["zakup", "10.77.0.1", "streaming", "sync", "0"]
+    ]
+    with pytest.raises(ValueError, match="unexpected SQL row"):
+        _parse_rows("too|few", 5)
+
+
+def test_cluster_view_accepts_replica_role_but_requires_sync_endpoint():
+    api, reserve = _nodes()
+    config = CheckerConfig(
+        api=api,
+        reserve=reserve,
+        ssh_options=(),
+        max_replay_lag_bytes=1_048_576,
+        role_agent_unit="mvn-patroni-role-agent.service",
+        etcd_check_command="check-etcd",
+        ready_url="http://127.0.0.1:18080/api/ready",
+    )
+    cluster = {
+        "members": [
+            {
+                "name": "mvn-api",
+                "role": "leader",
+                "state": "running",
+                "timeline": 2,
+            },
+            {
+                "name": "zakup",
+                "role": "replica",
+                "state": "streaming",
+                "timeline": 2,
+                "lag": 0,
+            },
+        ]
+    }
+
+    class FakeRunner:
+        sync_status = 0
+
+        def run(self, node, command, *, stdin=None, check=True):
+            del node, stdin, check
+            if command.endswith("/cluster"):
+                return subprocess.CompletedProcess([], 0, json.dumps(cluster), "")
+            if "/sync" in command:
+                return subprocess.CompletedProcess([], self.sync_status, "", "")
+            raise AssertionError(command)
+
+    report = Report()
+    runner = FakeRunner()
+    _check_cluster_views(config, runner, api, reserve, report)
+    assert report.failures == []
+    assert any("sync_standby=zakup" in message for message in report.ok)
+
+    runner.sync_status = 22
+    report = Report()
+    _check_cluster_views(config, runner, api, reserve, report)
+    assert report.failures == ["reserve: Patroni /sync endpoint is not healthy"]
+
+
+def test_replication_workflow_switches_to_role_aware_patroni_monitoring():
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/check-postgres-replication.yml").read_text(
+            encoding="utf-8"
+        ),
+        Loader=yaml.BaseLoader,
+    )
+    run = next(
+        step["run"]
+        for step in workflow["jobs"]["check"]["steps"]
+        if step.get("name") == "Run PostgreSQL replication check"
+    )
+
+    assert workflow["on"]["schedule"][0]["cron"] == "7,17,27,37,47,57 * * * *"
+    assert "API_DB_HA_MODE" in run
+    assert "check_patroni_production.py" in run
+    assert "check_postgres_replication.sh" in run
+    assert "API_NODE_SSH" in run
+    assert "RESERVE_NODE_SSH" in run
+
+
+def test_pitr_workflow_resolves_the_current_patroni_primary():
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/check-postgres-pitr.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    run = next(
+        step["run"]
+        for step in workflow["jobs"]["check"]["steps"]
+        if step.get("name") == "Run PostgreSQL PITR Check"
+    )
+
+    assert "check_patroni_production.py --resolve-primary" in run
+    assert "target_label=reserve" in run
+    assert "target_compose_file=docker-compose.patroni.yml" in run
+    assert "API_DB_HA_MODE must be physical or patroni" in run

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -152,6 +152,15 @@ def test_production_patroni_composes_are_role_driven_and_private():
         assert compose["services"]["app-blue"]["env_file"][-1] == ".ha-app-role.env"
         assert compose["services"]["bot"]["env_file"][-1] == ".ha-bot-role.env"
 
+    assert primary["volumes"]["postgres_data"] == {
+        "name": "air-api_postgres_data",
+        "external": True,
+    }
+    assert reserve["volumes"]["postgres_data"] == {
+        "name": "mvn_reserve_postgres_data",
+        "external": True,
+    }
+
     assert reserve["services"]["api-proxy"]["ports"] == ["127.0.0.1:18080:8000"]
     assert "proxy_set_header Host api.mvn.by" in PROXY_CONFIG.read_text(encoding="utf-8")
 

--- a/tests/unit/test_postgres_pitr_workflows.py
+++ b/tests/unit/test_postgres_pitr_workflows.py
@@ -28,9 +28,9 @@ def test_postgres_pitr_check_workflow_preserves_strict_remote_gate():
     assert "POSTGRES_PITR_MAX_WAL_AGE_MINUTES" in check_step["env"]["PITR_MAX_WAL_AGE_MINUTES"]
     assert "POSTGRES_PITR_MAX_BASEBACKUP_AGE_HOURS" in check_step["env"]["PITR_MAX_BASEBACKUP_AGE_HOURS"]
     assert "scripts/ha/check_postgres_pitr_status.sh" in check_step["run"]
-    assert "PITR_REQUIRED='${PITR_REQUIRED}'" in check_step["run"]
-    assert "PITR_MAX_WAL_AGE_MINUTES='${PITR_MAX_WAL_AGE_MINUTES}'" in check_step["run"]
-    assert "PITR_MAX_BASEBACKUP_AGE_HOURS='${PITR_MAX_BASEBACKUP_AGE_HOURS}'" in check_step["run"]
+    assert 'PITR_REQUIRED=$(quote "${PITR_REQUIRED}")' in check_step["run"]
+    assert 'PITR_MAX_WAL_AGE_MINUTES=$(quote "${PITR_MAX_WAL_AGE_MINUTES}")' in check_step["run"]
+    assert 'PITR_MAX_BASEBACKUP_AGE_HOURS=$(quote "${PITR_MAX_BASEBACKUP_AGE_HOURS}")' in check_step["run"]
     assert "postgres-pitr-check.log" in check_step["run"]
     assert "pitr_required:" in summary_step["run"]
     assert artifact_step["if"] == "always()"


### PR DESCRIPTION
## Summary
- make PostgreSQL replication and PITR checks resolve the current Patroni primary dynamically
- verify DCS, synchronous SQL replication, etcd quorum, API fencing, singleton bot/scheduler, and PITR timer ownership
- protect production PGDATA with external named Compose volumes and document the post-cutover runbook

## Validation
- `pytest -q $(rg --files tests/unit | rg '/test_(api_ha|ha_|patroni|etcd|postgres_pitr|postgres_replication)' | sort)` (80 passed)\n- `actionlint .github/workflows/check-postgres-replication.yml .github/workflows/check-postgres-pitr.yml`\n- both Patroni compose files validated against live server `.env` files without starting services\n- reserve R2 PITR freshness check passed