### PR TITLE
Codify HA host security monitoring

### DIFF
--- a/.github/workflows/check-infrastructure-security.yml
+++ b/.github/workflows/check-infrastructure-security.yml
@@ -1,0 +1,156 @@
+name: Infrastructure Security Check
+
+on:
+  schedule:
+    - cron: "37 */6 * * *"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_HOST: ${{ secrets.SSH_HOST_API }}
+          RESERVE_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          WEB_HOST: ${{ secrets.SSH_HOST_WEB }}
+        run: |
+          set -euo pipefail
+          for value_name in SSH_KEY API_HOST RESERVE_HOST WEB_HOST; do
+            [[ -n "${!value_name}" ]] || {
+              echo "::error::Missing ${value_name}"
+              exit 1
+            }
+          done
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/infrastructure_security_key
+          chmod 600 ~/.ssh/infrastructure_security_key
+          : > ~/.ssh/known_hosts
+          for host in "${API_HOST}" "${RESERVE_HOST}" "${WEB_HOST}"; do
+            scanned=false
+            for attempt in 1 2 3 4 5; do
+              if ssh-keyscan -T 10 -H "${host}" >> ~/.ssh/known_hosts 2>/dev/null; then
+                scanned=true
+                break
+              fi
+              sleep $((attempt * 2))
+            done
+            [[ "${scanned}" == "true" ]] || {
+              echo "::error::Could not obtain SSH host key"
+              exit 1
+            }
+          done
+
+      - name: Audit host hardening and private listeners
+        env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
+          API_HOST: ${{ secrets.SSH_HOST_API }}
+          API_USER: ${{ secrets.SSH_USER_API }}
+          RESERVE_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          RESERVE_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          WEB_HOST: ${{ secrets.SSH_HOST_WEB }}
+          WEB_USER: ${{ secrets.SSH_USER_WEB }}
+        run: |
+          set -euo pipefail
+          SSH_OPTIONS=(
+            -i ~/.ssh/infrastructure_security_key
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+          labels=(mvn-api zakup mvn-web)
+          hosts=("${API_HOST}" "${RESERVE_HOST}" "${WEB_HOST}")
+          users=("${API_USER}" "${RESERVE_USER}" "${WEB_USER}")
+          wireguard_ips=(10.77.0.2 10.77.0.1 10.77.0.3)
+          required_ports=("2379,2380,5432" "2379,2380,5432" "2379,2380")
+
+          for user in "${users[@]}"; do
+            [[ -n "${user}" ]] || {
+              echo "::error::Missing SSH user for infrastructure security check"
+              exit 1
+            }
+          done
+
+          if [[ "${API_DB_HA_MODE}" == "patroni" ]]; then
+            required_ports[0]="${required_ports[0]},8008"
+            required_ports[1]="${required_ports[1]},8008"
+          elif [[ "${API_DB_HA_MODE}" != "physical" ]]; then
+            echo "::error::API_DB_HA_MODE must be physical or patroni"
+            exit 1
+          fi
+
+          : > infrastructure-security-check.log
+          for index in 0 1 2; do
+            target="${users[$index]}@${hosts[$index]}"
+            ssh "${SSH_OPTIONS[@]}" "${target}" \
+              bash -s -- "${wireguard_ips[$index]}" "${labels[$index]}" "${required_ports[$index]}" \
+              < scripts/ha/check_host_security.sh | tee -a infrastructure-security-check.log
+          done
+
+      - name: Verify sensitive ports are closed publicly
+        env:
+          API_HOST: ${{ secrets.SSH_HOST_API }}
+          RESERVE_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          WEB_HOST: ${{ secrets.SSH_HOST_WEB }}
+        run: |
+          set -euo pipefail
+          labels=(mvn-api zakup mvn-web)
+          hosts=("${API_HOST}" "${RESERVE_HOST}" "${WEB_HOST}")
+          ports=(2379 2380 5432 8008 18000 18001 18002 18080)
+          failures=0
+
+          for index in 0 1 2; do
+            for port in "${ports[@]}"; do
+              if nc -z -w 2 "${hosts[$index]}" "${port}" >/dev/null 2>&1; then
+                echo "[host-security][fail] host=${labels[$index]} public_port=${port} is open" | tee -a infrastructure-security-check.log
+                failures=$((failures + 1))
+              fi
+            done
+          done
+          if (( failures > 0 )); then
+            echo "::error::Found ${failures} public sensitive listeners"
+            exit 1
+          fi
+          echo "[host-security][ok] all sensitive public ports are closed" | tee -a infrastructure-security-check.log
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Infrastructure Security Check"
+            echo "- hosts: mvn-api, zakup, mvn-web"
+            echo "- checks: effective sshd, fail2ban, WireGuard, private listeners, public port scan"
+            echo "- artifact: infrastructure-security-check-${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload security audit log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: infrastructure-security-check-${{ github.run_id }}
+          path: infrastructure-security-check.log
+          if-no-files-found: warn
+
+      - name: Notify HA failure
+        if: failure()
+        uses: ./.github/actions/notify-ha-failure
+        with:
+          bot-token: ${{ secrets.HA_ALERT_TELEGRAM_BOT_TOKEN }}
+          chat-id: ${{ secrets.HA_ALERT_TELEGRAM_CHAT_ID }}
+          thread-id: ${{ secrets.HA_ALERT_TELEGRAM_THREAD_ID }}
+          title: "MVN infrastructure security check failed"
+          details: "Artifact: infrastructure-security-check-${{ github.run_id }}"

--- a/deploy/ha/security/00-mvn-cicd-reliability.conf
+++ b/deploy/ha/security/00-mvn-cicd-reliability.conf
@@ -1,0 +1,8 @@
+# Managed for MVN CI/CD reliability and SSH hardening.
+LoginGraceTime 30
+MaxStartups 20:30:40
+PerSourceMaxStartups 10
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password

--- a/deploy/ha/security/mvn-sshd.local
+++ b/deploy/ha/security/mvn-sshd.local
@@ -1,0 +1,8 @@
+[sshd]
+enabled = true
+backend = systemd
+port = ssh
+maxretry = 5
+findtime = 10m
+bantime = 1h
+ignoreip = 127.0.0.1/8 ::1 10.77.0.0/29

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -212,7 +212,9 @@ Scheduled monitors:
 | `check-api-vps-health.yml` | every 6 hours | primary host, containers, DB, backups, media storage config |
 | `check-api-ha-readiness.yml` | every 6 hours | whole-system HA readiness rollup; direct-origin core checks fail, Cloudflare/PITR are soft blockers until strict |
 | `check-api-ha-invariants.yml` | every 30 minutes | direct primary ready and standby fenced; public Cloudflare routing is covered by the LB monitor/config checks |
+| `check-postgres-replication.yml` | every 10 minutes | physical replication before migration; role-aware Patroni/DCS/runtime ownership after `API_DB_HA_MODE=patroni` |
 | `check-cloudflare-lb-config.yml` | every 6 hours | Cloudflare LB pool order, fallback, host header, and monitor config |
+| `check-infrastructure-security.yml` | every 6 hours | effective SSH/fail2ban/WireGuard policy and private/public listener boundaries on all three hosts |
 | `api-restore-drill.yml` | daily after the 03:00 UTC backup | disposable DB restore drill |
 | `check-postgres-pitr.yml` | every 6 hours | PITR archive/timer/backlog and remote R2 freshness |
 | `postgres-pitr-restore-drill.yml` | daily when `POSTGRES_PITR_REQUIRED=true` | disposable physical restore from PITR basebackup + WAL |

--- a/docs/infrastructure-security-runbook.md
+++ b/docs/infrastructure-security-runbook.md
@@ -1,0 +1,104 @@
+# Infrastructure Security Runbook
+
+This runbook covers the three hosts in the MVN reliability topology:
+
+| Host | WireGuard IP | Public services | Private services |
+| --- | --- | --- | --- |
+| `mvn-api` | `10.77.0.2` | SSH, HTTPS | PostgreSQL, etcd, Patroni, API slots |
+| `zakup` | `10.77.0.1` | SSH, shared Caddy HTTPS | PostgreSQL, etcd, Patroni, MVN proxy/app slots |
+| `mvn` | `10.77.0.3` | SSH, web HTTPS | etcd witness |
+
+Do not enable or rewrite UFW on `mvn-api` or `zakup` as an incidental
+hardening step. Docker networking and the existing WireGuard mesh must be
+modeled first. The enforced boundary is: database, quorum, role API, and
+internal application ports bind only to loopback or `10.77.0.0/29`; public
+reachability is checked independently from a GitHub runner.
+
+## Tracked Policy
+
+- `deploy/ha/security/00-mvn-cicd-reliability.conf`: effective SSH policy;
+- `deploy/ha/security/mvn-sshd.local`: fail2ban SSH jail policy;
+- `scripts/ha/check_host_security.sh`: host-local effective-state audit;
+- `.github/workflows/check-infrastructure-security.yml`: three-host and public
+  listener audit every six hours.
+
+The SSH policy allows root only with a key because the current release path is
+root-based. Password and keyboard-interactive login stay disabled. CI
+connection bursts are bounded by `MaxStartups 20:30:40` and
+`PerSourceMaxStartups 10`; fail2ban remains the abuse-control layer.
+
+## Safe Apply
+
+Keep one working SSH session open throughout the operation. Apply one host at a
+time and do not continue until a second independent SSH session succeeds.
+
+```bash
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a /etc/ssh/sshd_config.d/00-mvn-cicd-reliability.conf \
+  "/etc/ssh/sshd_config.d/00-mvn-cicd-reliability.conf.bak-${stamp}" 2>/dev/null || true
+cp -a /etc/fail2ban/jail.d/mvn-sshd.local \
+  "/etc/fail2ban/jail.d/mvn-sshd.local.bak-${stamp}" 2>/dev/null || true
+```
+
+Stage the tracked files with mode `0644`, then validate before reload:
+
+```bash
+sshd -t
+fail2ban-client -t
+systemctl reload ssh
+systemctl reload fail2ban
+```
+
+Do not restart SSH. Open a new session and run the local checker with the host's
+WireGuard address and required listeners:
+
+```bash
+# mvn-api
+EXPECTED_WG_IP=10.77.0.2 \
+EXPECTED_LISTEN_PORTS="2379 2380 5432 8008" \
+bash scripts/ha/check_host_security.sh
+
+# zakup
+EXPECTED_WG_IP=10.77.0.1 \
+EXPECTED_LISTEN_PORTS="2379 2380 5432 8008" \
+bash scripts/ha/check_host_security.sh
+
+# mvn web/witness
+EXPECTED_WG_IP=10.77.0.3 \
+EXPECTED_LISTEN_PORTS="2379 2380" \
+bash scripts/ha/check_host_security.sh
+```
+
+Before Patroni adoption, omit `8008` on the two database hosts. The scheduled
+workflow handles this automatically from `API_DB_HA_MODE`.
+
+## Required Invariants
+
+The checker fails unless all of these remain true:
+
+1. password and keyboard-interactive SSH authentication are disabled;
+2. root login is key-only and public-key authentication is enabled;
+3. SSH connection limits match the tracked CI-safe values;
+4. fail2ban and its `sshd` jail are active with the tracked retry/window/ban
+   limits;
+5. loopback and the WireGuard subnet are excluded from fail2ban bans;
+6. `wg-mvn` is active;
+7. sensitive listeners use only loopback or the node's WireGuard address;
+8. the same sensitive ports are closed on all public server addresses.
+
+The external workflow uploads its audit log and sends the existing HA Telegram
+alert on failure. It is included in `scripts/ha/report_ha_status.py`, so a stale
+or failed security check makes the aggregate reliability report require
+attention.
+
+## Rollback
+
+If `sshd -t` or `fail2ban-client -t` fails, do not reload either service.
+Restore the timestamped file and validate again. If a reload succeeded but a
+new SSH session fails, use the still-open operator session or provider console
+to restore the backup, then reload SSH. Never close the last working session
+until an independent key-only login and `check_host_security.sh` both pass.
+
+Changing firewall policy, rotating SSH host keys, moving away from root-based
+deploys, or enabling Patroni watchdog fencing are separate changes with their
+own rollback plans. They must not be bundled into this config reload.

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -47,6 +47,8 @@ networking so it can bind directly to each node's WireGuard address.
   files. Normal API deploys must never recreate their `db` service.
 - `deploy/ha/proxy/`: the stable internal Nginx hop used only on `zakup`, so
   belzakupki Caddy never needs to follow blue/green container names.
+- `docs/infrastructure-security-runbook.md`: tracked SSH/fail2ban policy and
+  scheduled private-listener/public-port auditing for all three quorum hosts.
 
 ## PKI
 

--- a/scripts/ha/check_host_security.sh
+++ b/scripts/ha/check_host_security.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_WG_IP="${EXPECTED_WG_IP:-${1:-}}"
+HOST_LABEL="${HOST_LABEL:-${2:-$(hostname -s)}}"
+EXPECTED_LISTEN_PORTS="${EXPECTED_LISTEN_PORTS:-${3:-2379,2380}}"
+EXPECTED_LISTEN_PORTS="${EXPECTED_LISTEN_PORTS//,/ }"
+SENSITIVE_TCP_PORTS="${SENSITIVE_TCP_PORTS:-2379 2380 5432 8008 18000 18001 18002 18080}"
+FAIL2BAN_JAIL="${FAIL2BAN_JAIL:-sshd}"
+
+failures=0
+
+log() {
+  printf '[host-security][%s] host=%s %s\n' "$1" "${HOST_LABEL}" "$2"
+}
+
+fail() {
+  failures=$((failures + 1))
+  log fail "$*"
+}
+
+ok() {
+  log ok "$*"
+}
+
+is_port_listed() {
+  local expected="$1"
+  local value
+  for value in ${SENSITIVE_TCP_PORTS}; do
+    [[ "${value}" == "${expected}" ]] && return 0
+  done
+  return 1
+}
+
+[[ "${EXPECTED_WG_IP}" =~ ^10\.77\.0\.[0-9]+$ ]] || {
+  log fail "EXPECTED_WG_IP must be an MVN WireGuard IPv4 address"
+  exit 2
+}
+for value in ${EXPECTED_LISTEN_PORTS} ${SENSITIVE_TCP_PORTS}; do
+  [[ "${value}" =~ ^[0-9]+$ ]] || {
+    log fail "port lists must contain only integers"
+    exit 2
+  }
+done
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  PRIVILEGED=()
+else
+  command -v sudo >/dev/null 2>&1 || {
+    log fail "root or passwordless sudo is required"
+    exit 2
+  }
+  sudo -n true >/dev/null 2>&1 || {
+    log fail "passwordless sudo is required"
+    exit 2
+  }
+  PRIVILEGED=(sudo -n)
+fi
+
+for command in systemctl ss wg fail2ban-client; do
+  command -v "${command}" >/dev/null 2>&1 || fail "required command is missing: ${command}"
+done
+SSHD_BIN="$(command -v sshd || true)"
+[[ -n "${SSHD_BIN}" ]] || SSHD_BIN=/usr/sbin/sshd
+[[ -x "${SSHD_BIN}" ]] || fail "sshd executable is missing"
+
+if (( failures > 0 )); then
+  log summary "status=failed failures=${failures}"
+  exit 1
+fi
+
+effective_sshd="$("${PRIVILEGED[@]}" "${SSHD_BIN}" -T)"
+setting() {
+  local name="$1"
+  awk -v key="${name}" '$1 == key {print $2; exit}' <<< "${effective_sshd}"
+}
+
+expect_setting() {
+  local name="$1"
+  local expected="$2"
+  local actual
+  actual="$(setting "${name}")"
+  if [[ "${actual}" == "${expected}" ]]; then
+    ok "sshd ${name}=${actual}"
+  else
+    fail "sshd ${name}=${actual:-<empty>} expected=${expected}"
+  fi
+}
+
+expect_setting logingracetime 30
+expect_setting maxstartups 20:30:40
+expect_setting persourcemaxstartups 10
+expect_setting pubkeyauthentication yes
+expect_setting passwordauthentication no
+expect_setting kbdinteractiveauthentication no
+permit_root="$(setting permitrootlogin)"
+if [[ "${permit_root}" == "without-password" || "${permit_root}" == "prohibit-password" ]]; then
+  ok "sshd permitrootlogin=${permit_root}"
+else
+  fail "sshd permitrootlogin=${permit_root:-<empty>} expected key-only root"
+fi
+
+if systemctl is-active --quiet fail2ban.service; then
+  ok "fail2ban service is active"
+else
+  fail "fail2ban service is not active"
+fi
+if "${PRIVILEGED[@]}" fail2ban-client status "${FAIL2BAN_JAIL}" >/dev/null 2>&1; then
+  ok "fail2ban jail ${FAIL2BAN_JAIL} is active"
+else
+  fail "fail2ban jail ${FAIL2BAN_JAIL} is not active"
+fi
+
+check_fail2ban_value() {
+  local key="$1"
+  local expected="$2"
+  local actual
+  actual="$("${PRIVILEGED[@]}" fail2ban-client get "${FAIL2BAN_JAIL}" "${key}" 2>/dev/null || true)"
+  if [[ "${actual}" == "${expected}" ]]; then
+    ok "fail2ban ${key}=${actual}"
+  else
+    fail "fail2ban ${key}=${actual:-<empty>} expected=${expected}"
+  fi
+}
+
+check_fail2ban_value maxretry 5
+check_fail2ban_value findtime 600
+check_fail2ban_value bantime 3600
+ignore_output="$("${PRIVILEGED[@]}" fail2ban-client get "${FAIL2BAN_JAIL}" ignoreip 2>/dev/null || true)"
+for expected_network in 127.0.0.0/8 ::1 10.77.0.0/29; do
+  if grep -Fq -- "${expected_network}" <<< "${ignore_output}"; then
+    ok "fail2ban ignores ${expected_network}"
+  else
+    fail "fail2ban ignoreip is missing ${expected_network}"
+  fi
+done
+
+if "${PRIVILEGED[@]}" wg show wg-mvn >/dev/null 2>&1; then
+  ok "WireGuard interface wg-mvn is active"
+else
+  fail "WireGuard interface wg-mvn is not active"
+fi
+
+declare -A found_ports=()
+while read -r _state _recv_q _send_q local_endpoint _peer_endpoint; do
+  port="${local_endpoint##*:}"
+  is_port_listed "${port}" || continue
+  found_ports["${port}"]=true
+  address="${local_endpoint%:*}"
+  address="${address#[}"
+  address="${address%]}"
+  case "${address}" in
+    127.0.0.1|::1|"${EXPECTED_WG_IP}")
+      ok "listener ${address}:${port} is private"
+      ;;
+    *)
+      fail "sensitive listener ${local_endpoint} is not loopback/WireGuard-only"
+      ;;
+  esac
+done < <(ss -H -lnt)
+
+for port in ${EXPECTED_LISTEN_PORTS}; do
+  [[ "${found_ports[${port}]:-}" == "true" ]] || fail "expected private listener is missing: ${port}"
+done
+
+if (( failures > 0 )); then
+  log summary "status=failed failures=${failures}"
+  exit 1
+fi
+log summary "status=passed failures=0"

--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -78,6 +78,7 @@ EXPECTED_WORKFLOWS = (
     ExpectedWorkflow("API HA Invariant Check", max_age_hours=8),
     ExpectedWorkflow("API HA Readiness Audit", max_age_hours=8),
     ExpectedWorkflow("API VPS Health Check", max_age_hours=8),
+    ExpectedWorkflow("Infrastructure Security Check", max_age_hours=8),
     ExpectedWorkflow("Media CDN Check", max_age_hours=8),
     ExpectedWorkflow("PostgreSQL Replication Check", max_age_hours=8),
     ExpectedWorkflow("Cloudflare LB Config Check", max_age_hours=8),

--- a/tests/unit/test_host_security_assets.py
+++ b/tests/unit/test_host_security_assets.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import yaml
+
+from scripts.ha import report_ha_status
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SSHD_CONFIG = REPO_ROOT / "deploy/ha/security/00-mvn-cicd-reliability.conf"
+FAIL2BAN_CONFIG = REPO_ROOT / "deploy/ha/security/mvn-sshd.local"
+CHECK_SCRIPT = REPO_ROOT / "scripts/ha/check_host_security.sh"
+WORKFLOW = REPO_ROOT / ".github/workflows/check-infrastructure-security.yml"
+
+
+def test_security_configs_disable_password_login_and_protect_wireguard_clients():
+    sshd = SSHD_CONFIG.read_text(encoding="utf-8")
+    fail2ban = FAIL2BAN_CONFIG.read_text(encoding="utf-8")
+
+    assert "PasswordAuthentication no" in sshd
+    assert "KbdInteractiveAuthentication no" in sshd
+    assert "PermitRootLogin prohibit-password" in sshd
+    assert "MaxStartups 20:30:40" in sshd
+    assert "PerSourceMaxStartups 10" in sshd
+    assert "backend = systemd" in fail2ban
+    assert "ignoreip = 127.0.0.1/8 ::1 10.77.0.0/29" in fail2ban
+
+
+def test_host_checker_covers_effective_config_and_private_listener_ownership():
+    script = CHECK_SCRIPT.read_text(encoding="utf-8")
+
+    assert "sshd" in script and "-T" in script
+    assert "fail2ban-client get" in script
+    assert "wg show wg-mvn" in script
+    assert "SENSITIVE_TCP_PORTS" in script
+    assert "sensitive listener" in script
+    assert "status=passed failures=0" in script
+
+
+def test_security_workflow_checks_three_hosts_and_alerts():
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    job = workflow["jobs"]["check"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    assert workflow["on"]["schedule"][0]["cron"] == "37 */6 * * *"
+    audit = steps["Audit host hardening and private listeners"]["run"]
+    assert "labels=(mvn-api zakup mvn-web)" in audit
+    assert "scripts/ha/check_host_security.sh" in audit
+    assert "API_DB_HA_MODE" in audit
+    public_scan = steps["Verify sensitive ports are closed publicly"]["run"]
+    assert "2379 2380 5432 8008 18000 18001 18002 18080" in public_scan
+    assert steps["Upload security audit log"]["if"] == "always()"
+    assert steps["Notify HA failure"]["if"] == "failure()"
+
+
+def test_security_workflow_is_part_of_the_strict_ha_rollup():
+    expected = {workflow.name: workflow for workflow in report_ha_status.EXPECTED_WORKFLOWS}
+
+    assert expected["Infrastructure Security Check"].max_age_hours == 8


### PR DESCRIPTION
## Summary
- track the effective SSH and fail2ban policy used by all three HA hosts
- add a six-hour three-host audit for SSH, fail2ban, WireGuard, private listeners, and public sensitive ports
- include the security check in the strict HA rollup and document safe apply/rollback

## Validation
- `84` focused HA/security unit tests passed
- `shellcheck scripts/ha/check_host_security.sh`
- `actionlint .github/workflows/check-infrastructure-security.yml`
- checker passed live on `mvn-api`, `zakup`, and `mvn-web`
- new independent SSH session passed after correcting fail2ban drift on `mvn-web`