### PR TITLE
Use privileged web identity for security audit

### DIFF
--- a/.github/workflows/check-infrastructure-security.yml
+++ b/.github/workflows/check-infrastructure-security.yml
@@ -61,7 +61,7 @@ jobs:
           RESERVE_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
           RESERVE_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
           WEB_HOST: ${{ secrets.SSH_HOST_WEB }}
-          WEB_USER: ${{ secrets.SSH_USER_WEB }}
+          WEB_USER: ${{ vars.INFRA_SECURITY_WEB_USER || 'root' }}
         run: |
           set -euo pipefail
           SSH_OPTIONS=(

--- a/docs/infrastructure-security-runbook.md
+++ b/docs/infrastructure-security-runbook.md
@@ -91,6 +91,12 @@ alert on failure. It is included in `scripts/ha/report_ha_status.py`, so a stale
 or failed security check makes the aggregate reliability report require
 attention.
 
+The web deployment continues to use `SSH_USER_WEB` (normally `deploy`). The
+security audit uses repository variable `INFRA_SECURITY_WEB_USER`, defaulting
+to `root`, because reading fail2ban's control socket requires privilege. Keep
+these identities separate; do not grant the web deploy user broad sudo merely
+to satisfy monitoring.
+
 ## Rollback
 
 If `sshd -t` or `fail2ban-client -t` fails, do not reload either service.

--- a/tests/unit/test_host_security_assets.py
+++ b/tests/unit/test_host_security_assets.py
@@ -46,6 +46,8 @@ def test_security_workflow_checks_three_hosts_and_alerts():
     assert "labels=(mvn-api zakup mvn-web)" in audit
     assert "scripts/ha/check_host_security.sh" in audit
     assert "API_DB_HA_MODE" in audit
+    audit_env = steps["Audit host hardening and private listeners"]["env"]
+    assert "INFRA_SECURITY_WEB_USER" in audit_env["WEB_USER"]
     public_scan = steps["Verify sensitive ports are closed publicly"]["run"]
     assert "2379 2380 5432 8008 18000 18001 18002 18080" in public_scan
     assert steps["Upload security audit log"]["if"] == "always()"


### PR DESCRIPTION
## Summary
- keep web deployment on its unprivileged deploy identity
- run the fail2ban/SSH security audit as the dedicated `INFRA_SECURITY_WEB_USER` (default `root`)
- document why broad sudo is not granted to the deploy user

## Evidence
- first production workflow reached and passed both API hosts, then failed only because `deploy` correctly lacked passwordless sudo on the web host
- the CI key fingerprint is authorized for both deploy and root on the web host
- `4` focused tests and `actionlint` pass