### PR TITLE
Make Patroni HA audits role-aware

### DIFF
--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -38,6 +38,7 @@ jobs:
           STANDBY_ORIGIN: ${{ github.event.inputs.standby_origin || vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
           PRIMARY_ROLE: primary
           STANDBY_ROLE: standby
+          DISCOVER_PRIMARY_FROM_READY: ${{ vars.API_DB_HA_MODE == 'patroni' && 'true' || 'false' }}
           CHECK_PUBLIC_READY: "false"
         run: bash scripts/ha/check_active_passive.sh | tee api-ha-invariant.log
 

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Run API HA readiness audit
         env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}

--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -44,6 +44,7 @@ jobs:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
         run: |
           set -euo pipefail
           if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
@@ -54,18 +55,25 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/api_vps_health_key
           chmod 600 ~/.ssh/api_vps_health_key
-          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          for host in "${SSH_HOST_API}" "${API_STANDBY_HOST}"; do
+            ssh-keyscan -T 10 -H "${host}" >> ~/.ssh/known_hosts
+          done
 
       - name: Run API VPS Health Check
         env:
           BASE_URL: https://api.mvn.by
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           BACKUP_MAX_AGE_HOURS: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}
           CHECK_BACKUPS: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}
           SKIP_PUBLIC_CHECKS: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh' }}
           API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
           API_SSH_USER: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
           API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+          API_STANDBY_COMPOSE_FILE: ${{ vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.reserve.yml' }}
           API_COMPOSE_SERVICE_CHECKS: ${{ vars.API_COMPOSE_SERVICE_CHECKS || vars.API_SMOKE_COMPOSE_SERVICE_CHECKS || 'app bot db' }}
           API_LOCAL_HEALTH_URL: ${{ vars.API_LOCAL_HEALTH_URL || 'http://127.0.0.1:18080/api/health' }}
         run: |
@@ -75,7 +83,41 @@ jobs:
           if [ "${mode}" = "public-only" ]; then
             bash scripts/check_api_vps_health.sh --public-only | tee api-vps-health.log
           else
-            API_SSH_KEY_PATH="${HOME}/.ssh/api_vps_health_key" bash scripts/check_api_vps_health.sh | tee api-vps-health.log
+            target_host="${API_SSH_HOST}"
+            target_user="${API_SSH_USER}"
+            target_project_dir="${API_PROJECT_DIR}"
+            target_compose_file="${API_COMPOSE_FILE}"
+            if [ "${API_DB_HA_MODE}" = "patroni" ]; then
+              export SSH_OPTS="-i ${HOME}/.ssh/api_vps_health_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+              primary_label="$(
+                API_NODE_SSH="${API_SSH_USER}@${API_SSH_HOST}" \
+                  RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}" \
+                  API_NODE_PROJECT_DIR="${API_PROJECT_DIR}" \
+                  RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}" \
+                  API_NODE_COMPOSE_FILE="${API_COMPOSE_FILE}" \
+                  RESERVE_NODE_COMPOSE_FILE="${API_STANDBY_COMPOSE_FILE}" \
+                  python3 scripts/ha/check_patroni_production.py --resolve-primary
+              )"
+              if [ "${primary_label}" = "reserve" ]; then
+                target_host="${API_STANDBY_HOST}"
+                target_user="${API_STANDBY_USER}"
+                target_project_dir="${API_STANDBY_PROJECT_DIR}"
+                target_compose_file="${API_STANDBY_COMPOSE_FILE}"
+              elif [ "${primary_label}" != "api" ]; then
+                echo "::error::Unexpected Patroni primary label: ${primary_label:-empty}"
+                exit 1
+              fi
+            elif [ "${API_DB_HA_MODE}" != "physical" ]; then
+              echo "::error::API_DB_HA_MODE must be physical or patroni"
+              exit 1
+            fi
+
+            API_SSH_HOST="${target_host}" \
+              API_SSH_USER="${target_user}" \
+              API_PROJECT_DIR="${target_project_dir}" \
+              API_COMPOSE_FILE="${target_compose_file}" \
+              API_SSH_KEY_PATH="${HOME}/.ssh/api_vps_health_key" \
+              bash scripts/check_api_vps_health.sh | tee api-vps-health.log
           fi
 
       - name: Write Summary

--- a/.github/workflows/report-ha-status.yml
+++ b/.github/workflows/report-ha-status.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HA_EXTERNAL_METADATA_SOURCE: env
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           API_PRIMARY_ORIGIN: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
           API_STANDBY_ORIGIN: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}
           API_HA_READINESS_STRICT: ${{ vars.API_HA_READINESS_STRICT || 'false' }}

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -73,6 +73,13 @@ Never copy `ca-private/ca.key` to a server. Keep it offline after the three node
 certificates are installed. A lost node key can then be replaced without
 replacing the cluster CA.
 
+Before distribution, inspect `ca.crt` and require both critical extensions:
+`Basic Constraints: CA:TRUE` and `Key Usage: Certificate Sign, CRL Sign`.
+Validate the exact production Patroni image against every live etcd endpoint
+with this CA before opening the PostgreSQL cutover window. `etcdctl` accepting a
+certificate is not sufficient because Patroni's Python/OpenSSL client applies
+stricter CA validation.
+
 ## Installation Gate
 
 Before installation:

--- a/scripts/ha/check_active_passive.sh
+++ b/scripts/ha/check_active_passive.sh
@@ -8,6 +8,7 @@ STANDBY_ORIGIN="${STANDBY_ORIGIN:-193.47.42.213}"
 PRIMARY_ROLE="${PRIMARY_ROLE:-primary}"
 STANDBY_ROLE="${STANDBY_ROLE:-standby}"
 CHECK_PUBLIC_READY="${CHECK_PUBLIC_READY:-true}"
+DISCOVER_PRIMARY_FROM_READY="${DISCOVER_PRIMARY_FROM_READY:-false}"
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-15}"
 READY_RETRIES="${READY_RETRIES:-3}"
@@ -139,9 +140,61 @@ check_ready_with_retries() {
   return 1
 }
 
+discover_primary_origin() {
+  local configured_primary_file="$1"
+  local configured_standby_file="$2"
+  local attempt primary_code standby_code swap
+
+  for attempt in $(seq 1 "${READY_RETRIES}"); do
+    primary_code="$(
+      curl_json \
+        "configured primary origin discovery" \
+        "https://${API_HOST}/api/ready" \
+        "${configured_primary_file}" \
+        --resolve "${API_HOST}:443:${PRIMARY_ORIGIN}" \
+        || true
+    )"
+    standby_code="$(
+      curl_json \
+        "configured standby origin discovery" \
+        "https://${API_HOST}/api/ready" \
+        "${configured_standby_file}" \
+        --resolve "${API_HOST}:443:${STANDBY_ORIGIN}" \
+        || true
+    )"
+
+    if [[ "${primary_code}" == "200" && "${standby_code}" == "200" ]]; then
+      log "both origins returned HTTP 200 during discovery; split-brain risk"
+      return 1
+    fi
+    if [[ "${primary_code}" == "200" && "${standby_code}" != "200" ]]; then
+      log "discovered active origin=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN}"
+      return 0
+    fi
+    if [[ "${primary_code}" != "200" && "${standby_code}" == "200" ]]; then
+      swap="${PRIMARY_ORIGIN}"
+      PRIMARY_ORIGIN="${STANDBY_ORIGIN}"
+      STANDBY_ORIGIN="${swap}"
+      log "discovered active origin=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN}"
+      return 0
+    fi
+
+    log "origin discovery attempt ${attempt}/${READY_RETRIES} found no ready origin: configured_primary=${primary_code:-curl_failed} configured_standby=${standby_code:-curl_failed}"
+    if (( attempt < READY_RETRIES )); then
+      sleep "${READY_RETRY_SLEEP}"
+    fi
+  done
+
+  return 1
+}
+
 public_file="${TMP_DIR}/public-ready.json"
 primary_file="${TMP_DIR}/primary-ready.json"
 standby_file="${TMP_DIR}/standby-ready.json"
+
+if is_true "${DISCOVER_PRIMARY_FROM_READY}"; then
+  discover_primary_origin "${primary_file}" "${standby_file}"
+fi
 
 if is_true "${CHECK_PUBLIC_READY}"; then
   check_ready_with_retries "public ready" "${PUBLIC_BASE_URL%/}/api/ready" "${public_file}" "${PRIMARY_ROLE}" ready

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -18,6 +18,17 @@ PRIMARY_PROJECT_DIR="${PRIMARY_PROJECT_DIR:-${API_PROJECT_DIR:-/opt/air-api}}"
 PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE:-${API_COMPOSE_FILE:-docker-compose.prod.yml}}"
 STANDBY_PROJECT_DIR="${STANDBY_PROJECT_DIR:-${API_STANDBY_PROJECT_DIR:-/opt/mvn-reserve}}"
 STANDBY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE:-${API_STANDBY_COMPOSE_FILE:-docker-compose.reserve.yml}}"
+API_DB_HA_MODE="${API_DB_HA_MODE:-physical}"
+
+# Preserve node identity for Patroni checks before role-based variables are swapped.
+API_NODE_SSH="${API_NODE_SSH:-${PRIMARY_SSH}}"
+RESERVE_NODE_SSH="${RESERVE_NODE_SSH:-${STANDBY_SSH}}"
+API_NODE_PROJECT_DIR="${API_NODE_PROJECT_DIR:-${PRIMARY_PROJECT_DIR}}"
+RESERVE_NODE_PROJECT_DIR="${RESERVE_NODE_PROJECT_DIR:-${STANDBY_PROJECT_DIR}}"
+API_NODE_COMPOSE_FILE="${API_NODE_COMPOSE_FILE:-${PRIMARY_COMPOSE_FILE}}"
+RESERVE_NODE_COMPOSE_FILE="${RESERVE_NODE_COMPOSE_FILE:-${STANDBY_COMPOSE_FILE}}"
+CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"
+CONFIGURED_STANDBY_ORIGIN="${STANDBY_ORIGIN}"
 
 EXPECTED_CDN_BASE="${EXPECTED_CDN_BASE:-https://cdn.mvn.by}"
 MIN_DB_CDN_URLS="${MIN_DB_CDN_URLS:-3}"
@@ -102,13 +113,23 @@ run_active_passive() {
 }
 
 run_postgres_replication() {
-  PRIMARY_SSH="${PRIMARY_SSH}" \
-    STANDBY_SSH="${STANDBY_SSH}" \
-    PRIMARY_PROJECT_DIR="${PRIMARY_PROJECT_DIR}" \
-    PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE}" \
-    STANDBY_PROJECT_DIR="${STANDBY_PROJECT_DIR}" \
-    STANDBY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE}" \
-    bash scripts/ha/check_postgres_replication.sh
+  if [[ "${API_DB_HA_MODE}" == "patroni" ]]; then
+    API_NODE_SSH="${API_NODE_SSH}" \
+      RESERVE_NODE_SSH="${RESERVE_NODE_SSH}" \
+      API_NODE_PROJECT_DIR="${API_NODE_PROJECT_DIR}" \
+      RESERVE_NODE_PROJECT_DIR="${RESERVE_NODE_PROJECT_DIR}" \
+      API_NODE_COMPOSE_FILE="${API_NODE_COMPOSE_FILE}" \
+      RESERVE_NODE_COMPOSE_FILE="${RESERVE_NODE_COMPOSE_FILE}" \
+      python3 scripts/ha/check_patroni_production.py
+  else
+    PRIMARY_SSH="${PRIMARY_SSH}" \
+      STANDBY_SSH="${STANDBY_SSH}" \
+      PRIMARY_PROJECT_DIR="${PRIMARY_PROJECT_DIR}" \
+      PRIMARY_COMPOSE_FILE="${PRIMARY_COMPOSE_FILE}" \
+      STANDBY_PROJECT_DIR="${STANDBY_PROJECT_DIR}" \
+      STANDBY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE}" \
+      bash scripts/ha/check_postgres_replication.sh
+  fi
 }
 
 run_media_cdn_db() {
@@ -149,8 +170,8 @@ run_cloudflare_lb() {
   fi
 
   CF_LB_HOSTNAME="${CF_LB_HOSTNAME:-${API_HOST}}" \
-    CF_LB_PRIMARY_ORIGIN="${CF_LB_PRIMARY_ORIGIN:-${PRIMARY_ORIGIN}}" \
-    CF_LB_STANDBY_ORIGIN="${CF_LB_STANDBY_ORIGIN:-${STANDBY_ORIGIN}}" \
+    CF_LB_PRIMARY_ORIGIN="${CF_LB_PRIMARY_ORIGIN:-${CONFIGURED_PRIMARY_ORIGIN}}" \
+    CF_LB_STANDBY_ORIGIN="${CF_LB_STANDBY_ORIGIN:-${CONFIGURED_STANDBY_ORIGIN}}" \
     CF_LB_HOST_HEADER="${CF_LB_HOST_HEADER:-${API_HOST}}" \
     CF_LB_MONITOR_PATH="${CF_LB_MONITOR_PATH:-/api/ready}" \
     CF_LB_MONITOR_METHOD="${CF_LB_MONITOR_METHOD:-GET}" \
@@ -160,7 +181,40 @@ run_cloudflare_lb() {
     python3 scripts/ha/check_cloudflare_lb_config.py
 }
 
-log info "strict=${HA_READINESS_STRICT} primary=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN} primary_ssh=${PRIMARY_SSH} standby_ssh=${STANDBY_SSH}"
+case "${API_DB_HA_MODE}" in
+  patroni)
+    if ! patroni_primary_label="$(
+      API_NODE_SSH="${API_NODE_SSH}" \
+        RESERVE_NODE_SSH="${RESERVE_NODE_SSH}" \
+        API_NODE_PROJECT_DIR="${API_NODE_PROJECT_DIR}" \
+        RESERVE_NODE_PROJECT_DIR="${RESERVE_NODE_PROJECT_DIR}" \
+        API_NODE_COMPOSE_FILE="${API_NODE_COMPOSE_FILE}" \
+        RESERVE_NODE_COMPOSE_FILE="${RESERVE_NODE_COMPOSE_FILE}" \
+        python3 scripts/ha/check_patroni_production.py --resolve-primary
+    )"; then
+      log fail "could not resolve current Patroni primary"
+      exit 1
+    fi
+    if [[ "${patroni_primary_label}" == "reserve" ]]; then
+      swap="${PRIMARY_SSH}"; PRIMARY_SSH="${STANDBY_SSH}"; STANDBY_SSH="${swap}"
+      swap="${PRIMARY_PROJECT_DIR}"; PRIMARY_PROJECT_DIR="${STANDBY_PROJECT_DIR}"; STANDBY_PROJECT_DIR="${swap}"
+      swap="${PRIMARY_COMPOSE_FILE}"; PRIMARY_COMPOSE_FILE="${STANDBY_COMPOSE_FILE}"; STANDBY_COMPOSE_FILE="${swap}"
+      swap="${PRIMARY_ORIGIN}"; PRIMARY_ORIGIN="${STANDBY_ORIGIN}"; STANDBY_ORIGIN="${swap}"
+    elif [[ "${patroni_primary_label}" != "api" ]]; then
+      log fail "unexpected Patroni primary label: ${patroni_primary_label:-<empty>}"
+      exit 1
+    fi
+    ;;
+  physical)
+    patroni_primary_label=physical
+    ;;
+  *)
+    log fail "API_DB_HA_MODE must be physical or patroni"
+    exit 1
+    ;;
+esac
+
+log info "strict=${HA_READINESS_STRICT} ha_mode=${API_DB_HA_MODE} primary_label=${patroni_primary_label} primary=${PRIMARY_ORIGIN} standby=${STANDBY_ORIGIN} primary_ssh=${PRIMARY_SSH} standby_ssh=${STANDBY_SSH}"
 
 if is_true "${CHECK_ACTIVE_PASSIVE}"; then
   run_required "active_passive_invariant" run_active_passive

--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -357,7 +357,7 @@ def _check_postgres(
     replication_sql = """
 select
   coalesce(application_name, ''),
-  coalesce(client_addr::text, ''),
+  coalesce(host(client_addr), ''),
   coalesce(state, ''),
   coalesce(sync_state, ''),
   coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)::bigint, -1)

--- a/scripts/ha/generate_etcd_pki.sh
+++ b/scripts/ha/generate_etcd_pki.sh
@@ -53,13 +53,32 @@ umask 077
 mkdir -p "${OUTPUT_DIR}/ca-private" "${OUTPUT_DIR}/nodes" "${OUTPUT_DIR}/operator"
 ca_key="${OUTPUT_DIR}/ca-private/ca.key"
 ca_cert="${OUTPUT_DIR}/ca.crt"
+ca_config="${OUTPUT_DIR}/.ca.cnf"
+
+cat > "${ca_config}" <<'EOF'
+[req]
+distinguished_name = dn
+prompt = no
+x509_extensions = ca_ext
+
+[dn]
+CN = MVN PostgreSQL HA etcd CA
+
+[ca_ext]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
+EOF
 
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out "${ca_key}" >/dev/null 2>&1
 openssl req -x509 -new -sha256 \
   -key "${ca_key}" \
   -out "${ca_cert}" \
   -days "${VALID_DAYS}" \
-  -subj "/CN=MVN PostgreSQL HA etcd CA" >/dev/null 2>&1
+  -config "${ca_config}" \
+  -extensions ca_ext >/dev/null 2>&1
+rm -f "${ca_config}"
 
 issue_certificate() {
   local name="$1"

--- a/scripts/ha/report_ha_status.py
+++ b/scripts/ha/report_ha_status.py
@@ -247,6 +247,9 @@ def run_live_active_passive(
             "CHECK_PUBLIC_READY": "false",
             "PRIMARY_ORIGIN": primary_origin,
             "STANDBY_ORIGIN": standby_origin,
+            "DISCOVER_PRIMARY_FROM_READY": (
+                "true" if os.getenv("API_DB_HA_MODE", "physical") == "patroni" else "false"
+            ),
         }
     )
     actual_runner = runner

--- a/tests/unit/test_etcd_quorum_assets.py
+++ b/tests/unit/test_etcd_quorum_assets.py
@@ -54,6 +54,16 @@ def test_pki_generator_creates_distinct_valid_certificates(tmp_path):
     result = subprocess.run(["bash", str(GENERATE)], env=env, text=True, capture_output=True, check=False)
 
     assert result.returncode == 0, result.stderr
+    ca_text = subprocess.run(
+        ["openssl", "x509", "-in", str(output / "ca.crt"), "-noout", "-text"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert "X509v3 Basic Constraints: critical" in ca_text
+    assert "CA:TRUE" in ca_text
+    assert "X509v3 Key Usage: critical" in ca_text
+    assert "Certificate Sign, CRL Sign" in ca_text
     for node in ("mvn-api", "zakup", "mvn-web"):
         node_dir = output / "nodes" / node
         assert (node_dir / "ca.crt").is_file()

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -37,6 +38,7 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert "secrets.SSH_KEY" in ssh_step["env"]["SSH_KEY"]
     assert "CLOUDFLARE_LB_READ_TOKEN" in audit_step["env"]["CLOUDFLARE_API_TOKEN"]
     assert "POSTGRES_PITR_REQUIRED" in audit_step["env"]
+    assert "API_DB_HA_MODE" in audit_step["env"]
     assert audit_step["env"]["CHECK_PUBLIC_READY"] == "false"
     assert "scripts/ha/check_api_ha_readiness.sh" in audit_step["run"]
     assert "PRIMARY_SSH" in audit_step["run"]
@@ -47,9 +49,73 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert artifact_step["with"]["path"] == "api-ha-readiness.log"
 
 
+def test_ha_readiness_resolves_patroni_primary_and_uses_role_aware_monitor():
+    script = (REPO_ROOT / "scripts/ha/check_api_ha_readiness.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "check_patroni_production.py --resolve-primary" in script
+    assert "python3 scripts/ha/check_patroni_production.py" in script
+    assert 'API_DB_HA_MODE="${API_DB_HA_MODE:-physical}"' in script
+    assert 'CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"' in script
+
+
 def test_ha_invariant_workflow_skips_public_cloudflare_challenge_from_runner():
     workflow = _workflow(".github/workflows/check-api-ha-invariants.yml")
     check_step = next(step for step in workflow["jobs"]["check"]["steps"] if step.get("name") == "Run active-passive invariant check")
 
     assert check_step["env"]["CHECK_PUBLIC_READY"] == "false"
+    assert "API_DB_HA_MODE" in check_step["env"]["DISCOVER_PRIMARY_FROM_READY"]
     assert "scripts/ha/check_active_passive.sh" in check_step["run"]
+
+
+def test_active_passive_check_discovers_promoted_second_origin(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+output=''
+resolved=''
+while (( $# )); do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    --resolve) resolved="$2"; shift 2 ;;
+    -w|--connect-timeout|--max-time) shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "$resolved" == *':2.2.2.2' ]]; then
+  printf '%s' '{"status":"ok","api":"ready","app_role":"primary","traffic":"enabled","database":"online","database_writable":true}' > "$output"
+  printf '200'
+else
+  printf '%s' '{"status":"error","api":"not_ready","app_role":"standby","traffic":"disabled"}' > "$output"
+  printf '503'
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CHECK_PUBLIC_READY": "false",
+            "DISCOVER_PRIMARY_FROM_READY": "true",
+            "PRIMARY_ORIGIN": "1.1.1.1",
+            "STANDBY_ORIGIN": "2.2.2.2",
+            "READY_RETRIES": "1",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/ha/check_active_passive.sh")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "discovered active origin=2.2.2.2 standby=1.1.1.1" in result.stderr

--- a/tests/unit/test_ha_status_report_workflow.py
+++ b/tests/unit/test_ha_status_report_workflow.py
@@ -31,6 +31,7 @@ def test_ha_status_report_workflow_runs_scheduled_operator_rollup():
     run = report_step["run"]
     assert env["GH_TOKEN"] == "${{ github.token }}"
     assert env["HA_EXTERNAL_METADATA_SOURCE"] == "env"
+    assert "vars.API_DB_HA_MODE" in env["API_DB_HA_MODE"]
     assert "secrets.CLOUDFLARE_LB_READ_TOKEN" in env["CLOUDFLARE_LB_READ_TOKEN"]
     assert "vars.CLOUDFLARE_ACCOUNT_ID" in env["CLOUDFLARE_ACCOUNT_ID"]
     assert "vars.POSTGRES_PITR_REQUIRED" in env["POSTGRES_PITR_REQUIRED"]

--- a/tests/unit/test_patroni_production_check.py
+++ b/tests/unit/test_patroni_production_check.py
@@ -114,6 +114,15 @@ def test_sql_row_parser_is_strict():
         _parse_rows("too|few", 5)
 
 
+def test_patroni_monitor_strips_inet_netmask_in_sql():
+    source = (REPO_ROOT / "scripts/ha/check_patroni_production.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "host(client_addr)" in source
+    assert "client_addr::text" not in source
+
+
 def test_cluster_view_accepts_replica_role_but_requires_sync_endpoint():
     api, reserve = _nodes()
     config = CheckerConfig(
@@ -202,3 +211,22 @@ def test_pitr_workflow_resolves_the_current_patroni_primary():
     assert "target_label=reserve" in run
     assert "target_compose_file=docker-compose.patroni.yml" in run
     assert "API_DB_HA_MODE must be physical or patroni" in run
+
+
+def test_api_vps_health_workflow_targets_current_patroni_primary():
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/check-api-vps-health.yml").read_text(
+            encoding="utf-8"
+        ),
+        Loader=yaml.BaseLoader,
+    )
+    steps = workflow["jobs"]["check"]["steps"]
+    setup = next(step for step in steps if step.get("name") == "Setup API SSH Key")
+    check = next(step for step in steps if step.get("name") == "Run API VPS Health Check")
+
+    assert "API_STANDBY_HOST" in setup["env"]
+    assert '"${API_STANDBY_HOST}"' in setup["run"]
+    assert "API_DB_HA_MODE" in check["env"]
+    assert "check_patroni_production.py --resolve-primary" in check["run"]
+    assert 'target_host="${API_STANDBY_HOST}"' in check["run"]
+    assert "API_DB_HA_MODE must be physical or patroni" in check["run"]


### PR DESCRIPTION
## Summary
- issue etcd CA certificates with critical CA signing key usage and document exact Patroni TLS validation
- make readiness, invariant, status, and VPS health checks follow the current Patroni primary
- normalize PostgreSQL replication client addresses so `inet` netmasks do not cause false failures

## Production evidence
- Patroni cutover completed with `mvn-api` primary and `zakup` synchronous standby
- controlled switchover and switchback completed at zero replay lag
- exact Patroni image validated against all three TLS etcd endpoints
- local production readiness, media/PITR, and Cloudflare LB audits passed

## Tests
- `pytest tests/unit/test_patroni_production_check.py tests/unit/test_ha_readiness_workflow.py tests/unit/test_ha_status_report.py tests/unit/test_ha_status_report_workflow.py tests/unit/test_etcd_quorum_assets.py tests/unit/test_ha_alert_workflows.py -q`
- bash syntax and workflow YAML validation
- live `check_patroni_production.py` and role-aware readiness checks
