### PR TITLE
fix(ha): harden PITR restore and role reconciliation

### DIFF
--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -416,13 +416,14 @@ from pg_stat_wal_receiver;
         if not slot_name:
             report.fail(f"{standby.label}: WAL receiver has no replication slot")
         try:
-            receive_replay_lag = int(receive_replay_lag_raw)
+            # Replay may be ahead of the receiver after restart or archive recovery.
+            receive_replay_lag = max(0, int(receive_replay_lag_raw))
         except ValueError:
             report.fail(
                 f"{standby.label}: receive/replay lag is not numeric: {receive_replay_lag_raw!r}"
             )
         else:
-            if receive_replay_lag < 0 or receive_replay_lag > config.max_replay_lag_bytes:
+            if receive_replay_lag > config.max_replay_lag_bytes:
                 report.fail(
                     f"{standby.label}: receive/replay lag {receive_replay_lag} exceeds "
                     f"{config.max_replay_lag_bytes} bytes"

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -139,14 +139,20 @@ def _run_compose(config: AgentConfig, *args: str, check: bool = True) -> subproc
     )
 
 
-def _runtime_matches(config: AgentConfig, role: str, service: str) -> bool:
+def _running_services(config: AgentConfig) -> set[str]:
     result = _run_compose(config, "ps", "--status", "running", "--services", check=False)
     if result.returncode != 0:
-        return False
-    running = set(result.stdout.splitlines())
-    if service not in running:
-        return False
-    return ("bot" in running) == (role == "primary")
+        error = (result.stderr or result.stdout or "docker compose ps failed").strip()
+        raise RuntimeError(error)
+    return set(result.stdout.splitlines())
+
+
+def _start_service(config: AgentConfig, service: str, *, recreate: bool) -> None:
+    args = ["up", "-d", "--no-deps"]
+    if recreate:
+        args.append("--force-recreate")
+    args.append(service)
+    _run_compose(config, *args)
 
 
 def _systemd_units_match(config: AgentConfig, role: str) -> bool:
@@ -205,13 +211,40 @@ def reconcile(config: AgentConfig, role: str) -> bool:
     app_matches = config.app_role_env.exists() and config.app_role_env.read_text(encoding="utf-8") == desired_app
     bot_matches = config.bot_role_env.exists() and config.bot_role_env.read_text(encoding="utf-8") == desired_bot
     service = app_service(config)
-    if (
-        current_state == role
-        and app_matches
-        and bot_matches
-        and _runtime_matches(config, role, service)
-    ):
-        if not _systemd_units_match(config, role):
+    running = _running_services(config)
+    role_changed = current_state != role
+    app_env_changed = not app_matches
+    bot_env_changed = not bot_matches
+    app_running = service in running
+    bot_running = "bot" in running
+    bot_expected = role == "primary"
+    systemd_matches = _systemd_units_match(config, role)
+
+    reasons: list[str] = []
+    if role_changed:
+        reasons.append("role_state")
+    if app_env_changed:
+        reasons.append("app_env")
+    if bot_env_changed:
+        reasons.append("bot_env")
+    if not app_running:
+        reasons.append("app_not_running")
+    if bot_expected and not bot_running:
+        reasons.append("bot_not_running")
+    if not bot_expected and bot_running:
+        reasons.append("bot_running_on_standby")
+    if not systemd_matches:
+        reasons.append("systemd_units")
+
+    needs_runtime_reconcile = (
+        role_changed
+        or app_env_changed
+        or bot_env_changed
+        or not app_running
+        or bot_running != bot_expected
+    )
+    if not needs_runtime_reconcile:
+        if not systemd_matches:
             _reconcile_primary_systemd_units(config, role)
         return False
 
@@ -223,26 +256,54 @@ def reconcile(config: AgentConfig, role: str) -> bool:
             print("patroni_role_agent_status=deferred reason=deployment_lock_busy", flush=True)
             return False
 
-        if role == "primary" and config.promotion_delay_seconds:
+        if role == "primary" and role_changed and config.promotion_delay_seconds:
             time.sleep(config.promotion_delay_seconds)
             if fetch_patroni_role(config.patroni_url) != "primary":
                 print("patroni_role_agent_status=deferred reason=primary_role_not_stable", flush=True)
                 return False
 
-        _atomic_write(config.app_role_env, desired_app)
-        _atomic_write(config.bot_role_env, desired_bot)
-        if role == "standby":
-            _reconcile_primary_systemd_units(config, role)
-            _run_compose(config, "stop", "bot", check=False)
-            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
-        else:
-            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", service)
-            _wait_ready(config)
-            _run_compose(config, "up", "-d", "--no-deps", "--force-recreate", "bot")
-            _reconcile_primary_systemd_units(config, role)
+        actions: list[str] = []
+        if app_env_changed:
+            _atomic_write(config.app_role_env, desired_app)
+            actions.append("write_app_env")
+        if bot_env_changed:
+            _atomic_write(config.bot_role_env, desired_bot)
+            actions.append("write_bot_env")
 
-        _atomic_write(config.state_file, f"{role}\n")
-        print(f"patroni_role_agent_status=reconciled role={role} app_service={service}", flush=True)
+        app_needs_start = app_env_changed or not app_running
+        if role == "standby":
+            if not systemd_matches:
+                _reconcile_primary_systemd_units(config, role)
+                actions.append("stop_primary_units")
+            if bot_running:
+                _run_compose(config, "stop", "bot", check=False)
+                actions.append("stop_bot")
+            if app_needs_start:
+                _start_service(config, service, recreate=app_env_changed)
+                actions.append("recreate_app" if app_env_changed else "start_app")
+        else:
+            if app_needs_start:
+                _start_service(config, service, recreate=app_env_changed)
+                actions.append("recreate_app" if app_env_changed else "start_app")
+            bot_needs_start = bot_env_changed or not bot_running
+            if app_needs_start or bot_needs_start:
+                _wait_ready(config)
+                actions.append("wait_ready")
+            if bot_needs_start:
+                _start_service(config, "bot", recreate=bot_env_changed)
+                actions.append("recreate_bot" if bot_env_changed else "start_bot")
+            if not systemd_matches:
+                _reconcile_primary_systemd_units(config, role)
+                actions.append("start_primary_units")
+
+        if role_changed:
+            _atomic_write(config.state_file, f"{role}\n")
+            actions.append("write_role_state")
+        print(
+            f"patroni_role_agent_status=reconciled role={role} app_service={service} "
+            f"reasons={','.join(reasons)} actions={','.join(actions)}",
+            flush=True,
+        )
         return True
 
 

--- a/scripts/ha/restore_postgres_pitr_from_s3.py
+++ b/scripts/ha/restore_postgres_pitr_from_s3.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import sys
 import tarfile
 import tempfile
@@ -30,6 +31,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 WAL_NAME_RE = re.compile(
     r"^(?:[0-9A-F]{24}|[0-9A-F]{24}\.[0-9A-F]{8}\.backup|[0-9A-F]{8}\.history)$"
 )
+DEFAULT_WAL_SEGMENT_SIZE_BYTES = 16 * 1024 * 1024
+DEFAULT_MIN_FREE_BYTES = 1024 * 1024 * 1024
 
 
 def _load_python_module_from_path(module_name: str, path: Path) -> Any | None:
@@ -93,6 +96,13 @@ class BasebackupManifest:
     payload: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class WalObject:
+    key: str
+    filename: str
+    size_bytes: int
+
+
 def _read_s3_body(body: Any) -> bytes:
     data = body.read()
     if isinstance(data, str):
@@ -132,18 +142,202 @@ def _list_manifest_keys(client: Any, bucket: str, prefix: str) -> list[str]:
     return sorted(keys)
 
 
-def _list_wal_keys(client: Any, config: Any) -> list[str]:
+def _list_wal_objects(client: Any, config: Any) -> list[WalObject]:
     prefix = f"{config.key_prefix}/{config.cluster}/wal/"
     paginator = client.get_paginator("list_objects_v2")
-    keys: list[str] = []
+    objects: list[WalObject] = []
     for page in paginator.paginate(Bucket=config.bucket, Prefix=prefix):
         for item in page.get("Contents", []):
             key = str(item.get("Key") or "")
             filename = key.rsplit("/", 1)[-1]
             if key.endswith("/") or not WAL_NAME_RE.match(filename):
                 continue
-            keys.append(key)
-    return sorted(keys)
+            objects.append(
+                WalObject(
+                    key=key,
+                    filename=filename,
+                    size_bytes=int(item.get("Size") or 0),
+                )
+            )
+    return sorted(objects, key=lambda item: item.filename)
+
+
+def _parse_lsn(value: str) -> int:
+    try:
+        high, low = value.split("/", 1)
+        return (int(high, 16) << 32) + int(low, 16)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise SystemExit(f"Invalid WAL LSN in backup_manifest: {value!r}") from exc
+
+
+def _wal_segment_name(*, timeline: int, lsn: str, segment_size_bytes: int) -> str:
+    if (
+        segment_size_bytes <= 0
+        or segment_size_bytes > 0x100000000
+        or 0x100000000 % segment_size_bytes != 0
+    ):
+        raise SystemExit(
+            "WAL segment size must be a positive divisor of 2^32 bytes; "
+            f"got {segment_size_bytes}"
+        )
+    if timeline <= 0:
+        raise SystemExit(f"Invalid WAL timeline in backup_manifest: {timeline}")
+
+    segments_per_log = 0x100000000 // segment_size_bytes
+    segment_number = _parse_lsn(lsn) // segment_size_bytes
+    log = segment_number // segments_per_log
+    segment = segment_number % segments_per_log
+    return f"{timeline:08X}{log:08X}{segment:08X}"
+
+
+def _backup_manifest_entry(manifest: BasebackupManifest) -> dict[str, Any]:
+    for item in manifest.payload.get("files") or []:
+        if isinstance(item, dict) and item.get("name") == "backup_manifest":
+            if item.get("key"):
+                return item
+            break
+    raise SystemExit(
+        f"Basebackup {manifest.backup_id} has no backup_manifest file; "
+        "cannot select a safe WAL range"
+    )
+
+
+def _load_postgres_backup_manifest(
+    client: Any, bucket: str, manifest: BasebackupManifest
+) -> dict[str, Any]:
+    entry = _backup_manifest_entry(manifest)
+    response = client.get_object(Bucket=bucket, Key=str(entry["key"]))
+    try:
+        payload = json.loads(_read_s3_body(response["Body"]).decode("utf-8"))
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"Invalid PostgreSQL backup_manifest for {manifest.backup_id}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(
+            f"Invalid PostgreSQL backup_manifest for {manifest.backup_id}"
+        )
+    return payload
+
+
+def _backup_start_wal_name(
+    postgres_manifest: dict[str, Any], *, segment_size_bytes: int
+) -> str:
+    raw_ranges = postgres_manifest.get("WAL-Ranges")
+    if not isinstance(raw_ranges, list) or not raw_ranges:
+        raise SystemExit("PostgreSQL backup_manifest has no WAL-Ranges")
+
+    starts: list[tuple[int, int, str]] = []
+    for item in raw_ranges:
+        if not isinstance(item, dict):
+            raise SystemExit("PostgreSQL backup_manifest has an invalid WAL-Ranges entry")
+        try:
+            timeline = int(item.get("Timeline"))
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(
+                f"Invalid WAL timeline in backup_manifest: {item.get('Timeline')!r}"
+            ) from exc
+        start_lsn = str(item.get("Start-LSN") or "")
+        starts.append((timeline, _parse_lsn(start_lsn), start_lsn))
+
+    timeline, _numeric_lsn, start_lsn = min(starts)
+    return _wal_segment_name(
+        timeline=timeline,
+        lsn=start_lsn,
+        segment_size_bytes=segment_size_bytes,
+    )
+
+
+def _wal_position(filename: str) -> tuple[int, int, int] | None:
+    if filename.endswith(".history"):
+        return None
+    base = filename[:24]
+    if len(base) != 24:
+        return None
+    try:
+        return int(base[:8], 16), int(base[8:16], 16), int(base[16:24], 16)
+    except ValueError:
+        return None
+
+
+def _select_wal_objects(
+    objects: list[WalObject], *, start_wal_name: str
+) -> list[WalObject]:
+    start_position = _wal_position(start_wal_name)
+    if start_position is None:
+        raise SystemExit(f"Invalid start WAL filename: {start_wal_name}")
+    start_timeline = start_position[0]
+
+    selected: list[WalObject] = []
+    for item in objects:
+        if item.filename.endswith(".history"):
+            try:
+                history_timeline = int(item.filename[:8], 16)
+            except ValueError:
+                continue
+            if history_timeline >= start_timeline:
+                selected.append(item)
+            continue
+
+        position = _wal_position(item.filename)
+        if position is not None and position >= start_position:
+            selected.append(item)
+    return selected
+
+
+def _estimated_extracted_bytes(postgres_manifest: dict[str, Any]) -> int:
+    files = postgres_manifest.get("Files")
+    if not isinstance(files, list):
+        return 0
+    total = 0
+    for item in files:
+        if not isinstance(item, dict):
+            continue
+        try:
+            total += max(0, int(item.get("Size") or 0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _basebackup_download_bytes(files: list[Any]) -> int:
+    total = 0
+    for item in files:
+        if not isinstance(item, dict):
+            raise SystemExit(f"Basebackup manifest file entry is invalid: {item!r}")
+        try:
+            size_bytes = int(item.get("size_bytes"))
+        except (TypeError, ValueError) as exc:
+            raise SystemExit(
+                f"Basebackup manifest has invalid size_bytes: {item!r}"
+            ) from exc
+        if size_bytes < 0:
+            raise SystemExit(f"Basebackup manifest has negative size_bytes: {item!r}")
+        total += size_bytes
+    return total
+
+
+def _ensure_restore_space(
+    target_dir: Path,
+    *,
+    basebackup_bytes: int,
+    extracted_bytes: int,
+    wal_bytes: int,
+    min_free_bytes: int,
+) -> tuple[int, int]:
+    if min_free_bytes < 0:
+        raise SystemExit("PITR restore minimum free bytes must not be negative")
+    available_bytes = shutil.disk_usage(target_dir).free
+    restore_bytes = basebackup_bytes + extracted_bytes + wal_bytes
+    required_bytes = restore_bytes + min_free_bytes
+    if available_bytes < required_bytes:
+        raise SystemExit(
+            "Insufficient free space for PITR prepare: "
+            f"available_bytes={available_bytes} required_bytes={required_bytes} "
+            f"basebackup_bytes={basebackup_bytes} extracted_bytes={extracted_bytes} "
+            f"wal_bytes={wal_bytes} reserve_bytes={min_free_bytes}"
+        )
+    return available_bytes, required_bytes
 
 
 def _load_manifest(client: Any, bucket: str, key: str) -> BasebackupManifest:
@@ -294,14 +488,51 @@ def command_prepare(args: argparse.Namespace) -> int:
         target_time=target_time,
     )
 
+    files = manifest.payload.get("files") or []
+    if not isinstance(files, list) or not files:
+        raise SystemExit(f"Basebackup manifest has no files: {manifest.key}")
+
+    postgres_manifest = _load_postgres_backup_manifest(client, config.bucket, manifest)
+    start_wal_name = _backup_start_wal_name(
+        postgres_manifest,
+        segment_size_bytes=args.wal_segment_size_bytes,
+    )
+    wal_objects: list[WalObject] = []
+    if args.wal_mode == "local":
+        wal_objects = _select_wal_objects(
+            _list_wal_objects(client, config),
+            start_wal_name=start_wal_name,
+        )
+
+    basebackup_bytes = _basebackup_download_bytes(files)
+    extracted_bytes = _estimated_extracted_bytes(postgres_manifest)
+    wal_bytes = sum(item.size_bytes for item in wal_objects)
+    available_bytes, required_bytes = _ensure_restore_space(
+        target_dir,
+        basebackup_bytes=basebackup_bytes,
+        extracted_bytes=extracted_bytes,
+        wal_bytes=wal_bytes,
+        min_free_bytes=args.min_free_bytes,
+    )
+    print(
+        json.dumps(
+            {
+                "status": "preflight",
+                "backup_id": manifest.backup_id,
+                "start_wal": start_wal_name,
+                "selected_wal": len(wal_objects),
+                "selected_wal_bytes": wal_bytes,
+                "available_bytes": available_bytes,
+                "required_bytes": required_bytes,
+            },
+            sort_keys=True,
+        )
+    )
+
     downloads_dir = target_dir / "downloads"
     data_dir = target_dir / "data"
     downloads_dir.mkdir(parents=True)
     data_dir.mkdir(parents=True)
-
-    files = manifest.payload.get("files") or []
-    if not isinstance(files, list) or not files:
-        raise SystemExit(f"Basebackup manifest has no files: {manifest.key}")
 
     downloaded: list[Path] = []
     for item in files:
@@ -328,9 +559,8 @@ def command_prepare(args: argparse.Namespace) -> int:
     if args.wal_mode == "local":
         wal_dir = target_dir / "wal"
         wal_dir.mkdir(parents=True)
-        for key in _list_wal_keys(client, config):
-            filename = key.rsplit("/", 1)[-1]
-            _download_file(client, config.bucket, key, wal_dir / filename)
+        for item in wal_objects:
+            _download_file(client, config.bucket, item.key, wal_dir / item.filename)
             downloaded_wal += 1
 
     manifest_path = target_dir / "manifest.json"
@@ -353,6 +583,8 @@ def command_prepare(args: argparse.Namespace) -> int:
                 "data_dir": str(data_dir),
                 "downloaded_files": len(downloaded),
                 "downloaded_wal": downloaded_wal,
+                "downloaded_wal_bytes": wal_bytes,
+                "start_wal": start_wal_name,
                 "wal_mode": args.wal_mode,
             },
             sort_keys=True,
@@ -414,6 +646,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "local downloads archived WAL into target-dir/wal and writes a cp restore_command; "
             "remote writes a Python/R2 restore_command for containers that include this helper and boto3."
         ),
+    )
+    prepare.add_argument(
+        "--wal-segment-size-bytes",
+        type=int,
+        default=int(
+            os.getenv(
+                "POSTGRES_WAL_SEGMENT_SIZE_BYTES",
+                str(DEFAULT_WAL_SEGMENT_SIZE_BYTES),
+            )
+        ),
+        help="WAL segment size used to convert backup Start-LSN into a WAL filename.",
+    )
+    prepare.add_argument(
+        "--min-free-bytes",
+        type=int,
+        default=int(
+            os.getenv("PITR_RESTORE_MIN_FREE_BYTES", str(DEFAULT_MIN_FREE_BYTES))
+        ),
+        help="Free disk space that must remain after estimated download and extraction.",
     )
     prepare.add_argument(
         "--restore-mount-path",

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -14,6 +14,10 @@ BACKEND_IMAGE="${BACKEND_IMAGE:-}"
 SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-}"
 KEY_PATH="${RUNNER_TEMP:-/tmp}/mvn-patroni-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}.key"
 KNOWN_HOSTS_PATH="${KEY_PATH}.known_hosts"
+ROLE_AGENT_SOURCE="scripts/ha/patroni_role_agent.py"
+ROLE_AGENT_REMOTE="/tmp/mvn-patroni-role-agent-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}"
+ROLE_AGENT_TARGET="/usr/local/sbin/mvn-patroni-role-agent"
+ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
 
 log() {
   printf '[patroni-remote][%s] %s\n' "$1" "$2"
@@ -56,6 +60,10 @@ if [[ "${OPERATION}" == "deploy" ]]; then
   }
   [[ "${PROXY_MODE}" == "host_nginx" || "${PROXY_MODE}" == "container_nginx" ]] || {
     log error "API_NODE_PROXY_MODE must be host_nginx or container_nginx"
+    exit 1
+  }
+  [[ -f "${ROLE_AGENT_SOURCE}" ]] || {
+    log error "role agent source is missing: ${ROLE_AGENT_SOURCE}"
     exit 1
   }
 fi
@@ -113,6 +121,9 @@ scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
 scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
   scripts/ha/deploy_patroni_api_node.sh scripts/deploy_backend_blue_green.sh \
   "${REMOTE}:/tmp/"
+if [[ "${OPERATION}" == "deploy" ]]; then
+  scp "${SSH_OPTS[@]}" "${ROLE_AGENT_SOURCE}" "${REMOTE}:${ROLE_AGENT_REMOTE}"
+fi
 
 if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
   ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}/api-proxy")"
@@ -155,4 +166,14 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   ${proxy_env} \
   bash $(quote "${remote_script}")
 "
+if [[ "${OPERATION}" == "deploy" ]]; then
+  log agent "installing tested Patroni role agent on ${NODE_HOST}"
+  ssh "${SSH_OPTS[@]}" "${REMOTE}" "
+    set -euo pipefail
+    install -m 0755 $(quote "${ROLE_AGENT_REMOTE}") $(quote "${ROLE_AGENT_TARGET}")
+    rm -f $(quote "${ROLE_AGENT_REMOTE}")
+    systemctl restart $(quote "${ROLE_AGENT_UNIT}")
+    systemctl is-active --quiet $(quote "${ROLE_AGENT_UNIT}")
+  "
+fi
 log "done" "${OPERATION} completed on ${NODE_HOST}"

--- a/tests/unit/test_patroni_production_check.py
+++ b/tests/unit/test_patroni_production_check.py
@@ -10,6 +10,7 @@ from scripts.ha.check_patroni_production import (
     NodeConfig,
     Report,
     _check_cluster_views,
+    _check_postgres,
     _parse_rows,
     role_from_patroni,
     select_primary,
@@ -173,6 +174,47 @@ def test_cluster_view_accepts_replica_role_but_requires_sync_endpoint():
     report = Report()
     _check_cluster_views(config, runner, api, reserve, report)
     assert report.failures == ["reserve: Patroni /sync endpoint is not healthy"]
+
+
+def test_postgres_check_treats_negative_receiver_delta_as_zero_backlog():
+    api, reserve = _nodes()
+    config = CheckerConfig(
+        api=api,
+        reserve=reserve,
+        ssh_options=(),
+        max_replay_lag_bytes=1_048_576,
+        role_agent_unit="mvn-patroni-role-agent.service",
+        etcd_check_command="check-etcd",
+        ready_url="http://127.0.0.1:18080/api/ready",
+    )
+
+    class FakeRunner:
+        def run(self, node, command, *, stdin=None, check=True):
+            del command, check
+            statement = (stdin or "").strip()
+            if statement == "select pg_is_in_recovery();":
+                output = "f\n" if node == api else "t\n"
+            elif statement == "select system_identifier from pg_control_system();":
+                output = "7657288033494519840\n"
+            elif "from pg_stat_replication" in statement:
+                output = "zakup|10.77.0.1|streaming|sync|0\n"
+            elif "from pg_stat_wal_receiver" in statement:
+                output = "streaming|10.77.0.2|zakup|-10076160\n"
+            elif statement == "show synchronous_standby_names;":
+                output = "ANY 1 (zakup)\n"
+            elif statement == "show wal_log_hints;":
+                output = "on\n"
+            elif statement == "show archive_mode;":
+                output = "on\n"
+            else:
+                raise AssertionError(statement)
+            return subprocess.CompletedProcess([], 0, output, "")
+
+    report = Report()
+    _check_postgres(config, FakeRunner(), api, reserve, report)
+
+    assert report.failures == []
+    assert any("streams synchronously" in message for message in report.ok)
 
 
 def test_replication_workflow_switches_to_role_aware_patroni_monitoring():

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -15,6 +15,10 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert "run_patroni_migrations.sh" in text
     assert "deploy_patroni_api_node.sh" in text
     assert "deploy_backend_blue_green.sh" in text
+    assert "scripts/ha/patroni_role_agent.py" in text
+    assert "/usr/local/sbin/mvn-patroni-role-agent" in text
+    assert "systemctl restart" in text
+    assert "systemctl is-active --quiet" in text
     assert "API_PROXY_MODE=" in text
     assert "upstream.conf" in text
     assert "up -d db" not in text

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from scripts.ha import patroni_role_agent
 from scripts.ha.patroni_role_agent import AgentConfig, app_service, reconcile, role_env
 
@@ -133,3 +135,54 @@ def test_primary_only_systemd_units_follow_role_without_recreating_matching_runt
         ("systemctl", "is-active", "--quiet", "wal.timer"),
         ("systemctl", "start", "wal.timer"),
     ]
+
+
+def test_reconcile_primary_starts_missing_bot_without_recreating_app(
+    tmp_path, monkeypatch, capsys
+):
+    config = _config(tmp_path, app_service_override="app")
+    config.app_role_env.write_text(role_env("primary", bot_process=False), encoding="utf-8")
+    config.bot_role_env.write_text(role_env("primary", bot_process=True), encoding="utf-8")
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    calls: list[tuple[str, ...] | tuple[str]] = []
+
+    def fake_compose(_config, *args, check=True):
+        calls.append(args)
+        if args[:3] == ("ps", "--status", "running"):
+            return SimpleNamespace(returncode=0, stdout="app\n")
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", fake_compose)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_wait_ready",
+        lambda _config: calls.append(("wait-ready",)),
+    )
+
+    assert reconcile(config, "primary") is True
+    assert calls == [
+        ("ps", "--status", "running", "--services"),
+        ("wait-ready",),
+        ("up", "-d", "--no-deps", "bot"),
+    ]
+    output = capsys.readouterr().out
+    assert "reasons=bot_not_running" in output
+    assert "actions=wait_ready,start_bot" in output
+
+
+def test_reconcile_does_not_recreate_services_when_compose_ps_fails(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path, app_service_override="app")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_compose(_config, *args, check=True):
+        calls.append(args)
+        return SimpleNamespace(returncode=1, stdout="", stderr="docker busy")
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", fake_compose)
+
+    with pytest.raises(RuntimeError, match="docker busy"):
+        reconcile(config, "primary")
+
+    assert calls == [("ps", "--status", "running", "--services")]

--- a/tests/unit/test_postgres_pitr_restore.py
+++ b/tests/unit/test_postgres_pitr_restore.py
@@ -6,6 +6,7 @@ import sys
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -32,16 +33,20 @@ class FakeBody:
 
 
 class FakePaginator:
-    def __init__(self, keys):
-        self.keys = keys
+    def __init__(self, objects):
+        self.objects = objects
 
     def paginate(self, **kwargs):
         prefix = kwargs["Prefix"]
         return [
             {
                 "Contents": [
-                    {"Key": key, "LastModified": datetime(2026, 7, 2, tzinfo=timezone.utc)}
-                    for key in self.keys
+                    {
+                        "Key": key,
+                        "Size": len(content),
+                        "LastModified": datetime(2026, 7, 2, tzinfo=timezone.utc),
+                    }
+                    for key, content in self.objects.items()
                     if key.startswith(prefix)
                 ]
             }
@@ -55,7 +60,7 @@ class FakeClient:
 
     def get_paginator(self, name):
         assert name == "list_objects_v2"
-        return FakePaginator(list(self.objects))
+        return FakePaginator(self.objects)
 
     def get_object(self, *, Bucket, Key):
         assert Bucket == FakeConfig.bucket
@@ -84,6 +89,25 @@ def _manifest(backup_id: str, created_at: str, files: list[dict]) -> bytes:
             "created_at": created_at,
             "cluster": "mvn-api",
             "files": files,
+        }
+    ).encode("utf-8")
+
+
+def _postgres_backup_manifest(*, timeline: int = 1, start_lsn: str = "0/A000000") -> bytes:
+    return json.dumps(
+        {
+            "PostgreSQL-Backup-Manifest-Version": 1,
+            "Files": [
+                {"Path": "PG_VERSION", "Size": 3},
+                {"Path": "postgresql.conf", "Size": 0},
+            ],
+            "WAL-Ranges": [
+                {
+                    "Timeline": timeline,
+                    "Start-LSN": start_lsn,
+                    "End-LSN": "0/A000100",
+                }
+            ],
         }
     ).encode("utf-8")
 
@@ -144,11 +168,53 @@ def test_select_manifest_uses_latest_basebackup_before_target_time():
     assert selected.backup_id == "old"
 
 
+def test_wal_selection_starts_at_basebackup_segment_and_keeps_future_timelines():
+    assert pitr_restore._wal_segment_name(
+        timeline=5,
+        lsn="4/EF000028",
+        segment_size_bytes=16 * 1024 * 1024,
+    ) == "0000000500000004000000EF"
+
+    objects = [
+        pitr_restore.WalObject("old", "0000000500000004000000EE", 10),
+        pitr_restore.WalObject("start", "0000000500000004000000EF", 20),
+        pitr_restore.WalObject("next", "0000000500000004000000F0", 30),
+        pitr_restore.WalObject("history", "00000006.history", 40),
+        pitr_restore.WalObject("future", "000000060000000000000001", 50),
+    ]
+
+    selected = pitr_restore._select_wal_objects(
+        objects,
+        start_wal_name="0000000500000004000000EF",
+    )
+
+    assert [item.key for item in selected] == ["start", "next", "history", "future"]
+
+
+def test_restore_space_preflight_fails_before_large_download(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        pitr_restore.shutil,
+        "disk_usage",
+        lambda _path: SimpleNamespace(free=1_000),
+    )
+
+    with pytest.raises(SystemExit, match="Insufficient free space"):
+        pitr_restore._ensure_restore_space(
+            tmp_path,
+            basebackup_bytes=400,
+            extracted_bytes=300,
+            wal_bytes=200,
+            min_free_bytes=200,
+        )
+
+
 def test_prepare_downloads_extracts_and_writes_recovery_files(monkeypatch, tmp_path):
     base_tar = _tar_gz({"PG_VERSION": b"15\n", "postgresql.conf": b""})
     wal_tar = _tar_gz({"00000001000000000000000A": b"wal"})
     metadata = b'{"backup_id":"backup-1"}'
+    backup_manifest = _postgres_backup_manifest()
     files = [
+        _file_entry("backup-1", "backup_manifest", backup_manifest),
         _file_entry("backup-1", "base.tar.gz", base_tar),
         _file_entry("backup-1", "pg_wal.tar.gz", wal_tar),
         _file_entry("backup-1", "metadata.json", metadata),
@@ -159,9 +225,11 @@ def test_prepare_downloads_extracts_and_writes_recovery_files(monkeypatch, tmp_p
             "2026-07-02T01:00:00+00:00",
             files,
         ),
+        "postgres/pitr/mvn-api/basebackups/backup-1/backup_manifest": backup_manifest,
         "postgres/pitr/mvn-api/basebackups/backup-1/base.tar.gz": base_tar,
         "postgres/pitr/mvn-api/basebackups/backup-1/pg_wal.tar.gz": wal_tar,
         "postgres/pitr/mvn-api/basebackups/backup-1/metadata.json": metadata,
+        "postgres/pitr/mvn-api/wal/00000001/000000010000000000000009": b"old-wal",
         "postgres/pitr/mvn-api/wal/00000001/00000001000000000000000B": b"archived-wal",
     }
     client = FakeClient(objects)
@@ -187,6 +255,9 @@ def test_prepare_downloads_extracts_and_writes_recovery_files(monkeypatch, tmp_p
     assert (
         tmp_path / "restore" / "wal" / "00000001000000000000000B"
     ).read_bytes() == b"archived-wal"
+    assert not (
+        tmp_path / "restore" / "wal" / "000000010000000000000009"
+    ).exists()
     assert (data_dir / "recovery.signal").exists()
     auto_conf = (data_dir / "postgresql.auto.conf").read_text()
     assert "restore_command" in auto_conf


### PR DESCRIPTION
## Summary
- select archived WAL from the chosen basebackup start segment instead of downloading the entire R2 history
- fail PITR prepare early when estimated download/extraction would exhaust disk space
- treat negative receive/replay deltas as zero backlog while preserving strict primary replay-lag checks
- reconcile API and bot independently so a missing bot cannot restart a healthy API
- log reconcile reasons/actions and deploy the CI-tested role agent to both Patroni nodes

## Incident coverage
- fixes PITR drill `No space left on device` caused by downloading 22.8 GB of historical WAL instead of about 1.7 GB after the latest basebackup
- fixes the false replication alert for `receive/replay lag -10076160`
- prevents the bot/runtime mismatch path that force-recreated the API and produced a brief origin 502

## Validation
- `pytest tests/unit/test_patroni_*.py tests/unit/test_postgres_pitr_*.py tests/unit/test_ha_status_*.py -q` (78 passed)
- full `pytest tests/unit -q` with test PostgreSQL (890 passed)
- `shellcheck scripts/ha/run_patroni_node_remote.sh`
- `bash -n scripts/ha/run_patroni_node_remote.sh scripts/ha/restore_postgres_pitr_drill.sh`
- `python3 -m py_compile ...`
- `git diff --check`

## Production verification
After merge and Patroni deploy, rerun PostgreSQL Replication Check, PostgreSQL PITR Restore Drill, and API HA Status Report.