### PR TITLE
fix(deploy): refresh container proxy upstream

### DIFF
--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -66,6 +66,7 @@ jobs:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
         run: |
           set -euo pipefail
           if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
@@ -77,41 +78,94 @@ jobs:
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/postgres_pitr_restore_drill_key
           chmod 600 ~/.ssh/postgres_pitr_restore_drill_key
           ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
 
       - name: Run PostgreSQL PITR Restore Drill
         if: steps.gate.outputs.run == 'true'
         env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
           API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/postgres_pitr_restore_drill_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          SSH_OPTIONS=(
+            -i ~/.ssh/postgres_pitr_restore_drill_key
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+          export SSH_OPTS="${SSH_OPTIONS[*]}"
+          target_host="${SSH_HOST_API}"
+          target_user="${SSH_USER_API}"
+          target_project_dir="${API_PROJECT_DIR}"
+          target_compose_file="${API_COMPOSE_FILE}"
+          target_label=api
+
+          case "${API_DB_HA_MODE}" in
+            patroni)
+              export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+              export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+              primary_label="$(python3 scripts/ha/check_patroni_production.py --resolve-primary)"
+              case "${primary_label}" in
+                api)
+                  target_project_dir="${API_PROJECT_DIR}"
+                  ;;
+                reserve)
+                  target_host="${API_STANDBY_HOST}"
+                  target_user="${API_STANDBY_USER}"
+                  target_project_dir="${API_STANDBY_PROJECT_DIR}"
+                  target_label=reserve
+                  ;;
+                *)
+                  echo "::error::Unexpected Patroni primary label: ${primary_label:-empty}"
+                  exit 1
+                  ;;
+              esac
+              target_compose_file=docker-compose.patroni.yml
+              ;;
+            physical) ;;
+            *)
+              echo "::error::API_DB_HA_MODE must be physical or patroni"
+              exit 1
+              ;;
+          esac
+
           remote_script="/tmp/mvn-postgres-pitr-restore-drill-${GITHUB_RUN_ID}.sh"
           quote() {
             printf '%q' "$1"
           }
+          remote_target="${target_user}@${target_host}"
+          echo "[pitr-restore-drill][info] selected_node=${target_label} ha_mode=${API_DB_HA_MODE}" | tee postgres-pitr-restore-drill.log
 
-          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "cat > '${remote_script}' && chmod +x '${remote_script}'" \
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "cat > $(quote "${remote_script}") && chmod +x $(quote "${remote_script}")" \
             < scripts/ha/restore_postgres_pitr_drill.sh
 
-          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
-            PROJECT_DIR=$(quote "${API_PROJECT_DIR}") \
-            COMPOSE_FILE=$(quote "${API_COMPOSE_FILE}") \
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "\
+            PROJECT_DIR=$(quote "${target_project_dir}") \
+            COMPOSE_FILE=$(quote "${target_compose_file}") \
             BACKUP_ID=$(quote "${PITR_RESTORE_BACKUP_ID}") \
             TARGET_TIME=$(quote "${PITR_RESTORE_TARGET_TIME}") \
             REQUIRE_WAL=$(quote "${PITR_RESTORE_REQUIRE_WAL}") \
-            bash '${remote_script}'; \
+            bash $(quote "${remote_script}"); \
             status=\$?; \
-            rm -f '${remote_script}'; \
-            exit \${status}" | tee postgres-pitr-restore-drill.log
+            rm -f $(quote "${remote_script}"); \
+            exit \${status}" | tee -a postgres-pitr-restore-drill.log
 
       - name: Write Summary
         if: always()
         run: |
           {
             echo "## PostgreSQL PITR Restore Drill"
+            echo "- ha_mode: ${{ vars.API_DB_HA_MODE || 'physical' }}"
             echo "- required: ${PITR_RESTORE_DRILL_REQUIRED}"
             echo "- ran: ${{ steps.gate.outputs.run || 'false' }}"
             echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -270,6 +270,26 @@ reload_proxy() {
   esac
 }
 
+apply_replaced_upstream() {
+  case "${PROXY_MODE}" in
+    host_nginx)
+      reload_proxy
+      ;;
+    container_nginx)
+      # A file-level bind mount keeps the old inode after atomic replacement.
+      # Validate the new mount first, then recreate the proxy so it sees it.
+      "${COMPOSE[@]}" run -T --rm --no-deps "${PROXY_SERVICE}" nginx -t
+      "${COMPOSE[@]}" up -d --no-deps --force-recreate "${PROXY_SERVICE}"
+      wait_service_running "${PROXY_SERVICE}"
+      "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -t
+      ;;
+    *)
+      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
+      return 1
+      ;;
+  esac
+}
+
 ensure_container_proxy() {
   [[ -f "${PROXY_CONFIG_FILE}" ]] || {
     log error "container proxy config is missing: ${PROXY_CONFIG_FILE}"
@@ -444,7 +464,7 @@ rollback_on_error() {
 
   if [[ "${nginx_switch_attempted}" == "true" && -f "${NGINX_UPSTREAM_FILE}" ]]; then
     write_upstream "${active_slot}"
-    reload_proxy
+    apply_replaced_upstream
   fi
 
   if [[ "${bot_update_attempted}" == "true" ]] && is_immutable_image "${previous_image}"; then
@@ -586,7 +606,7 @@ wait_service_running bot
 
 nginx_switch_attempted=true
 write_upstream "${candidate_slot}"
-reload_proxy
+apply_replaced_upstream
 log switch "nginx now routes to ${candidate_slot} on ${candidate_port}"
 
 wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:443:127.0.0.1"

--- a/tests/unit/test_blue_green_deploy_script.py
+++ b/tests/unit/test_blue_green_deploy_script.py
@@ -205,8 +205,23 @@ def test_container_proxy_switches_by_service_name_without_host_nginx(tmp_path):
     assert result.returncode == 0, result.stderr
     commands = command_log.read_text(encoding="utf-8")
     assert "up -d --no-deps api-proxy" in commands
+    assert "run -T --rm --no-deps api-proxy nginx -t" in commands
+    assert "up -d --no-deps --force-recreate api-proxy" in commands
     assert "exec -T api-proxy nginx -t" in commands
     assert "exec -T api-proxy nginx -s reload" in commands
+    lines = commands.splitlines()
+    proxy_recreate = max(
+        index
+        for index, line in enumerate(lines)
+        if "up -d --no-deps --force-recreate api-proxy" in line
+    )
+    candidate_start = next(
+        index
+        for index, line in enumerate(lines)
+        if "up -d --no-deps --force-recreate app-blue" in line
+    )
+    old_stop = next(index for index, line in enumerate(lines) if line.endswith(" stop app"))
+    assert candidate_start < proxy_recreate < old_stop
     assert "proxy_pass http://app-blue:8000;" in upstream.read_text(encoding="utf-8")
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
 

--- a/tests/unit/test_postgres_pitr_workflows.py
+++ b/tests/unit/test_postgres_pitr_workflows.py
@@ -54,6 +54,7 @@ def test_postgres_pitr_restore_drill_workflow_preserves_required_gate_and_wal_pr
     env = workflow["env"]
     dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
     gate_step = _step(workflow, "pitr-restore-drill", "Decide Whether To Run")
+    ssh_step = _step(workflow, "pitr-restore-drill", "Setup API SSH Key")
     drill_step = _step(workflow, "pitr-restore-drill", "Run PostgreSQL PITR Restore Drill")
     summary_step = _step(workflow, "pitr-restore-drill", "Write Summary")
     artifact_step = _step(workflow, "pitr-restore-drill", "Upload PITR Restore Drill Log")
@@ -64,6 +65,13 @@ def test_postgres_pitr_restore_drill_workflow_preserves_required_gate_and_wal_pr
     assert "PITR restore drill skipped because POSTGRES_PITR_REQUIRED is not true." in gate_step["run"]
     assert "postgres-pitr-restore-drill.log" in gate_step["run"]
     assert drill_step["if"] == "steps.gate.outputs.run == 'true'"
+    assert "API_STANDBY_HOST" in ssh_step["env"]
+    assert 'ssh-keyscan -T 10 -H "${API_STANDBY_HOST}"' in ssh_step["run"]
+    assert "API_DB_HA_MODE" in drill_step["env"]
+    assert "API_STANDBY_PROJECT_DIR" in drill_step["env"]
+    assert "check_patroni_production.py --resolve-primary" in drill_step["run"]
+    assert "target_compose_file=docker-compose.patroni.yml" in drill_step["run"]
+    assert 'selected_node=${target_label} ha_mode=${API_DB_HA_MODE}' in drill_step["run"]
     assert "scripts/ha/restore_postgres_pitr_drill.sh" in drill_step["run"]
     assert "REQUIRE_WAL=$(quote \"${PITR_RESTORE_REQUIRE_WAL}\")" in drill_step["run"]
     assert "postgres-pitr-restore-drill.log" in drill_step["run"]


### PR DESCRIPTION
## Summary
- validate atomically replaced container-Nginx upstream config before activation
- recreate the proxy so Docker picks up the new bind-mounted inode before the old API slot stops
- resolve the live Patroni primary before running the PITR restore drill

## Production incident
The Patroni deploy replaced `api-proxy/upstream.conf` atomically, but the running proxy retained the old file inode and still routed to the legacy `app` service. After the old slot stopped, the active origin returned 502. The proxy was safely recreated on `zakup` and public `/api/ready` recovered to 200.

The PITR restore workflow also still targeted the API identity as a permanent primary. It now selects `mvn-api` or `zakup` from live Patroni roles before executing the isolated restore.

## Verification
- `pytest -q tests/unit/test_postgres_pitr_workflows.py tests/unit/test_blue_green_deploy_script.py tests/unit/test_release_safety_scripts.py tests/unit/test_patroni_remote_script.py tests/unit/test_ha_alert_workflows.py` (23 passed)
- `actionlint .github/workflows/postgres-pitr-restore-drill.yml`
- `bash -n scripts/deploy_backend_blue_green.sh`
- `shellcheck scripts/deploy_backend_blue_green.sh`
- `git diff --check`