### PR TITLE
fix(ha): make reserve deploy reload zero-downtime

### DIFF
--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -24,6 +24,7 @@ jobs:
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
           SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
         run: |
           set -euo pipefail
           if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
@@ -35,20 +36,81 @@ jobs:
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/api_restore_drill_key
           chmod 600 ~/.ssh/api_restore_drill_key
           ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
 
       - name: Run restore drill on current API primary
         env:
+          API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
           SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
           API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
           API_COMPOSE_FILE: ${{ vars.API_COMPOSE_FILE || 'docker-compose.prod.yml' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/api_restore_drill_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          ssh ${SSH_OPTS} "${SSH_USER_API}@${SSH_HOST_API}" "\
-            PROJECT_DIR='${API_PROJECT_DIR}' \
-            COMPOSE_FILE='${API_COMPOSE_FILE}' \
-            /usr/local/sbin/mvn-restore-drill-latest-db" | tee api-restore-drill.log
+          SSH_OPTIONS=(
+            -i ~/.ssh/api_restore_drill_key
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+          export SSH_OPTS="${SSH_OPTIONS[*]}"
+          target_host="${SSH_HOST_API}"
+          target_user="${SSH_USER_API}"
+          target_project_dir="${API_PROJECT_DIR}"
+          target_compose_file="${API_COMPOSE_FILE}"
+          target_label=api
+
+          case "${API_DB_HA_MODE}" in
+            patroni)
+              export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+              export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+              primary_label="$(python3 scripts/ha/check_patroni_production.py --resolve-primary)"
+              case "${primary_label}" in
+                api)
+                  target_project_dir="${API_PROJECT_DIR}"
+                  ;;
+                reserve)
+                  target_host="${API_STANDBY_HOST}"
+                  target_user="${API_STANDBY_USER}"
+                  target_project_dir="${API_STANDBY_PROJECT_DIR}"
+                  target_label=reserve
+                  ;;
+                *)
+                  echo "::error::Unexpected Patroni primary label: ${primary_label:-empty}"
+                  exit 1
+                  ;;
+              esac
+              target_compose_file=docker-compose.patroni.yml
+              ;;
+            physical) ;;
+            *)
+              echo "::error::API_DB_HA_MODE must be physical or patroni"
+              exit 1
+              ;;
+          esac
+
+          quote() {
+            printf '%q' "$1"
+          }
+          remote_target="${target_user}@${target_host}"
+          remote_script="/tmp/mvn-api-restore-drill-${GITHUB_RUN_ID}.sh"
+          echo "[restore-drill][info] selected_node=${target_label} ha_mode=${API_DB_HA_MODE}" | tee api-restore-drill.log
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "cat > $(quote "${remote_script}") && chmod +x $(quote "${remote_script}")" \
+            < scripts/ha/restore_drill_latest_db.sh
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "\
+            PROJECT_DIR=$(quote "${target_project_dir}") \
+            COMPOSE_FILE=$(quote "${target_compose_file}") \
+            bash $(quote "${remote_script}"); \
+            status=\$?; \
+            rm -f $(quote "${remote_script}"); \
+            exit \${status}" | tee -a api-restore-drill.log
 
       - name: Upload restore drill log
         if: always()

--- a/deploy/ha/proxy/nginx.conf
+++ b/deploy/ha/proxy/nginx.conf
@@ -17,7 +17,7 @@ http {
         server_name _;
 
         location / {
-            include /etc/nginx/conf.d/mvn-upstream.conf;
+            include /etc/nginx/mvn-proxy/upstream.conf;
             proxy_set_header Host api.mvn.by;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -119,7 +119,8 @@ services:
       - "127.0.0.1:18080:8000"
     volumes:
       - ./api-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./api-proxy/upstream.conf:/etc/nginx/conf.d/mvn-upstream.conf:ro
+      # Mount the directory so atomic upstream renames stay visible for graceful reloads.
+      - ./api-proxy:/etc/nginx/mvn-proxy:ro
     healthcheck:
       test: [CMD, nginx, -t]
       interval: 10s

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -270,26 +270,6 @@ reload_proxy() {
   esac
 }
 
-apply_replaced_upstream() {
-  case "${PROXY_MODE}" in
-    host_nginx)
-      reload_proxy
-      ;;
-    container_nginx)
-      # A file-level bind mount keeps the old inode after atomic replacement.
-      # Validate the new mount first, then recreate the proxy so it sees it.
-      "${COMPOSE[@]}" run -T --rm --no-deps "${PROXY_SERVICE}" nginx -t
-      "${COMPOSE[@]}" up -d --no-deps --force-recreate "${PROXY_SERVICE}"
-      wait_service_running "${PROXY_SERVICE}"
-      "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -t
-      ;;
-    *)
-      log error "unsupported API_PROXY_MODE=${PROXY_MODE}"
-      return 1
-      ;;
-  esac
-}
-
 ensure_container_proxy() {
   [[ -f "${PROXY_CONFIG_FILE}" ]] || {
     log error "container proxy config is missing: ${PROXY_CONFIG_FILE}"
@@ -464,7 +444,7 @@ rollback_on_error() {
 
   if [[ "${nginx_switch_attempted}" == "true" && -f "${NGINX_UPSTREAM_FILE}" ]]; then
     write_upstream "${active_slot}"
-    apply_replaced_upstream
+    reload_proxy
   fi
 
   if [[ "${bot_update_attempted}" == "true" ]] && is_immutable_image "${previous_image}"; then
@@ -606,7 +586,7 @@ wait_service_running bot
 
 nginx_switch_attempted=true
 write_upstream "${candidate_slot}"
-apply_replaced_upstream
+reload_proxy
 log switch "nginx now routes to ${candidate_slot} on ${candidate_port}"
 
 wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:443:127.0.0.1"

--- a/scripts/ha/restore_drill_latest_db.sh
+++ b/scripts/ha/restore_drill_latest_db.sh
@@ -106,16 +106,23 @@ docker run -d \
   -e POSTGRES_DB="${POSTGRES_DB}" \
   "${POSTGRES_IMAGE}" >/dev/null
 
-for _ in $(seq 1 30); do
-  if docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
-    break
+ready_streak=0
+for _ in $(seq 1 60); do
+  if docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -Atqc "SELECT 1" \
+    -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" 2>/dev/null | grep -Fxq 1; then
+    ready_streak=$((ready_streak + 1))
+    if [[ "${ready_streak}" -ge 3 ]]; then
+      break
+    fi
+  else
+    ready_streak=0
   fi
   sleep 1
 done
 
-if ! docker exec "${container}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+if [[ "${ready_streak}" -lt 3 ]]; then
   docker logs "${container}" || true
-  echo "Disposable PostgreSQL did not become ready." >&2
+  echo "Disposable PostgreSQL did not become SQL-ready for three consecutive checks." >&2
   exit 1
 fi
 
@@ -139,10 +146,22 @@ if [[ "${tables_count}" -lt 10 ]]; then
 fi
 
 log "public_tables=${tables_count}"
-docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
-SELECT 'product_count=' || count(*) FROM product;
-SELECT 'payment_count=' || count(*) FROM payment;
-SELECT 'order_count=' || count(*) FROM "order";
-SQL
+business_counts="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -AtF '|' \
+  -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+  -c 'SELECT (SELECT count(*) FROM product), (SELECT count(*) FROM payment), (SELECT count(*) FROM "order");')"
+IFS='|' read -r product_count payment_count order_count <<< "${business_counts}"
+for count in "${product_count}" "${payment_count}" "${order_count}"; do
+  case "${count}" in
+    ''|*[!0-9]*)
+      echo "Restore drill returned invalid business counts: ${business_counts}" >&2
+      exit 1
+      ;;
+  esac
+done
+log "product_count=${product_count} payment_count=${payment_count} order_count=${order_count}"
+if [[ "${product_count}" -lt 1 || "${order_count}" -lt 1 ]]; then
+  echo "Restore drill is missing required product/order data: ${business_counts}" >&2
+  exit 1
+fi
 
 log "restore drill passed; production and standby databases were not modified"

--- a/scripts/ha/restore_postgres_pitr_drill.sh
+++ b/scripts/ha/restore_postgres_pitr_drill.sh
@@ -220,10 +220,20 @@ if [[ "${tables_count}" -lt 10 ]]; then
 fi
 
 log "public_tables=${tables_count}"
-docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" <<'SQL'
-SELECT 'product_count=' || count(*) FROM product;
-SELECT 'payment_count=' || count(*) FROM payment;
-SELECT 'order_count=' || count(*) FROM "order";
-SQL
+business_counts="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" psql -AtF '|' \
+  -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+  -c 'SELECT (SELECT count(*) FROM product), (SELECT count(*) FROM payment), (SELECT count(*) FROM "order");')"
+IFS='|' read -r product_count payment_count order_count <<< "${business_counts}"
+for count in "${product_count}" "${payment_count}" "${order_count}"; do
+  if ! is_unsigned_int "${count}"; then
+    echo "PITR restore drill returned invalid business counts: ${business_counts}" >&2
+    exit 1
+  fi
+done
+log "product_count=${product_count} payment_count=${payment_count} order_count=${order_count}"
+if [[ "${product_count}" -lt 1 || "${order_count}" -lt 1 ]]; then
+  echo "PITR restore drill is missing required product/order data: ${business_counts}" >&2
+  exit 1
+fi
 
 log "PITR restore drill passed; production and standby databases were not modified"

--- a/tests/unit/test_blue_green_deploy_script.py
+++ b/tests/unit/test_blue_green_deploy_script.py
@@ -205,15 +205,15 @@ def test_container_proxy_switches_by_service_name_without_host_nginx(tmp_path):
     assert result.returncode == 0, result.stderr
     commands = command_log.read_text(encoding="utf-8")
     assert "up -d --no-deps api-proxy" in commands
-    assert "run -T --rm --no-deps api-proxy nginx -t" in commands
-    assert "up -d --no-deps --force-recreate api-proxy" in commands
+    assert "run -T --rm --no-deps api-proxy nginx -t" not in commands
+    assert "up -d --no-deps --force-recreate api-proxy" not in commands
     assert "exec -T api-proxy nginx -t" in commands
     assert "exec -T api-proxy nginx -s reload" in commands
     lines = commands.splitlines()
-    proxy_recreate = max(
+    proxy_reload = max(
         index
         for index, line in enumerate(lines)
-        if "up -d --no-deps --force-recreate api-proxy" in line
+        if "exec -T api-proxy nginx -s reload" in line
     )
     candidate_start = next(
         index
@@ -221,7 +221,7 @@ def test_container_proxy_switches_by_service_name_without_host_nginx(tmp_path):
         if "up -d --no-deps --force-recreate app-blue" in line
     )
     old_stop = next(index for index, line in enumerate(lines) if line.endswith(" stop app"))
-    assert candidate_start < proxy_recreate < old_stop
+    assert candidate_start < proxy_reload < old_stop
     assert "proxy_pass http://app-blue:8000;" in upstream.read_text(encoding="utf-8")
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
 

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -65,6 +65,29 @@ def test_ha_monitor_workflows_notify_on_failure_after_artifact_upload():
 def test_restore_drill_checks_out_repo_before_local_alert_action():
     workflow = _yaml(REPO_ROOT / ".github/workflows/api-restore-drill.yml")
     steps = workflow["jobs"]["restore-drill"]["steps"]
+    setup_step = next(step for step in steps if step.get("name") == "Setup API SSH Key")
+    run_step = next(
+        step for step in steps if step.get("name") == "Run restore drill on current API primary"
+    )
 
     assert steps[0]["name"] == "Checkout"
     assert steps[0]["uses"] == "actions/checkout@v6"
+    assert "API_STANDBY_HOST" in setup_step["env"]
+    assert 'ssh-keyscan -T 10 -H "${API_STANDBY_HOST}"' in setup_step["run"]
+    assert "API_DB_HA_MODE" in run_step["env"]
+    assert "API_STANDBY_PROJECT_DIR" in run_step["env"]
+    assert "check_patroni_production.py --resolve-primary" in run_step["run"]
+    assert "scripts/ha/restore_drill_latest_db.sh" in run_step["run"]
+    assert 'selected_node=${target_label} ha_mode=${API_DB_HA_MODE}' in run_step["run"]
+
+
+def test_restore_drill_waits_for_stable_sql_and_checks_business_data():
+    script = (REPO_ROOT / "scripts/ha/restore_drill_latest_db.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ready_streak" in script
+    assert '"${ready_streak}" -ge 3' in script
+    assert "business_counts=" in script
+    assert "product_count payment_count order_count" in script
+    assert '"${product_count}" -lt 1 || "${order_count}" -lt 1' in script

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -162,7 +162,15 @@ def test_production_patroni_composes_are_role_driven_and_private():
     }
 
     assert reserve["services"]["api-proxy"]["ports"] == ["127.0.0.1:18080:8000"]
+    assert "./api-proxy:/etc/nginx/mvn-proxy:ro" in reserve["services"]["api-proxy"]["volumes"]
+    assert all(
+        "/etc/nginx/conf.d/mvn-upstream.conf" not in mount
+        for mount in reserve["services"]["api-proxy"]["volumes"]
+    )
     assert "proxy_set_header Host api.mvn.by" in PROXY_CONFIG.read_text(encoding="utf-8")
+    assert "include /etc/nginx/mvn-proxy/upstream.conf;" in PROXY_CONFIG.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_patroni_image_publish_is_manual_sha_gated_and_digest_pinned():

--- a/tests/unit/test_postgres_pitr_workflows.py
+++ b/tests/unit/test_postgres_pitr_workflows.py
@@ -78,3 +78,14 @@ def test_postgres_pitr_restore_drill_workflow_preserves_required_gate_and_wal_pr
     assert "require_wal:" in summary_step["run"]
     assert artifact_step["if"] == "always()"
     assert artifact_step["with"]["path"] == "postgres-pitr-restore-drill.log"
+
+
+def test_postgres_pitr_restore_drill_requires_restored_business_data():
+    script = (REPO_ROOT / "scripts/ha/restore_postgres_pitr_drill.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "business_counts=" in script
+    assert "product_count payment_count order_count" in script
+    assert 'log "product_count=${product_count} payment_count=${payment_count} order_count=${order_count}"' in script
+    assert '"${product_count}" -lt 1 || "${order_count}" -lt 1' in script


### PR DESCRIPTION
## Summary
- mount the reserve proxy config directory instead of a single upstream file
- keep atomic upstream replacement visible inside running Nginx and use graceful reload
- make both PITR and logical restore drills validate restored business row counts
- make API Restore Drill resolve the live Patroni primary and run the exact repo script
- require three consecutive SQL-ready probes to avoid the official Postgres init restart race

## Confirmed causes
1. File-level Docker bind mount retained the old inode after atomic `upstream.conf` replacement. Recreating the singleton proxy fixed routing but caused one observed 2-second `502`. Directory bind + graceful Nginx reload removes that listener gap.
2. The logical restore drill could catch the temporary Postgres init server, then attempt restore during its restart. Stable SQL readiness fixes this race.
3. Final business-count commands in both drills used unattached stdin. Explicit `psql -c` now executes and validates them.
4. API Restore Drill assumed `mvn-api` was permanently primary and relied on a potentially stale host helper. It is now role-aware and uploads the tested repo script.

## Safe rollout
`mvn-api` is the current Patroni and Cloudflare primary. The first directory-mount migration occurs on fenced `zakup`, so public traffic remains on `mvn-api`.

## Verification
- 34 targeted HA/deploy tests passed
- `actionlint` passed for the changed workflow
- `bash -n`, `shellcheck -e SC2016`, and `git diff --check` passed
- pinned Nginx accepted the directory mount; atomic host rename was visible in-container and graceful reload succeeded
- required PITR freshness run `29195736023`: success
- role-aware PITR restore run `29195791762`: success, 64 tables, 4 WAL
- updated PITR drill live check: 1119 products, 79 payments, 99 orders, 5 WAL
- updated logical Drive restore live check: 64 tables, 1119 products, 79 payments, 99 orders
- strict readiness run `29196064153`: success
- production and standby databases were not modified by either restore drill