### PR TITLE
fix(deploy): reconcile standby proxy config

### DIFF
--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -9,6 +9,8 @@ PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
 READY_URL="${API_READY_URL:-http://127.0.0.1:18080/api/ready}"
 HEALTH_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}"
 BLUE_GREEN_SCRIPT="${API_BLUE_GREEN_SCRIPT:-/tmp/deploy_backend_blue_green.sh}"
+PROXY_MODE="${API_PROXY_MODE:-host_nginx}"
+PROXY_SERVICE="${API_PROXY_SERVICE:-api-proxy}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
@@ -104,6 +106,21 @@ PY
   return 1
 }
 
+reconcile_standby_proxy() {
+  if [[ "${PROXY_MODE}" != "container_nginx" ]]; then
+    return 0
+  fi
+
+  log standby "validating desired container proxy configuration"
+  "${COMPOSE[@]}" run -T --rm --no-deps "${PROXY_SERVICE}" nginx -t
+  "${COMPOSE[@]}" up -d --no-deps "${PROXY_SERVICE}"
+  if ! "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -t; then
+    log standby "running proxy has stale mounts; recreating fenced proxy"
+    "${COMPOSE[@]}" up -d --no-deps --force-recreate "${PROXY_SERVICE}"
+    "${COMPOSE[@]}" exec -T "${PROXY_SERVICE}" nginx -t
+  fi
+}
+
 rollback_standby() {
   local exit_code=$?
   trap - ERR
@@ -126,6 +143,10 @@ for command in docker curl python3 flock; do
 done
 [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
   log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
+  exit 1
+}
+[[ "${PROXY_MODE}" == "host_nginx" || "${PROXY_MODE}" == "container_nginx" ]] || {
+  log error "API_PROXY_MODE must be host_nginx or container_nginx"
   exit 1
 }
 [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
@@ -180,6 +201,7 @@ if [[ -n "${GHCR_PAT:-}" ]]; then
 fi
 
 trap rollback_standby ERR
+reconcile_standby_proxy
 log standby "updating fenced service ${active_service}"
 "${COMPOSE[@]}" pull "${active_service}" bot
 write_backend_image "${BACKEND_IMAGE}"

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -68,6 +68,11 @@ def test_node_deploy_keeps_migrations_separate_and_has_role_and_maintenance_fenc
     assert "standby image updated without enabling traffic" in text
     assert "alembic upgrade head" not in text
     assert 'up -d --no-deps --force-recreate "${active_service}"' in text
+    assert "reconcile_standby_proxy" in text
+    assert 'run -T --rm --no-deps "${PROXY_SERVICE}" nginx -t' in text
+    assert 'up -d --no-deps "${PROXY_SERVICE}"' in text
+    assert 'up -d --no-deps --force-recreate "${PROXY_SERVICE}"' in text
+    assert "running proxy has stale mounts" in text
     assert "up -d db" not in text
 
 


### PR DESCRIPTION
## Summary
- preflight the tracked container-Nginx config during every fenced standby deploy
- run `compose up` for the proxy so compose/mount drift is applied
- self-heal stale running mounts with a forced recreate only when post-apply `nginx -t` fails

## Why
The zero-downtime directory-mount compose reached `zakup`, but the standby image deploy updated only the app container. The existing proxy retained the previous mounts until it was manually recreated. Public traffic was never affected because `mvn-api` was primary and `zakup` was fenced.

## Safety
This path executes only after the node is verified as Patroni standby. A valid unchanged proxy is not recreated. Invalid desired config fails in a disposable preflight before touching the running proxy.

## Verification
- 23 targeted Patroni deploy/release tests passed
- `bash -n scripts/ha/deploy_patroni_api_node.sh`
- `shellcheck scripts/ha/deploy_patroni_api_node.sh`
- `git diff --check`
- live standby preflight/up/postflight passed; proxy creation timestamp remained unchanged and `/api/ready` stayed fenced at HTTP 503