### PR TITLE
feat: add transactional communications outbox foundation

### DIFF
--- a/alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py
+++ b/alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py
@@ -1,0 +1,235 @@
+"""add transactional outbox and communications delivery foundation
+
+Revision ID: 3f7a9c1d2e04
+Revises: 2d4f6a8b0c13
+Create Date: 2026-07-13 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "3f7a9c1d2e04"
+down_revision: Union[str, Sequence[str], None] = "2d4f6a8b0c13"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "integration_outbox_event",
+        sa.Column("event_id", sa.String(length=32), nullable=False),
+        sa.Column("event_type", sa.String(length=120), nullable=False),
+        sa.Column("schema_version", sa.Integer(), nullable=False),
+        sa.Column("aggregate_type", sa.String(length=80), nullable=False),
+        sa.Column("aggregate_id", sa.String(length=128), nullable=False),
+        sa.Column("aggregate_version", sa.Integer(), nullable=True),
+        sa.Column("deduplication_key", sa.String(length=255), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=255), nullable=True),
+        sa.Column("actor_id", sa.String(length=128), nullable=True),
+        sa.Column("correlation_id", sa.String(length=128), nullable=True),
+        sa.Column("causation_id", sa.String(length=128), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False),
+        sa.Column("max_attempts", sa.Integer(), nullable=False),
+        sa.Column("available_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("worker_id", sa.String(length=128), nullable=True),
+        sa.Column("lease_token", sa.String(length=255), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_code", sa.String(length=100), nullable=True),
+        sa.Column("last_error_message", sa.String(length=1000), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("attempts >= 0", name="ck_outbox_attempts_non_negative"),
+        sa.CheckConstraint("max_attempts > 0", name="ck_outbox_max_attempts_positive"),
+        sa.CheckConstraint("schema_version > 0", name="ck_outbox_schema_version_positive"),
+        sa.CheckConstraint(
+            "status IN ('pending', 'processing', 'published', 'dead')",
+            name="ck_outbox_status_valid",
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+        sa.UniqueConstraint(
+            "deduplication_key",
+            name="uq_integration_outbox_event_deduplication_key",
+        ),
+    )
+    op.create_index(
+        "ix_integration_outbox_event_aggregate",
+        "integration_outbox_event",
+        ["aggregate_type", "aggregate_id", "occurred_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_integration_outbox_event_claim",
+        "integration_outbox_event",
+        ["status", "available_at", "priority", "occurred_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_integration_outbox_event_created_at"),
+        "integration_outbox_event",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_integration_outbox_event_event_type"),
+        "integration_outbox_event",
+        ["event_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_integration_outbox_event_lease_expires_at"),
+        "integration_outbox_event",
+        ["lease_expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_integration_outbox_event_published_at"),
+        "integration_outbox_event",
+        ["published_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "consumer_inbox",
+        sa.Column("consumer_name", sa.String(length=120), nullable=False),
+        sa.Column("event_id", sa.String(length=32), nullable=False),
+        sa.Column("handler_version", sa.Integer(), nullable=False),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "handler_version > 0",
+            name="ck_consumer_inbox_handler_version_positive",
+        ),
+        sa.PrimaryKeyConstraint("consumer_name", "event_id"),
+    )
+    op.create_index(
+        "ix_consumer_inbox_processed_at",
+        "consumer_inbox",
+        ["processed_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "communication_delivery",
+        sa.Column("delivery_id", sa.String(length=32), nullable=False),
+        sa.Column("event_id", sa.String(length=32), nullable=False),
+        sa.Column("channel", sa.String(length=32), nullable=False),
+        sa.Column("recipient_key", sa.String(length=160), nullable=False),
+        sa.Column("destination", sa.String(length=255), nullable=False),
+        sa.Column("template_key", sa.String(length=120), nullable=False),
+        sa.Column("template_version", sa.Integer(), nullable=False),
+        sa.Column("render_context", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False),
+        sa.Column("max_attempts", sa.Integer(), nullable=False),
+        sa.Column("available_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("worker_id", sa.String(length=128), nullable=True),
+        sa.Column("lease_token", sa.String(length=255), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("provider_message_id", sa.String(length=255), nullable=True),
+        sa.Column("last_error_category", sa.String(length=80), nullable=True),
+        sa.Column("last_error_code", sa.String(length=100), nullable=True),
+        sa.Column("last_error_message", sa.String(length=1000), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("attempts >= 0", name="ck_delivery_attempts_non_negative"),
+        sa.CheckConstraint("max_attempts > 0", name="ck_delivery_max_attempts_positive"),
+        sa.CheckConstraint(
+            "status IN ('queued', 'running', 'retry', 'sent', 'dead', 'canceled')",
+            name="ck_delivery_status_valid",
+        ),
+        sa.CheckConstraint(
+            "template_version > 0",
+            name="ck_delivery_template_version_positive",
+        ),
+        sa.PrimaryKeyConstraint("delivery_id"),
+        sa.UniqueConstraint(
+            "event_id",
+            "channel",
+            "recipient_key",
+            "template_version",
+            name="uq_communication_delivery_event_channel_recipient_template",
+        ),
+    )
+    op.create_index(
+        "ix_communication_delivery_claim",
+        "communication_delivery",
+        ["status", "available_at", "priority", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_communication_delivery_created_at"),
+        "communication_delivery",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_communication_delivery_event_id",
+        "communication_delivery",
+        ["event_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_communication_delivery_lease_expires_at"),
+        "communication_delivery",
+        ["lease_expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_communication_delivery_sent_at"),
+        "communication_delivery",
+        ["sent_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_communication_delivery_sent_at"),
+        table_name="communication_delivery",
+    )
+    op.drop_index(
+        op.f("ix_communication_delivery_lease_expires_at"),
+        table_name="communication_delivery",
+    )
+    op.drop_index("ix_communication_delivery_event_id", table_name="communication_delivery")
+    op.drop_index(
+        op.f("ix_communication_delivery_created_at"),
+        table_name="communication_delivery",
+    )
+    op.drop_index("ix_communication_delivery_claim", table_name="communication_delivery")
+    op.drop_table("communication_delivery")
+
+    op.drop_index("ix_consumer_inbox_processed_at", table_name="consumer_inbox")
+    op.drop_table("consumer_inbox")
+
+    op.drop_index(
+        op.f("ix_integration_outbox_event_published_at"),
+        table_name="integration_outbox_event",
+    )
+    op.drop_index(
+        op.f("ix_integration_outbox_event_lease_expires_at"),
+        table_name="integration_outbox_event",
+    )
+    op.drop_index(
+        op.f("ix_integration_outbox_event_event_type"),
+        table_name="integration_outbox_event",
+    )
+    op.drop_index(
+        op.f("ix_integration_outbox_event_created_at"),
+        table_name="integration_outbox_event",
+    )
+    op.drop_index("ix_integration_outbox_event_claim", table_name="integration_outbox_event")
+    op.drop_index("ix_integration_outbox_event_aggregate", table_name="integration_outbox_event")
+    op.drop_table("integration_outbox_event")

--- a/docs/global-system-audit-2026-07-12.md
+++ b/docs/global-system-audit-2026-07-12.md
@@ -54,10 +54,10 @@ MVN уже состоит из нескольких независимо раз�
 | DATA-001 | P1 | Orders | Нет version/ETag; полный snapshot из drawer молча затирает параллельные изменения | Открыто |
 | DATA-002 | P1 | Customers | Неединая нормализация телефона и race find-or-create создают дубликаты; checkout не имеет idempotency key | Открыто |
 | JOB-001 | P1 | Runtime | Backup, restore, email import и часть catalog jobs используют память процесса и `create_task` | Открыто |
-| JOB-002 | P1 | Media | Два worker'а могут атомарно незащищённо забрать одну media job | Закрыто в коде Wave 0: atomic claim, lease token, heartbeat; production rollout ещё не выполнен |
+| JOB-002 | P1 | Media | Два worker'а могут атомарно незащищённо забрать одну media job | Закрыто и развернуто в API Wave 0: atomic claim, lease token, heartbeat; сам worker остаётся выключен до отдельного managed rollout |
 | COM-001 | P1 | Telegram | Ошибки проглатываются, попытка считается доставкой; живой log доказал ложный `notified_admins=2` при отказе | Закрыто в Wave 0 |
 | COM-002 | P1 | Telegram | Ручной bank import не вызывает notify, после dedupe уведомление теряется навсегда | Закрыто в Wave 0 |
-| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | Открыто |
+| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | В работе: additive outbox/inbox/per-recipient delivery foundation реализуется в Wave 1 PR-A; producer switch и consumer ещё открыты |
 | COM-004 | P1 | Tests | Integration checkout способен отправлять реальные Telegram-сообщения владельцам | Закрыто в Wave 0 |
 | PRIV-001 | P1 | Media | Реквизиты, order attachments и диагностические фото лежат в публичном `/media`/public R2 | Открыто |
 | WEB-001 | P1 | SSG | Build запрашивает только 1000 из 1117 товаров; product routes после 1000 отсутствуют и production URL отвечает 404 | Закрыто в Wave 0: пагинация, dedupe и hard-fail invariant |
@@ -328,7 +328,7 @@ Delivery uniqueness: `(event_id, channel, recipient_id, template_version)`. Work
 
 ### Wave 0 — ledger на текущем snapshot
 
-Кодовая часть Wave 0 прошла локальные release-gates и готова к публикации в draft PR. Это не означает production rollout и не закрывает явно перенесённые в Wave 1–2 риски. Фактические проверки:
+Wave 0 слита через PR #726 и развернута в production как immutable SHA `886593e0`. Backend migration/blue-green primary/fenced replica, frontend canary/atomic VPS/Cloudflare smoke, последующие replication и HA invariant checks прошли. Это не закрывает явно перенесённые в Wave 1–2 риски. Фактические проверки:
 
 | Gate | Результат | Статус |
 |---|---|---|
@@ -338,12 +338,14 @@ Delivery uniqueness: `(event_id, channel, recipient_id, template_version)`. Work
 | Storefront tests/build | Все scoped Node/theme tests; production-like API: **740 products**, build: **797 pages**, **740/740 product routes** | Пройден |
 | Alembic upgrade/check на clone существующей БД | Пройден на текущей цепочке migrations | Пройден |
 | Fresh empty-DB replay до текущего `head` + `alembic check` | Полная цепочка до `2d4f6a8b0c13`; `No new upgrade operations detected` | Пройден |
+| Единый GitHub CI после исправления Linux module collision | **1177 passed**, migration и codegen gates зелёные | Пройден |
+| Production deploy/smoke | Patroni migration + primary/replica deploy, Cloudflare/VPS storefront smoke, live API DB online | Пройден |
 
-Статусы выше означают «исправлено и локально проверено в рабочем diff», а не «развёрнуто в production». CI draft PR и совместимый production rollout остаются следующими gate. Открытые DATA/JOB/COM/PRIV/WEB/PERF/SUPPLY пункты переходят в Wave 1–2 и не должны теряться при публикации Wave 0.
+Wave 0 подтверждена локально, в CI и production. Media processing worker намеренно не активирован: в production нет worker unit/container/token и очередь пуста; его первое включение остаётся отдельным canary rollout только новой версии. Открытые DATA/JOB/COM/PRIV/WEB/PERF/SUPPLY пункты переходят в Wave 1–2.
 
 ### Wave 1 — данные и надёжность
 
-- Transactional outbox/inbox + communications worker.
+- Transactional outbox/inbox + communications worker. PR-A добавляет только выключенный additive persistence/contracts foundation; переключение producers и consumer выполняются следующими отдельными PR.
 - Order version/409 и command-specific updates.
 - Canonical customer identity + checkout idempotency.
 - Public contact/availability lead abuse policy: edge+app rate limit, canonical phone/email, dedupe window, idempotency key и risk-based anti-bot.

--- a/docs/service-decomposition-roadmap.md
+++ b/docs/service-decomposition-roadmap.md
@@ -6,7 +6,7 @@
 
 Сначала modular monolith, затем extraction. Storefront и Telegram process уже можно разворачивать отдельно, но это ещё не самостоятельные domain services: они используют общую backend-модель и не имеют устойчивых command/event contracts.
 
-Текущий рабочий diff закрывает foundation Wave 0 (RBAC, server-authoritative checkout, OAuth state, честный Telegram delivery result, SSG completeness, media leases и migration CI), но не завершает декомпозицию. Outbox, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Локальные gates пройдены: **996 unit**, **181 integration**, manager typecheck/build, storefront full-data build (**797 pages**, **740/740 product routes**) и fresh empty-DB Alembic replay/check. До production всё ещё обязательны PR CI и совместимый rollout.
+Wave 0 закрыта, слита через PR #726 и развернута в production как SHA `886593e0`: единый CI дал **1177 passed**, migration/codegen gates, Patroni primary/replica deploy и storefront canary/VPS/Cloudflare smoke прошли. Декомпозиция этим не завершена. Outbox producer switch/consumer, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Первая Wave 1 итерация добавляет только выключенный additive outbox/inbox/delivery foundation без изменения production notification path.
 
 ## Целевые bounded contexts
 
@@ -146,7 +146,7 @@ flowchart LR
   H --> I["Re-evaluate CRM/Catalog physical split"]
 ```
 
-Wave 0 на этой диаграмме локально проверена, но ещё не развёрнута: впереди PR CI и production rollout. В Wave 1 отдельно входят public lead abuse/dedupe/rate-limit contract, checkout idempotency/canonical identity, order versioning, outbox/inbox и durable operations. Media extraction нельзя начинать только на основании уже реализованного lease claim.
+Wave 0 на этой диаграмме развернута. В Wave 1 отдельно входят public lead abuse/dedupe/rate-limit contract, checkout idempotency/canonical identity, order versioning, переключение producers/consumer на outbox и durable operations. Media worker в production пока отсутствует и остаётся выключен; extraction нельзя начинать только на основании уже реализованного lease claim.
 
 ## Anti-goals
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -20,6 +20,8 @@ from .bot_fsm import BotFsmState
 from .cart import Cart, CartItem
 from .catalog_import import CatalogImportJob
 from .content import Article, GlobalConfig
+from .communication import CommunicationDelivery
+from .integration_event import ConsumerInbox, IntegrationOutboxEvent
 from .media import MediaAsset, MediaProcessingJob
 from .staff import StaffUser
 from .order import (
@@ -81,6 +83,8 @@ __all__ = [
     "BrandFeature",
     "BotFsmState",
     "CatalogImportJob",
+    "CommunicationDelivery",
+    "ConsumerInbox",
     "Customer",
     "CustomerBranch",
     "CustomerContract",
@@ -97,6 +101,7 @@ __all__ = [
     "Favorite",
     "GlobalConfig",
     "InstallationRate",
+    "IntegrationOutboxEvent",
     "ImportMediaCache",
     "Installer",
     "Lead",

--- a/models/communication.py
+++ b/models/communication.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, String, UniqueConstraint
+from sqlmodel import Field, JSON, SQLModel
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CommunicationDelivery(SQLModel, table=True):
+    __tablename__ = "communication_delivery"
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "channel",
+            "recipient_key",
+            "template_version",
+            name="uq_communication_delivery_event_channel_recipient_template",
+        ),
+        CheckConstraint("template_version > 0", name="ck_delivery_template_version_positive"),
+        CheckConstraint("attempts >= 0", name="ck_delivery_attempts_non_negative"),
+        CheckConstraint("max_attempts > 0", name="ck_delivery_max_attempts_positive"),
+        CheckConstraint(
+            "status IN ('queued', 'running', 'retry', 'sent', 'dead', 'canceled')",
+            name="ck_delivery_status_valid",
+        ),
+        Index(
+            "ix_communication_delivery_claim",
+            "status",
+            "available_at",
+            "priority",
+            "created_at",
+        ),
+        Index("ix_communication_delivery_event_id", "event_id"),
+    )
+
+    delivery_id: str = Field(
+        sa_column=Column(String(32), primary_key=True),
+    )
+    event_id: str = Field(sa_column=Column(String(32), nullable=False))
+    channel: str = Field(sa_column=Column(String(32), nullable=False))
+    recipient_key: str = Field(sa_column=Column(String(160), nullable=False))
+    destination: str = Field(sa_column=Column(String(255), nullable=False))
+    template_key: str = Field(sa_column=Column(String(120), nullable=False))
+    template_version: int = Field(default=1, nullable=False)
+    render_context: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    status: str = Field(default="queued", sa_column=Column(String(32), nullable=False))
+    priority: int = Field(default=100, nullable=False)
+    attempts: int = Field(default=0, nullable=False)
+    max_attempts: int = Field(default=8, nullable=False)
+    available_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    worker_id: Optional[str] = Field(default=None, sa_column=Column(String(128), nullable=True))
+    lease_token: Optional[str] = Field(default=None, sa_column=Column(String(255), nullable=True))
+    lease_expires_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+    provider_message_id: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    last_error_category: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(80), nullable=True),
+    )
+    last_error_code: Optional[str] = Field(default=None, sa_column=Column(String(100), nullable=True))
+    last_error_message: Optional[str] = Field(default=None, sa_column=Column(String(1000), nullable=True))
+    sent_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/models/integration_event.py
+++ b/models/integration_event.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, String, UniqueConstraint
+from sqlmodel import Field, JSON, SQLModel
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class IntegrationOutboxEvent(SQLModel, table=True):
+    __tablename__ = "integration_outbox_event"
+    __table_args__ = (
+        UniqueConstraint(
+            "deduplication_key",
+            name="uq_integration_outbox_event_deduplication_key",
+        ),
+        CheckConstraint("schema_version > 0", name="ck_outbox_schema_version_positive"),
+        CheckConstraint("attempts >= 0", name="ck_outbox_attempts_non_negative"),
+        CheckConstraint("max_attempts > 0", name="ck_outbox_max_attempts_positive"),
+        CheckConstraint(
+            "status IN ('pending', 'processing', 'published', 'dead')",
+            name="ck_outbox_status_valid",
+        ),
+        Index(
+            "ix_integration_outbox_event_claim",
+            "status",
+            "available_at",
+            "priority",
+            "occurred_at",
+        ),
+        Index(
+            "ix_integration_outbox_event_aggregate",
+            "aggregate_type",
+            "aggregate_id",
+            "occurred_at",
+        ),
+    )
+
+    event_id: str = Field(
+        sa_column=Column(String(32), primary_key=True),
+    )
+    event_type: str = Field(sa_column=Column(String(120), nullable=False, index=True))
+    schema_version: int = Field(default=1, nullable=False)
+    aggregate_type: str = Field(sa_column=Column(String(80), nullable=False))
+    aggregate_id: str = Field(sa_column=Column(String(128), nullable=False))
+    aggregate_version: Optional[int] = Field(default=None, nullable=True)
+    deduplication_key: str = Field(sa_column=Column(String(255), nullable=False))
+    idempotency_key: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    actor_id: Optional[str] = Field(default=None, sa_column=Column(String(128), nullable=True))
+    correlation_id: Optional[str] = Field(default=None, sa_column=Column(String(128), nullable=True))
+    causation_id: Optional[str] = Field(default=None, sa_column=Column(String(128), nullable=True))
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    status: str = Field(default="pending", sa_column=Column(String(32), nullable=False))
+    priority: int = Field(default=100, nullable=False)
+    attempts: int = Field(default=0, nullable=False)
+    max_attempts: int = Field(default=8, nullable=False)
+    available_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    worker_id: Optional[str] = Field(default=None, sa_column=Column(String(128), nullable=True))
+    lease_token: Optional[str] = Field(default=None, sa_column=Column(String(255), nullable=True))
+    lease_expires_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+    last_error_code: Optional[str] = Field(default=None, sa_column=Column(String(100), nullable=True))
+    last_error_message: Optional[str] = Field(default=None, sa_column=Column(String(1000), nullable=True))
+    occurred_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    published_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+    )
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class ConsumerInbox(SQLModel, table=True):
+    __tablename__ = "consumer_inbox"
+    __table_args__ = (
+        CheckConstraint("handler_version > 0", name="ck_consumer_inbox_handler_version_positive"),
+        Index("ix_consumer_inbox_processed_at", "processed_at"),
+    )
+
+    consumer_name: str = Field(
+        sa_column=Column(String(120), primary_key=True),
+    )
+    event_id: str = Field(
+        sa_column=Column(String(32), primary_key=True),
+    )
+    handler_version: int = Field(default=1, nullable=False)
+    received_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    processed_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/services/communications/__init__.py
+++ b/services/communications/__init__.py
@@ -1,0 +1,8 @@
+"""Durable communications contracts and persistence primitives."""
+
+from services.communications.outbox_service import (
+    IntegrationOutboxService,
+    OutboxEventConflictError,
+)
+
+__all__ = ["IntegrationOutboxService", "OutboxEventConflictError"]

--- a/services/communications/contracts.py
+++ b/services/communications/contracts.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class _ContractV1(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+
+class IntegrationEventEnvelopeV1(_ContractV1):
+    event_id: str = Field(pattern=r"^[0-9a-f]{32}$")
+    event_type: str = Field(
+        min_length=3,
+        max_length=120,
+        pattern=r"^[a-z][a-z0-9_.-]+$",
+    )
+    schema_version: Literal[1] = 1
+    aggregate_type: str = Field(
+        min_length=1,
+        max_length=80,
+        pattern=r"^[a-z][a-z0-9_.-]*$",
+    )
+    aggregate_id: str = Field(min_length=1, max_length=128)
+    aggregate_version: int | None = Field(default=None, ge=0)
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    actor_id: str | None = Field(default=None, max_length=128)
+    correlation_id: str | None = Field(default=None, max_length=128)
+    causation_id: str | None = Field(default=None, max_length=128)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=255)
+    payload: dict[str, Any]
+
+    @field_validator("occurred_at")
+    @classmethod
+    def occurred_at_must_include_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("occurred_at must include a timezone")
+        return value
+
+
+class PublicOrderCustomerSnapshotV1(_ContractV1):
+    name: str = Field(min_length=1, max_length=160)
+    phone: str = Field(min_length=1, max_length=80)
+    email: str | None = Field(default=None, max_length=254)
+    address: str | None = Field(default=None, max_length=500)
+    customer_type: Literal["individual", "company"] = "individual"
+
+
+class PublicOrderProductLineSnapshotV1(_ContractV1):
+    product_id: int | None = Field(default=None, gt=0)
+    title: str = Field(min_length=1, max_length=180)
+    quantity: int = Field(ge=1, le=20)
+    unit_price: Decimal = Field(ge=0, max_digits=14, decimal_places=2)
+    installation_included: bool = False
+    installation_price: Decimal = Field(
+        default=Decimal("0"),
+        ge=0,
+        max_digits=14,
+        decimal_places=2,
+    )
+
+
+class PublicOrderServiceLineSnapshotV1(_ContractV1):
+    service_id: int | None = Field(default=None, gt=0)
+    title: str = Field(min_length=1, max_length=180)
+    quantity: int = Field(ge=1, le=20)
+    unit_price: Decimal = Field(ge=0, max_digits=14, decimal_places=2)
+
+
+class PublicOrderCreatedPayloadV1(_ContractV1):
+    order_id: int = Field(gt=0)
+    status: str = Field(min_length=1, max_length=40)
+    customer: PublicOrderCustomerSnapshotV1
+    comment: str | None = Field(default=None, max_length=2000)
+    total_amount: Decimal = Field(ge=0, max_digits=14, decimal_places=2)
+    currency: Literal["BYN"] = "BYN"
+    product_lines: list[PublicOrderProductLineSnapshotV1] = Field(
+        default_factory=list,
+        max_length=20,
+    )
+    service_lines: list[PublicOrderServiceLineSnapshotV1] = Field(
+        default_factory=list,
+        max_length=20,
+    )
+
+
+class PublicContactLeadCreatedPayloadV1(_ContractV1):
+    lead_id: int = Field(gt=0)
+    status: str = Field(min_length=1, max_length=40)
+    name: str = Field(min_length=1, max_length=160)
+    phone: str = Field(min_length=1, max_length=80)
+    email: str | None = Field(default=None, max_length=254)
+    address: str | None = Field(default=None, max_length=500)
+    message: str | None = Field(default=None, max_length=2000)

--- a/services/communications/outbox_service.py
+++ b/services/communications/outbox_service.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy import or_
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import IntegrationOutboxEvent
+from services.communications.contracts import IntegrationEventEnvelopeV1
+
+
+class OutboxEventConflictError(ValueError):
+    """The same deterministic event key was reused with different content."""
+
+
+class IntegrationOutboxService:
+    _EVENT_NAMESPACE = uuid.UUID("970f0f76-e63c-4ea3-bb82-e955470f5af9")
+
+    @staticmethod
+    def build_deduplication_key(
+        *,
+        event_type: str,
+        schema_version: int,
+        aggregate_type: str,
+        aggregate_id: str,
+        aggregate_version: int | None,
+        idempotency_key: str | None,
+    ) -> str:
+        if aggregate_version is None and not idempotency_key:
+            raise ValueError(
+                "Outbox events require aggregate_version or idempotency_key"
+            )
+        identity = [
+            event_type,
+            schema_version,
+            aggregate_type,
+            aggregate_id,
+            aggregate_version,
+            idempotency_key,
+        ]
+        canonical_identity = json.dumps(
+            identity,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        digest = hashlib.sha256(canonical_identity.encode("utf-8")).hexdigest()
+        return f"sha256:{digest}"
+
+    @classmethod
+    def build_event_id(cls, deduplication_key: str) -> str:
+        return uuid.uuid5(cls._EVENT_NAMESPACE, deduplication_key).hex
+
+    @staticmethod
+    def _normalize_payload(payload: BaseModel | Mapping[str, Any]) -> dict[str, Any]:
+        normalized = (
+            payload.model_dump(mode="json")
+            if isinstance(payload, BaseModel)
+            else dict(payload)
+        )
+        try:
+            serialized = json.dumps(
+                normalized,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Outbox payload must be JSON serializable") from exc
+        return json.loads(serialized)
+
+    @staticmethod
+    async def _find_existing(
+        session: AsyncSession,
+        *,
+        event_id: str,
+        deduplication_key: str,
+    ) -> IntegrationOutboxEvent | None:
+        result = await session.execute(
+            select(IntegrationOutboxEvent).where(
+                or_(
+                    IntegrationOutboxEvent.event_id == event_id,
+                    IntegrationOutboxEvent.deduplication_key == deduplication_key,
+                )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    def _ensure_same_event(
+        existing: IntegrationOutboxEvent,
+        envelope: IntegrationEventEnvelopeV1,
+        deduplication_key: str,
+    ) -> None:
+        existing_identity = (
+            existing.event_id,
+            existing.deduplication_key,
+            existing.event_type,
+            existing.schema_version,
+            existing.aggregate_type,
+            existing.aggregate_id,
+            existing.aggregate_version,
+            existing.idempotency_key,
+            existing.payload,
+        )
+        requested_identity = (
+            envelope.event_id,
+            deduplication_key,
+            envelope.event_type,
+            envelope.schema_version,
+            envelope.aggregate_type,
+            envelope.aggregate_id,
+            envelope.aggregate_version,
+            envelope.idempotency_key,
+            envelope.payload,
+        )
+        if existing_identity != requested_identity:
+            raise OutboxEventConflictError(
+                "Outbox deduplication key was reused with different event content"
+            )
+
+    @classmethod
+    async def enqueue(
+        cls,
+        session: AsyncSession,
+        *,
+        event_type: str,
+        aggregate_type: str,
+        aggregate_id: int | str,
+        payload: BaseModel | Mapping[str, Any],
+        schema_version: int = 1,
+        aggregate_version: int | None = None,
+        occurred_at: datetime | None = None,
+        actor_id: str | None = None,
+        correlation_id: str | None = None,
+        causation_id: str | None = None,
+        idempotency_key: str | None = None,
+        priority: int = 100,
+        max_attempts: int = 8,
+    ) -> IntegrationOutboxEvent:
+        """Add an event to the current transaction without committing it."""
+
+        normalized_payload = cls._normalize_payload(payload)
+        normalized_event_type = str(event_type).strip()
+        normalized_aggregate_type = str(aggregate_type).strip()
+        normalized_aggregate_id = str(aggregate_id).strip()
+        normalized_idempotency_key = (
+            str(idempotency_key).strip() or None
+            if idempotency_key is not None
+            else None
+        )
+        deduplication_key = cls.build_deduplication_key(
+            event_type=normalized_event_type,
+            schema_version=schema_version,
+            aggregate_type=normalized_aggregate_type,
+            aggregate_id=normalized_aggregate_id,
+            aggregate_version=aggregate_version,
+            idempotency_key=normalized_idempotency_key,
+        )
+        event_id = cls.build_event_id(deduplication_key)
+        envelope = IntegrationEventEnvelopeV1(
+            event_id=event_id,
+            event_type=normalized_event_type,
+            schema_version=schema_version,
+            aggregate_type=normalized_aggregate_type,
+            aggregate_id=normalized_aggregate_id,
+            aggregate_version=aggregate_version,
+            occurred_at=occurred_at or datetime.now(timezone.utc),
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            causation_id=causation_id,
+            idempotency_key=normalized_idempotency_key,
+            payload=normalized_payload,
+        )
+
+        existing = await cls._find_existing(
+            session,
+            event_id=event_id,
+            deduplication_key=deduplication_key,
+        )
+        if existing is not None:
+            cls._ensure_same_event(existing, envelope, deduplication_key)
+            return existing
+
+        event = IntegrationOutboxEvent(
+            event_id=envelope.event_id,
+            event_type=envelope.event_type,
+            schema_version=envelope.schema_version,
+            aggregate_type=envelope.aggregate_type,
+            aggregate_id=envelope.aggregate_id,
+            aggregate_version=envelope.aggregate_version,
+            deduplication_key=deduplication_key,
+            idempotency_key=envelope.idempotency_key,
+            actor_id=envelope.actor_id,
+            correlation_id=envelope.correlation_id,
+            causation_id=envelope.causation_id,
+            payload=envelope.payload,
+            priority=max(0, int(priority)),
+            max_attempts=max(1, int(max_attempts)),
+            occurred_at=envelope.occurred_at,
+            available_at=envelope.occurred_at,
+        )
+        dialect_name = session.get_bind().dialect.name
+        event_values = event.model_dump()
+        if dialect_name == "postgresql":
+            statement = postgresql_insert(IntegrationOutboxEvent).values(**event_values)
+        elif dialect_name == "sqlite":
+            statement = sqlite_insert(IntegrationOutboxEvent).values(**event_values)
+        else:
+            raise NotImplementedError(
+                f"Atomic outbox enqueue is not implemented for dialect {dialect_name!r}"
+            )
+
+        inserted_event_id = (
+            await session.execute(
+                statement.on_conflict_do_nothing(
+                    index_elements=[IntegrationOutboxEvent.deduplication_key]
+                ).returning(IntegrationOutboxEvent.event_id)
+            )
+        ).scalar_one_or_none()
+        existing = await cls._find_existing(
+            session,
+            event_id=inserted_event_id or event_id,
+            deduplication_key=deduplication_key,
+        )
+        if existing is None:
+            raise RuntimeError("Outbox event insert completed without a readable row")
+        cls._ensure_same_event(existing, envelope, deduplication_key)
+        return existing

--- a/tests/integration/test_integration_outbox_concurrency.py
+++ b/tests/integration/test_integration_outbox_concurrency.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import IntegrationOutboxEvent
+from services.communications.contracts import PublicContactLeadCreatedPayloadV1
+from services.communications.outbox_service import IntegrationOutboxService
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_identical_enqueue_creates_one_event(db_engine):
+    assert db_engine.dialect.name == "postgresql"
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    barrier = asyncio.Barrier(2)
+
+    async def enqueue_from(worker_name: str) -> str:
+        async with session_factory() as session:
+            await barrier.wait()
+            event = await IntegrationOutboxService.enqueue(
+                session,
+                event_type="crm.public_contact_lead.created",
+                aggregate_type="lead",
+                aggregate_id=812,
+                aggregate_version=1,
+                correlation_id=worker_name,
+                idempotency_key="concurrent-contact-812",
+                payload=PublicContactLeadCreatedPayloadV1(
+                    lead_id=812,
+                    status="new",
+                    name="Иван",
+                    phone="+375291112233",
+                    message="Нужна консультация",
+                ),
+            )
+            await session.commit()
+            return event.event_id
+
+    event_ids = await asyncio.gather(
+        enqueue_from("request-a"),
+        enqueue_from("request-b"),
+    )
+
+    async with session_factory() as verification_session:
+        event_count = (
+            await verification_session.execute(
+                select(func.count(IntegrationOutboxEvent.event_id)).where(
+                    IntegrationOutboxEvent.aggregate_id == "812"
+                )
+            )
+        ).scalar_one()
+
+    assert event_ids[0] == event_ids[1]
+    assert event_count == 1

--- a/tests/unit/test_communication_contracts.py
+++ b/tests/unit/test_communication_contracts.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from services.communications.contracts import (
+    IntegrationEventEnvelopeV1,
+    PublicContactLeadCreatedPayloadV1,
+    PublicOrderCreatedPayloadV1,
+    PublicOrderCustomerSnapshotV1,
+    PublicOrderProductLineSnapshotV1,
+)
+
+
+def test_versioned_public_order_payload_is_bounded_and_json_safe():
+    payload = PublicOrderCreatedPayloadV1(
+        order_id=41,
+        status="negotiation",
+        customer=PublicOrderCustomerSnapshotV1(
+            name="Иван",
+            phone="+375291112233",
+            address="Минск " + "А" * 490,
+        ),
+        comment="К" * 2000,
+        total_amount=Decimal("1280.50"),
+        product_lines=[
+            PublicOrderProductLineSnapshotV1(
+                product_id=7,
+                title="TCL BreezeIN",
+                quantity=1,
+                unit_price=Decimal("1280.50"),
+            )
+        ],
+    )
+
+    dumped = payload.model_dump(mode="json")
+
+    assert dumped["total_amount"] == "1280.50"
+    assert dumped["currency"] == "BYN"
+    assert dumped["product_lines"][0]["product_id"] == 7
+
+
+def test_contact_lead_contract_matches_public_ingress_bounds():
+    payload = PublicContactLeadCreatedPayloadV1(
+        lead_id=12,
+        status="new",
+        name="Иван",
+        phone="+375291112233",
+        address="А" * 500,
+        message="М" * 2000,
+    )
+
+    assert len(payload.address or "") == 500
+    assert len(payload.message or "") == 2000
+
+    with pytest.raises(ValidationError):
+        PublicContactLeadCreatedPayloadV1(
+            lead_id=12,
+            status="new",
+            name="Иван",
+            phone="+375291112233",
+            message="М" * 2001,
+        )
+
+
+def test_event_envelope_requires_timezone_and_rejects_unknown_fields():
+    base = {
+        "event_id": "a" * 32,
+        "event_type": "crm.public_order.created",
+        "aggregate_type": "order",
+        "aggregate_id": "41",
+        "payload": {"order_id": 41},
+    }
+
+    with pytest.raises(ValidationError, match="timezone"):
+        IntegrationEventEnvelopeV1(
+            **base,
+            occurred_at=datetime(2026, 7, 13, 12, 0, 0),
+        )
+
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        IntegrationEventEnvelopeV1(
+            **base,
+            occurred_at=datetime.now(timezone.utc),
+            unexpected="not allowed",
+        )

--- a/tests/unit/test_communication_foundation_migration.py
+++ b/tests/unit/test_communication_foundation_migration.py
@@ -1,0 +1,75 @@
+import importlib.util
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect
+
+
+REVISION = "3f7a9c1d2e04"
+MIGRATION_PATH = Path("alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py")
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location("communication_foundation_migration", MIGRATION_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_communication_foundation_is_in_the_single_alembic_head_chain():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(REVISION)
+    heads = script.get_heads()
+
+    assert len(heads) == 1
+    assert revision is not None
+    assert revision.down_revision == "2d4f6a8b0c13"
+    assert REVISION in {
+        item.revision for item in script.iterate_revisions(heads[0], "base")
+    }
+
+
+def test_communication_foundation_migration_upgrades_and_downgrades_sqlite():
+    migration = _load_migration_module()
+    engine = create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+        inspector = inspect(connection)
+
+        assert {
+            "integration_outbox_event",
+            "consumer_inbox",
+            "communication_delivery",
+        }.issubset(inspector.get_table_names())
+        assert any(
+            item["name"] == "uq_integration_outbox_event_deduplication_key"
+            for item in inspector.get_unique_constraints("integration_outbox_event")
+        )
+        assert any(
+            item["name"]
+            == "uq_communication_delivery_event_channel_recipient_template"
+            and item["column_names"]
+            == ["event_id", "channel", "recipient_key", "template_version"]
+            for item in inspector.get_unique_constraints("communication_delivery")
+        )
+        assert any(
+            item["name"] == "ck_outbox_status_valid"
+            for item in inspector.get_check_constraints("integration_outbox_event")
+        )
+        assert any(
+            item["name"] == "ck_delivery_status_valid"
+            for item in inspector.get_check_constraints("communication_delivery")
+        )
+
+        migration.downgrade()
+        assert not {
+            "integration_outbox_event",
+            "consumer_inbox",
+            "communication_delivery",
+        }.intersection(inspect(connection).get_table_names())

--- a/tests/unit/test_integration_outbox_service.py
+++ b/tests/unit/test_integration_outbox_service.py
@@ -1,0 +1,171 @@
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import IntegrationOutboxEvent
+from services.communications.contracts import (
+    PublicContactLeadCreatedPayloadV1,
+    PublicOrderCreatedPayloadV1,
+    PublicOrderCustomerSnapshotV1,
+)
+from services.communications.outbox_service import (
+    IntegrationOutboxService,
+    OutboxEventConflictError,
+)
+
+
+@pytest.fixture
+async def outbox_session_factory(tmp_path):
+    database_path = tmp_path / "outbox.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    async with engine.begin() as connection:
+        await connection.run_sync(IntegrationOutboxEvent.__table__.create)
+
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _lead_payload(*, message: str = "Нужна консультация"):
+    return PublicContactLeadCreatedPayloadV1(
+        lead_id=12,
+        status="new",
+        name="Иван",
+        phone="+375291112233",
+        message=message,
+    )
+
+
+def test_deduplication_identity_is_canonical_and_requires_a_discriminator():
+    first = IntegrationOutboxService.build_deduplication_key(
+        event_type="crm.event",
+        schema_version=1,
+        aggregate_type="order",
+        aggregate_id="foo",
+        aggregate_version=1,
+        idempotency_key="av2:x",
+    )
+    second = IntegrationOutboxService.build_deduplication_key(
+        event_type="crm.event",
+        schema_version=1,
+        aggregate_type="order",
+        aggregate_id="foo:av1",
+        aggregate_version=2,
+        idempotency_key="x",
+    )
+
+    assert first != second
+    assert first.startswith("sha256:")
+    assert len(first) == 71
+
+    with pytest.raises(ValueError, match="aggregate_version or idempotency_key"):
+        IntegrationOutboxService.build_deduplication_key(
+            event_type="crm.event",
+            schema_version=1,
+            aggregate_type="order",
+            aggregate_id="foo",
+            aggregate_version=None,
+            idempotency_key=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_enqueue_is_deterministic_and_does_not_commit(outbox_session_factory):
+    async with outbox_session_factory() as session:
+        first = await IntegrationOutboxService.enqueue(
+            session,
+            event_type="crm.public_contact_lead.created",
+            aggregate_type="lead",
+            aggregate_id=12,
+            aggregate_version=1,
+            idempotency_key="contact-request-12",
+            payload=_lead_payload(),
+        )
+        duplicate = await IntegrationOutboxService.enqueue(
+            session,
+            event_type="crm.public_contact_lead.created",
+            aggregate_type="lead",
+            aggregate_id=12,
+            aggregate_version=1,
+            idempotency_key="contact-request-12",
+            payload=_lead_payload(),
+        )
+
+        assert duplicate is first
+        assert first.event_id == duplicate.event_id
+        assert (
+            await session.execute(select(func.count(IntegrationOutboxEvent.event_id)))
+        ).scalar_one() == 1
+        await session.rollback()
+
+    async with outbox_session_factory() as verification_session:
+        count = (
+            await verification_session.execute(
+                select(func.count(IntegrationOutboxEvent.event_id))
+            )
+        ).scalar_one()
+        assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_same_event_key_with_different_payload_is_a_conflict(
+    outbox_session_factory,
+):
+    async with outbox_session_factory() as session:
+        await IntegrationOutboxService.enqueue(
+            session,
+            event_type="crm.public_contact_lead.created",
+            aggregate_type="lead",
+            aggregate_id=12,
+            aggregate_version=1,
+            payload=_lead_payload(message="Первая версия"),
+        )
+
+        with pytest.raises(OutboxEventConflictError):
+            await IntegrationOutboxService.enqueue(
+                session,
+                event_type="crm.public_contact_lead.created",
+                aggregate_type="lead",
+                aggregate_id=12,
+                aggregate_version=1,
+                payload=_lead_payload(message="Другая версия"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_versions_produce_different_event_ids(outbox_session_factory):
+    payload = PublicOrderCreatedPayloadV1(
+        order_id=41,
+        status="negotiation",
+        customer=PublicOrderCustomerSnapshotV1(
+            name="Иван",
+            phone="+375291112233",
+        ),
+        total_amount=Decimal("1280.50"),
+    )
+    async with outbox_session_factory() as session:
+        version_one = await IntegrationOutboxService.enqueue(
+            session,
+            event_type="crm.public_order.changed",
+            aggregate_type="order",
+            aggregate_id=41,
+            aggregate_version=1,
+            payload=payload,
+        )
+        version_two = await IntegrationOutboxService.enqueue(
+            session,
+            event_type="crm.public_order.changed",
+            aggregate_type="order",
+            aggregate_id=41,
+            aggregate_version=2,
+            payload=payload,
+        )
+
+        assert version_one.event_id != version_two.event_id
+        assert version_one.deduplication_key != version_two.deduplication_key

--- a/tests/unit/test_model_schema_metadata.py
+++ b/tests/unit/test_model_schema_metadata.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Enum, String, UniqueConstraint
+from sqlalchemy import CheckConstraint, Enum, String, UniqueConstraint
 from sqlmodel import SQLModel
 
 import models  # noqa: F401
@@ -111,4 +111,53 @@ def test_model_indexes_match_current_database_shape():
     assert any(
         index.name == "ix_bank_receipt_account_balance_after"
         for index in bank_receipt.indexes
+    )
+
+
+def test_communication_foundation_metadata_has_durable_uniqueness_and_claim_indexes():
+    outbox = SQLModel.metadata.tables["integration_outbox_event"]
+    inbox = SQLModel.metadata.tables["consumer_inbox"]
+    delivery = SQLModel.metadata.tables["communication_delivery"]
+
+    assert [column.name for column in inbox.primary_key.columns] == [
+        "consumer_name",
+        "event_id",
+    ]
+    assert outbox.c.idempotency_key.nullable is True
+    assert outbox.c.deduplication_key.type.length == 255
+    assert any(
+        isinstance(constraint, UniqueConstraint)
+        and constraint.name == "uq_integration_outbox_event_deduplication_key"
+        and [column.name for column in constraint.columns] == ["deduplication_key"]
+        for constraint in outbox.constraints
+    )
+    assert any(
+        index.name == "ix_integration_outbox_event_claim"
+        and [column.name for column in index.columns]
+        == ["status", "available_at", "priority", "occurred_at"]
+        for index in outbox.indexes
+    )
+    assert any(
+        isinstance(constraint, UniqueConstraint)
+        and constraint.name
+        == "uq_communication_delivery_event_channel_recipient_template"
+        and [column.name for column in constraint.columns]
+        == ["event_id", "channel", "recipient_key", "template_version"]
+        for constraint in delivery.constraints
+    )
+    assert any(
+        index.name == "ix_communication_delivery_claim"
+        and [column.name for column in index.columns]
+        == ["status", "available_at", "priority", "created_at"]
+        for index in delivery.indexes
+    )
+    assert any(
+        isinstance(constraint, CheckConstraint)
+        and constraint.name == "ck_outbox_status_valid"
+        for constraint in outbox.constraints
+    )
+    assert any(
+        isinstance(constraint, CheckConstraint)
+        and constraint.name == "ck_delivery_status_valid"
+        for constraint in delivery.constraints
     )


### PR DESCRIPTION
## Scope

This is Wave 1 PR-A: an additive, disabled persistence and contract foundation only.

- adds versioned integration outbox, consumer inbox, and per-recipient communication delivery models
- adds the additive Alembic migration after the deployed Wave 0 head
- adds bounded v1 order/contact event snapshots
- adds deterministic atomic enqueue with canonical SHA-256 identity and PostgreSQL/SQLite ON CONFLICT semantics
- enforces aggregate-version or idempotency discrimination and template-version delivery uniqueness
- updates the audit/roadmap with the completed Wave 0 production rollout

## Explicit non-goals

- no website order/contact producer is switched yet
- no scheduler/worker/provider is enabled
- no Telegram or current notification behavior changes
- no production outbox rows are created by this PR

## Validation

- full unit suite: 1005 passed
- full integration suite: 182 passed
- final focused contracts/model/migration/PostgreSQL concurrency suite: 15 passed
- concurrent identical enqueue from two PostgreSQL sessions creates one row and one event id
- existing PostgreSQL clone downgrade/upgrade to head passed
- fresh empty PostgreSQL replay passed
- alembic check reports no drift
- py_compile and git diff check passed

## Follow-up sequence

PR-B will add dispatcher/inbox/per-recipient delivery materialization while still disabled. PR-C will add the leased delivery worker/provider adapter. Only after those are green will a producer switch atomically write domain state plus outbox and remove synchronous Telegram from the request path.