### PR TITLE
feat: add atomic communications dispatcher

### DIFF
--- a/docs/global-system-audit-2026-07-12.md
+++ b/docs/global-system-audit-2026-07-12.md
@@ -57,7 +57,7 @@ MVN уже состоит из нескольких независимо раз�
 | JOB-002 | P1 | Media | Два worker'а могут атомарно незащищённо забрать одну media job | Закрыто и развернуто в API Wave 0: atomic claim, lease token, heartbeat; сам worker остаётся выключен до отдельного managed rollout |
 | COM-001 | P1 | Telegram | Ошибки проглатываются, попытка считается доставкой; живой log доказал ложный `notified_admins=2` при отказе | Закрыто в Wave 0 |
 | COM-002 | P1 | Telegram | Ручной bank import не вызывает notify, после dedupe уведомление теряется навсегда | Закрыто в Wave 0 |
-| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | В работе: additive outbox/inbox/per-recipient delivery foundation реализуется в Wave 1 PR-A; producer switch и consumer ещё открыты |
+| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | В работе: PR-A (#727) развернул выключенный additive outbox/inbox/per-recipient delivery foundation; PR-B добавляет атомарную материализацию deliveries+inbox без runtime/scheduler/provider; producer switch и сетевой worker ещё открыты |
 | COM-004 | P1 | Tests | Integration checkout способен отправлять реальные Telegram-сообщения владельцам | Закрыто в Wave 0 |
 | PRIV-001 | P1 | Media | Реквизиты, order attachments и диагностические фото лежат в публичном `/media`/public R2 | Открыто |
 | WEB-001 | P1 | SSG | Build запрашивает только 1000 из 1117 товаров; product routes после 1000 отсутствуют и production URL отвечает 404 | Закрыто в Wave 0: пагинация, dedupe и hard-fail invariant |
@@ -345,7 +345,7 @@ Wave 0 подтверждена локально, в CI и production. Media pro
 
 ### Wave 1 — данные и надёжность
 
-- Transactional outbox/inbox + communications worker. PR-A добавляет только выключенный additive persistence/contracts foundation; переключение producers и consumer выполняются следующими отдельными PR.
+- Transactional outbox/inbox + communications worker. PR-A развернул только выключенный additive persistence/contracts foundation. PR-B добавляет caller-owned single-transaction dispatcher (`FOR UPDATE SKIP LOCKED`, deterministic delivery upsert, inbox-last, retry/dead bookkeeping) без scheduler и сетевых вызовов. Leased provider worker и атомарное переключение producers выполняются следующими отдельными PR.
 - Order version/409 и command-specific updates.
 - Canonical customer identity + checkout idempotency.
 - Public contact/availability lead abuse policy: edge+app rate limit, canonical phone/email, dedupe window, idempotency key и risk-based anti-bot.

--- a/docs/service-decomposition-roadmap.md
+++ b/docs/service-decomposition-roadmap.md
@@ -6,7 +6,7 @@
 
 Сначала modular monolith, затем extraction. Storefront и Telegram process уже можно разворачивать отдельно, но это ещё не самостоятельные domain services: они используют общую backend-модель и не имеют устойчивых command/event contracts.
 
-Wave 0 закрыта, слита через PR #726 и развернута в production как SHA `886593e0`: единый CI дал **1177 passed**, migration/codegen gates, Patroni primary/replica deploy и storefront canary/VPS/Cloudflare smoke прошли. Декомпозиция этим не завершена. Outbox producer switch/consumer, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Первая Wave 1 итерация добавляет только выключенный additive outbox/inbox/delivery foundation без изменения production notification path.
+Wave 0 закрыта, слита через PR #726 и развернута в production как SHA `886593e0`: единый CI дал **1177 passed**, migration/codegen gates, Patroni primary/replica deploy и storefront canary/VPS/Cloudflare smoke прошли. Декомпозиция этим не завершена. Outbox producer switch/consumer, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Wave 1 PR-A (#727, SHA `0c16ea38`) уже развернул выключенный additive outbox/inbox/delivery foundation; PR-B добавляет транзакционный dispatcher/materializer, но по-прежнему не включает scheduler, provider worker и producer switch, поэтому production notification path не меняется.
 
 ## Целевые bounded contexts
 

--- a/services/communications/contracts.py
+++ b/services/communications/contracts.py
@@ -95,3 +95,40 @@ class PublicContactLeadCreatedPayloadV1(_ContractV1):
     email: str | None = Field(default=None, max_length=254)
     address: str | None = Field(default=None, max_length=500)
     message: str | None = Field(default=None, max_length=2000)
+
+
+class CommunicationRecipientV1(_ContractV1):
+    channel: Literal["telegram"] = "telegram"
+    recipient_key: str = Field(
+        min_length=1,
+        max_length=160,
+        pattern=r"^[a-z][a-z0-9_.:-]*$",
+    )
+    destination: str = Field(pattern=r"^-?[1-9][0-9]{0,19}$")
+    source: Literal["staff", "legacy"]
+    staff_user_id: int | None = Field(default=None, gt=0)
+
+
+class CommunicationTemplatePlanV1(_ContractV1):
+    channel: Literal["telegram"] = "telegram"
+    audience: Literal["management"] = "management"
+    template_key: str = Field(
+        min_length=3,
+        max_length=120,
+        pattern=r"^[a-z][a-z0-9_.-]+$",
+    )
+    template_version: Literal[1] = 1
+    render_context: dict[str, Any]
+
+
+class DispatchOutcomeV1(_ContractV1):
+    outcome: Literal[
+        "materialized",
+        "already_materialized",
+        "retry_scheduled",
+        "dead",
+    ]
+    event_id: str = Field(pattern=r"^[0-9a-f]{32}$")
+    attempts: int = Field(ge=0)
+    delivery_count: int = Field(ge=0)
+    next_attempt_at: datetime | None = None

--- a/services/communications/delivery_materializer.py
+++ b/services/communications/delivery_materializer.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Sequence
+
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CommunicationDelivery, IntegrationOutboxEvent
+from services.communications.contracts import (
+    CommunicationRecipientV1,
+    CommunicationTemplatePlanV1,
+)
+
+
+class NoEligibleCommunicationRecipients(RuntimeError):
+    pass
+
+
+class DeliveryMaterializationConflict(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class DeliveryMaterializationResult:
+    delivery_count: int
+    created_count: int
+
+
+class CommunicationDeliveryMaterializer:
+    """Persist immutable delivery snapshots without owning the transaction."""
+
+    _DELIVERY_NAMESPACE = uuid.UUID("daebd691-4c30-4f36-8e08-4923c481d486")
+
+    @classmethod
+    def build_delivery_id(
+        cls,
+        *,
+        event_id: str,
+        channel: str,
+        recipient_key: str,
+        template_version: int,
+    ) -> str:
+        canonical_identity = json.dumps(
+            [event_id, channel, recipient_key, template_version],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        return uuid.uuid5(cls._DELIVERY_NAMESPACE, canonical_identity).hex
+
+    @classmethod
+    async def materialize(
+        cls,
+        session: AsyncSession,
+        *,
+        event: IntegrationOutboxEvent,
+        plan: CommunicationTemplatePlanV1,
+        recipients: Sequence[CommunicationRecipientV1],
+        now: datetime | None = None,
+    ) -> DeliveryMaterializationResult:
+        if not recipients:
+            raise NoEligibleCommunicationRecipients(
+                "No eligible communication recipients are configured"
+            )
+
+        recipient_keys = [recipient.recipient_key for recipient in recipients]
+        if len(set(recipient_keys)) != len(recipient_keys):
+            raise DeliveryMaterializationConflict(
+                "Recipient directory returned duplicate recipient keys"
+            )
+
+        materialized_at = now or datetime.now(timezone.utc)
+        rows = [
+            {
+                "delivery_id": cls.build_delivery_id(
+                    event_id=event.event_id,
+                    channel=plan.channel,
+                    recipient_key=recipient.recipient_key,
+                    template_version=plan.template_version,
+                ),
+                "event_id": event.event_id,
+                "channel": plan.channel,
+                "recipient_key": recipient.recipient_key,
+                "destination": recipient.destination,
+                "template_key": plan.template_key,
+                "template_version": plan.template_version,
+                "render_context": plan.render_context,
+                "status": "queued",
+                "priority": max(0, int(event.priority)),
+                "attempts": 0,
+                "max_attempts": max(1, int(event.max_attempts)),
+                "available_at": materialized_at,
+                "created_at": materialized_at,
+                "updated_at": materialized_at,
+            }
+            for recipient in recipients
+        ]
+
+        dialect_name = session.get_bind().dialect.name
+        if dialect_name == "postgresql":
+            statement = postgresql_insert(CommunicationDelivery).values(rows)
+        elif dialect_name == "sqlite":
+            statement = sqlite_insert(CommunicationDelivery).values(rows)
+        else:
+            raise NotImplementedError(
+                f"Atomic delivery materialization is not implemented for {dialect_name!r}"
+            )
+
+        created_ids = list(
+            (
+                await session.execute(
+                    # The deterministic primary key and the natural delivery
+                    # identity can both win a concurrent race. Ignore either
+                    # unique conflict, then re-read and verify the complete
+                    # immutable snapshot below.
+                    statement.on_conflict_do_nothing().returning(
+                        CommunicationDelivery.delivery_id
+                    )
+                )
+            ).scalars()
+        )
+        existing = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery).where(
+                        CommunicationDelivery.event_id == event.event_id,
+                        CommunicationDelivery.channel == plan.channel,
+                        CommunicationDelivery.template_version == plan.template_version,
+                    )
+                )
+            ).scalars()
+        )
+        existing_by_key = {delivery.recipient_key: delivery for delivery in existing}
+        if set(existing_by_key) != set(recipient_keys):
+            raise DeliveryMaterializationConflict(
+                "An immutable event delivery set was reused with different recipients"
+            )
+
+        expected_by_key = {row["recipient_key"]: row for row in rows}
+        for recipient_key, delivery in existing_by_key.items():
+            expected = expected_by_key[recipient_key]
+            immutable_snapshot = (
+                delivery.delivery_id,
+                delivery.destination,
+                delivery.template_key,
+                delivery.render_context,
+                delivery.priority,
+                delivery.max_attempts,
+            )
+            expected_snapshot = (
+                expected["delivery_id"],
+                expected["destination"],
+                expected["template_key"],
+                expected["render_context"],
+                expected["priority"],
+                expected["max_attempts"],
+            )
+            if immutable_snapshot != expected_snapshot:
+                raise DeliveryMaterializationConflict(
+                    "An immutable delivery identity was reused with different content"
+                )
+
+        return DeliveryMaterializationResult(
+            delivery_count=len(existing),
+            created_count=len(created_ids),
+        )

--- a/services/communications/dispatcher.py
+++ b/services/communications/dispatcher.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CommunicationDelivery, ConsumerInbox, IntegrationOutboxEvent
+from services.communications.contracts import DispatchOutcomeV1
+from services.communications.delivery_materializer import (
+    CommunicationDeliveryMaterializer,
+    DeliveryMaterializationConflict,
+    NoEligibleCommunicationRecipients,
+)
+from services.communications.recipient_directory import ManagementRecipientDirectory
+from services.communications.template_registry import (
+    CONSUMER_NAME,
+    HANDLER_VERSION,
+    SUPPORTED_EVENT_TYPES,
+    InvalidCommunicationEventPayload,
+    UnsupportedCommunicationEvent,
+    WebsiteTemplateRegistry,
+)
+from services.communications.templates import TemplateRenderError
+
+
+class ConsumerInboxConsistencyError(RuntimeError):
+    pass
+
+
+class CommunicationOutboxDispatcher:
+    """Atomically convert one supported outbox event into queued deliveries.
+
+    The caller owns commit/rollback. There is deliberately no lease here:
+    selection, rendering, recipient lookup and persistence are short database
+    work performed under one row lock. Leases belong to the later network
+    delivery worker.
+    """
+
+    _RETRY_BASE_SECONDS = 30
+    _RETRY_MAX_SECONDS = 3600
+
+    @staticmethod
+    def _utc_now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @classmethod
+    async def _select_next(
+        cls,
+        session: AsyncSession,
+        *,
+        now: datetime,
+    ) -> IntegrationOutboxEvent | None:
+        query = (
+            select(IntegrationOutboxEvent)
+            .where(
+                IntegrationOutboxEvent.status == "pending",
+                IntegrationOutboxEvent.available_at <= now,
+                IntegrationOutboxEvent.event_type.in_(SUPPORTED_EVENT_TYPES),
+            )
+            .order_by(
+                IntegrationOutboxEvent.priority.asc(),
+                IntegrationOutboxEvent.occurred_at.asc(),
+                IntegrationOutboxEvent.created_at.asc(),
+                IntegrationOutboxEvent.event_id.asc(),
+            )
+            .limit(1)
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            query = query.with_for_update(skip_locked=True)
+        return (await session.execute(query)).scalar_one_or_none()
+
+    @classmethod
+    def _retry_delay(cls, *, event_id: str, attempts: int) -> timedelta:
+        exponent = max(0, min(int(attempts) - 1, 16))
+        base_seconds = min(
+            cls._RETRY_MAX_SECONDS,
+            cls._RETRY_BASE_SECONDS * (2**exponent),
+        )
+        jitter_window = max(1, base_seconds // 5)
+        digest = hashlib.sha256(f"{event_id}:{attempts}".encode()).digest()
+        jitter_seconds = int.from_bytes(digest[:4], "big") % (jitter_window + 1)
+        return timedelta(
+            seconds=min(cls._RETRY_MAX_SECONDS, base_seconds + jitter_seconds)
+        )
+
+    @staticmethod
+    def _mark_published(event: IntegrationOutboxEvent, *, now: datetime) -> None:
+        event.status = "published"
+        event.published_at = now
+        event.worker_id = None
+        event.lease_token = None
+        event.lease_expires_at = None
+        event.last_error_code = None
+        event.last_error_message = None
+        event.updated_at = now
+
+    @classmethod
+    def _record_failure(
+        cls,
+        event: IntegrationOutboxEvent,
+        *,
+        error: Exception,
+        now: datetime,
+        permanent: bool,
+    ) -> DispatchOutcomeV1:
+        is_dead = permanent or event.attempts >= event.max_attempts
+        next_attempt_at = None
+        if not is_dead:
+            next_attempt_at = now + cls._retry_delay(
+                event_id=event.event_id,
+                attempts=event.attempts,
+            )
+            event.available_at = next_attempt_at
+        event.status = "dead" if is_dead else "pending"
+        event.worker_id = None
+        event.lease_token = None
+        event.lease_expires_at = None
+        event.last_error_code = type(error).__name__[:100]
+        event.last_error_message = (str(error).strip() or type(error).__name__)[:1000]
+        event.updated_at = now
+        return DispatchOutcomeV1(
+            outcome="dead" if is_dead else "retry_scheduled",
+            event_id=event.event_id,
+            attempts=event.attempts,
+            delivery_count=0,
+            next_attempt_at=next_attempt_at,
+        )
+
+    @classmethod
+    async def _recover_processed_event(
+        cls,
+        session: AsyncSession,
+        *,
+        event: IntegrationOutboxEvent,
+        now: datetime,
+    ) -> DispatchOutcomeV1 | None:
+        inbox = await session.get(ConsumerInbox, (CONSUMER_NAME, event.event_id))
+        if inbox is None:
+            return None
+        if inbox.handler_version != HANDLER_VERSION:
+            raise ConsumerInboxConsistencyError(
+                "Consumer inbox handler version is inconsistent"
+            )
+        plan = WebsiteTemplateRegistry.plan(event)
+        WebsiteTemplateRegistry.render(plan)
+        deliveries = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery).where(
+                        CommunicationDelivery.event_id == event.event_id,
+                        CommunicationDelivery.channel == plan.channel,
+                        CommunicationDelivery.template_version
+                        == plan.template_version,
+                    )
+                )
+            ).scalars()
+        )
+        if not deliveries:
+            raise ConsumerInboxConsistencyError(
+                "Consumer inbox exists without materialized deliveries"
+            )
+        for delivery in deliveries:
+            if (
+                delivery.channel != plan.channel
+                or delivery.template_key != plan.template_key
+                or delivery.template_version != plan.template_version
+                or delivery.render_context != plan.render_context
+                or delivery.delivery_id
+                != CommunicationDeliveryMaterializer.build_delivery_id(
+                    event_id=event.event_id,
+                    channel=delivery.channel,
+                    recipient_key=delivery.recipient_key,
+                    template_version=delivery.template_version,
+                )
+            ):
+                raise ConsumerInboxConsistencyError(
+                    "Consumer inbox delivery snapshot is inconsistent"
+                )
+        cls._mark_published(event, now=now)
+        return DispatchOutcomeV1(
+            outcome="already_materialized",
+            event_id=event.event_id,
+            attempts=event.attempts,
+            delivery_count=len(deliveries),
+        )
+
+    @classmethod
+    async def dispatch_next(
+        cls,
+        session: AsyncSession,
+        *,
+        dispatcher_id: str,
+        now: datetime | None = None,
+    ) -> DispatchOutcomeV1 | None:
+        normalized_dispatcher_id = str(dispatcher_id or "").strip()
+        if not normalized_dispatcher_id:
+            raise ValueError("Communication dispatcher_id is required")
+        if len(normalized_dispatcher_id) > 128:
+            raise ValueError("Communication dispatcher_id is too long")
+        dispatch_time = now or cls._utc_now()
+
+        event = await cls._select_next(session, now=dispatch_time)
+        if event is None:
+            return None
+
+        event.status = "processing"
+        event.attempts += 1
+        event.worker_id = normalized_dispatcher_id
+        event.lease_token = None
+        event.lease_expires_at = None
+        event.last_error_code = None
+        event.last_error_message = None
+        event.updated_at = dispatch_time
+        session.add(event)
+
+        try:
+            recovered = await cls._recover_processed_event(
+                session,
+                event=event,
+                now=dispatch_time,
+            )
+        except (
+            ConsumerInboxConsistencyError,
+            InvalidCommunicationEventPayload,
+            TemplateRenderError,
+            UnsupportedCommunicationEvent,
+        ) as exc:
+            return cls._record_failure(
+                event,
+                error=exc,
+                now=dispatch_time,
+                permanent=True,
+            )
+        if recovered is not None:
+            return recovered
+
+        try:
+            # A savepoint ensures a deterministic conflict cannot leave a
+            # partially inserted recipient set when the caller commits the
+            # failure state.
+            async with session.begin_nested():
+                plan = WebsiteTemplateRegistry.plan(event)
+                WebsiteTemplateRegistry.render(plan)
+                if plan.audience != "management":
+                    raise UnsupportedCommunicationEvent(
+                        f"Unsupported communication audience {plan.audience!r}"
+                    )
+                recipients = await ManagementRecipientDirectory.list_telegram(session)
+                materialized = await CommunicationDeliveryMaterializer.materialize(
+                    session,
+                    event=event,
+                    plan=plan,
+                    recipients=recipients,
+                    now=dispatch_time,
+                )
+        except NoEligibleCommunicationRecipients as exc:
+            return cls._record_failure(
+                event,
+                error=exc,
+                now=dispatch_time,
+                permanent=False,
+            )
+        except (
+            DeliveryMaterializationConflict,
+            InvalidCommunicationEventPayload,
+            TemplateRenderError,
+            UnsupportedCommunicationEvent,
+        ) as exc:
+            return cls._record_failure(
+                event,
+                error=exc,
+                now=dispatch_time,
+                permanent=True,
+            )
+
+        session.add(
+            ConsumerInbox(
+                consumer_name=CONSUMER_NAME,
+                event_id=event.event_id,
+                handler_version=HANDLER_VERSION,
+                received_at=dispatch_time,
+                processed_at=dispatch_time,
+            )
+        )
+        await session.flush()
+        cls._mark_published(event, now=dispatch_time)
+        return DispatchOutcomeV1(
+            outcome=(
+                "materialized"
+                if materialized.created_count
+                else "already_materialized"
+            ),
+            event_id=event.event_id,
+            attempts=event.attempts,
+            delivery_count=materialized.delivery_count,
+        )

--- a/services/communications/recipient_directory.py
+++ b/services/communications/recipient_directory.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from core.config import settings
+from models import StaffUser
+from services.communications.contracts import CommunicationRecipientV1
+from services.staff_user_service import StaffUserService
+
+
+class ManagementRecipientDirectory:
+    @staticmethod
+    async def list_telegram(
+        session: AsyncSession,
+    ) -> list[CommunicationRecipientV1]:
+        result = await session.execute(
+            select(StaffUser)
+            .where(StaffUser.telegram_id.is_not(None))
+            .order_by(StaffUser.id.asc())
+        )
+        staff_users = list(result.scalars().all())
+
+        recipients: list[CommunicationRecipientV1] = []
+        seen_destinations: set[str] = set()
+        # ADMIN_IDS is a compatibility bridge only. A legacy value must not
+        # silently re-enable an inactive, blocked, or otherwise ineligible
+        # database-backed StaffUser.
+        database_destinations = {
+            str(int(staff_user.telegram_id))
+            for staff_user in staff_users
+            if staff_user.telegram_id is not None
+        }
+        for staff_user in staff_users:
+            if not StaffUserService.can_receive_admin_notifications(staff_user):
+                continue
+            if staff_user.id is None or staff_user.telegram_id is None:
+                continue
+            destination = str(int(staff_user.telegram_id))
+            if destination in seen_destinations:
+                continue
+            seen_destinations.add(destination)
+            recipients.append(
+                CommunicationRecipientV1(
+                    recipient_key=f"staff:{staff_user.id}",
+                    destination=destination,
+                    source="staff",
+                    staff_user_id=int(staff_user.id),
+                )
+            )
+
+        if recipients:
+            return recipients
+
+        for telegram_id in settings.admin_list:
+            destination = str(int(telegram_id))
+            if (
+                destination in database_destinations
+                or destination in seen_destinations
+                or destination == "0"
+            ):
+                continue
+            seen_destinations.add(destination)
+            recipients.append(
+                CommunicationRecipientV1(
+                    recipient_key=f"legacy-telegram:{destination}",
+                    destination=destination,
+                    source="legacy",
+                )
+            )
+        return recipients

--- a/services/communications/template_registry.py
+++ b/services/communications/template_registry.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from models import IntegrationOutboxEvent
+from services.communications.contracts import (
+    CommunicationTemplatePlanV1,
+    PublicContactLeadCreatedPayloadV1,
+    PublicOrderCreatedPayloadV1,
+)
+from services.communications.templates.website import (
+    render_website_contact_lead_v1,
+    render_website_order_v1,
+)
+
+
+PUBLIC_ORDER_CREATED_EVENT = "crm.public_order.created"
+PUBLIC_CONTACT_LEAD_CREATED_EVENT = "crm.public_contact_lead.created"
+CONSUMER_NAME = "communications.management_telegram"
+HANDLER_VERSION = 1
+SUPPORTED_EVENT_TYPES = {
+    PUBLIC_ORDER_CREATED_EVENT,
+    PUBLIC_CONTACT_LEAD_CREATED_EVENT,
+}
+
+ORDER_TEMPLATE_KEY = "telegram.website_order_created"
+CONTACT_LEAD_TEMPLATE_KEY = "telegram.website_contact_lead_created"
+
+
+class UnsupportedCommunicationEvent(ValueError):
+    pass
+
+
+class InvalidCommunicationEventPayload(ValueError):
+    pass
+
+
+class WebsiteTemplateRegistry:
+    @staticmethod
+    def plan(event: IntegrationOutboxEvent) -> CommunicationTemplatePlanV1:
+        if event.schema_version != 1:
+            raise UnsupportedCommunicationEvent(
+                f"Unsupported schema version {event.schema_version} for {event.event_type}"
+            )
+        try:
+            if event.event_type == PUBLIC_ORDER_CREATED_EVENT:
+                payload = PublicOrderCreatedPayloadV1.model_validate(event.payload)
+                template_key = ORDER_TEMPLATE_KEY
+            elif event.event_type == PUBLIC_CONTACT_LEAD_CREATED_EVENT:
+                payload = PublicContactLeadCreatedPayloadV1.model_validate(event.payload)
+                template_key = CONTACT_LEAD_TEMPLATE_KEY
+            else:
+                raise UnsupportedCommunicationEvent(
+                    f"Unsupported communication event {event.event_type!r}"
+                )
+        except ValidationError as exc:
+            raise InvalidCommunicationEventPayload(
+                f"Invalid payload for {event.event_type} schema v{event.schema_version}"
+            ) from exc
+
+        return CommunicationTemplatePlanV1(
+            template_key=template_key,
+            render_context=payload.model_dump(mode="json"),
+        )
+
+    @staticmethod
+    def render(plan: CommunicationTemplatePlanV1) -> str:
+        if plan.template_version != 1:
+            raise UnsupportedCommunicationEvent(
+                f"Unsupported template version {plan.template_version}"
+            )
+        if plan.template_key == ORDER_TEMPLATE_KEY:
+            return render_website_order_v1(plan.render_context)
+        if plan.template_key == CONTACT_LEAD_TEMPLATE_KEY:
+            return render_website_contact_lead_v1(plan.render_context)
+        raise UnsupportedCommunicationEvent(
+            f"Unsupported communication template {plan.template_key!r}"
+        )

--- a/services/communications/templates/__init__.py
+++ b/services/communications/templates/__init__.py
@@ -1,0 +1,11 @@
+from services.communications.templates.website import (
+    TemplateRenderError,
+    render_website_contact_lead_v1,
+    render_website_order_v1,
+)
+
+__all__ = [
+    "TemplateRenderError",
+    "render_website_contact_lead_v1",
+    "render_website_order_v1",
+]

--- a/services/communications/templates/website.py
+++ b/services/communications/templates/website.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from html import escape
+from typing import Any, Mapping
+
+from services.communications.contracts import (
+    PublicContactLeadCreatedPayloadV1,
+    PublicOrderCreatedPayloadV1,
+)
+
+
+MAX_TELEGRAM_MESSAGE_LENGTH = 4096
+
+
+class TemplateRenderError(ValueError):
+    pass
+
+
+def _escape_bounded(value: Any, *, max_length: int) -> str:
+    source_value = "" if value is None else str(value)
+    raw_value = "".join(
+        " " if char in "\r\n\t" else char
+        for char in source_value
+        if char in "\r\n\t" or (ord(char) >= 32 and not 127 <= ord(char) < 160)
+    )
+    rendered = escape(raw_value)
+    if len(rendered) <= max_length:
+        return rendered
+
+    budget = max(0, max_length - 3)
+    parts: list[str] = []
+    used = 0
+    for char in raw_value:
+        escaped_char = escape(char)
+        if used + len(escaped_char) > budget:
+            break
+        parts.append(escaped_char)
+        used += len(escaped_char)
+    return "".join(parts) + ("..." if max_length >= 3 else "")
+
+
+def _format_amount(value: Decimal) -> str:
+    rendered = format(value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return rendered or "0"
+
+
+def _ensure_telegram_length(text: str) -> str:
+    if len(text) > MAX_TELEGRAM_MESSAGE_LENGTH:
+        raise TemplateRenderError(
+            f"Rendered Telegram message exceeds {MAX_TELEGRAM_MESSAGE_LENGTH} characters"
+        )
+    return text
+
+
+def render_website_order_v1(
+    context: PublicOrderCreatedPayloadV1 | Mapping[str, Any],
+) -> str:
+    payload = (
+        context
+        if isinstance(context, PublicOrderCreatedPayloadV1)
+        else PublicOrderCreatedPayloadV1.model_validate(context)
+    )
+    lines = [
+        f"🌐 <b>ЗАКАЗ С САЙТА #{payload.order_id}</b>",
+        f"👤 {_escape_bounded(payload.customer.name, max_length=160)}",
+        f"📱 {_escape_bounded(payload.customer.phone, max_length=80)}",
+    ]
+    if payload.customer.email:
+        lines.append(f"📧 {_escape_bounded(payload.customer.email, max_length=254)}")
+    if payload.customer.address:
+        lines.append(f"📍 {_escape_bounded(payload.customer.address, max_length=250)}")
+    if payload.comment:
+        lines.append(f"💬 {_escape_bounded(payload.comment, max_length=400)}")
+
+    lines.extend(["", "🛒 <b>Товары:</b>"])
+    for item in payload.product_lines[:6]:
+        line_total = item.unit_price * item.quantity
+        lines.append(
+            f"▫️ {_escape_bounded(item.title, max_length=120)} "
+            f"x{item.quantity} — {_format_amount(line_total)} {payload.currency}"
+        )
+        if item.installation_included:
+            lines.append(
+                "   └ 🔧 Монтаж: "
+                f"{_format_amount(item.installation_price)} {payload.currency}"
+            )
+    if len(payload.product_lines) > 6:
+        lines.append(f"… ещё товаров: {len(payload.product_lines) - 6}")
+
+    for item in payload.service_lines[:4]:
+        line_total = item.unit_price * item.quantity
+        lines.append(
+            f"🔧 {_escape_bounded(item.title, max_length=120)} "
+            f"x{item.quantity} — {_format_amount(line_total)} {payload.currency}"
+        )
+    if len(payload.service_lines) > 4:
+        lines.append(f"… ещё услуг: {len(payload.service_lines) - 4}")
+
+    lines.extend(
+        [
+            "",
+            f"💰 <b>Итого: {_format_amount(payload.total_amount)} {payload.currency}</b>",
+        ]
+    )
+    return _ensure_telegram_length("\n".join(lines))
+
+
+def render_website_contact_lead_v1(
+    context: PublicContactLeadCreatedPayloadV1 | Mapping[str, Any],
+) -> str:
+    payload = (
+        context
+        if isinstance(context, PublicContactLeadCreatedPayloadV1)
+        else PublicContactLeadCreatedPayloadV1.model_validate(context)
+    )
+    lines = [
+        f"🔔 <b>ЗАЯВКА С САЙТА #{payload.lead_id}</b>",
+        f"👤 {_escape_bounded(payload.name, max_length=160)}",
+        f"📱 {_escape_bounded(payload.phone, max_length=80)}",
+    ]
+    if payload.email:
+        lines.append(f"📧 {_escape_bounded(payload.email, max_length=254)}")
+    if payload.address:
+        lines.append(f"📍 {_escape_bounded(payload.address, max_length=250)}")
+    if payload.message:
+        lines.extend(
+            ["", f"💬 {_escape_bounded(payload.message, max_length=800)}"]
+        )
+    return _ensure_telegram_length("\n".join(lines))

--- a/tests/integration/test_communications_dispatcher_concurrency.py
+++ b/tests/integration/test_communications_dispatcher_concurrency.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import (
+    CommunicationDelivery,
+    ConsumerInbox,
+    IntegrationOutboxEvent,
+    StaffUser,
+)
+from services.communications.contracts import CommunicationRecipientV1
+from services.communications.delivery_materializer import (
+    CommunicationDeliveryMaterializer,
+)
+from services.communications.dispatcher import CommunicationOutboxDispatcher
+from services.communications.template_registry import WebsiteTemplateRegistry
+
+
+def _event(sequence: int, *, now: datetime) -> IntegrationOutboxEvent:
+    return IntegrationOutboxEvent(
+        event_id=f"{sequence:032x}",
+        event_type="crm.public_contact_lead.created",
+        schema_version=1,
+        aggregate_type="lead",
+        aggregate_id=str(sequence),
+        aggregate_version=1,
+        deduplication_key=f"dispatcher-concurrency:{sequence}",
+        payload={
+            "lead_id": sequence,
+            "status": "new",
+            "name": f"Клиент {sequence}",
+            "phone": "+375291112233",
+            "email": None,
+            "address": None,
+            "message": "Нужна консультация",
+        },
+        available_at=now,
+        occurred_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _dispatch_once(factory, barrier: asyncio.Barrier, worker: str, now: datetime):
+    async with factory() as session:
+        await barrier.wait()
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            dispatcher_id=worker,
+            now=now,
+        )
+        await session.commit()
+        return outcome
+
+
+async def _materialize_once(
+    factory,
+    barrier: asyncio.Barrier,
+    event_id: str,
+    now: datetime,
+):
+    async with factory() as session:
+        event = await session.get(IntegrationOutboxEvent, event_id)
+        assert event is not None
+        plan = WebsiteTemplateRegistry.plan(event)
+        recipient = CommunicationRecipientV1(
+            recipient_key="legacy-telegram:9001",
+            destination="9001",
+            source="legacy",
+        )
+        await barrier.wait()
+        result = await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[recipient],
+            now=now,
+        )
+        await session.commit()
+        return result
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_dispatchers_materialize_one_event_once(db_engine):
+    assert db_engine.dialect.name == "postgresql"
+    factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    event = _event(701, now=now)
+    async with factory() as setup_session:
+        setup_session.add_all(
+            [
+                event,
+                StaffUser(
+                    display_name="Owner",
+                    status="active",
+                    roles=["owner"],
+                    primary_role="owner",
+                    telegram_id=7001,
+                ),
+            ]
+        )
+        await setup_session.commit()
+
+    barrier = asyncio.Barrier(2)
+    outcomes = await asyncio.gather(
+        _dispatch_once(factory, barrier, "dispatcher-a", now),
+        _dispatch_once(factory, barrier, "dispatcher-b", now),
+    )
+
+    materialized = [outcome for outcome in outcomes if outcome is not None]
+    assert len(materialized) == 1
+    assert materialized[0].event_id == event.event_id
+    assert materialized[0].delivery_count == 1
+
+    async with factory() as verification_session:
+        stored_event = await verification_session.get(
+            IntegrationOutboxEvent, event.event_id
+        )
+        assert stored_event is not None
+        assert stored_event.status == "published"
+        assert stored_event.attempts == 1
+        assert (
+            await verification_session.execute(
+                select(func.count(CommunicationDelivery.delivery_id))
+            )
+        ).scalar_one() == 1
+        assert (
+            await verification_session.execute(
+                select(func.count(ConsumerInbox.event_id))
+            )
+        ).scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_dispatchers_skip_locked_to_distinct_events(db_engine):
+    assert db_engine.dialect.name == "postgresql"
+    factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    events = [_event(711, now=now), _event(712, now=now)]
+    async with factory() as setup_session:
+        setup_session.add_all(
+            [
+                *events,
+                StaffUser(
+                    display_name="Owner",
+                    status="active",
+                    roles=["owner"],
+                    primary_role="owner",
+                    telegram_id=7002,
+                ),
+            ]
+        )
+        await setup_session.commit()
+
+    barrier = asyncio.Barrier(2)
+    outcomes = await asyncio.gather(
+        _dispatch_once(factory, barrier, "dispatcher-a", now),
+        _dispatch_once(factory, barrier, "dispatcher-b", now),
+    )
+
+    assert all(outcome is not None for outcome in outcomes)
+    assert {outcome.event_id for outcome in outcomes if outcome is not None} == {
+        event.event_id for event in events
+    }
+    async with factory() as verification_session:
+        assert (
+            await verification_session.execute(
+                select(func.count(CommunicationDelivery.delivery_id))
+            )
+        ).scalar_one() == 2
+        assert (
+            await verification_session.execute(
+                select(func.count(ConsumerInbox.event_id))
+            )
+        ).scalar_one() == 2
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_materialization_is_idempotent(db_engine):
+    assert db_engine.dialect.name == "postgresql"
+    factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    event = _event(721, now=now)
+    async with factory() as setup_session:
+        setup_session.add(event)
+        await setup_session.commit()
+
+    barrier = asyncio.Barrier(2)
+    results = await asyncio.gather(
+        _materialize_once(factory, barrier, event.event_id, now),
+        _materialize_once(factory, barrier, event.event_id, now),
+    )
+
+    assert sorted(result.created_count for result in results) == [0, 1]
+    assert all(result.delivery_count == 1 for result in results)
+    async with factory() as verification_session:
+        assert (
+            await verification_session.execute(
+                select(func.count(CommunicationDelivery.delivery_id))
+            )
+        ).scalar_one() == 1

--- a/tests/unit/test_communications_delivery_planning.py
+++ b/tests/unit/test_communications_delivery_planning.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from core.config import settings
+from models import CommunicationDelivery, IntegrationOutboxEvent, StaffUser
+from services.communications.contracts import (
+    CommunicationRecipientV1,
+    PublicContactLeadCreatedPayloadV1,
+    PublicOrderCreatedPayloadV1,
+    PublicOrderCustomerSnapshotV1,
+    PublicOrderProductLineSnapshotV1,
+    PublicOrderServiceLineSnapshotV1,
+)
+from services.communications.delivery_materializer import (
+    CommunicationDeliveryMaterializer,
+    DeliveryMaterializationConflict,
+)
+from services.communications.recipient_directory import ManagementRecipientDirectory
+from services.communications.template_registry import (
+    CONTACT_LEAD_TEMPLATE_KEY,
+    InvalidCommunicationEventPayload,
+    WebsiteTemplateRegistry,
+)
+
+
+@pytest.fixture
+async def communications_session_factory(tmp_path):
+    database_path = tmp_path / "communications.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _lead_payload(*, lead_id: int = 12, message: str = "Нужна консультация"):
+    return PublicContactLeadCreatedPayloadV1(
+        lead_id=lead_id,
+        status="new",
+        name="Иван <b>не HTML</b>",
+        phone="+375291112233",
+        email="ivan@example.com",
+        message=message,
+    ).model_dump(mode="json")
+
+
+def _event(
+    sequence: int,
+    *,
+    event_type: str = "crm.public_contact_lead.created",
+    payload: dict | None = None,
+    now: datetime | None = None,
+    priority: int = 100,
+    max_attempts: int = 8,
+) -> IntegrationOutboxEvent:
+    occurred_at = now or datetime.now(timezone.utc)
+    return IntegrationOutboxEvent(
+        event_id=f"{sequence:032x}",
+        event_type=event_type,
+        schema_version=1,
+        aggregate_type="lead",
+        aggregate_id=str(sequence),
+        aggregate_version=1,
+        deduplication_key=f"test:{sequence}",
+        payload=payload if payload is not None else _lead_payload(lead_id=sequence),
+        priority=priority,
+        max_attempts=max_attempts,
+        available_at=occurred_at,
+        occurred_at=occurred_at,
+        created_at=occurred_at,
+        updated_at=occurred_at,
+    )
+
+
+def _owner(telegram_id: int, *, status: str = "active", name: str = "Owner"):
+    return StaffUser(
+        display_name=name,
+        status=status,
+        roles=["owner"],
+        primary_role="owner",
+        telegram_id=telegram_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recipient_directory_prefers_eligible_staff_and_filters_roles(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "999", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    async with communications_session_factory() as session:
+        session.add_all(
+            [
+                _owner(101, name="Owner"),
+                StaffUser(
+                    display_name="Manager",
+                    status="active",
+                    roles=["manager"],
+                    primary_role="manager",
+                    telegram_id=202,
+                ),
+                _owner(303, status="blocked", name="Blocked"),
+                StaffUser(
+                    display_name="Installer",
+                    status="active",
+                    roles=["installer"],
+                    primary_role="installer",
+                    telegram_id=404,
+                ),
+            ]
+        )
+        await session.flush()
+
+        recipients = await ManagementRecipientDirectory.list_telegram(session)
+
+        assert [recipient.destination for recipient in recipients] == ["101", "202"]
+        assert all(recipient.source == "staff" for recipient in recipients)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "primary_role"),
+    [
+        ("blocked", "owner"),
+        ("inactive", "owner"),
+        ("active", "installer"),
+    ],
+)
+async def test_recipient_directory_legacy_fallback_cannot_reenable_ineligible_staff(
+    communications_session_factory,
+    monkeypatch,
+    status,
+    primary_role,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "303,707", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    async with communications_session_factory() as session:
+        session.add(
+            StaffUser(
+                display_name="Ineligible",
+                status=status,
+                roles=[primary_role],
+                primary_role=primary_role,
+                telegram_id=303,
+            )
+        )
+        await session.flush()
+
+        recipients = await ManagementRecipientDirectory.list_telegram(session)
+
+        assert [recipient.destination for recipient in recipients] == ["707"]
+        assert recipients[0].recipient_key == "legacy-telegram:707"
+
+
+@pytest.mark.asyncio
+async def test_recipient_directory_propagates_database_failure(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "707", raising=False)
+    session = SimpleNamespace(execute=AsyncMock(side_effect=RuntimeError("db down")))
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await ManagementRecipientDirectory.list_telegram(session)
+
+
+def test_template_registry_validates_escapes_and_bounds_telegram_html():
+    event = _event(12, payload=_lead_payload(message="line\x00one\nline two"))
+    plan = WebsiteTemplateRegistry.plan(event)
+    rendered = WebsiteTemplateRegistry.render(plan)
+
+    assert plan.template_key == CONTACT_LEAD_TEMPLATE_KEY
+    assert plan.audience == "management"
+    assert "&lt;b&gt;не HTML&lt;/b&gt;" in rendered
+    assert "<b>не HTML</b>" not in rendered
+    assert "\x00" not in rendered
+    assert "lineone line two" in rendered
+    assert len(rendered) <= 4096
+
+    with pytest.raises(InvalidCommunicationEventPayload):
+        WebsiteTemplateRegistry.plan(_event(13, payload={"lead_id": 13}))
+
+
+def test_v1_templates_have_stable_golden_output():
+    lead = _event(
+        1,
+        payload=PublicContactLeadCreatedPayloadV1(
+            lead_id=1,
+            status="new",
+            name="Иван & Анна",
+            phone="+375291112233",
+            message="Хочу расчёт",
+        ).model_dump(mode="json"),
+    )
+    assert WebsiteTemplateRegistry.render(WebsiteTemplateRegistry.plan(lead)) == (
+        "🔔 <b>ЗАЯВКА С САЙТА #1</b>\n"
+        "👤 Иван &amp; Анна\n"
+        "📱 +375291112233\n\n"
+        "💬 Хочу расчёт"
+    )
+
+    order_payload = PublicOrderCreatedPayloadV1(
+        order_id=2,
+        status="new",
+        customer=PublicOrderCustomerSnapshotV1(
+            name="Иван",
+            phone="+375291112233",
+        ),
+        total_amount=Decimal("125.50"),
+        product_lines=[
+            PublicOrderProductLineSnapshotV1(
+                product_id=7,
+                title="Сплит <7>",
+                quantity=1,
+                unit_price=Decimal("100"),
+                installation_included=True,
+                installation_price=Decimal("20"),
+            )
+        ],
+        service_lines=[
+            PublicOrderServiceLineSnapshotV1(
+                service_id=8,
+                title="Доставка",
+                quantity=1,
+                unit_price=Decimal("5.50"),
+            )
+        ],
+    )
+    order = _event(
+        2,
+        event_type="crm.public_order.created",
+        payload=order_payload.model_dump(mode="json"),
+    )
+    assert WebsiteTemplateRegistry.render(WebsiteTemplateRegistry.plan(order)) == (
+        "🌐 <b>ЗАКАЗ С САЙТА #2</b>\n"
+        "👤 Иван\n"
+        "📱 +375291112233\n\n"
+        "🛒 <b>Товары:</b>\n"
+        "▫️ Сплит &lt;7&gt; x1 — 100 BYN\n"
+        "   └ 🔧 Монтаж: 20 BYN\n"
+        "🔧 Доставка x1 — 5.5 BYN\n\n"
+        "💰 <b>Итого: 125.5 BYN</b>"
+    )
+
+
+def test_order_template_caps_detail_rows_and_stays_within_telegram_limit():
+    payload = PublicOrderCreatedPayloadV1(
+        order_id=44,
+        status="new",
+        customer=PublicOrderCustomerSnapshotV1(
+            name="Иван",
+            phone="+375291112233",
+        ),
+        comment="<&>" * 600,
+        total_amount=Decimal("9000"),
+        product_lines=[
+            PublicOrderProductLineSnapshotV1(
+                product_id=index + 1,
+                title=f"Товар {index} " + "<&>" * 50,
+                quantity=1,
+                unit_price=Decimal("100"),
+            )
+            for index in range(20)
+        ],
+        service_lines=[
+            PublicOrderServiceLineSnapshotV1(
+                service_id=index + 1,
+                title=f"Услуга {index} " + "<&>" * 50,
+                quantity=1,
+                unit_price=Decimal("50"),
+            )
+            for index in range(20)
+        ],
+    )
+    event = _event(
+        44,
+        event_type="crm.public_order.created",
+        payload=payload.model_dump(mode="json"),
+    )
+
+    rendered = WebsiteTemplateRegistry.render(WebsiteTemplateRegistry.plan(event))
+
+    assert "… ещё товаров: 14" in rendered
+    assert "… ещё услуг: 16" in rendered
+    assert len(rendered) <= 4096
+
+
+@pytest.mark.asyncio
+async def test_materializer_is_idempotent_and_rejects_immutable_snapshot_drift(
+    communications_session_factory,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    event = _event(18, now=now)
+    plan = WebsiteTemplateRegistry.plan(event)
+    recipient = CommunicationRecipientV1(
+        recipient_key="legacy-telegram:700",
+        destination="700",
+        source="legacy",
+    )
+    async with communications_session_factory() as session:
+        session.add(event)
+        await session.commit()
+
+        first = await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[recipient],
+            now=now,
+        )
+        await session.commit()
+        duplicate = await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[recipient],
+            now=now + timedelta(minutes=1),
+        )
+
+        assert first.created_count == 1
+        assert duplicate.created_count == 0
+        with pytest.raises(DeliveryMaterializationConflict):
+            await CommunicationDeliveryMaterializer.materialize(
+                session,
+                event=event,
+                plan=plan,
+                recipients=[recipient.model_copy(update={"destination": "701"})],
+                now=now,
+            )
+
+
+@pytest.mark.asyncio
+async def test_materializer_rejects_recipient_set_drift_without_partial_rows(
+    communications_session_factory,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    event = _event(19, now=now)
+    plan = WebsiteTemplateRegistry.plan(event)
+    recipient_a = CommunicationRecipientV1(
+        recipient_key="legacy-telegram:700",
+        destination="700",
+        source="legacy",
+    )
+    recipient_b = CommunicationRecipientV1(
+        recipient_key="legacy-telegram:701",
+        destination="701",
+        source="legacy",
+    )
+    recipient_c = CommunicationRecipientV1(
+        recipient_key="legacy-telegram:702",
+        destination="702",
+        source="legacy",
+    )
+    async with communications_session_factory() as session:
+        session.add(event)
+        await session.flush()
+        await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[recipient_a, recipient_b],
+            now=now,
+        )
+        await session.commit()
+
+        with pytest.raises(DeliveryMaterializationConflict):
+            await CommunicationDeliveryMaterializer.materialize(
+                session,
+                event=event,
+                plan=plan,
+                recipients=[recipient_a, recipient_c],
+                now=now,
+            )
+        await session.rollback()
+
+        destinations = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery.destination).order_by(
+                        CommunicationDelivery.destination
+                    )
+                )
+            ).scalars()
+        )
+        assert destinations == ["700", "701"]

--- a/tests/unit/test_communications_dispatcher.py
+++ b/tests/unit/test_communications_dispatcher.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import pytest
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from core.config import settings
+from models import (
+    CommunicationDelivery,
+    ConsumerInbox,
+    IntegrationOutboxEvent,
+    StaffUser,
+)
+from services.communications.contracts import (
+    CommunicationRecipientV1,
+    CommunicationTemplatePlanV1,
+    PublicContactLeadCreatedPayloadV1,
+)
+from services.communications.delivery_materializer import CommunicationDeliveryMaterializer
+from services.communications.dispatcher import CommunicationOutboxDispatcher
+from services.communications.template_registry import (
+    CONSUMER_NAME,
+    CONTACT_LEAD_TEMPLATE_KEY,
+    WebsiteTemplateRegistry,
+)
+
+
+@pytest.fixture
+async def communications_session_factory(tmp_path):
+    database_path = tmp_path / "communications.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _lead_payload(*, lead_id: int = 12, message: str = "Нужна консультация"):
+    return PublicContactLeadCreatedPayloadV1(
+        lead_id=lead_id,
+        status="new",
+        name="Иван <b>не HTML</b>",
+        phone="+375291112233",
+        email="ivan@example.com",
+        message=message,
+    ).model_dump(mode="json")
+
+
+def _event(
+    sequence: int,
+    *,
+    event_type: str = "crm.public_contact_lead.created",
+    payload: dict | None = None,
+    now: datetime | None = None,
+    priority: int = 100,
+    max_attempts: int = 8,
+) -> IntegrationOutboxEvent:
+    occurred_at = now or datetime.now(timezone.utc)
+    return IntegrationOutboxEvent(
+        event_id=f"{sequence:032x}",
+        event_type=event_type,
+        schema_version=1,
+        aggregate_type="lead",
+        aggregate_id=str(sequence),
+        aggregate_version=1,
+        deduplication_key=f"test:{sequence}",
+        payload=payload if payload is not None else _lead_payload(lead_id=sequence),
+        priority=priority,
+        max_attempts=max_attempts,
+        available_at=occurred_at,
+        occurred_at=occurred_at,
+        created_at=occurred_at,
+        updated_at=occurred_at,
+    )
+
+
+def _owner(telegram_id: int, *, status: str = "active", name: str = "Owner"):
+    return StaffUser(
+        display_name=name,
+        status=status,
+        roles=["owner"],
+        primary_role="owner",
+        telegram_id=telegram_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_materializes_deliveries_inbox_and_published_atomically(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    dispatch_time = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(21, now=dispatch_time)
+        event_id = event.event_id
+        session.add_all([event, _owner(101), _owner(202, name="Second")])
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            dispatcher_id="dispatcher-a",
+            now=dispatch_time,
+        )
+
+        assert outcome is not None
+        assert outcome.outcome == "materialized"
+        assert outcome.delivery_count == 2
+        assert event.status == "published"
+        assert event.attempts == 1
+        assert await session.get(ConsumerInbox, (CONSUMER_NAME, event.event_id))
+        deliveries = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery).order_by(
+                        CommunicationDelivery.recipient_key
+                    )
+                )
+            ).scalars()
+        )
+        assert [delivery.destination for delivery in deliveries] == ["101", "202"]
+        await session.rollback()
+
+    async with communications_session_factory() as verification_session:
+        stored_event = await verification_session.get(
+            IntegrationOutboxEvent, event_id
+        )
+        assert stored_event is not None
+        assert stored_event.status == "pending"
+        assert stored_event.attempts == 0
+        assert (
+            await verification_session.execute(
+                select(func.count(CommunicationDelivery.delivery_id))
+            )
+        ).scalar_one() == 0
+        assert await verification_session.get(
+            ConsumerInbox, (CONSUMER_NAME, event_id)
+        ) is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ignores_unsupported_events_and_respects_priority(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        unsupported = _event(30, event_type="catalog.product.changed", now=now)
+        low_priority = _event(31, now=now - timedelta(minutes=1), priority=100)
+        high_priority = _event(32, now=now, priority=10)
+        session.add_all([unsupported, low_priority, high_priority])
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.event_id == high_priority.event_id
+        assert unsupported.status == "pending"
+        assert unsupported.attempts == 0
+        assert low_priority.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_retries_or_dead_letters_when_management_audience_is_empty(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        retry_event = _event(41, now=now, max_attempts=2)
+        session.add(retry_event)
+        await session.commit()
+
+        retry = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert retry is not None
+        assert retry.outcome == "retry_scheduled"
+        assert retry.next_attempt_at is not None
+        assert retry_event.status == "pending"
+        assert retry_event.last_error_code == "NoEligibleCommunicationRecipients"
+        assert await session.get(
+            ConsumerInbox, (CONSUMER_NAME, retry_event.event_id)
+        ) is None
+
+        dead = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            dispatcher_id="dispatcher-a",
+            now=retry.next_attempt_at,
+        )
+        await session.commit()
+
+        assert dead is not None
+        assert dead.outcome == "dead"
+        assert retry_event.status == "dead"
+        assert retry_event.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_and_dead_state_remain_owned_by_outer_transaction(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        retry_event = _event(42, now=now, max_attempts=2)
+        dead_event = _event(43, payload={"lead_id": 43}, now=now)
+        session.add_all([retry_event, dead_event])
+        await session.commit()
+
+        retry = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        assert retry is not None and retry.outcome == "retry_scheduled"
+        await session.rollback()
+        await session.refresh(retry_event)
+        assert retry_event.status == "pending"
+        assert retry_event.attempts == 0
+        assert retry_event.last_error_code is None
+
+        # Move the retryable event out of the selection window so the invalid
+        # payload is deterministically selected next.
+        retry_event.available_at = now + timedelta(days=1)
+        await session.commit()
+        dead = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        assert dead is not None and dead.outcome == "dead"
+        await session.rollback()
+        await session.refresh(dead_event)
+        assert dead_event.status == "pending"
+        assert dead_event.attempts == 0
+        assert dead_event.last_error_code is None
+
+
+def test_retry_backoff_is_deterministic_growing_and_capped():
+    event_id = f"{99:032x}"
+    first = CommunicationOutboxDispatcher._retry_delay(
+        event_id=event_id, attempts=1
+    )
+    repeated = CommunicationOutboxDispatcher._retry_delay(
+        event_id=event_id, attempts=1
+    )
+    later = CommunicationOutboxDispatcher._retry_delay(
+        event_id=event_id, attempts=5
+    )
+    capped = CommunicationOutboxDispatcher._retry_delay(
+        event_id=event_id, attempts=100
+    )
+
+    assert first == repeated
+    assert later > first
+    assert capped.total_seconds() == CommunicationOutboxDispatcher._RETRY_MAX_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_invalid_supported_payload_dead_without_deliveries(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(51, payload={"lead_id": 51}, now=now)
+        session.add(event)
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "dead"
+        assert event.status == "dead"
+        assert event.last_error_code == "InvalidCommunicationEventPayload"
+        assert (
+            await session.execute(select(func.count(CommunicationDelivery.delivery_id)))
+        ).scalar_one() == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_inconsistent_inbox_dead_instead_of_poisoning_queue(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(52, now=now)
+        session.add(event)
+        session.add(
+            ConsumerInbox(
+                consumer_name=CONSUMER_NAME,
+                event_id=event.event_id,
+                handler_version=1,
+                received_at=now,
+                processed_at=now,
+            )
+        )
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "dead"
+        assert event.status == "dead"
+        assert event.last_error_code == "ConsumerInboxConsistencyError"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_invalid_id_and_ignores_future_event(
+    communications_session_factory,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        future_event = _event(53, now=now + timedelta(minutes=1))
+        session.add(future_event)
+        await session.commit()
+
+        with pytest.raises(ValueError, match="required"):
+            await CommunicationOutboxDispatcher.dispatch_next(
+                session, dispatcher_id="", now=now
+            )
+        with pytest.raises(ValueError, match="too long"):
+            await CommunicationOutboxDispatcher.dispatch_next(
+                session, dispatcher_id="x" * 129, now=now
+            )
+        assert (
+            await CommunicationOutboxDispatcher.dispatch_next(
+                session, dispatcher_id="dispatcher-a", now=now
+            )
+            is None
+        )
+        assert future_event.status == "pending"
+        assert future_event.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_supported_future_schema_dead(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(54, now=now)
+        event.schema_version = 2
+        session.add(event)
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "dead"
+        assert event.last_error_code == "UnsupportedCommunicationEvent"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_materializer_conflict_rolls_back_new_recipient_savepoint(
+    communications_session_factory,
+    monkeypatch,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    event = _event(55, now=now)
+    plan = WebsiteTemplateRegistry.plan(event)
+    existing_recipients = [
+        CommunicationRecipientV1(
+            recipient_key=f"legacy-telegram:{destination}",
+            destination=destination,
+            source="legacy",
+        )
+        for destination in ("700", "701")
+    ]
+    async with communications_session_factory() as session:
+        session.add(event)
+        await session.flush()
+        await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=existing_recipients,
+            now=now,
+        )
+        await session.commit()
+        monkeypatch.setattr(settings, "ADMIN_IDS", "700,702", raising=False)
+        monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "dead"
+        assert event.last_error_code == "DeliveryMaterializationConflict"
+        destinations = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery.destination).order_by(
+                        CommunicationDelivery.destination
+                    )
+                )
+            ).scalars()
+        )
+        assert destinations == ["700", "701"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_recovers_existing_inbox_without_duplicate_delivery(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(61, now=now)
+        plan = CommunicationTemplatePlanV1(
+            template_key=CONTACT_LEAD_TEMPLATE_KEY,
+            render_context=event.payload,
+        )
+        recipient = CommunicationRecipientV1(
+            recipient_key="legacy-telegram:700",
+            destination="700",
+            source="legacy",
+        )
+        session.add(event)
+        await session.flush()
+        await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[recipient],
+            now=now,
+        )
+        session.add(
+            ConsumerInbox(
+                consumer_name=CONSUMER_NAME,
+                event_id=event.event_id,
+                handler_version=1,
+                received_at=now,
+                processed_at=now,
+            )
+        )
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session, dispatcher_id="dispatcher-a", now=now
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "already_materialized"
+        assert outcome.delivery_count == 1
+        assert event.status == "published"
+        assert (
+            await session.execute(select(func.count(CommunicationDelivery.delivery_id)))
+        ).scalar_one() == 1


### PR DESCRIPTION
## Summary
- add a caller-owned, single-transaction outbox dispatcher for website order/contact events
- atomically materialize deterministic per-recipient Telegram deliveries, write consumer inbox last, and publish the outbox event
- keep unsupported events untouched; retry empty audiences and dead-letter invalid immutable contracts
- resolve management recipients from eligible StaffUser rows without reviving blocked/inactive users through legacy ADMIN_IDS
- add escaped, bounded, versioned Telegram templates and update the audit/roadmap

## Safety boundary
- no scheduler or runtime registration
- no Telegram/provider network calls
- no producer switch
- no schema or migration changes
- no internal commit/rollback; caller owns the transaction

## Verification
- 1027 unit tests passed
- 185 integration tests passed
- 29 focused outbox/dispatcher tests passed, including PostgreSQL SKIP LOCKED and concurrent deterministic materialization
- independent review: no remaining P0/P1
- clean import of services.communications without application secrets
- git diff --check

## Follow-up
PR-C will add the leased provider delivery worker separately; producer switching remains a later atomic wave.