### PR TITLE
Harden scheduler ownership across blue-green handovers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -351,14 +351,16 @@ jobs:
             blue_green)
               cat scripts/ha/mvn-primary-status.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "install -m 0755 /dev/stdin /usr/local/sbin/mvn-primary-status"
               cat scripts/deploy_backend_blue_green.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green.sh"
+              cat scripts/deploy_backend_blue_green_safety.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green_safety.sh"
               printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-                chmod +x /tmp/deploy_backend_blue_green.sh && \
+                chmod +x /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh && \
                 IFS= read -r GHCR_PAT && export GHCR_PAT && \
                 GITHUB_ACTOR='${{ github.actor }}' \
                 API_PROJECT_DIR='${API_PROJECT_DIR}' \
                 API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
                 API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}' \
                 API_RUN_DEFAULTS='${API_RUN_DEFAULTS}' \
+                API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh' \
                 BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
                 API_BLUE_GREEN_SUMMARY_FILE='/tmp/backend_blue_green_summary.txt' \
                 bash /tmp/deploy_backend_blue_green.sh && \
@@ -455,9 +457,10 @@ jobs:
           set -euo pipefail
           SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
           cat scripts/deploy_backend_blue_green.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green.sh"
+          cat scripts/deploy_backend_blue_green_safety.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green_safety.sh"
           cat scripts/rollback_backend.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/rollback_backend.sh"
           printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-            chmod +x /tmp/rollback_backend.sh /tmp/deploy_backend_blue_green.sh && \
+            chmod +x /tmp/rollback_backend.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh && \
             IFS= read -r GHCR_PAT && export GHCR_PAT && \
             GITHUB_ACTOR='${{ github.actor }}' \
             CONFIRM_ROLLBACK=true \
@@ -465,6 +468,7 @@ jobs:
             API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
             API_DEPLOY_SERVICES='${API_DEPLOY_SERVICES}' \
             API_READY_URL='${API_READY_URL}' \
+            API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh' \
             EXPECTED_CURRENT_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
             bash /tmp/rollback_backend.sh" | tee backend_rollback.log
 

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -1,5 +1,8 @@
 import asyncio
-from contextlib import asynccontextmanager, suppress
+import os
+import signal
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 
 from fastapi import FastAPI
 
@@ -7,6 +10,81 @@ from core.config import settings
 from core.database import async_session_maker, init_db
 from core.logger import logger
 from services.runtime_lock_service import RuntimeLockService
+
+
+_SCHEDULER_RUNTIME_STATUSES = {
+    "disabled",
+    "waiting_lock",
+    "fencing",
+    "running",
+    "retrying",
+    "faulted",
+    "stopped",
+}
+_SCHEDULER_RUNTIME_REASONS = {
+    "runtime_control_disabled",
+    "lock_acquisition_pending",
+    "previous_owner_fencing",
+    "scheduler_loop_running",
+    "attempt_failed_retry_scheduled",
+    "ownership_lost",
+    "scheduler_loop_failed",
+    "application_shutdown",
+}
+_SCHEDULER_MIN_FENCING_GRACE_SECONDS = 12
+
+
+class SchedulerRuntimeFatal(RuntimeError):
+    """A post-start failure that requires terminating the whole process."""
+
+
+class SchedulerOwnershipLost(SchedulerRuntimeFatal):
+    """The scheduler can no longer prove exclusive runtime ownership."""
+
+
+_detached_scheduler_probe_tasks: set[asyncio.Task] = set()
+
+
+def _discard_detached_scheduler_probe(task: asyncio.Task) -> None:
+    _detached_scheduler_probe_tasks.discard(task)
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("Detached scheduler lock probe failed during cleanup.")
+
+
+def _detach_scheduler_probe(task: asyncio.Task) -> None:
+    _detached_scheduler_probe_tasks.add(task)
+    task.add_done_callback(_discard_detached_scheduler_probe)
+
+
+def _scheduler_runtime_fail_stop() -> None:
+    """Kill the container so threads and subprocesses cannot outlive ownership."""
+    logger.critical(
+        "Scheduler runtime entered a fatal state; terminating the process for fencing."
+    )
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _set_scheduler_runtime_snapshot(
+    app: FastAPI,
+    *,
+    expected: bool,
+    status: str,
+    reason: str,
+) -> None:
+    if status not in _SCHEDULER_RUNTIME_STATUSES:
+        raise ValueError(f"unsupported scheduler runtime status: {status}")
+    if reason not in _SCHEDULER_RUNTIME_REASONS:
+        raise ValueError(f"unsupported scheduler runtime reason: {reason}")
+    app.state.scheduler_runtime = {
+        "expected": expected,
+        "status": status,
+        "reason": reason,
+        "changed_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 async def _seed_installation_defaults() -> None:
@@ -31,23 +109,17 @@ async def _bootstrap_database() -> bool:
 async def _resume_catalog_import_jobs() -> bool:
     from services.catalog_import_runtime_service import catalog_import_runtime_service
 
-    await catalog_import_runtime_service.resume_pending_jobs()
-    return True
+    return await catalog_import_runtime_service.resume_pending_jobs()
 
 
-async def _acquire_scheduler_runtime_lock():
-    decision = settings.scheduler_control_decision
-    if not decision.enabled:
-        logger.warning("Scheduler runtime startup skipped: %s.", decision.reason)
-        return None
+async def _resume_catalog_import_jobs_once(app: FastAPI) -> bool:
+    if getattr(app.state, "catalog_import_jobs_resumed", False):
+        return False
 
-    lock = await RuntimeLockService.try_acquire(async_session_maker, "mvn:scheduler")
-    if not lock.acquired:
-        logger.warning("Scheduler runtime startup skipped: %s.", lock.reason)
-        return None
-
-    logger.info("Scheduler runtime lock acquired: %s.", lock.reason)
-    return lock
+    resumed = await _resume_catalog_import_jobs()
+    if resumed:
+        app.state.catalog_import_jobs_resumed = True
+    return resumed
 
 
 def _start_scheduler_loop(app: FastAPI) -> bool:
@@ -69,30 +141,339 @@ def _start_scheduler_loop(app: FastAPI) -> bool:
     return True
 
 
+def _scheduler_runtime_retry_seconds() -> int:
+    return max(1, int(settings.RUNTIME_LOCK_RETRY_SECONDS or 15))
+
+
+def _scheduler_lock_check_seconds() -> int:
+    return min(_scheduler_runtime_retry_seconds(), 5)
+
+
+def _scheduler_lock_probe_timeout_seconds() -> int:
+    return min(_scheduler_lock_check_seconds(), 3)
+
+
+def _scheduler_lock_fencing_grace_seconds() -> int:
+    return max(
+        _SCHEDULER_MIN_FENCING_GRACE_SECONDS,
+        _scheduler_lock_check_seconds()
+        + _scheduler_lock_probe_timeout_seconds()
+        + 1,
+    )
+
+
+async def _wait_before_scheduler_retry() -> None:
+    retry_seconds = _scheduler_runtime_retry_seconds()
+    logger.warning("Scheduler runtime will retry in %ss.", retry_seconds)
+    await asyncio.sleep(retry_seconds)
+
+
+async def _wait_for_scheduler_lock_fencing(runtime_lock) -> None:
+    grace_seconds = _scheduler_lock_fencing_grace_seconds()
+    logger.info(
+        "Scheduler runtime lock fencing started: grace_seconds=%s.",
+        grace_seconds,
+    )
+    await asyncio.sleep(grace_seconds)
+    await _probe_scheduler_runtime_lock(
+        runtime_lock,
+        timeout_message="scheduler runtime lock fencing probe timed out",
+        lost_message="scheduler runtime lock was lost during fencing",
+    )
+
+
+async def _probe_scheduler_runtime_lock(
+    runtime_lock,
+    *,
+    timeout_message: str,
+    lost_message: str,
+) -> None:
+    """Probe ownership without waiting for a stuck driver's cancellation cleanup."""
+    probe_task = asyncio.create_task(runtime_lock.is_held())
+    try:
+        done, _pending = await asyncio.wait(
+            {probe_task},
+            timeout=_scheduler_lock_probe_timeout_seconds(),
+        )
+    except asyncio.CancelledError:
+        probe_task.cancel()
+        _detach_scheduler_probe(probe_task)
+        raise
+
+    if not done:
+        probe_task.cancel()
+        _detach_scheduler_probe(probe_task)
+        raise SchedulerOwnershipLost(timeout_message)
+
+    try:
+        lock_is_held = probe_task.result()
+    except asyncio.CancelledError as exc:
+        raise SchedulerOwnershipLost(timeout_message) from exc
+    except Exception as exc:
+        raise SchedulerOwnershipLost(lost_message) from exc
+    if not lock_is_held:
+        raise SchedulerOwnershipLost(lost_message)
+
+
+async def _monitor_scheduler_runtime_lock(scheduler_task, runtime_lock) -> None:
+    check_interval = _scheduler_lock_check_seconds()
+    while True:
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(scheduler_task),
+                timeout=check_interval,
+            )
+        except asyncio.CancelledError as exc:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                raise
+            raise SchedulerRuntimeFatal(
+                "scheduler loop was cancelled unexpectedly"
+            ) from exc
+        except asyncio.TimeoutError:
+            await _probe_scheduler_runtime_lock(
+                runtime_lock,
+                timeout_message="scheduler runtime lock probe timed out",
+                lost_message="scheduler runtime lock was lost",
+            )
+        except Exception as exc:
+            raise SchedulerRuntimeFatal(
+                "scheduler loop failed unexpectedly"
+            ) from exc
+        else:
+            raise SchedulerRuntimeFatal("scheduler loop stopped unexpectedly")
+
+
+async def _cancel_scheduler_task(scheduler_task) -> None:
+    scheduler_task.cancel()
+    try:
+        await scheduler_task
+    except asyncio.CancelledError:
+        current_task = asyncio.current_task()
+        if current_task is not None and current_task.cancelling():
+            raise
+    except Exception:
+        # The attempt error is logged by the supervisor. Cleanup still owns the
+        # runtime lock and must continue to release it before retrying.
+        pass
+
+
+async def _run_scheduler_attempt(app: FastAPI) -> None:
+    runtime_lock = None
+    scheduler_task = None
+    scheduler_work_started = False
+    try:
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="waiting_lock",
+            reason="lock_acquisition_pending",
+        )
+        runtime_lock = await RuntimeLockService.wait_until_acquired(
+            async_session_maker,
+            "mvn:scheduler",
+            required=True,
+        )
+        if not runtime_lock.acquired:
+            logger.error("Scheduler runtime lock unavailable: %s.", runtime_lock.reason)
+            return
+
+        app.state.scheduler_runtime_lock = runtime_lock
+        logger.info("Scheduler runtime lock acquired: %s.", runtime_lock.reason)
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="fencing",
+            reason="previous_owner_fencing",
+        )
+        await _wait_for_scheduler_lock_fencing(runtime_lock)
+        await _resume_catalog_import_jobs_once(app)
+        if not _start_scheduler_loop(app):
+            raise RuntimeError("scheduler loop did not start")
+
+        scheduler_task = app.state.scheduler_task
+        # create_task() cannot run the child until this coroutine yields, so
+        # recording ownership here happens before any scheduler work executes.
+        scheduler_work_started = True
+        app.state.scheduler_work_started = True
+        await asyncio.sleep(0)
+        if scheduler_task.done():
+            if scheduler_task.cancelled():
+                raise SchedulerRuntimeFatal(
+                    "scheduler loop was cancelled during startup"
+                )
+            scheduler_error = scheduler_task.exception()
+            if scheduler_error is not None:
+                raise SchedulerRuntimeFatal(
+                    "scheduler loop failed during startup"
+                ) from scheduler_error
+            raise SchedulerRuntimeFatal("scheduler loop stopped during startup")
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="running",
+            reason="scheduler_loop_running",
+        )
+        await _monitor_scheduler_runtime_lock(scheduler_task, runtime_lock)
+    except SchedulerRuntimeFatal as exc:
+        reason = (
+            "ownership_lost"
+            if isinstance(exc, SchedulerOwnershipLost)
+            else "scheduler_loop_failed"
+        )
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="faulted",
+            reason=reason,
+        )
+        logger.critical("Scheduler runtime fail-stop: %s", exc)
+        if scheduler_task is not None and not scheduler_task.done():
+            scheduler_task.cancel()
+        app.state.scheduler_fail_stop_initiated = True
+        try:
+            _scheduler_runtime_fail_stop()
+        except BaseException:
+            logger.exception("Scheduler runtime fail-stop callback returned an error.")
+        # Production never reaches this await. It prevents an injected test
+        # callback (or a broken fail-stop implementation) from reacquiring.
+        await asyncio.Future()
+    finally:
+        try:
+            if scheduler_task is not None:
+                try:
+                    await _cancel_scheduler_task(scheduler_task)
+                finally:
+                    if getattr(app.state, "scheduler_task", None) is scheduler_task:
+                        app.state.scheduler_task = None
+        finally:
+            if runtime_lock is not None:
+                try:
+                    if runtime_lock.acquired:
+                        await runtime_lock.release()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "Scheduler runtime lock cleanup failed; retrying safely."
+                    )
+                finally:
+                    if getattr(app.state, "scheduler_runtime_lock", None) is runtime_lock:
+                        app.state.scheduler_runtime_lock = None
+                    if scheduler_work_started:
+                        app.state.scheduler_work_started = False
+
+
+async def _run_scheduler_supervisor(app: FastAPI) -> None:
+    while True:
+        try:
+            await _run_scheduler_attempt(app)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Scheduler runtime attempt failed.")
+
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="retrying",
+            reason="attempt_failed_retry_scheduled",
+        )
+        await _wait_before_scheduler_retry()
+
+
+def _start_scheduler_supervisor(app: FastAPI) -> bool:
+    existing_task = getattr(app.state, "scheduler_supervisor_task", None)
+    if existing_task is not None and not existing_task.done():
+        logger.warning("Scheduler runtime supervisor is already running.")
+        return False
+
+    decision = settings.scheduler_control_decision
+    if not decision.enabled:
+        app.state.scheduler_work_started = False
+        app.state.scheduler_fail_stop_initiated = False
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=False,
+            status="disabled",
+            reason="runtime_control_disabled",
+        )
+        logger.warning("Scheduler runtime startup skipped: %s.", decision.reason)
+        return False
+
+    app.state.scheduler_work_started = False
+    app.state.scheduler_fail_stop_initiated = False
+    logger.info("Scheduler runtime supervisor started: %s.", decision.reason)
+    _set_scheduler_runtime_snapshot(
+        app,
+        expected=True,
+        status="waiting_lock",
+        reason="lock_acquisition_pending",
+    )
+    app.state.scheduler_supervisor_task = asyncio.create_task(
+        _run_scheduler_supervisor(app),
+        name="scheduler-runtime-supervisor",
+    )
+    return True
+
+
+async def _stop_scheduler_supervisor(app: FastAPI) -> None:
+    supervisor_task = getattr(app.state, "scheduler_supervisor_task", None)
+    if supervisor_task is None:
+        return
+
+    runtime_lock = getattr(app.state, "scheduler_runtime_lock", None)
+    scheduler_work_started = bool(
+        getattr(app.state, "scheduler_work_started", False)
+    )
+    scheduler_ownership_active = bool(
+        scheduler_work_started
+        and runtime_lock is not None
+        and runtime_lock.acquired
+        and not getattr(app.state, "scheduler_fail_stop_initiated", False)
+    )
+    if scheduler_ownership_active:
+        logger.critical(
+            "Scheduler loop is active during application shutdown; "
+            "terminating the process before releasing runtime ownership."
+        )
+        app.state.scheduler_fail_stop_initiated = True
+        try:
+            _scheduler_runtime_fail_stop()
+        except BaseException:
+            logger.exception(
+                "Scheduler shutdown fail-stop callback returned an error."
+            )
+        # SIGKILL never returns in production. Keeping this fallback makes the
+        # shutdown sequence testable with an injected callback while preserving
+        # the critical ordering: fail-stop first, then cancellation and unlock.
+        logger.critical(
+            "Scheduler shutdown fail-stop callback returned; "
+            "continuing controlled cleanup fallback."
+        )
+
+    try:
+        await _cancel_scheduler_task(supervisor_task)
+    finally:
+        if getattr(app.state, "scheduler_supervisor_task", None) is supervisor_task:
+            app.state.scheduler_supervisor_task = None
+        _set_scheduler_runtime_snapshot(
+            app,
+            expected=True,
+            status="stopped",
+            reason="application_shutdown",
+        )
+
+
 @asynccontextmanager
 async def app_lifespan(app: FastAPI):
     logger.info("Starting Application...")
 
     await _bootstrap_database()
-    scheduler_lock = await _acquire_scheduler_runtime_lock()
-    if scheduler_lock:
-        app.state.scheduler_runtime_lock = scheduler_lock
-        try:
-            await _resume_catalog_import_jobs()
-            _start_scheduler_loop(app)
-        except Exception:
-            await scheduler_lock.release()
-            raise
+    _start_scheduler_supervisor(app)
 
-    yield
-
-    scheduler_task = getattr(app.state, "scheduler_task", None)
-    if scheduler_task:
-        scheduler_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await scheduler_task
-    scheduler_lock = getattr(app.state, "scheduler_runtime_lock", None)
-    if scheduler_lock:
-        await scheduler_lock.release()
-
-    logger.info("Stopping Application...")
+    try:
+        yield
+    finally:
+        await _stop_scheduler_supervisor(app)
+        logger.info("Stopping Application...")

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -540,10 +540,13 @@ cat scripts/prune_unused_docker_images.sh | ssh zakup \
 Manual zero-downtime code rollback on the current primary:
 
 ```bash
-scp scripts/deploy_backend_blue_green.sh scripts/rollback_backend.sh mvn-api:/tmp/
-ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh /tmp/rollback_backend.sh && \
+scp scripts/deploy_backend_blue_green.sh scripts/deploy_backend_blue_green_safety.sh \
+  scripts/rollback_backend.sh mvn-api:/tmp/
+ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh \
+  /tmp/deploy_backend_blue_green_safety.sh /tmp/rollback_backend.sh && \
   CONFIRM_ROLLBACK=true API_PROJECT_DIR=/opt/air-api \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
+  API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
   bash /tmp/rollback_backend.sh'
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -168,6 +168,56 @@ as the active primary default.
 | Primary/current production | `db`, `app`, `bot` | `APP_ROLE=primary` or unset; `SCHEDULER_ENABLED`/`BOT_ENABLED` unset or `true` | FastAPI starts scheduler loops; bot starts Telegram polling. |
 | Standby/passive API | `db`, `app` only | `APP_ROLE=standby`, `SCHEDULER_ENABLED=false`, `BOT_ENABLED=false` | FastAPI serves passive health/API checks without scheduler loops; bot must not be started. If started accidentally, it idles without polling. |
 
+During a blue-green overlap, an eligible API slot becomes ready without waiting
+for the scheduler advisory lock. Its background supervisor waits and starts the
+scheduler once the previous slot releases the lock. PostgreSQL runtime locks use
+one pinned `AUTOCOMMIT` connection for their full lifetime, so they are never
+returned to the pool while held and do not leave an idle transaction open. The
+scheduler probes that connection at least every five seconds while it runs; a
+probe is bounded to three seconds so a blackholed backend also stops the current
+loop. Ownership loss, a probe deadline, or an unexpected scheduler-loop exit is
+fail-stop: the API process records `faulted`, cancels the loop, and immediately
+sends itself `SIGKILL`. Docker restarts the container, which also guarantees that
+threads and subprocesses such as an in-flight backup cannot survive as a second
+scheduler owner. This is the safe temporary boundary until scheduler jobs move
+to a dedicated service with durable per-job fencing. A new owner holds the lock
+through a minimum twelve-second fencing grace before starting loops. Deployment
+also bounds scheduler-owner container shutdown to five seconds before Docker
+force-kills it. The fencing delay is therefore longer than both that kill
+deadline and the previous release's default shutdown/liveness window, including
+the first rollout where the old image does not yet have shutdown fail-stop.
+Normal application shutdown also sends `SIGKILL` before cancellation or runtime
+lock release once scheduler work has started. This applies even when the asyncio
+task already looks done or cancelled: cancellation of an `asyncio.to_thread`
+call does not stop its worker thread, and a cooperative unlock could otherwise
+let the next API slot start scheduler work while the old process is still
+draining. Shutdown remains graceful while the supervisor is only waiting for the
+lock or in the fencing delay, because no scheduler work has started in those
+states.
+`/api/ready.scheduler_runtime` exposes only the allowlisted ownership state;
+blue-green activation requires six consecutive `running` samples after the old
+slot has stopped and a monotonic stability window of at least nine seconds.
+Lowering the polling delay cannot shorten that safety window. Scheduler locking
+is fail-closed:
+`RUNTIME_DB_LOCKS_ENABLED=false` or a non-PostgreSQL database keeps scheduler
+loops stopped instead of permitting multiple owners.
+
+Catalog import startup is conservative: it may schedule a `queued` job only
+when the database contains no `running` job. A `running` job is never
+automatically moved back to `queued`, because the current job record has no
+durable owner lease proving that its worker is dead. Operators must investigate
+such a job; lease, heartbeat, and stale-owner reclaim remain a separate upgrade.
+
+Rollback after the old slot has already stopped uses the third free API slot as
+an API-only buffer. A temporary Compose override starts the previous image with
+database bootstrap, scheduler, and bot disabled; nginx routes to that ready
+buffer before the candidate is stopped. The old slot can then acquire the free
+scheduler lock and start normally. The buffer is removed only after a ready old
+slot, or a ready candidate with a stable scheduler, has received traffic. If
+neither recovers within the bounded checks, the managed buffer remains the live
+route and its override is preserved as `.rollback-api-buffer.compose.yml` for
+operator inspection instead of leaving a dead upstream.
+
 `SCHEDULER_ENABLED` and `BOT_ENABLED` are explicit overrides. If either is set
 to `false`, that process stays disabled even when `APP_ROLE=primary`; remove the
 override or set it to `true` before promoting a standby host.
@@ -306,6 +356,12 @@ Application release and database maintenance are separate lifecycles:
 - `scripts/deploy_backend_blue_green.sh` starts the candidate on private port
   `18001` or `18002`, validates readiness/products/filters, and only then
   atomically reloads nginx to the candidate;
+- under the deployment lock, the active container's immutable
+  `Config.Image` is the rollback source of truth; normal deploys reconcile
+  `.env` to it before mutations, while bootstrap validation fails on drift;
+- the `already_active` shortcut also requires a matching running bot image, no
+  preserved rollback buffer, and a scheduler that passes the monotonic
+  stability gate; otherwise the normal activation path repairs the release;
 - the previous API slot remains available during validation and is stopped only
   after origin and public readiness pass; `.active-api-slot` records the result;
 - `scripts/deploy.sh` remains the app-only standby deploy path; both scripts use
@@ -333,10 +389,13 @@ requests continue on the old worker while new requests move to the candidate.
 Manual code rollback on the active API host:
 
 ```bash
-scp scripts/deploy_backend_blue_green.sh scripts/rollback_backend.sh mvn-api:/tmp/
-ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh /tmp/rollback_backend.sh && \
+scp scripts/deploy_backend_blue_green.sh scripts/deploy_backend_blue_green_safety.sh \
+  scripts/rollback_backend.sh mvn-api:/tmp/
+ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh \
+  /tmp/deploy_backend_blue_green_safety.sh /tmp/rollback_backend.sh && \
   CONFIRM_ROLLBACK=true API_PROJECT_DIR=/opt/air-api \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
+  API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
   bash /tmp/rollback_backend.sh'
 ```
 

--- a/routers/api_admin.py
+++ b/routers/api_admin.py
@@ -1,6 +1,6 @@
 """Admin/search/health endpoints split from the main API router."""
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
@@ -59,7 +59,13 @@ async def health_check(session: AsyncSession = Depends(get_session)):
 
 
 @router.get("/ready")
-async def readiness_check(session: AsyncSession = Depends(get_session)):
+async def readiness_check(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Check whether this API node should receive public traffic."""
-    status_code, payload = await ReadinessService.check(session)
+    status_code, payload = await ReadinessService.check(
+        session,
+        scheduler_runtime=getattr(request.app.state, "scheduler_runtime", None),
+    )
     return JSONResponse(status_code=status_code, content=payload)

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 set -Eeuo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
@@ -27,6 +29,9 @@ API_HOST="${API_HOST:-api.mvn.by}"
 PUBLIC_READY_URL="${API_PUBLIC_READY_URL:-https://${API_HOST}/api/ready}"
 HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-45}"
 HEALTH_DELAY_SECONDS="${API_HEALTH_DELAY_SECONDS:-2}"
+SCHEDULER_READY_ATTEMPTS="${API_SCHEDULER_READY_ATTEMPTS:-${HEALTH_ATTEMPTS}}"
+SCHEDULER_STABILITY_SECONDS="${API_SCHEDULER_STABILITY_SECONDS:-9}"
+SERVICE_STOP_TIMEOUT_SECONDS="${API_SERVICE_STOP_TIMEOUT_SECONDS:-5}"
 DRAIN_SECONDS="${API_DRAIN_SECONDS:-5}"
 SUMMARY_FILE="${API_BLUE_GREEN_SUMMARY_FILE:-/tmp/backend_blue_green_summary.txt}"
 
@@ -41,7 +46,7 @@ env_updated=false
 bot_update_attempted=false
 nginx_switch_attempted=false
 candidate_started=false
-old_service_stopped=false
+old_service_stop_started=false
 TMP_DIR=""
 
 log() {
@@ -384,6 +389,57 @@ wait_ready_url() {
   return 1
 }
 
+validate_scheduler_running_payload() {
+  local path="$1"
+  python3 - "${path}" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+runtime = payload.get("scheduler_runtime")
+if not isinstance(runtime, dict):
+    raise SystemExit(f"scheduler runtime payload is missing: {payload}")
+if runtime.get("expected") is not True or runtime.get("status") != "running":
+    raise SystemExit(f"scheduler runtime is not active: {runtime}")
+PY
+}
+
+wait_scheduler_running_url() {
+  local label="$1"
+  local url="$2"
+  local output="${TMP_DIR}/${label//[^A-Za-z0-9]/_}.json"
+  local consecutive=0
+  local required_samples=6
+  local stable_since_ns=""
+  local current_ns=""
+
+  for attempt in $(seq 1 "${SCHEDULER_READY_ATTEMPTS}"); do
+    if curl -fsS "${url}" > "${output}" 2>/dev/null \
+      && validate_ready_payload "${output}" \
+      && validate_scheduler_running_payload "${output}"; then
+      consecutive=$((consecutive + 1))
+      current_ns="$(monotonic_now_ns)" || {
+        log error "could not read the monotonic clock for ${label}"
+        return 1
+      }
+      if (( consecutive == 1 )); then
+        stable_since_ns="${current_ns}"
+      fi
+      if (( consecutive >= required_samples )) \
+        && scheduler_stability_elapsed "${stable_since_ns}" "${current_ns}"; then
+        log smoke "${label} running for ${consecutive} consecutive samples and at least ${SCHEDULER_STABILITY_SECONDS}s (attempt ${attempt})"
+        return 0
+      fi
+    else
+      consecutive=0
+      stable_since_ns=""
+    fi
+    sleep "${HEALTH_DELAY_SECONDS}"
+  done
+  log error "${label} did not remain running for ${required_samples} consecutive samples and at least ${SCHEDULER_STABILITY_SECONDS}s: ${url}"
+  return 1
+}
+
 smoke_candidate() {
   local base_url="$1"
   local health_file="${TMP_DIR}/candidate-health.json"
@@ -427,47 +483,8 @@ wait_service_running() {
   return 1
 }
 
-rollback_on_error() {
-  local exit_code=$?
-  trap - ERR
-  set +e
-  log rollback "activation failed; restoring ${active_slot} on port ${active_port}"
-
-  if [[ "${env_updated}" == "true" ]] && is_immutable_image "${previous_image}"; then
-    export BACKEND_IMAGE="${previous_image}"
-    write_backend_image "${previous_image}"
-  fi
-  if [[ "${old_service_stopped}" == "true" ]] && is_immutable_image "${previous_image}"; then
-    export BACKEND_IMAGE="${previous_image}"
-    "${COMPOSE[@]}" up -d --no-deps "${active_service}"
-  fi
-
-  if [[ "${nginx_switch_attempted}" == "true" && -f "${NGINX_UPSTREAM_FILE}" ]]; then
-    write_upstream "${active_slot}"
-    reload_proxy
-  fi
-
-  if [[ "${bot_update_attempted}" == "true" ]] && is_immutable_image "${previous_image}"; then
-    export BACKEND_IMAGE="${previous_image}"
-    "${COMPOSE[@]}" up -d --no-deps --force-recreate bot
-  fi
-  if [[ "${candidate_started}" == "true" && -n "${candidate_service}" ]]; then
-    "${COMPOSE[@]}" stop "${candidate_service}"
-    "${COMPOSE[@]}" rm -f "${candidate_service}"
-  fi
-
-  if [[ "${active_slot}" == "legacy" ]]; then
-    rm -f "${ACTIVE_SLOT_FILE}"
-  else
-    atomic_write_line "${ACTIVE_SLOT_FILE}" "${active_slot}" 600
-  fi
-
-  summary "status=rolled_back"
-  summary "failed_candidate=${REQUESTED_IMAGE}"
-  summary "restored_slot=${active_slot}"
-  summary "restored_port=${active_port}"
-  exit "${exit_code}"
-}
+# shellcheck disable=SC1090,SC1091
+source "${API_BLUE_GREEN_SAFETY_HELPER:-${SCRIPT_DIR}/deploy_backend_blue_green_safety.sh}"
 
 required_commands=(docker curl python3 flock)
 if [[ "${PROXY_MODE}" == "host_nginx" ]]; then
@@ -485,6 +502,14 @@ docker compose version >/dev/null
   log error "BACKEND_IMAGE is required"
   exit 1
 }
+[[ "${SCHEDULER_STABILITY_SECONDS}" =~ ^[0-9]+([.][0-9]+)?$ ]] || {
+  log error "API_SCHEDULER_STABILITY_SECONDS must be a non-negative number"
+  exit 1
+}
+if [[ ! "${SERVICE_STOP_TIMEOUT_SECONDS}" =~ ^([1-9]|10)$ ]]; then
+  log error "API_SERVICE_STOP_TIMEOUT_SECONDS must be an integer from 1 to 10"
+  exit 1
+fi
 is_immutable_image "${BACKEND_IMAGE}" || {
   log error "BACKEND_IMAGE must use a Git SHA tag or sha256 digest"
   exit 1
@@ -512,21 +537,24 @@ if [[ "${DEPLOY_LOCK_ALREADY_HELD}" != "true" ]]; then
   }
 fi
 
-mkdir -p media model-cache/u2net
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 : > "${SUMMARY_FILE}"
 COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
 
 resolve_active_slot
-ensure_proxy
-previous_image="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
-is_immutable_image "${previous_image}" || {
-  log error "current BACKEND_IMAGE in ${ENV_FILE} is not immutable"
+configured_image="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
+previous_image="$(inspect_service_runtime_image "${active_service}")" || {
+  log error "active API runtime image could not be established"
   exit 1
 }
 
 if [[ "${BOOTSTRAP_ONLY}" == "true" ]]; then
+  if [[ "${configured_image}" != "${previous_image}" ]]; then
+    log error "BOOTSTRAP_ONLY refuses BACKEND_IMAGE drift: env=${configured_image:-missing} runtime=${previous_image}"
+    exit 1
+  fi
+  ensure_proxy
   smoke_candidate "http://127.0.0.1:${active_port}"
   wait_ready_url "internal_proxy" "http://127.0.0.1:${INTERNAL_PROXY_PORT}/api/ready"
   summary "status=bootstrap_complete"
@@ -537,16 +565,31 @@ if [[ "${BOOTSTRAP_ONLY}" == "true" ]]; then
   exit 0
 fi
 
-if [[ "${active_slot}" != "legacy" && "${BACKEND_IMAGE}" == "${previous_image}" ]]; then
-  smoke_candidate "http://127.0.0.1:${active_port}"
-  wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:443:127.0.0.1"
-  wait_ready_url "public" "${PUBLIC_READY_URL}"
-  summary "status=already_active"
-  summary "active_slot=${active_slot}"
-  summary "active_port=${active_port}"
-  summary "backend_image=${BACKEND_IMAGE}"
-  log "done" "requested image is already active"
-  exit 0
+if [[ "${configured_image}" != "${previous_image}" ]]; then
+  log reconcile "restoring BACKEND_IMAGE from active runtime ${previous_image}"
+  write_backend_image "${previous_image}"
+fi
+mkdir -p media model-cache/u2net
+ensure_proxy
+
+if [[ "${active_slot}" != "legacy" \
+  && "${BACKEND_IMAGE}" == "${previous_image}" \
+  && ! -f "${PROJECT_DIR}/.rollback-api-buffer.compose.yml" ]]; then
+  if service_runtime_matches_image bot "${REQUESTED_IMAGE}"; then
+    smoke_candidate "http://127.0.0.1:${active_port}"
+    wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:443:127.0.0.1"
+    wait_ready_url "public" "${PUBLIC_READY_URL}"
+    wait_scheduler_running_url \
+      "active_scheduler" \
+      "http://127.0.0.1:${active_port}/api/ready"
+    summary "status=already_active"
+    summary "active_slot=${active_slot}"
+    summary "active_port=${active_port}"
+    summary "backend_image=${BACKEND_IMAGE}"
+    log "done" "requested image is already active"
+    exit 0
+  fi
+  log reconcile "bot runtime does not match ${REQUESTED_IMAGE}; running a full activation"
 fi
 
 if [[ "${active_slot}" == "blue" ]]; then
@@ -593,11 +636,15 @@ wait_ready_url "origin" "https://${API_HOST}/api/ready" --resolve "${API_HOST}:4
 wait_ready_url "public" "${PUBLIC_READY_URL}"
 sleep "${DRAIN_SECONDS}"
 
-old_service_stopped=true
-"${COMPOSE[@]}" stop "${active_service}"
+old_service_stop_started=true
+"${COMPOSE[@]}" stop -t "${SERVICE_STOP_TIMEOUT_SECONDS}" "${active_service}"
 "${COMPOSE[@]}" rm -f "${active_service}"
-atomic_write_line "${PREVIOUS_IMAGE_FILE}" "${previous_image}" 600
 atomic_write_line "${ACTIVE_SLOT_FILE}" "${candidate_slot}" 600
+wait_scheduler_running_url \
+  "candidate_scheduler" \
+  "http://127.0.0.1:${candidate_port}/api/ready"
+rm -f "${PROJECT_DIR}/.rollback-api-buffer.compose.yml"
+atomic_write_line "${PREVIOUS_IMAGE_FILE}" "${previous_image}" 600
 
 trap - ERR
 summary "status=activated"

--- a/scripts/deploy_backend_blue_green_safety.sh
+++ b/scripts/deploy_backend_blue_green_safety.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+
+# Runtime-truth and rollback safety helpers sourced by deploy_backend_blue_green.sh.
+
+rollback_buffer_slot=""
+rollback_buffer_service=""
+rollback_buffer_port=""
+rollback_buffer_override=""
+rollback_buffer_started=false
+rollback_buffer_routed=false
+ROLLBACK_BUFFER_COMPOSE=()
+
+inspect_service_runtime_image() {
+  local service="$1"
+  local container_ids
+  local container_id
+  local image
+
+  container_ids="$("${COMPOSE[@]}" ps -q "${service}")" || {
+    log error "could not resolve the running container for ${service}"
+    return 1
+  }
+  if [[ -z "${container_ids}" || "${container_ids}" == *$'\n'* ]]; then
+    log error "expected exactly one running container for ${service}"
+    return 1
+  fi
+  container_id="${container_ids}"
+  image="$(docker inspect --format '{{.Config.Image}}' "${container_id}")" || {
+    log error "could not inspect the runtime image for ${service}"
+    return 1
+  }
+  if [[ -z "${image}" || "${image}" == *$'\n'* ]] \
+    || ! is_immutable_image "${image}"; then
+    log error "runtime image for ${service} is missing, ambiguous, or mutable"
+    return 1
+  fi
+  printf '%s\n' "${image}"
+}
+
+service_runtime_matches_image() {
+  local service="$1"
+  local expected_image="$2"
+  local runtime_image
+
+  runtime_image="$(inspect_service_runtime_image "${service}" 2>/dev/null)" \
+    || return 1
+  [[ "${runtime_image}" == "${expected_image}" ]]
+}
+
+monotonic_now_ns() {
+  python3 - <<'PY'
+import time
+
+print(time.monotonic_ns())
+PY
+}
+
+scheduler_stability_elapsed() {
+  local started_ns="$1"
+  local current_ns="$2"
+
+  python3 - "${started_ns}" "${current_ns}" "${SCHEDULER_STABILITY_SECONDS}" <<'PY'
+import decimal
+import sys
+
+started_ns = int(sys.argv[1])
+current_ns = int(sys.argv[2])
+required_ns = decimal.Decimal(sys.argv[3]) * decimal.Decimal(1_000_000_000)
+if decimal.Decimal(current_ns - started_ns) < required_ns:
+    raise SystemExit(1)
+PY
+}
+
+rollback_record_slot() {
+  local slot="$1"
+  if [[ "${slot}" == "legacy" ]]; then
+    rm -f "${ACTIVE_SLOT_FILE}"
+  else
+    atomic_write_line "${ACTIVE_SLOT_FILE}" "${slot}" 600
+  fi
+}
+
+rollback_select_buffer_slot() {
+  local slot
+  for slot in legacy blue green; do
+    if [[ "${slot}" != "${active_slot}" && "${slot}" != "${candidate_slot}" ]]; then
+      printf '%s\n' "${slot}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+rollback_write_buffer_override() {
+  local quoted_image
+  rollback_buffer_override="${TMP_DIR}/rollback-api-buffer.compose.yml"
+  if ! quoted_image="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "${previous_image}")"; then
+    log error "could not encode the rollback buffer image"
+    return 1
+  fi
+  if ! cat > "${rollback_buffer_override}" <<EOF
+services:
+  ${rollback_buffer_service}:
+    image: ${quoted_image}
+    restart: unless-stopped
+    environment:
+      APP_ROLE: primary
+      API_READY_ENABLED: "true"
+      DB_BOOTSTRAP_ENABLED: "false"
+      SCHEDULER_ENABLED: "false"
+      BOT_ENABLED: "false"
+      MAIL_IMAP_AUTO_IMPORT_ENABLED: "false"
+      MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED: "false"
+      CLOUDFLARE_PURGE_ENABLED: "false"
+      CLOUDFLARE_PURGE_DRY_RUN: "true"
+EOF
+  then
+    log error "could not write the rollback buffer Compose override"
+    return 1
+  fi
+  if ! chmod 600 "${rollback_buffer_override}"; then
+    log error "could not secure the rollback buffer Compose override"
+    return 1
+  fi
+  ROLLBACK_BUFFER_COMPOSE=(
+    docker compose -f "${COMPOSE_FILE}" -f "${rollback_buffer_override}" --profile bluegreen
+  )
+}
+
+rollback_buffer_stop() {
+  if [[ "${rollback_buffer_started}" != "true" ]]; then
+    return 0
+  fi
+  if ! "${ROLLBACK_BUFFER_COMPOSE[@]}" rm -s -f "${rollback_buffer_service}" \
+    >/dev/null 2>&1; then
+    log error "rollback buffer cleanup failed for ${rollback_buffer_service}"
+    return 1
+  fi
+  rollback_buffer_started=false
+  rm -f "${PROJECT_DIR}/.rollback-api-buffer.compose.yml"
+}
+
+rollback_buffer_start() {
+  rollback_buffer_slot="$(rollback_select_buffer_slot)" || {
+    log error "cannot select a third API slot for rollback buffer"
+    return 1
+  }
+  rollback_buffer_service="$(service_for_slot "${rollback_buffer_slot}")"
+  rollback_buffer_port="$(port_for_slot "${rollback_buffer_slot}")"
+  rollback_write_buffer_override || return 1
+
+  log rollback "starting API-only rollback buffer ${rollback_buffer_slot} on ${rollback_buffer_port}"
+  rollback_buffer_started=true
+  if ! "${ROLLBACK_BUFFER_COMPOSE[@]}" up -d --no-deps --force-recreate \
+    "${rollback_buffer_service}"; then
+    log error "rollback buffer container failed to start"
+    return 1
+  fi
+  if ! wait_ready_url \
+    "rollback_buffer" \
+    "http://127.0.0.1:${rollback_buffer_port}/api/ready"; then
+    log error "rollback buffer API did not become ready"
+    if ! rollback_buffer_stop; then
+      rollback_preserve_buffer_state
+    fi
+    return 1
+  fi
+}
+
+rollback_route_slot() {
+  local target_slot="$1"
+  local fallback_slot="$2"
+
+  if write_upstream "${target_slot}" && reload_proxy && rollback_record_slot "${target_slot}"; then
+    if [[ "${target_slot}" == "${rollback_buffer_slot}" ]]; then
+      rollback_buffer_routed=true
+    else
+      rollback_buffer_routed=false
+    fi
+    return 0
+  fi
+
+  log error "failed to route ${target_slot}; restoring ${fallback_slot}"
+  write_upstream "${fallback_slot}" || true
+  reload_proxy || true
+  rollback_record_slot "${fallback_slot}" || true
+  if [[ "${fallback_slot}" == "${rollback_buffer_slot}" ]]; then
+    rollback_buffer_routed=true
+  else
+    rollback_buffer_routed=false
+  fi
+  return 1
+}
+
+rollback_preserve_buffer_state() {
+  local image_state_synced=true
+
+  if [[ "${rollback_buffer_routed}" == "true" ]]; then
+    if rollback_restore_previous_image_state; then
+      summary "rollback_buffer_image_state_synced=true"
+    else
+      image_state_synced=false
+      summary "rollback_buffer_image_state_synced=false"
+      log error "rollback buffer is routed, but the previous image state could not be fully synchronized"
+    fi
+  fi
+  if ! cp -f "${rollback_buffer_override}" "${PROJECT_DIR}/.rollback-api-buffer.compose.yml" \
+    || ! chmod 600 "${PROJECT_DIR}/.rollback-api-buffer.compose.yml"; then
+    log error "could not preserve the rollback buffer Compose override"
+    return 1
+  fi
+  summary "rollback_buffer_container_present=true"
+  summary "rollback_buffer_routed=${rollback_buffer_routed}"
+  summary "rollback_buffer_slot=${rollback_buffer_slot}"
+  summary "rollback_buffer_service=${rollback_buffer_service}"
+  summary "rollback_buffer_image=${previous_image}"
+  summary "rollback_buffer_override=${PROJECT_DIR}/.rollback-api-buffer.compose.yml"
+  summary "rollback_buffer_cleanup=docker compose -f ${COMPOSE_FILE} -f ${PROJECT_DIR}/.rollback-api-buffer.compose.yml --profile bluegreen rm -s -f ${rollback_buffer_service}"
+  [[ "${image_state_synced}" == "true" ]]
+}
+
+rollback_stop_service() {
+  local service="$1"
+  "${COMPOSE[@]}" stop -t "${SERVICE_STOP_TIMEOUT_SECONDS}" "${service}" \
+    && "${COMPOSE[@]}" rm -f "${service}"
+}
+
+rollback_restore_previous_image_state() {
+  is_immutable_image "${previous_image}" || {
+    log error "cannot restore a non-immutable previous image"
+    return 1
+  }
+
+  export BACKEND_IMAGE="${previous_image}"
+  if [[ "${env_updated}" == "true" ]]; then
+    if ! write_backend_image "${previous_image}"; then
+      log error "could not restore BACKEND_IMAGE in ${ENV_FILE}"
+      return 1
+    fi
+  fi
+  if [[ "${bot_update_attempted}" == "true" ]]; then
+    if ! "${COMPOSE[@]}" up -d --no-deps --force-recreate bot \
+      || ! wait_service_running bot; then
+      log error "could not restore bot to the previous image"
+      return 1
+    fi
+  fi
+}
+
+rollback_restore_candidate_from_buffer() {
+  local candidate_ready=false
+
+  export BACKEND_IMAGE="${REQUESTED_IMAGE}"
+  if [[ "${env_updated}" == "true" ]]; then
+    if ! write_backend_image "${REQUESTED_IMAGE}"; then
+      log error "could not synchronize BACKEND_IMAGE before candidate recovery"
+      rollback_preserve_buffer_state
+      summary "candidate_image_state_synced=false"
+      summary "candidate_api_fallback_ready=false"
+      return 1
+    fi
+  fi
+  summary "candidate_image_state_synced=true"
+  candidate_started=true
+  if "${COMPOSE[@]}" up -d --no-deps --force-recreate "${candidate_service}" \
+    && wait_ready_url \
+      "rollback_candidate_fallback" \
+      "http://127.0.0.1:${candidate_port}/api/ready" \
+    && wait_scheduler_running_url \
+      "rollback_candidate_scheduler" \
+      "http://127.0.0.1:${candidate_port}/api/ready"; then
+    candidate_ready=true
+  fi
+
+  if [[ "${candidate_ready}" == "true" ]] \
+    && rollback_route_slot "${candidate_slot}" "${rollback_buffer_slot}"; then
+    if ! rollback_buffer_stop; then
+      rollback_preserve_buffer_state
+      summary "rollback_buffer_cleanup=false"
+      return 1
+    fi
+    summary "candidate_api_fallback_ready=true"
+    return 0
+  fi
+
+  rollback_preserve_buffer_state
+  summary "candidate_api_fallback_ready=false"
+  return 1
+}
+
+rollback_without_buffer() {
+  local image_state_synced=true
+
+  if [[ "${nginx_switch_attempted}" == "true" && -f "${NGINX_UPSTREAM_FILE}" ]]; then
+    if ! rollback_route_slot "${active_slot}" "${candidate_slot}"; then
+      summary "old_route_confirmed=false"
+      summary "candidate_preserved=true"
+      return 1
+    fi
+  fi
+  summary "old_route_confirmed=true"
+
+  if ! rollback_restore_previous_image_state; then
+    image_state_synced=false
+  fi
+  if [[ "${candidate_started}" == "true" && -n "${candidate_service}" ]]; then
+    if ! rollback_stop_service "${candidate_service}"; then
+      summary "candidate_stop_confirmed=false"
+      return 1
+    fi
+    candidate_started=false
+  fi
+  summary "candidate_stop_confirmed=true"
+  if ! rollback_record_slot "${active_slot}"; then
+    summary "old_slot_recorded=false"
+    return 1
+  fi
+  if [[ "${image_state_synced}" != "true" ]]; then
+    summary "previous_image_state_synced=false"
+    return 1
+  fi
+  summary "previous_image_state_synced=true"
+}
+
+rollback_on_error() {
+  local exit_code=$?
+  local old_ready=false
+  trap - ERR
+  set +e
+  log rollback "activation failed; restoring ${active_slot} on port ${active_port}"
+
+  if [[ "${old_service_stop_started}" != "true" ]]; then
+    if rollback_without_buffer; then
+      summary "status=rolled_back"
+    else
+      summary "status=rollback_failed"
+    fi
+    summary "failed_candidate=${REQUESTED_IMAGE}"
+    if [[ "$(parse_upstream_slot 2>/dev/null || true)" == "${active_slot}" ]]; then
+      summary "restored_slot=${active_slot}"
+      summary "restored_port=${active_port}"
+    fi
+    exit "${exit_code}"
+  fi
+
+  if ! rollback_buffer_start \
+    || ! rollback_route_slot "${rollback_buffer_slot}" "${candidate_slot}"; then
+    if ! rollback_buffer_stop; then
+      rollback_preserve_buffer_state
+    fi
+    summary "status=rollback_failed"
+    summary "failed_candidate=${REQUESTED_IMAGE}"
+    summary "candidate_preserved=true"
+    exit "${exit_code}"
+  fi
+
+  if ! rollback_stop_service "${candidate_service}"; then
+    log error "candidate did not stop cleanly; refusing to start another scheduler owner"
+    rollback_preserve_buffer_state
+    summary "status=rollback_buffer_active"
+    summary "candidate_stop_confirmed=false"
+    exit "${exit_code}"
+  fi
+  candidate_started=false
+
+  export BACKEND_IMAGE="${previous_image}"
+  if "${COMPOSE[@]}" up -d --no-deps "${active_service}" \
+    && wait_ready_url "rollback_old" "http://127.0.0.1:${active_port}/api/ready"; then
+    old_ready=true
+  fi
+
+  if [[ "${old_ready}" == "true" ]] \
+    && rollback_route_slot "${active_slot}" "${rollback_buffer_slot}"; then
+    local previous_image_state_synced=true
+    if rollback_restore_previous_image_state; then
+      summary "previous_image_state_synced=true"
+    else
+      previous_image_state_synced=false
+      summary "previous_image_state_synced=false"
+    fi
+    if ! rollback_buffer_stop; then
+      rollback_preserve_buffer_state
+      summary "rollback_buffer_cleanup=false"
+    fi
+    if [[ "${previous_image_state_synced}" == "true" ]]; then
+      summary "status=rolled_back"
+    else
+      summary "status=rollback_failed"
+    fi
+    summary "failed_candidate=${REQUESTED_IMAGE}"
+    summary "restored_slot=${active_slot}"
+    summary "restored_port=${active_port}"
+    exit "${exit_code}"
+  fi
+
+  log error "rollback old slot is not ready; candidate recovery will run behind the API buffer"
+  if ! rollback_stop_service "${active_service}"; then
+    log error "unhealthy old slot could not be removed; refusing candidate recovery"
+    rollback_preserve_buffer_state
+    summary "status=rollback_buffer_active"
+    summary "old_slot_stop_confirmed=false"
+    exit "${exit_code}"
+  fi
+  if rollback_restore_candidate_from_buffer; then
+    summary "status=rollback_failed"
+    summary "failed_candidate=${REQUESTED_IMAGE}"
+    summary "old_slot_ready=false"
+  else
+    summary "status=rollback_buffer_active"
+    summary "failed_candidate=${REQUESTED_IMAGE}"
+    summary "old_slot_ready=false"
+  fi
+  exit "${exit_code}"
+}

--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -589,6 +589,29 @@ def _check_runtime(
                 f"api={payload.get('api')} traffic={payload.get('traffic')}"
             )
 
+        scheduler_runtime = payload.get("scheduler_runtime")
+        if not isinstance(scheduler_runtime, dict):
+            report.fail(f"{node.label}: readiness scheduler_runtime is missing")
+        elif expected_primary:
+            if (
+                scheduler_runtime.get("expected") is not True
+                or scheduler_runtime.get("status") != "running"
+            ):
+                report.fail(
+                    f"{node.label}: primary scheduler runtime expected=true "
+                    f"status=running, got expected={scheduler_runtime.get('expected')!r} "
+                    f"status={scheduler_runtime.get('status')!r}"
+                )
+        elif (
+            scheduler_runtime.get("expected") is not False
+            or scheduler_runtime.get("status") not in {"disabled", "stopped"}
+        ):
+            report.fail(
+                f"{node.label}: standby scheduler runtime expected=false "
+                f"status=disabled|stopped, got expected={scheduler_runtime.get('expected')!r} "
+                f"status={scheduler_runtime.get('status')!r}"
+            )
+
         for timer in PITR_TIMERS:
             active = _unit_active(runner, node, timer)
             if active != (node == primary):

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -120,6 +120,7 @@ scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
   "${REMOTE}:${PROJECT_DIR}/docker-compose.patroni.yml"
 scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
   scripts/ha/deploy_patroni_api_node.sh scripts/deploy_backend_blue_green.sh \
+  scripts/deploy_backend_blue_green_safety.sh \
   "${REMOTE}:/tmp/"
 if [[ "${OPERATION}" == "deploy" ]]; then
   scp "${SSH_OPTS[@]}" "${ROLE_AGENT_SOURCE}" "${REMOTE}:${ROLE_AGENT_REMOTE}"
@@ -152,7 +153,7 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   set -euo pipefail
   IFS= read -r GHCR_PAT
   export GHCR_PAT
-  chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh
+  chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh
   API_PROJECT_DIR=$(quote "${PROJECT_DIR}") \
   API_COMPOSE_FILE=docker-compose.patroni.yml \
   API_EXPECTED_PATRONI_ROLE=$(quote "${EXPECTED_ROLE}") \
@@ -160,6 +161,7 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   API_HEALTH_URL=http://127.0.0.1:18080/api/health \
   API_INTERNAL_PROXY_PORT=18080 \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
+  API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
   API_PUBLIC_READY_URL=https://api.mvn.by/api/ready \
   BACKEND_IMAGE=$(quote "${BACKEND_IMAGE}") \
   GITHUB_ACTOR=$(quote "${GITHUB_ACTOR:-github-actions}") \

--- a/services/catalog_import_runtime_service.py
+++ b/services/catalog_import_runtime_service.py
@@ -118,22 +118,26 @@ class CatalogImportRuntimeService:
         if next_job_id:
             self._schedule_job(next_job_id)
 
-    async def resume_pending_jobs(self) -> None:
+    async def resume_pending_jobs(self) -> bool:
         async with async_session_maker() as session:
-            stale_running = (
+            running_job_id = (
                 await session.execute(
-                    select(CatalogImportJob).where(CatalogImportJob.status == "running")
+                    select(CatalogImportJob.job_id)
+                    .where(CatalogImportJob.status == "running")
+                    .order_by(CatalogImportJob.updated_at.desc())
                 )
-            ).scalars().all()
-            for job in stale_running:
-                job.status = "queued"
-                job.stage = "queued"
-                job.error = None
-                job.updated_at = datetime.now()
-                session.add(job)
-            await session.commit()
+            ).scalars().first()
+
+        if running_job_id:
+            logger.warning(
+                "Catalog import recovery skipped: running job %s has no durable "
+                "lease proof; leaving it unchanged to avoid duplicate execution.",
+                running_job_id,
+            )
+            return False
 
         await self._start_next_queued_job()
+        return True
 
     async def start_import(
         self,

--- a/services/readiness_service.py
+++ b/services/readiness_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import text
@@ -7,8 +8,70 @@ from core.config import settings
 
 
 class ReadinessService:
+    _SCHEDULER_STATUSES = {
+        "disabled",
+        "waiting_lock",
+        "fencing",
+        "running",
+        "retrying",
+        "faulted",
+        "stopped",
+    }
+    _SCHEDULER_REASONS = {
+        "runtime_control_disabled",
+        "lock_acquisition_pending",
+        "previous_owner_fencing",
+        "scheduler_loop_running",
+        "attempt_failed_retry_scheduled",
+        "ownership_lost",
+        "scheduler_loop_failed",
+        "application_shutdown",
+    }
+
     @staticmethod
-    async def check(session: AsyncSession) -> tuple[int, dict[str, Any]]:
+    def _scheduler_runtime_payload(
+        snapshot: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        decision = settings.scheduler_control_decision
+        fallback = {
+            "expected": decision.enabled,
+            "status": "waiting_lock" if decision.enabled else "disabled",
+            "reason": "runtime_state_unavailable",
+            "changed_at": None,
+        }
+        if not isinstance(snapshot, dict):
+            return fallback
+
+        expected = snapshot.get("expected")
+        status = snapshot.get("status")
+        reason = snapshot.get("reason")
+        changed_at = snapshot.get("changed_at")
+        changed_at_valid = False
+        if isinstance(changed_at, str) and len(changed_at) <= 64:
+            try:
+                changed_at_valid = datetime.fromisoformat(changed_at).tzinfo is not None
+            except ValueError:
+                changed_at_valid = False
+        if (
+            not isinstance(expected, bool)
+            or status not in ReadinessService._SCHEDULER_STATUSES
+            or reason not in ReadinessService._SCHEDULER_REASONS
+            or not changed_at_valid
+        ):
+            return fallback
+        return {
+            "expected": expected,
+            "status": status,
+            "reason": reason,
+            "changed_at": changed_at,
+        }
+
+    @staticmethod
+    async def check(
+        session: AsyncSession,
+        *,
+        scheduler_runtime: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any]]:
         decision = settings.api_ready_control_decision
         payload: dict[str, Any] = {
             "status": "ok",
@@ -16,6 +79,9 @@ class ReadinessService:
             "app_role": settings.APP_ROLE,
             "traffic": "enabled" if decision.enabled else "disabled",
             "reason": decision.reason,
+            "scheduler_runtime": ReadinessService._scheduler_runtime_payload(
+                scheduler_runtime
+            ),
         }
         if not decision.enabled:
             payload.update({"status": "error", "api": "not_ready"})

--- a/services/runtime_lock_service.py
+++ b/services/runtime_lock_service.py
@@ -1,82 +1,226 @@
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Callable, Optional
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 
 from core.config import settings
 from core.logger import logger
 
 
+_LOCK_IS_HELD_QUERY = text(
+    """
+    WITH lock_key AS (
+        SELECT hashtext(:lock_name)::bigint AS value
+    )
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_locks, lock_key
+        WHERE locktype = 'advisory'
+          AND pid = pg_backend_pid()
+          AND granted
+          AND classid = (((lock_key.value >> 32) & 4294967295)::oid)
+          AND objid = ((lock_key.value & 4294967295)::oid)
+          AND objsubid = 1
+    )
+    """
+)
+
+
+async def _invalidate_and_close(connection: AsyncConnection) -> None:
+    """Discard a connection whose advisory-lock state is no longer trustworthy."""
+    try:
+        await connection.invalidate()
+    except Exception:
+        logger.exception("Failed to invalidate a runtime-lock database connection.")
+    finally:
+        with suppress(Exception):
+            await connection.close()
+
+
 @dataclass
 class RuntimeLock:
     name: str
-    session: Optional[AsyncSession]
+    connection: Optional[AsyncConnection]
     acquired: bool
     reason: str
+    retryable: bool = False
+
+    async def is_held(self) -> bool:
+        """Check this lock on the same pinned PostgreSQL connection."""
+        connection = self.connection
+        if not self.acquired:
+            return False
+        if connection is None:
+            # Compatibility mode (locks explicitly disabled or a non-PostgreSQL
+            # local/test database) has no database-backed lock to probe.
+            return True
+        if connection.closed:
+            self.acquired = False
+            self.connection = None
+            return False
+
+        try:
+            result = await connection.execute(
+                _LOCK_IS_HELD_QUERY,
+                {"lock_name": self.name},
+            )
+            held = bool(result.scalar())
+        except asyncio.CancelledError:
+            self.acquired = False
+            self.connection = None
+            await _invalidate_and_close(connection)
+            raise
+        except Exception:
+            logger.exception("Runtime lock %r liveness check failed.", self.name)
+            self.acquired = False
+            self.connection = None
+            await _invalidate_and_close(connection)
+            return False
+
+        if not held:
+            self.acquired = False
+            self.connection = None
+            try:
+                await connection.close()
+            except asyncio.CancelledError:
+                await _invalidate_and_close(connection)
+                raise
+            except Exception:
+                await _invalidate_and_close(connection)
+        return held
 
     async def release(self) -> None:
-        if not self.acquired or self.session is None:
+        if not self.acquired:
             return
+
+        connection = self.connection
+        self.acquired = False
+        self.connection = None
+        if connection is None:
+            return
+
         try:
-            bind = self.session.get_bind()
-            dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
-            if dialect_name == "postgresql":
-                await self.session.execute(
-                    text("SELECT pg_advisory_unlock(hashtext(:lock_name))"),
-                    {"lock_name": self.name},
-                )
-        finally:
-            await self.session.close()
-            self.acquired = False
+            result = await connection.execute(
+                text("SELECT pg_advisory_unlock(hashtext(:lock_name))"),
+                {"lock_name": self.name},
+            )
+            if not bool(result.scalar()):
+                logger.warning("Runtime lock %r was not held during release.", self.name)
+        except BaseException:
+            # Returning an uncertain session-level lock to the pool can strand it
+            # on an unrelated future checkout. Invalidating physically drops it.
+            await _invalidate_and_close(connection)
+            raise
+        else:
+            try:
+                await connection.close()
+            except BaseException:
+                await _invalidate_and_close(connection)
+                raise
 
 
 class RuntimeLockService:
     @staticmethod
+    async def _resolve_engine(
+        session_factory: Callable[[], AsyncSession],
+    ) -> tuple[AsyncEngine, str]:
+        session = session_factory()
+        try:
+            async_bind = session.bind
+            sync_bind = session.get_bind()
+            dialect_name = getattr(getattr(sync_bind, "dialect", None), "name", "")
+        finally:
+            await session.close()
+
+        if isinstance(async_bind, AsyncConnection):
+            return async_bind.engine, dialect_name
+        if isinstance(async_bind, AsyncEngine):
+            return async_bind, dialect_name
+        raise RuntimeError("Runtime lock session factory has no async engine bind")
+
+    @staticmethod
     async def try_acquire(
         session_factory: Callable[[], AsyncSession],
         lock_name: str,
+        *,
+        required: bool = False,
     ) -> RuntimeLock:
         if not settings.RUNTIME_DB_LOCKS_ENABLED:
+            if required:
+                return RuntimeLock(
+                    lock_name,
+                    None,
+                    False,
+                    "runtime database lock is required but RUNTIME_DB_LOCKS_ENABLED=false",
+                )
             return RuntimeLock(lock_name, None, True, "RUNTIME_DB_LOCKS_ENABLED=false")
 
-        session = session_factory()
-        bind = session.get_bind()
-        dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
+        engine, dialect_name = await RuntimeLockService._resolve_engine(session_factory)
         if dialect_name != "postgresql":
+            if required:
+                return RuntimeLock(
+                    lock_name,
+                    None,
+                    False,
+                    f"runtime database lock is required but dialect is {dialect_name!r}",
+                )
             return RuntimeLock(
                 lock_name,
-                session,
+                None,
                 True,
                 f"database dialect {dialect_name!r} has no runtime lock",
             )
 
+        connection = await engine.connect()
         try:
-            result = await session.execute(
+            # Session-level advisory locks survive transaction boundaries. Keep a
+            # dedicated connection in AUTOCOMMIT so it is never idle-in-transaction
+            # and cannot be handed to another consumer until explicit unlock.
+            connection = await connection.execution_options(isolation_level="AUTOCOMMIT")
+            result = await connection.execute(
                 text("SELECT pg_try_advisory_lock(hashtext(:lock_name))"),
                 {"lock_name": lock_name},
             )
             acquired = bool(result.scalar())
-        except Exception:
-            await session.close()
+        except BaseException:
+            await _invalidate_and_close(connection)
             raise
 
         if not acquired:
-            await session.close()
-            return RuntimeLock(lock_name, None, False, f"runtime lock {lock_name!r} is already held")
+            await connection.close()
+            return RuntimeLock(
+                lock_name,
+                None,
+                False,
+                f"runtime lock {lock_name!r} is already held",
+                retryable=True,
+            )
 
-        return RuntimeLock(lock_name, session, True, f"runtime lock {lock_name!r} acquired")
+        return RuntimeLock(
+            lock_name,
+            connection,
+            True,
+            f"runtime lock {lock_name!r} acquired",
+        )
 
     @staticmethod
     async def wait_until_acquired(
         session_factory: Callable[[], AsyncSession],
         lock_name: str,
+        *,
+        required: bool = False,
     ) -> RuntimeLock:
         retry_seconds = max(1, int(settings.RUNTIME_LOCK_RETRY_SECONDS or 15))
         while True:
-            lock = await RuntimeLockService.try_acquire(session_factory, lock_name)
-            if lock.acquired:
+            lock = await RuntimeLockService.try_acquire(
+                session_factory,
+                lock_name,
+                required=required,
+            )
+            if lock.acquired or not lock.retryable:
                 return lock
             logger.warning("%s; retrying in %ss", lock.reason, retry_seconds)
             await asyncio.sleep(retry_seconds)

--- a/tests/integration/test_api_readiness.py
+++ b/tests/integration/test_api_readiness.py
@@ -15,12 +15,29 @@ async def test_api_ready_returns_503_when_public_traffic_disabled(async_client, 
     assert payload["status"] == "error"
     assert payload["api"] == "not_ready"
     assert payload["traffic"] == "disabled"
+    assert payload["scheduler_runtime"]["expected"] is False
+    assert payload["scheduler_runtime"]["status"] == "disabled"
 
 
 @pytest.mark.asyncio
 async def test_api_ready_returns_200_when_public_traffic_enabled(async_client, monkeypatch):
+    from main import app
+
     monkeypatch.setattr(settings, "APP_ROLE", "standby", raising=False)
     monkeypatch.setattr(settings, "API_READY_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings, "SCHEDULER_ENABLED", True, raising=False)
+    scheduler_runtime = {
+        "expected": True,
+        "status": "retrying",
+        "reason": "attempt_failed_retry_scheduled",
+        "changed_at": "2026-07-13T08:00:00+00:00",
+    }
+    monkeypatch.setattr(
+        app.state,
+        "scheduler_runtime",
+        scheduler_runtime,
+        raising=False,
+    )
 
     response = await async_client.get("/api/ready")
 
@@ -30,3 +47,4 @@ async def test_api_ready_returns_200_when_public_traffic_enabled(async_client, m
     assert payload["api"] == "ready"
     assert payload["traffic"] == "enabled"
     assert payload["database"] == "online"
+    assert payload["scheduler_runtime"] == scheduler_runtime

--- a/tests/integration/test_runtime_lock_postgres.py
+++ b/tests/integration/test_runtime_lock_postgres.py
@@ -1,0 +1,262 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+import core.app_lifespan as scheduler_runtime
+from services.runtime_lock_service import RuntimeLockService
+
+
+@pytest.mark.asyncio
+async def test_postgres_runtime_lock_survives_without_transaction_and_recovers_backend_loss(
+    db_engine,
+):
+    assert db_engine.dialect.name == "postgresql"
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    lock_name = f"mvn:test:runtime-lock:{uuid4()}"
+    owner_lock = contender_lock = replacement_lock = None
+    checkout_count = 0
+
+    def count_checkout(_dbapi_connection, _connection_record, _connection_proxy):
+        nonlocal checkout_count
+        checkout_count += 1
+
+    event.listen(db_engine.sync_engine, "checkout", count_checkout)
+    try:
+        owner_lock = await RuntimeLockService.try_acquire(
+            session_factory,
+            lock_name,
+            required=True,
+        )
+        assert owner_lock.acquired is True
+        assert owner_lock.connection is not None
+        assert await owner_lock.is_held() is True
+
+        owner_pid = int(
+            (
+                await owner_lock.connection.execute(text("SELECT pg_backend_pid()"))
+            ).scalar_one()
+        )
+        async with db_engine.connect() as observer:
+            observer = await observer.execution_options(isolation_level="AUTOCOMMIT")
+            activity = (
+                await observer.execute(
+                    text(
+                        """
+                        SELECT state, xact_start
+                        FROM pg_stat_activity
+                        WHERE pid = :pid
+                        """
+                    ),
+                    {"pid": owner_pid},
+                )
+            ).mappings().one()
+            assert activity["state"] != "idle in transaction"
+            assert activity["xact_start"] is None
+
+            contender_lock = await RuntimeLockService.try_acquire(
+                session_factory,
+                lock_name,
+                required=True,
+            )
+            assert contender_lock.acquired is False
+            assert contender_lock.retryable is True
+
+            terminated = (
+                await observer.execute(
+                    text("SELECT pg_terminate_backend(:pid)"),
+                    {"pid": owner_pid},
+                )
+            ).scalar_one()
+            assert terminated is True
+
+            checkouts_before_liveness = checkout_count
+            for _ in range(20):
+                if not await owner_lock.is_held():
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                pytest.fail("terminated runtime-lock backend still reports the lock as held")
+
+            # A failed liveness probe must invalidate the original connection,
+            # not reconnect it under the same RuntimeLock instance.
+            assert checkout_count == checkouts_before_liveness
+            assert owner_lock.acquired is False
+            assert owner_lock.connection is None
+
+            for _ in range(20):
+                candidate = await RuntimeLockService.try_acquire(
+                    session_factory,
+                    lock_name,
+                    required=True,
+                )
+                if candidate.acquired:
+                    replacement_lock = candidate
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                pytest.fail("runtime lock was not reacquired after backend termination")
+
+            assert replacement_lock is not None
+            assert await replacement_lock.is_held() is True
+    finally:
+        try:
+            for runtime_lock in (replacement_lock, contender_lock, owner_lock):
+                if runtime_lock is not None:
+                    await runtime_lock.release()
+        finally:
+            event.remove(db_engine.sync_engine, "checkout", count_checkout)
+
+
+@pytest.mark.asyncio
+async def test_real_postgres_fencing_prevents_two_supervisor_loops_from_overlapping(
+    db_engine,
+    monkeypatch,
+):
+    assert db_engine.dialect.name == "postgresql"
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(scheduler_runtime, "async_session_maker", session_factory)
+    monkeypatch.setattr(
+        scheduler_runtime.settings,
+        "RUNTIME_DB_LOCKS_ENABLED",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler_runtime.settings,
+        "RUNTIME_LOCK_RETRY_SECONDS",
+        1,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler_runtime,
+        "_scheduler_lock_check_seconds",
+        lambda: 0.05,
+    )
+    monkeypatch.setattr(
+        scheduler_runtime,
+        "_scheduler_lock_probe_timeout_seconds",
+        lambda: 0.5,
+    )
+    monkeypatch.setattr(
+        scheduler_runtime,
+        "_scheduler_lock_fencing_grace_seconds",
+        lambda: 0.6,
+    )
+
+    async def hold_failed_owner_before_retry():
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(
+        scheduler_runtime,
+        "_wait_before_scheduler_retry",
+        hold_failed_owner_before_retry,
+    )
+    fail_stop_called = asyncio.Event()
+    fail_stop_calls = 0
+
+    def fail_stop():
+        nonlocal fail_stop_calls
+        fail_stop_calls += 1
+        fail_stop_called.set()
+
+    monkeypatch.setattr(
+        scheduler_runtime,
+        "_scheduler_runtime_fail_stop",
+        fail_stop,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(scheduler_runtime, "_resume_catalog_import_jobs", resume_jobs)
+    started = []
+    cancelled = []
+    active_loops = 0
+    maximum_active_loops = 0
+
+    def start(app):
+        started_event = asyncio.Event()
+        cancelled_event = asyncio.Event()
+        started.append(started_event)
+        cancelled.append(cancelled_event)
+
+        async def loop():
+            nonlocal active_loops, maximum_active_loops
+            active_loops += 1
+            maximum_active_loops = max(maximum_active_loops, active_loops)
+            started_event.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                active_loops -= 1
+                cancelled_event.set()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(scheduler_runtime, "_start_scheduler_loop", start)
+    first_app = SimpleNamespace(state=SimpleNamespace())
+    second_app = SimpleNamespace(state=SimpleNamespace())
+    first_supervisor = asyncio.create_task(
+        scheduler_runtime._run_scheduler_supervisor(first_app)
+    )
+    second_supervisor = None
+
+    try:
+        await asyncio.wait_for(_wait_for_count(started, 1), timeout=2)
+        await asyncio.wait_for(started[0].wait(), timeout=2)
+        first_lock = first_app.state.scheduler_runtime_lock
+        first_pid = int(
+            (
+                await first_lock.connection.execute(text("SELECT pg_backend_pid()"))
+            ).scalar_one()
+        )
+        async with db_engine.connect() as observer:
+            observer = await observer.execution_options(isolation_level="AUTOCOMMIT")
+            assert (
+                await observer.execute(
+                    text("SELECT pg_terminate_backend(:pid)"),
+                    {"pid": first_pid},
+                )
+            ).scalar_one() is True
+
+        second_supervisor = asyncio.create_task(
+            scheduler_runtime._run_scheduler_supervisor(second_app)
+        )
+        await asyncio.wait_for(_wait_for_count(started, 2), timeout=5)
+        await asyncio.wait_for(started[1].wait(), timeout=2)
+        await asyncio.wait_for(fail_stop_called.wait(), timeout=1)
+
+        assert cancelled[0].is_set()
+        assert maximum_active_loops == 1
+        assert fail_stop_calls == 1
+        assert first_app.state.scheduler_runtime["status"] == "faulted"
+        assert first_app.state.scheduler_runtime["reason"] == "ownership_lost"
+        assert second_app.state.scheduler_runtime["status"] == "running"
+        assert resume_jobs.await_count == 2
+    finally:
+        tasks = [first_supervisor]
+        if second_supervisor is not None:
+            tasks.append(second_supervisor)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert cancelled[1].is_set()
+    assert maximum_active_loops == 1
+
+
+async def _wait_for_count(items, expected):
+    while len(items) < expected:
+        await asyncio.sleep(0)

--- a/tests/unit/blue_green_deploy_harness.py
+++ b/tests/unit/blue_green_deploy_harness.py
@@ -1,0 +1,282 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/deploy_backend_blue_green.sh"
+SAFETY_SCRIPT = REPO_ROOT / "scripts/deploy_backend_blue_green_safety.sh"
+OLD_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "1" * 64
+NEW_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "2" * 64
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "docker-compose.prod.yml").write_text(
+        "services: {}\n", encoding="utf-8"
+    )
+    (project / ".env").write_text(
+        f"POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=test\nPOSTGRES_DB=test\nBACKEND_IMAGE={OLD_IMAGE}\n",
+        encoding="utf-8",
+    )
+
+    nginx_dir = tmp_path / "nginx"
+    site = nginx_dir / "sites-available/air-api"
+    site.parent.mkdir(parents=True)
+    site.write_text(
+        "server {\n    location / {\n        proxy_pass http://127.0.0.1:8000;\n    }\n}\n",
+        encoding="utf-8",
+    )
+    upstream = nginx_dir / "snippets/mvn-api-upstream.conf"
+
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(
+        fake_bin / "mv",
+        """#!/usr/bin/env bash
+source_path=""
+destination_path=""
+for argument in "$@"; do
+  source_path="$destination_path"
+  destination_path="$argument"
+done
+if [[ "$destination_path" == "$API_PROJECT_DIR/.env" ]]; then
+  if [[ "${FAIL_PREVIOUS_ENV_WRITE:-false}" == "true" ]] \
+    && grep -Fq "BACKEND_IMAGE=$TEST_OLD_IMAGE" "$source_path"; then
+    exit 1
+  fi
+  if [[ "${FAIL_REQUESTED_ENV_WRITE_AFTER_OLD_STOP:-false}" == "true" ]] \
+    && grep -Fq "BACKEND_IMAGE=$TEST_NEW_IMAGE" "$source_path"; then
+    old_stops="$(grep -Ec ' stop -t [0-9]+ app$' "$COMMAND_LOG" || true)"
+    if (( old_stops >= 2 )); then
+      exit 1
+    fi
+  fi
+fi
+exec /bin/mv "$@"
+""",
+    )
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -u
+printf 'docker %s\n' "$*" >> "$COMMAND_LOG"
+if [[ "${1:-}" == "inspect" ]]; then
+  case "${*: -1}" in
+    cid-app) runtime_image="${FAKE_RUNTIME_APP_IMAGE:-}" ;;
+    cid-app-blue) runtime_image="${FAKE_RUNTIME_APP_BLUE_IMAGE:-}" ;;
+    cid-app-green) runtime_image="${FAKE_RUNTIME_APP_GREEN_IMAGE:-}" ;;
+    cid-bot) runtime_image="${FAKE_RUNTIME_BOT_IMAGE:-}" ;;
+    *) exit 1 ;;
+  esac
+  [[ -n "$runtime_image" ]] || exit 1
+  printf '%s\n' "$runtime_image"
+  exit 0
+fi
+if [[ "$*" == *" ps -q "* ]]; then
+  case "${*: -1}" in
+    app) runtime_image="${FAKE_RUNTIME_APP_IMAGE:-}" ;;
+    app-blue) runtime_image="${FAKE_RUNTIME_APP_BLUE_IMAGE:-}" ;;
+    app-green) runtime_image="${FAKE_RUNTIME_APP_GREEN_IMAGE:-}" ;;
+    bot) runtime_image="${FAKE_RUNTIME_BOT_IMAGE:-}" ;;
+    *) runtime_image="" ;;
+  esac
+  [[ -n "$runtime_image" ]] && printf 'cid-%s\n' "${*: -1}"
+  exit 0
+fi
+if [[ "$*" == *" up -d --no-deps --force-recreate bot" ]]; then
+  printf 'bot_image %s\n' "${BACKEND_IMAGE:-}" >> "$COMMAND_LOG"
+fi
+previous=""
+for argument in "$@"; do
+  if [[ "$previous" == "-f" && "$argument" == *"rollback-api-buffer.compose.yml" && -f "$argument" ]]; then
+    sed 's/^/override /' "$argument" >> "$COMMAND_LOG"
+  fi
+  previous="$argument"
+done
+if [[ "$*" == *"nginx -s reload"* && -f "${UPSTREAM_FILE:-}" ]]; then
+  sed 's/^/upstream /' "$UPSTREAM_FILE" >> "$COMMAND_LOG"
+fi
+if [[ "${FAIL_CANDIDATE_STOP:-false}" == "true" && "$*" == *" stop -t 5 app-blue" ]]; then
+  exit 1
+fi
+if [[ "${FAIL_INITIAL_ACTIVE_STOP:-false}" == "true" && "$*" == *" stop -t 5 app" ]]; then
+  exit 1
+fi
+if [[ "${FAIL_BUFFER_REMOVE:-false}" == "true" && "$*" == *" rm -s -f app-green" ]]; then
+  exit 1
+fi
+if [[ "${FAIL_BUFFER_START:-false}" == "true" && "$*" == *"rollback-api-buffer.compose.yml"* && "$*" == *" up -d --no-deps --force-recreate app-green" ]]; then
+  exit 1
+fi
+if [[ "${FAIL_OLD_STOP:-false}" == "true" && "$*" == *" stop -t 5 app" ]]; then
+  old_stops="$(grep -Ec ' stop -t [0-9]+ app$' "$COMMAND_LOG" || true)"
+  if (( old_stops >= 2 )); then
+    exit 1
+  fi
+fi
+if [[ "$*" == *"ps --status running --services"* ]]; then
+  printf 'app\napp-blue\napp-green\nbot\napi-proxy\n'
+fi
+exit 0
+""",
+    )
+    _executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+set -u
+url="${*: -1}"
+printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+if [[ "${FAIL_CANDIDATE_READY:-false}" == "true" && "$url" == *":18001/api/ready"* ]]; then
+  exit 22
+fi
+if [[ "${FAIL_ROLLBACK_OLD_READY:-false}" == "true" && "$url" == *":8000/api/ready"* ]]; then
+  exit 22
+fi
+if [[ "${FAIL_PUBLIC_READY:-false}" == "true" && "$url" == "https://public.test/api/ready" ]]; then
+  exit 22
+fi
+case "$url" in
+  */api/ready)
+    scheduler_status="running"
+    if [[ "${FAIL_SCHEDULER_RUNNING:-false}" == "true" ]]; then
+      scheduler_status="retrying"
+    elif [[ "${FAIL_SCHEDULER_AFTER_ROUTE_FAILURE:-false}" == "true" ]] \
+      && [[ "$url" == *":18001/api/ready"* ]] \
+      && grep -Fq 'rollback_old_route_failed' "$COMMAND_LOG"; then
+      scheduler_status="retrying"
+    elif [[ "${FAIL_SCHEDULER_BEFORE_FALLBACK:-false}" == "true" ]]; then
+      candidate_recreates="$(grep -c 'up -d --no-deps --force-recreate app-blue' "$COMMAND_LOG" || true)"
+      if (( candidate_recreates < 2 )); then
+        scheduler_status="retrying"
+      fi
+    fi
+    printf '{"status":"ok","api":"ready","database":"online","database_writable":true,"scheduler_runtime":{"expected":true,"status":"%s","reason":"scheduler_loop_running","changed_at":"2026-07-13T08:00:00+00:00"}}\n' "$scheduler_status"
+    ;;
+  */api/health)
+    printf '{"status":"ok","database":"online"}\n'
+    ;;
+  *products*)
+    printf '{"items":[]}\n'
+    ;;
+  *filters/config*)
+    printf '{"price":{},"area":{},"brands":[],"expert_tags":[]}\n'
+    ;;
+  *)
+    exit 22
+    ;;
+esac
+""",
+    )
+    _executable(
+        fake_bin / "nginx",
+        "#!/usr/bin/env bash\nprintf 'nginx %s\n' \"$*\" >> \"$COMMAND_LOG\"\nexit 0\n",
+    )
+    _executable(
+        fake_bin / "systemctl",
+        """#!/usr/bin/env bash
+printf 'systemctl %s\n' "$*" >> "$COMMAND_LOG"
+if [[ "$*" == *"reload nginx"* && -f "${UPSTREAM_FILE:-}" ]]; then
+  sed 's/^/upstream /' "$UPSTREAM_FILE" >> "$COMMAND_LOG"
+  if [[ "${FAIL_ROLLBACK_OLD_ROUTE:-false}" == "true" ]] \
+    && grep -Fq 'proxy_pass http://127.0.0.1:8000;' "$UPSTREAM_FILE" \
+    && grep -Fq 'upstream proxy_pass http://127.0.0.1:18001;' "$COMMAND_LOG"; then
+    printf 'rollback_old_route_failed\n' >> "$COMMAND_LOG"
+    exit 1
+  fi
+fi
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "UPSTREAM_FILE": str(upstream),
+            "TEST_OLD_IMAGE": OLD_IMAGE,
+            "TEST_NEW_IMAGE": NEW_IMAGE,
+            "FAKE_RUNTIME_APP_IMAGE": OLD_IMAGE,
+            "FAKE_RUNTIME_BOT_IMAGE": OLD_IMAGE,
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "docker-compose.prod.yml",
+            "API_NGINX_SITE_FILE": str(site),
+            "API_NGINX_UPSTREAM_FILE": str(upstream),
+            "API_NGINX_INTERNAL_FILE": str(nginx_dir / "conf.d/mvn-api-internal.conf"),
+            "API_BLUE_GREEN_SUMMARY_FILE": str(tmp_path / "summary.txt"),
+            "API_HEALTH_ATTEMPTS": "2",
+            "API_SCHEDULER_READY_ATTEMPTS": "6",
+            "API_SCHEDULER_STABILITY_SECONDS": "0",
+            "API_SERVICE_STOP_TIMEOUT_SECONDS": "5",
+            "API_HEALTH_DELAY_SECONDS": "0",
+            "API_DRAIN_SECONDS": "0",
+            "BACKEND_IMAGE": NEW_IMAGE,
+            "GHCR_PAT": "test-token",
+            "GITHUB_ACTOR": "test-user",
+        }
+    )
+    return env, project, site, command_log
+
+
+def run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def configure_active_slot(
+    env: dict[str, str],
+    project: Path,
+    site: Path,
+    active_slot: str,
+    proxy_mode: str,
+) -> Path:
+    service = {"legacy": "app", "blue": "app-blue", "green": "app-green"}[
+        active_slot
+    ]
+    port = {"legacy": 8000, "blue": 18001, "green": 18002}[active_slot]
+
+    if proxy_mode == "container_nginx":
+        proxy_dir = project / "api-proxy"
+        proxy_dir.mkdir(exist_ok=True)
+        (proxy_dir / "nginx.conf").write_text("events {}\nhttp {}\n", encoding="utf-8")
+        upstream = proxy_dir / "upstream.conf"
+        upstream.write_text(f"proxy_pass http://{service}:8000;\n", encoding="utf-8")
+        env.update(
+            {
+                "API_PROXY_MODE": "container_nginx",
+                "API_PROXY_CONFIG_FILE": str(proxy_dir / "nginx.conf"),
+                "API_NGINX_UPSTREAM_FILE": str(upstream),
+                "UPSTREAM_FILE": str(upstream),
+            }
+        )
+    else:
+        upstream = Path(env["API_NGINX_UPSTREAM_FILE"])
+        upstream.parent.mkdir(parents=True, exist_ok=True)
+        upstream.write_text(f"proxy_pass http://127.0.0.1:{port};\n", encoding="utf-8")
+        site.write_text(
+            f"server {{\n    location / {{\n        include {upstream};\n    }}\n}}\n",
+            encoding="utf-8",
+        )
+
+    active_file = project / ".active-api-slot"
+    env[f"FAKE_RUNTIME_{service.upper().replace('-', '_')}_IMAGE"] = OLD_IMAGE
+    if active_slot == "legacy":
+        active_file.unlink(missing_ok=True)
+    else:
+        active_file.write_text(f"{active_slot}\n", encoding="utf-8")
+    return upstream

--- a/tests/unit/test_app_lifespan_scheduler_resilience.py
+++ b/tests/unit/test_app_lifespan_scheduler_resilience.py
@@ -1,0 +1,588 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import core.app_lifespan as app_lifespan
+
+
+class FakeRuntimeLock:
+    def __init__(self, *, held_results=None, release_error=None):
+        self.acquired = True
+        self.reason = "test lock acquired"
+        self.release_calls = 0
+        self.released = asyncio.Event()
+        self._held_results = list(held_results or [True])
+        self._release_error = release_error
+
+    async def is_held(self):
+        if len(self._held_results) > 1:
+            return self._held_results.pop(0)
+        return self._held_results[0]
+
+    async def release(self):
+        self.release_calls += 1
+        self.acquired = False
+        self.released.set()
+        if self._release_error is not None:
+            raise self._release_error
+
+
+class HangingRuntimeLock(FakeRuntimeLock):
+    def __init__(self):
+        super().__init__()
+        self.probe_started = asyncio.Event()
+        self.probe_cancelled = asyncio.Event()
+
+    async def is_held(self):
+        self.probe_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            self.probe_cancelled.set()
+
+
+class UncooperativeProbeRuntimeLock(FakeRuntimeLock):
+    def __init__(self):
+        super().__init__()
+        self.probe_started = asyncio.Event()
+        self.cleanup_started = asyncio.Event()
+        self.allow_cleanup = asyncio.Event()
+
+    async def is_held(self):
+        self.probe_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cleanup_started.set()
+            await self.allow_cleanup.wait()
+            return False
+
+
+async def _wait_until(predicate, *, timeout=1.0):
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def _enable_scheduler(monkeypatch):
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "primary", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", True, raising=False)
+    monkeypatch.setattr(app_lifespan, "_bootstrap_database", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_for_scheduler_lock_fencing",
+        AsyncMock(return_value=None),
+    )
+    fail_stop = Mock()
+    monkeypatch.setattr(app_lifespan, "_scheduler_runtime_fail_stop", fail_stop)
+    return fail_stop
+
+
+def _install_controllable_scheduler(monkeypatch):
+    started = []
+    cancelled = []
+
+    def start(app):
+        started_event = asyncio.Event()
+        cancelled_event = asyncio.Event()
+        started.append(started_event)
+        cancelled.append(cancelled_event)
+
+        async def loop():
+            started_event.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled_event.set()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    return started, cancelled
+
+
+@pytest.mark.asyncio
+async def test_lock_loss_fail_stops_without_reacquiring(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(app_lifespan, "_scheduler_lock_check_seconds", lambda: 0.001)
+    retry = AsyncMock(return_value=None)
+    monkeypatch.setattr(app_lifespan, "_wait_before_scheduler_retry", retry)
+    runtime_lock = FakeRuntimeLock(held_results=[False])
+    wait_for_lock = AsyncMock(return_value=runtime_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    started, cancelled = _install_controllable_scheduler(monkeypatch)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: fail_stop.call_count == 1)
+        await asyncio.wait_for(cancelled[0].wait(), timeout=0.2)
+        assert len(started) == 1
+        assert cancelled[0].is_set()
+        assert runtime_lock.release_calls == 0
+        assert wait_for_lock.await_count == 1
+        assert resume_jobs.await_count == 1
+        assert retry.await_count == 0
+        assert app.state.scheduler_runtime["status"] == "faulted"
+        assert app.state.scheduler_runtime["reason"] == "ownership_lost"
+
+    assert runtime_lock.release_calls == 1
+    fail_stop.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_hanging_liveness_probe_fail_stops_without_reacquiring(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(app_lifespan, "_scheduler_lock_check_seconds", lambda: 0.001)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_scheduler_lock_probe_timeout_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_before_scheduler_retry",
+        AsyncMock(return_value=None),
+    )
+    hanging_lock = HangingRuntimeLock()
+    wait_for_lock = AsyncMock(return_value=hanging_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    started, cancelled = _install_controllable_scheduler(monkeypatch)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: fail_stop.call_count == 1)
+        await asyncio.wait_for(cancelled[0].wait(), timeout=0.2)
+        assert hanging_lock.probe_started.is_set()
+        assert hanging_lock.probe_cancelled.is_set()
+        assert cancelled[0].is_set()
+        assert hanging_lock.release_calls == 0
+        assert wait_for_lock.await_count == 1
+        assert resume_jobs.await_count == 1
+        assert app.state.scheduler_runtime["status"] == "faulted"
+        assert app.state.scheduler_runtime["reason"] == "ownership_lost"
+
+    assert hanging_lock.release_calls == 1
+    fail_stop.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_probe_timeout_does_not_wait_for_stuck_cancellation_cleanup(monkeypatch):
+    monkeypatch.setattr(app_lifespan, "_scheduler_lock_check_seconds", lambda: 0.001)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_scheduler_lock_probe_timeout_seconds",
+        lambda: 0.001,
+    )
+    runtime_lock = UncooperativeProbeRuntimeLock()
+
+    async def loop():
+        await asyncio.Event().wait()
+
+    scheduler_task = asyncio.create_task(loop())
+    try:
+        with pytest.raises(app_lifespan.SchedulerOwnershipLost):
+            await asyncio.wait_for(
+                app_lifespan._monitor_scheduler_runtime_lock(
+                    scheduler_task,
+                    runtime_lock,
+                ),
+                timeout=0.05,
+        )
+        assert runtime_lock.probe_started.is_set()
+        await asyncio.wait_for(runtime_lock.cleanup_started.wait(), timeout=0.05)
+    finally:
+        runtime_lock.allow_cleanup.set()
+        scheduler_task.cancel()
+        await asyncio.gather(scheduler_task, return_exceptions=True)
+        await _wait_until(
+            lambda: not app_lifespan._detached_scheduler_probe_tasks
+        )
+
+
+@pytest.mark.asyncio
+async def test_acquire_exception_retries_then_starts_scheduler(monkeypatch):
+    _enable_scheduler(monkeypatch)
+    retry = AsyncMock(return_value=None)
+    monkeypatch.setattr(app_lifespan, "_wait_before_scheduler_retry", retry)
+    runtime_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(
+        side_effect=[ConnectionError("database unavailable"), runtime_lock]
+    )
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    started, _cancelled = _install_controllable_scheduler(monkeypatch)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: len(started) == 1)
+        await asyncio.wait_for(started[0].wait(), timeout=0.2)
+        assert wait_for_lock.await_count == 2
+        retry.assert_awaited_once_with()
+
+    assert runtime_lock.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_release_failure_does_not_stop_reacquisition(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_before_scheduler_retry",
+        AsyncMock(return_value=None),
+    )
+    first_lock = FakeRuntimeLock(
+        release_error=ConnectionError("unlock failed"),
+    )
+    second_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(side_effect=[first_lock, second_lock])
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    start_calls = 0
+    started = asyncio.Event()
+
+    def start(app):
+        nonlocal start_calls
+        start_calls += 1
+        if start_calls == 1:
+            return False
+
+        async def loop():
+            started.set()
+            await asyncio.Event().wait()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(started.wait(), timeout=0.2)
+        assert first_lock.release_calls == 1
+        assert wait_for_lock.await_count == 2
+        assert start_calls == 2
+        fail_stop.assert_not_called()
+
+    assert second_lock.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_supervisor_during_retry_backoff(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    retry_started = asyncio.Event()
+    retry_cancelled = asyncio.Event()
+
+    async def wait_for_retry():
+        retry_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            retry_cancelled.set()
+
+    monkeypatch.setattr(app_lifespan, "_wait_before_scheduler_retry", wait_for_retry)
+    acquire = AsyncMock(side_effect=ConnectionError("database unavailable"))
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        acquire,
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(retry_started.wait(), timeout=0.2)
+        assert acquire.await_count == 1
+
+    assert retry_cancelled.is_set()
+    assert acquire.await_count == 1
+    assert app.state.scheduler_supervisor_task is None
+    fail_stop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_scheduler_shutdown_fail_stops_before_cancel_and_unlock(
+    monkeypatch,
+):
+    fail_stop = _enable_scheduler(monkeypatch)
+    events = []
+    fail_stop.side_effect = lambda: events.append("fail_stop")
+    runtime_lock = FakeRuntimeLock()
+    original_release = runtime_lock.release
+
+    async def release_in_order():
+        events.append("lock_release")
+        await original_release()
+
+    runtime_lock.release = release_in_order
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        AsyncMock(return_value=runtime_lock),
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    scheduler_started = asyncio.Event()
+
+    def start(app):
+        async def loop():
+            scheduler_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                events.append("scheduler_cancel")
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(scheduler_started.wait(), timeout=0.2)
+        await _wait_until(
+            lambda: app.state.scheduler_runtime["status"] == "running"
+        )
+
+    fail_stop.assert_called_once_with()
+    assert events == ["fail_stop", "scheduler_cancel", "lock_release"]
+    assert runtime_lock.release_calls == 1
+    assert app.state.scheduler_work_started is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_fail_stops_cancelled_scheduler_before_unlock(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    events = []
+    fail_stop.side_effect = lambda: events.append("fail_stop")
+    runtime_lock = FakeRuntimeLock()
+    original_release = runtime_lock.release
+
+    async def release_in_order():
+        events.append("lock_release")
+        await original_release()
+
+    runtime_lock.release = release_in_order
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        AsyncMock(return_value=runtime_lock),
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    monitor_started = asyncio.Event()
+
+    def start(app):
+        async def loop():
+            try:
+                await asyncio.Event().wait()
+            finally:
+                events.append("scheduler_cancel")
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    async def hold_monitor(_scheduler_task, _runtime_lock):
+        monitor_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_monitor_scheduler_runtime_lock",
+        hold_monitor,
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+    lifespan = app_lifespan.app_lifespan(app)
+    await lifespan.__aenter__()
+
+    await asyncio.wait_for(monitor_started.wait(), timeout=0.2)
+    scheduler_task = app.state.scheduler_task
+    scheduler_task.cancel()
+    await asyncio.gather(scheduler_task, return_exceptions=True)
+    assert scheduler_task.done()
+    assert scheduler_task.cancelled()
+    assert app.state.scheduler_work_started is True
+    assert runtime_lock.acquired is True
+
+    await lifespan.__aexit__(None, None, None)
+
+    fail_stop.assert_called_once_with()
+    assert events == ["scheduler_cancel", "fail_stop", "lock_release"]
+    assert runtime_lock.release_calls == 1
+    assert app.state.scheduler_work_started is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_fencing_releases_lock_without_fail_stop(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    fencing_started = asyncio.Event()
+    fencing_cancelled = asyncio.Event()
+
+    async def wait_during_fencing(_runtime_lock):
+        fencing_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            fencing_cancelled.set()
+
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_for_scheduler_lock_fencing",
+        wait_during_fencing,
+    )
+    runtime_lock = FakeRuntimeLock()
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        AsyncMock(return_value=runtime_lock),
+    )
+    resume_jobs = AsyncMock()
+    start_loop = Mock()
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start_loop)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(fencing_started.wait(), timeout=0.2)
+        assert app.state.scheduler_runtime["status"] == "fencing"
+        assert getattr(app.state, "scheduler_task", None) is None
+
+    fail_stop.assert_not_called()
+    assert fencing_cancelled.is_set()
+    assert runtime_lock.release_calls == 1
+    resume_jobs.assert_not_awaited()
+    start_loop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_cancel_during_child_cleanup_releases_lock_without_retry(
+    monkeypatch,
+):
+    _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(app_lifespan, "_scheduler_lock_check_seconds", lambda: 0.001)
+    runtime_lock = FakeRuntimeLock(held_results=[False])
+    acquire = AsyncMock(return_value=runtime_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        acquire,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    child_started = asyncio.Event()
+    child_cleanup_started = asyncio.Event()
+    child_cleanup_finished = asyncio.Event()
+    retry_called = asyncio.Event()
+
+    def start(app):
+        async def loop():
+            child_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                child_cleanup_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    child_cleanup_finished.set()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    async def unexpected_retry():
+        retry_called.set()
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    monkeypatch.setattr(app_lifespan, "_wait_before_scheduler_retry", unexpected_retry)
+    app = SimpleNamespace(state=SimpleNamespace())
+    lifespan = app_lifespan.app_lifespan(app)
+    await lifespan.__aenter__()
+
+    try:
+        await asyncio.wait_for(child_started.wait(), timeout=0.2)
+        await asyncio.wait_for(child_cleanup_started.wait(), timeout=0.2)
+        supervisor_task = app.state.scheduler_supervisor_task
+        supervisor_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(supervisor_task, timeout=0.2)
+
+        assert supervisor_task.done()
+        assert child_cleanup_finished.is_set()
+        assert runtime_lock.release_calls == 1
+        assert acquire.await_count == 1
+        assert retry_called.is_set() is False
+    finally:
+        await lifespan.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_during_supervisor_shutdown_is_not_swallowed():
+    cleanup_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def supervisor():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleanup_finished.set()
+
+    supervisor_task = asyncio.create_task(supervisor())
+    app = SimpleNamespace(
+        state=SimpleNamespace(scheduler_supervisor_task=supervisor_task)
+    )
+    stop_task = asyncio.create_task(app_lifespan._stop_scheduler_supervisor(app))
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.2)
+
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(stop_task, timeout=0.2)
+
+    assert cleanup_finished.is_set()
+    assert supervisor_task.done()
+    assert app.state.scheduler_supervisor_task is None
+    assert app.state.scheduler_runtime["status"] == "stopped"

--- a/tests/unit/test_app_lifespan_scheduler_supervisor.py
+++ b/tests/unit/test_app_lifespan_scheduler_supervisor.py
@@ -1,0 +1,544 @@
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import core.app_lifespan as app_lifespan
+
+
+REAL_WAIT_FOR_SCHEDULER_LOCK_FENCING = (
+    app_lifespan._wait_for_scheduler_lock_fencing
+)
+
+
+class FakeRuntimeLock:
+    def __init__(self, *, on_release=None, held_results=None, release_error=None):
+        self.acquired = True
+        self.reason = "test lock acquired"
+        self.release_calls = 0
+        self.is_held_calls = 0
+        self.released = asyncio.Event()
+        self._on_release = on_release
+        self._held_results = list(held_results or [True])
+        self._release_error = release_error
+
+    async def is_held(self):
+        self.is_held_calls += 1
+        if len(self._held_results) > 1:
+            return self._held_results.pop(0)
+        return self._held_results[0]
+
+    async def release(self):
+        self.release_calls += 1
+        self.acquired = False
+        if self._on_release is not None:
+            await self._on_release(self)
+        self.released.set()
+        if self._release_error is not None:
+            raise self._release_error
+
+
+class HangingRuntimeLock(FakeRuntimeLock):
+    def __init__(self):
+        super().__init__()
+        self.probe_started = asyncio.Event()
+        self.probe_cancelled = asyncio.Event()
+
+    async def is_held(self):
+        self.is_held_calls += 1
+        self.probe_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            self.probe_cancelled.set()
+
+
+class ExclusiveLockPool:
+    def __init__(self):
+        self._condition = asyncio.Condition()
+        self._owner = None
+        self.locks = []
+
+    async def wait_until_acquired(self, _session_factory, _lock_name, **_kwargs):
+        async with self._condition:
+            await self._condition.wait_for(lambda: self._owner is None)
+            lock = FakeRuntimeLock(on_release=self._release)
+            self._owner = lock
+            self.locks.append(lock)
+            return lock
+
+    async def _release(self, lock):
+        async with self._condition:
+            if self._owner is lock:
+                self._owner = None
+                self._condition.notify_all()
+
+    async def revoke_owner(self):
+        async with self._condition:
+            if self._owner is None:
+                return
+            self._owner._held_results = [False]
+            self._owner = None
+            self._condition.notify_all()
+
+
+async def _wait_until(predicate, *, timeout=1.0):
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def _enable_scheduler(monkeypatch):
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "primary", raising=False)
+    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", True, raising=False)
+    monkeypatch.setattr(app_lifespan, "_bootstrap_database", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_for_scheduler_lock_fencing",
+        AsyncMock(return_value=None),
+    )
+    fail_stop = Mock()
+    monkeypatch.setattr(app_lifespan, "_scheduler_runtime_fail_stop", fail_stop)
+    return fail_stop
+
+
+def _install_controllable_scheduler(monkeypatch):
+    started = []
+    cancelled = []
+
+    def start(app):
+        started_event = asyncio.Event()
+        cancelled_event = asyncio.Event()
+        started.append(started_event)
+        cancelled.append(cancelled_event)
+
+        async def loop():
+            started_event.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled_event.set()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    return started, cancelled
+
+
+def test_scheduler_lock_check_interval_is_bounded_separately_from_retry(monkeypatch):
+    monkeypatch.setattr(
+        app_lifespan.settings,
+        "RUNTIME_LOCK_RETRY_SECONDS",
+        15,
+        raising=False,
+    )
+    assert app_lifespan._scheduler_runtime_retry_seconds() == 15
+    assert app_lifespan._scheduler_lock_check_seconds() == 5
+    assert app_lifespan._scheduler_lock_probe_timeout_seconds() == 3
+    assert app_lifespan._scheduler_lock_fencing_grace_seconds() == 12
+
+    monkeypatch.setattr(
+        app_lifespan.settings,
+        "RUNTIME_LOCK_RETRY_SECONDS",
+        2,
+        raising=False,
+    )
+    assert app_lifespan._scheduler_runtime_retry_seconds() == 2
+    assert app_lifespan._scheduler_lock_check_seconds() == 2
+    assert app_lifespan._scheduler_lock_probe_timeout_seconds() == 2
+    assert app_lifespan._scheduler_lock_fencing_grace_seconds() == 12
+
+    monkeypatch.setattr(
+        app_lifespan.settings,
+        "RUNTIME_LOCK_RETRY_SECONDS",
+        -3,
+        raising=False,
+    )
+    assert app_lifespan._scheduler_runtime_retry_seconds() == 1
+    assert app_lifespan._scheduler_lock_check_seconds() == 1
+    assert app_lifespan._scheduler_lock_probe_timeout_seconds() == 1
+    assert app_lifespan._scheduler_lock_fencing_grace_seconds() == 12
+
+
+@pytest.mark.asyncio
+async def test_overlapping_apps_reacquire_scheduler_after_owner_releases(monkeypatch):
+    _enable_scheduler(monkeypatch)
+    pool = ExclusiveLockPool()
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        pool.wait_until_acquired,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    started, cancelled = _install_controllable_scheduler(monkeypatch)
+
+    first_app = SimpleNamespace(state=SimpleNamespace())
+    second_app = SimpleNamespace(state=SimpleNamespace())
+    first_lifespan = app_lifespan.app_lifespan(first_app)
+    second_lifespan = app_lifespan.app_lifespan(second_app)
+    first_entered = second_entered = False
+
+    try:
+        await asyncio.wait_for(first_lifespan.__aenter__(), timeout=0.2)
+        first_entered = True
+        await _wait_until(lambda: len(started) == 1)
+        await asyncio.wait_for(started[0].wait(), timeout=0.2)
+
+        # The overlapping API becomes ready even while its supervisor waits.
+        await asyncio.wait_for(second_lifespan.__aenter__(), timeout=0.2)
+        second_entered = True
+        await asyncio.sleep(0)
+        assert len(started) == 1
+
+        await first_lifespan.__aexit__(None, None, None)
+        first_entered = False
+        await _wait_until(lambda: len(started) == 2)
+        await asyncio.wait_for(started[1].wait(), timeout=0.2)
+
+        assert resume_jobs.await_count == 2
+        assert len(pool.locks) == 2
+        assert pool.locks[0].release_calls == 1
+        assert cancelled[0].is_set()
+    finally:
+        if first_entered:
+            await first_lifespan.__aexit__(None, None, None)
+        if second_entered:
+            await second_lifespan.__aexit__(None, None, None)
+
+    assert pool.locks[1].release_calls == 1
+    assert cancelled[1].is_set()
+
+
+@pytest.mark.asyncio
+async def test_fencing_prevents_two_apps_from_overlapping_after_server_lock_loss(
+    monkeypatch,
+):
+    _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_for_scheduler_lock_fencing",
+        REAL_WAIT_FOR_SCHEDULER_LOCK_FENCING,
+    )
+    monkeypatch.setattr(app_lifespan, "_scheduler_lock_check_seconds", lambda: 0.001)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_scheduler_lock_probe_timeout_seconds",
+        lambda: 0.001,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_scheduler_lock_fencing_grace_seconds",
+        lambda: 0.01,
+    )
+    pool = ExclusiveLockPool()
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        pool.wait_until_acquired,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    started = []
+    cancelled = []
+    active_loops = 0
+    maximum_active_loops = 0
+
+    def start(app):
+        started_event = asyncio.Event()
+        cancelled_event = asyncio.Event()
+        started.append(started_event)
+        cancelled.append(cancelled_event)
+
+        async def loop():
+            nonlocal active_loops, maximum_active_loops
+            active_loops += 1
+            maximum_active_loops = max(maximum_active_loops, active_loops)
+            started_event.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                active_loops -= 1
+                cancelled_event.set()
+
+        app.state.scheduler_task = asyncio.create_task(loop())
+        return True
+
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start)
+    first_app = SimpleNamespace(state=SimpleNamespace())
+    second_app = SimpleNamespace(state=SimpleNamespace())
+    first_lifespan = app_lifespan.app_lifespan(first_app)
+    second_lifespan = app_lifespan.app_lifespan(second_app)
+    first_entered = second_entered = False
+
+    try:
+        await first_lifespan.__aenter__()
+        first_entered = True
+        await _wait_until(lambda: len(started) == 1)
+        await asyncio.wait_for(started[0].wait(), timeout=0.2)
+
+        await second_lifespan.__aenter__()
+        second_entered = True
+        await pool.revoke_owner()
+        await _wait_until(lambda: len(started) == 2)
+        await asyncio.wait_for(started[1].wait(), timeout=0.2)
+
+        assert cancelled[0].is_set()
+        assert maximum_active_loops == 1
+        assert resume_jobs.await_count == 2
+    finally:
+        if first_entered:
+            await first_lifespan.__aexit__(None, None, None)
+        if second_entered:
+            await second_lifespan.__aexit__(None, None, None)
+
+    assert cancelled[1].is_set()
+    assert maximum_active_loops == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_scheduler_supervisor_before_lock_acquire(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    waiting = asyncio.Event()
+    waiter_cancelled = asyncio.Event()
+
+    async def wait_forever(_session_factory, _lock_name, **_kwargs):
+        waiting.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            waiter_cancelled.set()
+
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_forever,
+    )
+    resume_jobs = AsyncMock()
+    start_loop = Mock()
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    monkeypatch.setattr(app_lifespan, "_start_scheduler_loop", start_loop)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(waiting.wait(), timeout=0.2)
+        assert app.state.scheduler_supervisor_task.done() is False
+        assert app.state.scheduler_runtime["expected"] is True
+        assert app.state.scheduler_runtime["status"] == "waiting_lock"
+
+    assert waiter_cancelled.is_set()
+    resume_jobs.assert_not_awaited()
+    start_loop.assert_not_called()
+    fail_stop.assert_not_called()
+    assert app.state.scheduler_supervisor_task is None
+    assert app.state.scheduler_runtime["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_supervisor_starts_once_and_cleans_up(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    runtime_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(return_value=runtime_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    resume_jobs = AsyncMock(return_value=True)
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    started, cancelled = _install_controllable_scheduler(monkeypatch)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: len(started) == 1)
+        await asyncio.wait_for(started[0].wait(), timeout=0.2)
+        assert app.state.scheduler_runtime_lock is runtime_lock
+        assert app.state.scheduler_runtime["expected"] is True
+        assert app.state.scheduler_runtime["status"] == "running"
+        assert app.state.scheduler_runtime["reason"] == "scheduler_loop_running"
+        assert app.state.scheduler_runtime["changed_at"].endswith("+00:00")
+        resume_jobs.assert_awaited_once_with()
+        wait_for_lock.assert_awaited_once_with(
+            app_lifespan.async_session_maker,
+            "mvn:scheduler",
+            required=True,
+        )
+        supervisor_task = app.state.scheduler_supervisor_task
+        assert app_lifespan._start_scheduler_supervisor(app) is False
+        assert app.state.scheduler_supervisor_task is supervisor_task
+        assert app.state.scheduler_work_started is True
+
+    assert cancelled[0].is_set()
+    fail_stop.assert_called_once_with()
+    assert runtime_lock.release_calls == 1
+    assert app.state.scheduler_task is None
+    assert app.state.scheduler_runtime_lock is None
+    assert app.state.scheduler_supervisor_task is None
+    assert app.state.scheduler_runtime["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_disabled_scheduler_exposes_disabled_runtime_state(monkeypatch):
+    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
+    monkeypatch.setattr(
+        app_lifespan.settings,
+        "SCHEDULER_ENABLED",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(app_lifespan, "_bootstrap_database", AsyncMock(return_value=False))
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        assert app.state.scheduler_runtime["expected"] is False
+        assert app.state.scheduler_runtime["status"] == "disabled"
+        assert app.state.scheduler_runtime["reason"] == "runtime_control_disabled"
+
+    assert app.state.scheduler_runtime["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_supervisor_releases_lock_when_resume_fails(monkeypatch):
+    _enable_scheduler(monkeypatch)
+    monkeypatch.setattr(
+        app_lifespan,
+        "_wait_before_scheduler_retry",
+        AsyncMock(return_value=None),
+    )
+    failed_lock = FakeRuntimeLock()
+    recovered_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(side_effect=[failed_lock, recovered_lock])
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    resume_jobs = AsyncMock(side_effect=[RuntimeError("resume failed"), True])
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        resume_jobs,
+    )
+    started, _cancelled = _install_controllable_scheduler(monkeypatch)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: len(started) == 1)
+        await asyncio.wait_for(started[0].wait(), timeout=0.2)
+        assert app.state.scheduler_supervisor_task.done() is False
+        assert wait_for_lock.await_count == 2
+        assert resume_jobs.await_count == 2
+        assert failed_lock.release_calls == 1
+
+    assert recovered_lock.release_calls == 1
+    assert app.state.scheduler_runtime_lock is None
+
+
+@pytest.mark.asyncio
+async def test_scheduler_loop_failure_after_start_fail_stops_without_retry(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    runtime_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(return_value=runtime_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    loop_calls = 0
+
+    async def start_loop(*, interval_hours):
+        nonlocal loop_calls
+        assert interval_hours == app_lifespan.settings.SCHEDULER_INTERVAL
+        loop_calls += 1
+        raise RuntimeError("scheduler failed")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "services.scheduler_service",
+        SimpleNamespace(scheduler_service=SimpleNamespace(start_loop=start_loop)),
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await _wait_until(lambda: fail_stop.call_count == 1)
+        assert app.state.scheduler_supervisor_task.done() is False
+        assert wait_for_lock.await_count == 1
+        assert runtime_lock.release_calls == 0
+        assert app.state.scheduler_runtime["status"] == "faulted"
+        assert app.state.scheduler_runtime["reason"] == "scheduler_loop_failed"
+
+    assert loop_calls == 1
+    fail_stop.assert_called_once_with()
+    assert runtime_lock.release_calls == 1
+    assert app.state.scheduler_task is None
+    assert app.state.scheduler_runtime_lock is None
+
+
+@pytest.mark.asyncio
+async def test_scheduler_loop_failure_after_running_fail_stops_without_retry(monkeypatch):
+    fail_stop = _enable_scheduler(monkeypatch)
+    runtime_lock = FakeRuntimeLock()
+    wait_for_lock = AsyncMock(return_value=runtime_lock)
+    monkeypatch.setattr(
+        app_lifespan.RuntimeLockService,
+        "wait_until_acquired",
+        wait_for_lock,
+    )
+    monkeypatch.setattr(
+        app_lifespan,
+        "_resume_catalog_import_jobs",
+        AsyncMock(return_value=True),
+    )
+    loop_started = asyncio.Event()
+    fail_loop = asyncio.Event()
+
+    async def start_loop(*, interval_hours):
+        assert interval_hours == app_lifespan.settings.SCHEDULER_INTERVAL
+        loop_started.set()
+        await fail_loop.wait()
+        raise RuntimeError("scheduler failed after startup")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "services.scheduler_service",
+        SimpleNamespace(scheduler_service=SimpleNamespace(start_loop=start_loop)),
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with app_lifespan.app_lifespan(app):
+        await asyncio.wait_for(loop_started.wait(), timeout=0.2)
+        await _wait_until(lambda: app.state.scheduler_runtime["status"] == "running")
+        fail_loop.set()
+        await _wait_until(lambda: fail_stop.call_count == 1)
+        assert wait_for_lock.await_count == 1
+        assert app.state.scheduler_runtime["status"] == "faulted"
+        assert app.state.scheduler_runtime["reason"] == "scheduler_loop_failed"
+
+    fail_stop.assert_called_once_with()
+    assert runtime_lock.release_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_catalog_resume_false_is_rechecked_until_safe(monkeypatch):
+    resume_jobs = AsyncMock(side_effect=[False, True])
+    monkeypatch.setattr(app_lifespan, "_resume_catalog_import_jobs", resume_jobs)
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    assert await app_lifespan._resume_catalog_import_jobs_once(app) is False
+    assert getattr(app.state, "catalog_import_jobs_resumed", False) is False
+
+    assert await app_lifespan._resume_catalog_import_jobs_once(app) is True
+    assert app.state.catalog_import_jobs_resumed is True
+
+    assert await app_lifespan._resume_catalog_import_jobs_once(app) is False
+    assert resume_jobs.await_count == 2

--- a/tests/unit/test_blue_green_deploy_recovery.py
+++ b/tests/unit/test_blue_green_deploy_recovery.py
@@ -1,0 +1,531 @@
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.unit.blue_green_deploy_harness import (
+    NEW_IMAGE,
+    OLD_IMAGE,
+    environment as _environment,
+    run as _run,
+)
+
+
+def test_failed_candidate_keeps_legacy_active(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_CANDIDATE_READY"] = "true"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert not (project / ".active-api-slot").exists()
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(encoding="utf-8")
+    assert "proxy_pass http://127.0.0.1:8000;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    commands = command_log.read_text(encoding="utf-8")
+    assert "stop -t 5 app-blue" in commands
+    assert not any(line.endswith(" stop -t 5 app") for line in commands.splitlines())
+
+
+def test_pre_stop_rollback_keeps_candidate_live_when_old_route_restore_fails(
+    tmp_path,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env.update(
+        {
+            "API_PUBLIC_READY_URL": "https://public.test/api/ready",
+            "FAIL_PUBLIC_READY": "true",
+            "FAIL_ROLLBACK_OLD_ROUTE": "true",
+        }
+    )
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert not any(
+        line.endswith(" stop -t 5 app-blue") for line in commands.splitlines()
+    )
+    assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
+    assert "proxy_pass http://127.0.0.1:18001;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert f"BACKEND_IMAGE={NEW_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_failed" in summary
+    assert "old_route_confirmed=false" in summary
+    assert "candidate_preserved=true" in summary
+
+
+def test_same_image_retry_does_not_accept_candidate_without_scheduler_ownership(
+    tmp_path,
+):
+    env, _, _, command_log = _environment(tmp_path)
+    env.update(
+        {
+            "API_PUBLIC_READY_URL": "https://public.test/api/ready",
+            "FAIL_PUBLIC_READY": "true",
+            "FAIL_ROLLBACK_OLD_ROUTE": "true",
+        }
+    )
+
+    first = _run(env)
+
+    assert first.returncode != 0
+    env.pop("FAIL_PUBLIC_READY")
+    env.pop("FAIL_ROLLBACK_OLD_ROUTE")
+    env["FAKE_RUNTIME_APP_BLUE_IMAGE"] = NEW_IMAGE
+    env["FAKE_RUNTIME_BOT_IMAGE"] = NEW_IMAGE
+    env["FAIL_SCHEDULER_AFTER_ROUTE_FAILURE"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+    second = _run(env)
+
+    assert second.returncode != 0
+    assert "requested image is already active" not in second.stdout
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=already_active" not in summary
+    assert not any(
+        line.endswith(" stop -t 5 app")
+        for line in command_log.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_pre_stop_rollback_requires_confirmed_candidate_stop(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env.update(
+        {
+            "API_PUBLIC_READY_URL": "https://public.test/api/ready",
+            "FAIL_PUBLIC_READY": "true",
+            "FAIL_CANDIDATE_STOP": "true",
+        }
+    )
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert any(
+        line.endswith(" stop -t 5 app-blue") for line in commands.splitlines()
+    )
+    assert "proxy_pass http://127.0.0.1:8000;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert not (project / ".active-api-slot").exists()
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    assert f"bot_image {OLD_IMAGE}" in commands
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_failed" in summary
+    assert "old_route_confirmed=true" in summary
+    assert "candidate_stop_confirmed=false" in summary
+
+
+@pytest.mark.parametrize("health_delay", ["0", "1"])
+def test_scheduler_gate_requires_monotonic_stability_despite_delay_override(
+    tmp_path,
+    health_delay,
+):
+    env, _, _, _ = _environment(tmp_path)
+    env.pop("API_SCHEDULER_STABILITY_SECONDS")
+    env["API_HEALTH_DELAY_SECONDS"] = health_delay
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "6"
+
+    started = time.monotonic()
+    result = _run(env)
+    elapsed = time.monotonic() - started
+
+    assert result.returncode != 0
+    assert elapsed < 2
+    assert "did not remain running for 6 consecutive samples and at least 9s" in (
+        result.stdout
+    )
+
+
+def test_scheduler_activation_timeout_rolls_back_after_old_service_stop(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    lines = commands.splitlines()
+    assert any(line.endswith(" stop -t 5 app") for line in lines)
+    assert "up -d --no-deps app" in commands
+    assert "stop -t 5 app-blue" in commands
+    assert "rm -f app-blue" in commands
+    candidate_stop = next(
+        index
+        for index, line in enumerate(lines)
+        if line.endswith(" stop -t 5 app-blue")
+    )
+    buffer_ready = next(
+        index for index, line in enumerate(lines) if ":18002/api/ready" in line
+    )
+    buffer_route = next(
+        index
+        for index, line in enumerate(lines)
+        if line == "upstream proxy_pass http://127.0.0.1:18002;"
+    )
+    old_start = next(
+        index for index, line in enumerate(lines) if line.endswith(" up -d --no-deps app")
+    )
+    rollback_ready = next(
+        index for index, line in enumerate(lines) if ":8000/api/ready" in line
+    )
+    assert buffer_ready < buffer_route < candidate_stop < old_start < rollback_ready
+    assert "rm -s -f app-green" in commands
+    assert f'override     image: "{OLD_IMAGE}"' in commands
+    assert "override     restart: unless-stopped" in commands
+    assert 'override       DB_BOOTSTRAP_ENABLED: "false"' in commands
+    assert 'override       SCHEDULER_ENABLED: "false"' in commands
+    assert 'override       BOT_ENABLED: "false"' in commands
+    assert 'override       API_READY_ENABLED: "true"' in commands
+    assert not (project / ".active-api-slot").exists()
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_uncertain_initial_active_stop_uses_buffer_before_candidate_stop(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_INITIAL_ACTIVE_STOP"] = "true"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    lines = command_log.read_text(encoding="utf-8").splitlines()
+    initial_stop = next(
+        index for index, line in enumerate(lines) if line.endswith(" stop -t 5 app")
+    )
+    buffer_route = next(
+        index
+        for index, line in enumerate(lines[initial_stop + 1 :], start=initial_stop + 1)
+        if line == "upstream proxy_pass http://127.0.0.1:18002;"
+    )
+    candidate_stop = next(
+        index
+        for index, line in enumerate(lines[buffer_route + 1 :], start=buffer_route + 1)
+        if line.endswith(" stop -t 5 app-blue")
+    )
+    old_start = next(
+        index
+        for index, line in enumerate(lines[candidate_stop + 1 :], start=candidate_stop + 1)
+        if line.endswith(" up -d --no-deps app")
+    )
+    assert initial_stop < buffer_route < candidate_stop < old_start
+    assert "proxy_pass http://127.0.0.1:8000;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rolled_back" in summary
+
+
+def test_ready_old_slot_reports_failed_rollback_when_image_state_sync_fails(
+    tmp_path,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["FAIL_PREVIOUS_ENV_WRITE"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert "proxy_pass http://127.0.0.1:8000;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert "rm -s -f app-green" in commands
+    assert f"BACKEND_IMAGE={NEW_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_failed" in summary
+    assert "previous_image_state_synced=false" in summary
+
+
+def test_failed_old_readiness_serves_buffer_until_candidate_is_stable(
+    tmp_path,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_BEFORE_FALLBACK"] = "true"
+    env["FAIL_ROLLBACK_OLD_READY"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "6"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    lines = commands.splitlines()
+    candidate_stop = next(
+        index
+        for index, line in enumerate(lines)
+        if line.endswith(" stop -t 5 app-blue")
+    )
+    old_start = next(
+        index for index, line in enumerate(lines) if line.endswith(" up -d --no-deps app")
+    )
+    old_stop = next(
+        index
+        for index, line in enumerate(lines[old_start + 1 :], start=old_start + 1)
+        if line.endswith(" stop -t 5 app")
+    )
+    fallback_start = next(
+        index
+        for index, line in enumerate(lines[old_stop + 1 :], start=old_stop + 1)
+        if line.endswith(" up -d --no-deps --force-recreate app-blue")
+    )
+    buffer_ready = next(
+        index for index, line in enumerate(lines) if ":18002/api/ready" in line
+    )
+    buffer_stop = next(
+        index
+        for index, line in enumerate(lines[fallback_start + 1 :], start=fallback_start + 1)
+        if line.endswith(" rm -s -f app-green")
+    )
+    assert buffer_ready < candidate_stop < old_start < old_stop < fallback_start
+    assert fallback_start < buffer_stop
+    assert sum(line.endswith(" stop -t 5 app-blue") for line in lines) == 1
+    assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
+    assert f"BACKEND_IMAGE={NEW_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    assert "proxy_pass http://127.0.0.1:18001;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_failed" in summary
+    assert "old_slot_ready=false" in summary
+    assert "candidate_api_fallback_ready=true" in summary
+
+
+def test_candidate_recovery_does_not_route_when_requested_image_sync_fails(
+    tmp_path,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_BEFORE_FALLBACK"] = "true"
+    env["FAIL_ROLLBACK_OLD_READY"] = "true"
+    env["FAIL_REQUESTED_ENV_WRITE_AFTER_OLD_STOP"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "6"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert sum(
+        line.endswith(" up -d --no-deps --force-recreate app-blue")
+        for line in commands.splitlines()
+    ) == 1
+    assert "proxy_pass http://127.0.0.1:18002;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    assert (project / ".rollback-api-buffer.compose.yml").exists()
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_buffer_active" in summary
+    assert "candidate_image_state_synced=false" in summary
+    assert "candidate_api_fallback_ready=false" in summary
+    assert "rollback_buffer_routed=true" in summary
+
+
+def test_candidate_stop_failure_keeps_buffer_live_and_never_starts_old(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["FAIL_CANDIDATE_STOP"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert "upstream proxy_pass http://127.0.0.1:18002;" in commands
+    assert not any(
+        line.endswith(" up -d --no-deps app") for line in commands.splitlines()
+    )
+    assert "proxy_pass http://127.0.0.1:18002;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    marker = project / ".rollback-api-buffer.compose.yml"
+    assert marker.exists()
+    assert f'image: "{OLD_IMAGE}"' in marker.read_text(encoding="utf-8")
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_buffer_active" in summary
+    assert "candidate_stop_confirmed=false" in summary
+    assert "rollback_buffer_routed=true" in summary
+
+
+@pytest.mark.parametrize("retry_image", [NEW_IMAGE, OLD_IMAGE])
+def test_preserved_routed_buffer_syncs_image_and_same_image_retry_deploys(
+    tmp_path,
+    retry_image,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["FAIL_CANDIDATE_STOP"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    first = _run(env)
+
+    assert first.returncode != 0
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    first_commands = command_log.read_text(encoding="utf-8")
+    assert f"bot_image {OLD_IMAGE}" in first_commands
+    assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "green"
+    first_summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(
+        encoding="utf-8"
+    )
+    assert "rollback_buffer_image_state_synced=true" in first_summary
+    assert f"rollback_buffer_image={OLD_IMAGE}" in first_summary
+
+    env.pop("FAIL_SCHEDULER_RUNNING")
+    env.pop("FAIL_CANDIDATE_STOP")
+    env["FAKE_RUNTIME_APP_GREEN_IMAGE"] = OLD_IMAGE
+    env["FAKE_RUNTIME_BOT_IMAGE"] = OLD_IMAGE
+    env["BACKEND_IMAGE"] = retry_image
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "6"
+    second = _run(env)
+
+    assert second.returncode == 0, second.stderr
+    second_summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(
+        encoding="utf-8"
+    )
+    assert "status=activated" in second_summary
+    assert "status=already_active" not in second_summary
+    assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
+    assert f"BACKEND_IMAGE={retry_image}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    assert not (project / ".rollback-api-buffer.compose.yml").exists()
+
+
+def test_buffer_cleanup_failure_is_preserved_as_managed_state(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["FAIL_BUFFER_REMOVE"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert "rm -s -f app-green" in commands
+    assert "proxy_pass http://127.0.0.1:8000;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert (project / ".rollback-api-buffer.compose.yml").exists()
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rolled_back" in summary
+    assert "rollback_buffer_cleanup=false" in summary
+    assert "rollback_buffer_routed=false" in summary
+
+
+def test_partial_buffer_start_is_cleaned_without_stopping_candidate(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["FAIL_BUFFER_START"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    lines = command_log.read_text(encoding="utf-8").splitlines()
+    buffer_start = next(
+        index
+        for index, line in enumerate(lines)
+        if "rollback-api-buffer.compose.yml" in line
+        and line.endswith(" up -d --no-deps --force-recreate app-green")
+    )
+    buffer_cleanup = next(
+        index
+        for index, line in enumerate(lines[buffer_start + 1 :], start=buffer_start + 1)
+        if line.endswith(" rm -s -f app-green")
+    )
+    assert buffer_start < buffer_cleanup
+    assert not any(line.endswith(" stop -t 5 app-blue") for line in lines)
+    assert "proxy_pass http://127.0.0.1:18001;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert not (project / ".rollback-api-buffer.compose.yml").exists()
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_failed" in summary
+    assert "candidate_preserved=true" in summary
+
+
+def test_unhealthy_old_stop_failure_keeps_buffer_and_refuses_candidate_restart(
+    tmp_path,
+):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAIL_SCHEDULER_BEFORE_FALLBACK"] = "true"
+    env["FAIL_ROLLBACK_OLD_READY"] = "true"
+    env["FAIL_OLD_STOP"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "6"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    commands = command_log.read_text(encoding="utf-8")
+    assert sum(
+        line.endswith(" up -d --no-deps --force-recreate app-blue")
+        for line in commands.splitlines()
+    ) == 1
+    assert "proxy_pass http://127.0.0.1:18002;" in Path(
+        env["API_NGINX_UPSTREAM_FILE"]
+    ).read_text(encoding="utf-8")
+    assert (project / ".rollback-api-buffer.compose.yml").exists()
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rollback_buffer_active" in summary
+    assert "old_slot_stop_confirmed=false" in summary
+    assert "rollback_buffer_routed=true" in summary
+
+
+def test_preserved_buffer_marker_is_removed_only_after_successful_activation(
+    tmp_path,
+):
+    failed_root = tmp_path / "failed"
+    failed_root.mkdir()
+    failed_env, failed_project, _, _ = _environment(failed_root)
+    failed_marker = failed_project / ".rollback-api-buffer.compose.yml"
+    failed_marker.write_text("preserved\n", encoding="utf-8")
+    failed_env["FAIL_CANDIDATE_READY"] = "true"
+
+    failed = _run(failed_env)
+
+    assert failed.returncode != 0
+    assert failed_marker.read_text(encoding="utf-8") == "preserved\n"
+
+    success_root = tmp_path / "success"
+    success_root.mkdir()
+    success_env, success_project, _, _ = _environment(success_root)
+    success_marker = success_project / ".rollback-api-buffer.compose.yml"
+    success_marker.write_text("preserved\n", encoding="utf-8")
+
+    succeeded = _run(success_env)
+
+    assert succeeded.returncode == 0, succeeded.stderr
+    assert not success_marker.exists()
+
+    rollback_root = tmp_path / "rollback"
+    rollback_root.mkdir()
+    rollback_env, rollback_project, _, _ = _environment(rollback_root)
+    rollback_marker = rollback_project / ".rollback-api-buffer.compose.yml"
+    rollback_marker.write_text("preserved\n", encoding="utf-8")
+    rollback_env["FAIL_SCHEDULER_RUNNING"] = "true"
+    rollback_env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    rolled_back = _run(rollback_env)
+
+    assert rolled_back.returncode != 0
+    assert not rollback_marker.exists()

--- a/tests/unit/test_blue_green_deploy_script.py
+++ b/tests/unit/test_blue_green_deploy_script.py
@@ -1,120 +1,126 @@
-import os
-import subprocess
 from pathlib import Path
 
+import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = REPO_ROOT / "scripts/deploy_backend_blue_green.sh"
-OLD_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "1" * 64
-NEW_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "2" * 64
+from tests.unit.blue_green_deploy_harness import (
+    NEW_IMAGE,
+    OLD_IMAGE,
+    SAFETY_SCRIPT,
+    SCRIPT,
+    configure_active_slot as _configure_active_slot,
+    environment as _environment,
+    run as _run,
+)
 
 
-def _executable(path: Path, content: str) -> None:
-    path.write_text(content, encoding="utf-8")
-    path.chmod(0o755)
+def test_scheduler_gate_records_candidate_slot_after_old_service_removal():
+    source = SCRIPT.read_text(encoding="utf-8")
+    old_remove = source.index('"${COMPOSE[@]}" rm -f "${active_service}"')
+    candidate_slot_write = source.index(
+        'atomic_write_line "${ACTIVE_SLOT_FILE}" "${candidate_slot}" 600'
+    )
+    scheduler_gate = source.index("wait_scheduler_running_url", candidate_slot_write)
+
+    assert old_remove < candidate_slot_write < scheduler_gate
 
 
-def _environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path]:
-    project = tmp_path / "project"
-    project.mkdir()
-    (project / "docker-compose.prod.yml").write_text("services: {}\n", encoding="utf-8")
-    (project / ".env").write_text(
-        f"POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=test\nPOSTGRES_DB=test\nBACKEND_IMAGE={OLD_IMAGE}\n",
-        encoding="utf-8",
+def test_rollback_routes_ready_buffer_before_stopping_candidate():
+    source = SAFETY_SCRIPT.read_text(encoding="utf-8")
+    rollback = source[source.index("rollback_on_error() {") :]
+    buffer_start = rollback.index("rollback_buffer_start")
+    buffer_route = rollback.index(
+        'rollback_route_slot "${rollback_buffer_slot}" "${candidate_slot}"'
+    )
+    candidate_stop = rollback.index('rollback_stop_service "${candidate_service}"')
+    old_start = rollback.index(
+        '"${COMPOSE[@]}" up -d --no-deps "${active_service}"'
+    )
+    old_ready = rollback.index('"rollback_old"')
+    old_route = rollback.index('rollback_route_slot "${active_slot}"')
+    buffer_stop = rollback.index("rollback_buffer_stop", old_route)
+
+    assert buffer_start < buffer_route < candidate_stop < old_start < old_ready
+    assert old_ready < old_route < buffer_stop
+
+
+@pytest.mark.parametrize("proxy_mode", ["host_nginx", "container_nginx"])
+@pytest.mark.parametrize(
+    ("active_slot", "candidate_slot", "buffer_slot"),
+    [
+        ("legacy", "blue", "green"),
+        ("blue", "green", "legacy"),
+        ("green", "blue", "legacy"),
+    ],
+)
+def test_zero_gap_buffer_covers_every_slot_and_proxy_combination(
+    tmp_path,
+    proxy_mode,
+    active_slot,
+    candidate_slot,
+    buffer_slot,
+):
+    env, project, site, command_log = _environment(tmp_path)
+    upstream = _configure_active_slot(env, project, site, active_slot, proxy_mode)
+    env["FAIL_SCHEDULER_RUNNING"] = "true"
+    env["API_SCHEDULER_READY_ATTEMPTS"] = "2"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    lines = command_log.read_text(encoding="utf-8").splitlines()
+    services = {"legacy": "app", "blue": "app-blue", "green": "app-green"}
+    ports = {"legacy": 8000, "blue": 18001, "green": 18002}
+    target = (
+        f"127.0.0.1:{ports[buffer_slot]}"
+        if proxy_mode == "host_nginx"
+        else f"{services[buffer_slot]}:8000"
+    )
+    old_target = (
+        f"127.0.0.1:{ports[active_slot]}"
+        if proxy_mode == "host_nginx"
+        else f"{services[active_slot]}:8000"
+    )
+    buffer_route = next(
+        index
+        for index, line in enumerate(lines)
+        if line == f"upstream proxy_pass http://{target};"
+    )
+    candidate_stop = next(
+        index
+        for index, line in enumerate(lines[buffer_route + 1 :], start=buffer_route + 1)
+        if line.endswith(f" stop -t 5 {services[candidate_slot]}")
+    )
+    old_start = next(
+        index
+        for index, line in enumerate(lines[candidate_stop + 1 :], start=candidate_stop + 1)
+        if line.endswith(f" up -d --no-deps {services[active_slot]}")
+    )
+    old_ready = next(
+        index
+        for index, line in enumerate(lines[old_start + 1 :], start=old_start + 1)
+        if f":{ports[active_slot]}/api/ready" in line
+    )
+    old_route = next(
+        index
+        for index, line in enumerate(lines[old_ready + 1 :], start=old_ready + 1)
+        if line == f"upstream proxy_pass http://{old_target};"
+    )
+    buffer_cleanup = next(
+        index
+        for index, line in enumerate(lines[old_route + 1 :], start=old_route + 1)
+        if line.endswith(f" rm -s -f {services[buffer_slot]}")
     )
 
-    nginx_dir = tmp_path / "nginx"
-    site = nginx_dir / "sites-available/air-api"
-    site.parent.mkdir(parents=True)
-    site.write_text(
-        "server {\n    location / {\n        proxy_pass http://127.0.0.1:8000;\n    }\n}\n",
-        encoding="utf-8",
+    assert buffer_route < candidate_stop < old_start < old_ready < old_route
+    assert old_route < buffer_cleanup
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
     )
-    upstream = nginx_dir / "snippets/mvn-api-upstream.conf"
-
-    command_log = tmp_path / "commands.log"
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
-    _executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
-    _executable(
-        fake_bin / "docker",
-        """#!/usr/bin/env bash
-set -u
-printf 'docker %s\n' "$*" >> "$COMMAND_LOG"
-if [[ "$*" == *"ps --status running --services"* ]]; then
-  printf 'app\napp-blue\napp-green\nbot\napi-proxy\n'
-fi
-exit 0
-""",
-    )
-    _executable(
-        fake_bin / "curl",
-        """#!/usr/bin/env bash
-set -u
-url="${*: -1}"
-printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
-if [[ "${FAIL_CANDIDATE_READY:-false}" == "true" && "$url" == *":18001/api/ready"* ]]; then
-  exit 22
-fi
-case "$url" in
-  */api/ready)
-    printf '{"status":"ok","api":"ready","database":"online","database_writable":true}\n'
-    ;;
-  */api/health)
-    printf '{"status":"ok","database":"online"}\n'
-    ;;
-  *products*)
-    printf '{"items":[]}\n'
-    ;;
-  *filters/config*)
-    printf '{"price":{},"area":{},"brands":[],"expert_tags":[]}\n'
-    ;;
-  *)
-    exit 22
-    ;;
-esac
-""",
-    )
-    _executable(
-        fake_bin / "nginx",
-        "#!/usr/bin/env bash\nprintf 'nginx %s\n' \"$*\" >> \"$COMMAND_LOG\"\nexit 0\n",
-    )
-    _executable(
-        fake_bin / "systemctl",
-        "#!/usr/bin/env bash\nprintf 'systemctl %s\n' \"$*\" >> \"$COMMAND_LOG\"\nexit 0\n",
-    )
-
-    env = os.environ.copy()
-    env.update(
-        {
-            "PATH": f"{fake_bin}:{env['PATH']}",
-            "COMMAND_LOG": str(command_log),
-            "API_PROJECT_DIR": str(project),
-            "API_COMPOSE_FILE": "docker-compose.prod.yml",
-            "API_NGINX_SITE_FILE": str(site),
-            "API_NGINX_UPSTREAM_FILE": str(upstream),
-            "API_NGINX_INTERNAL_FILE": str(nginx_dir / "conf.d/mvn-api-internal.conf"),
-            "API_BLUE_GREEN_SUMMARY_FILE": str(tmp_path / "summary.txt"),
-            "API_HEALTH_ATTEMPTS": "2",
-            "API_HEALTH_DELAY_SECONDS": "0",
-            "API_DRAIN_SECONDS": "0",
-            "BACKEND_IMAGE": NEW_IMAGE,
-            "GHCR_PAT": "test-token",
-            "GITHUB_ACTOR": "test-user",
-        }
-    )
-    return env, project, site, command_log
-
-
-def _run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", str(SCRIPT)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    if active_slot == "legacy":
+        assert not (project / ".active-api-slot").exists()
+    else:
+        assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == active_slot
+    assert old_target in upstream.read_text(encoding="utf-8")
 
 
 def test_first_deploy_activates_blue_without_touching_database(tmp_path):
@@ -128,8 +134,20 @@ def test_first_deploy_activates_blue_without_touching_database(tmp_path):
     assert "run -T --rm --no-deps app-blue alembic upgrade head" in commands
     assert "up -d --no-deps --force-recreate app-blue" in commands
     assert "up -d --no-deps --force-recreate bot" in commands
-    assert "stop app" in commands
+    assert "stop -t 5 app" in commands
     assert "rm -f app" in commands
+    candidate_ready_calls = [
+        line for line in commands.splitlines() if ":18001/api/ready" in line
+    ]
+    assert len(candidate_ready_calls) >= 7
+    lines = commands.splitlines()
+    old_remove = next(index for index, line in enumerate(lines) if line.endswith(" rm -f app"))
+    post_stop_scheduler_samples = [
+        index
+        for index, line in enumerate(lines)
+        if index > old_remove and ":18001/api/ready" in line
+    ]
+    assert len(post_stop_scheduler_samples) >= 6
     assert " pull db" not in commands
     assert " up -d db" not in commands
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
@@ -142,6 +160,24 @@ def test_first_deploy_activates_blue_without_touching_database(tmp_path):
         encoding="utf-8"
     )
     assert "include " in site.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "stop_timeout",
+    ["0", "11", "not-an-int", "999999999999999999999999999999999999999"],
+)
+def test_service_stop_timeout_must_preserve_fencing_window(tmp_path, stop_timeout):
+    env, _, _, command_log = _environment(tmp_path)
+    env["API_SERVICE_STOP_TIMEOUT_SECONDS"] = stop_timeout
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "must be an integer from 1 to 10" in result.stdout
+    commands = command_log.read_text(encoding="utf-8")
+    assert " ps -q " not in commands
+    assert " pull " not in commands
+    assert " up " not in commands
 
 
 def test_bootstrap_only_installs_stable_proxy_without_container_changes(tmp_path):
@@ -172,6 +208,7 @@ def test_next_deploy_uses_green_and_stops_blue(tmp_path):
         encoding="utf-8",
     )
     (project / ".active-api-slot").write_text("blue\n", encoding="utf-8")
+    env["FAKE_RUNTIME_APP_BLUE_IMAGE"] = OLD_IMAGE
 
     result = _run(env)
 
@@ -179,7 +216,7 @@ def test_next_deploy_uses_green_and_stops_blue(tmp_path):
     commands = command_log.read_text(encoding="utf-8")
     assert "pull app-green bot" in commands
     assert "up -d --no-deps --force-recreate app-green" in commands
-    assert "stop app-blue" in commands
+    assert "stop -t 5 app-blue" in commands
     assert "rm -f app-blue" in commands
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "green"
     assert "proxy_pass http://127.0.0.1:18002;" in upstream.read_text(encoding="utf-8")
@@ -220,24 +257,108 @@ def test_container_proxy_switches_by_service_name_without_host_nginx(tmp_path):
         for index, line in enumerate(lines)
         if "up -d --no-deps --force-recreate app-blue" in line
     )
-    old_stop = next(index for index, line in enumerate(lines) if line.endswith(" stop app"))
+    old_stop = next(
+        index for index, line in enumerate(lines) if line.endswith(" stop -t 5 app")
+    )
     assert candidate_start < proxy_reload < old_stop
     assert "proxy_pass http://app-blue:8000;" in upstream.read_text(encoding="utf-8")
     assert (project / ".active-api-slot").read_text(encoding="utf-8").strip() == "blue"
 
 
-def test_failed_candidate_keeps_legacy_active(tmp_path):
-    env, project, _, command_log = _environment(tmp_path)
-    env["FAIL_CANDIDATE_READY"] = "true"
+def test_runtime_image_reconciles_env_and_remains_rollback_source_of_truth(tmp_path):
+    env, project, site, command_log = _environment(tmp_path)
+    upstream = _configure_active_slot(env, project, site, "blue", "host_nginx")
+    (project / ".env").write_text(
+        f"POSTGRES_USER=postgres\nBACKEND_IMAGE={NEW_IMAGE}\n", encoding="utf-8"
+    )
+    env.update(
+        {
+            "API_PUBLIC_READY_URL": "https://public.test/api/ready",
+            "FAIL_PUBLIC_READY": "true",
+        }
+    )
 
     result = _run(env)
 
     assert result.returncode != 0
-    assert not (project / ".active-api-slot").exists()
-    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(encoding="utf-8")
-    assert "proxy_pass http://127.0.0.1:8000;" in Path(
-        env["API_NGINX_UPSTREAM_FILE"]
-    ).read_text(encoding="utf-8")
+    assert "requested image is already active" not in result.stdout
     commands = command_log.read_text(encoding="utf-8")
-    assert "stop app-blue" in commands
-    assert not any(line.endswith(" stop app") for line in commands.splitlines())
+    assert "pull app-green bot" in commands
+    assert "stop -t 5 app-green" in commands
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    assert "proxy_pass http://127.0.0.1:18001;" in upstream.read_text(
+        encoding="utf-8"
+    )
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=rolled_back" in summary
+    assert f"failed_candidate={NEW_IMAGE}" in summary
+
+
+def test_bot_runtime_mismatch_bypasses_already_active_shortcut(tmp_path):
+    env, project, site, command_log = _environment(tmp_path)
+    _configure_active_slot(env, project, site, "blue", "host_nginx")
+    env["BACKEND_IMAGE"] = OLD_IMAGE
+    env["FAKE_RUNTIME_BOT_IMAGE"] = NEW_IMAGE
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert "pull app-green bot" in commands
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=activated" in summary
+    assert "status=already_active" not in summary
+
+
+def test_matching_api_and_bot_runtime_can_use_already_active_shortcut(tmp_path):
+    env, project, site, command_log = _environment(tmp_path)
+    _configure_active_slot(env, project, site, "blue", "host_nginx")
+    env["BACKEND_IMAGE"] = OLD_IMAGE
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert " pull " not in commands
+    summary = Path(env["API_BLUE_GREEN_SUMMARY_FILE"]).read_text(encoding="utf-8")
+    assert "status=already_active" in summary
+
+
+def test_bootstrap_only_refuses_env_runtime_drift_without_mutation(tmp_path):
+    env, project, _, command_log = _environment(tmp_path)
+    (project / ".env").write_text(
+        f"POSTGRES_USER=postgres\nBACKEND_IMAGE={NEW_IMAGE}\n", encoding="utf-8"
+    )
+    env["API_BLUE_GREEN_BOOTSTRAP_ONLY"] = "true"
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert f"BACKEND_IMAGE={NEW_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    commands = command_log.read_text(encoding="utf-8")
+    assert " up " not in commands
+    assert "systemctl reload nginx" not in commands
+
+
+@pytest.mark.parametrize(
+    "runtime_image",
+    ["", "ghcr.io/mvnby/air-api/backend:latest", f"{OLD_IMAGE}\n{NEW_IMAGE}"],
+)
+def test_active_runtime_image_must_be_unique_and_immutable(tmp_path, runtime_image):
+    env, project, _, command_log = _environment(tmp_path)
+    env["FAKE_RUNTIME_APP_IMAGE"] = runtime_image
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert f"BACKEND_IMAGE={OLD_IMAGE}" in (project / ".env").read_text(
+        encoding="utf-8"
+    )
+    commands = command_log.read_text(encoding="utf-8")
+    assert " pull " not in commands
+    assert " up " not in commands
+    assert "systemctl reload nginx" not in commands

--- a/tests/unit/test_catalog_import_runtime_service.py
+++ b/tests/unit/test_catalog_import_runtime_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import select
@@ -80,57 +81,74 @@ async def test_catalog_import_job_is_persisted_and_progress_updates(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_catalog_import_runtime_resumes_running_job_from_database(monkeypatch):
+async def test_catalog_import_runtime_leaves_running_job_untouched(monkeypatch):
+    engine, session_factory = await _sqlite_session_factory()
+    monkeypatch.setattr(runtime_module, "async_session_maker", session_factory)
+
+    async with session_factory() as session:
+        session.add_all(
+            [
+                CatalogImportJob(
+                    job_id="already-running",
+                    status="running",
+                    stage="importing",
+                    error="preserve-me",
+                    input_urls=["https://example.com/running"],
+                    input_total=1,
+                ),
+                CatalogImportJob(
+                    job_id="queued-behind-running",
+                    status="queued",
+                    stage="queued",
+                    input_urls=["https://example.com/queued"],
+                    input_total=1,
+                ),
+            ]
+        )
+        await session.commit()
+
+    service = CatalogImportRuntimeService()
+    schedule_job = Mock(return_value=True)
+    monkeypatch.setattr(service, "_schedule_job", schedule_job)
+
+    assert await service.resume_pending_jobs() is False
+
+    async with session_factory() as session:
+        running = await session.get(CatalogImportJob, "already-running")
+        queued = await session.get(CatalogImportJob, "queued-behind-running")
+        assert running is not None
+        assert running.status == "running"
+        assert running.stage == "importing"
+        assert running.error == "preserve-me"
+        assert queued is not None
+        assert queued.status == "queued"
+    schedule_job.assert_not_called()
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_catalog_import_runtime_starts_queued_job_when_none_running(monkeypatch):
     engine, session_factory = await _sqlite_session_factory()
     monkeypatch.setattr(runtime_module, "async_session_maker", session_factory)
 
     async with session_factory() as session:
         session.add(
             CatalogImportJob(
-                job_id="resume-me",
-                status="running",
-                stage="importing",
-                input_urls=["https://example.com/resume"],
+                job_id="ready-to-start",
+                status="queued",
+                stage="queued",
+                input_urls=["https://example.com/queued"],
                 input_total=1,
             )
         )
         await session.commit()
 
-    class _FakeImporter:
-        async def import_products_bulk(
-            self,
-            urls,
-            with_related=False,  # noqa: ARG002
-            update_existing=False,  # noqa: ARG002
-            progress_callback=None,
-        ):
-            if progress_callback:
-                await progress_callback(
-                    {
-                        "stage": "importing",
-                        "total": len(urls),
-                        "processed": 1,
-                        "pending": 0,
-                        "success_count": 1,
-                        "error_count": 0,
-                    }
-                )
-            return {"success": ["Resumed import product"], "errors": []}
-
-    monkeypatch.setattr(runtime_module, "ImporterService", _FakeImporter)
-
     service = CatalogImportRuntimeService()
-    await service.resume_pending_jobs()
+    schedule_job = Mock(return_value=True)
+    monkeypatch.setattr(service, "_schedule_job", schedule_job)
 
-    for _ in range(20):
-        current = await service.get_job("resume-me")
-        if current and current["status"] == "success":
-            break
-        await asyncio.sleep(0.05)
-
-    current = await service.get_job("resume-me")
-    assert current is not None
-    assert current["status"] == "success"
-    assert current["successes"] == ["Resumed import product"]
+    assert await service.resume_pending_jobs() is True
+    schedule_job.assert_called_once_with("ready-to-start")
 
     await engine.dispose()

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -136,11 +136,18 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     assert "EXPECTED_CURRENT_IMAGE=" in rollback["run"]
     assert "scripts/rollback_backend.sh" in rollback["run"]
     assert "scripts/deploy_backend_blue_green.sh" in primary_deploy["run"]
+    assert "scripts/deploy_backend_blue_green_safety.sh" in primary_deploy["run"]
     assert 'case "${API_DEPLOY_STRATEGY}" in' in primary_deploy["run"]
     assert "blue_green)" in primary_deploy["run"]
     assert "in_place)" in primary_deploy["run"]
     assert "API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}'" in primary_deploy["run"]
     assert "scripts/deploy_backend_blue_green.sh" in rollback["run"]
+    assert "scripts/deploy_backend_blue_green_safety.sh" in rollback["run"]
+    safety_helper_env = (
+        "API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh'"
+    )
+    assert safety_helper_env in primary_deploy["run"]
+    assert safety_helper_env in rollback["run"]
     assert "scripts/deploy.sh" in standby_deploy["run"]
     assert "API_DEPLOY_SERVICES='app'" in standby_deploy["run"]
     assert "API_RUN_MIGRATIONS='false'" in standby_deploy["run"]

--- a/tests/unit/test_patroni_production_check.py
+++ b/tests/unit/test_patroni_production_check.py
@@ -5,12 +5,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+from scripts.ha import check_patroni_production as patroni_check
 from scripts.ha.check_patroni_production import (
     CheckerConfig,
     NodeConfig,
     Report,
     _check_cluster_views,
     _check_postgres,
+    _check_runtime,
     _parse_rows,
     role_from_patroni,
     select_primary,
@@ -215,6 +217,98 @@ def test_postgres_check_treats_negative_receiver_delta_as_zero_backlog():
 
     assert report.failures == []
     assert any("streams synchronously" in message for message in report.ok)
+
+
+def test_runtime_check_requires_role_aware_scheduler_state(monkeypatch):
+    api, reserve = _nodes()
+    config = CheckerConfig(
+        api=api,
+        reserve=reserve,
+        ssh_options=(),
+        max_replay_lag_bytes=1_048_576,
+        role_agent_unit="mvn-patroni-role-agent.service",
+        etcd_check_command="check-etcd",
+        ready_url="http://127.0.0.1:18080/api/ready",
+    )
+    readiness = {
+        "api": (
+            200,
+            {
+                "api": "ready",
+                "traffic": "enabled",
+                "scheduler_runtime": {"expected": True, "status": "running"},
+            },
+        ),
+        "reserve": (
+            503,
+            {
+                "api": "not_ready",
+                "traffic": "disabled",
+                "scheduler_runtime": {"expected": False, "status": "disabled"},
+            },
+        ),
+    }
+
+    class FakeRunner:
+        def run(self, node, command, *, stdin=None, check=True):
+            del stdin, check
+            if command.endswith("/.ha-runtime-role"):
+                role = "primary" if node == api else "standby"
+                return subprocess.CompletedProcess([], 0, f"{role}\n", "")
+            raise AssertionError(command)
+
+    def role_env(_runner, node, filename):
+        primary = node == api
+        role = "primary" if primary else "standby"
+        common = {
+            "APP_ROLE": role,
+            "API_READY_ENABLED": str(primary).lower() if filename == ".ha-app-role.env" else "false",
+            "DB_BOOTSTRAP_ENABLED": "false",
+            "SCHEDULER_ENABLED": str(primary).lower() if filename == ".ha-app-role.env" else "false",
+        }
+        if filename == ".ha-bot-role.env":
+            common["BOT_ENABLED"] = str(primary).lower()
+        if not primary and filename == ".ha-app-role.env":
+            common.update(
+                {
+                    "MAIL_IMAP_AUTO_IMPORT_ENABLED": "false",
+                    "MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED": "false",
+                    "CLOUDFLARE_PURGE_ENABLED": "false",
+                }
+            )
+        return common
+
+    monkeypatch.setattr(patroni_check, "_unit_enabled", lambda *_args: True)
+    monkeypatch.setattr(
+        patroni_check,
+        "_unit_active",
+        lambda _runner, node, unit: (
+            True if unit == config.role_agent_unit else node == api
+        ),
+    )
+    monkeypatch.setattr(patroni_check, "_role_env", role_env)
+    monkeypatch.setattr(
+        patroni_check,
+        "_running_services",
+        lambda _runner, node: {"app-blue", "bot"} if node == api else {"app-blue"},
+    )
+    monkeypatch.setattr(
+        patroni_check,
+        "_ready_response",
+        lambda _runner, node, _url: readiness[node.label],
+    )
+
+    report = Report()
+    _check_runtime(config, FakeRunner(), api, reserve, report)
+    assert report.failures == []
+
+    readiness["api"][1]["scheduler_runtime"] = {
+        "expected": True,
+        "status": "retrying",
+    }
+    report = Report()
+    _check_runtime(config, FakeRunner(), api, reserve, report)
+    assert any("primary scheduler runtime" in failure for failure in report.failures)
 
 
 def test_replication_workflow_switches_to_role_aware_patroni_monitoring():

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -15,6 +15,10 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert "run_patroni_migrations.sh" in text
     assert "deploy_patroni_api_node.sh" in text
     assert "deploy_backend_blue_green.sh" in text
+    assert "deploy_backend_blue_green_safety.sh" in text
+    assert (
+        "API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh" in text
+    )
     assert "scripts/ha/patroni_role_agent.py" in text
     assert "/usr/local/sbin/mvn-patroni-role-agent" in text
     assert "systemctl restart" in text

--- a/tests/unit/test_readiness_service.py
+++ b/tests/unit/test_readiness_service.py
@@ -1,0 +1,33 @@
+from services.readiness_service import ReadinessService
+
+
+def test_scheduler_runtime_payload_accepts_only_allowlisted_snapshot(monkeypatch):
+    monkeypatch.setattr(
+        "services.readiness_service.settings.APP_ROLE",
+        "primary",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "services.readiness_service.settings.SCHEDULER_ENABLED",
+        True,
+        raising=False,
+    )
+    valid = {
+        "expected": True,
+        "status": "running",
+        "reason": "scheduler_loop_running",
+        "changed_at": "2026-07-13T08:00:00+00:00",
+    }
+    assert ReadinessService._scheduler_runtime_payload(valid) == valid
+
+    unsafe = {
+        **valid,
+        "reason": "database password leaked in raw exception",
+        "changed_at": "not-a-timestamp",
+    }
+    sanitized = ReadinessService._scheduler_runtime_payload(unsafe)
+    assert sanitized["expected"] is True
+    assert sanitized["status"] == "waiting_lock"
+    assert sanitized["reason"] == "runtime_state_unavailable"
+    assert sanitized["changed_at"] is None
+    assert "password" not in str(sanitized)

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -149,38 +149,11 @@ async def test_database_bootstrap_explicit_switch_overrides_standby(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_scheduler_runtime_lock_skips_for_standby(monkeypatch):
-    _set_required_env(monkeypatch)
-    app_lifespan = importlib.import_module("core.app_lifespan")
-
-    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "standby", raising=False)
-    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
-
-    assert await app_lifespan._acquire_scheduler_runtime_lock() is None
-
-
-@pytest.mark.asyncio
-async def test_scheduler_runtime_lock_requires_free_lock(monkeypatch):
-    _set_required_env(monkeypatch)
-    app_lifespan = importlib.import_module("core.app_lifespan")
-
-    monkeypatch.setattr(app_lifespan.settings, "APP_ROLE", "primary", raising=False)
-    monkeypatch.setattr(app_lifespan.settings, "SCHEDULER_ENABLED", None, raising=False)
-    monkeypatch.setattr(
-        app_lifespan.RuntimeLockService,
-        "try_acquire",
-        AsyncMock(return_value=SimpleNamespace(acquired=False, reason="held elsewhere")),
-    )
-
-    assert await app_lifespan._acquire_scheduler_runtime_lock() is None
-
-
-@pytest.mark.asyncio
 async def test_catalog_import_resume_runs_inside_scheduler_lock(monkeypatch):
     _set_required_env(monkeypatch)
     app_lifespan = importlib.import_module("core.app_lifespan")
 
-    resume_pending_jobs = AsyncMock()
+    resume_pending_jobs = AsyncMock(return_value=True)
     monkeypatch.setitem(
         sys.modules,
         "services.catalog_import_runtime_service",

--- a/tests/unit/test_runtime_lock_service.py
+++ b/tests/unit/test_runtime_lock_service.py
@@ -1,0 +1,333 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from services import runtime_lock_service as runtime_locks
+from services.runtime_lock_service import RuntimeLock, RuntimeLockService
+
+
+class FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class FakeConnection:
+    def __init__(self, *, acquire_result=True, liveness_result=True, unlock_result=True):
+        self.acquire_result = acquire_result
+        self.liveness_result = liveness_result
+        self.unlock_result = unlock_result
+        self.closed = False
+        self.invalidated = False
+        self.execution_options_calls = []
+        self.execute_calls = []
+        self.acquire_error = None
+        self.liveness_error = None
+        self.unlock_error = None
+
+    async def execution_options(self, **options):
+        self.execution_options_calls.append(options)
+        return self
+
+    async def execute(self, statement, parameters):
+        sql = str(statement)
+        self.execute_calls.append((sql, parameters))
+        if "pg_try_advisory_lock" in sql:
+            if self.acquire_error is not None:
+                raise self.acquire_error
+            return FakeResult(self.acquire_result)
+        if "pg_advisory_unlock" in sql:
+            if self.unlock_error is not None:
+                raise self.unlock_error
+            return FakeResult(self.unlock_result)
+        if "pg_locks" in sql:
+            if self.liveness_error is not None:
+                raise self.liveness_error
+            return FakeResult(self.liveness_result)
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    async def invalidate(self):
+        self.invalidated = True
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeEngine:
+    def __init__(self, connection):
+        self.connection = connection
+        self.connect_calls = 0
+
+    async def connect(self):
+        self.connect_calls += 1
+        return self.connection
+
+
+def _enable_runtime_locks(monkeypatch):
+    monkeypatch.setattr(
+        runtime_locks.settings,
+        "RUNTIME_DB_LOCKS_ENABLED",
+        True,
+        raising=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_lock_uses_one_pinned_autocommit_connection(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    connection = FakeConnection()
+    engine = FakeEngine(connection)
+    resolve_engine = AsyncMock(return_value=(engine, "postgresql"))
+    monkeypatch.setattr(RuntimeLockService, "_resolve_engine", resolve_engine)
+    session_factory = Mock()
+
+    lock = await RuntimeLockService.try_acquire(session_factory, "mvn:test")
+
+    assert lock.acquired is True
+    assert lock.connection is connection
+    assert connection.closed is False
+    assert connection.execution_options_calls == [{"isolation_level": "AUTOCOMMIT"}]
+    assert await lock.is_held() is True
+
+    await lock.release()
+
+    assert lock.acquired is False
+    assert lock.connection is None
+    assert connection.closed is True
+    assert connection.invalidated is False
+    assert engine.connect_calls == 1
+    assert [
+        "pg_try_advisory_lock"
+        if "pg_try_advisory_lock" in sql
+        else "pg_advisory_unlock"
+        if "pg_advisory_unlock" in sql
+        else "pg_locks"
+        for sql, _ in connection.execute_calls
+    ] == ["pg_try_advisory_lock", "pg_locks", "pg_advisory_unlock"]
+
+
+@pytest.mark.asyncio
+async def test_held_postgres_lock_closes_connection_and_is_retryable(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    connection = FakeConnection(acquire_result=False)
+    engine = FakeEngine(connection)
+    monkeypatch.setattr(
+        RuntimeLockService,
+        "_resolve_engine",
+        AsyncMock(return_value=(engine, "postgresql")),
+    )
+
+    lock = await RuntimeLockService.try_acquire(Mock(), "mvn:test")
+
+    assert lock.acquired is False
+    assert lock.retryable is True
+    assert lock.connection is None
+    assert connection.closed is True
+    assert connection.invalidated is False
+
+
+@pytest.mark.asyncio
+async def test_required_lock_fails_closed_when_database_locks_disabled(monkeypatch):
+    monkeypatch.setattr(
+        runtime_locks.settings,
+        "RUNTIME_DB_LOCKS_ENABLED",
+        False,
+        raising=False,
+    )
+    session_factory = Mock()
+
+    required_lock = await RuntimeLockService.try_acquire(
+        session_factory,
+        "mvn:test",
+        required=True,
+    )
+    compatibility_lock = await RuntimeLockService.try_acquire(session_factory, "mvn:test")
+
+    assert required_lock.acquired is False
+    assert required_lock.retryable is False
+    assert "required" in required_lock.reason
+    assert compatibility_lock.acquired is True
+    session_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_required_lock_fails_closed_for_non_postgres(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    engine = FakeEngine(FakeConnection())
+    monkeypatch.setattr(
+        RuntimeLockService,
+        "_resolve_engine",
+        AsyncMock(return_value=(engine, "sqlite")),
+    )
+
+    lock = await RuntimeLockService.wait_until_acquired(
+        Mock(),
+        "mvn:test",
+        required=True,
+    )
+
+    assert lock.acquired is False
+    assert lock.retryable is False
+    assert "sqlite" in lock.reason
+    assert engine.connect_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_real_session_factory_resolves_non_postgres_fail_closed(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    engine = create_async_engine("sqlite+aiosqlite://")
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        lock = await RuntimeLockService.try_acquire(
+            session_factory,
+            "mvn:test",
+            required=True,
+        )
+    finally:
+        await engine.dispose()
+
+    assert lock.acquired is False
+    assert lock.connection is None
+    assert "sqlite" in lock.reason
+
+
+@pytest.mark.asyncio
+async def test_lock_liveness_returns_false_for_closed_or_failed_connection():
+    closed_connection = FakeConnection()
+    closed_connection.closed = True
+    closed_lock = RuntimeLock("mvn:closed", closed_connection, True, "test")
+
+    assert await closed_lock.is_held() is False
+    assert closed_connection.execute_calls == []
+
+    failed_connection = FakeConnection()
+    failed_connection.liveness_error = RuntimeError("connection lost")
+    failed_lock = RuntimeLock("mvn:failed", failed_connection, True, "test")
+
+    assert await failed_lock.is_held() is False
+    failed_connection.liveness_error = None
+    await failed_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_lock_liveness_failure_does_not_reconnect(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    connection = FakeConnection()
+    engine = FakeEngine(connection)
+    monkeypatch.setattr(
+        RuntimeLockService,
+        "_resolve_engine",
+        AsyncMock(return_value=(engine, "postgresql")),
+    )
+    lock = await RuntimeLockService.try_acquire(Mock(), "mvn:test")
+    connection.liveness_error = ConnectionError("backend terminated")
+
+    assert await lock.is_held() is False
+    assert engine.connect_calls == 1
+
+    connection.liveness_error = None
+    await lock.release()
+
+
+@pytest.mark.asyncio
+async def test_release_failure_invalidates_connection_instead_of_pooling_it():
+    connection = FakeConnection()
+    connection.unlock_error = ConnectionError("backend lost during unlock")
+    lock = RuntimeLock("mvn:test", connection, True, "test")
+
+    with pytest.raises(ConnectionError, match="backend lost"):
+        await lock.release()
+
+    assert lock.acquired is False
+    assert lock.connection is None
+    assert connection.invalidated is True
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_acquire_invalidates_uncertain_connection(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    connection = FakeConnection()
+    connection.acquire_error = asyncio.CancelledError()
+    engine = FakeEngine(connection)
+    monkeypatch.setattr(
+        RuntimeLockService,
+        "_resolve_engine",
+        AsyncMock(return_value=(engine, "postgresql")),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await RuntimeLockService.try_acquire(Mock(), "mvn:test")
+
+    assert connection.invalidated is True
+    assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_wait_until_acquired_is_cancellable_during_backoff(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    held_lock = RuntimeLock(
+        "mvn:test",
+        None,
+        False,
+        "held elsewhere",
+        retryable=True,
+    )
+    try_acquire = AsyncMock(return_value=held_lock)
+    monkeypatch.setattr(RuntimeLockService, "try_acquire", try_acquire)
+    sleeping = asyncio.Event()
+
+    async def sleep_forever(_seconds):
+        sleeping.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(runtime_locks.asyncio, "sleep", sleep_forever)
+    task = asyncio.create_task(
+        RuntimeLockService.wait_until_acquired(Mock(), "mvn:test")
+    )
+    await asyncio.wait_for(sleeping.wait(), timeout=0.2)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    try_acquire.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_wait_until_acquired_retries_held_lock_then_returns_new_owner(monkeypatch):
+    _enable_runtime_locks(monkeypatch)
+    held_lock = RuntimeLock(
+        "mvn:test",
+        None,
+        False,
+        "held elsewhere",
+        retryable=True,
+    )
+    acquired_lock = RuntimeLock("mvn:test", None, True, "acquired")
+    try_acquire = AsyncMock(side_effect=[held_lock, acquired_lock])
+    monkeypatch.setattr(RuntimeLockService, "try_acquire", try_acquire)
+    backoff_started = asyncio.Event()
+    allow_retry = asyncio.Event()
+
+    async def controlled_sleep(_seconds):
+        backoff_started.set()
+        await allow_retry.wait()
+
+    monkeypatch.setattr(runtime_locks.asyncio, "sleep", controlled_sleep)
+    task = asyncio.create_task(
+        RuntimeLockService.wait_until_acquired(Mock(), "mvn:test")
+    )
+    await asyncio.wait_for(backoff_started.wait(), timeout=0.2)
+
+    allow_retry.set()
+    result = await asyncio.wait_for(task, timeout=0.2)
+
+    assert result is acquired_lock
+    assert try_acquire.await_count == 2


### PR DESCRIPTION
## Summary

- move PostgreSQL runtime advisory locks onto a dedicated pinned `AUTOCOMMIT` connection and continuously prove ownership
- replace one-shot scheduler startup with a retrying supervisor, bounded probes, minimum 12-second fencing, and whole-process fail-stop for ownership loss, scheduler failure, or shutdown after scheduler work begins
- expose allowlisted `scheduler_runtime` readiness state and require a monotonic stability window before blue-green activation
- make blue-green rollback zero-gap through a third API-only slot, fail closed on uncertain stops/routes, and bound scheduler-owner shutdown to 5 seconds for backward-compatible first rollout safety
- use the active container's immutable `Config.Image` as runtime truth, reconcile `.env` drift, and require both API and bot images before `already_active`
- stop automatically requeueing unleased `running` catalog imports during startup
- extend production Patroni checks, deploy/helper delivery, runbooks, and failure-injection coverage

## Safety invariants

- at most one scheduler owner can execute work
- a new owner cannot start before the previous process is fenced or force-killed
- no advisory lock connection is returned to the pool while held and no lock transaction remains idle
- rollback never stops the routed candidate until a ready API-only buffer or confirmed old route is serving
- ambiguous runtime image, container count, stop, route, or state synchronization fails closed

## Verification

- `pytest tests/unit -q` — **1096 passed**
- `pytest tests/integration -q` — **187 passed** (one pre-existing isolated SQLAlchemy warning in supplier flow)
- focused scheduler/deploy/runtime-lock suite — **116 passed**
- real PostgreSQL two-supervisor takeover repeated successfully
- `bash -n` — passed
- `shellcheck -e SC2016` — passed
- `python3 -m compileall` — passed
- `git diff --check` — passed
- pre-commit OpenAPI and manager client sync — passed with no generated diff

## Rollout checks

After deploy, verify:

1. `/api/ready.scheduler_runtime` is `expected=true`, `status=running` on the primary.
2. Exactly one `mvn:scheduler` advisory lock exists.
3. Its PostgreSQL backend is `idle` with `xact_start IS NULL`, never `idle in transaction`.
4. Candidate logs show wait/fence/start only after the old slot is stopped.
5. Patroni production checks and public API smoke checks remain green.
