### PR TITLE
Modernize Telegram defect act workflow

### DIFF
--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -17,6 +17,7 @@ from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.bot_task_service import BotTaskService
+from .repair_context import repair_context_keyboard as _repair_context_keyboard
 from ..config import bot
 from ..states import ShopState
 
@@ -343,24 +344,6 @@ def _serial_details_preview_lines(validation_flags: dict) -> list[str]:
     return lines
 
 
-def _repair_context_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
-        ]
-    )
-
-
-def _repair_comment_preview_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="Записать и продолжить", callback_data="repair_comment_confirm")],
-            [InlineKeyboardButton(text="Не записывать", callback_data="repair_comment_cancel")],
-            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
-        ]
-    )
-
-
 def _repair_nameplate_preview_text(data: dict[str, object]) -> str:
     extracted = data.get("extracted") if isinstance(data.get("extracted"), dict) else {}
     validation_flags = data.get("validation_flags") if isinstance(data.get("validation_flags"), dict) else {}
@@ -459,35 +442,6 @@ def _warranty_nameplate_preview_text(data: dict[str, object]) -> str:
     if warnings:
         lines.extend(["", "<b>Предупреждения:</b>"])
         lines.extend(f"• {escape(str(message))}" for message in warnings.values())
-    return "\n".join(lines)
-
-
-def _repair_comment_preview_text(data: dict[str, object]) -> str:
-    merge_preview = data.get("merge_preview") if isinstance(data.get("merge_preview"), dict) else {}
-    changes = merge_preview.get("changes") if isinstance(merge_preview.get("changes"), dict) else {}
-    unchanged = merge_preview.get("unchanged") if isinstance(merge_preview.get("unchanged"), dict) else {}
-
-    lines = ["<b>Подготовил поля дефектного акта из комментария:</b>"]
-    if changes:
-        lines.extend(["", "<b>Будет записано/обновлено:</b>"])
-        for field, values in changes.items():
-            label = BotRepairNameplateService.COMMENT_FIELD_LABELS.get(field, field)
-            candidate = values.get("candidate") if isinstance(values, dict) else values
-            existing = values.get("existing") if isinstance(values, dict) else ""
-            if existing:
-                lines.append(f"• <b>{escape(label)}:</b> {escape(str(candidate))}")
-                lines.append(f"  Было: {escape(str(existing))}")
-            else:
-                lines.append(f"• <b>{escape(label)}:</b> {escape(str(candidate))}")
-    if unchanged:
-        lines.extend(["", "<b>Без изменений:</b>"])
-        lines.extend(
-            f"• {escape(BotRepairNameplateService.COMMENT_FIELD_LABELS.get(field, field))}"
-            for field in unchanged.keys()
-        )
-    if not changes and not unchanged:
-        lines.append("")
-        lines.append("AI не вернул полезных полей. Лучше отправить комментарий подробнее.")
     return "\n".join(lines)
 
 
@@ -1118,7 +1072,11 @@ async def confirm_repair_nameplate(callback: CallbackQuery, state: FSMContext):
     if conflict_count:
         lines.append(f"Конфликты оставил без перезаписи: {conflict_count}.")
     lines.append("")
-    lines.append("Теперь можно отправлять комментарии по диагностике текстом или голосом в текст. Я подготовлю поля дефектного акта по этому заказу.")
+    lines.append("Выберите частый диагноз кнопкой ниже или пришлите свободный комментарий текстом.")
+    lines.append(
+        "Например: «КЗ компрессора», «обрыв обмотки», «компрессор хрустит и выбивает автомат» "
+        "или «после пайки вскрываются новые свищи теплообменника»."
+    )
     await callback.message.edit_text("\n".join(lines), reply_markup=_repair_context_keyboard())
     await callback.answer()
 
@@ -1397,119 +1355,6 @@ async def cancel_warranty_nameplate(callback: CallbackQuery, state: FSMContext):
     await state.update_data(pending_warranty_nameplate=None, pending_requisites_file=None)
     await state.set_state(None)
     await callback.message.edit_text("Ок, гарантийный шильдик оставил без обработки.")
-    await callback.answer()
-
-
-@router.message(ShopState.waiting_for_repair_context_comment)
-async def handle_repair_context_comment(message: types.Message, state: FSMContext):
-    context = await _get_bot_access_context(message.from_user.id if message.from_user else None)
-    if not context.is_staff:
-        await state.clear()
-        return
-
-    text = str(message.text or "").strip()
-    if not text:
-        await message.answer("Пришлите диагностический комментарий текстом.")
-        return
-    if text.casefold() in {"стоп", "завершить", "готово", "отмена"}:
-        await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
-        await state.set_state(None)
-        await message.answer("Ок, вышел из режима заметок по ремонту.")
-        return
-
-    data = await state.get_data()
-    active_context = data.get("active_repair_order_context") or {}
-    order_id = _parse_order_id(str(active_context.get("order_id") if isinstance(active_context, dict) else ""))
-    if not order_id:
-        await state.set_state(None)
-        await message.answer("Контекст ремонтного заказа потерян. Отправьте шильдик или выберите заказ заново.")
-        return
-
-    progress = await message.answer("Готовлю поля дефектного акта из комментария…")
-    try:
-        async with async_session_maker() as session:
-            draft = await BotRepairNameplateService.build_diagnostic_comment_draft(
-                session,
-                order_id=order_id,
-                comment=text,
-            )
-    except Exception as exc:
-        await progress.edit_text(f"❌ Не удалось обработать комментарий: {escape(str(exc))}")
-        return
-
-    if not draft:
-        await progress.edit_text("Ремонтный заказ не найден. Выйдите из режима и выберите заказ заново.")
-        return
-
-    draft["telegram_message_id"] = message.message_id
-    draft["telegram_chat_id"] = message.chat.id if message.chat else None
-    await state.update_data(pending_repair_comment=draft)
-    await progress.edit_text(
-        _repair_comment_preview_text(draft),
-        reply_markup=_repair_comment_preview_keyboard(),
-        parse_mode="HTML",
-    )
-
-
-@router.callback_query(F.data == "repair_comment_confirm")
-async def confirm_repair_context_comment(callback: CallbackQuery, state: FSMContext):
-    context = await _get_bot_access_context(callback.from_user.id)
-    if not context.is_staff:
-        await callback.answer("Недостаточно прав", show_alert=True)
-        return
-
-    data = await state.get_data()
-    active_context = data.get("active_repair_order_context") or {}
-    order_id = _parse_order_id(str(active_context.get("order_id") if isinstance(active_context, dict) else ""))
-    draft = data.get("pending_repair_comment") or {}
-    if not order_id or not isinstance(draft, dict):
-        await callback.answer("Черновик комментария не найден.", show_alert=True)
-        return
-
-    async with async_session_maker() as session:
-        result = await BotRepairNameplateService.apply_diagnostic_comment(
-            session,
-            order_id,
-            repair_meta_draft=draft.get("repair_meta") or {},
-            raw_comment=str(draft.get("comment") or ""),
-            telegram_user_id=callback.from_user.id,
-            telegram_chat_id=draft.get("telegram_chat_id"),
-            telegram_message_id=draft.get("telegram_message_id"),
-            can_attach_any=context.is_manager,
-        )
-
-    if not result:
-        await callback.answer("Заказ не найден или недоступен.", show_alert=True)
-        return
-
-    await state.update_data(pending_repair_comment=None)
-    await state.set_state(ShopState.waiting_for_repair_context_comment)
-    changed_count = len(result.get("changes") or {})
-    await callback.message.edit_text(
-        f"✅ Комментарий записан в ремонт #{result['id']}.\n"
-        f"Обновлено полей: {changed_count}.\n\n"
-        "Можно отправить следующий диагностический комментарий.",
-        reply_markup=_repair_context_keyboard(),
-    )
-    await callback.answer()
-
-
-@router.callback_query(F.data == "repair_comment_cancel")
-async def cancel_repair_context_comment(callback: CallbackQuery, state: FSMContext):
-    await state.update_data(pending_repair_comment=None)
-    await state.set_state(ShopState.waiting_for_repair_context_comment)
-    await callback.message.edit_text(
-        "Ок, комментарий не записал. Можно отправить следующий диагностический комментарий.",
-        reply_markup=_repair_context_keyboard(),
-    )
-    await callback.answer()
-
-
-@router.callback_query(F.data == "repair_context_finish")
-async def finish_repair_context(callback: CallbackQuery, state: FSMContext):
-    await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
-    await state.set_state(None)
-    await callback.message.edit_text("Ок, вышел из режима заметок по ремонту.")
     await callback.answer()
 
 

--- a/bot_app/handlers/repair_context.py
+++ b/bot_app/handlers/repair_context.py
@@ -1,0 +1,253 @@
+from html import escape
+
+from aiogram import F, Router, types
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
+
+from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
+from services.bot_defect_act_service import BotDefectActService
+
+from ..states import ShopState
+
+router = Router()
+
+REPAIR_PRESET_FAULT_TYPES = {
+    "repair_preset_compressor_short": "compressor_short_circuit",
+    "repair_preset_compressor_open": "compressor_winding_open",
+    "repair_preset_compressor_mechanical": "compressor_mechanical_failure",
+    "repair_preset_heat_exchanger_multiple": "heat_exchanger_multiple_leaks",
+}
+
+
+async def _access_context(user_id: int | None):
+    async with async_session_maker() as session:
+        return await BotAccessService.get_context(session, user_id)
+
+
+def _parse_order_id(value: object) -> int | None:
+    text = str(value or "").strip().lstrip("#").strip()
+    if not text.isdigit():
+        return None
+    order_id = int(text)
+    return order_id if order_id > 0 else None
+
+
+def repair_context_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="КЗ компрессора", callback_data="repair_preset_compressor_short")],
+            [InlineKeyboardButton(text="Обрыв обмотки", callback_data="repair_preset_compressor_open")],
+            [InlineKeyboardButton(text="Механика компрессора", callback_data="repair_preset_compressor_mechanical")],
+            [
+                InlineKeyboardButton(
+                    text="Множественные утечки",
+                    callback_data="repair_preset_heat_exchanger_multiple",
+                )
+            ],
+            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
+        ]
+    )
+
+
+def repair_comment_preview_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Записать и продолжить", callback_data="repair_comment_confirm")],
+            [InlineKeyboardButton(text="Не записывать", callback_data="repair_comment_cancel")],
+            [InlineKeyboardButton(text="Завершить заметки", callback_data="repair_context_finish")],
+        ]
+    )
+
+
+def repair_comment_preview_text(data: dict[str, object]) -> str:
+    repair_meta = data.get("repair_meta") if isinstance(data.get("repair_meta"), dict) else {}
+    merge_preview = data.get("merge_preview") if isinstance(data.get("merge_preview"), dict) else {}
+    changes = merge_preview.get("changes") if isinstance(merge_preview.get("changes"), dict) else {}
+
+    lines = ["<b>Проверьте дефектный акт перед записью:</b>"]
+    preview_fields = (
+        ("likely_diagnosis", "Диагноз"),
+        ("inspection_work_done", "Проведено"),
+        ("diagnostic_result", "Выявлено"),
+        ("technical_conclusion", "Заключение"),
+    )
+    preview_values = 0
+    for field, label in preview_fields:
+        value = repair_meta.get(field)
+        if value:
+            lines.append(f"<b>{label}:</b> {escape(str(value))}")
+            preview_values += 1
+
+    preview_field_names = {field for field, _label in preview_fields}
+    replacement_count = sum(
+        1
+        for field, values in changes.items()
+        if field in preview_field_names
+        and isinstance(values, dict)
+        and values.get("existing") not in (None, "")
+    )
+    if replacement_count:
+        lines.extend(["", f"Ранее заполненные данные будут обновлены: {replacement_count}."])
+    if not preview_values:
+        lines.extend(["", "Основные строки не заполнены. Лучше отправить комментарий подробнее."])
+    return "\n".join(lines)
+
+
+@router.callback_query(F.data.startswith("repair_preset_"))
+async def prepare_repair_diagnostic_preset(callback: CallbackQuery, state: FSMContext):
+    context = await _access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    fault_type = REPAIR_PRESET_FAULT_TYPES.get(str(callback.data or ""))
+    if not fault_type:
+        await callback.answer("Неизвестный вариант диагностики.", show_alert=True)
+        return
+
+    data = await state.get_data()
+    active_context = data.get("active_repair_order_context") or {}
+    order_id = _parse_order_id(active_context.get("order_id") if isinstance(active_context, dict) else None)
+    if not order_id:
+        await state.update_data(pending_repair_comment=None)
+        await state.set_state(None)
+        await callback.answer("Контекст ремонтного заказа потерян. Выберите заказ заново.", show_alert=True)
+        return
+
+    try:
+        async with async_session_maker() as session:
+            draft = await BotDefectActService.build_diagnostic_preset_draft(
+                session,
+                order_id=order_id,
+                fault_type=fault_type,
+            )
+    except Exception as exc:
+        await callback.answer(f"Не удалось подготовить дефектный акт: {exc}", show_alert=True)
+        return
+
+    if not isinstance(draft, dict):
+        await callback.answer("Ремонтный заказ не найден. Выберите заказ заново.", show_alert=True)
+        return
+
+    await state.update_data(pending_repair_comment=draft)
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    await callback.message.edit_text(
+        repair_comment_preview_text(draft),
+        reply_markup=repair_comment_preview_keyboard(),
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@router.message(ShopState.waiting_for_repair_context_comment)
+async def handle_repair_context_comment(message: types.Message, state: FSMContext):
+    context = await _access_context(message.from_user.id if message.from_user else None)
+    if not context.is_staff:
+        await state.clear()
+        return
+
+    text = str(message.text or "").strip()
+    if not text:
+        await message.answer("Пришлите диагностический комментарий текстом.")
+        return
+    if text.casefold() in {"стоп", "завершить", "готово", "отмена"}:
+        await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
+        await state.set_state(None)
+        await message.answer("Ок, вышел из режима заметок по ремонту.")
+        return
+
+    data = await state.get_data()
+    active_context = data.get("active_repair_order_context") or {}
+    order_id = _parse_order_id(active_context.get("order_id") if isinstance(active_context, dict) else None)
+    if not order_id:
+        await state.set_state(None)
+        await message.answer("Контекст ремонтного заказа потерян. Отправьте шильдик или выберите заказ заново.")
+        return
+
+    progress = await message.answer("Готовлю краткий дефектный акт из комментария…")
+    try:
+        async with async_session_maker() as session:
+            draft = await BotDefectActService.build_diagnostic_comment_draft(
+                session,
+                order_id=order_id,
+                comment=text,
+            )
+    except Exception as exc:
+        await progress.edit_text(f"❌ Не удалось обработать комментарий: {escape(str(exc))}")
+        return
+
+    if not draft:
+        await progress.edit_text("Ремонтный заказ не найден. Выйдите из режима и выберите заказ заново.")
+        return
+
+    draft["telegram_message_id"] = message.message_id
+    draft["telegram_chat_id"] = message.chat.id if message.chat else None
+    await state.update_data(pending_repair_comment=draft)
+    await progress.edit_text(
+        repair_comment_preview_text(draft),
+        reply_markup=repair_comment_preview_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(F.data == "repair_comment_confirm")
+async def confirm_repair_context_comment(callback: CallbackQuery, state: FSMContext):
+    context = await _access_context(callback.from_user.id)
+    if not context.is_staff:
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    data = await state.get_data()
+    active_context = data.get("active_repair_order_context") or {}
+    order_id = _parse_order_id(active_context.get("order_id") if isinstance(active_context, dict) else None)
+    draft = data.get("pending_repair_comment") or {}
+    if not order_id or not isinstance(draft, dict):
+        await callback.answer("Черновик комментария не найден.", show_alert=True)
+        return
+
+    async with async_session_maker() as session:
+        result = await BotDefectActService.apply_diagnostic_comment(
+            session,
+            order_id,
+            repair_meta_draft=draft.get("repair_meta") or {},
+            raw_comment=str(draft.get("comment") or ""),
+            telegram_user_id=callback.from_user.id,
+            telegram_chat_id=draft.get("telegram_chat_id"),
+            telegram_message_id=draft.get("telegram_message_id"),
+            can_attach_any=context.is_manager,
+        )
+
+    if not result:
+        await callback.answer("Заказ не найден или недоступен.", show_alert=True)
+        return
+
+    await state.update_data(pending_repair_comment=None)
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    changed_count = len(result.get("changes") or {})
+    await callback.message.edit_text(
+        f"✅ Комментарий записан в ремонт #{result['id']}.\n"
+        f"Обновлено полей: {changed_count}.\n\n"
+        "Можно отправить следующий диагностический комментарий.",
+        reply_markup=repair_context_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_comment_cancel")
+async def cancel_repair_context_comment(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(pending_repair_comment=None)
+    await state.set_state(ShopState.waiting_for_repair_context_comment)
+    await callback.message.edit_text(
+        "Ок, комментарий не записал. Можно отправить следующий диагностический комментарий.",
+        reply_markup=repair_context_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "repair_context_finish")
+async def finish_repair_context(callback: CallbackQuery, state: FSMContext):
+    await state.update_data(active_repair_order_context=None, pending_repair_comment=None)
+    await state.set_state(None)
+    await callback.message.edit_text("Ок, вышел из режима заметок по ремонту.")
+    await callback.answer()

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -2,7 +2,7 @@ import asyncio
 from aiogram import types
 from aiogram.types import BotCommand
 from .config import bot, dp
-from .handlers import admin, base, catalog, work
+from .handlers import admin, base, catalog, repair_context, work
 from core.config import settings
 from core.database import async_session_maker
 from core.logger import setup_logging
@@ -64,6 +64,7 @@ async def main(*, wait_when_disabled: bool = True):
     dp.include_router(base.router)
     dp.include_router(work.router)
     dp.include_router(catalog.router)
+    dp.include_router(repair_context.router)
     dp.include_router(admin.router)
     
     try:

--- a/docs/bot-defect-act-v3.md
+++ b/docs/bot-defect-act-v3.md
@@ -1,0 +1,44 @@
+# Telegram defect act V3
+
+## Goal
+
+The bot produces a short customer-facing defect act from a nameplate and field comments. DeepSeek classifies facts; local templates own the final wording.
+
+## Document structure
+
+1. Equipment: `Кондиционер <brand> <model>`.
+2. Performed: one controlled diagnostic-work sentence.
+3. Detected: one diagnosis sentence plus up to three explicitly stated facts.
+4. Conclusion: repair, additional diagnostics, or decommissioning/write-off.
+
+Raw technician comments remain in order history but are not copied into the document verbatim.
+
+## Controlled write-off profiles
+
+- `compressor_short_circuit`: short circuit in compressor windings.
+- `compressor_winding_open`: open compressor winding.
+- `compressor_mechanical_failure`: mechanical failure, seizure, abnormal noise, or no pressure differential.
+- `heat_exchanger_multiple_leaks`: multiple through-corrosion points and recurring heat-exchanger leaks.
+
+The last profile uses the engineering term "multiple corrosion perforation". It explains why local brazing cannot restore reliable tightness.
+
+## AI boundary
+
+DeepSeek may return only:
+
+- a known `fault_type`;
+- controlled `inspection_codes`;
+- up to three `confirmed_facts` copied from input meaning;
+- structured operation and decision codes.
+
+It must not generate document prose, measurements, serial numbers, dates, or completed checks that are absent from the input. Temperature is kept low; local templates force the write-off decision for the four exact profiles.
+
+## Extension rule
+
+Add a new diagnosis in three places:
+
+1. Backend profile in `RepairDefectTemplateService.TEMPLATES`.
+2. Classification guidance in `DefectActAIService.build_prompt`.
+3. Manager option or Telegram preset only when staff need a direct control for it.
+
+Keep generic `compressor_failure`, `heat_exchanger_damage`, and `unknown_fault` as fallbacks when the subtype is not confirmed.

--- a/manager_frontend/src/components/orders/repair-meta.ts
+++ b/manager_frontend/src/components/orders/repair-meta.ts
@@ -18,6 +18,7 @@ export type RepairMeta = {
   equipment_name: string;
   equipment_brand: string;
   equipment_model: string;
+  equipment_models?: string[];
   equipment_power: string;
   equipment_serial_number: string;
   equipment_inventory_number: string;
@@ -42,6 +43,9 @@ export type RepairMeta = {
   repair_estimate_text: string;
   risks?: string[];
   recommended_actions?: string[];
+  inspection_codes?: string[];
+  confirmed_facts?: string[];
+  decision?: 'repair' | 'write_off' | 'additional_diagnostics' | string;
   hidden_defects_possible?: boolean;
   structured_diagnosis?: Record<string, any>;
   defect_act_blocks?: Record<string, string>;
@@ -101,6 +105,7 @@ export const emptyRepairMeta = (): RepairMeta => ({
   equipment_name: '',
   equipment_brand: '',
   equipment_model: '',
+  equipment_models: [],
   equipment_power: '',
   equipment_serial_number: '',
   equipment_inventory_number: '',
@@ -125,6 +130,9 @@ export const emptyRepairMeta = (): RepairMeta => ({
   repair_estimate_text: '',
   risks: [],
   recommended_actions: [],
+  inspection_codes: [],
+  confirmed_facts: [],
+  decision: '',
   hidden_defects_possible: false,
   structured_diagnosis: {},
   defect_act_blocks: {},
@@ -170,9 +178,29 @@ export const REPAIR_AI_DEFECT_TYPES: RepairAiDefectType[] = [
     hint: 'шум, отсутствие вращения, перегрев, ошибка вентилятора',
   },
   {
+    value: 'compressor_short_circuit',
+    label: 'Короткое замыкание обмоток компрессора',
+    hint: 'низкое сопротивление обмоток, пробой на корпус, срабатывание автомата или защиты',
+  },
+  {
+    value: 'compressor_winding_open',
+    label: 'Обрыв обмотки компрессора',
+    hint: 'обрыв при прозвонке, компрессор не запускается, одна из обмоток не определяется',
+  },
+  {
+    value: 'compressor_mechanical_failure',
+    label: 'Механическая неисправность компрессора',
+    hint: 'стук или гул, заклинивание, повышенный ток, нет перепада давления',
+  },
+  {
     value: 'compressor_failure',
     label: 'Неисправность компрессора',
     hint: 'электрическая или механическая неисправность компрессора, срабатывание защиты',
+  },
+  {
+    value: 'heat_exchanger_multiple_leaks',
+    label: 'Множественная коррозионная перфорация теплообменника',
+    hint: 'сквозная коррозия и утечки в нескольких точках, новые свищи после опрессовки',
   },
   {
     value: 'heat_exchanger_damage',

--- a/openapi.json
+++ b/openapi.json
@@ -31453,7 +31453,7 @@
           "prompt_version": {
             "type": "string",
             "title": "Prompt Version",
-            "default": "defect_act_v2"
+            "default": "defect_act_v3"
           }
         },
         "type": "object",

--- a/schemas.py
+++ b/schemas.py
@@ -3772,7 +3772,7 @@ class ManagerRepairActAiDraftResponse(BaseModel):
     repair_meta: Dict[str, Any] = Field(default_factory=dict)
     provider: str = "deepseek"
     model: str
-    prompt_version: str = "defect_act_v2"
+    prompt_version: str = "defect_act_v3"
 
 
 # --- SERVICE ESTIMATES ---

--- a/services/bot_defect_act_service.py
+++ b/services/bot_defect_act_service.py
@@ -1,0 +1,281 @@
+import re
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+
+from models import Order
+from schemas import ManagerRepairActAiDraftPayload
+from services.bot_repair_nameplate_service import BotRepairNameplateService
+from services.defect_act_ai_service import DefectActAIService
+from services.order_service import OrderService
+from services.repair_defect_template_service import RepairDefectTemplateService
+
+
+class BotDefectActService:
+    """Builds and applies compact defect-act drafts for an active repair order."""
+
+    COMMENT_HISTORY_META_KEY = "bot_diagnostic_comments"
+    PRESET_FAULT_TYPES = {
+        "compressor_short_circuit",
+        "compressor_winding_open",
+        "compressor_mechanical_failure",
+        "heat_exchanger_multiple_leaks",
+    }
+    COMMENT_FIELDS = (
+        "fault_type",
+        "fault_location",
+        "operation_status",
+        "decision",
+        "risks",
+        "recommended_actions",
+        "inspection_codes",
+        "confirmed_facts",
+        "hidden_defects_possible",
+        "structured_diagnosis",
+        "defect_act_blocks",
+        "customer_complaint",
+        "complaint_official",
+        "likely_diagnosis",
+        "technical_condition",
+        "inspection_work_done",
+        "startup_check_result",
+        "compressor_check_result",
+        "measurement_result",
+        "diagnostic_result",
+        "further_use_assessment",
+        "operation_restrictions",
+        "technical_conclusion",
+        "repair_feasibility",
+        "recommended_decision",
+        "repair_recommendation",
+        "repair_possible",
+        "refrigerant_type",
+        "refrigerant_amount",
+        "refrigerant_pricing_mode",
+        "repair_not_viable",
+        "repair_not_viable_reason",
+        "repair_estimate_text",
+    )
+
+    @staticmethod
+    def _clean_text(value: Any, *, max_length: int = 1200) -> str:
+        text = str(value or "").strip()
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text[:max_length].strip()
+
+    @classmethod
+    def _normalize_comment_value(cls, value: Any) -> Any:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, dict):
+            return deepcopy(value)
+        if isinstance(value, list):
+            items = [cls._clean_text(item, max_length=300) for item in value]
+            return [item for item in items if item]
+        return cls._clean_text(value)
+
+    @staticmethod
+    def _has_comment_value(value: Any) -> bool:
+        if isinstance(value, bool):
+            return True
+        return bool(value)
+
+    @classmethod
+    def preview_comment_merge(
+        cls,
+        current_repair_meta: dict[str, Any],
+        draft_meta: dict[str, Any],
+    ) -> dict[str, Any]:
+        changes: dict[str, dict[str, Any]] = {}
+        unchanged: dict[str, Any] = {}
+        for field in cls.COMMENT_FIELDS:
+            candidate = cls._normalize_comment_value(draft_meta.get(field))
+            if not cls._has_comment_value(candidate):
+                continue
+            existing = cls._normalize_comment_value(current_repair_meta.get(field))
+            if existing == candidate:
+                unchanged[field] = candidate
+                continue
+            changes[field] = {
+                "existing": existing if cls._has_comment_value(existing) else "",
+                "candidate": candidate,
+            }
+        return {"changes": changes, "unchanged": unchanged}
+
+    @classmethod
+    def _comment_payload(
+        cls,
+        *,
+        repair_meta: dict[str, Any],
+        comment: str,
+    ) -> ManagerRepairActAiDraftPayload:
+        return ManagerRepairActAiDraftPayload(
+            defect_type="field_diagnostic_note",
+            defect_label="Диагностическая заметка с выезда",
+            allow_assumptions=False,
+            polish_existing=True,
+            equipment_name=cls._clean_text(repair_meta.get("equipment_name"), max_length=200),
+            equipment_brand=cls._clean_text(repair_meta.get("equipment_brand"), max_length=120),
+            equipment_model=cls._clean_text(repair_meta.get("equipment_model"), max_length=200),
+            equipment_power=cls._clean_text(repair_meta.get("equipment_power"), max_length=120),
+            customer_complaint=cls._clean_text(repair_meta.get("customer_complaint"), max_length=500),
+            complaint_official=cls._clean_text(repair_meta.get("complaint_official"), max_length=500),
+            likely_diagnosis=cls._clean_text(repair_meta.get("likely_diagnosis"), max_length=500),
+            extra_context=comment,
+            current_meta=repair_meta,
+        )
+
+    @classmethod
+    async def build_diagnostic_comment_draft(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        comment: str,
+    ) -> dict[str, Any] | None:
+        result = await session.execute(
+            select(Order)
+            .where(Order.id == order_id)
+            .options(selectinload(Order.customer))
+            .limit(1)
+        )
+        order = result.scalars().first()
+        if not order or OrderService._normalize_workflow_type(order.workflow_type) != "repair":
+            return None
+
+        raw_comment = cls._clean_text(comment, max_length=4000)
+        if not raw_comment:
+            raise ValueError("Комментарий пустой")
+
+        repair_meta = OrderService._get_repair_meta(order)
+        ai_meta = await DefectActAIService.generate_repair_meta(
+            cls._comment_payload(repair_meta=repair_meta, comment=raw_comment)
+        )
+        return {
+            "order": BotRepairNameplateService._map_order(order),
+            "comment": raw_comment,
+            "repair_meta": ai_meta,
+            "merge_preview": cls.preview_comment_merge(repair_meta, ai_meta),
+        }
+
+    @classmethod
+    async def build_diagnostic_preset_draft(
+        cls,
+        session: AsyncSession,
+        *,
+        order_id: int,
+        fault_type: str,
+    ) -> dict[str, Any] | None:
+        normalized_fault_type = RepairDefectTemplateService.normalize_fault_type(fault_type)
+        if normalized_fault_type not in cls.PRESET_FAULT_TYPES:
+            raise ValueError("Неизвестный шаблон диагностики")
+
+        result = await session.execute(
+            select(Order)
+            .where(Order.id == order_id)
+            .options(selectinload(Order.customer))
+            .limit(1)
+        )
+        order = result.scalars().first()
+        if not order or OrderService._normalize_workflow_type(order.workflow_type) != "repair":
+            return None
+
+        repair_meta = OrderService._get_repair_meta(order)
+        template = RepairDefectTemplateService.TEMPLATES[normalized_fault_type]
+        render_current_meta = {
+            key: value
+            for key, value in repair_meta.items()
+            if key not in DefectActAIService.FIELD_NOTE_REFRESH_KEYS
+        }
+        preset_meta = RepairDefectTemplateService.build_meta_from_structured(
+            raw={
+                "fault_type": normalized_fault_type,
+                "repairable": template["repairable"],
+                "decision": template.get("decision"),
+                "operation_status": template["operation_status"],
+                "risks": template["risks"],
+                "recommended_actions": template["recommended_actions"],
+                "inspection_codes": template.get("inspection_codes", []),
+                "hidden_defects_possible": False,
+            },
+            current_meta=render_current_meta,
+        )
+        return {
+            "order": BotRepairNameplateService._map_order(order),
+            "comment": f"Типовой диагноз: {template['label']}",
+            "repair_meta": preset_meta,
+            "merge_preview": cls.preview_comment_merge(repair_meta, preset_meta),
+        }
+
+    @classmethod
+    async def apply_diagnostic_comment(
+        cls,
+        session: AsyncSession,
+        order_id: int,
+        *,
+        repair_meta_draft: dict[str, Any],
+        raw_comment: str,
+        telegram_user_id: int | None,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+        can_attach_any: bool = False,
+    ) -> dict[str, Any] | None:
+        allowed = await BotRepairNameplateService.can_use_order(
+            session,
+            order_id,
+            telegram_user_id=telegram_user_id,
+            can_attach_any=can_attach_any,
+        )
+        if not allowed:
+            return None
+
+        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
+        order = result.scalars().first()
+        if not order:
+            return None
+
+        repair_meta = OrderService._get_repair_meta(order)
+        merge = cls.preview_comment_merge(repair_meta, repair_meta_draft)
+        for field, values in merge["changes"].items():
+            repair_meta[field] = values["candidate"]
+
+        raw_history = repair_meta.get(cls.COMMENT_HISTORY_META_KEY)
+        history = list(raw_history) if isinstance(raw_history, list) else []
+        history.append(
+            {
+                "source": "telegram_bot",
+                "telegram_user_id": telegram_user_id,
+                "telegram_chat_id": telegram_chat_id,
+                "telegram_message_id": telegram_message_id,
+                "comment": cls._clean_text(raw_comment, max_length=4000),
+                "ai_meta": {
+                    key: deepcopy(value)
+                    for key, value in repair_meta_draft.items()
+                    if cls._has_comment_value(value)
+                },
+                "applied_fields": list(merge["changes"].keys()),
+                "created_at": datetime.now().isoformat(timespec="seconds"),
+            }
+        )
+        repair_meta[cls.COMMENT_HISTORY_META_KEY] = history[-20:]
+        OrderService._set_repair_meta(
+            order,
+            repair_meta,
+            default_status=OrderService.REPAIR_DEFAULT_STATUS,
+        )
+        flag_modified(order, "technical_meta")
+        session.add(order)
+        await session.commit()
+        await session.refresh(order)
+
+        return {
+            "id": int(order.id or 0),
+            "changes": merge["changes"],
+            "unchanged": merge["unchanged"],
+        }

--- a/services/bot_repair_nameplate_service.py
+++ b/services/bot_repair_nameplate_service.py
@@ -13,10 +13,8 @@ from core.config import settings
 from models import Order, OrderInstaller, OrderStatus, OrderWorkStage, StaffUser
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
-from services.defect_act_ai_service import DefectActAIService
 from services.order_service import OrderService
 from services.staff_user_service import StaffUserService
-from schemas import ManagerRepairActAiDraftPayload
 
 
 class BotRepairNameplateService:
@@ -60,53 +58,6 @@ class BotRepairNameplateService:
         "refrigerant_amount": "Количество хладагента",
     }
     HISTORY_META_KEY = "nameplate_recognitions"
-    COMMENT_HISTORY_META_KEY = "bot_diagnostic_comments"
-    COMMENT_FIELDS = (
-        "customer_complaint",
-        "complaint_official",
-        "likely_diagnosis",
-        "technical_condition",
-        "inspection_work_done",
-        "startup_check_result",
-        "compressor_check_result",
-        "measurement_result",
-        "diagnostic_result",
-        "further_use_assessment",
-        "operation_restrictions",
-        "technical_conclusion",
-        "repair_feasibility",
-        "recommended_decision",
-        "repair_recommendation",
-        "repair_possible",
-        "refrigerant_type",
-        "refrigerant_amount",
-        "refrigerant_pricing_mode",
-        "repair_not_viable",
-        "repair_not_viable_reason",
-    )
-    COMMENT_FIELD_LABELS = {
-        "customer_complaint": "Жалоба клиента",
-        "complaint_official": "Жалоба для акта",
-        "likely_diagnosis": "Вероятная причина",
-        "technical_condition": "Техническое состояние",
-        "startup_check_result": "Проверка запуска",
-        "compressor_check_result": "Проверка компрессора",
-        "measurement_result": "Результаты замеров",
-        "diagnostic_result": "Результат диагностики",
-        "further_use_assessment": "Дальнейшая эксплуатация",
-        "operation_restrictions": "Ограничения эксплуатации",
-        "technical_conclusion": "Техническое заключение",
-        "repair_feasibility": "Целесообразность ремонта",
-        "recommended_decision": "Рекомендованное решение",
-        "repair_recommendation": "Рекомендация по ремонту",
-        "repair_possible": "Ремонт возможен",
-        "refrigerant_type": "Хладагент",
-        "refrigerant_amount": "Количество хладагента",
-        "refrigerant_pricing_mode": "Расчет хладагента",
-        "repair_not_viable": "Ремонт нецелесообразен",
-        "repair_not_viable_reason": "Причина нецелесообразности",
-        "inspection_work_done": "Выполненные работы",
-    }
 
     @staticmethod
     def _clean_text(value: Any, *, max_length: int = 500) -> Optional[str]:
@@ -673,140 +624,6 @@ class BotRepairNameplateService:
         return cls.preview_merge(OrderService._get_repair_meta(order), extracted)
 
     @classmethod
-    def preview_comment_merge(cls, current_repair_meta: dict[str, Any], draft_meta: dict[str, Any]) -> dict[str, Any]:
-        changes: dict[str, dict[str, str]] = {}
-        unchanged: dict[str, str] = {}
-        for field in cls.COMMENT_FIELDS:
-            candidate = cls._clean_text(draft_meta.get(field), max_length=1200)
-            if not candidate:
-                continue
-            existing = cls._clean_text(current_repair_meta.get(field), max_length=1200)
-            if existing == candidate:
-                unchanged[field] = candidate
-            else:
-                changes[field] = {"existing": existing or "", "candidate": candidate}
-        return {"changes": changes, "unchanged": unchanged}
-
-    @classmethod
-    def _comment_payload(cls, *, repair_meta: dict[str, Any], comment: str) -> ManagerRepairActAiDraftPayload:
-        return ManagerRepairActAiDraftPayload(
-            defect_type="field_diagnostic_note",
-            defect_label="Диагностическая заметка с выезда",
-            allow_assumptions=False,
-            polish_existing=True,
-            equipment_name=cls._clean_text(repair_meta.get("equipment_name"), max_length=200),
-            equipment_brand=cls._clean_text(repair_meta.get("equipment_brand"), max_length=120),
-            equipment_model=cls._clean_text(repair_meta.get("equipment_model"), max_length=200),
-            equipment_power=cls._clean_text(repair_meta.get("equipment_power"), max_length=120),
-            customer_complaint=cls._clean_text(repair_meta.get("customer_complaint"), max_length=500),
-            complaint_official=cls._clean_text(repair_meta.get("complaint_official"), max_length=500),
-            likely_diagnosis=cls._clean_text(repair_meta.get("likely_diagnosis"), max_length=500),
-            extra_context=comment,
-            current_meta=repair_meta,
-        )
-
-    @classmethod
-    async def build_diagnostic_comment_draft(
-        cls,
-        session: AsyncSession,
-        *,
-        order_id: int,
-        comment: str,
-    ) -> dict[str, Any] | None:
-        result = await session.execute(
-            select(Order)
-            .where(Order.id == order_id)
-            .options(selectinload(Order.customer))
-            .limit(1)
-        )
-        order = result.scalars().first()
-        if not order or OrderService._normalize_workflow_type(getattr(order, "workflow_type", None)) != "repair":
-            return None
-
-        raw_comment = cls._clean_text(comment, max_length=4000)
-        if not raw_comment:
-            raise ValueError("Комментарий пустой")
-
-        repair_meta = OrderService._get_repair_meta(order)
-        ai_meta = await DefectActAIService.generate_repair_meta(
-            cls._comment_payload(repair_meta=repair_meta, comment=raw_comment)
-        )
-        merge_preview = cls.preview_comment_merge(repair_meta, ai_meta)
-        return {
-            "order": cls._map_order(order),
-            "comment": raw_comment,
-            "repair_meta": ai_meta,
-            "merge_preview": merge_preview,
-        }
-
-    @classmethod
-    async def apply_diagnostic_comment(
-        cls,
-        session: AsyncSession,
-        order_id: int,
-        *,
-        repair_meta_draft: dict[str, Any],
-        raw_comment: str,
-        telegram_user_id: int | None,
-        telegram_chat_id: int | None,
-        telegram_message_id: int | None,
-        can_attach_any: bool = False,
-    ) -> dict[str, Any] | None:
-        allowed = await cls.can_use_order(
-            session,
-            order_id,
-            telegram_user_id=telegram_user_id,
-            can_attach_any=can_attach_any,
-        )
-        if not allowed:
-            return None
-
-        result = await session.execute(select(Order).where(Order.id == order_id).limit(1))
-        order = result.scalars().first()
-        if not order:
-            return None
-
-        repair_meta = OrderService._get_repair_meta(order)
-        merge = cls.preview_comment_merge(repair_meta, repair_meta_draft)
-        for field, values in merge["changes"].items():
-            repair_meta[field] = values["candidate"]
-
-        raw_history = repair_meta.get(cls.COMMENT_HISTORY_META_KEY)
-        history = list(raw_history) if isinstance(raw_history, list) else []
-        history.append(
-            {
-                "source": "telegram_bot",
-                "telegram_user_id": telegram_user_id,
-                "telegram_chat_id": telegram_chat_id,
-                "telegram_message_id": telegram_message_id,
-                "comment": cls._clean_text(raw_comment, max_length=4000),
-                "ai_meta": {
-                    key: cls._clean_text(value, max_length=1200)
-                    for key, value in repair_meta_draft.items()
-                    if cls._clean_text(value, max_length=1200)
-                },
-                "applied_fields": list(merge["changes"].keys()),
-                "created_at": datetime.now().isoformat(timespec="seconds"),
-            }
-        )
-        repair_meta[cls.COMMENT_HISTORY_META_KEY] = history[-20:]
-        OrderService._set_repair_meta(
-            order,
-            repair_meta,
-            default_status=OrderService.REPAIR_DEFAULT_STATUS,
-        )
-        flag_modified(order, "technical_meta")
-        session.add(order)
-        await session.commit()
-        await session.refresh(order)
-
-        return {
-            "id": int(order.id or 0),
-            "changes": merge["changes"],
-            "unchanged": merge["unchanged"],
-        }
-
-    @classmethod
     async def apply_to_order(
         cls,
         session: AsyncSession,
@@ -847,6 +664,26 @@ class BotRepairNameplateService:
         merge = cls.preview_merge(repair_meta, extracted)
         if merge["applied"]:
             repair_meta.update(merge["applied"])
+
+        model_candidates: list[str] = []
+        raw_models = repair_meta.get("equipment_models")
+        if isinstance(raw_models, list):
+            model_candidates.extend(str(item) for item in raw_models)
+        model_candidates.extend(
+            str(value)
+            for value in (repair_meta.get("equipment_model"), extracted.get("equipment_model"))
+            if value
+        )
+        equipment_models: list[str] = []
+        seen_models: set[str] = set()
+        for value in model_candidates:
+            model = cls._clean_text(value, max_length=200)
+            if not model or model.casefold() in seen_models:
+                continue
+            seen_models.add(model.casefold())
+            equipment_models.append(model)
+        if equipment_models:
+            repair_meta["equipment_models"] = equipment_models[:4]
 
         raw_nameplate_history = repair_meta.get(cls.HISTORY_META_KEY)
         attachments = list(raw_nameplate_history) if isinstance(raw_nameplate_history, list) else []

--- a/services/defect_act_ai_service.py
+++ b/services/defect_act_ai_service.py
@@ -18,6 +18,9 @@ class DefectActAIService:
         "operation_status",
         "risks",
         "recommended_actions",
+        "inspection_codes",
+        "confirmed_facts",
+        "decision",
         "structured_diagnosis",
         "defect_act_blocks",
         "hidden_defects_possible",
@@ -28,6 +31,7 @@ class DefectActAIService:
         "equipment_name",
         "equipment_brand",
         "equipment_model",
+        "equipment_models",
         "equipment_power",
         "technical_condition",
         "startup_check_result",
@@ -60,6 +64,9 @@ class DefectActAIService:
         "refrigerant_type",
         "refrigerant_amount",
         "hidden_defects_possible",
+        "inspection_codes",
+        "confirmed_facts",
+        "decision",
     }
     STRUCTURED_RESPONSE_KEYS = {
         "fault_type",
@@ -67,6 +74,9 @@ class DefectActAIService:
         "operation_status",
         "risks",
         "recommended_actions",
+        "inspection_codes",
+        "confirmed_facts",
+        "decision",
         "structured_diagnosis",
         "defect_act_blocks",
         "hidden_defects_possible",
@@ -83,6 +93,25 @@ class DefectActAIService:
         "refrigerant_amount",
         "repair_estimate_text",
     }
+    FIELD_NOTE_RESPONSE_KEYS = PRIMARY_RESPONSE_KEYS | {
+        "inspection_work_done",
+        "technical_condition",
+        "measurement_result",
+        "further_use_assessment",
+        "operation_restrictions",
+        "technical_conclusion",
+        "repair_feasibility",
+        "recommended_decision",
+    }
+
+    FIELD_NOTE_REFRESH_KEYS = {
+        "diagnostic_result",
+        "repair_recommendation",
+        "technical_conclusion",
+        "measurement_result",
+        "diagnostic_notes",
+    }
+
     @staticmethod
     def _clean_text(value: Any, *, max_length: int = 1200) -> str:
         text = str(value or "").strip()
@@ -135,11 +164,16 @@ class DefectActAIService:
         for key in DefectActAIService.ALLOWED_STRUCTURED_KEYS:
             value = raw.get(key)
             if isinstance(value, list):
-                cleaned[key] = [
+                items = [
                     DefectActAIService._clean_text(item, max_length=120)
                     for item in value
                     if DefectActAIService._clean_text(item, max_length=120)
                 ]
+                if key == "inspection_codes":
+                    items = [item for item in items if item in RepairDefectTemplateService.INSPECTION_TEXTS]
+                if key == "confirmed_facts":
+                    items = items[:3]
+                cleaned[key] = items
             elif isinstance(value, bool):
                 cleaned[key] = value
             elif value is not None:
@@ -154,6 +188,7 @@ class DefectActAIService:
     def build_prompt(payload: ManagerRepairActAiDraftPayload) -> str:
         current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
         fault_types = ", ".join(sorted(RepairDefectTemplateService.TEMPLATES.keys()))
+        inspection_codes = ", ".join(sorted(RepairDefectTemplateService.INSPECTION_TEXTS.keys()))
         inputs = {
             "defect_type": payload.defect_type,
             "defect_label": payload.defect_label,
@@ -176,19 +211,17 @@ class DefectActAIService:
             "- Не выдумывай серийный номер, инвентарный номер, дату ввода, точные давления, токи, сопротивления, "
             "температуры и ошибки, если их нет во входных данных.\n"
             "- Не утверждай, что выполнены конкретные измерения сопротивления, давления, токов, температуры или "
-            "поиск утечки, если такие работы и результаты прямо не указаны во входных данных.\n"
+            "поиск утечки, если они не указаны прямо и не следуют неизбежно из подтвержденного диагноза "
+            "по правилам ниже.\n"
             "- Если нужны дополнительные проверки, формулируй это как рекомендацию или необходимость проверки, "
             "а не как уже выполненное действие.\n"
             "- Для неизвестных измерений используй обобщенные формулировки: визуальный осмотр, проверка запуска, "
             "косвенные признаки, требуется инструментальная проверка.\n"
         )
         assumptions_rules = (
-            "- Разрешен бюрократический сценарий списания: можно заполнить акт на основании типовой картины дефекта, "
-            "даже если фактические замеры и часть деталей не указаны.\n"
-            "- Не придумывай серийный или инвентарный номер. Не указывай точные числовые замеры, если их нет.\n"
-            "- Можно формулировать осмотр и выводы как типовые: визуальные дефекты, износ, коррозия, следы длительного хранения, "
-            "отсутствие целесообразности ремонта, вывод из эксплуатации или списание.\n"
-            "- Делай текст цельным и уверенным для дефектного акта, но без лишних технических чисел.\n"
+            "- Разрешено выбрать ближайший типовой сценарий списания и его стандартный набор inspection_codes.\n"
+            "- Даже в этом режиме не придумывай конкретные симптомы, измерения, даты, номера и выполненные операции.\n"
+            "- confirmed_facts оставляй пустым, если факты не названы прямо.\n"
         )
         mode_rules = assumptions_rules if payload.allow_assumptions else strict_rules
         existing_rules = (
@@ -203,27 +236,43 @@ class DefectActAIService:
 
         return (
             "Ты инженер по ремонту систем кондиционирования. Нужно определить структурированные выводы "
-            "по диагностике, а не писать готовый дефектный акт.\n\n"
+            "по диагностике. Ты работаешь как классификатор, а не сочиняешь готовый дефектный акт.\n\n"
             "Документ и смета будут собраны отдельными шаблонами. Не дублируй одну мысль разными словами "
             "и не возвращай длинные документные формулировки.\n\n"
             "Правила:\n"
             "- Верни только JSON-объект без markdown.\n"
             f"{mode_rules}"
             f"{existing_rules}"
-            "- Итог должен быть пригоден для выбора шаблона, но не должен обещать невозможное без диагностики.\n\n"
+            "- confirmed_facts: не более трех коротких фактов, только прямо указанных во входных данных. "
+            "Сохраняй числовые значения без изменения; не добавляй выводы от себя.\n"
+            "- inspection_codes: только проверки, названные прямо или неизбежно следующие из подтвержденного диагноза.\n"
+            "- КЗ, короткое замыкание, межвитковое замыкание или пробой обмоток -> compressor_short_circuit.\n"
+            "- Бесконечное сопротивление, нет цепи или обрыв обмотки -> compressor_winding_open.\n"
+            "- Компрессор заклинил, хрустит, гремит, не создает перепад давления или вызывает срабатывание автомата "
+            "без подтвержденного КЗ/обрыва -> compressor_mechanical_failure.\n"
+            "- Много мелких свищей, повторная утечка после пайки, точечная/язвенная коррозия или перфорация теплообменника -> heat_exchanger_multiple_leaks.\n"
+            "- Если подтип не подтвержден, выбирай общий compressor_failure или heat_exchanger_damage.\n"
+            "- Для compressor_short_circuit и compressor_winding_open допустим winding_resistance_test как проверка, неизбежно следующая из диагноза.\n"
+            "- Для heat_exchanger_multiple_leaks допустимы pressure_test и leak_test, если описаны множественные места утечки или повторное вскрытие течи.\n"
+            "- Итог должен быть пригоден для выбора локального шаблона и не должен обещать невозможное без диагностики.\n\n"
             "Разрешенные fault_type:\n"
             f"{fault_types}\n\n"
+            "Разрешенные inspection_codes:\n"
+            f"{inspection_codes}\n\n"
             "Верни JSON в такой структуре:\n"
             "{\n"
-            '  "fault_type": "refrigerant_leak",\n'
-            '  "fault_location": "flare_connections",\n'
-            '  "repairable": true,\n'
-            '  "operation_status": "limited",\n'
-            '  "risks": ["compressor_damage"],\n'
-            '  "recommended_actions": ["restore_circuit_tightness", "vacuuming", "full_refrigerant_charge"],\n'
-            '  "refrigerant": "R410A",\n'
-            '  "refrigerant_amount": "790 g",\n'
-            '  "hidden_defects_possible": true\n'
+            '  "fault_type": "compressor_short_circuit",\n'
+            '  "fault_location": "compressor",\n'
+            '  "repairable": false,\n'
+            '  "decision": "write_off",\n'
+            '  "operation_status": "not_allowed",\n'
+            '  "risks": ["electrical_damage"],\n'
+            '  "recommended_actions": ["decommission_equipment"],\n'
+            '  "inspection_codes": ["visual_inspection", "functional_test", "winding_resistance_test"],\n'
+            '  "confirmed_facts": ["сопротивление между выводами близко к нулю"],\n'
+            '  "refrigerant": null,\n'
+            '  "refrigerant_amount": null,\n'
+            '  "hidden_defects_possible": false\n'
             "}\n\n"
             "Если данных недостаточно, используй fault_type=unknown_fault и operation_status=unknown.\n\n"
             "Входные данные:\n"
@@ -265,12 +314,12 @@ class DefectActAIService:
                 },
                 json={
                     "model": settings.DEEPSEEK_MODEL,
-                    "temperature": 0.35,
+                    "temperature": 0.05,
                     "response_format": {"type": "json_object"},
                     "messages": [
                         {
                             "role": "system",
-                            "content": "Ты аккуратный технический редактор дефектных актов по климатическому оборудованию.",
+                            "content": "Ты строгий классификатор результатов диагностики климатического оборудования.",
                         },
                         {"role": "user", "content": prompt},
                     ],
@@ -297,14 +346,25 @@ class DefectActAIService:
         parsed = DefectActAIService._extract_json_object(content)
         structured = DefectActAIService._clean_structured(parsed, payload)
         current_meta = DefectActAIService._clean_meta(payload.current_meta or {})
+        render_current_meta = current_meta
+        is_field_note = payload.defect_type == "field_diagnostic_note"
+        if is_field_note:
+            render_current_meta = {
+                key: value
+                for key, value in current_meta.items()
+                if key not in DefectActAIService.FIELD_NOTE_REFRESH_KEYS
+            }
         meta = RepairDefectTemplateService.build_meta_from_structured(
             raw=structured,
-            current_meta=current_meta,
+            current_meta=render_current_meta,
             fallback_fault_type=payload.defect_type,
             diagnostic_notes=payload.diagnostic_notes or payload.extra_context,
         )
-        response_keys = DefectActAIService.STRUCTURED_RESPONSE_KEYS | DefectActAIService.PRIMARY_RESPONSE_KEYS
-        if payload.polish_existing:
+        if is_field_note:
+            response_keys = (
+                DefectActAIService.STRUCTURED_RESPONSE_KEYS
+                | DefectActAIService.FIELD_NOTE_RESPONSE_KEYS
+            )
             return {
                 key: value
                 for key, value in meta.items()

--- a/services/documents/standard.py
+++ b/services/documents/standard.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from typing import Any, List, Optional
 from sqlmodel import select
@@ -238,6 +239,81 @@ class DefectActStrategy(GoogleDocStrategy):
             return first_link.product.title
         return self.order.title or ""
 
+    @staticmethod
+    def _clean_equipment_model(value: Any) -> str:
+        if isinstance(value, dict):
+            value = next(
+                (value.get(key) for key in ("model", "equipment_model", "name") if value.get(key)),
+                "",
+            )
+        text = re.sub(
+            r"\b(?:внутренний|наружный)\s+блок\b",
+            " ",
+            str(value or "").strip(),
+            flags=re.IGNORECASE,
+        )
+        text = re.sub(r"\(\s*\)|\[\s*\]|\{\s*\}", " ", text)
+        return re.sub(r"\s+", " ", text).strip(" \t:;,/|—–-")
+
+    def _equipment_models(self) -> list[str]:
+        raw_models = self._meta_value("equipment_models")
+        values = raw_models if isinstance(raw_models, (list, tuple)) else []
+        if not values:
+            values = [self._meta_text("equipment_model", "model")]
+
+        models: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            model = self._clean_equipment_model(value)
+            identity = model.casefold()
+            if not model or identity in seen:
+                continue
+            seen.add(identity)
+            models.append(model)
+        return models
+
+    @staticmethod
+    def _without_leading_brand(model: str, brand: str) -> str:
+        if not brand:
+            return model
+        match = re.match(re.escape(brand), model, flags=re.IGNORECASE)
+        if not match:
+            return model
+        remainder = model[match.end():]
+        if remainder and not (remainder[0].isspace() or remainder[0] in ":;,/|—–-"):
+            return model
+        return remainder.lstrip(" \t:;,/|—–-")
+
+    def _format_equipment_name(self, brand: str, models: list[str]) -> str:
+        if not brand and not models:
+            equipment_name = self._clean_equipment_model(
+                self._meta_text("equipment_name", "defect_equipment_name")
+            )
+            fallback = equipment_name or self._clean_equipment_model(self._first_equipment_title())
+            generic_markers = ("ремонт", "диагностик", "сервис", "заявк", "заказ")
+            if fallback.casefold() == "оборудование" or any(
+                marker in fallback.casefold() for marker in generic_markers
+            ):
+                fallback = ""
+            if not fallback:
+                return "Кондиционер"
+            if fallback.casefold().startswith("кондиционер"):
+                return fallback[0].upper() + fallback[1:]
+            return f"Кондиционер {fallback}"
+
+        unique_models: list[str] = []
+        seen: set[str] = set()
+        for model in models:
+            model_without_brand = self._without_leading_brand(model, brand)
+            identity = model_without_brand.casefold()
+            if not model_without_brand or identity in seen:
+                continue
+            seen.add(identity)
+            unique_models.append(model_without_brand)
+
+        details = " ".join(part for part in (brand, " / ".join(unique_models)) if part)
+        return f"Кондиционер {details}" if details else "Кондиционер"
+
     @classmethod
     def _date_text(cls, value: Optional[datetime]) -> str:
         effective = value or datetime.now()
@@ -246,18 +322,11 @@ class DefectActStrategy(GoogleDocStrategy):
 
     def _add_specific_replacements(self, replacements: dict):
         document_date = datetime.strptime(replacements.get("{{date}}", ""), "%d.%m.%Y") if replacements.get("{{date}}") else datetime.now()
-        equipment_name = self._first_text(
-            self._meta_text("equipment_name", "defect_equipment_name"),
-            self._first_equipment_title(),
-            default="кондиционер",
-        )
         equipment_brand = self._meta_text("equipment_brand", "brand")
-        equipment_model = self._meta_text("equipment_model", "model")
+        equipment_models = self._equipment_models()
+        equipment_model = " / ".join(equipment_models)
+        equipment_name = self._format_equipment_name(equipment_brand, equipment_models)
         equipment_power = self._meta_text("equipment_power", "power")
-        if equipment_name == "кондиционер":
-            detailed_name = " ".join(part for part in [equipment_brand, equipment_model, equipment_power] if part)
-            if detailed_name:
-                equipment_name = detailed_name
         generated_repair_meta = RepairDefectTemplateService.build_document_fields(self._repair_meta())
         technical_condition = self._first_text(
             self._meta_text("technical_condition", "defect_technical_condition"),

--- a/services/repair_defect_template_service.py
+++ b/services/repair_defect_template_service.py
@@ -8,8 +8,11 @@ class RepairDefectTemplateService:
     """Templates for structured repair diagnostics and defect-act wording."""
 
     FAULT_ALIASES = {
-        "multiple_heat_exchanger_defects": "heat_exchanger_damage",
+        "multiple_heat_exchanger_defects": "heat_exchanger_multiple_leaks",
         "compressor_winding_breakdown": "compressor_failure",
+        "compressor_short": "compressor_short_circuit",
+        "compressor_open": "compressor_winding_open",
+        "heat_exchanger_perforation": "heat_exchanger_multiple_leaks",
     }
 
     DEFAULT_ACTIONS = {
@@ -23,6 +26,7 @@ class RepairDefectTemplateService:
         "replace_fan_motor": "заменить двигатель вентилятора",
         "replace_compressor": "заменить компрессор",
         "replace_heat_exchanger": "заменить теплообменник",
+        "decommission_equipment": "вывести кондиционер из эксплуатации и оформить списание",
         "deep_cleaning": "выполнить глубокую очистку оборудования",
         "correct_installation": "устранить нарушения монтажа",
         "additional_diagnostics": "выполнить дополнительную диагностику",
@@ -36,6 +40,20 @@ class RepairDefectTemplateService:
         "repeated_failure": "повторное возникновение неисправности",
         "low_efficiency": "снижение эффективности работы оборудования",
     }
+
+    INSPECTION_TEXTS = {
+        "visual_inspection": "внешний осмотр оборудования",
+        "functional_test": "проверка работоспособности и пробный запуск",
+        "supply_voltage_test": "контроль питающего напряжения",
+        "compressor_current_test": "контроль рабочего тока компрессора",
+        "winding_resistance_test": "измерение сопротивления обмоток компрессора",
+        "insulation_to_case_test": "проверка изоляции обмоток относительно корпуса",
+        "noise_vibration_check": "проверка механических шумов и вибрации компрессора",
+        "pressure_test": "манометрическая диагностика холодильного контура",
+        "leak_test": "проверка герметичности и локализация мест утечки",
+    }
+
+    DECISIONS = {"repair", "write_off", "additional_diagnostics"}
 
     TEMPLATES: dict[str, dict[str, Any]] = {
         "refrigerant_leak": {
@@ -54,6 +72,7 @@ class RepairDefectTemplateService:
                 "vacuuming",
                 "full_refrigerant_charge",
             ],
+            "inspection_codes": ["visual_inspection", "functional_test", "pressure_test", "leak_test"],
         },
         "drainage_failure": {
             "label": "Нарушение отвода конденсата",
@@ -66,6 +85,7 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["water_leak", "repeated_failure"],
             "recommended_actions": ["clean_drainage", "restore_drainage_slope"],
+            "inspection_codes": ["visual_inspection", "functional_test"],
         },
         "control_board_failure": {
             "label": "Неисправность платы управления",
@@ -78,6 +98,7 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["electrical_damage", "repeated_failure"],
             "recommended_actions": ["replace_control_board"],
+            "inspection_codes": ["visual_inspection", "functional_test", "supply_voltage_test"],
         },
         "fan_motor_failure": {
             "label": "Неисправность двигателя вентилятора",
@@ -90,6 +111,73 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["overheating", "repeated_failure"],
             "recommended_actions": ["replace_fan_motor"],
+            "inspection_codes": ["visual_inspection", "functional_test"],
+        },
+        "compressor_short_circuit": {
+            "label": "Короткое замыкание обмоток компрессора",
+            "diagnosis_text": "Выявлено короткое замыкание обмоток компрессора.",
+            "operation_text": "Эксплуатация кондиционера не допускается.",
+            "risk_text": "Повторный запуск может вызвать срабатывание защиты и повреждение электрических цепей.",
+            "repair_text": "Замена компрессора экономически нецелесообразна. Кондиционер подлежит выводу из эксплуатации и списанию.",
+            "estimate_text": "Вывод кондиционера из эксплуатации и списание по причине отказа компрессора.",
+            "not_viable_reason": "Короткое замыкание обмоток компрессора; замена основного агрегата экономически нецелесообразна.",
+            "operation_status": "not_allowed",
+            "decision": "write_off",
+            "repairable": False,
+            "risks": ["electrical_damage"],
+            "recommended_actions": ["decommission_equipment"],
+            "inspection_codes": [
+                "visual_inspection",
+                "functional_test",
+                "supply_voltage_test",
+                "winding_resistance_test",
+                "insulation_to_case_test",
+            ],
+        },
+        "compressor_winding_open": {
+            "label": "Обрыв обмотки компрессора",
+            "diagnosis_text": "Выявлен обрыв электрической обмотки компрессора.",
+            "operation_text": "Эксплуатация кондиционера невозможна.",
+            "risk_text": "Компрессор не запускается и не обеспечивает работу холодильного контура.",
+            "repair_text": "Замена компрессора экономически нецелесообразна. Кондиционер подлежит выводу из эксплуатации и списанию.",
+            "estimate_text": "Вывод кондиционера из эксплуатации и списание по причине отказа компрессора.",
+            "not_viable_reason": "Обрыв обмотки компрессора; восстановление агрегата в условиях эксплуатации не предусмотрено.",
+            "operation_status": "not_allowed",
+            "decision": "write_off",
+            "repairable": False,
+            "risks": ["repeated_failure"],
+            "recommended_actions": ["decommission_equipment"],
+            "inspection_codes": [
+                "visual_inspection",
+                "functional_test",
+                "supply_voltage_test",
+                "winding_resistance_test",
+            ],
+        },
+        "compressor_mechanical_failure": {
+            "label": "Механическая неисправность компрессора",
+            "diagnosis_text": (
+                "Выявлена механическая неисправность компрессора, исключающая его штатную работу "
+                "и создание требуемого перепада давления."
+            ),
+            "operation_text": "Эксплуатация кондиционера не допускается.",
+            "risk_text": "Повторные запуски могут привести к срабатыванию защиты и повреждению электрических цепей.",
+            "repair_text": "Замена компрессора экономически нецелесообразна. Кондиционер подлежит выводу из эксплуатации и списанию.",
+            "estimate_text": "Вывод кондиционера из эксплуатации и списание по причине механического отказа компрессора.",
+            "not_viable_reason": "Механический отказ компрессора; замена основного агрегата экономически нецелесообразна.",
+            "operation_status": "not_allowed",
+            "decision": "write_off",
+            "repairable": False,
+            "risks": ["electrical_damage", "repeated_failure"],
+            "recommended_actions": ["decommission_equipment"],
+            "inspection_codes": [
+                "visual_inspection",
+                "functional_test",
+                "supply_voltage_test",
+                "compressor_current_test",
+                "noise_vibration_check",
+                "pressure_test",
+            ],
         },
         "compressor_failure": {
             "label": "Неисправность компрессора",
@@ -102,6 +190,25 @@ class RepairDefectTemplateService:
             "repairable": False,
             "risks": ["electrical_damage", "repeated_failure"],
             "recommended_actions": ["replace_compressor"],
+            "inspection_codes": ["visual_inspection", "functional_test", "supply_voltage_test"],
+        },
+        "heat_exchanger_multiple_leaks": {
+            "label": "Множественная коррозионная перфорация теплообменника",
+            "diagnosis_text": (
+                "Выявлены множественные очаги сквозной коррозии теплообменника "
+                "с нарушением герметичности холодильного контура."
+            ),
+            "operation_text": "Эксплуатация кондиционера не допускается.",
+            "risk_text": "Локальная пайка не обеспечивает надежного восстановления: после устранения одного очага утечки возникают на соседних участках.",
+            "repair_text": "Восстановительный ремонт теплообменника технически ненадежен и экономически нецелесообразен. Кондиционер подлежит выводу из эксплуатации и списанию.",
+            "estimate_text": "Вывод кондиционера из эксплуатации и списание по причине множественной коррозионной перфорации теплообменника.",
+            "not_viable_reason": "Множественные сквозные коррозионные повреждения теплообменника не позволяют надежно восстановить герметичность.",
+            "operation_status": "not_allowed",
+            "decision": "write_off",
+            "repairable": False,
+            "risks": ["repeated_failure", "compressor_damage"],
+            "recommended_actions": ["decommission_equipment"],
+            "inspection_codes": ["visual_inspection", "pressure_test", "leak_test"],
         },
         "heat_exchanger_damage": {
             "label": "Повреждение теплообменника",
@@ -114,6 +221,7 @@ class RepairDefectTemplateService:
             "repairable": False,
             "risks": ["low_efficiency", "compressor_damage"],
             "recommended_actions": ["replace_heat_exchanger"],
+            "inspection_codes": ["visual_inspection", "pressure_test", "leak_test"],
         },
         "contamination": {
             "label": "Загрязнение оборудования",
@@ -126,6 +234,7 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["low_efficiency", "overheating"],
             "recommended_actions": ["deep_cleaning"],
+            "inspection_codes": ["visual_inspection", "functional_test"],
         },
         "poor_installation": {
             "label": "Нарушение монтажа",
@@ -138,6 +247,7 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["repeated_failure", "compressor_damage"],
             "recommended_actions": ["correct_installation"],
+            "inspection_codes": ["visual_inspection", "functional_test"],
         },
         "unknown_fault": {
             "label": "Неисправность требует уточнения",
@@ -150,6 +260,7 @@ class RepairDefectTemplateService:
             "repairable": True,
             "risks": ["repeated_failure"],
             "recommended_actions": ["additional_diagnostics"],
+            "inspection_codes": ["visual_inspection", "functional_test"],
         },
     }
 
@@ -189,13 +300,30 @@ class RepairDefectTemplateService:
         current_meta = current_meta if isinstance(current_meta, dict) else {}
         fault_type = cls.normalize_fault_type(raw.get("fault_type") or current_meta.get("fault_type") or current_meta.get("likely_diagnosis"))
         template = cls.TEMPLATES[fault_type]
+        repairable = cls._bool(raw.get("repairable"), bool(template["repairable"]))
+        decision = cls._clean_text(raw.get("decision") or template.get("decision"), 40)
+        if decision not in cls.DECISIONS:
+            decision = "repair" if repairable else "additional_diagnostics"
+        operation_status = cls._clean_text(raw.get("operation_status") or template["operation_status"], 80)
+        risks = cls._list(raw.get("risks"), template["risks"])
+        recommended_actions = cls._list(raw.get("recommended_actions"), template["recommended_actions"])
+        if template.get("decision") == "write_off":
+            repairable = False
+            decision = "write_off"
+            operation_status = str(template["operation_status"])
+            risks = list(template["risks"])
+            recommended_actions = list(template["recommended_actions"])
+
         return {
             "fault_type": fault_type,
             "fault_location": cls._clean_text(raw.get("fault_location") or current_meta.get("fault_location"), 160),
-            "repairable": cls._bool(raw.get("repairable"), bool(template["repairable"])),
-            "operation_status": cls._clean_text(raw.get("operation_status") or template["operation_status"], 80),
-            "risks": cls._list(raw.get("risks"), template["risks"]),
-            "recommended_actions": cls._list(raw.get("recommended_actions"), template["recommended_actions"]),
+            "repairable": repairable,
+            "decision": decision,
+            "operation_status": operation_status,
+            "risks": risks,
+            "recommended_actions": recommended_actions,
+            "inspection_codes": cls._list(raw.get("inspection_codes"), template.get("inspection_codes", [])),
+            "confirmed_facts": cls._list(raw.get("confirmed_facts"), [])[:3],
             "refrigerant": cls._clean_text(
                 raw.get("refrigerant") or raw.get("refrigerant_type") or current_meta.get("refrigerant_type"),
                 80,
@@ -204,7 +332,10 @@ class RepairDefectTemplateService:
                 raw.get("refrigerant_amount") or current_meta.get("refrigerant_amount"),
                 80,
             ),
-            "hidden_defects_possible": cls._bool(raw.get("hidden_defects_possible"), True),
+            "hidden_defects_possible": cls._bool(
+                raw.get("hidden_defects_possible"),
+                bool(template.get("hidden_defects_possible", False)),
+            ),
         }
 
     @classmethod
@@ -221,61 +352,57 @@ class RepairDefectTemplateService:
         structured = deepcopy(structured)
         structured["fault_type"] = fault_type
 
-        risks_text = cls._risks_text(structured.get("risks") or template["risks"])
-        actions_text = cls._actions_text(structured.get("recommended_actions") or template["recommended_actions"])
+        decision = structured.get("decision") or template.get("decision") or (
+            "repair" if structured.get("repairable") else "additional_diagnostics"
+        )
         diagnosis_text = cls._clean_text(current_meta.get("diagnostic_result") or template["diagnosis_text"])
         repair_text = cls._clean_text(current_meta.get("repair_recommendation") or template["repair_text"])
-        if actions_text and actions_text.lower() not in repair_text.lower():
-            repair_text = f"{repair_text} Основные работы: {actions_text}."
         notes = cls._clean_text(diagnostic_notes or current_meta.get("diagnostic_notes") or current_meta.get("measurement_result"), 900)
-
-        hidden_tail = ""
-        if structured.get("hidden_defects_possible"):
-            hidden_tail = (
-                " В процессе ремонта могут быть выявлены дополнительные неисправности, "
-                "не определяемые при первичном обследовании и требующие отдельного согласования."
-            )
+        inspection_text = cls._inspection_text(structured.get("inspection_codes") or template.get("inspection_codes"))
+        confirmed_facts = [fact.rstrip(".;") for fact in cls._list(structured.get("confirmed_facts"), [])[:3]]
+        finding_text = diagnosis_text
+        if confirmed_facts:
+            finding_text = f"{finding_text} Подтверждено: {'; '.join(confirmed_facts)}."
+        conclusion_text = cls._clean_text(current_meta.get("technical_conclusion") or repair_text)
+        not_viable_reason = cls._clean_text(template.get("not_viable_reason"), 500)
 
         blocks = {
-            "technical_condition": f"Неисправное. {diagnosis_text}",
-            "inspection": " ".join(
-                part for part in [
-                    "Проверена работоспособность оборудования.",
-                    notes,
-                    diagnosis_text,
-                    "Точный объем дефекта уточняется в ходе ремонтных работ с применением специализированного оборудования."
-                    if structured.get("hidden_defects_possible")
-                    else "",
-                ] if part
-            ),
-            "operation": " ".join(part for part in [template["operation_text"], template["risk_text"], risks_text] if part),
-            "conclusion": f"{repair_text}{hidden_tail}",
+            "technical_condition": f"Неисправен. {finding_text}",
+            "inspection": inspection_text,
+            "diagnosis": finding_text,
+            "operation": template["operation_text"],
+            "conclusion": conclusion_text,
         }
 
         return {
             "fault_type": fault_type,
             "fault_location": structured.get("fault_location") or "",
             "operation_status": structured.get("operation_status") or "",
+            "decision": decision,
             "risks": structured.get("risks") or [],
             "recommended_actions": structured.get("recommended_actions") or [],
+            "inspection_codes": structured.get("inspection_codes") or [],
+            "confirmed_facts": confirmed_facts,
             "hidden_defects_possible": bool(structured.get("hidden_defects_possible")),
             "structured_diagnosis": structured,
             "defect_act_blocks": blocks,
             "likely_diagnosis": template["label"],
-            "diagnostic_result": diagnosis_text,
+            "diagnostic_result": finding_text,
             "diagnostic_notes": notes,
             "inspection_work_done": blocks["inspection"],
             "technical_condition": blocks["technical_condition"],
-            "measurement_result": blocks["inspection"],
+            "measurement_result": finding_text,
             "further_use_assessment": template["operation_text"],
-            "operation_restrictions": " ".join(part for part in [template["risk_text"], risks_text] if part),
+            "operation_restrictions": template["risk_text"],
             "repair_recommendation": repair_text,
             "technical_conclusion": blocks["conclusion"],
-            "recommended_decision": repair_text,
-            "repair_feasibility": "Ремонт возможен." if structured.get("repairable") else "Ремонт невозможен или экономически нецелесообразен.",
+            "recommended_decision": blocks["conclusion"],
+            "repair_feasibility": "Ремонт возможен." if structured.get("repairable") else "Ремонт экономически нецелесообразен.",
             "repair_possible": "Да" if structured.get("repairable") else "Нет",
             "repair_not_viable": "Нет" if structured.get("repairable") else "Да",
-            "repair_not_viable_reason": "" if structured.get("repairable") else "Ремонт требует отдельной оценки экономической целесообразности.",
+            "repair_not_viable_reason": "" if structured.get("repairable") else (
+                not_viable_reason or "Ремонт требует отдельной оценки экономической целесообразности."
+            ),
             "refrigerant_type": structured.get("refrigerant") or "",
             "refrigerant_amount": structured.get("refrigerant_amount") or "",
             "repair_estimate_text": template["estimate_text"],
@@ -326,3 +453,15 @@ class RepairDefectTemplateService:
     def _actions_text(cls, actions: Any) -> str:
         labels = [cls.DEFAULT_ACTIONS.get(str(item), str(item)) for item in cls._list(actions, [])]
         return ", ".join(labels)
+
+    @classmethod
+    def _inspection_text(cls, codes: Any) -> str:
+        labels = [cls.INSPECTION_TEXTS.get(str(item), "") for item in cls._list(codes, [])]
+        labels = [label for label in labels if label]
+        if not labels:
+            return "Проведен внешний осмотр оборудования."
+        if len(labels) == 1:
+            joined = labels[0]
+        else:
+            joined = ", ".join(labels[:-1]) + f" и {labels[-1]}"
+        return f"Выполнен комплекс диагностических работ: {joined}."

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -539,7 +539,7 @@ async def test_manager_repair_act_ai_draft_generates_sanitized_meta(async_client
     assert response.status_code == 200, response.text
     data = response.json()
     assert data["provider"] == "deepseek"
-    assert data["prompt_version"] == "defect_act_v2"
+    assert data["prompt_version"] == "defect_act_v3"
     assert data["repair_meta"]["fault_type"] == "refrigerant_leak"
     assert data["repair_meta"]["structured_diagnosis"]["fault_location"] == "flare_connections"
     assert data["repair_meta"]["diagnostic_result"].startswith("Выявлены признаки утечки")
@@ -2564,10 +2564,12 @@ async def test_manager_order_generate_defect_act_from_structured_repair_meta(asy
     )
     assert response.status_code == 200, response.text
     replacements = captured["replacements"]
-    assert replacements["{{technical_condition}}"].startswith("Неисправное. Выявлены признаки утечки хладагента")
-    assert "Обмерзает теплообменник" in replacements["{{measurement_result}}"]
+    assert replacements["{{technical_condition}}"].startswith("Неисправен. Выявлены признаки утечки хладагента")
+    assert replacements["{{measurement_result}}"].startswith("Выявлены признаки утечки хладагента")
+    assert "манометрическая диагностика" in replacements["{{inspection_work_done}}"]
+    assert "Обмерзает теплообменник" not in replacements["{{measurement_result}}"]
     assert "Эксплуатация оборудования допускается только с ограничениями" in replacements["{{further_use_assessment}}"]
-    assert "повреждение компрессора" in replacements["{{operation_restrictions}}"]
+    assert "повреждению компрессора" in replacements["{{operation_restrictions}}"]
     assert "восстановить герметичность холодильного контура" in replacements["{{technical_conclusion}}"]
     assert replacements["{{repair_possible}}"] == "Да"
     assert replacements["{{refrigerant_type}}"] == "R410A"

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -11,6 +11,7 @@ from core.config import settings
 
 settings.BOT_TOKEN = "123:test"
 from bot_app.handlers import admin as admin_handler
+from bot_app.handlers import repair_context as repair_context_handler
 
 
 class _DummyMessage:
@@ -836,8 +837,11 @@ async def test_repair_nameplate_confirm_applies_and_clears_pending(monkeypatch):
     callback.message.edit_text.assert_awaited_once()
     args, kwargs = callback.message.edit_text.await_args
     assert "Данные со шильдика записаны" in args[0]
-    assert "можно отправлять комментарии" in args[0]
-    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_context_finish"
+    assert "Выберите частый диагноз" in args[0]
+    assert "свободный комментарий" in args[0]
+    assert "КЗ компрессора" in args[0]
+    assert "новые свищи теплообменника" in args[0]
+    assert kwargs["reply_markup"].inline_keyboard[-1][0].callback_data == "repair_context_finish"
 
 
 @pytest.mark.asyncio
@@ -1015,6 +1019,119 @@ def test_nameplate_preview_shows_serial_candidates():
     assert "партия: 44" in text
 
 
+def test_repair_context_keyboard_has_presets_and_finish():
+    keyboard = repair_context_handler.repair_context_keyboard()
+    callbacks = [button.callback_data for row in keyboard.inline_keyboard for button in row]
+
+    assert callbacks == [
+        "repair_preset_compressor_short",
+        "repair_preset_compressor_open",
+        "repair_preset_compressor_mechanical",
+        "repair_preset_heat_exchanger_multiple",
+        "repair_context_finish",
+    ]
+    assert repair_context_handler.REPAIR_PRESET_FAULT_TYPES == {
+        "repair_preset_compressor_short": "compressor_short_circuit",
+        "repair_preset_compressor_open": "compressor_winding_open",
+        "repair_preset_compressor_mechanical": "compressor_mechanical_failure",
+        "repair_preset_heat_exchanger_multiple": "heat_exchanger_multiple_leaks",
+    }
+
+
+def test_repair_comment_preview_is_compact_and_counts_replacements():
+    text = repair_context_handler.repair_comment_preview_text(
+        {
+            "repair_meta": {
+                "likely_diagnosis": "Короткое замыкание обмотки компрессора.",
+                "inspection_work_done": "Проверены сопротивление и изоляция обмоток.",
+                "diagnostic_result": "Зафиксировано короткое замыкание.",
+                "technical_conclusion": "Компрессор подлежит замене.",
+            },
+            "merge_preview": {
+                "changes": {
+                    "likely_diagnosis": {
+                        "existing": "Старый диагноз",
+                        "candidate": "Короткое замыкание обмотки компрессора.",
+                    },
+                    "inspection_work_done": {
+                        "existing": "",
+                        "candidate": "Проверены сопротивление и изоляция обмоток.",
+                    },
+                    "diagnostic_result": {
+                        "existing": "Старый результат",
+                        "candidate": "Зафиксировано короткое замыкание.",
+                    },
+                },
+                "unchanged": {"technical_conclusion": "Компрессор подлежит замене."},
+            },
+        }
+    )
+
+    assert "<b>Диагноз:</b> Короткое замыкание обмотки компрессора." in text
+    assert "<b>Проведено:</b> Проверены сопротивление и изоляция обмоток." in text
+    assert "<b>Выявлено:</b> Зафиксировано короткое замыкание." in text
+    assert "<b>Заключение:</b> Компрессор подлежит замене." in text
+    assert "Ранее заполненные данные будут обновлены: 2." in text
+    assert "Старый диагноз" not in text
+    assert "Будет записано/обновлено" not in text
+    assert "Без изменений" not in text
+    assert "Было:" not in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callback_data", "fault_type"),
+    [
+        ("repair_preset_compressor_short", "compressor_short_circuit"),
+        ("repair_preset_compressor_open", "compressor_winding_open"),
+        ("repair_preset_compressor_mechanical", "compressor_mechanical_failure"),
+        ("repair_preset_heat_exchanger_multiple", "heat_exchanger_multiple_leaks"),
+    ],
+)
+async def test_repair_preset_builds_existing_confirmation(monkeypatch, callback_data, fault_type):
+    callback = _DummyCallback(data=callback_data, user_id=5)
+    state = _DummyState({"active_repair_order_context": {"order_id": 42}})
+    draft = {
+        "order": {"id": 42},
+        "comment": "",
+        "repair_meta": {
+            "likely_diagnosis": "Диагноз из пресета.",
+            "diagnostic_result": "Результат из пресета.",
+        },
+        "merge_preview": {"changes": {}, "unchanged": {}},
+    }
+
+    async def fake_build(session, *, order_id, fault_type: str):
+        assert order_id == 42
+        assert fault_type == expected_fault_type
+        return draft
+
+    expected_fault_type = fault_type
+    monkeypatch.setattr(
+        repair_context_handler,
+        "_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(repair_context_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(
+        repair_context_handler.BotDefectActService,
+        "build_diagnostic_preset_draft",
+        fake_build,
+        raising=False,
+    )
+
+    await repair_context_handler.prepare_repair_diagnostic_preset(callback, state)
+
+    assert state._data["pending_repair_comment"] == draft
+    state.set_state.assert_awaited_once_with(repair_context_handler.ShopState.waiting_for_repair_context_comment)
+    callback.message.edit_text.assert_awaited_once()
+    args, kwargs = callback.message.edit_text.await_args
+    assert "<b>Диагноз:</b> Диагноз из пресета." in args[0]
+    assert kwargs["parse_mode"] == "HTML"
+    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_comment_confirm"
+    callback.answer.assert_awaited_once_with()
+
+
 @pytest.mark.asyncio
 async def test_repair_context_comment_builds_ai_preview(monkeypatch):
     message = _DummyMessage(text="фреона нет, утечку нашли, компрессор не качает", user_id=5)
@@ -1041,16 +1158,20 @@ async def test_repair_context_comment_builds_ai_preview(monkeypatch):
         }
 
     monkeypatch.setattr(
-        admin_handler,
-        "_get_bot_access_context",
+        repair_context_handler,
+        "_access_context",
         AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
     )
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
-    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "build_diagnostic_comment_draft", fake_build)
+    monkeypatch.setattr(repair_context_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(
+        repair_context_handler.BotDefectActService,
+        "build_diagnostic_comment_draft",
+        fake_build,
+    )
 
-    await admin_handler.handle_repair_context_comment(message, state)
+    await repair_context_handler.handle_repair_context_comment(message, state)
 
-    message.answer.assert_awaited_once_with("Готовлю поля дефектного акта из комментария…")
+    message.answer.assert_awaited_once_with("Готовлю краткий дефектный акт из комментария…")
     progress.edit_text.assert_awaited_once()
     args, kwargs = progress.edit_text.await_args
     assert "Компрессор не создает давление" in args[0]
@@ -1084,21 +1205,25 @@ async def test_repair_context_comment_confirm_applies_and_keeps_context(monkeypa
         }
 
     monkeypatch.setattr(
-        admin_handler,
-        "_get_bot_access_context",
+        repair_context_handler,
+        "_access_context",
         AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
     )
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
-    monkeypatch.setattr(admin_handler.BotRepairNameplateService, "apply_diagnostic_comment", fake_apply)
+    monkeypatch.setattr(repair_context_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(
+        repair_context_handler.BotDefectActService,
+        "apply_diagnostic_comment",
+        fake_apply,
+    )
 
-    await admin_handler.confirm_repair_context_comment(callback, state)
+    await repair_context_handler.confirm_repair_context_comment(callback, state)
 
     assert state._data["pending_repair_comment"] is None
-    state.set_state.assert_awaited_with(admin_handler.ShopState.waiting_for_repair_context_comment)
+    state.set_state.assert_awaited_with(repair_context_handler.ShopState.waiting_for_repair_context_comment)
     callback.message.edit_text.assert_awaited_once()
     args, kwargs = callback.message.edit_text.await_args
     assert "Комментарий записан" in args[0]
-    assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "repair_context_finish"
+    assert kwargs["reply_markup"].inline_keyboard[-1][0].callback_data == "repair_context_finish"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_repair_nameplate_service.py
+++ b/tests/unit/test_bot_repair_nameplate_service.py
@@ -19,6 +19,7 @@ from models import (
     StaffUser,
 )
 from services.bot_order_attachment_service import BotOrderAttachmentService
+from services.bot_defect_act_service import BotDefectActService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
@@ -255,6 +256,7 @@ async def test_apply_to_order_merges_without_overwriting_existing_repair_meta(sq
     await sqlite_repair_nameplate_session.refresh(order)
     repair_meta = order.technical_meta["repair"]
     assert repair_meta["equipment_model"] == "Введено вручную"
+    assert repair_meta["equipment_models"] == ["Введено вручную", "ALASKA AL-12LHJ"]
     assert repair_meta["equipment_serial_number"] == "SN-001"
     assert repair_meta["customer_complaint"] == "Не охлаждает"
     assert repair_meta["repair_status"] == "scheduled"
@@ -495,7 +497,7 @@ async def test_build_diagnostic_comment_draft_uses_ai_and_previews_changes(sqlit
 
     monkeypatch.setattr(DefectActAIService, "generate_repair_meta", fake_generate)
 
-    draft = await BotRepairNameplateService.build_diagnostic_comment_draft(
+    draft = await BotDefectActService.build_diagnostic_comment_draft(
         sqlite_repair_nameplate_session,
         order_id=int(order.id),
         comment="подключили шланги, утечку устранили, компрессор не качает",
@@ -509,12 +511,58 @@ async def test_build_diagnostic_comment_draft_uses_ai_and_previews_changes(sqlit
 
 
 @pytest.mark.asyncio
+async def test_build_diagnostic_preset_draft_is_deterministic_and_compact(sqlite_repair_nameplate_session):
+    order = Order(
+        title="Ремонт",
+        status=OrderStatus.EXECUTION,
+        workflow_type="repair",
+        technical_meta={"repair": {"equipment_brand": "MDV", "equipment_model": "MDSAF-12HRN1"}},
+    )
+    sqlite_repair_nameplate_session.add(order)
+    await sqlite_repair_nameplate_session.commit()
+
+    draft = await BotDefectActService.build_diagnostic_preset_draft(
+        sqlite_repair_nameplate_session,
+        order_id=int(order.id),
+        fault_type="compressor_short_circuit",
+    )
+
+    assert draft is not None
+    repair_meta = draft["repair_meta"]
+    assert repair_meta["fault_type"] == "compressor_short_circuit"
+    assert repair_meta["decision"] == "write_off"
+    assert repair_meta["repair_possible"] == "Нет"
+    assert "измерение сопротивления обмоток" in repair_meta["inspection_work_done"]
+    assert "подлежит выводу из эксплуатации и списанию" in repair_meta["technical_conclusion"]
+    assert isinstance(repair_meta["structured_diagnosis"], dict)
+    assert draft["merge_preview"]["changes"]["structured_diagnosis"]["candidate"]["repairable"] is False
+
+
+def test_preview_comment_merge_keeps_structured_values_typed():
+    preview = BotDefectActService.preview_comment_merge(
+        {"hidden_defects_possible": True},
+        {
+            "hidden_defects_possible": False,
+            "inspection_codes": ["visual_inspection", "winding_resistance_test"],
+            "structured_diagnosis": {"fault_type": "compressor_short_circuit", "repairable": False},
+        },
+    )
+
+    assert preview["changes"]["hidden_defects_possible"]["candidate"] is False
+    assert preview["changes"]["inspection_codes"]["candidate"] == [
+        "visual_inspection",
+        "winding_resistance_test",
+    ]
+    assert preview["changes"]["structured_diagnosis"]["candidate"]["repairable"] is False
+
+
+@pytest.mark.asyncio
 async def test_apply_diagnostic_comment_updates_repair_meta_and_keeps_history(sqlite_repair_nameplate_session):
     order = Order(title="Ремонт", status=OrderStatus.EXECUTION, workflow_type="repair")
     sqlite_repair_nameplate_session.add(order)
     await sqlite_repair_nameplate_session.commit()
 
-    result = await BotRepairNameplateService.apply_diagnostic_comment(
+    result = await BotDefectActService.apply_diagnostic_comment(
         sqlite_repair_nameplate_session,
         int(order.id),
         repair_meta_draft={

--- a/tests/unit/test_defect_act_ai_service.py
+++ b/tests/unit/test_defect_act_ai_service.py
@@ -120,3 +120,52 @@ async def test_defect_act_ai_sanitization_keeps_structured_keys_and_drops_workfl
     assert "customer_approval_status" not in result
     assert "parts_status" not in result
     assert "unknown_key" not in result
+
+
+@pytest.mark.asyncio
+async def test_defect_act_ai_classifies_field_note_into_controlled_write_off_template(monkeypatch):
+    async def _fake_request_completion(prompt: str) -> str:
+        assert "Бесконечное сопротивление" in prompt
+        assert "compressor_winding_open" in prompt
+        assert "heat_exchanger_multiple_leaks" in prompt
+        assert "Ты работаешь как классификатор" in prompt
+        return json.dumps(
+            {
+                "fault_type": "compressor_winding_open",
+                "repairable": True,
+                "decision": "repair",
+                "operation_status": "not_allowed",
+                "inspection_codes": [
+                    "visual_inspection",
+                    "winding_resistance_test",
+                    "invented_check",
+                ],
+                "confirmed_facts": [
+                    "напряжение на компрессор поступает",
+                    "обмотка не прозванивается",
+                    "факт 3",
+                    "факт 4",
+                ],
+            },
+            ensure_ascii=False,
+        )
+
+    monkeypatch.setattr(DefectActAIService, "_request_completion", staticmethod(_fake_request_completion))
+
+    result = await DefectActAIService.generate_repair_meta(
+        ManagerRepairActAiDraftPayload(
+            defect_type="field_diagnostic_note",
+            polish_existing=True,
+            extra_context="напряжение приходит, сопротивление бесконечное, обмотка не прозванивается",
+            current_meta={"diagnostic_result": "Старый предварительный результат"},
+        )
+    )
+
+    assert result["fault_type"] == "compressor_winding_open"
+    assert result["decision"] == "write_off"
+    assert result["structured_diagnosis"]["repairable"] is False
+    assert result["inspection_codes"] == ["visual_inspection", "winding_resistance_test"]
+    assert len(result["confirmed_facts"]) == 3
+    assert "Старый предварительный результат" not in result["diagnostic_result"]
+    assert "обмотка не прозванивается" in result["diagnostic_result"]
+    assert "подлежит выводу из эксплуатации и списанию" in result["technical_conclusion"]

--- a/tests/unit/test_document_service_base_documents.py
+++ b/tests/unit/test_document_service_base_documents.py
@@ -682,3 +682,43 @@ async def test_defect_act_legacy_conclusion_placeholder_prefers_legacy_value(sql
     assert replacements["{{repair_recommendation}}"] == (
         "Заменить компрессор при наличии экономической целесообразности."
     )
+
+
+@pytest.mark.parametrize(
+    ("repair_meta", "title", "expected_name"),
+    [
+        (
+            {
+                "equipment_name": "Наружный блок",
+                "equipment_brand": "TCL",
+                "equipment_model": "TCL I-12",
+                "equipment_power": "3,5 кВт",
+            },
+            "Не использовать",
+            "Кондиционер TCL I-12",
+        ),
+        (
+            {
+                "equipment_name": "Внутренний блок",
+                "equipment_brand": "TCL",
+                "equipment_models": [
+                    "Внутренний блок: TCL I-12",
+                    "Наружный блок — TCL O-12",
+                    "Внутренний блок: TCL I-12",
+                ],
+            },
+            "Не использовать",
+            "Кондиционер TCL I-12 / O-12",
+        ),
+        ({"equipment_name": "Наружный блок"}, "Товар из заказа", "Кондиционер"),
+        ({"equipment_name": "Наружный блок"}, "Ремонт", "Кондиционер"),
+        ({"equipment_name": "Наружный блок"}, "Ремонт кондиционера", "Кондиционер"),
+        ({"equipment_name": "Наружный блок"}, None, "Кондиционер"),
+    ],
+)
+def test_defect_act_formats_equipment_name(repair_meta, title, expected_name):
+    strategy = DefectActStrategy(None, 0)
+    strategy.order = Order(title=title, technical_meta={"repair": repair_meta})
+    replacements = {}
+    strategy._add_specific_replacements(replacements)
+    assert replacements["{{equipment_name}}"] == expected_name

--- a/tests/unit/test_repair_defect_template_service.py
+++ b/tests/unit/test_repair_defect_template_service.py
@@ -1,0 +1,45 @@
+from services.repair_defect_template_service import RepairDefectTemplateService
+
+
+def test_compressor_short_circuit_builds_compact_write_off_act():
+    meta = RepairDefectTemplateService.build_meta_from_structured(
+        raw={
+            "fault_type": "compressor_short_circuit",
+            "repairable": True,
+            "confirmed_facts": ["сопротивление между выводами близко к нулю."],
+        },
+        diagnostic_notes="кз компрессора, автомат выбивает, много разговорных подробностей",
+    )
+
+    assert meta["decision"] == "write_off"
+    assert meta["repair_possible"] == "Нет"
+    assert meta["likely_diagnosis"] == "Короткое замыкание обмоток компрессора"
+    assert "измерение сопротивления обмоток компрессора" in meta["inspection_work_done"]
+    assert "сопротивление между выводами близко к нулю" in meta["diagnostic_result"]
+    assert "подлежит выводу из эксплуатации и списанию" in meta["technical_conclusion"]
+    assert "разговорных подробностей" not in meta["inspection_work_done"]
+    assert "скрыт" not in meta["technical_conclusion"].lower()
+
+
+def test_heat_exchanger_multiple_leaks_uses_corrosion_perforation_wording():
+    meta = RepairDefectTemplateService.build_meta_from_structured(
+        raw={"fault_type": "multiple_heat_exchanger_defects"},
+    )
+
+    assert meta["fault_type"] == "heat_exchanger_multiple_leaks"
+    assert meta["decision"] == "write_off"
+    assert "манометрическая диагностика" in meta["inspection_work_done"]
+    assert "множественные очаги сквозной коррозии" in meta["diagnostic_result"].lower()
+    assert "локальная пайка" in meta["operation_restrictions"].lower()
+    assert "подлежит выводу из эксплуатации и списанию" in meta["recommended_decision"]
+
+
+def test_repairable_template_keeps_short_repair_decision():
+    meta = RepairDefectTemplateService.build_meta_from_structured(
+        raw={"fault_type": "drainage_failure"},
+    )
+
+    assert meta["decision"] == "repair"
+    assert meta["repair_possible"] == "Да"
+    assert meta["inspection_work_done"].startswith("Выполнен комплекс диагностических работ:")
+    assert meta["technical_conclusion"].startswith("Рекомендуется прочистить дренажную систему")


### PR DESCRIPTION
## Что изменено

- Добавлены четыре быстрых сценария дефектного акта в Telegram: КЗ компрессора, обрыв обмотки, механический отказ компрессора и множественная коррозионная перфорация теплообменника.
- Диалог после шильдика сохраняет контекст ремонтного заказа, принимает следующие текстовые комментарии и показывает компактное превью: диагноз, проведенные проверки, выявленное и заключение.
- DeepSeek переведен в режим строгого классификатора с низкой температурой. Итоговые формулировки, решение о списании и перечень диагностических работ собираются локальными контролируемыми шаблонами.
- Название в акте нормализуется до формата `Кондиционер <бренд> <модель>`; обозначения внутреннего/наружного блока убираются. При двух шильдиках сохраняются обе модели.
- Новые дефекты доступны и в Manager UI.
- Диалог и бизнес-логика вынесены в отдельные handler/service модули, чтобы не раздувать существующие файлы.

## Проверка

- Полный unit-набор на основной реализации: `1113 passed`.
- Финальный профильный unit-набор после разделения модулей: `90 passed`.
- Интеграционные сценарии Manager API и генерации документов: `4 passed`.
- Manager frontend: TypeScript typecheck и production build прошли.
- OpenAPI и типизированный Manager-клиент синхронизированы обязательным pre-commit hook.
