### PR TITLE
fix: harden Google OAuth persistence and deploy recovery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,6 +39,11 @@ backups
 media
 logs
 generated_documents
+google-oauth
+token.json
+client_secret.json
+credentials.json
+g-vision-ocr.json
 
 # Environment files
 .env

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ CLOUDFLARE_API_TOKEN=
 # Google Cloud Console -> OAuth client -> Authorized redirect URIs.
 # Example: GOOGLE_OAUTH_REDIRECT_URI=https://api.mvn.by/api/manager/google-auth/callback
 GOOGLE_OAUTH_REDIRECT_URI=http://127.0.0.1:8000/api/manager/google-auth/callback
+# Local Python uses this relative path. Production compose overrides it with
+# /app/google-oauth/token.json; a single-file bind mount breaks atomic refresh.
+GOOGLE_TOKEN_FILE=google-oauth/token.json
 
 # Google Vision OCR service account for requisites recognition.
 GOOGLE_VISION_CREDENTIALS_FILE=/app/g-vision-ocr.json

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@
 - Фоновые задачи (ценовые синки и т.п.) запускаются из `main.py` (например, `services/scheduler_service.py`).
 
 5. Интеграции и секреты
-- Google API (Docs/Drive): `client_secret.json` + `token.json` (в корне). Генерация токена: `python scripts/get_token.py`.
+- Google API (Docs/Drive): `client_secret.json` + `GOOGLE_TOKEN_FILE` (production: `/app/google-oauth/token.json`). Генерация токена: `python scripts/get_token.py`.
 - Ветка `feature/gdocs-service-phase28` содержит изменения, связанные с переходом на OAuth2 (user account) — проверяйте `services/google_service.py` и `services/document_service.py`.
 
 6. Частые изменения, которых стоит избегать

--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -5,6 +5,10 @@ on:
     - cron: "42 4 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: api-restore-drill
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
@@ -99,17 +103,22 @@ jobs:
           }
           remote_target="${target_user}@${target_host}"
           remote_script="/tmp/mvn-api-restore-drill-${GITHUB_RUN_ID}.sh"
+          remote_cleanup_script="/tmp/mvn-api-restore-drill-cleanup-${GITHUB_RUN_ID}.sh"
           echo "[restore-drill][info] selected_node=${target_label} ha_mode=${API_DB_HA_MODE}" | tee api-restore-drill.log
           # shellcheck disable=SC2029
           ssh "${SSH_OPTIONS[@]}" "${remote_target}" "cat > $(quote "${remote_script}") && chmod +x $(quote "${remote_script}")" \
             < scripts/ha/restore_drill_latest_db.sh
           # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" "${remote_target}" "cat > $(quote "${remote_cleanup_script}") && chmod +x $(quote "${remote_cleanup_script}")" \
+            < scripts/ha/cleanup_restore_drill_runtime.sh
+          # shellcheck disable=SC2029
           ssh "${SSH_OPTIONS[@]}" "${remote_target}" "\
             PROJECT_DIR=$(quote "${target_project_dir}") \
             COMPOSE_FILE=$(quote "${target_compose_file}") \
+            RESTORE_DRILL_CLEANUP_SCRIPT=$(quote "${remote_cleanup_script}") \
             bash $(quote "${remote_script}"); \
             status=\$?; \
-            rm -f $(quote "${remote_script}"); \
+            rm -f $(quote "${remote_script}") $(quote "${remote_cleanup_script}"); \
             exit \${status}" | tee -a api-restore-drill.log
 
       - name: Upload restore drill log

--- a/.github/workflows/deploy-api-standby.yml
+++ b/.github/workflows/deploy-api-standby.yml
@@ -29,7 +29,8 @@ jobs:
       API_STANDBY_USER: ${{ vars.API_STANDBY_USER || 'root' }}
       API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/air-api' }}
       API_STANDBY_COMPOSE_FILE: ${{ vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.prod.yml' }}
-      API_STANDBY_COPY_COMPOSE: ${{ vars.API_STANDBY_COPY_COMPOSE || 'false' }}
+      # A standby image must never advance without the matching mount contract.
+      API_STANDBY_COPY_COMPOSE: 'true'
       API_STANDBY_COMPOSE_SOURCE_FILE: ${{ vars.API_STANDBY_COMPOSE_SOURCE_FILE || vars.API_STANDBY_COMPOSE_FILE || 'docker-compose.prod.yml' }}
       API_STANDBY_HEALTH_URL: ${{ vars.API_STANDBY_HEALTH_URL || 'http://localhost:8000/api/health' }}
       API_PRIMARY_ORIGIN: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}
@@ -56,62 +57,88 @@ jobs:
           BACKEND_IMAGE: ${{ inputs.backend_image }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          SCP_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3
+          )
+          SCP_OPTS=("${SSH_OPTS[@]}")
           echo "Deploying standby backend image: ${BACKEND_IMAGE}"
+          deploy_compose_file="${API_STANDBY_COMPOSE_FILE}"
 
           if [ "${API_STANDBY_COPY_COMPOSE}" = "true" ]; then
             if [ ! -f "${API_STANDBY_COMPOSE_SOURCE_FILE}" ]; then
               echo "::error::API_STANDBY_COMPOSE_SOURCE_FILE not found: ${API_STANDBY_COMPOSE_SOURCE_FILE}"
               exit 1
             fi
-            ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "mkdir -p '${API_STANDBY_PROJECT_DIR}'"
-            scp ${SCP_OPTS} "${API_STANDBY_COMPOSE_SOURCE_FILE}" \
-              "${API_STANDBY_USER}@${API_STANDBY_HOST}:${API_STANDBY_PROJECT_DIR}/${API_STANDBY_COMPOSE_FILE}"
+            # shellcheck disable=SC2029
+            ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "mkdir -p '${API_STANDBY_PROJECT_DIR}'"
+            deploy_compose_file="${API_STANDBY_COMPOSE_FILE}.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            scp "${SCP_OPTS[@]}" "${API_STANDBY_COMPOSE_SOURCE_FILE}" \
+              "${API_STANDBY_USER}@${API_STANDBY_HOST}:${API_STANDBY_PROJECT_DIR}/${deploy_compose_file}"
           fi
 
-          cat scripts/ha/promote_local_standby.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-promote-local-standby"
-          cat scripts/ha/mvn-standby-status.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-standby-status"
-          cat scripts/deploy.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/deploy.sh"
+          cat scripts/ha/promote_local_standby.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-promote-local-standby"
+          cat scripts/ha/mvn-standby-status.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "install -m 0755 /dev/stdin /usr/local/sbin/mvn-standby-status"
+          cat scripts/deploy.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/deploy.sh"
+          cat scripts/prepare_google_oauth_token_dir.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/prepare_google_oauth_token_dir.sh"
+          cat scripts/post_deploy_smoke_check.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/post_deploy_smoke_check.sh"
+          cat scripts/compose_candidate_transaction.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/compose_candidate_transaction.sh"
+          cat scripts/reconcile_backend_compose_runtime.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/reconcile_backend_compose_runtime.sh"
+          cat scripts/deploy_backend_candidate_transaction.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/deploy_backend_candidate_transaction.sh"
 
-          printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
-            chmod +x /tmp/deploy.sh && \
+          # shellcheck disable=SC2029
+          printf '%s\n' "${GHCR_PAT}" | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
+            set -euo pipefail; \
+            chmod +x /tmp/deploy.sh /tmp/prepare_google_oauth_token_dir.sh /tmp/post_deploy_smoke_check.sh /tmp/compose_candidate_transaction.sh /tmp/reconcile_backend_compose_runtime.sh /tmp/deploy_backend_candidate_transaction.sh && \
             IFS= read -r GHCR_PAT && export GHCR_PAT && \
             GITHUB_ACTOR='${{ github.actor }}' \
             API_PROJECT_DIR='${API_STANDBY_PROJECT_DIR}' \
-            API_COMPOSE_FILE='${API_STANDBY_COMPOSE_FILE}' \
+            API_ACTIVE_SLOT_FILE='${API_STANDBY_PROJECT_DIR}/.standby-api-slot-disabled' \
+            API_CANONICAL_COMPOSE_FILE='${API_STANDBY_PROJECT_DIR}/${API_STANDBY_COMPOSE_FILE}' \
+            API_CANDIDATE_COMPOSE_FILE='${API_STANDBY_PROJECT_DIR}/${deploy_compose_file}' \
+            API_COMPOSE_TRANSACTIONAL='${API_STANDBY_COPY_COMPOSE}' \
+            API_DEPLOY_STRATEGY=in_place \
             API_DEPLOY_SERVICES='app' \
             API_MIGRATION_SERVICE='app' \
             API_RUN_MIGRATIONS='false' \
             API_RUN_DEFAULTS='false' \
+            API_STOP_SERVICES_AFTER_DEPLOY=bot \
+            API_IN_PLACE_DEPLOY_SCRIPT='/tmp/deploy.sh' \
+            API_SMOKE_SCRIPT='/tmp/post_deploy_smoke_check.sh' \
+            API_RECONCILE_SCRIPT='/tmp/reconcile_backend_compose_runtime.sh' \
+            COMPOSE_CANDIDATE_TRANSACTION_SCRIPT='/tmp/compose_candidate_transaction.sh' \
+            GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT='/tmp/prepare_google_oauth_token_dir.sh' \
+            BASE_URL='${API_STANDBY_HEALTH_URL%/api/health}' \
+            READY_URL='${API_STANDBY_HEALTH_URL%/api/health}/api/ready' \
+            READY_EXPECTATION=fenced \
+            COMPOSE_SERVICE_CHECKS='app' \
+            BOT_EXPECT_ENABLED=false \
+            API_READY_URL='${API_STANDBY_HEALTH_URL}' \
             BACKEND_IMAGE='${BACKEND_IMAGE}' \
-            bash /tmp/deploy.sh && \
-            cd '${API_STANDBY_PROJECT_DIR}' && \
-            (docker compose -f '${API_STANDBY_COMPOSE_FILE}' stop bot >/dev/null 2>&1 || true) && \
-            for i in \$(seq 1 30); do \
-              if curl -fsS '${API_STANDBY_HEALTH_URL}' >/tmp/mvn-standby-health.out; then \
-                cat /tmp/mvn-standby-health.out; \
-                exit 0; \
-              fi; \
-              sleep 2; \
-            done; \
-            docker compose -f '${API_STANDBY_COMPOSE_FILE}' logs --tail=120 app; \
-            exit 1"
+            SMOKE_SUMMARY_FILE='/tmp/standby_smoke_summary.txt' \
+            bash /tmp/deploy_backend_candidate_transaction.sh; \
+            cat /tmp/standby_smoke_summary.txt"
 
       - name: Roll Back Standby After Failed Activation
         id: rollback_standby
         if: ${{ always() && steps.deploy_standby.outcome == 'failure' }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          cat scripts/rollback_backend.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/rollback_backend.sh"
-          ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3
+          )
+          cat scripts/rollback_backend.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/rollback_backend.sh"
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
             chmod +x /tmp/rollback_backend.sh && \
             CONFIRM_ROLLBACK=true \
             API_PROJECT_DIR='${API_STANDBY_PROJECT_DIR}' \
+            API_ACTIVE_SLOT_FILE='${API_STANDBY_PROJECT_DIR}/.standby-api-slot-disabled' \
             API_COMPOSE_FILE='${API_STANDBY_COMPOSE_FILE}' \
             API_DEPLOY_SERVICES='app' \
             API_READY_URL='${API_STANDBY_HEALTH_URL}' \
+            API_FORCE_COMPOSE_RECONCILE_ON_NOOP=true \
             EXPECTED_CURRENT_IMAGE='${{ inputs.backend_image }}' \
             bash /tmp/rollback_backend.sh" | tee standby_rollback.log
 
@@ -129,9 +156,12 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          cat scripts/prune_unused_docker_images.sh | ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/prune_unused_docker_images.sh"
-          ssh ${SSH_OPTS} "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3
+          )
+          cat scripts/prune_unused_docker_images.sh | ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "cat > /tmp/prune_unused_docker_images.sh"
+          ssh "${SSH_OPTS[@]}" "${API_STANDBY_USER}@${API_STANDBY_HOST}" "\
             chmod +x /tmp/prune_unused_docker_images.sh && \
             KEEP_BACKEND_IMAGES=3 bash /tmp/prune_unused_docker_images.sh" | tee standby_docker_prune.log
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,15 +317,20 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -T 10 -H ${{ secrets.SSH_HOST_API }} >> ~/.ssh/known_hosts
 
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
-          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "mkdir -p '${API_PROJECT_DIR}'"
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v
+          )
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "mkdir -p '${API_PROJECT_DIR}'"
 
           if [ "${API_COPY_COMPOSE}" = "true" ]; then
             if [ ! -f "${API_COMPOSE_SOURCE_FILE}" ]; then
               echo "::error::API_COMPOSE_SOURCE_FILE not found: ${API_COMPOSE_SOURCE_FILE}"
               exit 1
             fi
-            echo "📄 Copying ${API_COMPOSE_SOURCE_FILE} to ${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
+            candidate_file="${API_COMPOSE_FILE}.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            echo "📄 Staging ${API_COMPOSE_SOURCE_FILE} as ${API_PROJECT_DIR}/${candidate_file}"
             scp \
               -i ~/.ssh/deploy_key \
               -o BatchMode=yes \
@@ -334,7 +339,7 @@ jobs:
               -o ServerAliveInterval=15 \
               -o ServerAliveCountMax=3 \
               -v "${API_COMPOSE_SOURCE_FILE}" \
-              "${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}:${API_PROJECT_DIR}/${API_COMPOSE_FILE}"
+              "${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }}:${API_PROJECT_DIR}/${candidate_file}"
           else
             echo "⏭️ API_COPY_COMPOSE=${API_COPY_COMPOSE}; keeping remote compose unchanged"
           fi
@@ -345,47 +350,54 @@ jobs:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
-
-          case "${API_DEPLOY_STRATEGY}" in
-            blue_green)
-              cat scripts/ha/mvn-primary-status.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "install -m 0755 /dev/stdin /usr/local/sbin/mvn-primary-status"
-              cat scripts/deploy_backend_blue_green.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green.sh"
-              cat scripts/deploy_backend_blue_green_safety.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green_safety.sh"
-              printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-                chmod +x /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh && \
-                IFS= read -r GHCR_PAT && export GHCR_PAT && \
-                GITHUB_ACTOR='${{ github.actor }}' \
-                API_PROJECT_DIR='${API_PROJECT_DIR}' \
-                API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
-                API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}' \
-                API_RUN_DEFAULTS='${API_RUN_DEFAULTS}' \
-                API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh' \
-                BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
-                API_BLUE_GREEN_SUMMARY_FILE='/tmp/backend_blue_green_summary.txt' \
-                bash /tmp/deploy_backend_blue_green.sh && \
-                cat /tmp/backend_blue_green_summary.txt"
-              ;;
-            in_place)
-              cat scripts/deploy.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy.sh"
-              printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-                chmod +x /tmp/deploy.sh && \
-                IFS= read -r GHCR_PAT && export GHCR_PAT && \
-                GITHUB_ACTOR='${{ github.actor }}' \
-                API_PROJECT_DIR='${API_PROJECT_DIR}' \
-                API_COMPOSE_FILE='${API_COMPOSE_FILE}' \
-                API_DEPLOY_SERVICES='${API_DEPLOY_SERVICES}' \
-                API_MIGRATION_SERVICE='${API_MIGRATION_SERVICE}' \
-                API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}' \
-                API_RUN_DEFAULTS='${API_RUN_DEFAULTS}' \
-                BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
-                bash /tmp/deploy.sh"
-              ;;
-            *)
-              echo "::error::Unsupported API_DEPLOY_STRATEGY=${API_DEPLOY_STRATEGY}"
-              exit 1
-              ;;
-          esac 2>&1 | tee backend_deploy.log
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v
+          )
+          candidate_file="${API_COMPOSE_FILE}"
+          if [ "${API_COPY_COMPOSE}" = "true" ]; then
+            candidate_file="${API_COMPOSE_FILE}.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          fi
+          cat scripts/ha/mvn-primary-status.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "install -m 0755 /dev/stdin /usr/local/sbin/mvn-primary-status"
+          for script in deploy.sh deploy_backend_blue_green.sh deploy_backend_blue_green_safety.sh \
+            prepare_google_oauth_token_dir.sh post_deploy_smoke_check.sh \
+            compose_candidate_transaction.sh reconcile_backend_compose_runtime.sh \
+            deploy_backend_candidate_transaction.sh; do
+            # shellcheck disable=SC2029
+            cat "scripts/${script}" | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/${script}"
+          done
+          # shellcheck disable=SC2029
+          printf '%s\n' "${GHCR_PAT}" | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+            set -euo pipefail; \
+            chmod 0755 /tmp/deploy.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh /tmp/post_deploy_smoke_check.sh /tmp/compose_candidate_transaction.sh /tmp/reconcile_backend_compose_runtime.sh /tmp/deploy_backend_candidate_transaction.sh && \
+            IFS= read -r GHCR_PAT && export GHCR_PAT && \
+            GITHUB_ACTOR='${{ github.actor }}' \
+            API_PROJECT_DIR='${API_PROJECT_DIR}' \
+            API_CANONICAL_COMPOSE_FILE='${API_PROJECT_DIR}/${API_COMPOSE_FILE}' \
+            API_CANDIDATE_COMPOSE_FILE='${API_PROJECT_DIR}/${candidate_file}' \
+            API_COMPOSE_TRANSACTIONAL='${API_COPY_COMPOSE}' \
+            API_DEPLOY_STRATEGY='${API_DEPLOY_STRATEGY}' \
+            API_DEPLOY_SERVICES='${API_DEPLOY_SERVICES}' \
+            API_MIGRATION_SERVICE='${API_MIGRATION_SERVICE}' \
+            API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}' \
+            API_RUN_DEFAULTS='${API_RUN_DEFAULTS}' \
+            API_BLUE_GREEN_SCRIPT='/tmp/deploy_backend_blue_green.sh' \
+            API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh' \
+            API_IN_PLACE_DEPLOY_SCRIPT='/tmp/deploy.sh' \
+            API_SMOKE_SCRIPT='/tmp/post_deploy_smoke_check.sh' \
+            API_RECONCILE_SCRIPT='/tmp/reconcile_backend_compose_runtime.sh' \
+            COMPOSE_CANDIDATE_TRANSACTION_SCRIPT='/tmp/compose_candidate_transaction.sh' \
+            GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT='/tmp/prepare_google_oauth_token_dir.sh' \
+            BASE_URL='${API_BASE_URL}' \
+            READY_URL='${API_READY_URL}' \
+            COMPOSE_SERVICE_CHECKS='${API_SMOKE_COMPOSE_SERVICE_CHECKS}' \
+            BOT_EXPECT_ENABLED='${API_BOT_EXPECT_ENABLED}' \
+            BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
+            API_BLUE_GREEN_SUMMARY_FILE='/tmp/backend_blue_green_summary.txt' \
+            SMOKE_SUMMARY_FILE='/tmp/smoke_summary.txt' \
+            bash /tmp/deploy_backend_candidate_transaction.sh; \
+            cat /tmp/backend_blue_green_summary.txt 2>/dev/null || true; \
+            cat /tmp/smoke_summary.txt" 2>&1 | tee backend_deploy.log
 
       - name: Optional Post-Deploy Backend Ops
         id: post_deploy_ops
@@ -402,7 +414,10 @@ jobs:
           DRY_RUN: ${{ secrets.DRY_RUN }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v
+          )
           : "${RUN_POST_DEPLOY_OPS:=true}"
           : "${OPS_MODE:=report_only}"
           : "${RUN_NORMALIZE_LEGACY:=false}"
@@ -412,9 +427,10 @@ jobs:
           : "${RUN_CLEANUP_LEGACY_LINKS:=false}"
           : "${DRY_RUN:=true}"
 
-          cat scripts/ops_post_deploy.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/ops_post_deploy.sh"
+          cat scripts/ops_post_deploy.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/ops_post_deploy.sh"
 
-          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
             chmod +x /tmp/ops_post_deploy.sh && \
             RUN_POST_DEPLOY_OPS='${RUN_POST_DEPLOY_OPS}' \
             OPS_MODE='${OPS_MODE}' \
@@ -435,32 +451,28 @@ jobs:
         id: post_deploy_smoke
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
-          cat scripts/post_deploy_smoke_check.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/post_deploy_smoke_check.sh"
-          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-            chmod +x /tmp/post_deploy_smoke_check.sh && \
-            BASE_URL='${API_BASE_URL}' \
-            READY_URL='${API_READY_URL}' \
-            COMPOSE_FILE='${API_PROJECT_DIR}/${API_COMPOSE_FILE}' \
-            COMPOSE_SERVICE_CHECKS='${API_SMOKE_COMPOSE_SERVICE_CHECKS}' \
-            BOT_EXPECT_ENABLED='${API_BOT_EXPECT_ENABLED}' \
-            BACKEND_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
-            SMOKE_SUMMARY_FILE='/tmp/smoke_summary.txt' \
-            bash /tmp/post_deploy_smoke_check.sh && cat /tmp/smoke_summary.txt" | tee backend_smoke.log
+          grep -Fq 'smoke_status=passed' backend_deploy.log
+          grep -Fq 'backend candidate activation, smoke, and compose promotion completed' backend_deploy.log
+          cp backend_deploy.log backend_smoke.log
 
       - name: Roll Back Backend After Failed Activation
         id: rollback_backend
-        if: ${{ always() && (steps.deploy_backend.outcome == 'failure' || steps.post_deploy_smoke.outcome == 'failure') }}
+        if: ${{ always() && steps.deploy_backend.outcome == 'failure' }}
         env:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
-          cat scripts/deploy_backend_blue_green.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green.sh"
-          cat scripts/deploy_backend_blue_green_safety.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green_safety.sh"
-          cat scripts/rollback_backend.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/rollback_backend.sh"
-          printf '%s\n' "${GHCR_PAT}" | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
-            chmod +x /tmp/rollback_backend.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh && \
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3
+          )
+          cat scripts/deploy_backend_blue_green.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green.sh"
+          cat scripts/deploy_backend_blue_green_safety.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/deploy_backend_blue_green_safety.sh"
+          cat scripts/prepare_google_oauth_token_dir.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/prepare_google_oauth_token_dir.sh"
+          cat scripts/rollback_backend.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/rollback_backend.sh"
+          # shellcheck disable=SC2029
+          printf '%s\n' "${GHCR_PAT}" | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+            chmod +x /tmp/rollback_backend.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh && \
             IFS= read -r GHCR_PAT && export GHCR_PAT && \
             GITHUB_ACTOR='${{ github.actor }}' \
             CONFIRM_ROLLBACK=true \
@@ -469,6 +481,8 @@ jobs:
             API_DEPLOY_SERVICES='${API_DEPLOY_SERVICES}' \
             API_READY_URL='${API_READY_URL}' \
             API_BLUE_GREEN_SAFETY_HELPER='/tmp/deploy_backend_blue_green_safety.sh' \
+            GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT='/tmp/prepare_google_oauth_token_dir.sh' \
+            API_FORCE_COMPOSE_RECONCILE_ON_NOOP=true \
             EXPECTED_CURRENT_IMAGE='${{ steps.resolve_backend_image.outputs.reference }}' \
             bash /tmp/rollback_backend.sh" | tee backend_rollback.log
 
@@ -477,9 +491,12 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v"
-          cat scripts/prune_unused_docker_images.sh | ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/prune_unused_docker_images.sh"
-          ssh ${SSH_OPTS} ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
+          SSH_OPTS=(
+            -i ~/.ssh/deploy_key -o BatchMode=yes -o StrictHostKeyChecking=yes
+            -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -v
+          )
+          cat scripts/prune_unused_docker_images.sh | ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "cat > /tmp/prune_unused_docker_images.sh"
+          ssh "${SSH_OPTS[@]}" ${{ secrets.SSH_USER_API }}@${{ secrets.SSH_HOST_API }} "\
             chmod +x /tmp/prune_unused_docker_images.sh && \
             KEEP_BACKEND_IMAGES=3 bash /tmp/prune_unused_docker_images.sh" | tee backend_docker_prune.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ AI_AGENT_CONTEXT.md
 credentials.json
 client_secret.json
 token.json
+google-oauth/
 g-vision-ocr.json
 backups/*
 /media/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+LABEL org.mvn.google-oauth-token-contract="directory-v1"
+
 # Set working directory
 WORKDIR /app
 

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -9,13 +9,14 @@ x-api-app: &api-app
     - .ha-app-role.env
   environment:
     DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+    GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
   volumes:
     - ./media:/app/media
     - ./postgres-wal-archive:/postgres-wal-archive
     - ./model-cache/u2net:/root/.u2net
-    - ./token.json:/app/token.json
-    - ./client_secret.json:/app/client_secret.json
-    - ./credentials.json:/app/credentials.json
+    - ./google-oauth:/app/google-oauth
+    - ./client_secret.json:/app/client_secret.json:ro
+    - ./credentials.json:/app/credentials.json:ro
     - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
 
 services:

--- a/deploy/ha/mvn-api/docker-compose.primary.yml
+++ b/deploy/ha/mvn-api/docker-compose.primary.yml
@@ -12,13 +12,14 @@ x-api-app: &api-app
     BOT_ENABLED: "false"
     API_READY_ENABLED: "true"
     DB_BOOTSTRAP_ENABLED: "true"
+    GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
   volumes:
     - ./media:/app/media
     - ./postgres-wal-archive:/postgres-wal-archive
     - ./model-cache/u2net:/root/.u2net
-    - ./token.json:/app/token.json
-    - ./client_secret.json:/app/client_secret.json
-    - ./credentials.json:/app/credentials.json
+    - ./google-oauth:/app/google-oauth
+    - ./client_secret.json:/app/client_secret.json:ro
+    - ./credentials.json:/app/credentials.json:ro
     - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
 
 services:

--- a/deploy/ha/mvn-api/docker-compose.standby.yml
+++ b/deploy/ha/mvn-api/docker-compose.standby.yml
@@ -33,12 +33,13 @@ services:
       MAIL_IMAP_AUTO_IMPORT_ENABLED: "false"
       MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED: "false"
       BACKGROUND_REMOVAL_PROVIDER: noop
+      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
     ports:
       - "127.0.0.1:8000:8000"
     volumes:
       - ./media:/app/media
       - ./model-cache/u2net:/root/.u2net
-      - ./token.json:/app/token.json
+      - ./google-oauth:/app/google-oauth
       - ./client_secret.json:/app/client_secret.json:ro
       - ./credentials.json:/app/credentials.json:ro
       - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -16,11 +16,12 @@ x-api-app: &api-app
     BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
     BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
     BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+    GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
   volumes:
     - ./media:/app/media
     - ./postgres-wal-archive:/postgres-wal-archive
     - ./model-cache/u2net:/root/.u2net
-    - ./secrets/token.json:/app/token.json
+    - ./google-oauth:/app/google-oauth
     - ./secrets/client_secret.json:/app/client_secret.json:ro
     - ./secrets/credentials.json:/app/credentials.json:ro
     - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro

--- a/deploy/ha/zakup/docker-compose.primary.yml
+++ b/deploy/ha/zakup/docker-compose.primary.yml
@@ -59,13 +59,14 @@ services:
       BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
       BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
       BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
     ports:
       - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
     volumes:
       - ./media:/app/media
       - ./postgres-wal-archive:/postgres-wal-archive
       - ./model-cache/u2net:/root/.u2net
-      - ./secrets/token.json:/app/token.json
+      - ./google-oauth:/app/google-oauth
       - ./secrets/client_secret.json:/app/client_secret.json:ro
       - ./secrets/credentials.json:/app/credentials.json:ro
       - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro

--- a/deploy/ha/zakup/docker-compose.standby.yml
+++ b/deploy/ha/zakup/docker-compose.standby.yml
@@ -52,12 +52,13 @@ services:
       BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS: ""
       BACKGROUND_REMOVAL_PROCESS_MAX_MEMORY_MB: "384"
       BACKGROUND_REMOVAL_PROCESS_MAX_CPU_SECONDS: "45"
+      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
     ports:
       - "127.0.0.1:${MVN_RESERVE_APP_PORT:-18000}:8000"
     volumes:
       - ./media:/app/media
       - ./model-cache/u2net:/root/.u2net
-      - ./secrets/token.json:/app/token.json
+      - ./google-oauth:/app/google-oauth
       - ./secrets/client_secret.json:/app/client_secret.json:ro
       - ./secrets/credentials.json:/app/credentials.json:ro
       - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro

--- a/deploy_api.sh
+++ b/deploy_api.sh
@@ -1,71 +1,11 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Configuration
-REMOTE_HOST="${REMOTE_HOST:-root@185.250.45.54}"
-REMOTE_DIR="/opt/air-api"
-DOCKER_COMPOSE_FILE="docker-compose.api.yml"
+cat >&2 <<'MESSAGE'
+deploy_api.sh is retired because its source bind mount changes the running
+application before a health check and cannot provide a real rollback.
 
-echo "========================================"
-echo "🚀 Deploying API + Manager to $REMOTE_HOST..."
-echo "========================================"
-
-# 0. Pre-flight: Check if manager frontend is built
-echo "🔍 Checking pre-built artifacts..."
-if [ ! -d "./manager_frontend/dist" ]; then
-    echo "❌ ERROR: manager_frontend/dist not found!"
-    echo "📦 Please build the manager frontend first:"
-    echo "   cd manager_frontend && npm run build"
-    exit 1
-fi
-echo "✅ Manager frontend dist found"
-
-# 1. Sync files (code + alembic migrations + manager dist)
-echo "📂 Syncing files..."
-rsync -avz --delete \
-    --exclude 'web/' \
-    --exclude 'web' \
-    --exclude '__pycache__' \
-    --exclude '.git' \
-    --exclude '.venv' \
-    --exclude 'node_modules' \
-    --exclude 'media' \
-    --exclude 'backups' \
-    --exclude 'tmp' \
-    --exclude '.env' \
-    --exclude 'env.prod' \
-    ./ "$REMOTE_HOST:$REMOTE_DIR"
-
-# 1.5. Deploy production environment file
-echo "⚙️  Setting up production environment..."
-rsync -avz ./env.prod "$REMOTE_HOST:$REMOTE_DIR/.env"
-
-# 2. Update Google tokens on remote
-echo "🔑 Syncing Google tokens..."
-rsync -avz ./token.json "$REMOTE_HOST:$REMOTE_DIR/token.json" 2>/dev/null || echo "⚠️  No token.json found, skipping..."
-
-# 3. Build new images on remote
-echo "🐳 Building containers..."
-ssh "$REMOTE_HOST" "cd $REMOTE_DIR && \
-    docker compose -f $DOCKER_COMPOSE_FILE build --no-cache app bot"
-
-# 4. Run database migrations BEFORE restarting
-echo "📦 Running database migrations..."
-ssh "$REMOTE_HOST" "cd $REMOTE_DIR && \
-    docker compose -f $DOCKER_COMPOSE_FILE run --rm app alembic upgrade head"
-
-# 5. Restart services with new images
-echo "🔄 Restarting services..."
-ssh "$REMOTE_HOST" "cd $REMOTE_DIR && \
-    docker compose -f $DOCKER_COMPOSE_FILE up -d --remove-orphans && \
-    docker system prune -f"
-
-# 6. Verify deployment
-echo "🔍 Checking logs..."
-ssh "$REMOTE_HOST" "cd $REMOTE_DIR && docker compose logs app --tail=10"
-
-echo ""
-echo "✅ API + Manager Deployment Complete!"
-echo "   Admin: https://api.mvn.by/admin/"
-echo "   Manager: https://api.mvn.by/manager/"
-echo "   Health: https://api.mvn.by/api/health"
+Publish a tested commit through the production GitHub Actions image workflow.
+See docs/deployment.md and docs/google-oauth-token-runbook.md.
+MESSAGE
+exit 1

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -22,12 +22,13 @@ services:
       - .env
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-mvnadmin}:${POSTGRES_PASSWORD:-securepass}@db/${POSTGRES_DB:-air_conditioners}
+      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
     ports:
       - "8000:8000"
     volumes:
       - .:/app
       - ./media:/app/media
-      - ./token.json:/app/token.json
+      - ./google-oauth:/app/google-oauth
 
   bot:
     build: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,12 +9,13 @@ x-api-app: &api-app
     - .env
   environment:
     DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+    GOOGLE_TOKEN_FILE: /app/google-oauth/token.json
   volumes:
     - ./media:/app/media
     - ./model-cache/u2net:/root/.u2net
-    - ./token.json:/app/token.json
-    - ./client_secret.json:/app/client_secret.json
-    - ./credentials.json:/app/credentials.json
+    - ./google-oauth:/app/google-oauth
+    - ./client_secret.json:/app/client_secret.json:ro
+    - ./credentials.json:/app/credentials.json:ro
     - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
 
 services:

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -76,6 +76,12 @@ unreviewed host-local compose edits:
 | Media sync helper/timer | `scripts/ha/media_sync_pull.sh`, `deploy/ha/systemd/mvn-media-sync.*` |
 | PostgreSQL quorum preparation | `docs/postgres-quorum-runbook.md`, `deploy/ha/quorum/`, `deploy/ha/patroni/`, `scripts/ha/generate_etcd_pki.sh`, `scripts/ha/check_etcd_quorum.sh`, `scripts/ha/patroni_role_agent.py` |
 
+Every API compose source mounts `<project>/google-oauth/` at
+`/app/google-oauth` and sets `GOOGLE_TOKEN_FILE=/app/google-oauth/token.json`.
+Follow [`google-oauth-token-runbook.md`](google-oauth-token-runbook.md) for the
+replica-first migration and restore-drill proof; never restore the old
+single-file token mount.
+
 ## Daily Status Checks
 
 Primary:
@@ -514,11 +520,14 @@ Expected deploy behavior:
   older than seven days;
 - frontend deploy is skipped unless explicitly requested.
 
-If primary activation or smoke checks fail, the workflow runs a guarded
-code-only rollback to `.previous-backend-image`. The guard verifies that the
-failed candidate was actually persisted before changing anything. Rollback does
-not downgrade Alembic, so every production migration must follow the
-expand/contract compatibility policy.
+If activation or smoke checks fail before compose promotion, the transactional
+handler restores the previous runtime image through the unchanged canonical
+compose while the deployment lock is still held. The later workflow guard then
+reconciles only when necessary. After the OAuth directory migration, a manual
+rollback accepts only a `directory-v1` image and must pass the durable Google
+backup probe; pre-hotfix images are roll-forward-only. Rollback does not
+downgrade Alembic, so every production migration must follow the expand/contract
+compatibility policy.
 
 Manual disk pressure check:
 
@@ -541,12 +550,14 @@ Manual zero-downtime code rollback on the current primary:
 
 ```bash
 scp scripts/deploy_backend_blue_green.sh scripts/deploy_backend_blue_green_safety.sh \
-  scripts/rollback_backend.sh mvn-api:/tmp/
+  scripts/prepare_google_oauth_token_dir.sh scripts/rollback_backend.sh mvn-api:/tmp/
 ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh \
-  /tmp/deploy_backend_blue_green_safety.sh /tmp/rollback_backend.sh && \
+  /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh \
+  /tmp/rollback_backend.sh && \
   CONFIRM_ROLLBACK=true API_PROJECT_DIR=/opt/air-api \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
   API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
+  GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT=/tmp/prepare_google_oauth_token_dir.sh \
   bash /tmp/rollback_backend.sh'
 ```
 
@@ -858,8 +869,15 @@ ssh mvn-api /usr/local/sbin/mvn-restore-drill-latest-db
 
 The drill downloads the latest DB backup through the app container, starts a
 disposable PostgreSQL container on the same Docker network, restores the dump
-there, checks that public tables exist, and then removes the disposable
-container. It does not touch the production or standby database.
+there, requires at least 64 public tables plus non-empty product/order data, and
+then removes the disposable container together with its dedicated Postgres data
+volume. Both disposable objects are labeled
+`com.mvn.purpose=api-restore-drill` and `com.mvn.run_id=<run>`; cleanup removes
+only objects whose exact names and run labels both match, while a hard-kill
+residue remains safely inventoryable by label. Every run also uses its own
+`/tmp/mvn-restore-drill/<run-id>` directory and removes only its three known
+files. The GitHub workflow serializes runs with the `api-restore-drill`
+concurrency group. It does not touch the production or standby database.
 
 GitHub also runs this daily:
 

--- a/docs/api-reliability-plan.md
+++ b/docs/api-reliability-plan.md
@@ -187,8 +187,9 @@ Planned migration steps:
 2. Prepare the new VPS baseline: Docker, Compose, nginx, firewall, TLS, and
    `/opt/air-api`.
 3. Copy runtime files from old API to new API without printing secrets:
-   `.env`, `docker-compose.prod.yml`, `token.json`, `client_secret.json`,
-   `credentials.json`.
+   `.env`, `docker-compose.prod.yml`, the `google-oauth/` directory,
+   `client_secret.json`, and `credentials.json`. Retain a legacy `token.json`
+   only as a temporary rollback artifact.
 4. Create `docker-compose.cutover.yml` on the new host with the SHA-pinned
    backend image.
 5. Start only `db` on the new host.
@@ -409,8 +410,10 @@ Current state:
 
 - Generated order documents, uploaded order documents, customer contracts, and
   document downloads use Google Drive file ids and edit URLs stored in the DB.
-- The app needs mounted Google credential files in production:
-  `token.json`, `client_secret.json`, and `credentials.json`.
+- The app needs Google credential files in production. The refreshable OAuth
+  token uses the writable directory contract
+  `google-oauth/token.json -> /app/google-oauth/token.json`; client secret and
+  service credentials remain read-only runtime files.
 - The migration runbook already treats these credential files as runtime files
   that must be copied to the new VPS without printing contents.
 

--- a/docs/api-vps-migration-runbook.md
+++ b/docs/api-vps-migration-runbook.md
@@ -119,10 +119,11 @@ Record `.env` key names without values:
 awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/{print $1"=<redacted>"}' .env | sort
 ```
 
-Confirm required runtime files exist:
+Confirm required runtime files exist. Keep the legacy token only as a migration
+source; the running container uses `google-oauth/token.json`:
 
 ```bash
-for f in .env docker-compose.prod.yml token.json client_secret.json credentials.json; do
+for f in .env docker-compose.prod.yml google-oauth/token.json client_secret.json credentials.json; do
   if [ -f "$f" ]; then
     stat -c '%n %s bytes mode=%a owner=%U:%G' "$f"
   else
@@ -153,7 +154,10 @@ Inventory Google Drive backup visibility from the app container:
 docker compose -f docker-compose.prod.yml exec -T app python scripts/restore_db.py --list
 ```
 
-This confirms `token.json` is usable and shows available DB/media backups. Do not use Drive backups as the primary migration source unless a direct frozen dump cannot be used; a fresh dump taken after the maintenance freeze is the least stale source of truth.
+This confirms the configured `GOOGLE_TOKEN_FILE` is usable and shows available
+DB/media backups. Do not use Drive backups as the primary migration source
+unless a direct frozen dump cannot be used; a fresh dump taken after the
+maintenance freeze is the least stale source of truth.
 
 ## Phase 2: New VPS Baseline
 
@@ -278,8 +282,9 @@ ssh "${API_USER}@${OLD_API_HOST}" '
   set -euo pipefail
   cd /opt/air-api
   install -m 700 -d /root/api-migration-stage
-  tar -czf /root/api-migration-stage/runtime-files.tar.gz \
-    .env docker-compose.prod.yml token.json client_secret.json credentials.json
+  set -- .env docker-compose.prod.yml google-oauth/token.json client_secret.json credentials.json
+  test ! -f token.json || set -- "$@" token.json
+  tar -czf /root/api-migration-stage/runtime-files.tar.gz "$@"
   chmod 600 /root/api-migration-stage/runtime-files.tar.gz
 '
 
@@ -290,7 +295,9 @@ ssh "${API_USER}@${NEW_API_HOST}" '
   set -euo pipefail
   cd /opt/air-api
   tar -xzf /root/runtime-files.tar.gz
-  chmod 600 .env token.json client_secret.json credentials.json
+  install -d -m 0700 google-oauth
+  chmod 600 .env google-oauth/token.json client_secret.json credentials.json
+  test ! -f token.json || chmod 600 token.json
 '
 ```
 

--- a/docs/api-vps-monitoring.md
+++ b/docs/api-vps-monitoring.md
@@ -218,7 +218,10 @@ PY
 ```
 
 Check that production still has `ENVIRONMENT=production`, `BACKUP_FOLDER_ID`,
-and the mounted Google credential files expected by `docker-compose.prod.yml`.
+and the directory-backed OAuth token contract described in
+[`google-oauth-token-runbook.md`](google-oauth-token-runbook.md). The token must
+resolve to `/app/google-oauth/token.json`; do not restore the old single-file
+bind mount.
 Trigger a manual backup only after the owner approves a state-changing action.
 
 ## Safety Notes

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,6 +83,11 @@ The multi-origin API HA target and Cloudflare/DB/media runbook is documented in
 [`api-ha-runbook.md`](api-ha-runbook.md). Use `/api/health` for basic smoke
 checks and `/api/ready` for Cloudflare Load Balancer origin health.
 
+Google OAuth refresh state uses a writable directory mount, not a bind-mounted
+file. Prepare and verify it with
+[`google-oauth-token-runbook.md`](google-oauth-token-runbook.md) before manual
+deployments; automated deploy paths run the same fail-closed preparation.
+
 The backend deploy workflow is primary-host configurable. Keep sensitive values
 in GitHub secrets and non-secret routing values in GitHub variables.
 
@@ -375,10 +380,13 @@ Application release and database maintenance are separate lifecycles:
 - cleanup retains three backend releases and never runs a global
   `docker system prune -af`.
 
-Automatic rollback restores the previous application image only when the failed
-candidate was actually activated. It never downgrades the database schema. Use
-expand/contract migrations so both the new image and retained rollback images
-can run against the current schema.
+Before compose promotion, failed-candidate recovery restores the active runtime
+image and canonical compose together under the same deployment lock. After the
+Google token-directory migration, manual rollback accepts only images labeled
+with the `directory-v1` token contract and requires a durable Google backup probe;
+pre-hotfix images fail closed and must be replaced by a roll-forward release.
+Rollback never downgrades the database schema. Use expand/contract migrations so
+all retained directory-compatible images can run against the current schema.
 
 The primary compose keeps the legacy `app` service on port `8000` only for the
 first migration and emergency compatibility. Normal releases alternate between
@@ -390,14 +398,22 @@ Manual code rollback on the active API host:
 
 ```bash
 scp scripts/deploy_backend_blue_green.sh scripts/deploy_backend_blue_green_safety.sh \
-  scripts/rollback_backend.sh mvn-api:/tmp/
+  scripts/prepare_google_oauth_token_dir.sh scripts/rollback_backend.sh mvn-api:/tmp/
 ssh mvn-api 'chmod +x /tmp/deploy_backend_blue_green.sh \
-  /tmp/deploy_backend_blue_green_safety.sh /tmp/rollback_backend.sh && \
+  /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh \
+  /tmp/rollback_backend.sh && \
   CONFIRM_ROLLBACK=true API_PROJECT_DIR=/opt/air-api \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
   API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
+  GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT=/tmp/prepare_google_oauth_token_dir.sh \
   bash /tmp/rollback_backend.sh'
 ```
+
+This command refuses an unlabeled pre-hotfix image. It also restores the current
+image automatically if the post-activation Google durability probe fails.
+
+The old `deploy_api.sh` source-bind path is intentionally retired. Production
+changes must use the CI-tested immutable-image workflow.
 
 ### Web Release Safety
 

--- a/docs/google-oauth-token-runbook.md
+++ b/docs/google-oauth-token-runbook.md
@@ -1,0 +1,102 @@
+# Google OAuth Token Persistence Runbook
+
+## Contract
+
+Google OAuth credentials must be stored in a writable directory mount, never as
+an individual bind-mounted file. OAuth refresh persistence uses an atomic
+temporary-file rename. Linux rejects that rename when the destination itself is
+a bind-mount point (`EBUSY`).
+
+All seven production/HA compose sources use this contract:
+
+```text
+host:      <project>/google-oauth/token.json
+container: /app/google-oauth/token.json
+env:       GOOGLE_TOKEN_FILE=/app/google-oauth/token.json
+directory mode: 0700
+token mode:     0600
+```
+
+The local `docker-compose.api.yml` follows the same rule. The former
+`deploy_api.sh` source-bind deployment is retired because it changed live code
+before smoke checks and could not provide a real rollback.
+
+## Safe Preparation
+
+The deployment scripts run this helper while holding the deployment lock and
+before any migration or container activation:
+
+```bash
+GOOGLE_OAUTH_PROJECT_DIR=/opt/air-api \
+  bash scripts/prepare_google_oauth_token_dir.sh prepare
+```
+
+It creates `google-oauth/` with mode `0700`, copies a valid legacy token to a
+same-directory temporary file, sets mode `0600`, and atomically renames it to
+`google-oauth/token.json`. It accepts both historical locations:
+
+- `/opt/air-api/token.json`
+- `/opt/mvn-reserve/secrets/token.json`
+
+The helper never prints token contents and never deletes the legacy source. If
+both historical files exist with different contents, deployment fails closed;
+select the intended source explicitly with `GOOGLE_OAUTH_LEGACY_TOKEN_FILE`.
+
+Read-only verification:
+
+```bash
+GOOGLE_OAUTH_PROJECT_DIR=/opt/air-api \
+  bash scripts/prepare_google_oauth_token_dir.sh verify
+```
+
+## HA Rollout
+
+Keep the current legacy token files through the complete proof and rollback
+window.
+
+1. Prepare both nodes without deleting or moving either legacy token.
+   Every rollout uses a run-unique candidate compose. The deployment lock is
+   held continuously across candidate activation, smoke checks, and the final
+   atomic promotion, so concurrent deploys cannot overwrite or promote another
+   run's candidate. Patroni migrations also use a run-unique candidate and do
+   not replace the active compose on disk.
+2. Deploy the fenced Patroni replica first. Confirm `/api/health` is healthy and
+   `/api/ready` remains fenced with HTTP 503.
+3. Deploy the primary through the blue-green path.
+4. Confirm exactly one ready API origin and one scheduler owner.
+5. Confirm the active container sees the directory-backed token without
+   printing it:
+
+   ```bash
+   docker compose -f docker-compose.patroni.yml --profile bluegreen exec -T app-green \
+     sh -lc 'test "$GOOGLE_TOKEN_FILE" = /app/google-oauth/token.json && test -f "$GOOGLE_TOKEN_FILE" && test -w "$GOOGLE_TOKEN_FILE"'
+   ```
+
+   Replace `app-green` with the service named by `.active-api-slot`.
+6. Run the manual Google Drive restore drill and require a real backup selection,
+   at least the expected table count, and non-zero product/order counts.
+7. Check host metadata only: directory mode `700`, token mode `600`, token mtime
+   advanced after refresh, and the legacy source still exists.
+8. Re-run the Patroni production and PITR checks.
+
+Do not delete the legacy token as part of this rollout. Retirement is a separate
+manual cleanup after an agreed rollback window and repeated successful refresh,
+backup, and restore-drill evidence.
+
+## Rollback Policy
+
+Before promotion, failure cleanup removes only that run's candidate; canonical
+compose is still the legacy compose. The failure path force-recreates the
+actually active API service (and `bot` where applicable) through canonical
+compose before the workflow's guard runs. This preserves the exact pre-release
+runtime; it does not claim that the already-known legacy Google defect is fixed.
+
+After a successful atomic promotion, rollback to a pre-hotfix image is forbidden:
+an unlabeled image cannot durably refresh through either mount contract. The
+rollback helper accepts only images labeled
+`org.mvn.google-oauth-token-contract=directory-v1`, validates the exact compose
+environment and directory mount, proves an atomic same-directory write, requires
+healthy durable credentials, and lists a real backup before declaring success.
+For a pre-hotfix target, use a normal roll-forward release of the OAuth-aware
+image. The preserved `<compose>.pre-google-oauth-dir` is diagnostic evidence, not
+an approved automatic rollback input.

--- a/manager_frontend/src/client/models/ManagerGoogleAuthStatusResponse.ts
+++ b/manager_frontend/src/client/models/ManagerGoogleAuthStatusResponse.ts
@@ -8,5 +8,7 @@ export type ManagerGoogleAuthStatusResponse = {
     expired: boolean;
     expiry?: (string | null);
     scopes?: Array<string>;
+    persistence_ok: boolean;
+    persistence_error_code?: (string | null);
 };
 

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -976,13 +976,17 @@ onMounted(() => {
             </div>
 
             <div class="mt-4 p-3 rounded-lg border"
-                :class="googleAuthStatus?.valid
+                :class="googleAuthStatus?.valid && googleAuthStatus?.persistence_ok
                     ? 'bg-green-50 border-green-200 text-green-800 dark:bg-green-500/10 dark:border-green-500/40 dark:text-green-300'
                     : 'bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-500/10 dark:border-amber-500/40 dark:text-amber-300'">
                 <div class="text-sm font-medium">
                     <span v-if="googleAuthLoading">Проверяем статус...</span>
-                    <span v-else-if="googleAuthStatus?.valid">Подключено</span>
+                    <span v-else-if="googleAuthStatus?.valid && googleAuthStatus?.persistence_ok">Подключено</span>
+                    <span v-else-if="googleAuthStatus?.valid">Работает временно — токен не сохранён</span>
                     <span v-else>Не подключено / токен истёк</span>
+                </div>
+                <div v-if="googleAuthStatus?.valid && !googleAuthStatus?.persistence_ok" class="text-xs mt-1 opacity-80">
+                    Переподключите Google: после перезапуска доступ может пропасть.
                 </div>
                 <div v-if="googleAuthStatus?.expiry" class="text-xs mt-1 opacity-80">
                     Действует до: {{ googleAuthStatus.expiry }}

--- a/openapi.json
+++ b/openapi.json
@@ -25923,13 +25923,29 @@
             "type": "array",
             "title": "Scopes",
             "default": []
+          },
+          "persistence_ok": {
+            "type": "boolean",
+            "title": "Persistence Ok"
+          },
+          "persistence_error_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Persistence Error Code"
           }
         },
         "type": "object",
         "required": [
           "exists",
           "valid",
-          "expired"
+          "expired",
+          "persistence_ok"
         ],
         "title": "ManagerGoogleAuthStatusResponse"
       },

--- a/routers/manager_backups.py
+++ b/routers/manager_backups.py
@@ -1,8 +1,10 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from starlette.concurrency import run_in_threadpool
 
 from core.config import settings
+from core.manager_api_errors import manager_http_error
 from core.security import get_current_owner_username
 from routers.manager_operation_ids import (
     GET_MANAGER_BACKUP_RUN_STATUS,
@@ -22,7 +24,8 @@ from services.backup_run_runtime_service import (
     BackupRunConflictError,
     backup_run_runtime_service,
 )
-from services.backup_service import backup_service
+from services.backup_service import BackupConfigurationError, backup_service
+from services.google_oauth_credentials import GoogleCredentialsError, GoogleDriveListError
 from services.backup_restore_runtime_service import (
     BackupNotFoundError,
     RestoreConflictError,
@@ -37,11 +40,30 @@ router = APIRouter(
     tags=["manager/backups"],
     dependencies=[Depends(get_current_owner_username)],
 )
+BACKUP_LIST_UNAVAILABLE = "backup_list_unavailable"
+BACKUP_LIST_UNAVAILABLE_MESSAGE = "Список резервных копий временно недоступен"
 
 
 @router.get("", response_model=ManagerBackupListResponse, operation_id=LIST_MANAGER_BACKUPS)
 async def list_manager_backups():
-    items = backup_service.list_backups(limit=100)
+    try:
+        items = await run_in_threadpool(lambda: backup_service.list_backups(limit=100))
+    except BackupConfigurationError as exc:
+        logger.error("Backup list is unavailable because backup storage is not configured")
+        raise manager_http_error(
+            status_code=503,
+            endpoint=LIST_MANAGER_BACKUPS,
+            error_code=BACKUP_LIST_UNAVAILABLE,
+            message=BACKUP_LIST_UNAVAILABLE_MESSAGE,
+        ) from exc
+    except (GoogleCredentialsError, GoogleDriveListError) as exc:
+        logger.warning("Backup list is unavailable error_type=%s", type(exc).__name__)
+        raise manager_http_error(
+            status_code=502,
+            endpoint=LIST_MANAGER_BACKUPS,
+            error_code=BACKUP_LIST_UNAVAILABLE,
+            message=BACKUP_LIST_UNAVAILABLE_MESSAGE,
+        ) from exc
     return ManagerBackupListResponse(items=items)
 
 

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, UploadFile, File, Form, Query
@@ -36,12 +37,33 @@ from schemas import (
 )
 from services.document_service import DocumentHasDependentsError, DocumentService
 from services.document_template_service import DocumentTemplateService
+from services.google_oauth_credentials import GoogleCredentialsError, GoogleDriveListError
 from services.google_service import get_google_service
 
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/manager", tags=["manager-docs"])
 
 DEFAULT_DOCUMENT_TEMPLATE_FOLDER_ID = "1SClclCJS2FUVtfF-vbVqN8zI77Sl_E9t"
+DOCUMENT_TEMPLATE_FILES_UNAVAILABLE = "document_template_files_unavailable"
+DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE = (
+    "Список файлов шаблонов временно недоступен"
+)
+
+
+def _document_template_files_google_error(
+    exc: GoogleCredentialsError | GoogleDriveListError,
+):
+    logger.warning(
+        "Document template files are unavailable error_type=%s",
+        type(exc).__name__,
+    )
+    return manager_http_error(
+        status_code=502,
+        endpoint=LIST_MANAGER_DOCUMENT_TEMPLATE_FILES,
+        error_code=DOCUMENT_TEMPLATE_FILES_UNAVAILABLE,
+        message=DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE,
+    )
 
 
 @router.get(
@@ -285,7 +307,12 @@ async def list_manager_document_template_files(
     limit: int = Query(100, ge=1, le=200),
     _: str = Depends(get_current_username),
 ):
-    files = await run_in_threadpool(lambda: get_google_service().list_files(folder_id, limit=limit))
+    try:
+        files = await run_in_threadpool(
+            lambda: get_google_service().list_files(folder_id, limit=limit)
+        )
+    except (GoogleCredentialsError, GoogleDriveListError) as exc:
+        raise _document_template_files_google_error(exc) from exc
     return {
         "items": [
             DocumentTemplateFileItem(

--- a/schemas.py
+++ b/schemas.py
@@ -3538,6 +3538,8 @@ class ManagerGoogleAuthStatusResponse(BaseModel):
     expired: bool
     expiry: Optional[str] = None
     scopes: List[str] = []
+    persistence_ok: bool
+    persistence_error_code: Optional[str] = None
 
 
 class ManagerGoogleAuthUrlResponse(BaseModel):

--- a/scripts/compose_candidate_transaction.sh
+++ b/scripts/compose_candidate_transaction.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ACTION="${1:-}"
+CANONICAL_FILE="${CANONICAL_COMPOSE_FILE:-}"
+CANDIDATE_FILE="${CANDIDATE_COMPOSE_FILE:-}"
+LEGACY_BACKUP_FILE="${LEGACY_COMPOSE_BACKUP_FILE:-${CANONICAL_FILE}.pre-google-oauth-dir}"
+
+log() {
+  printf '[compose-candidate][%s] %s\n' "$1" "$2"
+}
+
+fail() {
+  log error "$1" >&2
+  exit 1
+}
+
+fsync_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+descriptor = os.open(sys.argv[1], os.O_RDONLY)
+try:
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+PY
+}
+
+atomic_copy() {
+  local source="$1"
+  local destination="$2"
+  local temporary
+  temporary="$(mktemp "${destination}.tmp.XXXXXX")"
+  if ! cp -p -- "${source}" "${temporary}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  fsync_path "${temporary}" || {
+    rm -f -- "${temporary}"
+    return 1
+  }
+  if ! mv -f -- "${temporary}" "${destination}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  fsync_path "$(dirname "${destination}")"
+}
+
+[[ "${ACTION}" == "stage" || "${ACTION}" == "promote" || "${ACTION}" == "cleanup" ]] || {
+  echo "usage: compose_candidate_transaction.sh stage|promote|cleanup" >&2
+  exit 2
+}
+[[ -n "${CANONICAL_FILE}" && -n "${CANDIDATE_FILE}" ]] || {
+  fail "CANONICAL_COMPOSE_FILE and CANDIDATE_COMPOSE_FILE are required"
+}
+[[ "${CANONICAL_FILE}" != "${CANDIDATE_FILE}" ]] || {
+  fail "candidate compose must differ from canonical compose"
+}
+[[ "$(dirname "${CANONICAL_FILE}")" == "$(dirname "${CANDIDATE_FILE}")" ]] || {
+  fail "candidate and canonical compose must share a directory for atomic promotion"
+}
+
+case "${ACTION}" in
+  stage)
+    [[ -f "${CANONICAL_FILE}" && ! -L "${CANONICAL_FILE}" ]] || {
+      fail "canonical compose is missing or unsafe: ${CANONICAL_FILE}"
+    }
+    [[ -f "${CANDIDATE_FILE}" && ! -L "${CANDIDATE_FILE}" ]] || {
+      fail "candidate compose is missing or unsafe: ${CANDIDATE_FILE}"
+    }
+    if grep -Fq '/app/token.json' "${CANONICAL_FILE}"; then
+      if [[ -e "${LEGACY_BACKUP_FILE}" || -L "${LEGACY_BACKUP_FILE}" ]]; then
+        [[ -f "${LEGACY_BACKUP_FILE}" && ! -L "${LEGACY_BACKUP_FILE}" ]] || {
+          fail "legacy compose backup is unsafe: ${LEGACY_BACKUP_FILE}"
+        }
+        cmp -s "${CANONICAL_FILE}" "${LEGACY_BACKUP_FILE}" || {
+          fail "legacy compose backup differs from canonical; refusing a stale emergency artifact"
+        }
+      else
+        atomic_copy "${CANONICAL_FILE}" "${LEGACY_BACKUP_FILE}"
+      fi
+    fi
+    log stage "candidate staged; canonical compose remains unchanged"
+    ;;
+  promote)
+    [[ -f "${CANDIDATE_FILE}" && ! -L "${CANDIDATE_FILE}" ]] || {
+      fail "candidate compose is missing or unsafe: ${CANDIDATE_FILE}"
+    }
+    fsync_path "${CANDIDATE_FILE}"
+    mv -f -- "${CANDIDATE_FILE}" "${CANONICAL_FILE}"
+    fsync_path "$(dirname "${CANONICAL_FILE}")"
+    ;;
+  cleanup)
+    rm -f -- "${CANDIDATE_FILE}"
+    log cleanup "candidate removed"
+    ;;
+esac

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 echo "🚀 Starting deployment script on server..."
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
 DEPLOY_SERVICES="${API_DEPLOY_SERVICES:-app bot}"
@@ -11,6 +12,8 @@ RUN_MIGRATIONS="${API_RUN_MIGRATIONS:-true}"
 RUN_DEFAULTS="${API_RUN_DEFAULTS:-true}"
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+DEPLOY_LOCK_ALREADY_HELD="${API_DEPLOY_LOCK_ALREADY_HELD:-false}"
+GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/prepare_google_oauth_token_dir.sh}"
 
 if [[ ! "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
     echo "❌ BACKEND_IMAGE must use a 40-character Git SHA tag or sha256 digest" >&2
@@ -31,11 +34,20 @@ if [[ ! -f "${COMPOSE_FILE}" ]]; then
     exit 1
 fi
 
-exec 9>"${DEPLOY_LOCK_FILE}"
-if ! flock -n 9; then
-    echo "❌ Another deployment holds ${DEPLOY_LOCK_FILE}; refusing to overlap" >&2
+if [[ "${DEPLOY_LOCK_ALREADY_HELD}" != "true" ]]; then
+    exec 9>"${DEPLOY_LOCK_FILE}"
+    if ! flock -n 9; then
+        echo "❌ Another deployment holds ${DEPLOY_LOCK_FILE}; refusing to overlap" >&2
+        exit 1
+    fi
+fi
+
+if [[ ! -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]]; then
+    echo "❌ Google OAuth token preparation script not found: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" >&2
     exit 1
 fi
+GOOGLE_OAUTH_PROJECT_DIR="${PROJECT_DIR}" \
+    bash "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" prepare
 
 COMPOSE=(docker compose -f "${COMPOSE_FILE}")
 read -r -a deploy_services <<<"${DEPLOY_SERVICES}"

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -34,6 +34,7 @@ SCHEDULER_STABILITY_SECONDS="${API_SCHEDULER_STABILITY_SECONDS:-9}"
 SERVICE_STOP_TIMEOUT_SECONDS="${API_SERVICE_STOP_TIMEOUT_SECONDS:-5}"
 DRAIN_SECONDS="${API_DRAIN_SECONDS:-5}"
 SUMMARY_FILE="${API_BLUE_GREEN_SUMMARY_FILE:-/tmp/backend_blue_green_summary.txt}"
+GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/prepare_google_oauth_token_dir.sh}"
 
 active_slot="legacy"
 active_service="app"
@@ -536,6 +537,13 @@ if [[ "${DEPLOY_LOCK_ALREADY_HELD}" != "true" ]]; then
     exit 1
   }
 fi
+
+[[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
+  log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
+  exit 1
+}
+GOOGLE_OAUTH_PROJECT_DIR="${PROJECT_DIR}" \
+  bash "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" prepare
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT

--- a/scripts/deploy_backend_candidate_transaction.sh
+++ b/scripts/deploy_backend_candidate_transaction.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+CANONICAL_FILE="${API_CANONICAL_COMPOSE_FILE:-${PROJECT_DIR}/docker-compose.prod.yml}"
+CANDIDATE_FILE="${API_CANDIDATE_COMPOSE_FILE:-}"
+TRANSACTION_ENABLED="${API_COMPOSE_TRANSACTIONAL:-true}"
+DEPLOY_STRATEGY="${API_DEPLOY_STRATEGY:-blue_green}"
+TRANSACTION_SCRIPT="${COMPOSE_CANDIDATE_TRANSACTION_SCRIPT:-/tmp/compose_candidate_transaction.sh}"
+BLUE_GREEN_SCRIPT="${API_BLUE_GREEN_SCRIPT:-/tmp/deploy_backend_blue_green.sh}"
+IN_PLACE_SCRIPT="${API_IN_PLACE_DEPLOY_SCRIPT:-/tmp/deploy.sh}"
+SMOKE_SCRIPT="${API_SMOKE_SCRIPT:-/tmp/post_deploy_smoke_check.sh}"
+RECONCILE_SCRIPT="${API_RECONCILE_SCRIPT:-/tmp/reconcile_backend_compose_runtime.sh}"
+DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+STOP_SERVICES_AFTER_DEPLOY="${API_STOP_SERVICES_AFTER_DEPLOY:-}"
+ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
+PREVIOUS_BACKEND_IMAGE="${API_PREVIOUS_BACKEND_IMAGE:-}"
+CANDIDATE_CHECKSUM=""
+
+transaction() {
+  CANONICAL_COMPOSE_FILE="${CANONICAL_FILE}" \
+    CANDIDATE_COMPOSE_FILE="${CANDIDATE_FILE}" \
+    bash "${TRANSACTION_SCRIPT}" "$1"
+}
+
+cleanup_candidate_only() {
+  local status=$?
+  trap - EXIT
+  set +e
+  if [[ "${TRANSACTION_ENABLED}" == "true" ]]; then
+    transaction cleanup
+  fi
+  exit "${status}"
+}
+
+failed_candidate() {
+  local status=$?
+  local restoration_failed=false
+  trap - EXIT
+  set +e
+  if promotion_committed; then
+    echo "candidate compose promotion committed; preserving the consistent new runtime" >&2
+    exit "${status}"
+  fi
+  if [[ "${TRANSACTION_ENABLED}" == "true" ]]; then
+    transaction cleanup || restoration_failed=true
+  fi
+  if ! API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
+    API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
+    bash "${RECONCILE_SCRIPT}"; then
+    restoration_failed=true
+  fi
+  if [[ "${restoration_failed}" == "true" ]]; then
+    echo "CRITICAL: failed candidate could not be fully restored to canonical runtime" >&2
+    exit 90
+  fi
+  exit "${status}"
+}
+
+promotion_committed() {
+  local canonical_checksum=""
+  [[ "${TRANSACTION_ENABLED}" == "true" ]] || return 1
+  [[ -n "${CANDIDATE_CHECKSUM}" && ! -e "${CANDIDATE_FILE}" ]] || return 1
+  [[ -f "${CANONICAL_FILE}" && ! -L "${CANONICAL_FILE}" ]] || return 1
+  canonical_checksum="$(cksum < "${CANONICAL_FILE}")" || return 1
+  [[ "${canonical_checksum}" == "${CANDIDATE_CHECKSUM}" ]]
+}
+
+resolve_previous_backend_image() {
+  local active_service="app"
+  local active_slot=""
+  local container_ids=""
+  local runtime_image=""
+
+  if [[ -n "${PREVIOUS_BACKEND_IMAGE}" ]]; then
+    [[ "${PREVIOUS_BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+      echo "API_PREVIOUS_BACKEND_IMAGE must be immutable" >&2
+      return 1
+    }
+    return 0
+  fi
+  if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
+    active_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+    case "${active_slot}" in
+      blue|green) active_service="app-${active_slot}" ;;
+      *) echo "invalid active API slot: ${active_slot}" >&2; return 1 ;;
+    esac
+  fi
+  container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen ps -q "${active_service}")"
+  [[ -n "${container_ids}" && "${container_ids}" != *$'\n'* ]] || {
+    echo "could not resolve exactly one active backend container for rollback" >&2
+    return 1
+  }
+  runtime_image="$(docker inspect --format '{{.Config.Image}}' "${container_ids}")"
+  [[ "${runtime_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    echo "active backend runtime image is not immutable" >&2
+    return 1
+  }
+  PREVIOUS_BACKEND_IMAGE="${runtime_image}"
+}
+
+[[ "${TRANSACTION_ENABLED}" == "true" || "${TRANSACTION_ENABLED}" == "false" ]] || {
+  echo "API_COMPOSE_TRANSACTIONAL must be true or false" >&2
+  exit 1
+}
+if [[ "${TRANSACTION_ENABLED}" == "true" ]]; then
+  [[ -n "${CANDIDATE_FILE}" && -f "${CANDIDATE_FILE}" ]] || {
+    echo "candidate compose is required for transactional deploy" >&2
+    exit 1
+  }
+  CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
+else
+  CANDIDATE_FILE="${CANONICAL_FILE}"
+fi
+
+mkdir -p "${PROJECT_DIR}"
+trap cleanup_candidate_only EXIT
+exec 9>"${DEPLOY_LOCK_FILE}"
+flock -n 9 || {
+  echo "another deployment holds ${DEPLOY_LOCK_FILE}" >&2
+  exit 1
+}
+resolve_previous_backend_image
+
+if [[ "${TRANSACTION_ENABLED}" == "true" ]]; then
+  if ! transaction stage; then
+    transaction cleanup || true
+    exit 1
+  fi
+fi
+trap failed_candidate EXIT
+
+candidate_name="$(basename "${CANDIDATE_FILE}")"
+case "${DEPLOY_STRATEGY}" in
+  blue_green)
+    API_COMPOSE_FILE="${candidate_name}" \
+      API_DEPLOY_LOCK_ALREADY_HELD=true \
+      bash "${BLUE_GREEN_SCRIPT}"
+    ;;
+  in_place)
+    API_COMPOSE_FILE="${candidate_name}" \
+      API_DEPLOY_LOCK_ALREADY_HELD=true \
+      bash "${IN_PLACE_SCRIPT}"
+    ;;
+  *)
+    echo "unsupported API_DEPLOY_STRATEGY=${DEPLOY_STRATEGY}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -n "${STOP_SERVICES_AFTER_DEPLOY}" ]]; then
+  read -r -a stop_services <<<"${STOP_SERVICES_AFTER_DEPLOY}"
+  docker compose -f "${CANDIDATE_FILE}" --profile bluegreen stop "${stop_services[@]}"
+fi
+
+COMPOSE_FILE="${CANDIDATE_FILE}" bash "${SMOKE_SCRIPT}"
+if [[ "${TRANSACTION_ENABLED}" == "true" ]]; then
+  transaction promote
+fi
+trap - EXIT
+echo "backend candidate activation, smoke, and compose promotion completed"

--- a/scripts/get_token.py
+++ b/scripts/get_token.py
@@ -1,10 +1,12 @@
 import os
 import sys
+from pathlib import Path
 
 # Добавляем путь к корню проекта для корректных импортов (если понадобятся)
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from google_auth_oauthlib.flow import InstalledAppFlow
+from services.google_oauth_credentials import GoogleOAuthCredentialStore
 
 # Права: полный доступ к Диску и Документам
 # Это позволит боту создавать файлы от вашего имени
@@ -13,6 +15,15 @@ SCOPES = [
     'https://www.googleapis.com/auth/documents',
     'https://www.googleapis.com/auth/spreadsheets'
 ]
+
+
+def get_token_file() -> Path:
+    return Path(os.environ.get('GOOGLE_TOKEN_FILE', 'token.json')).expanduser()
+
+
+def persist_token(creds, token_file: Path) -> None:
+    GoogleOAuthCredentialStore(str(token_file), SCOPES).persist(creds)
+
 
 def main():
     # Проверка наличия файла секрета
@@ -34,10 +45,10 @@ def main():
     creds = flow.run_local_server(port=0)
     
     # Сохраняем полученный токен доступа
-    with open('token.json', 'w') as token:
-        token.write(creds.to_json())
+    token_file = get_token_file()
+    persist_token(creds, token_file)
     
-    print("\n✅ Успешно! Файл token.json создан.")
+    print(f"\n✅ Успешно! Файл {token_file} создан.")
     print("Теперь бот имеет доступ к вашему Диску и будет использовать вашу квоту.")
 
 if __name__ == '__main__':

--- a/scripts/ha/cleanup_restore_drill_runtime.sh
+++ b/scripts/ha/cleanup_restore_drill_runtime.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+CONTAINER="${RESTORE_DRILL_CONTAINER:-}"
+DATA_VOLUME="${RESTORE_DRILL_DATA_VOLUME:-}"
+RUN_ID="${RESTORE_DRILL_RUN_ID:-}"
+DRILL_DIR="${RESTORE_DRILL_DIR:-/tmp/mvn-restore-drill}"
+KEEP_CONTAINER="${KEEP_DRILL_CONTAINER:-false}"
+KEEP_FILES="${KEEP_DRILL_FILES:-false}"
+
+log() {
+  printf '[restore-drill] %s\n' "$*"
+}
+
+inspect_object() {
+  local kind="$1"
+  local name="$2"
+  local output=""
+
+  if [[ "${kind}" == "container" ]]; then
+    output="$(docker inspect "${name}" 2>&1)" && return 0
+  else
+    output="$(docker volume inspect "${name}" 2>&1)" && return 0
+  fi
+  case "${output}" in
+    *"No such object"*|*"No such container"*|*"No such volume"*) return 1 ;;
+    *) log "cleanup_error=${kind}_inspect_failed name=${name}"; return 2 ;;
+  esac
+}
+
+labels_match() {
+  local kind="$1"
+  local name="$2"
+  local labels=""
+
+  if [[ "${kind}" == "container" ]]; then
+    labels="$(docker inspect --format '{{ index .Config.Labels "com.mvn.purpose" }}|{{ index .Config.Labels "com.mvn.run_id" }}' "${name}" 2>/dev/null)" \
+      || return 1
+  else
+    labels="$(docker volume inspect --format '{{ index .Labels "com.mvn.purpose" }}|{{ index .Labels "com.mvn.run_id" }}' "${name}" 2>/dev/null)" \
+      || return 1
+  fi
+  [[ "${labels}" == "api-restore-drill|${RUN_ID}" ]]
+}
+
+[[ -n "${CONTAINER}" && -n "${DATA_VOLUME}" && -n "${RUN_ID}" ]] || {
+  echo "RESTORE_DRILL_CONTAINER, RESTORE_DRILL_DATA_VOLUME, and RESTORE_DRILL_RUN_ID are required" >&2
+  exit 2
+}
+[[ "${KEEP_CONTAINER}" == "true" || "${KEEP_CONTAINER}" == "false" ]] || exit 2
+[[ "${KEEP_FILES}" == "true" || "${KEEP_FILES}" == "false" ]] || exit 2
+
+cleanup_failed=false
+if [[ "${KEEP_CONTAINER}" != "true" ]]; then
+  if inspect_object container "${CONTAINER}"; then
+    if ! labels_match container "${CONTAINER}"; then
+      log "cleanup_error=container_label_mismatch container=${CONTAINER}"
+      cleanup_failed=true
+    elif ! docker rm -fv "${CONTAINER}" >/dev/null 2>&1; then
+      log "cleanup_error=container_remove_failed container=${CONTAINER}"
+      cleanup_failed=true
+    fi
+  elif [[ "$?" -eq 2 ]]; then
+    cleanup_failed=true
+  fi
+  if inspect_object volume "${DATA_VOLUME}"; then
+    if ! labels_match volume "${DATA_VOLUME}"; then
+      log "cleanup_error=volume_label_mismatch volume=${DATA_VOLUME}"
+      cleanup_failed=true
+    elif ! docker volume rm "${DATA_VOLUME}" >/dev/null 2>&1; then
+      log "cleanup_error=volume_remove_failed volume=${DATA_VOLUME}"
+      cleanup_failed=true
+    fi
+  elif [[ "$?" -eq 2 ]]; then
+    cleanup_failed=true
+  fi
+  if inspect_object container "${CONTAINER}"; then
+    log "cleanup_error=container_still_exists container=${CONTAINER}"
+    cleanup_failed=true
+  elif [[ "$?" -eq 2 ]]; then
+    cleanup_failed=true
+  fi
+  if inspect_object volume "${DATA_VOLUME}"; then
+    log "cleanup_error=volume_still_exists volume=${DATA_VOLUME}"
+    cleanup_failed=true
+  elif [[ "$?" -eq 2 ]]; then
+    cleanup_failed=true
+  fi
+else
+  log "cleanup_skipped=true container=${CONTAINER} volume=${DATA_VOLUME}"
+fi
+
+if [[ "${KEEP_FILES}" != "true" ]]; then
+  if ! rm -f \
+    "${DRILL_DIR}/latest-db-backup.sql" \
+    "${DRILL_DIR}/latest-db-backup.sql.gz" \
+    "${DRILL_DIR}/restore.log"; then
+    log "cleanup_error=drill_files_remove_failed"
+    cleanup_failed=true
+  fi
+  if [[ -d "${DRILL_DIR}" ]] && ! rmdir "${DRILL_DIR}"; then
+    log "cleanup_error=drill_directory_remove_failed directory=${DRILL_DIR}"
+    cleanup_failed=true
+  fi
+fi
+
+[[ "${cleanup_failed}" == "false" ]]

--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.patroni.yml}"
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
@@ -12,11 +13,13 @@ BLUE_GREEN_SCRIPT="${API_BLUE_GREEN_SCRIPT:-/tmp/deploy_backend_blue_green.sh}"
 PROXY_MODE="${API_PROXY_MODE:-host_nginx}"
 PROXY_SERVICE="${API_PROXY_SERVICE:-api-proxy}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+DEPLOY_LOCK_ALREADY_HELD="${API_DEPLOY_LOCK_ALREADY_HELD:-false}"
 MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
 ENV_FILE="${PROJECT_DIR}/.env"
 HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
+GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/../prepare_google_oauth_token_dir.sh}"
 
 previous_image=""
 active_service="app"
@@ -34,7 +37,12 @@ payload = json.load(sys.stdin)
 if payload.get("state") != "running":
     raise SystemExit(1)
 role = str(payload.get("role") or "").lower()
-print("primary" if role in {"leader", "master", "primary"} else "standby")
+if role in {"leader", "master", "primary"}:
+    print("primary")
+elif role in {"replica", "standby"}:
+    print("standby")
+else:
+    raise SystemExit(1)
 '
 }
 
@@ -163,12 +171,20 @@ done
 }
 
 cd "${PROJECT_DIR}"
-exec 9>"${DEPLOY_LOCK_FILE}"
-flock -n 9 || {
-  log error "another deployment holds ${DEPLOY_LOCK_FILE}"
+if [[ "${DEPLOY_LOCK_ALREADY_HELD}" != "true" ]]; then
+  exec 9>"${DEPLOY_LOCK_FILE}"
+  flock -n 9 || {
+    log error "another deployment holds ${DEPLOY_LOCK_FILE}"
+    exit 1
+  }
+fi
+require_expected_role
+[[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
+  log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
   exit 1
 }
-require_expected_role
+GOOGLE_OAUTH_PROJECT_DIR="${PROJECT_DIR}" \
+  bash "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" prepare
 
 if [[ "${EXPECTED_ROLE}" == "primary" ]]; then
   [[ -x "${BLUE_GREEN_SCRIPT}" ]] || {

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 
 PRIMARY_ROLES = {"leader", "master", "primary"}
+REPLICA_ROLES = {"replica", "standby"}
 
 
 @dataclass(frozen=True)
@@ -75,7 +76,11 @@ def fetch_patroni_role(url: str, *, timeout: float = 3.0) -> str:
     if payload.get("state") != "running":
         return "standby"
     role = str(payload.get("role") or "").strip().lower()
-    return "primary" if role in PRIMARY_ROLES else "standby"
+    if role in PRIMARY_ROLES:
+        return "primary"
+    if role in REPLICA_ROLES:
+        return "standby"
+    raise ValueError(f"unsupported Patroni role: {role or '<empty>'}")
 
 
 def app_service(config: AgentConfig) -> str:

--- a/scripts/ha/restore_drill_latest_db.sh
+++ b/scripts/ha/restore_drill_latest_db.sh
@@ -1,40 +1,63 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 APP_SERVICE="${APP_SERVICE:-app}"
 DB_SERVICE="${DB_SERVICE:-db}"
 POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:15.18-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f}"
-DRILL_DIR="${DRILL_DIR:-/tmp/mvn-restore-drill}"
+DRILL_ROOT="${DRILL_ROOT:-${DRILL_DIR:-/tmp/mvn-restore-drill}}"
 KEEP_DRILL_CONTAINER="${KEEP_DRILL_CONTAINER:-false}"
 KEEP_DRILL_FILES="${KEEP_DRILL_FILES:-false}"
+MIN_PUBLIC_TABLES="${MIN_PUBLIC_TABLES:-64}"
+CLEANUP_SCRIPT="${RESTORE_DRILL_CLEANUP_SCRIPT:-${SCRIPT_DIR}/cleanup_restore_drill_runtime.sh}"
 
 log() {
   printf '[restore-drill] %s\n' "$*"
 }
 
 cd "${PROJECT_DIR}"
+if [[ ! "${MIN_PUBLIC_TABLES}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MIN_PUBLIC_TABLES must be a positive integer: ${MIN_PUBLIC_TABLES}" >&2
+  exit 1
+fi
 if [[ ! -f "${COMPOSE_FILE}" ]]; then
   echo "Compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
   exit 1
 fi
 
 COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+run_id="${RESTORE_DRILL_RUN_ID:-${GITHUB_RUN_ID:-$(date -u +%Y%m%d%H%M%S)}-$$}"
+if [[ ! "${run_id}" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+  echo "RESTORE_DRILL_RUN_ID must contain only letters, digits, dot, underscore, and dash" >&2
+  exit 1
+fi
+DRILL_DIR="${DRILL_ROOT}/${run_id}"
 mkdir -p "${DRILL_DIR}"
 chmod 700 "${DRILL_DIR}"
 
-container="mvn_restore_drill_$(date -u +%Y%m%d%H%M%S)"
+container="mvn_restore_drill_$(date -u +%Y%m%d%H%M%S)_$$"
+data_volume="${container}_data"
 backup_path=""
 sql_path="${DRILL_DIR}/latest-db-backup.sql"
 
 cleanup() {
-  if [[ "${KEEP_DRILL_CONTAINER}" != "true" ]]; then
-    docker rm -f "${container}" >/dev/null 2>&1 || true
+  local original_status=$?
+  local cleanup_status=0
+  trap - EXIT
+  set +e
+  RESTORE_DRILL_CONTAINER="${container}" \
+    RESTORE_DRILL_DATA_VOLUME="${data_volume}" \
+    RESTORE_DRILL_RUN_ID="${run_id}" \
+    RESTORE_DRILL_DIR="${DRILL_DIR}" \
+    KEEP_DRILL_CONTAINER="${KEEP_DRILL_CONTAINER}" \
+    KEEP_DRILL_FILES="${KEEP_DRILL_FILES}" \
+    bash "${CLEANUP_SCRIPT}" || cleanup_status=$?
+  if [[ "${cleanup_status}" -ne 0 && "${original_status}" -eq 0 ]]; then
+    exit "${cleanup_status}"
   fi
-  if [[ "${KEEP_DRILL_FILES}" != "true" ]]; then
-    rm -f "${DRILL_DIR}"/latest-db-backup*
-  fi
+  exit "${original_status}"
 }
 trap cleanup EXIT
 
@@ -98,13 +121,21 @@ sed -i.bak '/^SET transaction_timeout = .*;$/d' "${sql_path}"
 rm -f "${sql_path}.bak"
 
 log "Starting disposable PostgreSQL container on network ${network}..."
+docker volume create \
+  --label com.mvn.purpose=api-restore-drill \
+  --label "com.mvn.run_id=${run_id}" \
+  "${data_volume}" >/dev/null
 docker run -d \
   --name "${container}" \
+  --label com.mvn.purpose=api-restore-drill \
+  --label "com.mvn.run_id=${run_id}" \
   --network "${network}" \
+  --mount "type=volume,source=${data_volume},target=/var/lib/postgresql/data" \
   -e POSTGRES_USER="${POSTGRES_USER}" \
   -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
   -e POSTGRES_DB="${POSTGRES_DB}" \
   "${POSTGRES_IMAGE}" >/dev/null
+log "drill_container=${container} drill_data_volume=${data_volume} run_id=${run_id}"
 
 ready_streak=0
 for _ in $(seq 1 60); do
@@ -140,8 +171,8 @@ tables_count="$(docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" "${container}" 
   "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" \
   -U "${POSTGRES_USER}" -d "${POSTGRES_DB}")"
 
-if [[ "${tables_count}" -lt 10 ]]; then
-  echo "Restore drill produced too few public tables: ${tables_count}" >&2
+if [[ "${tables_count}" -lt "${MIN_PUBLIC_TABLES}" ]]; then
+  echo "Restore drill produced too few public tables: ${tables_count}; required=${MIN_PUBLIC_TABLES}" >&2
   exit 1
 fi
 

--- a/scripts/ha/run_patroni_candidate_transaction.sh
+++ b/scripts/ha/run_patroni_candidate_transaction.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+OPERATION="${PATRONI_CANDIDATE_OPERATION:-}"
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+CANONICAL_FILE="${PATRONI_CANONICAL_COMPOSE_FILE:-${PROJECT_DIR}/docker-compose.patroni.yml}"
+CANDIDATE_FILE="${PATRONI_CANDIDATE_COMPOSE_FILE:-}"
+TRANSACTION_SCRIPT="${COMPOSE_CANDIDATE_TRANSACTION_SCRIPT:-/tmp/compose_candidate_transaction.sh}"
+MIGRATION_SCRIPT="${PATRONI_MIGRATION_SCRIPT:-/tmp/run_patroni_migrations.sh}"
+DEPLOY_SCRIPT="${PATRONI_DEPLOY_SCRIPT:-/tmp/deploy_patroni_api_node.sh}"
+ROLE_AGENT_SOURCE="${PATRONI_ROLE_AGENT_SOURCE:-}"
+ROLE_AGENT_TARGET="${PATRONI_ROLE_AGENT_TARGET:-/usr/local/sbin/mvn-patroni-role-agent}"
+ROLE_AGENT_UNIT="${PATRONI_ROLE_AGENT_UNIT:-mvn-patroni-role-agent.service}"
+RECONCILE_SCRIPT="${API_RECONCILE_SCRIPT:-/tmp/reconcile_backend_compose_runtime.sh}"
+DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
+ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
+PREVIOUS_BACKEND_IMAGE="${API_PREVIOUS_BACKEND_IMAGE:-}"
+ROLE_AGENT_BACKUP=""
+ROLE_AGENT_PREEXISTED=false
+ROLE_AGENT_CHANGED=false
+CANDIDATE_CHECKSUM=""
+PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
+CURRENT_ROLE_OVERRIDE="${API_CURRENT_PATRONI_ROLE:-}"
+EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+
+transaction() {
+  CANONICAL_COMPOSE_FILE="${CANONICAL_FILE}" \
+    CANDIDATE_COMPOSE_FILE="${CANDIDATE_FILE}" \
+    bash "${TRANSACTION_SCRIPT}" "$1"
+}
+
+cleanup_migration_candidate() {
+  local status=$?
+  trap - EXIT
+  set +e
+  transaction cleanup
+  exit "${status}"
+}
+
+cleanup_candidate_only() {
+  local status=$?
+  trap - EXIT
+  set +e
+  transaction cleanup
+  exit "${status}"
+}
+
+resolve_previous_backend_image() {
+  local active_service="app"
+  local active_slot=""
+  local container_ids=""
+  local runtime_image=""
+
+  if [[ -n "${PREVIOUS_BACKEND_IMAGE}" ]]; then
+    [[ "${PREVIOUS_BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+      echo "API_PREVIOUS_BACKEND_IMAGE must be immutable" >&2
+      return 1
+    }
+    return 0
+  fi
+  if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
+    active_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+    case "${active_slot}" in
+      blue|green) active_service="app-${active_slot}" ;;
+      *) echo "invalid active API slot: ${active_slot}" >&2; return 1 ;;
+    esac
+  fi
+  container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen ps -q "${active_service}")"
+  [[ -n "${container_ids}" && "${container_ids}" != *$'\n'* ]] || {
+    echo "could not resolve exactly one active Patroni API container" >&2
+    return 1
+  }
+  runtime_image="$(docker inspect --format '{{.Config.Image}}' "${container_ids}")"
+  [[ "${runtime_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    echo "active Patroni API runtime image is not immutable" >&2
+    return 1
+  }
+  PREVIOUS_BACKEND_IMAGE="${runtime_image}"
+}
+
+backup_role_agent() {
+  if [[ -e "${ROLE_AGENT_TARGET}" || -L "${ROLE_AGENT_TARGET}" ]]; then
+    [[ -f "${ROLE_AGENT_TARGET}" && ! -L "${ROLE_AGENT_TARGET}" ]] || {
+      echo "existing Patroni role agent target is unsafe" >&2
+      return 1
+    }
+    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || {
+      echo "existing Patroni role agent unit is not active" >&2
+      return 1
+    }
+    ROLE_AGENT_BACKUP="$(mktemp "${PROJECT_DIR}/.patroni-role-agent.backup.XXXXXX")"
+    cp -p -- "${ROLE_AGENT_TARGET}" "${ROLE_AGENT_BACKUP}"
+    ROLE_AGENT_PREEXISTED=true
+  fi
+}
+
+restore_role_agent() {
+  [[ "${ROLE_AGENT_CHANGED}" == "true" ]] || return 0
+  if [[ "${ROLE_AGENT_PREEXISTED}" == "true" ]]; then
+    cp -p -- "${ROLE_AGENT_BACKUP}" "${ROLE_AGENT_TARGET}" || return 1
+    systemctl restart "${ROLE_AGENT_UNIT}" || return 1
+    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || return 1
+  else
+    systemctl stop "${ROLE_AGENT_UNIT}" >/dev/null 2>&1 || return 1
+    if systemctl is-active --quiet "${ROLE_AGENT_UNIT}"; then
+      echo "new Patroni role agent unit remained active after stop" >&2
+      return 1
+    fi
+    rm -f -- "${ROLE_AGENT_TARGET}" || return 1
+  fi
+}
+
+current_patroni_role() {
+  if [[ -n "${CURRENT_ROLE_OVERRIDE}" ]]; then
+    [[ "${CURRENT_ROLE_OVERRIDE}" == "primary" || "${CURRENT_ROLE_OVERRIDE}" == "standby" ]] \
+      || return 1
+    printf '%s\n' "${CURRENT_ROLE_OVERRIDE}"
+    return 0
+  fi
+  curl -fsS --max-time 5 "${PATRONI_URL}" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+if payload.get("state") != "running":
+    raise SystemExit(1)
+role = str(payload.get("role") or "").lower()
+if role in {"leader", "master", "primary"}:
+    print("primary")
+elif role in {"replica", "standby"}:
+    print("standby")
+else:
+    raise SystemExit(1)
+'
+}
+
+fence_runtime_for_role_drift() {
+  docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+    stop app app-blue app-green bot >/dev/null 2>&1
+}
+
+reconcile_failed_deploy() {
+  local status=$?
+  local restoration_failed=false
+  local role_agent_restore_failed=false
+  local recovery_role=""
+  trap - EXIT
+  set +e
+  if promotion_committed; then
+    echo "Patroni candidate compose promotion committed; preserving the consistent new runtime" >&2
+    [[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}"
+    exit "${status}"
+  fi
+  transaction cleanup || restoration_failed=true
+  if ! restore_role_agent; then
+    echo "failed to restore the previous Patroni role agent" >&2
+    role_agent_restore_failed=true
+    restoration_failed=true
+  fi
+  if ! recovery_role="$(current_patroni_role)"; then
+    echo "CRITICAL: could not establish live Patroni role during recovery; fencing API and bot" >&2
+    fence_runtime_for_role_drift || restoration_failed=true
+    restoration_failed=true
+  elif [[ "${recovery_role}" != "${EXPECTED_ROLE}" ]]; then
+    echo "CRITICAL: Patroni role changed during deployment (expected=${EXPECTED_ROLE}, live=${recovery_role}); fencing API and bot until the role agent reconciles fresh role state" >&2
+    fence_runtime_for_role_drift || restoration_failed=true
+    restoration_failed=true
+  elif [[ "${recovery_role}" == "primary" ]]; then
+    if ! API_DEPLOY_SERVICES="app bot" \
+      API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
+      API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
+      API_READY_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}" \
+      bash "${RECONCILE_SCRIPT}"; then
+      restoration_failed=true
+    fi
+  else
+    if ! API_DEPLOY_SERVICES="app" \
+      API_STOP_SERVICES_AFTER_DEPLOY="bot" \
+      API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
+      API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
+      API_READY_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}" \
+      bash "${RECONCILE_SCRIPT}"; then
+      restoration_failed=true
+    fi
+  fi
+  [[ -z "${ROLE_AGENT_SOURCE}" ]] || rm -f -- "${ROLE_AGENT_SOURCE}"
+  if [[ -n "${ROLE_AGENT_BACKUP}" ]]; then
+    if [[ "${role_agent_restore_failed}" == "true" ]]; then
+      echo "CRITICAL: previous Patroni role agent backup retained at ${ROLE_AGENT_BACKUP}" >&2
+    else
+      rm -f -- "${ROLE_AGENT_BACKUP}" || restoration_failed=true
+    fi
+  fi
+  if [[ "${restoration_failed}" == "true" ]]; then
+    echo "CRITICAL: failed Patroni candidate could not be fully restored" >&2
+    exit 90
+  fi
+  exit "${status}"
+}
+
+promotion_committed() {
+  local canonical_checksum=""
+  [[ -n "${CANDIDATE_CHECKSUM}" && ! -e "${CANDIDATE_FILE}" ]] || return 1
+  [[ -f "${CANONICAL_FILE}" && ! -L "${CANONICAL_FILE}" ]] || return 1
+  canonical_checksum="$(cksum < "${CANONICAL_FILE}")" || return 1
+  [[ "${canonical_checksum}" == "${CANDIDATE_CHECKSUM}" ]]
+}
+
+[[ "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]] || {
+  echo "PATRONI_CANDIDATE_OPERATION must be migrate or deploy" >&2
+  exit 2
+}
+if [[ "${OPERATION}" == "deploy" ]]; then
+  [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
+    echo "API_EXPECTED_PATRONI_ROLE must be primary or standby" >&2
+    exit 2
+  }
+fi
+[[ -n "${CANDIDATE_FILE}" ]] || {
+  echo "PATRONI_CANDIDATE_COMPOSE_FILE must name this run's unique candidate" >&2
+  exit 1
+}
+[[ -f "${CANDIDATE_FILE}" ]] || {
+  echo "candidate compose is missing: ${CANDIDATE_FILE}" >&2
+  exit 1
+}
+CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
+[[ -f "${TRANSACTION_SCRIPT}" ]] || {
+  echo "compose transaction helper is missing: ${TRANSACTION_SCRIPT}" >&2
+  exit 1
+}
+
+if [[ "${OPERATION}" == "migrate" ]]; then
+  trap cleanup_migration_candidate EXIT
+  API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" bash "${MIGRATION_SCRIPT}"
+  trap - EXIT
+  transaction cleanup
+  exit 0
+fi
+
+trap cleanup_candidate_only EXIT
+exec 9>"${DEPLOY_LOCK_FILE}"
+flock -n 9 || {
+  echo "another deployment holds ${DEPLOY_LOCK_FILE}" >&2
+  exit 1
+}
+resolve_previous_backend_image
+backup_role_agent
+trap reconcile_failed_deploy EXIT
+transaction stage
+
+[[ -f "${ROLE_AGENT_SOURCE}" ]] || {
+  echo "Patroni role agent source is missing: ${ROLE_AGENT_SOURCE}" >&2
+  exit 1
+}
+install -m 0755 "${ROLE_AGENT_SOURCE}" "${ROLE_AGENT_TARGET}"
+ROLE_AGENT_CHANGED=true
+rm -f -- "${ROLE_AGENT_SOURCE}"
+systemctl restart "${ROLE_AGENT_UNIT}"
+systemctl is-active --quiet "${ROLE_AGENT_UNIT}"
+
+API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" \
+  API_DEPLOY_LOCK_ALREADY_HELD=true \
+bash "${DEPLOY_SCRIPT}"
+transaction promote
+trap - EXIT
+[[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}" \
+  || echo "warning: stale Patroni role agent backup remains at ${ROLE_AGENT_BACKUP}" >&2

--- a/scripts/ha/run_patroni_migrations.sh
+++ b/scripts/ha/run_patroni_migrations.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.patroni.yml}"
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
@@ -9,6 +10,7 @@ PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
 RUN_DEFAULTS="${API_RUN_DEFAULTS:-true}"
+GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/../prepare_google_oauth_token_dir.sh}"
 
 log() {
   printf '[patroni-migrate][%s] %s\n' "$1" "$2"
@@ -21,7 +23,12 @@ payload = json.load(sys.stdin)
 if payload.get("state") != "running":
     raise SystemExit(1)
 role = str(payload.get("role") or "").lower()
-print("primary" if role in {"leader", "master", "primary"} else "standby")
+if role in {"leader", "master", "primary"}:
+    print("primary")
+elif role in {"replica", "standby"}:
+    print("standby")
+else:
+    raise SystemExit(1)
 '
 }
 
@@ -64,6 +71,12 @@ flock -n 9 || {
 }
 
 require_primary
+[[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
+  log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
+  exit 1
+}
+GOOGLE_OAUTH_PROJECT_DIR="${PROJECT_DIR}" \
+  bash "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" prepare
 export BACKEND_IMAGE
 COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
 if [[ -n "${GHCR_PAT:-}" ]]; then

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -18,6 +18,8 @@ ROLE_AGENT_SOURCE="scripts/ha/patroni_role_agent.py"
 ROLE_AGENT_REMOTE="/tmp/mvn-patroni-role-agent-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}"
 ROLE_AGENT_TARGET="/usr/local/sbin/mvn-patroni-role-agent"
 ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
+CANDIDATE_RUNNER_SOURCE="scripts/ha/run_patroni_candidate_transaction.sh"
+TRANSACTION_SOURCE="scripts/compose_candidate_transaction.sh"
 
 log() {
   printf '[patroni-remote][%s] %s\n' "$1" "$2"
@@ -67,6 +69,12 @@ if [[ "${OPERATION}" == "deploy" ]]; then
     exit 1
   }
 fi
+if [[ "${OPERATION}" != "probe" ]]; then
+  [[ -f "${CANDIDATE_RUNNER_SOURCE}" && -f "${TRANSACTION_SOURCE}" ]] || {
+    log error "compose candidate transaction scripts are missing"
+    exit 1
+  }
+fi
 
 for command in ssh scp ssh-keyscan; do
   command -v "${command}" >/dev/null 2>&1 || {
@@ -103,7 +111,7 @@ REMOTE="${NODE_USER}@${NODE_HOST}"
 
 if [[ "${OPERATION}" == "probe" ]]; then
   role="$(ssh "${SSH_OPTS[@]}" "${REMOTE}" \
-    "curl -fsS --max-time 5 http://127.0.0.1:8008/patroni | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); print(\"primary\" if r in {\"leader\",\"master\",\"primary\"} else \"standby\")'")"
+    "curl -fsS --max-time 5 http://127.0.0.1:8008/patroni | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); m={\"leader\":\"primary\",\"master\":\"primary\",\"primary\":\"primary\",\"replica\":\"standby\",\"standby\":\"standby\"}; n=m.get(r); n or sys.exit(1); print(n)'")"
   [[ "${role}" == "primary" || "${role}" == "standby" ]] || {
     log error "invalid Patroni role from ${NODE_HOST}: ${role}"
     exit 1
@@ -116,11 +124,16 @@ if [[ "${OPERATION}" == "probe" ]]; then
 fi
 
 ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}")"
+CANONICAL_REMOTE_COMPOSE_FILE="docker-compose.patroni.yml"
+candidate_id="$(printf '%s' "${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}-${OPERATION}-$$" | tr -c 'A-Za-z0-9_.-' '-')"
+REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"
 scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
-  "${REMOTE}:${PROJECT_DIR}/docker-compose.patroni.yml"
+  "${REMOTE}:${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}"
 scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
   scripts/ha/deploy_patroni_api_node.sh scripts/deploy_backend_blue_green.sh \
-  scripts/deploy_backend_blue_green_safety.sh \
+  scripts/deploy_backend_blue_green_safety.sh scripts/prepare_google_oauth_token_dir.sh \
+  scripts/reconcile_backend_compose_runtime.sh \
+  "${CANDIDATE_RUNNER_SOURCE}" "${TRANSACTION_SOURCE}" \
   "${REMOTE}:/tmp/"
 if [[ "${OPERATION}" == "deploy" ]]; then
   scp "${SSH_OPTS[@]}" "${ROLE_AGENT_SOURCE}" "${REMOTE}:${ROLE_AGENT_REMOTE}"
@@ -136,11 +149,6 @@ if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
   fi
 fi
 
-remote_script="/tmp/run_patroni_migrations.sh"
-if [[ "${OPERATION}" == "deploy" ]]; then
-  remote_script="/tmp/deploy_patroni_api_node.sh"
-fi
-
 proxy_env="API_PROXY_MODE=$(quote "${PROXY_MODE}")"
 if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
   proxy_env+=" API_NGINX_UPSTREAM_FILE=$(quote "${PROJECT_DIR}/api-proxy/upstream.conf")"
@@ -153,29 +161,26 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   set -euo pipefail
   IFS= read -r GHCR_PAT
   export GHCR_PAT
-  chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh
+  chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh /tmp/reconcile_backend_compose_runtime.sh /tmp/run_patroni_candidate_transaction.sh /tmp/compose_candidate_transaction.sh
   API_PROJECT_DIR=$(quote "${PROJECT_DIR}") \
-  API_COMPOSE_FILE=docker-compose.patroni.yml \
   API_EXPECTED_PATRONI_ROLE=$(quote "${EXPECTED_ROLE}") \
   API_READY_URL=http://127.0.0.1:18080/api/ready \
   API_HEALTH_URL=http://127.0.0.1:18080/api/health \
   API_INTERNAL_PROXY_PORT=18080 \
   API_BLUE_GREEN_SCRIPT=/tmp/deploy_backend_blue_green.sh \
   API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh \
+  GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT=/tmp/prepare_google_oauth_token_dir.sh \
+  API_RECONCILE_SCRIPT=/tmp/reconcile_backend_compose_runtime.sh \
   API_PUBLIC_READY_URL=https://api.mvn.by/api/ready \
   BACKEND_IMAGE=$(quote "${BACKEND_IMAGE}") \
   GITHUB_ACTOR=$(quote "${GITHUB_ACTOR:-github-actions}") \
+  PATRONI_CANDIDATE_OPERATION=$(quote "${OPERATION}") \
+  PATRONI_CANONICAL_COMPOSE_FILE=$(quote "${PROJECT_DIR}/${CANONICAL_REMOTE_COMPOSE_FILE}") \
+  PATRONI_CANDIDATE_COMPOSE_FILE=$(quote "${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}") \
+  PATRONI_ROLE_AGENT_SOURCE=$(quote "${ROLE_AGENT_REMOTE}") \
+  PATRONI_ROLE_AGENT_TARGET=$(quote "${ROLE_AGENT_TARGET}") \
+  PATRONI_ROLE_AGENT_UNIT=$(quote "${ROLE_AGENT_UNIT}") \
   ${proxy_env} \
-  bash $(quote "${remote_script}")
+  bash /tmp/run_patroni_candidate_transaction.sh
 "
-if [[ "${OPERATION}" == "deploy" ]]; then
-  log agent "installing tested Patroni role agent on ${NODE_HOST}"
-  ssh "${SSH_OPTS[@]}" "${REMOTE}" "
-    set -euo pipefail
-    install -m 0755 $(quote "${ROLE_AGENT_REMOTE}") $(quote "${ROLE_AGENT_TARGET}")
-    rm -f $(quote "${ROLE_AGENT_REMOTE}")
-    systemctl restart $(quote "${ROLE_AGENT_UNIT}")
-    systemctl is-active --quiet $(quote "${ROLE_AGENT_UNIT}")
-  "
-fi
 log "done" "${OPERATION} completed on ${NODE_HOST}"

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -76,7 +76,11 @@ if [[ "${OPERATION}" != "probe" ]]; then
   }
 fi
 
-for command in ssh scp ssh-keyscan; do
+required_commands=(ssh ssh-keyscan)
+if [[ "${OPERATION}" != "probe" ]]; then
+  required_commands+=(scp)
+fi
+for command in "${required_commands[@]}"; do
   command -v "${command}" >/dev/null 2>&1 || {
     log error "required command is missing: ${command}"
     exit 1

--- a/scripts/post_deploy_smoke_check.sh
+++ b/scripts/post_deploy_smoke_check.sh
@@ -9,6 +9,7 @@ ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-$(dirname "${COMPOSE_FILE}")/.active-a
 BOT_RUNTIME_CHECK_SERVICE="${BOT_RUNTIME_CHECK_SERVICE:-bot}"
 BOT_EXPECT_ENABLED="${BOT_EXPECT_ENABLED:-true}"
 READY_URL="${READY_URL:-}"
+READY_EXPECTATION="${READY_EXPECTATION:-ready}"
 MAX_RETRIES=${MAX_RETRIES:-20}
 RETRY_DELAY=${RETRY_DELAY:-2}
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
@@ -147,20 +148,31 @@ PY
 checks_done="health,products,filters_config"
 if [[ -n "${READY_URL}" ]]; then
   log request "GET ${READY_URL}"
-  ready_payload="$(curl -fsS "${READY_URL}")"
-  READY_PAYLOAD="${ready_payload}" python3 - <<'PY'
+  ready_status="$(curl -sS -o /tmp/mvn-post-deploy-ready.json -w '%{http_code}' "${READY_URL}")"
+  ready_payload="$(cat /tmp/mvn-post-deploy-ready.json)"
+  READY_PAYLOAD="${ready_payload}" \
+  READY_HTTP_STATUS="${ready_status}" \
+  READY_EXPECTATION="${READY_EXPECTATION}" python3 - <<'PY'
 import json
 import os
 
 ready = json.loads(os.environ["READY_PAYLOAD"])
-if ready.get("status") != "ok" or ready.get("api") != "ready":
-    raise SystemExit("readiness payload is not ready")
+http_status = os.environ["READY_HTTP_STATUS"]
+expectation = os.environ["READY_EXPECTATION"]
+if expectation == "ready":
+    if http_status != "200" or ready.get("status") != "ok" or ready.get("api") != "ready":
+        raise SystemExit("readiness payload is not ready")
+elif expectation == "fenced":
+    if http_status != "503" or ready.get("api") != "not_ready" or ready.get("traffic") != "disabled":
+        raise SystemExit("standby readiness payload is not fenced")
+else:
+    raise SystemExit(f"unsupported READY_EXPECTATION={expectation}")
 
 print(f"ready_status={ready.get('status')}")
 print(f"ready_traffic={ready.get('traffic')}")
 print(f"ready_database={ready.get('database')}")
 PY
-  checks_done="${checks_done},readiness"
+  checks_done="${checks_done},readiness_${READY_EXPECTATION}"
 fi
 
 log request "docker compose ps --status running --services"

--- a/scripts/prepare_google_oauth_token_dir.sh
+++ b/scripts/prepare_google_oauth_token_dir.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+MODE="${1:-prepare}"
+PROJECT_DIR="${GOOGLE_OAUTH_PROJECT_DIR:-${API_PROJECT_DIR:-/opt/air-api}}"
+TOKEN_DIR="${GOOGLE_OAUTH_HOST_DIR:-${PROJECT_DIR}/google-oauth}"
+TOKEN_FILE="${GOOGLE_OAUTH_HOST_TOKEN_FILE:-${TOKEN_DIR}/token.json}"
+TOKEN_REQUIRED="${GOOGLE_OAUTH_TOKEN_REQUIRED:-true}"
+LEGACY_TOKEN_FILE="${GOOGLE_OAUTH_LEGACY_TOKEN_FILE:-}"
+
+log() {
+  printf '[google-oauth-token][%s] %s\n' "$1" "$2"
+}
+
+fail() {
+  log error "$1" >&2
+  exit 1
+}
+
+validate_token() {
+  python3 - "$1" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid Google OAuth token JSON: {type(exc).__name__}") from None
+
+required = ("refresh_token", "client_id", "client_secret", "token_uri")
+missing = [key for key in required if not isinstance(payload, dict) or not payload.get(key)]
+if missing:
+    raise SystemExit(f"Google OAuth token JSON is missing required fields: {','.join(missing)}")
+PY
+}
+
+fsync_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+descriptor = os.open(sys.argv[1], os.O_RDONLY)
+try:
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+PY
+}
+
+secure_retained_legacy_token() {
+  local candidate="$1"
+  [[ -e "${candidate}" || -L "${candidate}" ]] || return 0
+  [[ ! -L "${candidate}" && -f "${candidate}" && -r "${candidate}" ]] || {
+    fail "retained legacy token is missing or unsafe: ${candidate}"
+  }
+  validate_token "${candidate}"
+  chmod 0600 "${candidate}"
+  log permissions "retained legacy token secured at ${candidate}"
+}
+
+verify_layout() {
+  python3 - "${TOKEN_DIR}" "${TOKEN_FILE}" <<'PY'
+import pathlib
+import stat
+import sys
+
+directory = pathlib.Path(sys.argv[1])
+token = pathlib.Path(sys.argv[2])
+if directory.is_symlink() or not directory.is_dir():
+    raise SystemExit("Google OAuth token directory is missing or is a symlink")
+if token.is_symlink() or not token.is_file():
+    raise SystemExit("Google OAuth token file is missing or is a symlink")
+if stat.S_IMODE(directory.stat().st_mode) != 0o700:
+    raise SystemExit("Google OAuth token directory mode must be 0700")
+if stat.S_IMODE(token.stat().st_mode) != 0o600:
+    raise SystemExit("Google OAuth token file mode must be 0600")
+PY
+  validate_token "${TOKEN_FILE}"
+  log verify "secure writable-directory layout is ready at ${TOKEN_FILE}"
+}
+
+[[ "${MODE}" == "prepare" || "${MODE}" == "verify" ]] || {
+  echo "usage: prepare_google_oauth_token_dir.sh [prepare|verify]" >&2
+  exit 2
+}
+[[ "${TOKEN_REQUIRED}" == "true" || "${TOKEN_REQUIRED}" == "false" ]] || {
+  fail "GOOGLE_OAUTH_TOKEN_REQUIRED must be true or false"
+}
+[[ "$(dirname "${TOKEN_FILE}")" == "${TOKEN_DIR}" ]] || {
+  fail "GOOGLE_OAUTH_HOST_TOKEN_FILE must be inside GOOGLE_OAUTH_HOST_DIR"
+}
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+if [[ "${MODE}" == "verify" ]]; then
+  verify_layout
+  exit 0
+fi
+
+[[ -d "${PROJECT_DIR}" ]] || fail "project directory is missing: ${PROJECT_DIR}"
+[[ ! -L "${TOKEN_DIR}" ]] || fail "refusing symlink token directory: ${TOKEN_DIR}"
+[[ ! -e "${TOKEN_DIR}" || -d "${TOKEN_DIR}" ]] || {
+  fail "token directory path is not a directory: ${TOKEN_DIR}"
+}
+
+umask 077
+install -d -m 0700 "${TOKEN_DIR}"
+
+if [[ ! -e "${TOKEN_FILE}" ]]; then
+  source_token=""
+  consider_legacy_token() {
+    local candidate="$1"
+    [[ -e "${candidate}" || -L "${candidate}" ]] || return 0
+    [[ ! -L "${candidate}" ]] || fail "refusing symlink legacy token: ${candidate}"
+    [[ -f "${candidate}" && -r "${candidate}" ]] || return 0
+    if [[ -z "${source_token}" ]]; then
+      source_token="${candidate}"
+      return 0
+    fi
+    cmp -s "${source_token}" "${candidate}" || {
+      fail "multiple different legacy tokens found; set GOOGLE_OAUTH_LEGACY_TOKEN_FILE"
+    }
+  }
+
+  if [[ -n "${LEGACY_TOKEN_FILE}" ]]; then
+    consider_legacy_token "${LEGACY_TOKEN_FILE}"
+  else
+    consider_legacy_token "${PROJECT_DIR}/token.json"
+    consider_legacy_token "${PROJECT_DIR}/secrets/token.json"
+  fi
+
+  if [[ -z "${source_token}" ]]; then
+    if [[ "${TOKEN_REQUIRED}" == "false" ]]; then
+      chmod 0700 "${TOKEN_DIR}"
+      log prepare "token is optional and no legacy file was found; directory is ready"
+      exit 0
+    fi
+    fail "no readable legacy Google OAuth token found; refusing an auth-broken deploy"
+  fi
+
+  validate_token "${source_token}"
+
+  temporary="$(mktemp "${TOKEN_DIR}/.token.json.migrate.XXXXXX")"
+  trap 'rm -f "${temporary:-}"' EXIT
+  install -m 0600 "${source_token}" "${temporary}"
+  chown --reference="${source_token}" "${temporary}" 2>/dev/null || true
+  fsync_path "${temporary}"
+  mv -f "${temporary}" "${TOKEN_FILE}"
+  fsync_path "${TOKEN_DIR}"
+  trap - EXIT
+  log prepare "copied the legacy token atomically; the legacy file was retained"
+fi
+
+[[ ! -L "${TOKEN_FILE}" && -f "${TOKEN_FILE}" ]] || {
+  fail "refusing non-regular token file: ${TOKEN_FILE}"
+}
+chmod 0700 "${TOKEN_DIR}"
+chmod 0600 "${TOKEN_FILE}"
+verify_layout
+if [[ -n "${LEGACY_TOKEN_FILE}" ]]; then
+  secure_retained_legacy_token "${LEGACY_TOKEN_FILE}"
+else
+  secure_retained_legacy_token "${PROJECT_DIR}/token.json"
+  secure_retained_legacy_token "${PROJECT_DIR}/secrets/token.json"
+fi

--- a/scripts/reconcile_backend_compose_runtime.sh
+++ b/scripts/reconcile_backend_compose_runtime.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
+COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
+DEPLOY_SERVICES="${API_DEPLOY_SERVICES:-app bot}"
+ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
+HEALTH_URL="${API_READY_URL:-http://127.0.0.1:8000/api/health}"
+HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
+STOP_SERVICES="${API_STOP_SERVICES_AFTER_DEPLOY:-}"
+ENV_FILE="${API_ENV_FILE:-${PROJECT_DIR}/.env}"
+RECONCILE_BACKEND_IMAGE="${API_RECONCILE_BACKEND_IMAGE:-}"
+
+write_backend_image() {
+  local image="$1"
+  local temporary
+
+  touch "${ENV_FILE}"
+  temporary="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+  grep -v '^BACKEND_IMAGE=' "${ENV_FILE}" > "${temporary}" || true
+  printf 'BACKEND_IMAGE=%s\n' "${image}" >> "${temporary}"
+  chmod --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || chmod 600 "${temporary}"
+  chown --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || true
+  mv "${temporary}" "${ENV_FILE}"
+}
+
+cd "${PROJECT_DIR}"
+[[ -f "${COMPOSE_FILE}" ]] || {
+  echo "canonical compose is missing: ${PROJECT_DIR}/${COMPOSE_FILE}" >&2
+  exit 1
+}
+if [[ -n "${RECONCILE_BACKEND_IMAGE}" ]]; then
+  BACKEND_IMAGE="${RECONCILE_BACKEND_IMAGE}"
+else
+  BACKEND_IMAGE="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
+fi
+[[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+  echo "canonical reconcile requires an immutable BACKEND_IMAGE" >&2
+  exit 1
+}
+if [[ -n "${RECONCILE_BACKEND_IMAGE}" ]]; then
+  write_backend_image "${BACKEND_IMAGE}"
+fi
+export BACKEND_IMAGE
+
+read -r -a requested_services <<<"${DEPLOY_SERVICES}"
+resolved_services=()
+for service in "${requested_services[@]}"; do
+  if [[ "${service}" == "app" && -f "${ACTIVE_SLOT_FILE}" ]]; then
+    active_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+    case "${active_slot}" in
+      blue|green) service="app-${active_slot}" ;;
+      *) echo "invalid active API slot: ${active_slot}" >&2; exit 1 ;;
+    esac
+  fi
+  resolved_services+=("${service}")
+done
+
+docker compose -f "${COMPOSE_FILE}" --profile bluegreen \
+  up -d --no-deps --force-recreate "${resolved_services[@]}"
+if [[ -n "${STOP_SERVICES}" ]]; then
+  read -r -a stop_services <<<"${STOP_SERVICES}"
+  docker compose -f "${COMPOSE_FILE}" --profile bluegreen stop "${stop_services[@]}"
+fi
+
+for _ in $(seq 1 "${HEALTH_ATTEMPTS}"); do
+  if curl -fsS "${HEALTH_URL}" >/tmp/mvn-canonical-compose-health.out; then
+    cat /tmp/mvn-canonical-compose-health.out
+    printf '\n'
+    echo "canonical compose runtime reconciled"
+    exit 0
+  fi
+  sleep 2
+done
+echo "canonical compose runtime did not become healthy" >&2
+exit 1

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -3,7 +3,7 @@
 Database Restore Script
 =======================
 Downloads the latest SQL dump from Google Drive and restores it to the local database.
-Uses the project's Google Drive API credentials (token.json).
+Uses the project's Google Drive API credentials (`GOOGLE_TOKEN_FILE`).
 
 Usage (inside Docker container):
     python scripts/restore_db.py                    # Restore latest backup
@@ -22,15 +22,14 @@ import subprocess
 import tempfile
 import logging
 from io import BytesIO
+from pathlib import Path
 
 # Add project root to path so we can import google_service
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from google_auth_oauthlib.flow import Flow
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
+from services.google_oauth_credentials import GoogleOAuthCredentialStore
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 logger = logging.getLogger(__name__)
@@ -38,7 +37,7 @@ logger = logging.getLogger(__name__)
 # Google Drive backup folder ID
 BACKUP_FOLDER_ID = '1jhl2Mp__fqcVlZMzR5lOgWo8JuIUWsNy'
 SCOPES = ['https://www.googleapis.com/auth/drive']
-TOKEN_FILE = 'token.json'
+DEFAULT_TOKEN_FILE = 'token.json'
 
 # Database settings from environment
 DB_USER = os.environ.get('POSTGRES_USER', 'mvnadmin')
@@ -80,24 +79,30 @@ def sanitize_plain_sql_dump(dump_path):
     return changed
 
 
+def get_token_file() -> Path:
+    """Return the configured OAuth token path for local and container runs."""
+    return Path(os.environ.get('GOOGLE_TOKEN_FILE', DEFAULT_TOKEN_FILE)).expanduser()
+
+
+def persist_credentials(creds, token_file: Path) -> None:
+    """Persist refreshed credentials atomically inside the token directory."""
+    GoogleOAuthCredentialStore(str(token_file), SCOPES).persist(creds)
+
+
 def get_credentials():
-    """Load Google API credentials from token.json."""
-    if not os.path.exists(TOKEN_FILE):
-        logger.error(f"❌ Token file '{TOKEN_FILE}' not found!")
+    """Load Google API credentials from GOOGLE_TOKEN_FILE."""
+    token_file = get_token_file()
+    if not token_file.exists():
+        logger.error(f"❌ Token file '{token_file}' not found!")
         logger.error("   Run the app and authenticate via /admin/google-auth first.")
         sys.exit(1)
 
-    creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-            with open(TOKEN_FILE, 'w') as f:
-                f.write(creds.to_json())
-        else:
-            logger.error("❌ Google credentials are invalid or expired.")
-            logger.error("   Re-authenticate via /admin/google-auth")
-            sys.exit(1)
-    return creds
+    state = GoogleOAuthCredentialStore(str(token_file), SCOPES).load()
+    if state.error is not None or state.credentials is None or not state.credentials.valid:
+        logger.error("❌ Google credentials are invalid, unavailable, or not durable.")
+        logger.error("   Re-authenticate via the manager Google settings page.")
+        sys.exit(1)
+    return state.credentials
 
 
 def list_backups(creds, file_type='sql'):

--- a/scripts/rollback_backend.sh
+++ b/scripts/rollback_backend.sh
@@ -11,6 +11,10 @@ CONFIRM_ROLLBACK="${CONFIRM_ROLLBACK:-false}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 BLUE_GREEN_SCRIPT="${API_BLUE_GREEN_SCRIPT:-/tmp/deploy_backend_blue_green.sh}"
+FORCE_COMPOSE_RECONCILE_ON_NOOP="${API_FORCE_COMPOSE_RECONCILE_ON_NOOP:-false}"
+GOOGLE_TOKEN_CONTRACT_LABEL="org.mvn.google-oauth-token-contract"
+GOOGLE_TOKEN_CONTRACT_REQUIRED="directory-v1"
+GOOGLE_ROLLBACK_PROBE_REQUIRED="${API_GOOGLE_ROLLBACK_PROBE_REQUIRED:-true}"
 
 usage() {
   cat <<'USAGE'
@@ -64,7 +68,129 @@ ENV_FILE="${PROJECT_DIR}/.env"
 PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
 touch "${ENV_FILE}"
 current_image="$(sed -n 's/^BACKEND_IMAGE=//p' "${ENV_FILE}" | tail -n 1)"
+
+reconcile_current_compose() {
+  local service active_slot
+  local resolved_services=()
+  [[ "${current_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    echo "Cannot reconcile compose without an immutable current image" >&2
+    return 1
+  }
+  read -r -a requested_services <<<"${DEPLOY_SERVICES}"
+  for service in "${requested_services[@]}"; do
+    if [[ "${service}" == "app" && -f "${ACTIVE_SLOT_FILE}" ]]; then
+      active_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+      case "${active_slot}" in
+        blue|green) service="app-${active_slot}" ;;
+        *) echo "Invalid active API slot: ${active_slot}" >&2; return 1 ;;
+      esac
+    fi
+    resolved_services+=("${service}")
+  done
+  export BACKEND_IMAGE="${current_image}"
+  docker compose -f "${COMPOSE_FILE}" --profile bluegreen \
+    up -d --no-deps --force-recreate "${resolved_services[@]}"
+  for _ in $(seq 1 30); do
+    if curl -fsS "${READY_URL}" >/tmp/mvn-backend-compose-reconcile.out; then
+      cat /tmp/mvn-backend-compose-reconcile.out
+      printf '\n'
+      echo "Canonical compose runtime reconciled"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Canonical compose runtime did not become healthy" >&2
+  return 1
+}
+
+resolve_active_app_service() {
+  local service="app"
+  local active_slot=""
+  if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
+    active_slot="$(tr -d '\r\n' < "${ACTIVE_SLOT_FILE}")"
+    case "${active_slot}" in
+      blue|green) service="app-${active_slot}" ;;
+      *) echo "Invalid active API slot: ${active_slot}" >&2; return 1 ;;
+    esac
+  fi
+  printf '%s\n' "${service}"
+}
+
+probe_google_backups() {
+  local app_service
+  [[ "${GOOGLE_ROLLBACK_PROBE_REQUIRED}" == "true" ]] || return 0
+  app_service="$(resolve_active_app_service)"
+  docker compose -f "${COMPOSE_FILE}" --profile bluegreen exec -T "${app_service}" \
+    python3 - <<'PY'
+from services.backup_service import backup_service
+from services.google_service import get_google_service
+import os
+import tempfile
+from pathlib import Path
+
+google = get_google_service()
+token_file = Path(os.environ["GOOGLE_TOKEN_FILE"])
+probe_path = token_file.parent / ".rollback-write-probe"
+fd, temporary = tempfile.mkstemp(dir=token_file.parent, prefix=".rollback-write-probe.")
+try:
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(b"ok")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, probe_path)
+    temporary = ""
+    probe_path.unlink()
+    directory_fd = os.open(token_file.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if temporary:
+        Path(temporary).unlink(missing_ok=True)
+    probe_path.unlink(missing_ok=True)
+# Listing forces credential load/refresh and retries persistence after a
+# transient write failure before the durable-auth verdict is evaluated.
+items = backup_service.list_backups(limit=1)
+if not items:
+    raise SystemExit("Google backup probe returned no backup objects")
+status = google.get_token_status()
+if google.auth_error is not None or status.get("persistence_ok") is not True:
+    raise SystemExit("Google OAuth persistence is not healthy")
+print(f"google_backup_probe=passed items={len(items)}")
+PY
+}
+
+restore_current_image_after_failed_probe() {
+  echo "Google backup probe failed; restoring the previously active image." >&2
+  if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
+    BACKEND_IMAGE="${current_image}" \
+      API_RUN_MIGRATIONS=false \
+      API_RUN_DEFAULTS=false \
+      API_DRAIN_SECONDS=0 \
+      API_DEPLOY_LOCK_ALREADY_HELD=true \
+      bash "${BLUE_GREEN_SCRIPT}"
+    return
+  fi
+  write_backend_image "${current_image}"
+  reconcile_current_compose
+}
+
+restore_current_image_or_critical() {
+  if restore_current_image_after_failed_probe; then
+    echo "Previously active image restored after failed Google backup probe." >&2
+    return 0
+  fi
+  echo "CRITICAL: Google backup probe failed and the previously active image could not be restored." >&2
+  return 90
+}
+
 if [[ -n "${EXPECTED_CURRENT_IMAGE}" && "${current_image}" != "${EXPECTED_CURRENT_IMAGE}" ]]; then
+  if [[ "${FORCE_COMPOSE_RECONCILE_ON_NOOP}" == "true" ]]; then
+    echo "Candidate was not activated; reconciling current image with restored canonical compose."
+    reconcile_current_compose
+    exit 0
+  fi
   echo "Candidate was not activated; current image is ${current_image:-unset}. Nothing to roll back."
   exit 0
 fi
@@ -75,6 +201,10 @@ if [[ -z "${ROLLBACK_TARGET}" ]]; then
   echo "No rollback target supplied and ${PREVIOUS_IMAGE_FILE} is empty" >&2
   exit 1
 fi
+if [[ ! "${current_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
+  echo "Refusing rollback without an immutable currently active image for recovery." >&2
+  exit 1
+fi
 if [[ ! "${ROLLBACK_TARGET}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
   echo "Rollback target must use a 40-character Git SHA tag or sha256 digest" >&2
   exit 1
@@ -82,6 +212,28 @@ fi
 if [[ "${ROLLBACK_TARGET}" == "${current_image}" ]]; then
   echo "Rollback target is already active: ${ROLLBACK_TARGET}"
   exit 0
+fi
+
+if ! docker image inspect "${ROLLBACK_TARGET}" >/dev/null 2>&1; then
+  echo "Pulling rollback image: ${ROLLBACK_TARGET}"
+  docker pull "${ROLLBACK_TARGET}"
+fi
+target_contract="$(
+  docker image inspect \
+    --format '{{ index .Config.Labels "org.mvn.google-oauth-token-contract" }}' \
+    "${ROLLBACK_TARGET}"
+)"
+if [[ "${target_contract}" != "${GOOGLE_TOKEN_CONTRACT_REQUIRED}" ]]; then
+  echo "Refusing rollback: target image does not declare ${GOOGLE_TOKEN_CONTRACT_LABEL}=${GOOGLE_TOKEN_CONTRACT_REQUIRED}." >&2
+  echo "Pre-hotfix images cannot durably refresh Google OAuth credentials; use a normal roll-forward release." >&2
+  exit 1
+fi
+if [[ -L "${COMPOSE_FILE}" || ! -f "${COMPOSE_FILE}" ]] \
+  || ! grep -Fq '/app/google-oauth' "${COMPOSE_FILE}" \
+  || ! grep -Eq 'GOOGLE_TOKEN_FILE(:[[:space:]]*|=)/app/google-oauth/token\.json' "${COMPOSE_FILE}" \
+  || grep -Fq '/app/token.json' "${COMPOSE_FILE}"; then
+  echo "Refusing rollback: canonical compose does not provide the directory-v1 Google token contract." >&2
+  exit 1
 fi
 
 if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
@@ -96,6 +248,10 @@ if [[ -f "${ACTIVE_SLOT_FILE}" ]]; then
     API_DRAIN_SECONDS=0 \
     API_DEPLOY_LOCK_ALREADY_HELD=true \
     bash "${BLUE_GREEN_SCRIPT}"
+  if ! probe_google_backups; then
+    restore_current_image_or_critical || exit $?
+    exit 1
+  fi
   exit 0
 fi
 
@@ -109,11 +265,6 @@ write_backend_image() {
   chown --reference="${ENV_FILE}" "${tmp}" 2>/dev/null || true
   mv "${tmp}" "${ENV_FILE}"
 }
-
-if ! docker image inspect "${ROLLBACK_TARGET}" >/dev/null 2>&1; then
-  echo "Pulling rollback image: ${ROLLBACK_TARGET}"
-  docker pull "${ROLLBACK_TARGET}"
-fi
 
 read -r -a deploy_services <<<"${DEPLOY_SERVICES}"
 COMPOSE=(docker compose -f "${COMPOSE_FILE}")
@@ -131,6 +282,10 @@ for _ in $(seq 1 30); do
       printf '%s\n' "${current_image}" > "${PREVIOUS_IMAGE_FILE}"
       chmod 600 "${PREVIOUS_IMAGE_FILE}"
     fi
+    if ! probe_google_backups; then
+      restore_current_image_or_critical || exit $?
+      exit 1
+    fi
     echo "Backend rollback completed"
     exit 0
   fi
@@ -142,6 +297,9 @@ if [[ -n "${current_image}" ]]; then
   echo "Rollback target failed readiness; restoring ${current_image}" >&2
   export BACKEND_IMAGE="${current_image}"
   write_backend_image "${current_image}"
-  "${COMPOSE[@]}" up -d --no-deps --force-recreate "${deploy_services[@]}" || true
+  if ! reconcile_current_compose; then
+    echo "CRITICAL: rollback target and previously active image both failed readiness." >&2
+    exit 90
+  fi
 fi
 exit 1

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -16,6 +16,10 @@ from services.google_service import get_google_service
 BACKUP_DIR = "backups"
 
 
+class BackupConfigurationError(RuntimeError):
+    """Required production backup configuration is missing or invalid."""
+
+
 class BackupService:
     # pg_dump from a newer client can emit SET commands unsupported by our
     # current postgres:15 server. Keep plain SQL dumps restorable on the server
@@ -81,15 +85,18 @@ class BackupService:
         except (TypeError, ValueError):
             return None
 
+    def _require_backup_folder_id(self) -> str:
+        folder_id = (self.backup_folder_id or "").strip()
+        if not folder_id:
+            raise BackupConfigurationError("BACKUP_FOLDER_ID is not configured")
+        return folder_id
+
     def list_backups(self, limit: int = 50) -> List[Dict[str, Any]]:
         """
         Returns available backups from Google Drive folder with `db/media` classification.
         """
-        if not self.backup_folder_id:
-            logger.warning("BACKUP_FOLDER_ID not set. Returning empty backup list.")
-            return []
-
-        files = get_google_service().list_files(self.backup_folder_id, limit=limit)
+        folder_id = self._require_backup_folder_id()
+        files = get_google_service().list_files(folder_id, limit=limit)
         items: List[Dict[str, Any]] = []
         for item in files:
             name = item.get("name", "")
@@ -211,11 +218,10 @@ class BackupService:
         """
         Keeps only the latest 10 backup sets in Google Drive (db + media).
         """
-        if not self.backup_folder_id:
-            return
+        folder_id = self._require_backup_folder_id()
 
         try:
-            files = get_google_service().list_files(self.backup_folder_id, limit=50)
+            files = get_google_service().list_files(folder_id, limit=50)
             keep_limit = 10 * 2
 
             if len(files) > keep_limit:
@@ -245,9 +251,7 @@ class BackupService:
             )
             return False
 
-        if not self.backup_folder_id:
-            logger.warning("BACKUP_FOLDER_ID not set. Skipping upload.")
-            return
+        folder_id = self._require_backup_folder_id()
 
         created_files: List[str] = []
         try:
@@ -267,7 +271,7 @@ class BackupService:
                     file_path=filepath,
                     filename=filename,
                     mime_type=mime,
-                    folder_id=self.backup_folder_id,
+                    folder_id=folder_id,
                 )
                 uploaded_count += 1
 

--- a/services/google_oauth_credentials.py
+++ b/services/google_oauth_credentials.py
@@ -1,0 +1,152 @@
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Sequence
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+
+
+class GoogleCredentialsError(RuntimeError):
+    """Base error for unavailable Google OAuth credentials."""
+
+
+class GoogleTokenUnavailableError(GoogleCredentialsError):
+    """The configured token is missing or cannot authorize requests."""
+
+
+class GoogleTokenLoadError(GoogleCredentialsError):
+    """The configured token file cannot be parsed."""
+
+
+class GoogleTokenRefreshError(GoogleCredentialsError):
+    """Google rejected or failed the token refresh request."""
+
+
+class GoogleTokenPersistenceError(GoogleCredentialsError):
+    """A refreshed or newly issued token cannot be persisted safely."""
+
+
+class GoogleTokenExchangeError(GoogleCredentialsError):
+    """The OAuth authorization code cannot be exchanged for credentials."""
+
+
+class GoogleDriveListError(RuntimeError):
+    """Google Drive failed to list files; this is not an empty result."""
+
+
+@dataclass(frozen=True)
+class GoogleCredentialState:
+    credentials: Credentials | None
+    error: GoogleCredentialsError | None = None
+
+
+class GoogleOAuthCredentialStore:
+    """Loads, refreshes, and atomically persists one OAuth token file."""
+
+    def __init__(self, token_file: str, scopes: Sequence[str]):
+        self.token_file = os.path.abspath(token_file)
+        self.scopes = list(scopes)
+
+    def load(self) -> GoogleCredentialState:
+        if not os.path.exists(self.token_file):
+            return GoogleCredentialState(
+                credentials=None,
+                error=GoogleTokenUnavailableError(
+                    f"Google OAuth token file is missing: {self.token_file}"
+                ),
+            )
+
+        try:
+            credentials = Credentials.from_authorized_user_file(
+                self.token_file,
+                self.scopes,
+            )
+        except Exception as exc:
+            error = GoogleTokenLoadError(
+                f"Google OAuth token file could not be loaded: {self.token_file}"
+            )
+            error.__cause__ = exc
+            return GoogleCredentialState(
+                credentials=None,
+                error=error,
+            )
+
+        if credentials.valid:
+            return GoogleCredentialState(credentials=credentials)
+
+        if credentials.expired and credentials.refresh_token:
+            try:
+                credentials.refresh(Request())
+            except Exception as exc:
+                error = GoogleTokenRefreshError("Google OAuth token refresh failed")
+                error.__cause__ = exc
+                return GoogleCredentialState(
+                    credentials=credentials,
+                    error=error,
+                )
+
+            try:
+                self.persist(credentials)
+            except GoogleTokenPersistenceError as exc:
+                # Keep the refreshed in-memory credentials for status reporting,
+                # and let the caller decide whether current-process availability
+                # can continue while the persistence incident remains visible.
+                return GoogleCredentialState(credentials=credentials, error=exc)
+
+            if credentials.valid:
+                return GoogleCredentialState(credentials=credentials)
+
+        return GoogleCredentialState(
+            credentials=credentials,
+            error=GoogleTokenUnavailableError(
+                "Google OAuth credentials are invalid and cannot be refreshed"
+            ),
+        )
+
+    def persist(self, credentials: Credentials) -> None:
+        token_dir = os.path.dirname(self.token_file)
+        temp_path: str | None = None
+        required_fields = ("refresh_token", "client_id", "client_secret", "token_uri")
+        missing = [name for name in required_fields if not getattr(credentials, name, None)]
+        if missing:
+            raise GoogleTokenPersistenceError(
+                "Google OAuth credentials cannot be persisted without: "
+                + ",".join(missing)
+            )
+        try:
+            parent_existed = os.path.isdir(token_dir)
+            os.makedirs(token_dir, mode=0o700, exist_ok=True)
+            if not parent_existed:
+                os.chmod(token_dir, 0o700)
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=token_dir,
+                prefix=f".{os.path.basename(self.token_file)}.",
+                delete=False,
+            ) as token:
+                temp_path = token.name
+                os.chmod(temp_path, 0o600)
+                token.write(credentials.to_json())
+                token.flush()
+                os.fsync(token.fileno())
+
+            os.replace(temp_path, self.token_file)
+            temp_path = None
+            os.chmod(self.token_file, 0o600)
+            directory_fd = os.open(token_dir, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except Exception as exc:
+            raise GoogleTokenPersistenceError(
+                f"Google OAuth token could not be persisted: {self.token_file}"
+            ) from exc
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass

--- a/services/google_service.py
+++ b/services/google_service.py
@@ -1,16 +1,23 @@
 import os
 import logging
 import re
-import tempfile
 from typing import Dict, Any, List, Optional
 from io import BytesIO
 
 from google_auth_oauthlib.flow import Flow
-from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload, MediaIoBaseUpload
 import datetime
+
+from services.google_oauth_credentials import (
+    GoogleCredentialsError,
+    GoogleDriveListError,
+    GoogleOAuthCredentialStore,
+    GoogleTokenExchangeError,
+    GoogleTokenPersistenceError,
+    GoogleTokenUnavailableError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +26,7 @@ SCOPES = [
     'https://www.googleapis.com/auth/documents',
     'https://www.googleapis.com/auth/spreadsheets'
 ]
-TOKEN_FILE = 'token.json'
+TOKEN_FILE = os.getenv("GOOGLE_TOKEN_FILE", "token.json").strip() or "token.json"
 CLIENT_SECRET_FILE = 'client_secret.json'
 DESTINATION_FOLDER_ID = '1kLK6Vque3V5iPV1i1HjeH_su-TmyCzQt' 
 DEFAULT_OAUTH_REDIRECT_URI = "http://127.0.0.1:8000/api/manager/google-auth/callback"
@@ -31,16 +38,33 @@ def get_default_oauth_redirect_uri() -> str:
 class GoogleDocsService:
     def __init__(self):
         self.creds = None
+        self._auth_error: GoogleCredentialsError | None = None
         self._authenticate()
 
+    @property
+    def auth_error(self) -> GoogleCredentialsError | None:
+        return self._auth_error
+
+    @staticmethod
+    def _credential_store() -> GoogleOAuthCredentialStore:
+        return GoogleOAuthCredentialStore(TOKEN_FILE, SCOPES)
+
     def get_token_status(self) -> Dict[str, Any]:
-        """Returns status of current token."""
+        """Return current-process usability and separate durable-store health.
+
+        A refresh can remain usable in memory even when saving it fails, so
+        ``valid`` alone must never be treated as proof of durable persistence.
+        """
         status = {
             "exists": os.path.exists(TOKEN_FILE),
             "valid": False,
             "expired": False,
             "expiry": None,
-            "scopes": []
+            "scopes": [],
+            "persistence_ok": self._auth_error is None,
+            "persistence_error_code": (
+                type(self._auth_error).__name__ if self._auth_error is not None else None
+            ),
         }
         if self.creds:
             status["valid"] = self.creds.valid
@@ -82,54 +106,83 @@ class GoogleDocsService:
             scopes=SCOPES,
             redirect_uri=redirect_uri
         )
-        flow.fetch_token(code=code)
+        try:
+            flow.fetch_token(code=code)
+        except Exception as exc:
+            raise GoogleTokenExchangeError(
+                "Google OAuth authorization code exchange failed"
+            ) from exc
+
         self.creds = flow.credentials
-        
         self._write_token_file()
+        self._auth_error = None
             
         return True
 
-    def _authenticate(self):
-        if os.path.exists(TOKEN_FILE):
-            try:
-                self.creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
-            except Exception: self.creds = None
-        
-        if not self.creds or not self.creds.valid:
-            if self.creds and self.creds.expired and self.creds.refresh_token:
+    def _authenticate(self) -> None:
+        state = self._credential_store().load()
+        self.creds = state.credentials
+        self._auth_error = state.error
+
+        if isinstance(state.error, GoogleTokenPersistenceError):
+            logger.error(
+                "Google OAuth token refresh succeeded but persistence failed "
+                "persistence_state=failed credentials_valid=%s error_type=%s",
+                bool(state.credentials and state.credentials.valid),
+                type(state.error).__name__,
+            )
+        elif state.error and not isinstance(state.error, GoogleTokenUnavailableError):
+            logger.warning(
+                "Google OAuth credentials are unavailable error_type=%s",
+                type(state.error).__name__,
+            )
+
+    def _require_credentials(self) -> Credentials:
+        if self.creds is not None and self.creds.valid:
+            if self._auth_error is not None and not isinstance(
+                self._auth_error,
+                GoogleTokenPersistenceError,
+            ):
+                raise self._auth_error
+            if isinstance(self._auth_error, GoogleTokenPersistenceError):
                 try:
-                    self.creds.refresh(Request())
-                    # Сохраняем токен ТОЛЬКО если успешно обновили
-                    self._write_token_file()
-                except Exception: self.creds = None
+                    self._credential_store().persist(self.creds)
+                except GoogleTokenPersistenceError as exc:
+                    self._auth_error = exc
+                    logger.warning(
+                        "Google OAuth persistence retry failed error_type=%s",
+                        type(exc).__name__,
+                    )
+                else:
+                    self._auth_error = None
+                    logger.info("Google OAuth persistence recovered")
+            return self.creds
+
+        self._authenticate()
+        if self._auth_error is not None and not isinstance(
+            self._auth_error,
+            GoogleTokenPersistenceError,
+        ):
+            raise self._auth_error
+        if self.creds is not None and self.creds.valid:
+            return self.creds
+        if self._auth_error is not None:
+            raise self._auth_error
+        raise GoogleTokenUnavailableError("Google OAuth credentials are unavailable")
 
     def _write_token_file(self) -> None:
         if self.creds is None:
-            raise RuntimeError("Google credentials are not available")
-
-        token_path = os.path.abspath(TOKEN_FILE)
-        token_dir = os.path.dirname(token_path)
-        temp_path: str | None = None
+            raise GoogleTokenUnavailableError("Google OAuth credentials are unavailable")
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=token_dir,
-                prefix=f".{os.path.basename(token_path)}.",
-                delete=False,
-            ) as token:
-                temp_path = token.name
-                os.chmod(temp_path, 0o600)
-                token.write(self.creds.to_json())
-                token.flush()
-                os.fsync(token.fileno())
-
-            os.replace(temp_path, token_path)
-            temp_path = None
-            os.chmod(token_path, 0o600)
-        finally:
-            if temp_path and os.path.exists(temp_path):
-                os.unlink(temp_path)
+            self._credential_store().persist(self.creds)
+        except GoogleTokenPersistenceError as exc:
+            self._auth_error = exc
+            logger.error(
+                "Google OAuth credentials were issued but persistence failed "
+                "error_type=%s",
+                type(exc).__name__,
+            )
+            raise
 
     def generate_sheet(self, template_id: str, title: str, replacements: Dict[str, str], 
                        table_data: Optional[List[List[str]]] = None,
@@ -143,13 +196,11 @@ class GoogleDocsService:
         start_cell_addr: Адрес ячейки (напр. "A12").
         target_sheet_name: Имя листа (вкладки), куда писать данные (напр. "ТН-2").
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds: return "Ошибка: Нет доступа к Google API (проверьте права)."
+        credentials = self._require_credentials()
 
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
-            sheets_service = build('sheets', 'v4', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
+            sheets_service = build('sheets', 'v4', credentials=credentials)
 
             # 1. Копируем файл
             copy_body = {'name': title, 'parents': [DESTINATION_FOLDER_ID] if DESTINATION_FOLDER_ID else []}
@@ -190,12 +241,8 @@ class GoogleDocsService:
         sheet_name: Optional[str] = None,
         range_a1: Optional[str] = None,
     ) -> List[List[str]]:
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API (проверьте права).")
-
-        sheets_service = build("sheets", "v4", credentials=self.creds)
+        credentials = self._require_credentials()
+        sheets_service = build("sheets", "v4", credentials=credentials)
         query_range = range_a1
         if not query_range:
             query_range = f"{sheet_name}" if sheet_name else "A:Z"
@@ -218,12 +265,8 @@ class GoogleDocsService:
         return m.group(1) if m else raw
 
     def list_sheet_tabs(self, spreadsheet_id: str) -> List[Dict[str, Any]]:
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API (проверьте права).")
-
-        sheets_service = build("sheets", "v4", credentials=self.creds)
+        credentials = self._require_credentials()
+        sheets_service = build("sheets", "v4", credentials=credentials)
         spreadsheet = (
             sheets_service.spreadsheets()
             .get(spreadsheetId=spreadsheet_id, includeGridData=False)
@@ -501,13 +544,11 @@ class GoogleDocsService:
         """
         has_footer=True: Включает режим объединения ячеек в последней строке таблицы (Итого).
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds: return "Ошибка: Нет доступа к Google API."
+        credentials = self._require_credentials()
 
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
-            docs_service = build('docs', 'v1', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
+            docs_service = build('docs', 'v1', credentials=credentials)
 
             # 1. Копируем
             copy_body = {'name': title, 'parents': [DESTINATION_FOLDER_ID] if DESTINATION_FOLDER_ID else []}
@@ -538,8 +579,8 @@ class GoogleDocsService:
             return f"Google API Error: {str(e)}"
     def export_pdf(self, file_id: str) -> bytes:
         """Скачивает Google Doc как PDF."""
-        if not self.creds: self._authenticate()
-        drive_service = build('drive', 'v3', credentials=self.creds)
+        credentials = self._require_credentials()
+        drive_service = build('drive', 'v3', credentials=credentials)
         
         request = drive_service.files().export_media(fileId=file_id, mimeType='application/pdf')
         file_io = BytesIO()
@@ -564,13 +605,10 @@ class GoogleDocsService:
             - file_id: ID созданного файла
             - edit_url: Ссылка для редактирования
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
         
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             
             # Копируем файл
             copy_body = {
@@ -598,13 +636,10 @@ class GoogleDocsService:
             file_id: ID документа в Google Drive
             replacements: Словарь замен {"{{placeholder}}": "value"}
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
         
         try:
-            docs_service = build('docs', 'v1', credentials=self.creds)
+            docs_service = build('docs', 'v1', credentials=credentials)
             self.render_conditional_blocks(docs_service, file_id, replacements)
             
             # Формируем запросы на замену
@@ -752,13 +787,10 @@ class GoogleDocsService:
         Returns:
             BytesIO объект с содержимым файла
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
         
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             
             request = drive_service.files().export_media(fileId=file_id, mimeType=mime_type)
             file_io = BytesIO()
@@ -981,13 +1013,10 @@ class GoogleDocsService:
         Args:
             file_id: ID файла в Google Drive
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
                 
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             
             # Обновляем метаданные файла, устанавливая trashed=True
             drive_service.files().update(fileId=file_id, body={'trashed': True}).execute()
@@ -1010,13 +1039,10 @@ class GoogleDocsService:
         Returns:
             ID загруженного файла
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                 raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
         
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             
             file_metadata = {'name': filename}
             if folder_id:
@@ -1032,13 +1058,10 @@ class GoogleDocsService:
 
     def create_document_from_html(self, title: str, html: str, folder_id: str = None) -> Dict[str, str]:
         """Creates an editable Google Doc by uploading HTML and converting it."""
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                 raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
 
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             file_metadata = {
                 'name': title,
                 'mimeType': 'application/vnd.google-apps.document',
@@ -1075,13 +1098,10 @@ class GoogleDocsService:
         Returns:
             BytesIO объект с содержимым файла
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-            if not self.creds:
-                raise Exception("Ошибка: Нет доступа к Google API.")
+        credentials = self._require_credentials()
 
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             request = drive_service.files().get_media(fileId=file_id)
             file_io = BytesIO()
             downloader = MediaIoBaseDownload(file_io, request)
@@ -1099,11 +1119,10 @@ class GoogleDocsService:
         """
         Возвращает список файлов в папке, отсортированный по дате создания (DESC).
         """
-        if not self.creds or not self.creds.valid:
-            self._authenticate()
-        
+        credentials = self._require_credentials()
+
         try:
-            drive_service = build('drive', 'v3', credentials=self.creds)
+            drive_service = build('drive', 'v3', credentials=credentials)
             
             query = f"'{folder_id}' in parents and trashed = false"
             
@@ -1116,9 +1135,12 @@ class GoogleDocsService:
             
             return results.get('files', [])
             
-        except Exception as e:
-            logger.error(f"Google Drive List Files Error: {e}")
-            return []
+        except Exception as exc:
+            logger.error(
+                "Google Drive list files failed error_type=%s",
+                type(exc).__name__,
+            )
+            raise GoogleDriveListError("Google Drive failed to list files") from exc
 
 _google_service_instance = None
 

--- a/services/scheduler_service.py
+++ b/services/scheduler_service.py
@@ -242,14 +242,19 @@ class SchedulerService:
                 await asyncio.sleep(wait_seconds)
                 
                 logger.info("⏳ Starting Daily Backup (DB + Media)...")
-                # We need to run sync method in thread executor because subprocess is blocking
-                await asyncio.to_thread(backup_service.perform_backup, cleanup=True)
-                logger.info("✅ Daily Backup Completed.")
+                await self._run_daily_backup()
                 
             except Exception:
                 logger.exception("❌ Backup Loop Error")
                 # Retry in 1 hour if it crashed to avoid loop spam
                 await asyncio.sleep(3600)
+
+    async def _run_daily_backup(self) -> None:
+        """Run one production backup and reject skipped/partial success states."""
+        result = await asyncio.to_thread(backup_service.perform_backup, cleanup=True)
+        if result is not True:
+            raise RuntimeError("Daily backup was skipped or did not complete")
+        logger.info("✅ Daily Backup Completed.")
 
     async def _lead_archive_loop(self):
         """Archives lost/spam leads older than 90 days once every 24 hours."""

--- a/tests/unit/blue_green_deploy_harness.py
+++ b/tests/unit/blue_green_deploy_harness.py
@@ -223,6 +223,7 @@ exit 0
             "BACKEND_IMAGE": NEW_IMAGE,
             "GHCR_PAT": "test-token",
             "GITHUB_ACTOR": "test-user",
+            "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
         }
     )
     return env, project, site, command_log

--- a/tests/unit/test_backup_service.py
+++ b/tests/unit/test_backup_service.py
@@ -3,7 +3,8 @@ import tarfile
 import io
 from pathlib import Path
 
-from services.backup_service import BackupService
+from services.backup_service import BackupConfigurationError, BackupService
+from services.google_oauth_credentials import GoogleTokenRefreshError
 
 
 def test_list_backups_classifies_and_sorts(monkeypatch):
@@ -50,6 +51,52 @@ def test_list_backups_classifies_and_sorts(monkeypatch):
     assert items[1]["kind"] == "media"
     assert items[1]["size_bytes"] == 1024
     assert items[0]["created_at"] > items[1]["created_at"]
+
+
+def test_list_backups_propagates_google_auth_failure(monkeypatch):
+    service = BackupService()
+    service.backup_folder_id = "folder-id"
+
+    class _FailingGoogleService:
+        def list_files(self, _folder_id: str, limit: int = 20):
+            raise GoogleTokenRefreshError("Google OAuth token refresh failed")
+
+    monkeypatch.setattr(
+        "services.backup_service.get_google_service",
+        lambda: _FailingGoogleService(),
+    )
+
+    with pytest.raises(GoogleTokenRefreshError, match="token refresh failed"):
+        service.list_backups(limit=100)
+
+
+def test_list_backups_fails_closed_without_backup_folder_id():
+    service = BackupService()
+    service.backup_folder_id = None
+
+    with pytest.raises(BackupConfigurationError, match="BACKUP_FOLDER_ID"):
+        service.list_backups(limit=100)
+
+
+def test_production_backup_fails_before_dump_without_backup_folder_id(monkeypatch):
+    service = BackupService()
+    service.backup_folder_id = None
+    monkeypatch.setattr(
+        "services.backup_service.settings",
+        type(
+            "ProductionSettings",
+            (),
+            {"is_production": True, "ENVIRONMENT": "production"},
+        )(),
+    )
+    monkeypatch.setattr(
+        service,
+        "create_dump",
+        lambda: pytest.fail("dump must not start without a destination folder"),
+    )
+
+    with pytest.raises(BackupConfigurationError, match="BACKUP_FOLDER_ID"):
+        service.perform_backup()
 
 
 def test_sanitize_plain_sql_dump_removes_client_only_settings(tmp_path: Path):

--- a/tests/unit/test_compose_candidate_transactions.py
+++ b/tests/unit/test_compose_candidate_transactions.py
@@ -1,0 +1,714 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRANSACTION = REPO_ROOT / "scripts/compose_candidate_transaction.sh"
+BACKEND_RUNNER = REPO_ROOT / "scripts/deploy_backend_candidate_transaction.sh"
+PATRONI_RUNNER = REPO_ROOT / "scripts/ha/run_patroni_candidate_transaction.sh"
+PREVIOUS_IMAGE = "ghcr.io/mvnby/air-api/backend:" + "1" * 40
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _transaction(project: Path, action: str):
+    return subprocess.run(
+        ["bash", str(TRANSACTION), action],
+        env={
+            **os.environ,
+            "CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+            "CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _compose_pair(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "compose.yml").write_text(
+        "services:\n  app:\n    volumes:\n      - ./token.json:/app/token.json\n",
+        encoding="utf-8",
+    )
+    (project / "compose.yml.candidate").write_text(
+        "services:\n  app:\n    volumes:\n      - ./google-oauth:/app/google-oauth\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def test_candidate_transaction_keeps_canonical_until_atomic_promotion(tmp_path):
+    project = _compose_pair(tmp_path)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+
+    staged = _transaction(project, "stage")
+    assert staged.returncode == 0, staged.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert (project / "compose.yml.candidate").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.rollback-candidate").exists()
+    assert (project / "compose.yml.pre-google-oauth-dir").read_text(encoding="utf-8") == old
+
+    promoted = _transaction(project, "promote")
+    assert promoted.returncode == 0, promoted.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.candidate").exists()
+
+    script = TRANSACTION.read_text(encoding="utf-8")
+    assert 'fsync_path "${CANDIDATE_FILE}"' in script
+    assert 'fsync_path "$(dirname "${CANONICAL_FILE}")"' in script
+
+
+def test_candidate_cleanup_only_removes_this_runs_candidate(tmp_path):
+    project = _compose_pair(tmp_path)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    assert _transaction(project, "stage").returncode == 0
+
+    cleaned = _transaction(project, "cleanup")
+
+    assert cleaned.returncode == 0, cleaned.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (project / "compose.yml.rollback-candidate").exists()
+
+
+def _backend_runner(
+    tmp_path: Path,
+    *,
+    strategy: str = "in_place",
+    child_exit: int = 0,
+    smoke_exit: int = 0,
+    promote_exit: int = 0,
+    promote_after_move_exit: int = 0,
+    reconcile_exit: int = 0,
+    discover_previous: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    project = _compose_pair(tmp_path)
+    if discover_previous:
+        (project / ".active-api-slot").write_text("green\n", encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "flock",
+        "#!/usr/bin/env bash\nprintf 'flock:%s\\n' \"$*\" >> \"$ORDER_LOG\"\nexit 0\n",
+    )
+    order_log = tmp_path / "order.log"
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker:%s\n' "$*" >> "$ORDER_LOG"
+if [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
+  printf 'active-green-container\n'
+elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
+  printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
+else
+  exit 91
+fi
+""",
+    )
+    child = tmp_path / "deploy-child.sh"
+    _executable(
+        child,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
+grep -Fq '/app/google-oauth' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
+printf 'child:%s:lock=%s\n' "$API_COMPOSE_FILE" "$API_DEPLOY_LOCK_ALREADY_HELD" >> "$ORDER_LOG"
+exit {child_exit}
+""",
+    )
+    smoke = tmp_path / "smoke.sh"
+    _executable(
+        smoke,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
+grep -Fq '/app/google-oauth' "$COMPOSE_FILE"
+printf 'smoke:%s\n' "$COMPOSE_FILE" >> "$ORDER_LOG"
+exit {smoke_exit}
+""",
+    )
+    reconcile = tmp_path / "reconcile.sh"
+    _executable(
+        reconcile,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
+printf 'reconcile:%s\n' "$API_COMPOSE_FILE" >> "$ORDER_LOG"
+test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_PREVIOUS_IMAGE"
+exit {reconcile_exit}
+""",
+    )
+    transaction_driver = tmp_path / "transaction.sh"
+    _executable(
+        transaction_driver,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "promote" && {promote_exit} -ne 0 ]]; then exit {promote_exit}; fi
+if [[ "$1" == "promote" && {promote_after_move_exit} -ne 0 ]]; then
+  bash "$REAL_TRANSACTION" "$1"
+  exit {promote_after_move_exit}
+fi
+exec bash "$REAL_TRANSACTION" "$@"
+""",
+    )
+    result = subprocess.run(
+        ["bash", str(BACKEND_RUNNER)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "ORDER_LOG": str(order_log),
+            "API_PROJECT_DIR": str(project),
+            "API_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+            "API_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+            "API_DEPLOY_STRATEGY": strategy,
+            "API_IN_PLACE_DEPLOY_SCRIPT": str(child),
+            "API_BLUE_GREEN_SCRIPT": str(child),
+            "API_SMOKE_SCRIPT": str(smoke),
+            "API_RECONCILE_SCRIPT": str(reconcile),
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
+            "REAL_TRANSACTION": str(TRANSACTION),
+            "API_PREVIOUS_BACKEND_IMAGE": "" if discover_previous else PREVIOUS_IMAGE,
+            "EXPECTED_PREVIOUS_IMAGE": PREVIOUS_IMAGE,
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, project, order_log
+
+
+@pytest.mark.parametrize("strategy", ["in_place", "blue_green"])
+def test_backend_failure_cleans_candidate_and_force_reconciles_canonical(
+    tmp_path,
+    strategy,
+):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        strategy=strategy,
+        child_exit=42,
+    )
+
+    assert result.returncode == 42
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    assert order_log.read_text(encoding="utf-8").splitlines() == [
+        "flock:-n 9",
+        "child:compose.yml.candidate:lock=true",
+        "reconcile:compose.yml",
+    ]
+
+
+@pytest.mark.parametrize("strategy", ["in_place", "blue_green"])
+def test_backend_promotes_only_after_candidate_smoke_succeeds(tmp_path, strategy):
+    result, project, order_log = _backend_runner(tmp_path, strategy=strategy)
+
+    assert result.returncode == 0, result.stderr
+    assert "/app/google-oauth" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    assert order_log.read_text(encoding="utf-8").splitlines() == [
+        "flock:-n 9",
+        "child:compose.yml.candidate:lock=true",
+        f"smoke:{project / 'compose.yml.candidate'}",
+    ]
+
+
+@pytest.mark.parametrize("strategy", ["in_place", "blue_green"])
+def test_backend_smoke_failure_cleans_candidate_and_reconciles_canonical(
+    tmp_path,
+    strategy,
+):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        strategy=strategy,
+        smoke_exit=43,
+    )
+
+    assert result.returncode == 43
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    assert order_log.read_text(encoding="utf-8").splitlines() == [
+        "flock:-n 9",
+        "child:compose.yml.candidate:lock=true",
+        f"smoke:{project / 'compose.yml.candidate'}",
+        "reconcile:compose.yml",
+    ]
+
+
+@pytest.mark.parametrize("strategy", ["in_place", "blue_green"])
+def test_backend_promotion_failure_restores_old_image_and_canonical(
+    tmp_path,
+    strategy,
+):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        strategy=strategy,
+        promote_exit=44,
+    )
+
+    assert result.returncode == 44
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    assert order_log.read_text(encoding="utf-8").splitlines()[-1] == "reconcile:compose.yml"
+
+
+@pytest.mark.parametrize("strategy", ["in_place", "blue_green"])
+def test_backend_post_rename_failure_keeps_committed_runtime_contract(
+    tmp_path,
+    strategy,
+):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        strategy=strategy,
+        promote_after_move_exit=46,
+    )
+
+    assert result.returncode == 46
+    assert "/app/google-oauth" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    assert "reconcile:compose.yml" not in order_log.read_text(encoding="utf-8")
+    assert "promotion committed" in result.stderr
+
+
+def test_backend_reports_critical_status_when_canonical_reconcile_fails(tmp_path):
+    result, project, _ = _backend_runner(
+        tmp_path,
+        smoke_exit=43,
+        reconcile_exit=45,
+    )
+
+    assert result.returncode == 90
+    assert "CRITICAL" in result.stderr
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+
+
+def test_backend_discovers_previous_runtime_image_from_active_slot_before_reconcile(
+    tmp_path,
+):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        child_exit=42,
+        discover_previous=True,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    commands = order_log.read_text(encoding="utf-8").splitlines()
+    ps_index = next(i for i, line in enumerate(commands) if " ps -q app-green" in line)
+    inspect_index = next(
+        i for i, line in enumerate(commands) if line.startswith("docker:inspect --format ")
+    )
+    reconcile_index = commands.index("reconcile:compose.yml")
+    assert ps_index < inspect_index < reconcile_index
+
+
+def _patroni_runner_env(
+    tmp_path: Path,
+    child_exit: int,
+    *,
+    current_role: str = "primary",
+    expected_role: str = "primary",
+    discover_previous: bool = False,
+) -> tuple[dict[str, str], Path]:
+    project = _compose_pair(tmp_path)
+    if discover_previous:
+        (project / ".active-api-slot").write_text("green\n", encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    command_log = tmp_path / "patroni-commands.log"
+    command_log.touch()
+    systemctl_log = tmp_path / "systemctl.log"
+    systemctl_log.touch()
+    systemctl_state = tmp_path / "systemctl-state"
+    systemctl_state.write_text("active\n", encoding="utf-8")
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PATRONI_COMMAND_LOG"
+if [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
+  printf 'active-green-container\n'
+elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
+  printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
+elif [[ "$1" == "compose" && "$*" == *" stop app app-blue app-green bot" ]]; then
+  exit 0
+else
+  exit 91
+fi
+""",
+    )
+    _executable(
+        fake_bin / "systemctl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+case "$1" in
+  restart)
+    count=0
+    if [[ -f "$SYSTEMCTL_RESTART_COUNT" ]]; then
+      count="$(cat "$SYSTEMCTL_RESTART_COUNT")"
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$SYSTEMCTL_RESTART_COUNT"
+    if [[ "$count" -eq "${SYSTEMCTL_FAIL_RESTART_NUMBER:-0}" ]]; then
+      printf 'inactive\n' > "$SYSTEMCTL_STATE"
+      exit 47
+    fi
+    printf 'active\n' > "$SYSTEMCTL_STATE"
+    ;;
+  start)
+    printf 'active\n' > "$SYSTEMCTL_STATE"
+    ;;
+  stop)
+    printf 'inactive\n' > "$SYSTEMCTL_STATE"
+    ;;
+  is-active)
+    [[ "$(cat "$SYSTEMCTL_STATE")" == "active" ]]
+    ;;
+esac
+""",
+    )
+    child = tmp_path / "deploy-child.sh"
+    _executable(
+        child,
+        f'''#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
+printf "%s|%s\n" "$API_COMPOSE_FILE" "$API_DEPLOY_LOCK_ALREADY_HELD" > "$CHILD_LOG"
+exit {child_exit}
+''',
+    )
+    role_agent = tmp_path / "role-agent.py"
+    role_agent.write_text("#!/usr/bin/env python3\n# new role agent\n", encoding="utf-8")
+    reconcile = tmp_path / "reconcile.sh"
+    _executable(
+        reconcile,
+        """#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
+printf '%s|%s\n' "$API_COMPOSE_FILE" "$API_DEPLOY_SERVICES" > "$RECONCILE_LOG"
+printf 'reconcile:%s\n' "$API_COMPOSE_FILE" >> "$PATRONI_COMMAND_LOG"
+test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_PREVIOUS_IMAGE"
+exit 0
+""",
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "PATRONI_CANDIDATE_OPERATION": "deploy",
+        "API_PROJECT_DIR": str(project),
+        "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+        "PATRONI_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+        "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
+        "PATRONI_DEPLOY_SCRIPT": str(child),
+        "API_RECONCILE_SCRIPT": str(reconcile),
+        "API_EXPECTED_PATRONI_ROLE": expected_role,
+        "API_CURRENT_PATRONI_ROLE": current_role,
+        "PATRONI_ROLE_AGENT_SOURCE": str(role_agent),
+        "PATRONI_ROLE_AGENT_TARGET": str(tmp_path / "installed-role-agent"),
+        "PATRONI_ROLE_AGENT_UNIT": "test.service",
+        "CHILD_LOG": str(tmp_path / "child.log"),
+        "RECONCILE_LOG": str(tmp_path / "reconcile.log"),
+        "PATRONI_COMMAND_LOG": str(command_log),
+        "SYSTEMCTL_LOG": str(systemctl_log),
+        "SYSTEMCTL_STATE": str(systemctl_state),
+        "SYSTEMCTL_RESTART_COUNT": str(tmp_path / "systemctl-restart-count"),
+        "API_PREVIOUS_BACKEND_IMAGE": "" if discover_previous else PREVIOUS_IMAGE,
+        "EXPECTED_PREVIOUS_IMAGE": PREVIOUS_IMAGE,
+    }
+    return env, project
+
+
+def test_patroni_candidate_failure_leaves_canonical_old(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert (tmp_path / "child.log").read_text(encoding="utf-8").strip() == "compose.yml.candidate|true"
+    assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == "compose.yml|app bot"
+
+
+def test_patroni_candidate_promotes_only_after_success(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+
+
+def test_patroni_discovers_previous_runtime_image_from_active_slot_before_reconcile(
+    tmp_path,
+):
+    env, project = _patroni_runner_env(
+        tmp_path,
+        child_exit=42,
+        discover_previous=True,
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8").splitlines()
+    ps_index = next(i for i, line in enumerate(commands) if " ps -q app-green" in line)
+    inspect_index = next(
+        i for i, line in enumerate(commands) if line.startswith("inspect --format ")
+    )
+    reconcile_index = commands.index("reconcile:compose.yml")
+    assert ps_index < inspect_index < reconcile_index
+    assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == (
+        "compose.yml|app bot"
+    )
+
+
+def test_patroni_role_drift_fences_all_api_slots_and_bot_without_reconcile(tmp_path):
+    env, project = _patroni_runner_env(
+        tmp_path,
+        child_exit=42,
+        expected_role="primary",
+        current_role="standby",
+    )
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "Patroni role changed during deployment" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8").splitlines()
+    assert any(
+        " stop app app-blue app-green bot" in command for command in commands
+    )
+
+
+def test_patroni_unknown_live_role_fences_runtime_instead_of_assuming_standby(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    env.pop("API_CURRENT_PATRONI_ROLE")
+    _executable(
+        tmp_path / "bin/curl",
+        "#!/usr/bin/env bash\nprintf '%s\n' '{\"state\":\"running\",\"role\":\"mystery\"}'\n",
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "could not establish live Patroni role" in result.stderr
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert " stop app app-blue app-green bot" in commands
+
+
+@pytest.mark.parametrize(
+    ("failure_source", "child_exit", "restart_failure", "expected_exit"),
+    [
+        ("child", 42, "0", 42),
+        ("systemctl", 0, "1", 47),
+    ],
+)
+def test_patroni_failure_restores_preexisting_role_agent(
+    tmp_path,
+    failure_source,
+    child_exit,
+    restart_failure,
+    expected_exit,
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=child_exit)
+    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
+    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
+    target.write_text(old_content, encoding="utf-8")
+    target.chmod(0o755)
+    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = restart_failure
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == expected_exit, (
+        failure_source,
+        result.stdout,
+        result.stderr,
+    )
+    assert target.read_text(encoding="utf-8") == old_content
+    assert not Path(env["PATRONI_ROLE_AGENT_SOURCE"]).exists()
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    restarts = [
+        line
+        for line in (tmp_path / "systemctl.log").read_text(encoding="utf-8").splitlines()
+        if line.startswith("restart ")
+    ]
+    assert len(restarts) == 2
+    assert (tmp_path / "reconcile.log").exists()
+
+
+def test_patroni_retains_role_agent_backup_when_restore_restart_fails(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
+    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
+    target.write_text(old_content, encoding="utf-8")
+    target.chmod(0o755)
+    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = "2"
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "role agent backup retained" in result.stderr
+    backups = list(project.glob(".patroni-role-agent.backup.*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == old_content
+    assert target.read_text(encoding="utf-8") == old_content
+    assert not (project / "compose.yml.candidate").exists()
+
+
+@pytest.mark.parametrize("migration_exit", [0, 48])
+def test_patroni_migration_always_cleans_candidate_without_promoting(
+    tmp_path,
+    migration_exit,
+):
+    project = _compose_pair(tmp_path)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    migration_log = tmp_path / "migration.log"
+    migration = tmp_path / "migration.sh"
+    _executable(
+        migration,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$API_COMPOSE_FILE" > "$MIGRATION_LOG"
+exit {migration_exit}
+""",
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env={
+            **os.environ,
+            "PATRONI_CANDIDATE_OPERATION": "migrate",
+            "API_PROJECT_DIR": str(project),
+            "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+            "PATRONI_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
+            "PATRONI_MIGRATION_SCRIPT": str(migration),
+            "MIGRATION_LOG": str(migration_log),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == migration_exit, result.stderr
+    assert migration_log.read_text(encoding="utf-8").strip() == "compose.yml.candidate"
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_patroni_post_rename_promotion_error_preserves_new_canonical(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+    transaction_driver = tmp_path / "patroni-transaction.sh"
+    _executable(
+        transaction_driver,
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "promote" ]]; then
+  bash "$REAL_TRANSACTION" "$1"
+  exit 46
+fi
+exec bash "$REAL_TRANSACTION" "$@"
+""",
+    )
+    env.update(
+        {
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
+            "REAL_TRANSACTION": str(TRANSACTION),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 46
+    assert "promotion committed" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+
+
+def test_legacy_source_bind_deploy_is_retired():
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "deploy_api.sh")],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "retired" in result.stderr
+    assert "GitHub Actions image workflow" in result.stderr

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -125,22 +125,35 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     backend = jobs["deploy-backend"]
     standby = standby_workflow["jobs"]["deploy-api-standby"]
     rollback = _step(backend, "Roll Back Backend After Failed Activation")
+    primary_copy = _step(backend, "Copy Compose Files and Scripts to Server")
     primary_deploy = _step(backend, "Execute Deployment Script")
+    primary_smoke = _step(backend, "Post-Deploy Smoke Check")
     standby_deploy = _step(standby, "Deploy standby API app image")
     standby_rollback = _step(standby, "Roll Back Standby After Failed Activation")
     primary_prune = _step(backend, "Prune Unused Backend Docker Images")
     standby_prune = _step(standby, "Prune Unused Standby Docker Images")
 
     assert "steps.deploy_backend.outcome == 'failure'" in rollback["if"]
-    assert "steps.post_deploy_smoke.outcome == 'failure'" in rollback["if"]
+    assert "steps.post_deploy_smoke.outcome" not in rollback["if"]
     assert "EXPECTED_CURRENT_IMAGE=" in rollback["run"]
+    assert "API_FORCE_COMPOSE_RECONCILE_ON_NOOP=true" in rollback["run"]
     assert "scripts/rollback_backend.sh" in rollback["run"]
-    assert "scripts/deploy_backend_blue_green.sh" in primary_deploy["run"]
-    assert "scripts/deploy_backend_blue_green_safety.sh" in primary_deploy["run"]
-    assert 'case "${API_DEPLOY_STRATEGY}" in' in primary_deploy["run"]
-    assert "blue_green)" in primary_deploy["run"]
-    assert "in_place)" in primary_deploy["run"]
+    assert '.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}' in primary_copy["run"]
+    assert "scp \\" in primary_copy["run"]
+    assert 'cat "scripts/${script}"' in primary_deploy["run"]
+    assert "deploy_backend_blue_green.sh" in primary_deploy["run"]
+    assert "deploy_backend_blue_green_safety.sh" in primary_deploy["run"]
+    assert "compose_candidate_transaction.sh" in primary_deploy["run"]
+    assert "reconcile_backend_compose_runtime.sh" in primary_deploy["run"]
+    assert "deploy_backend_candidate_transaction.sh" in primary_deploy["run"]
+    assert "API_CANONICAL_COMPOSE_FILE=" in primary_deploy["run"]
+    assert "API_CANDIDATE_COMPOSE_FILE=" in primary_deploy["run"]
+    assert "API_COMPOSE_TRANSACTIONAL=" in primary_deploy["run"]
+    assert "API_SMOKE_SCRIPT='/tmp/post_deploy_smoke_check.sh'" in primary_deploy["run"]
+    assert "bash /tmp/deploy_backend_candidate_transaction.sh" in primary_deploy["run"]
     assert "API_RUN_MIGRATIONS='${API_RUN_MIGRATIONS}'" in primary_deploy["run"]
+    assert "smoke_status=passed" in primary_smoke["run"]
+    assert "compose promotion completed" in primary_smoke["run"]
     assert "scripts/deploy_backend_blue_green.sh" in rollback["run"]
     assert "scripts/deploy_backend_blue_green_safety.sh" in rollback["run"]
     safety_helper_env = (
@@ -149,10 +162,18 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     assert safety_helper_env in primary_deploy["run"]
     assert safety_helper_env in rollback["run"]
     assert "scripts/deploy.sh" in standby_deploy["run"]
+    assert '.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}' in standby_deploy["run"]
+    assert "scripts/deploy_backend_candidate_transaction.sh" in standby_deploy["run"]
+    assert "API_COMPOSE_TRANSACTIONAL='${API_STANDBY_COPY_COMPOSE}'" in standby_deploy["run"]
+    assert "API_SMOKE_SCRIPT='/tmp/post_deploy_smoke_check.sh'" in standby_deploy["run"]
+    assert "bash /tmp/deploy_backend_candidate_transaction.sh" in standby_deploy["run"]
     assert "API_DEPLOY_SERVICES='app'" in standby_deploy["run"]
+    assert "API_ACTIVE_SLOT_FILE='${API_STANDBY_PROJECT_DIR}/.standby-api-slot-disabled'" in standby_deploy["run"]
     assert "API_RUN_MIGRATIONS='false'" in standby_deploy["run"]
     assert "steps.deploy_standby.outcome == 'failure'" in standby_rollback["if"]
     assert "API_DEPLOY_SERVICES='app'" in standby_rollback["run"]
+    assert "API_ACTIVE_SLOT_FILE='${API_STANDBY_PROJECT_DIR}/.standby-api-slot-disabled'" in standby_rollback["run"]
+    assert "API_FORCE_COMPOSE_RECONCILE_ON_NOOP=true" in standby_rollback["run"]
     assert primary_prune["continue-on-error"] == "true"
     assert standby_prune["continue-on-error"] == "true"
     workflow_text = "\n".join(
@@ -161,6 +182,7 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     )
     assert "GHCR_PAT='${{ secrets.GHCR_PAT }}'" not in workflow_text
     assert "IFS= read -r GHCR_PAT" in workflow_text
+    assert ".rollback-candidate" not in workflow_text
 
 
 def test_production_compose_requires_backend_release_and_pins_postgres_digest():

--- a/tests/unit/test_google_oauth_token_runtime.py
+++ b/tests/unit/test_google_oauth_token_runtime.py
@@ -1,0 +1,239 @@
+import importlib.util
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PREPARE_SCRIPT = REPO_ROOT / "scripts/prepare_google_oauth_token_dir.sh"
+PRODUCTION_COMPOSE_FILES = (
+    "docker-compose.prod.yml",
+    "deploy/ha/mvn-api/docker-compose.primary.yml",
+    "deploy/ha/mvn-api/docker-compose.standby.yml",
+    "deploy/ha/mvn-api/docker-compose.patroni.yml",
+    "deploy/ha/zakup/docker-compose.primary.yml",
+    "deploy/ha/zakup/docker-compose.standby.yml",
+    "deploy/ha/zakup/docker-compose.patroni.yml",
+)
+
+
+def _token_payload(marker: str = "secret-marker") -> str:
+    return json.dumps(
+        {
+            "token": marker,
+            "refresh_token": f"refresh-{marker}",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+        }
+    )
+
+
+def _run_prepare(project: Path, *arguments: str, **extra_env: str):
+    return subprocess.run(
+        ["bash", str(PREPARE_SCRIPT), *arguments],
+        env={
+            **os.environ,
+            "GOOGLE_OAUTH_PROJECT_DIR": str(project),
+            **extra_env,
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_script_module(name: str, path: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_all_production_ha_composes_use_writable_oauth_directory_contract():
+    assert len(PRODUCTION_COMPOSE_FILES) == 7
+    forbidden = re.compile(r"token\.json\s*:\s*/app/token\.json")
+
+    for relative_path in PRODUCTION_COMPOSE_FILES:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "GOOGLE_TOKEN_FILE: /app/google-oauth/token.json" in text
+        assert "./google-oauth:/app/google-oauth" in text
+        assert "/app/client_secret.json:ro" in text
+        assert "/app/credentials.json:ro" in text
+        assert "/app/token.json" not in text
+        assert not forbidden.search(text)
+
+
+def test_no_repo_compose_reintroduces_single_file_oauth_token_mount():
+    forbidden = re.compile(r"token\.json\s*:\s*/app/token\.json")
+    compose_files = tuple(REPO_ROOT.rglob("docker-compose*.yml"))
+    assert compose_files
+    for path in compose_files:
+        assert not forbidden.search(path.read_text(encoding="utf-8")), path
+
+
+def test_prepare_migrates_legacy_token_atomically_and_retains_source(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    legacy = project / "token.json"
+    legacy.write_text(_token_payload(), encoding="utf-8")
+    legacy.chmod(0o644)
+
+    result = _run_prepare(project, "prepare")
+
+    assert result.returncode == 0, result.stderr
+    destination = project / "google-oauth/token.json"
+    assert destination.read_text(encoding="utf-8") == legacy.read_text(encoding="utf-8")
+    assert legacy.exists()
+    assert stat.S_IMODE(legacy.stat().st_mode) == 0o600
+    assert stat.S_IMODE(destination.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+    assert "secret-marker" not in result.stdout + result.stderr
+    assert list(destination.parent.glob(".token.json.migrate.*")) == []
+    assert _run_prepare(project, "verify").returncode == 0
+
+    script = PREPARE_SCRIPT.read_text(encoding="utf-8")
+    assert 'fsync_path "${temporary}"' in script
+    assert 'fsync_path "${TOKEN_DIR}"' in script
+
+
+def test_prepare_supports_reserve_secrets_layout_without_deleting_legacy(tmp_path):
+    project = tmp_path / "reserve"
+    legacy = project / "secrets/token.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(_token_payload("reserve"), encoding="utf-8")
+
+    result = _run_prepare(project, "prepare")
+
+    assert result.returncode == 0, result.stderr
+    assert (project / "google-oauth/token.json").is_file()
+    assert legacy.is_file()
+
+
+def test_prepare_rejects_ambiguous_or_invalid_legacy_tokens(tmp_path):
+    project = tmp_path / "project"
+    (project / "secrets").mkdir(parents=True)
+    (project / "token.json").write_text(_token_payload("one"), encoding="utf-8")
+    (project / "secrets/token.json").write_text(
+        _token_payload("two"), encoding="utf-8"
+    )
+
+    ambiguous = _run_prepare(project, "prepare")
+    assert ambiguous.returncode != 0
+    assert "multiple different legacy tokens" in ambiguous.stderr
+    assert not (project / "google-oauth/token.json").exists()
+
+    (project / "secrets/token.json").unlink()
+    (project / "token.json").write_text("{}", encoding="utf-8")
+    invalid = _run_prepare(project, "prepare")
+    assert invalid.returncode != 0
+    assert "missing required fields" in invalid.stderr
+
+
+def test_prepare_requires_complete_refresh_credentials(tmp_path):
+    required_fields = ("refresh_token", "client_id", "client_secret", "token_uri")
+    for field in required_fields:
+        project = tmp_path / field
+        project.mkdir()
+        payload = json.loads(_token_payload(field))
+        payload.pop(field)
+        (project / "token.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        result = _run_prepare(project, "prepare")
+
+        assert result.returncode != 0
+        assert f"missing required fields: {field}" in result.stderr
+        assert not (project / "google-oauth/token.json").exists()
+
+
+def test_legacy_python_consumers_honor_configured_token_path(tmp_path, monkeypatch):
+    restore_db = _load_script_module("restore_db_token_test", "scripts/restore_db.py")
+    get_token = _load_script_module("get_token_path_test", "scripts/get_token.py")
+    token_file = tmp_path / "oauth/token.json"
+    monkeypatch.setenv("GOOGLE_TOKEN_FILE", str(token_file))
+
+    class Credentials:
+        refresh_token = "refresh-token"
+        client_id = "client-id"
+        client_secret = "client-secret"
+        token_uri = "https://oauth2.googleapis.com/token"
+
+        @staticmethod
+        def to_json():
+            return _token_payload("python-consumer")
+
+    assert restore_db.get_token_file() == token_file
+    assert get_token.get_token_file() == token_file
+    restore_db.persist_credentials(Credentials(), token_file)
+    assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
+    assert list(token_file.parent.glob(".token.json.*")) == []
+
+    generated_token = tmp_path / "generated-oauth/token.json"
+    get_token.persist_token(Credentials(), generated_token)
+    assert stat.S_IMODE(generated_token.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(generated_token.stat().st_mode) == 0o600
+    assert list(generated_token.parent.glob(".token.json.*")) == []
+
+
+def test_get_token_does_not_chmod_an_existing_parent_directory(tmp_path):
+    get_token = _load_script_module("get_token_mode_test", "scripts/get_token.py")
+    existing_parent = tmp_path / "shared"
+    existing_parent.mkdir()
+    existing_parent.chmod(0o755)
+
+    class Credentials:
+        refresh_token = "refresh-token"
+        client_id = "client-id"
+        client_secret = "client-secret"
+        token_uri = "https://oauth2.googleapis.com/token"
+
+        @staticmethod
+        def to_json():
+            return _token_payload("existing-parent")
+
+    get_token.persist_token(Credentials(), existing_parent / "token.json")
+
+    assert stat.S_IMODE(existing_parent.stat().st_mode) == 0o755
+    assert stat.S_IMODE((existing_parent / "token.json").stat().st_mode) == 0o600
+
+
+def test_deploy_paths_run_token_preparation_before_compose_activation():
+    scripts = (
+        "scripts/deploy.sh",
+        "scripts/deploy_backend_blue_green.sh",
+        "scripts/ha/run_patroni_migrations.sh",
+        "scripts/ha/deploy_patroni_api_node.sh",
+    )
+    for relative_path in scripts:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT" in text
+        assert 'bash "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" prepare' in text
+
+    remote = (REPO_ROOT / "scripts/ha/run_patroni_node_remote.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "scripts/prepare_google_oauth_token_dir.sh" in remote
+    assert "GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT=/tmp/prepare_google_oauth_token_dir.sh" in remote
+    assert 'candidate_id="$(printf' in remote
+    assert 'REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"' in remote
+    assert "run_patroni_candidate_transaction.sh" in remote
+    assert "compose_candidate_transaction.sh" in remote
+
+    workflows = "\n".join(
+        (REPO_ROOT / path).read_text(encoding="utf-8")
+        for path in (
+            ".github/workflows/deploy.yml",
+            ".github/workflows/deploy-api-standby.yml",
+        )
+    )
+    assert "scripts/prepare_google_oauth_token_dir.sh" in workflows
+    assert "deploy_backend_candidate_transaction.sh" in workflows
+    assert ".candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" in workflows
+
+    legacy_deploy = (REPO_ROOT / "deploy_api.sh").read_text(encoding="utf-8")
+    assert "is retired" in legacy_deploy
+    assert "GitHub Actions image workflow" in legacy_deploy

--- a/tests/unit/test_google_service_security.py
+++ b/tests/unit/test_google_service_security.py
@@ -1,10 +1,26 @@
 import os
 import stat
 
+import pytest
+
 from services import google_service
+from services import google_oauth_credentials
+from services.google_oauth_credentials import (
+    GoogleDriveListError,
+    GoogleTokenExchangeError,
+    GoogleTokenLoadError,
+    GoogleTokenPersistenceError,
+    GoogleTokenRefreshError,
+    GoogleTokenUnavailableError,
+)
 
 
 class _CredentialsStub:
+    refresh_token = "refresh-token"
+    client_id = "client-id"
+    client_secret = "client-secret"
+    token_uri = "https://oauth2.googleapis.com/token"
+
     @staticmethod
     def to_json() -> str:
         return '{"refresh_token":"secret"}'
@@ -28,6 +44,12 @@ class _FlowStub:
 
     def fetch_token(self, *, code: str):
         assert code == "oauth-code"
+
+
+class _FailingFlowStub(_FlowStub):
+    def fetch_token(self, *, code: str):
+        super().fetch_token(code=code)
+        raise RuntimeError("provider exchange failed")
 
 
 def _service_without_authentication() -> google_service.GoogleDocsService:
@@ -66,7 +88,7 @@ def test_google_token_file_is_replaced_atomically_with_private_mode(tmp_path, mo
         replace_calls.append((source, destination))
         real_replace(source, destination)
 
-    monkeypatch.setattr(google_service.os, "replace", record_replace)
+    monkeypatch.setattr(google_oauth_credentials.os, "replace", record_replace)
     service.finish_auth("oauth-code", "https://api.example/callback")
 
     assert token_file.read_text(encoding="utf-8") == '{"refresh_token":"secret"}'
@@ -75,3 +97,317 @@ def test_google_token_file_is_replaced_atomically_with_private_mode(tmp_path, mo
     assert replace_calls[0][1] == str(token_file)
     assert replace_calls[0][0] != str(token_file)
     assert list(tmp_path.glob(".token.json.*")) == []
+
+
+class _RefreshingCredentials:
+    def __init__(self, *, refresh_error: Exception | None = None):
+        self.valid = False
+        self.expired = True
+        self.refresh_token = "refresh-token"
+        self.client_id = "client-id"
+        self.client_secret = "client-secret"
+        self.token_uri = "https://oauth2.googleapis.com/token"
+        self.scopes = list(google_service.SCOPES)
+        self.expiry = None
+        self.refresh_error = refresh_error
+        self.refresh_calls = 0
+
+    def refresh(self, _request) -> None:
+        self.refresh_calls += 1
+        if self.refresh_error is not None:
+            raise self.refresh_error
+        self.valid = True
+        self.expired = False
+
+    @staticmethod
+    def to_json() -> str:
+        return '{"refresh_token":"rotated-secret"}'
+
+
+class _PartiallyRefreshingCredentials(_RefreshingCredentials):
+    def refresh(self, _request) -> None:
+        self.refresh_calls += 1
+        self.valid = True
+        self.expired = False
+        raise RuntimeError("refresh failed after a partial mutation")
+
+
+class _DriveListRequest:
+    def __init__(self, *, result=None, error: Exception | None = None):
+        self.result = result
+        self.error = error
+
+    def execute(self):
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _DriveFiles:
+    def __init__(self, request: _DriveListRequest):
+        self.request = request
+
+    def list(self, **_kwargs):
+        return self.request
+
+
+class _DriveService:
+    def __init__(self, request: _DriveListRequest):
+        self.request = request
+
+    def files(self):
+        return _DriveFiles(self.request)
+
+
+def _configure_loaded_credentials(monkeypatch, credentials) -> None:
+    monkeypatch.setattr(
+        google_oauth_credentials.Credentials,
+        "from_authorized_user_file",
+        lambda *_args, **_kwargs: credentials,
+    )
+
+
+def test_missing_token_keeps_reauthentication_available(tmp_path, monkeypatch):
+    token_file = tmp_path / "oauth" / "token.json"
+    token_file.parent.mkdir()
+    client_secret = tmp_path / "client-secret.json"
+    client_secret.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(google_service, "CLIENT_SECRET_FILE", str(client_secret))
+    monkeypatch.setattr(google_service, "Flow", _FlowStub)
+
+    service = google_service.GoogleDocsService()
+
+    assert service.creds is None
+    assert service.get_auth_url(
+        "https://api.example/callback",
+        state="signed-session-state",
+    ).startswith("https://accounts.google.com/")
+    assert service.finish_auth("oauth-code", "https://api.example/callback") is True
+    assert token_file.read_text(encoding="utf-8") == '{"refresh_token":"secret"}'
+
+
+def test_missing_token_fails_api_operation_without_building_adc_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(tmp_path / "missing-token.json"))
+    build_calls = []
+    monkeypatch.setattr(
+        google_service,
+        "build",
+        lambda *_args, **_kwargs: build_calls.append(True),
+    )
+
+    service = google_service.GoogleDocsService()
+
+    with pytest.raises(GoogleTokenUnavailableError, match="token file is missing"):
+        service.list_files("backup-folder")
+    assert build_calls == []
+
+
+def test_oauth_exchange_failure_is_typed_and_does_not_write_token(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.json"
+    client_secret = tmp_path / "client-secret.json"
+    client_secret.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(google_service, "CLIENT_SECRET_FILE", str(client_secret))
+    monkeypatch.setattr(google_service, "Flow", _FailingFlowStub)
+    service = google_service.GoogleDocsService()
+
+    with pytest.raises(GoogleTokenExchangeError, match="code exchange failed"):
+        service.finish_auth("oauth-code", "https://api.example/callback")
+    assert not token_file.exists()
+
+
+def test_refresh_persistence_failure_keeps_valid_credentials_and_never_uses_adc(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    token_file = tmp_path / "oauth" / "token.json"
+    token_file.parent.mkdir()
+    token_file.write_text("stale", encoding="utf-8")
+    credentials = _RefreshingCredentials()
+    _configure_loaded_credentials(monkeypatch, credentials)
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+
+    def fail_replace(_source, _destination):
+        raise OSError(16, "Device or resource busy")
+
+    monkeypatch.setattr(google_oauth_credentials.os, "replace", fail_replace)
+    built_with = []
+
+    def fake_build(_api, _version, *, credentials):
+        built_with.append(credentials)
+        return _DriveService(_DriveListRequest(result={"files": []}))
+
+    monkeypatch.setattr(google_service, "build", fake_build)
+
+    service = google_service.GoogleDocsService()
+
+    assert credentials.refresh_calls == 1
+    assert credentials.valid is True
+    assert isinstance(service.auth_error, GoogleTokenPersistenceError)
+    assert service.get_token_status()["valid"] is True
+    assert service.get_token_status()["persistence_ok"] is False
+    assert (
+        service.get_token_status()["persistence_error_code"]
+        == "GoogleTokenPersistenceError"
+    )
+    assert "persistence_state=failed" in caplog.text
+    assert service.list_files("backup-folder") == []
+    assert built_with == [credentials]
+    assert list(token_file.parent.glob(".token.json.*")) == []
+
+
+def test_valid_in_memory_refresh_retries_and_recovers_durable_persistence(
+    tmp_path,
+    monkeypatch,
+):
+    token_file = tmp_path / "oauth" / "token.json"
+    token_file.parent.mkdir()
+    token_file.write_text("stale", encoding="utf-8")
+    credentials = _RefreshingCredentials()
+    _configure_loaded_credentials(monkeypatch, credentials)
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    real_replace = google_oauth_credentials.os.replace
+    attempts = 0
+
+    def fail_first_replace(source, destination):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError(16, "Device or resource busy")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(google_oauth_credentials.os, "replace", fail_first_replace)
+    monkeypatch.setattr(
+        google_service,
+        "build",
+        lambda *_args, **_kwargs: _DriveService(
+            _DriveListRequest(result={"files": []})
+        ),
+    )
+
+    service = google_service.GoogleDocsService()
+    assert isinstance(service.auth_error, GoogleTokenPersistenceError)
+
+    assert service.list_files("backup-folder") == []
+    assert service.auth_error is None
+    assert service.get_token_status()["persistence_ok"] is True
+    assert token_file.read_text(encoding="utf-8") == credentials.to_json()
+    assert attempts == 2
+
+
+def test_non_refreshable_oauth_exchange_does_not_replace_durable_token(
+    tmp_path,
+    monkeypatch,
+):
+    token_file = tmp_path / "token.json"
+    token_file.write_text('{"refresh_token":"durable"}', encoding="utf-8")
+    client_secret = tmp_path / "client-secret.json"
+    client_secret.write_text("{}", encoding="utf-8")
+
+    class NonRefreshableCredentials(_CredentialsStub):
+        refresh_token = None
+
+    class NonRefreshableFlow(_FlowStub):
+        def __init__(self):
+            super().__init__()
+            self.credentials = NonRefreshableCredentials()
+
+    monkeypatch.setattr(google_service, "CLIENT_SECRET_FILE", str(client_secret))
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    monkeypatch.setattr(google_service, "Flow", NonRefreshableFlow)
+    service = _service_without_authentication()
+
+    with pytest.raises(GoogleTokenPersistenceError, match="refresh_token"):
+        service.finish_auth("oauth-code", "https://api.example/callback")
+
+    assert token_file.read_text(encoding="utf-8") == '{"refresh_token":"durable"}'
+
+
+def test_refresh_failure_is_typed_and_does_not_build_google_client(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.json"
+    token_file.write_text("stale", encoding="utf-8")
+    credentials = _RefreshingCredentials(refresh_error=RuntimeError("provider rejected refresh"))
+    _configure_loaded_credentials(monkeypatch, credentials)
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    build_calls = []
+    monkeypatch.setattr(google_service, "build", lambda *_args, **_kwargs: build_calls.append(True))
+
+    service = google_service.GoogleDocsService()
+
+    with pytest.raises(GoogleTokenRefreshError, match="token refresh failed"):
+        service.list_files("backup-folder")
+    assert build_calls == []
+
+
+def test_refresh_error_wins_even_if_provider_partially_marks_credentials_valid(
+    tmp_path,
+    monkeypatch,
+):
+    token_file = tmp_path / "token.json"
+    token_file.write_text("stale", encoding="utf-8")
+    credentials = _PartiallyRefreshingCredentials()
+    _configure_loaded_credentials(monkeypatch, credentials)
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+    build_calls = []
+    monkeypatch.setattr(
+        google_service,
+        "build",
+        lambda *_args, **_kwargs: build_calls.append(True),
+    )
+
+    service = google_service.GoogleDocsService()
+
+    with pytest.raises(GoogleTokenRefreshError, match="token refresh failed"):
+        service.list_files("backup-folder")
+    assert credentials.valid is True
+    assert build_calls == []
+
+
+def test_malformed_token_is_distinct_from_refresh_failure(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.json"
+    token_file.write_text("not-json", encoding="utf-8")
+    monkeypatch.setattr(google_service, "TOKEN_FILE", str(token_file))
+
+    def fail_to_load_token(*_args, **_kwargs):
+        raise ValueError("invalid json")
+
+    monkeypatch.setattr(
+        google_oauth_credentials.Credentials,
+        "from_authorized_user_file",
+        fail_to_load_token,
+    )
+    build_calls = []
+    monkeypatch.setattr(
+        google_service,
+        "build",
+        lambda *_args, **_kwargs: build_calls.append(True),
+    )
+
+    service = google_service.GoogleDocsService()
+
+    with pytest.raises(GoogleTokenLoadError, match="could not be loaded"):
+        service.list_files("backup-folder")
+    assert build_calls == []
+
+
+def test_list_files_propagates_provider_failure_instead_of_returning_empty(
+    monkeypatch,
+):
+    service = _service_without_authentication()
+    credentials = _RefreshingCredentials()
+    credentials.valid = True
+    credentials.expired = False
+    service.creds = credentials
+    service._auth_error = None
+    monkeypatch.setattr(
+        google_service,
+        "build",
+        lambda *_args, **_kwargs: _DriveService(
+            _DriveListRequest(error=RuntimeError("drive unavailable"))
+        ),
+    )
+
+    with pytest.raises(GoogleDriveListError, match="failed to list files"):
+        service.list_files("backup-folder")

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -72,12 +72,18 @@ def test_restore_drill_checks_out_repo_before_local_alert_action():
 
     assert steps[0]["name"] == "Checkout"
     assert steps[0]["uses"] == "actions/checkout@v6"
+    assert workflow["concurrency"] == {
+        "group": "api-restore-drill",
+        "cancel-in-progress": "false",
+    }
     assert "API_STANDBY_HOST" in setup_step["env"]
     assert 'ssh-keyscan -T 10 -H "${API_STANDBY_HOST}"' in setup_step["run"]
     assert "API_DB_HA_MODE" in run_step["env"]
     assert "API_STANDBY_PROJECT_DIR" in run_step["env"]
     assert "check_patroni_production.py --resolve-primary" in run_step["run"]
     assert "scripts/ha/restore_drill_latest_db.sh" in run_step["run"]
+    assert "scripts/ha/cleanup_restore_drill_runtime.sh" in run_step["run"]
+    assert "RESTORE_DRILL_CLEANUP_SCRIPT=" in run_step["run"]
     assert 'selected_node=${target_label} ha_mode=${API_DB_HA_MODE}' in run_step["run"]
 
 
@@ -91,3 +97,23 @@ def test_restore_drill_waits_for_stable_sql_and_checks_business_data():
     assert "business_counts=" in script
     assert "product_count payment_count order_count" in script
     assert '"${product_count}" -lt 1 || "${order_count}" -lt 1' in script
+    assert 'MIN_PUBLIC_TABLES="${MIN_PUBLIC_TABLES:-64}"' in script
+    assert '"${tables_count}" -lt "${MIN_PUBLIC_TABLES}"' in script
+    cleanup = (REPO_ROOT / "scripts/ha/cleanup_restore_drill_runtime.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'docker rm -fv "${CONTAINER}"' in cleanup
+    assert 'docker rm -f "${CONTAINER}"' not in cleanup
+    assert "docker volume create" in script
+    assert "com.mvn.purpose=api-restore-drill" in script
+    assert 'com.mvn.run_id=${run_id}' in script
+    assert 'DRILL_DIR="${DRILL_ROOT}/${run_id}"' in script
+    assert "RESTORE_DRILL_RUN_ID must contain only" in script
+    assert 'source=${data_volume},target=/var/lib/postgresql/data' in script
+    assert 'docker volume rm "${DATA_VOLUME}"' in cleanup
+    assert 'docker volume rm -f "${DATA_VOLUME}"' not in cleanup
+    assert "RESTORE_DRILL_RUN_ID" in cleanup
+    assert "container_label_mismatch" in cleanup
+    assert "volume_label_mismatch" in cleanup
+    assert "cleanup_error=${kind}_inspect_failed" in cleanup
+    assert "latest-db-backup*" not in cleanup

--- a/tests/unit/test_manager_backups_api_unit.py
+++ b/tests/unit/test_manager_backups_api_unit.py
@@ -4,6 +4,8 @@ from httpx import ASGITransport, AsyncClient
 
 from core.security import get_current_owner_username
 from routers.manager_backups import router as manager_backups_router
+from services.backup_service import BackupConfigurationError
+from services.google_oauth_credentials import GoogleTokenRefreshError
 
 
 @pytest.fixture()
@@ -15,6 +17,44 @@ async def backups_client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
+
+
+@pytest.mark.asyncio
+async def test_list_backups_maps_google_auth_failure_to_redacted_502(
+    backups_client,
+    monkeypatch,
+):
+    def _fail_list(*, limit: int):
+        assert limit == 100
+        raise GoogleTokenRefreshError("provider-secret-detail")
+
+    monkeypatch.setattr("routers.manager_backups.backup_service.list_backups", _fail_list)
+
+    response = await backups_client.get("/api/manager/backups")
+
+    assert response.status_code == 502
+    payload = response.json()
+    assert payload["detail"]["error_code"] == "backup_list_unavailable"
+    assert "provider-secret-detail" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_list_backups_maps_missing_storage_configuration_to_redacted_503(
+    backups_client,
+    monkeypatch,
+):
+    def _fail_list(*, limit: int):
+        assert limit == 100
+        raise BackupConfigurationError("BACKUP_FOLDER_ID=private-provider-detail")
+
+    monkeypatch.setattr("routers.manager_backups.backup_service.list_backups", _fail_list)
+
+    response = await backups_client.get("/api/manager/backups")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["detail"]["error_code"] == "backup_list_unavailable"
+    assert "private-provider-detail" not in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manager_document_template_files_api.py
+++ b/tests/unit/test_manager_document_template_files_api.py
@@ -1,0 +1,59 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from core.security import get_current_username
+from routers.manager_docs import (
+    DOCUMENT_TEMPLATE_FILES_UNAVAILABLE,
+    DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE,
+    router as manager_docs_router,
+)
+from services.google_oauth_credentials import (
+    GoogleDriveListError,
+    GoogleTokenRefreshError,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "google_error",
+    [
+        GoogleTokenRefreshError("provider-secret-auth-error"),
+        GoogleDriveListError("provider-secret-drive-error"),
+    ],
+    ids=["oauth", "drive"],
+)
+async def test_document_template_files_maps_google_failures_to_controlled_502(
+    monkeypatch,
+    google_error,
+):
+    class _FailingGoogleService:
+        def list_files(self, _folder_id: str, *, limit: int):
+            raise google_error
+
+    monkeypatch.setattr(
+        "routers.manager_docs.get_google_service",
+        lambda: _FailingGoogleService(),
+    )
+    app = FastAPI()
+    app.include_router(manager_docs_router)
+    app.dependency_overrides[get_current_username] = lambda: "admin"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/api/manager/docs/document-template-files",
+            params={"folder_id": "templates", "limit": 25},
+        )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": {
+            "message": DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE,
+            "error_code": DOCUMENT_TEMPLATE_FILES_UNAVAILABLE,
+            "field_errors": {},
+        }
+    }
+    assert "provider-secret" not in response.text

--- a/tests/unit/test_manager_google_auth_api.py
+++ b/tests/unit/test_manager_google_auth_api.py
@@ -33,6 +33,8 @@ class _GoogleServiceStub:
             "expired": False,
             "expiry": "2026-04-20 22:00:00",
             "scopes": ["drive"],
+            "persistence_ok": True,
+            "persistence_error_code": None,
         }
 
     def get_auth_url(self, redirect_uri=None, *, state: str):
@@ -88,6 +90,7 @@ async def test_google_auth_status_endpoint(google_auth_client, monkeypatch):
     assert response.status_code == 200
     assert response.json()["valid"] is True
     assert response.json()["exists"] is True
+    assert response.json()["persistence_ok"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manager_rbac_api.py
+++ b/tests/unit/test_manager_rbac_api.py
@@ -36,6 +36,8 @@ class _GoogleServiceStub:
             "expired": False,
             "expiry": None,
             "scopes": ["drive"],
+            "persistence_ok": True,
+            "persistence_error_code": None,
         }
 
 

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -42,6 +42,7 @@ def test_migration_script_requires_primary_and_never_manages_database_service(tm
             "API_PROJECT_DIR": str(project),
             "API_COMPOSE_FILE": "compose.yml",
             "BACKEND_IMAGE": IMAGE,
+            "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
         }
     )
 
@@ -56,6 +57,54 @@ def test_migration_script_requires_primary_and_never_manages_database_service(tm
     assert "ensure_global_config_defaults.py" in commands
     assert " up " not in commands
     assert " db" not in commands
+
+
+def test_deploy_and_migration_scripts_reject_unknown_running_patroni_role(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\nprintf '{\"state\":\"running\",\"role\":\"mystery\"}\\n'\n",
+    )
+    _executable(
+        fake_bin / "docker",
+        '#!/usr/bin/env bash\nprintf "docker %s\\n" "$*" >> "$COMMAND_LOG"\n',
+    )
+    base_env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "COMMAND_LOG": str(command_log),
+        "API_PROJECT_DIR": str(project),
+        "API_COMPOSE_FILE": "compose.yml",
+        "BACKEND_IMAGE": IMAGE,
+        "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
+    }
+
+    deploy = subprocess.run(
+        ["bash", str(DEPLOY)],
+        env={**base_env, "API_EXPECTED_PATRONI_ROLE": "standby"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    migrate = subprocess.run(
+        ["bash", str(MIGRATE)],
+        env=base_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert deploy.returncode != 0
+    assert migrate.returncode != 0
+    assert "local Patroni API is unavailable" in deploy.stdout
+    assert "local Patroni API is unavailable" in migrate.stdout
+    assert not command_log.exists()
 
 
 def test_node_deploy_keeps_migrations_separate_and_has_role_and_maintenance_fences():

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -1,8 +1,50 @@
+import os
+import subprocess
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts/ha/run_patroni_node_remote.sh"
+TRANSACTION_RUNNER = REPO_ROOT / "scripts/ha/run_patroni_candidate_transaction.sh"
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_probe(tmp_path: Path, role: str) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "ssh-keyscan",
+        "#!/usr/bin/env bash\nprintf 'example.invalid ssh-ed25519 AAAATEST\\n'\n",
+    )
+    _executable(
+        fake_bin / "ssh",
+        '#!/usr/bin/env bash\nremote_command="${!#}"\nbash -c "${remote_command}"\n',
+    )
+    _executable(
+        fake_bin / "curl",
+        f"#!/usr/bin/env bash\nprintf '{{\"state\":\"running\",\"role\":\"{role}\"}}\\n'\n",
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT), "probe"],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "API_NODE_HOST": "example.invalid",
+            "API_NODE_USER": "deploy",
+            "SSH_PRIVATE_KEY": "test-private-key",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_RUN_ID": "test-run",
+            "GITHUB_JOB": "probe",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
@@ -16,13 +58,23 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert "deploy_patroni_api_node.sh" in text
     assert "deploy_backend_blue_green.sh" in text
     assert "deploy_backend_blue_green_safety.sh" in text
+    assert "prepare_google_oauth_token_dir.sh" in text
+    assert 'candidate_id="$(printf' in text
+    assert 'REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"' in text
+    assert "run_patroni_candidate_transaction.sh" in text
+    assert "compose_candidate_transaction.sh" in text
+    assert "reconcile_backend_compose_runtime.sh" in text
     assert (
         "API_BLUE_GREEN_SAFETY_HELPER=/tmp/deploy_backend_blue_green_safety.sh" in text
     )
     assert "scripts/ha/patroni_role_agent.py" in text
     assert "/usr/local/sbin/mvn-patroni-role-agent" in text
-    assert "systemctl restart" in text
-    assert "systemctl is-active --quiet" in text
+    transaction_runner = TRANSACTION_RUNNER.read_text(encoding="utf-8")
+    assert "systemctl restart" in transaction_runner
+    assert "systemctl is-active --quiet" in transaction_runner
+    assert "API_DEPLOY_LOCK_ALREADY_HELD=true" in transaction_runner
+    assert 'transaction cleanup' in transaction_runner
+    assert 'API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")"' in transaction_runner
     assert "API_PROXY_MODE=" in text
     assert "upstream.conf" in text
     assert "up -d db" not in text
@@ -35,3 +87,17 @@ def test_remote_orchestrator_passes_token_over_stdin_not_command_line():
     assert "IFS= read -r GHCR_PAT" in text
     assert "export GHCR_PAT" in text
     assert "GHCR_PAT='" not in text
+
+
+def test_remote_probe_normalizes_replica_to_standby(tmp_path):
+    result = _run_probe(tmp_path, "replica")
+
+    assert result.returncode == 0, result.stderr
+    assert "example.invalid role=standby" in result.stdout
+
+
+def test_remote_probe_rejects_unknown_running_role(tmp_path):
+    result = _run_probe(tmp_path, "mystery")
+
+    assert result.returncode != 0
+    assert "role=standby" not in result.stdout

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -51,6 +51,8 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert "probe|migrate|deploy" in text
+    assert "required_commands=(ssh ssh-keyscan)" in text
+    assert 'required_commands+=(scp)' in text
     assert "StrictHostKeyChecking=yes" in text
     assert "UserKnownHostsFile=" in text
     assert "docker-compose.patroni.yml" in text

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -4,7 +4,13 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ha import patroni_role_agent
-from scripts.ha.patroni_role_agent import AgentConfig, app_service, reconcile, role_env
+from scripts.ha.patroni_role_agent import (
+    AgentConfig,
+    app_service,
+    fetch_patroni_role,
+    reconcile,
+    role_env,
+)
 
 
 def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
@@ -24,6 +30,51 @@ def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
         promotion_delay_seconds=0,
         ready_attempts=2,
     )
+
+
+class _PatroniResponse:
+    def __init__(self, payload: str):
+        self.payload = payload.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+@pytest.mark.parametrize(
+    ("reported_role", "expected_role"),
+    [("leader", "primary"), ("primary", "primary"), ("replica", "standby")],
+)
+def test_fetch_patroni_role_uses_explicit_role_whitelist(
+    monkeypatch, reported_role, expected_role
+):
+    response = _PatroniResponse(
+        f'{{"state":"running","role":"{reported_role}"}}'
+    )
+    monkeypatch.setattr(
+        patroni_role_agent.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: response,
+    )
+
+    assert fetch_patroni_role("http://patroni.invalid/patroni") == expected_role
+
+
+def test_fetch_patroni_role_rejects_unknown_running_role(monkeypatch):
+    response = _PatroniResponse('{"state":"running","role":"mystery"}')
+    monkeypatch.setattr(
+        patroni_role_agent.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: response,
+    )
+
+    with pytest.raises(ValueError, match="unsupported Patroni role: mystery"):
+        fetch_patroni_role("http://patroni.invalid/patroni")
 
 
 def test_role_env_opens_api_and_singleton_processes_only_on_primary():

--- a/tests/unit/test_post_deploy_smoke_check.py
+++ b/tests/unit/test_post_deploy_smoke_check.py
@@ -25,14 +25,30 @@ def test_smoke_check_resolves_active_green_service(tmp_path):
     _executable(
         fake_bin / "curl",
         """#!/usr/bin/env bash
-url="${*: -1}"
+output_file=""
+write_format=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) output_file="$2"; shift 2 ;;
+    -w) write_format="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
 case "$url" in
-  */api/ready) printf '{"status":"ok","api":"ready","traffic":"enabled","database":"online"}\n' ;;
-  */api/health|*/health) printf '{"status":"ok","database":"online"}\n' ;;
-  *products*) printf '{"items":[]}\n' ;;
-  *filters/config*) printf '{"price":{},"area":{},"brands":[],"expert_tags":[]}\n' ;;
+  */api/ready) payload='{"status":"ok","api":"ready","traffic":"enabled","database":"online"}'; status=200 ;;
+  */api/health|*/health) payload='{"status":"ok","database":"online"}'; status=200 ;;
+  *products*) payload='{"items":[]}'; status=200 ;;
+  *filters/config*) payload='{"price":{},"area":{},"brands":[],"expert_tags":[]}'; status=200 ;;
   *) exit 22 ;;
 esac
+if [[ -n "$output_file" ]]; then
+  printf '%s\n' "$payload" > "$output_file"
+else
+  printf '%s\n' "$payload"
+fi
+[[ -z "$write_format" ]] || printf '%s' "$status"
 """,
     )
     _executable(

--- a/tests/unit/test_post_deploy_smoke_modes.py
+++ b/tests/unit/test_post_deploy_smoke_modes.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_SCRIPT = REPO_ROOT / "scripts/post_deploy_smoke_check.sh"
+
+
+def _run_smoke(tmp_path: Path, *, mode: str, expectation: str):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    curl = fake_bin / "curl"
+    curl.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+output_file=""
+url=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o) output_file="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  */api/ready)
+    if [[ "$READY_MODE" == "fenced" ]]; then
+      payload='{"status":"degraded","api":"not_ready","traffic":"disabled","database":"online"}'
+      status=503
+    else
+      payload='{"status":"ok","api":"ready","traffic":"enabled","database":"online"}'
+      status=200
+    fi
+    printf '%s' "$payload" > "$output_file"
+    printf '%s' "$status"
+    ;;
+  */api/v1/products*) printf '{"items":[]}' ;;
+  */api/v1/filters/config) printf '{"price":{},"area":{},"brands":[],"expert_tags":[]}' ;;
+  */health|*/api/health) printf '{"status":"ok","database":"online"}' ;;
+  *) exit 22 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    docker = fake_bin / "docker"
+    docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == "compose version" ]]; then exit 0; fi
+if [[ "$*" == *"ps --status running --services"* ]]; then
+  printf 'app\n'
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services:\n  app:\n    image: test\n", encoding="utf-8")
+    summary = tmp_path / "summary.txt"
+    result = subprocess.run(
+        ["bash", str(SMOKE_SCRIPT)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "READY_MODE": mode,
+            "BASE_URL": "http://127.0.0.1:18080",
+            "READY_URL": "http://127.0.0.1:18080/api/ready",
+            "READY_EXPECTATION": expectation,
+            "COMPOSE_FILE": str(compose),
+            "COMPOSE_SERVICE_CHECKS": "app",
+            "BOT_EXPECT_ENABLED": "false",
+            "SMOKE_SUMMARY_FILE": str(summary),
+            "MAX_RETRIES": "1",
+            "RETRY_DELAY": "0",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, summary
+
+
+def test_smoke_accepts_locally_healthy_but_fenced_standby(tmp_path):
+    result, summary = _run_smoke(tmp_path, mode="fenced", expectation="fenced")
+
+    assert result.returncode == 0, result.stderr
+    text = summary.read_text(encoding="utf-8")
+    assert "smoke_status=passed" in text
+    assert "readiness_fenced" in text
+
+
+def test_smoke_rejects_fenced_payload_when_active_readiness_is_required(tmp_path):
+    result, _ = _run_smoke(tmp_path, mode="fenced", expectation="ready")
+
+    assert result.returncode != 0
+    assert "readiness payload is not ready" in result.stderr
+
+
+def test_smoke_accepts_active_ready_payload(tmp_path):
+    result, summary = _run_smoke(tmp_path, mode="ready", expectation="ready")
+
+    assert result.returncode == 0, result.stderr
+    assert "readiness_ready" in summary.read_text(encoding="utf-8")

--- a/tests/unit/test_release_safety_scripts.py
+++ b/tests/unit/test_release_safety_scripts.py
@@ -40,6 +40,8 @@ if [[ "$*" == *"compose -f docker-compose.prod.yml"* && "$*" == *"ps --status ru
   printf '%s\n' "${DOCKER_PS_SERVICES:-app}"
 elif [[ "$1 $2" == "image ls" ]]; then
   cat "${IMAGE_IDS_FILE:-/dev/null}"
+elif [[ "$1 $2" == "image inspect" && "$*" == *"--format"* ]]; then
+  printf '%s\n' "${DOCKER_IMAGE_CONTRACT:-directory-v1}"
 elif [[ "$1 $2" == "ps -aq" && "$*" == *"ancestor=${RUNNING_IMAGE_ID:-__none__}"* ]]; then
   printf 'container-id\n'
 fi
@@ -54,6 +56,7 @@ exit 0
             "DOCKER_LOG": str(docker_log),
             "GHCR_PAT": "test-token",
             "GITHUB_ACTOR": "test-user",
+            "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
         }
     )
     return fake_bin, env, docker_log
@@ -62,7 +65,18 @@ exit 0
 def _project(tmp_path: Path, image: str = OLD_IMAGE) -> Path:
     project = tmp_path / "project"
     project.mkdir()
-    (project / "docker-compose.prod.yml").write_text("services: {}\n", encoding="utf-8")
+    (project / "docker-compose.prod.yml").write_text(
+        "services:\n"
+        "  app:\n"
+        "    image: ${BACKEND_IMAGE}\n"
+        "    environment:\n"
+        "      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json\n"
+        "    volumes:\n"
+        "      - ./google-oauth:/app/google-oauth\n"
+        "  bot:\n"
+        "    image: ${BACKEND_IMAGE}\n",
+        encoding="utf-8",
+    )
     (project / ".env").write_text(f"KEEP=value\nBACKEND_IMAGE={image}\n", encoding="utf-8")
     return project
 
@@ -189,7 +203,58 @@ def test_deploy_rejects_mutable_image_tag_before_docker_calls(tmp_path):
 
     assert result.returncode == 1
     assert "40-character Git SHA tag or sha256 digest" in result.stderr
-    assert docker_log.read_text(encoding="utf-8") == ""
+    calls = docker_log.read_text(encoding="utf-8")
+    assert "up -d" not in calls
+
+
+def test_rollback_refuses_pre_directory_contract_image(tmp_path):
+    _, env, _ = _fake_environment(tmp_path)
+    project = _project(tmp_path, image=NEW_IMAGE)
+    (project / ".previous-backend-image").write_text(OLD_IMAGE + "\n", encoding="utf-8")
+    env.update(
+        {
+            "API_PROJECT_DIR": str(project),
+            "CONFIRM_ROLLBACK": "true",
+            "EXPECTED_CURRENT_IMAGE": NEW_IMAGE,
+            "DOCKER_IMAGE_CONTRACT": "legacy-file-mount",
+        }
+    )
+
+    result = _run("scripts/rollback_backend.sh", env)
+
+    assert result.returncode != 0
+    assert "cannot durably refresh Google OAuth" in result.stderr
+
+
+def test_rollback_refuses_compose_without_exact_token_environment(tmp_path):
+    _, env, _ = _fake_environment(tmp_path)
+    project = _project(tmp_path, image=NEW_IMAGE)
+    compose = project / "docker-compose.prod.yml"
+    compose.write_text(
+        compose.read_text(encoding="utf-8").replace(
+            "      GOOGLE_TOKEN_FILE: /app/google-oauth/token.json\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+    (project / ".previous-backend-image").write_text(OLD_IMAGE + "\n", encoding="utf-8")
+    env.update(
+        {
+            "API_PROJECT_DIR": str(project),
+            "CONFIRM_ROLLBACK": "true",
+            "EXPECTED_CURRENT_IMAGE": NEW_IMAGE,
+        }
+    )
+
+    result = _run("scripts/rollback_backend.sh", env)
+
+    assert result.returncode != 0
+    assert "does not provide the directory-v1" in result.stderr
+
+
+def test_dockerfile_declares_directory_token_contract():
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert 'org.mvn.google-oauth-token-contract="directory-v1"' in dockerfile
 
 
 def test_automatic_rollback_is_noop_when_candidate_was_not_activated(tmp_path):
@@ -257,7 +322,86 @@ def test_rollback_delegates_to_blue_green_when_active_slot_exists(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert delegate_log.read_text(encoding="utf-8").strip() == f"{OLD_IMAGE}|false|true"
-    assert docker_log.read_text(encoding="utf-8") == ""
+    calls = docker_log.read_text(encoding="utf-8")
+    assert "google-oauth-token-contract" in calls
+    assert "exec -T app-blue python3 -" in calls
+    assert "up -d" not in calls
+
+
+def test_rollback_probe_failure_reactivates_previous_blue_green_image(tmp_path):
+    _, env, _ = _fake_environment(tmp_path)
+    project = _project(tmp_path, image=NEW_IMAGE)
+    (project / ".previous-backend-image").write_text(OLD_IMAGE + "\n", encoding="utf-8")
+    (project / ".active-api-slot").write_text("blue\n", encoding="utf-8")
+    delegate_log = tmp_path / "delegate.log"
+    delegate = tmp_path / "blue-green.sh"
+    _executable(
+        delegate,
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$BACKEND_IMAGE\" >> \"$DELEGATE_LOG\"\n",
+    )
+    env.update(
+        {
+            "API_PROJECT_DIR": str(project),
+            "CONFIRM_ROLLBACK": "true",
+            "EXPECTED_CURRENT_IMAGE": NEW_IMAGE,
+            "API_BLUE_GREEN_SCRIPT": str(delegate),
+            "DELEGATE_LOG": str(delegate_log),
+            "DOCKER_FAIL_MATCH": "exec -T app-blue python3 -",
+        }
+    )
+
+    result = _run("scripts/rollback_backend.sh", env)
+
+    assert result.returncode != 0
+    assert delegate_log.read_text(encoding="utf-8").splitlines() == [
+        OLD_IMAGE,
+        NEW_IMAGE,
+    ]
+    assert f"BACKEND_IMAGE={NEW_IMAGE}" in (project / ".env").read_text(encoding="utf-8")
+
+
+def test_rollback_reports_critical_when_probe_and_reactivation_both_fail(tmp_path):
+    _, env, _ = _fake_environment(tmp_path)
+    project = _project(tmp_path, image=NEW_IMAGE)
+    (project / ".previous-backend-image").write_text(OLD_IMAGE + "\n", encoding="utf-8")
+    (project / ".active-api-slot").write_text("blue\n", encoding="utf-8")
+    delegate = tmp_path / "blue-green.sh"
+    _executable(
+        delegate,
+        f"""#!/usr/bin/env bash
+if [[ "$BACKEND_IMAGE" == "{NEW_IMAGE}" ]]; then
+  exit 77
+fi
+exit 0
+""",
+    )
+    env.update(
+        {
+            "API_PROJECT_DIR": str(project),
+            "CONFIRM_ROLLBACK": "true",
+            "EXPECTED_CURRENT_IMAGE": NEW_IMAGE,
+            "API_BLUE_GREEN_SCRIPT": str(delegate),
+            "DOCKER_FAIL_MATCH": "exec -T app-blue python3 -",
+        }
+    )
+
+    result = _run("scripts/rollback_backend.sh", env)
+
+    assert result.returncode == 90
+    assert "CRITICAL" in result.stderr
+    assert "could not be restored" in result.stderr
+
+
+def test_rollback_probe_requires_durable_auth_and_atomic_directory_write():
+    script = (REPO_ROOT / "scripts/rollback_backend.sh").read_text(encoding="utf-8")
+    assert "google.auth_error is not None" in script
+    assert 'status.get("persistence_ok") is not True' in script
+    assert 'os.replace(temporary, probe_path)' in script
+    assert "Google backup probe returned no backup objects" in script
+    list_index = script.index("items = backup_service.list_backups(limit=1)")
+    status_index = script.index("status = google.get_token_status()")
+    persistence_index = script.index('status.get("persistence_ok") is not True')
+    assert list_index < status_index < persistence_index
 
 
 def test_prune_keeps_three_newest_and_every_container_image(tmp_path):

--- a/tests/unit/test_restore_drill_cleanup.py
+++ b/tests/unit/test_restore_drill_cleanup.py
@@ -1,0 +1,184 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLEANUP_SCRIPT = REPO_ROOT / "scripts/ha/cleanup_restore_drill_runtime.sh"
+
+
+def _cleanup_run(
+    tmp_path: Path,
+    *,
+    daemon_failure: bool = False,
+    volume_remove_failure: bool = False,
+    keep_container: bool = False,
+    keep_files: bool = False,
+    create_objects: bool = True,
+    label_mismatch: bool = False,
+):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    container_state = tmp_path / "container.exists"
+    volume_state = tmp_path / "volume.exists"
+    if create_objects:
+        container_state.touch()
+        volume_state.touch()
+    command_log = tmp_path / "docker.log"
+    command_log.touch()
+    docker = fake_bin / "docker"
+    docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+if [[ "${DAEMON_FAILURE}" == "true" && ( "$1" == "inspect" || "$1 $2" == "volume inspect" ) ]]; then
+  echo 'Cannot connect to the Docker daemon' >&2
+  exit 1
+fi
+if [[ "$1" == "inspect" ]]; then
+  if [[ "$*" == *"--format"* ]]; then
+    [[ -f "$CONTAINER_STATE" ]] || exit 1
+    if [[ "${LABEL_MISMATCH}" == "true" ]]; then printf 'other|other\n'; else printf 'api-restore-drill|test-run\n'; fi
+    exit 0
+  fi
+  [[ -f "$CONTAINER_STATE" ]] && exit 0
+  echo 'No such container' >&2
+  exit 1
+fi
+if [[ "$1 $2" == "volume inspect" ]]; then
+  if [[ "$*" == *"--format"* ]]; then
+    [[ -f "$VOLUME_STATE" ]] || exit 1
+    if [[ "${LABEL_MISMATCH}" == "true" ]]; then printf 'other|other\n'; else printf 'api-restore-drill|test-run\n'; fi
+    exit 0
+  fi
+  [[ -f "$VOLUME_STATE" ]] && exit 0
+  echo 'No such volume' >&2
+  exit 1
+fi
+if [[ "$1 $2" == "rm -fv" ]]; then
+  rm -f "$CONTAINER_STATE"
+  exit 0
+fi
+if [[ "$1 $2 $3" == "volume rm drill-volume" ]]; then
+  if [[ "${VOLUME_REMOVE_FAILURE}" == "true" ]]; then exit 42; fi
+  rm -f "$VOLUME_STATE"
+  exit 0
+fi
+exit 2
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    drill_dir = tmp_path / "drill"
+    drill_dir.mkdir()
+    backup_file = drill_dir / "latest-db-backup.sql"
+    backup_file.write_text("backup", encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(CLEANUP_SCRIPT)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "CONTAINER_STATE": str(container_state),
+            "VOLUME_STATE": str(volume_state),
+            "DAEMON_FAILURE": str(daemon_failure).lower(),
+            "VOLUME_REMOVE_FAILURE": str(volume_remove_failure).lower(),
+            "LABEL_MISMATCH": str(label_mismatch).lower(),
+            "RESTORE_DRILL_CONTAINER": "drill-container",
+            "RESTORE_DRILL_DATA_VOLUME": "drill-volume",
+            "RESTORE_DRILL_RUN_ID": "test-run",
+            "RESTORE_DRILL_DIR": str(drill_dir),
+            "KEEP_DRILL_CONTAINER": str(keep_container).lower(),
+            "KEEP_DRILL_FILES": str(keep_files).lower(),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, container_state, volume_state, backup_file, command_log
+
+
+def test_cleanup_removes_exact_runtime_and_files(tmp_path):
+    result, container, volume, backup, log = _cleanup_run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert not container.exists()
+    assert not volume.exists()
+    assert not backup.exists()
+    assert not backup.parent.exists()
+    calls = log.read_text(encoding="utf-8")
+    assert "rm -fv drill-container" in calls
+    assert "volume rm drill-volume" in calls
+    assert "system prune" not in calls
+
+
+def test_cleanup_script_never_uses_a_shared_backup_glob():
+    text = CLEANUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "latest-db-backup*" not in text
+    assert '"${DRILL_DIR}/latest-db-backup.sql"' in text
+    assert '"${DRILL_DIR}/latest-db-backup.sql.gz"' in text
+    assert 'rmdir "${DRILL_DIR}"' in text
+
+
+def test_cleanup_fails_closed_when_docker_inspection_is_unavailable(tmp_path):
+    result, container, volume, _, _ = _cleanup_run(tmp_path, daemon_failure=True)
+
+    assert result.returncode != 0
+    assert container.exists()
+    assert volume.exists()
+    assert "cleanup_error=container_inspect_failed" in result.stdout
+    assert "cleanup_error=volume_inspect_failed" in result.stdout
+
+
+def test_cleanup_reports_named_volume_removal_failure(tmp_path):
+    result, container, volume, _, _ = _cleanup_run(
+        tmp_path,
+        volume_remove_failure=True,
+    )
+
+    assert result.returncode != 0
+    assert not container.exists()
+    assert volume.exists()
+    assert "cleanup_error=volume_remove_failed" in result.stdout
+    assert "cleanup_error=volume_still_exists" in result.stdout
+
+
+def test_cleanup_honors_explicit_keep_flags(tmp_path):
+    result, container, volume, backup, log = _cleanup_run(
+        tmp_path,
+        keep_container=True,
+        keep_files=True,
+    )
+
+    assert result.returncode == 0
+    assert container.exists()
+    assert volume.exists()
+    assert backup.exists()
+    assert "cleanup_skipped=true" in result.stdout
+    assert "rm -fv" not in log.read_text(encoding="utf-8")
+
+
+def test_cleanup_accepts_already_absent_runtime(tmp_path):
+    result, _, _, backup, _ = _cleanup_run(tmp_path, create_objects=False)
+
+    assert result.returncode == 0
+    assert not backup.exists()
+    assert not backup.parent.exists()
+
+
+def test_cleanup_refuses_objects_without_this_runs_labels(tmp_path):
+    result, container, volume, _, log = _cleanup_run(
+        tmp_path,
+        label_mismatch=True,
+    )
+
+    assert result.returncode != 0
+    assert container.exists()
+    assert volume.exists()
+    assert "cleanup_error=container_label_mismatch" in result.stdout
+    assert "cleanup_error=volume_label_mismatch" in result.stdout
+    calls = log.read_text(encoding="utf-8")
+    assert "rm -fv drill-container" not in calls
+    assert "volume rm drill-volume" not in calls

--- a/tests/unit/test_scheduler_service.py
+++ b/tests/unit/test_scheduler_service.py
@@ -114,3 +114,16 @@ async def test_start_loop_cancels_child_tasks(monkeypatch):
 
     assert started == 6
     assert cancelled == 6
+
+
+@pytest.mark.asyncio
+async def test_daily_backup_rejects_skipped_result(monkeypatch):
+    service = SchedulerService()
+    monkeypatch.setattr(
+        scheduler_module.backup_service,
+        "perform_backup",
+        lambda cleanup=True: False,
+    )
+
+    with pytest.raises(RuntimeError, match="skipped or did not complete"):
+        await service._run_daily_backup()


### PR DESCRIPTION
## Что исправлено

- переводит refreshable Google OAuth token с одиночного bind mount на атомарно обновляемый каталог `google-oauth/token.json` с режимами `0700/0600`, миграцией legacy token и fail-closed проверками;
- не маскирует ошибки Google Drive и отсутствие `BACKUP_FOLDER_ID` под пустой список или успешный backup;
- показывает в manager UI отдельное состояние: credentials работают в памяти, но ещё не сохранены надёжно;
- делает backend/Patroni compose promotion транзакционным с восстановлением прежнего runtime и жёстким fencing при неизвестной/сменившейся роли;
- изолирует restore drill по run id, маркирует disposable Docker objects и удаляет только точные объекты/файлы текущего запуска;
- усиливает rollback: проверяет directory-v1 image contract, атомарную запись, self-heal OAuth persistence и наличие реального backup object.

## Проверки

- `1172 passed` — полный unit suite;
- `187 passed` — полный integration suite;
- manager Vue: typecheck + production build, `1894 modules transformed`;
- OpenAPI и generated manager client пересозданы pre-commit hook;
- `bash -n`, ShellCheck, actionlint, Python compile и `git diff --check` — пройдены;
- 8 production/HA Compose-конфигураций разобраны успешно;
- два независимых rereview: P0/P1/P2 не осталось, verdict MERGEABLE.

## Выкладка

1. Дождаться полного CI.
2. Deploy replica-first, затем primary.
3. Проверить на обоих узлах directory mount и права; legacy token оставить на rollback window.
4. На primary принудительно пройти Drive list/refresh и подтвердить `persistence_ok=true` и реальный backup object.
5. Запустить API restore drill, Patroni 5/5 и PITR checks.
6. Только после зелёного live proof удалить точный allowlist старых restore-drill volumes; без broad prune.
