### PR TITLE
Add Manager equipment registry UI

### DIFF
--- a/manager_frontend/src/components/equipment/EquipmentAttentionBadges.vue
+++ b/manager_frontend/src/components/equipment/EquipmentAttentionBadges.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import {
+  CircleAlert,
+  CircleCheck,
+  Clock3,
+  ShieldAlert,
+  TriangleAlert,
+} from 'lucide-vue-next';
+import { sortAttentionReasons } from './registry';
+
+const props = defineProps<{
+  reasons: string[];
+}>();
+
+const visibleReasons = computed(() => sortAttentionReasons(props.reasons || []));
+
+const reasonLabel = (reason: string) => {
+  if (reason === 'needs_decision') return 'Требует решения';
+  if (reason === 'maintenance_overdue') return 'ТО просрочено';
+  if (reason === 'maintenance_due_soon') return 'ТО скоро';
+  if (reason === 'warranty_expired') return 'Гарантия истекла';
+  if (reason === 'warranty_expiring') return 'Гарантия истекает';
+  return 'Требует внимания';
+};
+
+const reasonClass = (reason: string) => {
+  if (reason === 'needs_decision') {
+    return 'border-red-200 bg-red-50 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-300';
+  }
+  if (reason === 'maintenance_overdue') {
+    return 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-300';
+  }
+  if (reason === 'maintenance_due_soon') {
+    return 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-300';
+  }
+  if (reason === 'warranty_expired') {
+    return 'border-gray-300 bg-gray-100 text-gray-700 dark:border-slate-500 dark:bg-slate-700 dark:text-slate-200';
+  }
+  if (reason === 'warranty_expiring') {
+    return 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-300';
+  }
+  return 'border-gray-200 bg-white text-gray-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200';
+};
+
+const reasonIcon = (reason: string) => {
+  if (reason === 'needs_decision') return CircleAlert;
+  if (reason === 'maintenance_overdue') return TriangleAlert;
+  if (reason === 'maintenance_due_soon') return Clock3;
+  return ShieldAlert;
+};
+</script>
+
+<template>
+  <div class="flex flex-wrap gap-1.5">
+    <span
+      v-if="!visibleReasons.length"
+      class="inline-flex min-h-6 items-center gap-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-semibold leading-none text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-300"
+    >
+      <CircleCheck class="h-3.5 w-3.5 shrink-0" />
+      Без срочных действий
+    </span>
+
+    <span
+      v-for="reason in visibleReasons"
+      :key="reason"
+      class="inline-flex min-h-6 items-center gap-1 rounded-md border px-2 py-1 text-xs font-semibold leading-none"
+      :class="reasonClass(reason)"
+    >
+      <component :is="reasonIcon(reason)" class="h-3.5 w-3.5 shrink-0" />
+      {{ reasonLabel(reason) }}
+    </span>
+  </div>
+</template>

--- a/manager_frontend/src/components/equipment/EquipmentMaintenanceOrderDialog.vue
+++ b/manager_frontend/src/components/equipment/EquipmentMaintenanceOrderDialog.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
+import { LoaderCircle, Wrench, X } from 'lucide-vue-next';
+import { equipmentLocation, equipmentTitle } from './registry';
+import type { EquipmentRegistryItem } from './types';
+
+const props = defineProps<{
+  equipment: EquipmentRegistryItem;
+  loading: boolean;
+  error: string;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  confirm: [];
+}>();
+
+const confirmButton = ref<HTMLButtonElement | null>(null);
+
+const close = () => {
+  if (!props.loading) emit('close');
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') close();
+};
+
+onMounted(async () => {
+  window.addEventListener('keydown', onKeydown);
+  await nextTick();
+  confirmButton.value?.focus();
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="fixed inset-0 z-[120] flex items-end justify-center bg-black/50 p-0 sm:items-center sm:p-4"
+      @click.self="close"
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="maintenance-order-title"
+        aria-describedby="maintenance-order-description"
+        class="w-full max-w-md rounded-t-lg border border-gray-200 bg-white shadow-2xl sm:rounded-lg dark:border-slate-700 dark:bg-slate-800"
+      >
+        <header class="flex items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-slate-700">
+          <div class="flex min-w-0 items-center gap-2.5">
+            <span class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-teal-50 text-teal-700 dark:bg-teal-500/10 dark:text-teal-300">
+              <Wrench class="h-4 w-4" />
+            </span>
+            <h2 id="maintenance-order-title" class="truncate text-base font-semibold text-gray-950 dark:text-white">
+              Создать заказ на ТО
+            </h2>
+          </div>
+          <button
+            type="button"
+            class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-white"
+            :disabled="loading"
+            title="Закрыть"
+            aria-label="Закрыть"
+            @click="close"
+          >
+            <X class="h-4 w-4" />
+          </button>
+        </header>
+
+        <form @submit.prevent="emit('confirm')">
+          <div class="px-4 py-4">
+            <p id="maintenance-order-description" class="text-sm leading-6 text-gray-600 dark:text-slate-300">
+              Будет создан новый заказ на плановое техническое обслуживание.
+            </p>
+
+            <dl class="mt-4 divide-y divide-gray-200 border-y border-gray-200 text-sm dark:divide-slate-700 dark:border-slate-700">
+              <div class="grid grid-cols-[100px,minmax(0,1fr)] gap-3 py-2.5">
+                <dt class="text-gray-500 dark:text-slate-400">Оборудование</dt>
+                <dd class="break-words font-semibold text-gray-900 dark:text-slate-100">{{ equipmentTitle(equipment) }}</dd>
+              </div>
+              <div class="grid grid-cols-[100px,minmax(0,1fr)] gap-3 py-2.5">
+                <dt class="text-gray-500 dark:text-slate-400">Клиент</dt>
+                <dd class="break-words font-semibold text-gray-900 dark:text-slate-100">
+                  {{ equipment.customer_name || `Клиент #${equipment.customer_id}` }}
+                </dd>
+              </div>
+              <div v-if="equipmentLocation(equipment)" class="grid grid-cols-[100px,minmax(0,1fr)] gap-3 py-2.5">
+                <dt class="text-gray-500 dark:text-slate-400">Объект</dt>
+                <dd class="break-words font-semibold text-gray-900 dark:text-slate-100">{{ equipmentLocation(equipment) }}</dd>
+              </div>
+            </dl>
+
+            <div
+              v-if="error"
+              class="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-300"
+            >
+              {{ error }}
+            </div>
+          </div>
+
+          <footer class="flex items-center justify-end gap-2 border-t border-gray-200 px-4 py-3 dark:border-slate-700">
+            <button
+              type="button"
+              class="min-h-9 rounded-md border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-700 transition hover:bg-gray-50 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              :disabled="loading"
+              @click="close"
+            >
+              Отмена
+            </button>
+            <button
+              ref="confirmButton"
+              type="submit"
+              class="inline-flex min-h-9 items-center justify-center gap-2 rounded-md bg-teal-600 px-3 text-sm font-semibold text-white transition hover:bg-teal-700 disabled:cursor-wait disabled:opacity-70"
+              :disabled="loading"
+            >
+              <LoaderCircle v-if="loading" class="h-4 w-4 animate-spin" />
+              <Wrench v-else class="h-4 w-4" />
+              {{ loading ? 'Создание...' : 'Создать заказ на ТО' }}
+            </button>
+          </footer>
+        </form>
+      </section>
+    </div>
+  </Teleport>
+</template>

--- a/manager_frontend/src/components/equipment/EquipmentRegistryCards.vue
+++ b/manager_frontend/src/components/equipment/EquipmentRegistryCards.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { MapPin, Phone, UserRound, Wrench } from 'lucide-vue-next';
+import EquipmentAttentionBadges from './EquipmentAttentionBadges.vue';
+import {
+  equipmentIdentifiers,
+  equipmentLocation,
+  equipmentSubtitle,
+  equipmentTitle,
+  formatEquipmentDate,
+  hasDistinctServiceContact,
+  maintenanceDateClass,
+  phoneHref,
+  serviceContactName,
+  serviceContactPhone,
+  warrantyDateClass,
+} from './registry';
+import type { EquipmentRegistryItem } from './types';
+
+defineProps<{
+  items: EquipmentRegistryItem[];
+}>();
+
+const emit = defineEmits<{
+  createMaintenanceOrder: [item: EquipmentRegistryItem];
+}>();
+</script>
+
+<template>
+  <div class="grid gap-3 lg:hidden">
+    <article
+      v-for="item in items"
+      :key="item.id"
+      class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
+    >
+      <div class="min-w-0">
+        <p class="break-words text-base font-semibold leading-snug text-gray-950 dark:text-white">{{ equipmentTitle(item) }}</p>
+        <p v-if="equipmentSubtitle(item)" class="mt-1 break-words text-xs text-gray-500 dark:text-slate-400">
+          {{ equipmentSubtitle(item) }}
+        </p>
+        <p v-if="equipmentIdentifiers(item)" class="mt-1 break-words text-xs font-medium text-gray-500 dark:text-slate-400">
+          {{ equipmentIdentifiers(item) }}
+        </p>
+      </div>
+
+      <div class="mt-3">
+        <EquipmentAttentionBadges :reasons="item.attention_reasons" />
+      </div>
+
+      <div class="mt-4 space-y-2.5 border-t border-gray-100 pt-3 text-sm dark:border-slate-700">
+        <div class="flex items-start gap-2.5">
+          <UserRound class="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-slate-500" />
+          <div class="min-w-0">
+            <p class="break-words font-semibold text-gray-900 dark:text-slate-100">
+              {{ item.customer_name || `Клиент #${item.customer_id}` }}
+            </p>
+            <a
+              v-if="item.customer_phone"
+              class="mt-0.5 block w-fit text-xs font-medium text-teal-700 hover:underline dark:text-teal-300"
+              :href="phoneHref(item.customer_phone)"
+            >
+              {{ item.customer_phone }}
+            </a>
+          </div>
+        </div>
+
+        <div v-if="equipmentLocation(item)" class="flex items-start gap-2.5">
+          <MapPin class="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-slate-500" />
+          <p class="min-w-0 break-words text-gray-600 dark:text-slate-300">{{ equipmentLocation(item) }}</p>
+        </div>
+
+        <div v-if="hasDistinctServiceContact(item)" class="flex items-start gap-2.5">
+          <Phone class="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-slate-500" />
+          <div class="min-w-0">
+            <p class="break-words text-gray-600 dark:text-slate-300">{{ serviceContactName(item) || 'Контакт по сервису' }}</p>
+            <a
+              v-if="serviceContactPhone(item)"
+              class="mt-0.5 block w-fit text-xs font-medium text-teal-700 hover:underline dark:text-teal-300"
+              :href="phoneHref(serviceContactPhone(item))"
+            >
+              {{ serviceContactPhone(item) }}
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <dl class="mt-4 grid grid-cols-3 divide-x divide-gray-200 border-y border-gray-200 py-3 text-center dark:divide-slate-700 dark:border-slate-700">
+        <div class="min-w-0 px-1.5">
+          <dt class="text-[11px] font-medium leading-tight text-gray-500 dark:text-slate-400">Последнее ТО</dt>
+          <dd class="mt-1 break-words text-xs font-semibold text-gray-800 dark:text-slate-200">{{ formatEquipmentDate(item.last_service_at) }}</dd>
+        </div>
+        <div class="min-w-0 px-1.5">
+          <dt class="text-[11px] font-medium leading-tight text-gray-500 dark:text-slate-400">Следующее ТО</dt>
+          <dd class="mt-1 break-words text-xs font-semibold" :class="maintenanceDateClass(item)">
+            {{ formatEquipmentDate(item.next_maintenance_due_at) }}
+          </dd>
+        </div>
+        <div class="min-w-0 px-1.5">
+          <dt class="text-[11px] font-medium leading-tight text-gray-500 dark:text-slate-400">Гарантия до</dt>
+          <dd class="mt-1 break-words text-xs font-semibold" :class="warrantyDateClass(item)">
+            {{ formatEquipmentDate(item.warranty_expires_at) }}
+          </dd>
+        </div>
+      </dl>
+
+      <button
+        type="button"
+        class="mt-4 inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-md bg-teal-600 px-3 py-2 text-sm font-semibold leading-tight text-white transition hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 dark:ring-offset-slate-800"
+        @click="emit('createMaintenanceOrder', item)"
+      >
+        <Wrench class="h-4 w-4 shrink-0" />
+        Создать заказ на ТО
+      </button>
+    </article>
+  </div>
+</template>

--- a/manager_frontend/src/components/equipment/EquipmentRegistryFilters.vue
+++ b/manager_frontend/src/components/equipment/EquipmentRegistryFilters.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { RefreshCw, Search, X } from 'lucide-vue-next';
+import { ATTENTION_FILTER_OPTIONS } from './registry';
+import type { EquipmentAttentionFilter } from './types';
+
+defineProps<{
+  modelValue: string;
+  attention: EquipmentAttentionFilter;
+  loading: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+  'update:attention': [value: EquipmentAttentionFilter];
+  refresh: [];
+}>();
+
+const updateSearch = (event: Event) => {
+  emit('update:modelValue', (event.target as HTMLInputElement).value);
+};
+</script>
+
+<template>
+  <section class="border-y border-gray-200 py-3 dark:border-slate-700">
+    <div class="flex items-center gap-2">
+      <label class="relative min-w-0 flex-1 sm:max-w-xl">
+        <span class="sr-only">Поиск оборудования</span>
+        <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-slate-500" />
+        <input
+          :value="modelValue"
+          type="search"
+          class="h-10 w-full rounded-lg border border-gray-200 bg-white pl-9 pr-9 text-sm text-gray-900 outline-none transition focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white"
+          placeholder="Оборудование, клиент, адрес, серийный номер"
+          @input="updateSearch"
+        >
+        <button
+          v-if="modelValue"
+          type="button"
+          class="absolute right-1.5 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-white"
+          title="Очистить поиск"
+          aria-label="Очистить поиск"
+          @click="emit('update:modelValue', '')"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </label>
+
+      <button
+        type="button"
+        class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-600 transition hover:border-teal-300 hover:text-teal-700 disabled:cursor-wait disabled:opacity-60 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:border-teal-600 dark:hover:text-teal-300"
+        :disabled="loading"
+        title="Обновить список"
+        aria-label="Обновить список"
+        @click="emit('refresh')"
+      >
+        <RefreshCw class="h-4 w-4" :class="loading ? 'animate-spin' : ''" />
+      </button>
+    </div>
+
+    <div class="mt-3 overflow-x-auto pb-1">
+      <div class="inline-flex min-w-max gap-1 rounded-lg bg-gray-100 p-1 dark:bg-slate-800" role="tablist" aria-label="Статус оборудования">
+        <button
+          v-for="option in ATTENTION_FILTER_OPTIONS"
+          :key="option.value"
+          type="button"
+          role="tab"
+          class="h-8 rounded-md px-3 text-xs font-semibold transition sm:text-sm"
+          :class="attention === option.value
+            ? 'bg-white text-teal-700 shadow-sm dark:bg-slate-700 dark:text-teal-300'
+            : 'text-gray-600 hover:bg-white/70 hover:text-gray-900 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-white'"
+          :aria-selected="attention === option.value"
+          @click="emit('update:attention', option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/manager_frontend/src/components/equipment/EquipmentRegistryTable.vue
+++ b/manager_frontend/src/components/equipment/EquipmentRegistryTable.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { Wrench } from 'lucide-vue-next';
+import EquipmentAttentionBadges from './EquipmentAttentionBadges.vue';
+import {
+  equipmentIdentifiers,
+  equipmentLocation,
+  equipmentSubtitle,
+  equipmentTitle,
+  formatEquipmentDate,
+  maintenanceDateClass,
+  phoneHref,
+  serviceContactName,
+  serviceContactPhone,
+  warrantyDateClass,
+} from './registry';
+import type { EquipmentRegistryItem } from './types';
+
+defineProps<{
+  items: EquipmentRegistryItem[];
+}>();
+
+const emit = defineEmits<{
+  createMaintenanceOrder: [item: EquipmentRegistryItem];
+}>();
+</script>
+
+<template>
+  <div class="hidden overflow-x-auto border-y border-gray-200 dark:border-slate-700 lg:block">
+    <table class="w-full min-w-[1120px] table-fixed border-collapse">
+      <colgroup>
+        <col class="w-[21%]">
+        <col class="w-[18%]">
+        <col class="w-[14%]">
+        <col class="w-[19%]">
+        <col class="w-[14%]">
+        <col class="w-[14%]">
+      </colgroup>
+      <thead class="bg-gray-50 text-left text-xs font-semibold text-gray-500 dark:bg-slate-900/60 dark:text-slate-400">
+        <tr>
+          <th class="px-4 py-2.5">Оборудование</th>
+          <th class="px-4 py-2.5">Клиент и объект</th>
+          <th class="px-4 py-2.5">Контакт по сервису</th>
+          <th class="px-4 py-2.5">Контрольные даты</th>
+          <th class="px-4 py-2.5">Статус</th>
+          <th class="px-4 py-2.5 text-right">Действие</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white dark:divide-slate-700 dark:bg-slate-800">
+        <tr v-for="item in items" :key="item.id" class="align-top transition hover:bg-gray-50 dark:hover:bg-slate-700/50">
+          <td class="px-4 py-3">
+            <p class="break-words text-sm font-semibold text-gray-950 dark:text-white">{{ equipmentTitle(item) }}</p>
+            <p v-if="equipmentSubtitle(item)" class="mt-0.5 break-words text-xs text-gray-500 dark:text-slate-400">
+              {{ equipmentSubtitle(item) }}
+            </p>
+            <p v-if="equipmentIdentifiers(item)" class="mt-1 break-words text-xs font-medium text-gray-500 dark:text-slate-400">
+              {{ equipmentIdentifiers(item) }}
+            </p>
+          </td>
+
+          <td class="px-4 py-3">
+            <p class="break-words text-sm font-semibold text-gray-900 dark:text-slate-100">
+              {{ item.customer_name || `Клиент #${item.customer_id}` }}
+            </p>
+            <a
+              v-if="item.customer_phone"
+              class="mt-0.5 block w-fit text-xs font-medium text-teal-700 hover:underline dark:text-teal-300"
+              :href="phoneHref(item.customer_phone)"
+            >
+              {{ item.customer_phone }}
+            </a>
+            <p v-if="equipmentLocation(item)" class="mt-1.5 break-words text-xs leading-5 text-gray-500 dark:text-slate-400">
+              {{ equipmentLocation(item) }}
+            </p>
+          </td>
+
+          <td class="px-4 py-3">
+            <p class="break-words text-sm font-medium text-gray-900 dark:text-slate-100">
+              {{ serviceContactName(item) || '—' }}
+            </p>
+            <a
+              v-if="serviceContactPhone(item)"
+              class="mt-0.5 block w-fit text-xs font-medium text-teal-700 hover:underline dark:text-teal-300"
+              :href="phoneHref(serviceContactPhone(item))"
+            >
+              {{ serviceContactPhone(item) }}
+            </a>
+          </td>
+
+          <td class="px-4 py-3">
+            <dl class="space-y-1.5 text-xs">
+              <div class="flex items-baseline justify-between gap-3">
+                <dt class="text-gray-500 dark:text-slate-400">Последнее ТО</dt>
+                <dd class="shrink-0 font-semibold text-gray-800 dark:text-slate-200">{{ formatEquipmentDate(item.last_service_at) }}</dd>
+              </div>
+              <div class="flex items-baseline justify-between gap-3">
+                <dt class="text-gray-500 dark:text-slate-400">Следующее ТО</dt>
+                <dd class="shrink-0 font-semibold" :class="maintenanceDateClass(item)">
+                  {{ formatEquipmentDate(item.next_maintenance_due_at) }}
+                </dd>
+              </div>
+              <div class="flex items-baseline justify-between gap-3">
+                <dt class="text-gray-500 dark:text-slate-400">Гарантия до</dt>
+                <dd class="shrink-0 font-semibold" :class="warrantyDateClass(item)">
+                  {{ formatEquipmentDate(item.warranty_expires_at) }}
+                </dd>
+              </div>
+            </dl>
+          </td>
+
+          <td class="px-4 py-3">
+            <EquipmentAttentionBadges :reasons="item.attention_reasons" />
+          </td>
+
+          <td class="px-4 py-3 text-right">
+            <button
+              type="button"
+              class="ml-auto inline-flex min-h-9 w-full items-center justify-center gap-1.5 rounded-md bg-teal-600 px-2.5 py-1.5 text-xs font-semibold leading-tight text-white transition hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 dark:ring-offset-slate-800"
+              @click="emit('createMaintenanceOrder', item)"
+            >
+              <Wrench class="h-3.5 w-3.5 shrink-0" />
+              Создать заказ на ТО
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/manager_frontend/src/components/equipment/api.ts
+++ b/manager_frontend/src/components/equipment/api.ts
@@ -1,0 +1,38 @@
+import type { ManagerOrderDetailResponse } from '../../client';
+import { OpenAPI } from '../../client/core/OpenAPI';
+import { request } from '../../client/core/request';
+import type { EquipmentRegistryListResponse, EquipmentRegistryQuery } from './types';
+
+export const listEquipmentRegistry = (query: EquipmentRegistryQuery) => request<EquipmentRegistryListResponse>(
+  OpenAPI,
+  {
+    method: 'GET',
+    url: '/api/manager/equipment',
+    query: {
+      page: query.page,
+      limit: query.limit,
+      q: query.q?.trim() || undefined,
+      attention: query.attention === 'all' ? undefined : query.attention,
+    },
+    errors: {
+      400: 'Некорректный фильтр оборудования',
+      422: 'Некорректные параметры запроса',
+    },
+  },
+);
+
+export const createEquipmentMaintenanceOrder = (equipmentId: number) => request<ManagerOrderDetailResponse>(
+  OpenAPI,
+  {
+    method: 'POST',
+    url: '/api/manager/equipment/{equipment_id}/maintenance-order',
+    path: {
+      equipment_id: equipmentId,
+    },
+    errors: {
+      400: 'Не удалось создать заказ на ТО',
+      404: 'Оборудование не найдено',
+      422: 'Некорректный идентификатор оборудования',
+    },
+  },
+);

--- a/manager_frontend/src/components/equipment/registry.ts
+++ b/manager_frontend/src/components/equipment/registry.ts
@@ -1,0 +1,111 @@
+import type {
+  EquipmentAttentionFilter,
+  EquipmentAttentionReason,
+  EquipmentRegistryItem,
+} from './types';
+
+export const ATTENTION_FILTER_OPTIONS: ReadonlyArray<{
+  value: EquipmentAttentionFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'Все' },
+  { value: 'needs_decision', label: 'Требует решения' },
+  { value: 'maintenance_due_soon', label: 'ТО скоро' },
+  { value: 'maintenance_overdue', label: 'ТО просрочено' },
+  { value: 'warranty_expiring', label: 'Гарантия истекает' },
+  { value: 'warranty_expired', label: 'Гарантия истекла' },
+];
+
+const ATTENTION_PRIORITY: Record<EquipmentAttentionReason, number> = {
+  needs_decision: 0,
+  maintenance_overdue: 1,
+  warranty_expired: 2,
+  maintenance_due_soon: 3,
+  warranty_expiring: 4,
+};
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('ru-BY', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
+const compactText = (value: string | null | undefined) => value?.trim() || '';
+
+export const equipmentTitle = (item: EquipmentRegistryItem) => (
+  compactText(item.display_name)
+  || [compactText(item.brand), compactText(item.model)].filter(Boolean).join(' ')
+  || compactText(item.equipment_type)
+  || `Оборудование #${item.id}`
+);
+
+export const equipmentSubtitle = (item: EquipmentRegistryItem) => {
+  const identity = [compactText(item.brand), compactText(item.model)].filter(Boolean).join(' ');
+  if (identity && identity.toLocaleLowerCase() !== compactText(item.display_name).toLocaleLowerCase()) {
+    return identity;
+  }
+  return compactText(item.equipment_type);
+};
+
+export const equipmentIdentifiers = (item: EquipmentRegistryItem) => [
+  compactText(item.serial) ? `S/N ${compactText(item.serial)}` : '',
+  compactText(item.inventory_number) ? `Инв. ${compactText(item.inventory_number)}` : '',
+].filter(Boolean).join(' · ');
+
+export const equipmentLocation = (item: EquipmentRegistryItem) => [
+  compactText(item.branch_name),
+  compactText(item.branch_address) || compactText(item.location_hint),
+].filter(Boolean).join(' · ');
+
+export const serviceContactName = (item: EquipmentRegistryItem) => (
+  compactText(item.service_contact_name) || compactText(item.customer_name)
+);
+
+export const serviceContactPhone = (item: EquipmentRegistryItem) => (
+  compactText(item.service_contact_phone) || compactText(item.customer_phone)
+);
+
+export const hasDistinctServiceContact = (item: EquipmentRegistryItem) => {
+  const contactName = serviceContactName(item).toLocaleLowerCase();
+  const customerName = compactText(item.customer_name).toLocaleLowerCase();
+  const contactPhone = serviceContactPhone(item).replace(/\D/g, '');
+  const customerPhone = compactText(item.customer_phone).replace(/\D/g, '');
+  return Boolean(
+    (contactName && contactName !== customerName)
+    || (contactPhone && contactPhone !== customerPhone)
+  );
+};
+
+export const phoneHref = (phone: string | null | undefined) => {
+  const normalized = compactText(phone).replace(/[^+\d]/g, '');
+  return normalized ? `tel:${normalized}` : '';
+};
+
+export const formatEquipmentDate = (value: string | null | undefined) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '—' : DATE_FORMATTER.format(date);
+};
+
+export const hasAttentionReason = (item: EquipmentRegistryItem, reason: EquipmentAttentionReason) => (
+  item.attention_reasons?.includes(reason) ?? false
+);
+
+export const sortAttentionReasons = (reasons: string[]) => [...new Set(reasons)]
+  .sort((left, right) => {
+    const leftPriority = ATTENTION_PRIORITY[left as EquipmentAttentionReason] ?? 99;
+    const rightPriority = ATTENTION_PRIORITY[right as EquipmentAttentionReason] ?? 99;
+    return leftPriority - rightPriority || left.localeCompare(right);
+  });
+
+export const maintenanceDateClass = (item: EquipmentRegistryItem) => {
+  if (hasAttentionReason(item, 'maintenance_overdue')) return 'text-red-700 dark:text-red-300';
+  if (hasAttentionReason(item, 'maintenance_due_soon')) return 'text-amber-700 dark:text-amber-300';
+  return 'text-gray-800 dark:text-slate-200';
+};
+
+export const warrantyDateClass = (item: EquipmentRegistryItem) => {
+  if (hasAttentionReason(item, 'warranty_expired')) return 'text-red-700 dark:text-red-300';
+  if (hasAttentionReason(item, 'warranty_expiring')) return 'text-amber-700 dark:text-amber-300';
+  return 'text-gray-800 dark:text-slate-200';
+};

--- a/manager_frontend/src/components/equipment/types.ts
+++ b/manager_frontend/src/components/equipment/types.ts
@@ -1,0 +1,39 @@
+import type {
+  ManagerEquipmentItemResponse,
+  ManagerEquipmentListResponse,
+} from '../../client';
+
+export const EQUIPMENT_ATTENTION_FILTERS = [
+  'all',
+  'needs_decision',
+  'maintenance_due_soon',
+  'maintenance_overdue',
+  'warranty_expiring',
+  'warranty_expired',
+] as const;
+
+export type EquipmentAttentionFilter = typeof EQUIPMENT_ATTENTION_FILTERS[number];
+export type EquipmentAttentionReason = Exclude<EquipmentAttentionFilter, 'all'>;
+
+export type EquipmentRegistryItem = ManagerEquipmentItemResponse & {
+  customer_name?: string | null;
+  customer_phone?: string | null;
+  branch_name?: string | null;
+  branch_address?: string | null;
+  service_contact_name?: string | null;
+  service_contact_phone?: string | null;
+  last_service_at?: string | null;
+  next_maintenance_due_at?: string | null;
+  attention_reasons: string[];
+};
+
+export type EquipmentRegistryListResponse = Omit<ManagerEquipmentListResponse, 'items'> & {
+  items: EquipmentRegistryItem[];
+};
+
+export type EquipmentRegistryQuery = {
+  page: number;
+  limit: number;
+  q?: string;
+  attention?: EquipmentAttentionFilter;
+};

--- a/manager_frontend/src/views/EquipmentRegistryView.vue
+++ b/manager_frontend/src/views/EquipmentRegistryView.vue
@@ -1,0 +1,300 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { watchDebounced } from '@vueuse/core';
+import {
+  Boxes,
+  ChevronLeft,
+  ChevronRight,
+  CircleAlert,
+  LoaderCircle,
+  RotateCcw,
+} from 'lucide-vue-next';
+import EquipmentMaintenanceOrderDialog from '../components/equipment/EquipmentMaintenanceOrderDialog.vue';
+import EquipmentRegistryCards from '../components/equipment/EquipmentRegistryCards.vue';
+import EquipmentRegistryFilters from '../components/equipment/EquipmentRegistryFilters.vue';
+import EquipmentRegistryTable from '../components/equipment/EquipmentRegistryTable.vue';
+import {
+  createEquipmentMaintenanceOrder,
+  listEquipmentRegistry,
+} from '../components/equipment/api';
+import type {
+  EquipmentAttentionFilter,
+  EquipmentRegistryItem,
+} from '../components/equipment/types';
+import { getApiErrorMessage } from '../utils/api-errors';
+
+const PAGE_LIMIT = 25;
+
+const items = ref<EquipmentRegistryItem[]>([]);
+const search = ref('');
+const attention = ref<EquipmentAttentionFilter>('all');
+const page = ref(1);
+const meta = ref({ total: 0, page: 1, limit: PAGE_LIMIT, pages: 1 });
+const loading = ref(false);
+const hasLoaded = ref(false);
+const error = ref('');
+
+const selectedEquipment = ref<EquipmentRegistryItem | null>(null);
+const creatingOrder = ref(false);
+const orderError = ref('');
+
+let pendingListRequest: ReturnType<typeof listEquipmentRegistry> | null = null;
+let pendingOrderRequest: ReturnType<typeof createEquipmentMaintenanceOrder> | null = null;
+
+const totalPages = computed(() => Math.max(1, meta.value.pages || 1));
+const hasActiveFilters = computed(() => Boolean(search.value.trim()) || attention.value !== 'all');
+const emptyTitle = computed(() => (
+  hasActiveFilters.value ? 'Ничего не найдено' : 'Оборудование пока не добавлено'
+));
+const equipmentCountLabel = computed(() => {
+  const count = meta.value.total;
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  const unit = mod10 === 1 && mod100 !== 11
+    ? 'единица'
+    : mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)
+      ? 'единицы'
+      : 'единиц';
+  return `${count} ${unit}`;
+});
+
+const isCanceledRequest = (requestError: unknown) => (
+  requestError instanceof Error && requestError.name === 'CancelError'
+);
+
+const loadEquipment = async () => {
+  pendingListRequest?.cancel();
+  const currentRequest = listEquipmentRegistry({
+    page: page.value,
+    limit: PAGE_LIMIT,
+    q: search.value,
+    attention: attention.value,
+  });
+  pendingListRequest = currentRequest;
+  loading.value = true;
+  error.value = '';
+
+  try {
+    const response = await currentRequest;
+    if (pendingListRequest !== currentRequest) return;
+
+    items.value = response.items || [];
+    meta.value = {
+      ...response.meta,
+      pages: Math.max(1, response.meta.pages || 1),
+    };
+    page.value = response.meta.page || 1;
+  } catch (requestError) {
+    if (isCanceledRequest(requestError) || pendingListRequest !== currentRequest) return;
+    error.value = getApiErrorMessage(requestError);
+  } finally {
+    if (pendingListRequest === currentRequest) {
+      pendingListRequest = null;
+      loading.value = false;
+      hasLoaded.value = true;
+    }
+  }
+};
+
+const changeAttention = (value: EquipmentAttentionFilter) => {
+  if (attention.value === value) return;
+  attention.value = value;
+  page.value = 1;
+  void loadEquipment();
+};
+
+const goToPage = (nextPage: number) => {
+  const normalizedPage = Math.min(Math.max(1, nextPage), totalPages.value);
+  if (normalizedPage === page.value) return;
+  page.value = normalizedPage;
+  void loadEquipment();
+};
+
+const resetFilters = () => {
+  const searchChanged = search.value !== '';
+  search.value = '';
+  attention.value = 'all';
+  page.value = 1;
+  if (!searchChanged) void loadEquipment();
+};
+
+const openMaintenanceOrderDialog = (item: EquipmentRegistryItem) => {
+  selectedEquipment.value = item;
+  orderError.value = '';
+};
+
+const closeMaintenanceOrderDialog = () => {
+  if (creatingOrder.value) return;
+  selectedEquipment.value = null;
+  orderError.value = '';
+};
+
+const openCreatedOrder = (orderId: number) => {
+  const target = `/manager/orders/kanban?orderId=${encodeURIComponent(String(orderId))}`;
+  window.history.pushState({}, '', target);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+const confirmMaintenanceOrder = async () => {
+  const equipment = selectedEquipment.value;
+  if (!equipment || creatingOrder.value) return;
+
+  creatingOrder.value = true;
+  orderError.value = '';
+  const currentRequest = createEquipmentMaintenanceOrder(equipment.id);
+  pendingOrderRequest = currentRequest;
+
+  try {
+    const order = await currentRequest;
+    if (pendingOrderRequest !== currentRequest) return;
+    selectedEquipment.value = null;
+    openCreatedOrder(order.id);
+  } catch (requestError) {
+    if (isCanceledRequest(requestError) || pendingOrderRequest !== currentRequest) return;
+    orderError.value = getApiErrorMessage(requestError);
+  } finally {
+    if (pendingOrderRequest === currentRequest) {
+      pendingOrderRequest = null;
+      creatingOrder.value = false;
+    }
+  }
+};
+
+watchDebounced(search, () => {
+  page.value = 1;
+  void loadEquipment();
+}, { debounce: 350 });
+
+onMounted(() => {
+  void loadEquipment();
+});
+
+onBeforeUnmount(() => {
+  pendingListRequest?.cancel();
+  pendingOrderRequest?.cancel();
+});
+</script>
+
+<template>
+  <main class="w-full px-4 py-5 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-[1500px]">
+      <header class="flex items-center justify-between gap-4 pb-4">
+        <div class="flex min-w-0 items-center gap-3">
+          <span class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-teal-50 text-teal-700 dark:bg-teal-500/10 dark:text-teal-300">
+            <Boxes class="h-5 w-5" />
+          </span>
+          <div class="min-w-0">
+            <h1 class="truncate text-2xl font-semibold text-gray-950 dark:text-white">Реестр оборудования</h1>
+            <p class="mt-0.5 text-sm font-medium text-gray-500 dark:text-slate-400">
+              {{ hasLoaded ? equipmentCountLabel : 'Загрузка данных' }}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <EquipmentRegistryFilters
+        v-model="search"
+        :attention="attention"
+        :loading="loading"
+        @update:attention="changeAttention"
+        @refresh="loadEquipment"
+      />
+
+      <div
+        v-if="error"
+        class="mt-4 flex flex-col gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 sm:flex-row sm:items-center sm:justify-between dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-300"
+      >
+        <span class="flex min-w-0 items-start gap-2 font-medium">
+          <CircleAlert class="mt-0.5 h-4 w-4 shrink-0" />
+          <span class="break-words">{{ error }}</span>
+        </span>
+        <button
+          type="button"
+          class="inline-flex min-h-8 shrink-0 items-center justify-center rounded-md border border-red-200 bg-white px-3 text-xs font-semibold text-red-700 transition hover:bg-red-100 dark:border-red-500/40 dark:bg-transparent dark:text-red-300 dark:hover:bg-red-500/10"
+          @click="loadEquipment"
+        >
+          Повторить
+        </button>
+      </div>
+
+      <div class="flex items-center justify-between gap-3 py-3 text-sm">
+        <p class="font-medium text-gray-500 dark:text-slate-400">
+          Найдено: <span class="font-semibold text-gray-900 dark:text-slate-100">{{ meta.total }}</span>
+        </p>
+        <p v-if="totalPages > 1" class="text-xs font-medium text-gray-500 dark:text-slate-400">
+          Страница {{ page }} из {{ totalPages }}
+        </p>
+      </div>
+
+      <div
+        v-if="loading && !hasLoaded"
+        class="flex min-h-56 items-center justify-center gap-2 border-y border-gray-200 text-sm font-medium text-gray-500 dark:border-slate-700 dark:text-slate-400"
+      >
+        <LoaderCircle class="h-5 w-5 animate-spin text-teal-600 dark:text-teal-300" />
+        Загрузка оборудования
+      </div>
+
+      <div
+        v-else-if="hasLoaded && !error && !items.length"
+        class="flex min-h-56 flex-col items-center justify-center border-y border-dashed border-gray-300 px-4 text-center dark:border-slate-700"
+      >
+        <Boxes class="h-9 w-9 text-gray-300 dark:text-slate-600" />
+        <h2 class="mt-3 text-base font-semibold text-gray-900 dark:text-white">{{ emptyTitle }}</h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">По текущим условиям нет записей.</p>
+        <button
+          v-if="hasActiveFilters"
+          type="button"
+          class="mt-4 inline-flex min-h-9 items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-700 transition hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-teal-600 dark:hover:text-teal-300"
+          @click="resetFilters"
+        >
+          <RotateCcw class="h-4 w-4" />
+          Сбросить фильтры
+        </button>
+      </div>
+
+      <div v-else :class="loading ? 'pointer-events-none opacity-60' : ''" class="transition-opacity">
+        <EquipmentRegistryTable :items="items" @create-maintenance-order="openMaintenanceOrderDialog" />
+        <EquipmentRegistryCards :items="items" @create-maintenance-order="openMaintenanceOrderDialog" />
+      </div>
+
+      <nav
+        v-if="hasLoaded && totalPages > 1"
+        class="mt-3 flex items-center justify-center gap-3 border-t border-gray-200 pt-3 dark:border-slate-700"
+        aria-label="Страницы реестра оборудования"
+      >
+        <button
+          type="button"
+          class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 transition hover:border-teal-300 hover:text-teal-700 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:border-teal-600 dark:hover:text-teal-300"
+          :disabled="page <= 1 || loading"
+          title="Предыдущая страница"
+          aria-label="Предыдущая страница"
+          @click="goToPage(page - 1)"
+        >
+          <ChevronLeft class="h-4 w-4" />
+        </button>
+        <span class="min-w-20 text-center text-sm font-semibold text-gray-600 dark:text-slate-300">
+          {{ page }} / {{ totalPages }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 transition hover:border-teal-300 hover:text-teal-700 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:border-teal-600 dark:hover:text-teal-300"
+          :disabled="page >= totalPages || loading"
+          title="Следующая страница"
+          aria-label="Следующая страница"
+          @click="goToPage(page + 1)"
+        >
+          <ChevronRight class="h-4 w-4" />
+        </button>
+      </nav>
+    </div>
+
+    <EquipmentMaintenanceOrderDialog
+      v-if="selectedEquipment"
+      :equipment="selectedEquipment"
+      :loading="creatingOrder"
+      :error="orderError"
+      @close="closeMaintenanceOrderDialog"
+      @confirm="confirmMaintenanceOrder"
+    />
+  </main>
+</template>


### PR DESCRIPTION
## Что изменено

- добавлены переиспользуемые модули реестра оборудования: поиск, фильтры внимания, статусы, desktop-таблица и mobile-карточки
- добавлен API helper поверх общей конфигурации OpenAPI для списка оборудования и создания заказа на ТО
- добавлены подтверждение действия, обработка ошибок и переход в созданный заказ Kanban

## Границы

`App.vue`, `manager-navigation.ts`, backend, generated client и `OrderEditDrawer.vue` не изменялись. Подключение страницы к маршруту остаётся отдельным интеграционным шагом.

## Проверка

- `cd manager_frontend && npm run build`