### PR TITLE
fix: accept Docker lowercase restore cleanup errors

### DIFF
--- a/scripts/ha/cleanup_restore_drill_runtime.sh
+++ b/scripts/ha/cleanup_restore_drill_runtime.sh
@@ -16,14 +16,20 @@ inspect_object() {
   local kind="$1"
   local name="$2"
   local output=""
+  local output_lower=""
 
   if [[ "${kind}" == "container" ]]; then
     output="$(docker inspect "${name}" 2>&1)" && return 0
   else
     output="$(docker volume inspect "${name}" 2>&1)" && return 0
   fi
-  case "${output}" in
-    *"No such object"*|*"No such container"*|*"No such volume"*) return 1 ;;
+  # Docker CLI/daemon versions disagree on the capitalization of not-found
+  # errors (for example, `No such container` vs `no such object`). Normalize
+  # only for the known absence signatures; every other inspect failure remains
+  # fail-closed.
+  output_lower="$(printf '%s' "${output}" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+  case "${output_lower}" in
+    *"no such object"*|*"no such container"*|*"no such volume"*) return 1 ;;
     *) log "cleanup_error=${kind}_inspect_failed name=${name}"; return 2 ;;
   esac
 }

--- a/tests/unit/test_restore_drill_cleanup.py
+++ b/tests/unit/test_restore_drill_cleanup.py
@@ -11,6 +11,7 @@ def _cleanup_run(
     tmp_path: Path,
     *,
     daemon_failure: bool = False,
+    lowercase_absence_errors: bool = False,
     volume_remove_failure: bool = False,
     keep_container: bool = False,
     keep_files: bool = False,
@@ -42,7 +43,11 @@ if [[ "$1" == "inspect" ]]; then
     exit 0
   fi
   [[ -f "$CONTAINER_STATE" ]] && exit 0
-  echo 'No such container' >&2
+  if [[ "${LOWERCASE_ABSENCE_ERRORS}" == "true" ]]; then
+    printf '[]\nerror: no such object: drill-container\n' >&2
+  else
+    echo 'No such container' >&2
+  fi
   exit 1
 fi
 if [[ "$1 $2" == "volume inspect" ]]; then
@@ -52,7 +57,11 @@ if [[ "$1 $2" == "volume inspect" ]]; then
     exit 0
   fi
   [[ -f "$VOLUME_STATE" ]] && exit 0
-  echo 'No such volume' >&2
+  if [[ "${LOWERCASE_ABSENCE_ERRORS}" == "true" ]]; then
+    printf '[]\nError response from daemon: get drill-volume: no such volume\n' >&2
+  else
+    echo 'No such volume' >&2
+  fi
   exit 1
 fi
 if [[ "$1 $2" == "rm -fv" ]]; then
@@ -83,6 +92,7 @@ exit 2
             "CONTAINER_STATE": str(container_state),
             "VOLUME_STATE": str(volume_state),
             "DAEMON_FAILURE": str(daemon_failure).lower(),
+            "LOWERCASE_ABSENCE_ERRORS": str(lowercase_absence_errors).lower(),
             "VOLUME_REMOVE_FAILURE": str(volume_remove_failure).lower(),
             "LABEL_MISMATCH": str(label_mismatch).lower(),
             "RESTORE_DRILL_CONTAINER": "drill-container",
@@ -161,9 +171,26 @@ def test_cleanup_honors_explicit_keep_flags(tmp_path):
 
 
 def test_cleanup_accepts_already_absent_runtime(tmp_path):
-    result, _, _, backup, _ = _cleanup_run(tmp_path, create_objects=False)
+    result, _, _, backup, _ = _cleanup_run(
+        tmp_path,
+        create_objects=False,
+        lowercase_absence_errors=True,
+    )
 
     assert result.returncode == 0
+    assert not backup.exists()
+    assert not backup.parent.exists()
+
+
+def test_cleanup_accepts_docker_lowercase_absence_errors(tmp_path):
+    result, container, volume, backup, _ = _cleanup_run(
+        tmp_path,
+        lowercase_absence_errors=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not container.exists()
+    assert not volume.exists()
     assert not backup.exists()
     assert not backup.parent.exists()
 


### PR DESCRIPTION
## Что исправлено
- нормализована капитализация только для известных Docker not-found ответов
- все остальные ошибки inspect остаются fail-closed
- добавлены регрессионные сценарии для точных сообщений Docker 29 до и после удаления runtime

## Почему
Production restore drill 29247684264 успешно восстановил 64 таблицы и бизнес-данные, но ошибочно завершился failure после фактической очистки: Docker 29 вернул строчные no such object/volume.

## Проверка
- 123 связанных HA/PITR unit tests
- bash syntax, shellcheck, diff check
- production Docker 29 compatibility smoke на уже удалённых объектах