### PR TITLE
Add dormant communications delivery worker

### DIFF
--- a/alembic/versions/4a8b1c2d3e05_harden_communication_delivery_leases.py
+++ b/alembic/versions/4a8b1c2d3e05_harden_communication_delivery_leases.py
@@ -1,0 +1,105 @@
+"""harden communication delivery lease state
+
+Revision ID: 4a8b1c2d3e05
+Revises: 3f7a9c1d2e04
+Create Date: 2026-07-13 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "4a8b1c2d3e05"
+down_revision: Union[str, Sequence[str], None] = "3f7a9c1d2e04"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("communication_delivery") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_delivery_attempts_within_max",
+            "attempts <= max_attempts",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_active_attempts_remaining",
+            "status NOT IN ('queued', 'retry') OR attempts < max_attempts",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_lease_state",
+            "(status = 'running' AND worker_id IS NOT NULL "
+            "AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL) "
+            "OR (status <> 'running' AND worker_id IS NULL "
+            "AND lease_token IS NULL AND lease_expires_at IS NULL)",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_terminal_timestamps",
+            "(status = 'sent' AND sent_at IS NOT NULL AND finished_at IS NOT NULL) "
+            "OR (status IN ('dead', 'canceled') AND sent_at IS NULL "
+            "AND finished_at IS NOT NULL) "
+            "OR (status IN ('queued', 'running', 'retry') AND sent_at IS NULL "
+            "AND finished_at IS NULL)",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_attempt_phase",
+            "(status = 'queued' AND attempts = 0) "
+            "OR (status IN ('running', 'retry', 'sent', 'dead', 'canceled') "
+            "AND attempts >= 1)",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_provider_message_state",
+            "(status = 'sent' AND provider_message_id IS NOT NULL "
+            "AND length(trim(provider_message_id)) > 0) "
+            "OR (status <> 'sent' AND provider_message_id IS NULL)",
+        )
+
+    op.create_index(
+        "ix_communication_delivery_channel_claim",
+        "communication_delivery",
+        ["channel", "priority", "available_at", "created_at", "delivery_id"],
+        unique=False,
+        postgresql_where=sa.text("status IN ('queued', 'retry')"),
+    )
+    op.create_index(
+        "ix_communication_delivery_channel_recovery",
+        "communication_delivery",
+        ["channel", "lease_expires_at", "created_at", "delivery_id"],
+        unique=False,
+        postgresql_where=sa.text("status = 'running'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_communication_delivery_channel_recovery",
+        table_name="communication_delivery",
+    )
+    op.drop_index(
+        "ix_communication_delivery_channel_claim",
+        table_name="communication_delivery",
+    )
+    with op.batch_alter_table("communication_delivery") as batch_op:
+        batch_op.drop_constraint(
+            "ck_delivery_provider_message_state",
+            type_="check",
+        )
+        batch_op.drop_constraint(
+            "ck_delivery_attempt_phase",
+            type_="check",
+        )
+        batch_op.drop_constraint(
+            "ck_delivery_terminal_timestamps",
+            type_="check",
+        )
+        batch_op.drop_constraint("ck_delivery_lease_state", type_="check")
+        batch_op.drop_constraint(
+            "ck_delivery_attempts_within_max",
+            type_="check",
+        )
+        batch_op.drop_constraint(
+            "ck_delivery_active_attempts_remaining",
+            type_="check",
+        )

--- a/docs/global-system-audit-2026-07-12.md
+++ b/docs/global-system-audit-2026-07-12.md
@@ -57,7 +57,7 @@ MVN уже состоит из нескольких независимо раз�
 | JOB-002 | P1 | Media | Два worker'а могут атомарно незащищённо забрать одну media job | Закрыто и развернуто в API Wave 0: atomic claim, lease token, heartbeat; сам worker остаётся выключен до отдельного managed rollout |
 | COM-001 | P1 | Telegram | Ошибки проглатываются, попытка считается доставкой; живой log доказал ложный `notified_admins=2` при отказе | Закрыто в Wave 0 |
 | COM-002 | P1 | Telegram | Ручной bank import не вызывает notify, после dedupe уведомление теряется навсегда | Закрыто в Wave 0 |
-| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | В работе: PR-A (#727) развернул выключенный additive outbox/inbox/per-recipient delivery foundation; PR-B добавляет атомарную материализацию deliveries+inbox без runtime/scheduler/provider; producer switch и сетевой worker ещё открыты |
+| COM-003 | P1 | Telegram/Email | Нет transactional outbox: события теряются/дублируются, внешние вызовы блокируют HTTP transaction | В работе: PR-A (#727) развернул выключенный additive foundation; PR-B добавил dispatcher/materializer; C1 добавляет выключенный per-recipient leased Telegram worker, provider result/retry/DLQ и lease fencing. Runtime/scheduler и атомарный producer switch намеренно остаются C2 после transaction review |
 | COM-004 | P1 | Tests | Integration checkout способен отправлять реальные Telegram-сообщения владельцам | Закрыто в Wave 0 |
 | PRIV-001 | P1 | Media | Реквизиты, order attachments и диагностические фото лежат в публичном `/media`/public R2 | Открыто |
 | WEB-001 | P1 | SSG | Build запрашивает только 1000 из 1117 товаров; product routes после 1000 отсутствуют и production URL отвечает 404 | Закрыто в Wave 0: пагинация, dedupe и hard-fail invariant |
@@ -236,7 +236,7 @@ Checkout, contact/availability leads, repair upload/AI и proxies не имею�
 
 На исходном срезе `BotService.send_message` глотал provider error, а callers увеличивали `sent_count` после любой попытки. В локальном operational log найдено пять реальных отказов, включая обоих текущих owners; рядом scheduler заявил двух уведомлённых. Это был доказанный false-success, а не теоретическая ветка.
 
-Wave 0 перевела текущий контракт на подтверждённый `bool`, сделала partial fan-out видимым и сохранила multi-recipient delivery; ручной bank import теперь также уведомляет. Полный structured `DeliveryResult` с provider message ID/error code/retry-after и durable retry queue остаётся частью Communications/outbox.
+Wave 0 перевела текущий production-контракт на подтверждённый `bool`, сделала partial fan-out видимым и сохранила multi-recipient delivery; ручной bank import теперь также уведомляет. C1 добавляет отдельный structured provider result с message ID/error code/retry-after и durable per-recipient retry/DLQ, но этот worker остаётся dormant и не меняет текущий production path до C2 rollout.
 
 ### 8.2 Outbox
 
@@ -252,7 +252,9 @@ Wave 0 перевела текущий контракт на подтвержд�
 - `installer.assigned`;
 - `work_stage.status_changed`.
 
-Delivery uniqueness: `(event_id, channel, recipient_id, template_version)`. Worker: `SKIP LOCKED`, backoff+jitter, Telegram `retry_after`, terminal blocked/403, chunking, fallback, DLQ, queue-age/delivery metrics.
+Delivery uniqueness: `(event_id, channel, recipient_key, template_version)`. C1 worker берёт только due `queued/retry` через `SKIP LOCKED`; claim коммитится до network, а renew/sent/retry/dead/cancel fenced по `worker_id + lease_token + unexpired lease`. Истёкший `running` сначала отдельно переводится в delayed retry/DLQ и не переотправляется тем же claim. Реализованы deterministic backoff+jitter, Telegram `retry_after`, terminal recipient errors, sanitized diagnostics, active-recipient revalidation и независимый partial fan-out. Chunking/fallback, queue-age/delivery metrics и managed runtime rollout остаются открыты.
+
+Семантика остаётся честной **at-least-once**: если Telegram принял сообщение, но ответ потерян/неоднозначен, либо process аварийно завершился до terminal DB commit, lease recovery может отправить дубликат. Fencing запрещает stale worker менять состояние, но без provider idempotency не превращает Telegram delivery в exactly-once; этот риск обязателен для C2 canary/runbook и метрик duplicate suspicion.
 
 ### 8.3 Access и privacy
 
@@ -345,7 +347,7 @@ Wave 0 подтверждена локально, в CI и production. Media pro
 
 ### Wave 1 — данные и надёжность
 
-- Transactional outbox/inbox + communications worker. PR-A развернул только выключенный additive persistence/contracts foundation. PR-B добавляет caller-owned single-transaction dispatcher (`FOR UPDATE SKIP LOCKED`, deterministic delivery upsert, inbox-last, retry/dead bookkeeping) без scheduler и сетевых вызовов. Leased provider worker и атомарное переключение producers выполняются следующими отдельными PR.
+- Transactional outbox/inbox + communications worker. PR-A развернул выключенный additive persistence/contracts foundation; PR-B добавил caller-owned single-transaction dispatcher (`FOR UPDATE SKIP LOCKED`, deterministic delivery upsert, inbox-last, retry/dead bookkeeping). C1 добавляет всё ещё выключенный provider worker с durable claim-before-network, token fencing, heartbeat, retry/DLQ и Telegram adapter. C2 отдельно проводит transaction review, атомарно переключает producers и только затем подключает managed runtime/scheduler.
 - Order version/409 и command-specific updates.
 - Canonical customer identity + checkout idempotency.
 - Public contact/availability lead abuse policy: edge+app rate limit, canonical phone/email, dedupe window, idempotency key и risk-based anti-bot.

--- a/docs/service-decomposition-roadmap.md
+++ b/docs/service-decomposition-roadmap.md
@@ -6,7 +6,7 @@
 
 Сначала modular monolith, затем extraction. Storefront и Telegram process уже можно разворачивать отдельно, но это ещё не самостоятельные domain services: они используют общую backend-модель и не имеют устойчивых command/event contracts.
 
-Wave 0 закрыта, слита через PR #726 и развернута в production как SHA `886593e0`: единый CI дал **1177 passed**, migration/codegen gates, Patroni primary/replica deploy и storefront canary/VPS/Cloudflare smoke прошли. Декомпозиция этим не завершена. Outbox producer switch/consumer, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Wave 1 PR-A (#727, SHA `0c16ea38`) уже развернул выключенный additive outbox/inbox/delivery foundation; PR-B добавляет транзакционный dispatcher/materializer, но по-прежнему не включает scheduler, provider worker и producer switch, поэтому production notification path не меняется.
+Wave 0 закрыта, слита через PR #726 и развернута в production как SHA `886593e0`: единый CI дал **1177 passed**, migration/codegen gates, Patroni primary/replica deploy и storefront canary/VPS/Cloudflare smoke прошли. Декомпозиция этим не завершена. Outbox producer switch/consumer, optimistic concurrency, canonical customer identity, private media, lean DTO, dependency upgrades и общий durable job framework остаются открыты. Wave 1 PR-A (#727, SHA `0c16ea38`) уже развернул выключенный additive outbox/inbox/delivery foundation; PR-B добавил транзакционный dispatcher/materializer. C1 добавляет dormant leased Telegram provider worker, но не включает runtime/scheduler и не переключает producers, поэтому production notification path по-прежнему не меняется.
 
 ## Целевые bounded contexts
 
@@ -59,7 +59,11 @@ Rollback выполняется в обратном безопасном пор�
 
 Владеет templates, channel routing, deliveries, retry/DLQ и provider diagnostics. Producers не вызывают Telegram/SMTP напрямую; они пишут domain event/outbox.
 
-Можно выделять после стабилизации in-process worker: перенос worker не меняет producer contract.
+C1 формирует безопасное in-process ядро: immutable recipient snapshot, durable claim до network, per-recipient lease token/heartbeat, строго fenced terminal transitions, отдельное восстановление expired lease, deterministic retry с provider `retry_after`, DLQ и повторная проверка активного получателя. Ядро остаётся не подключённым к runtime.
+
+Delivery остаётся at-least-once: ambiguous provider timeout или hard crash после принятия Telegram-сообщения, но до terminal DB commit, может привести к повтору после lease recovery. Lease fencing защищает состояние от stale worker, но exactly-once невозможно без idempotency со стороны провайдера.
+
+C2 начинается только после review транзакций producer use cases: domain mutation и outbox event должны коммититься атомарно. Затем нужен managed single-active/canary rollout, метрики queue age/lease expiry/delivery outcome и rollback без mixed worker versions. Выделять Communications можно после этой стабилизации: перенос worker не меняет producer contract.
 
 ### Documents
 
@@ -146,7 +150,7 @@ flowchart LR
   H --> I["Re-evaluate CRM/Catalog physical split"]
 ```
 
-Wave 0 на этой диаграмме развернута. В Wave 1 отдельно входят public lead abuse/dedupe/rate-limit contract, checkout idempotency/canonical identity, order versioning, переключение producers/consumer на outbox и durable operations. Media worker в production пока отсутствует и остаётся выключен; extraction нельзя начинать только на основании уже реализованного lease claim.
+Wave 0 на этой диаграмме развернута. В Wave 1 отдельно входят public lead abuse/dedupe/rate-limit contract, checkout idempotency/canonical identity, order versioning, C2 transaction review и переключение producers/consumer на outbox, managed communications-worker rollout и durable operations. Media и Communications workers в production пока отсутствуют и остаются выключены; extraction нельзя начинать только на основании реализованного lease claim.
 
 ## Anti-goals
 

--- a/models/communication.py
+++ b/models/communication.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Index, String, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    Index,
+    String,
+    UniqueConstraint,
+    text,
+)
 from sqlmodel import Field, JSON, SQLModel
 
 
@@ -25,8 +33,43 @@ class CommunicationDelivery(SQLModel, table=True):
         CheckConstraint("attempts >= 0", name="ck_delivery_attempts_non_negative"),
         CheckConstraint("max_attempts > 0", name="ck_delivery_max_attempts_positive"),
         CheckConstraint(
+            "attempts <= max_attempts",
+            name="ck_delivery_attempts_within_max",
+        ),
+        CheckConstraint(
+            "status NOT IN ('queued', 'retry') OR attempts < max_attempts",
+            name="ck_delivery_active_attempts_remaining",
+        ),
+        CheckConstraint(
             "status IN ('queued', 'running', 'retry', 'sent', 'dead', 'canceled')",
             name="ck_delivery_status_valid",
+        ),
+        CheckConstraint(
+            "(status = 'running' AND worker_id IS NOT NULL "
+            "AND lease_token IS NOT NULL AND lease_expires_at IS NOT NULL) "
+            "OR (status <> 'running' AND worker_id IS NULL "
+            "AND lease_token IS NULL AND lease_expires_at IS NULL)",
+            name="ck_delivery_lease_state",
+        ),
+        CheckConstraint(
+            "(status = 'sent' AND sent_at IS NOT NULL AND finished_at IS NOT NULL) "
+            "OR (status IN ('dead', 'canceled') AND sent_at IS NULL "
+            "AND finished_at IS NOT NULL) "
+            "OR (status IN ('queued', 'running', 'retry') AND sent_at IS NULL "
+            "AND finished_at IS NULL)",
+            name="ck_delivery_terminal_timestamps",
+        ),
+        CheckConstraint(
+            "(status = 'queued' AND attempts = 0) "
+            "OR (status IN ('running', 'retry', 'sent', 'dead', 'canceled') "
+            "AND attempts >= 1)",
+            name="ck_delivery_attempt_phase",
+        ),
+        CheckConstraint(
+            "(status = 'sent' AND provider_message_id IS NOT NULL "
+            "AND length(trim(provider_message_id)) > 0) "
+            "OR (status <> 'sent' AND provider_message_id IS NULL)",
+            name="ck_delivery_provider_message_state",
         ),
         Index(
             "ix_communication_delivery_claim",
@@ -34,6 +77,23 @@ class CommunicationDelivery(SQLModel, table=True):
             "available_at",
             "priority",
             "created_at",
+        ),
+        Index(
+            "ix_communication_delivery_channel_claim",
+            "channel",
+            "priority",
+            "available_at",
+            "created_at",
+            "delivery_id",
+            postgresql_where=text("status IN ('queued', 'retry')"),
+        ),
+        Index(
+            "ix_communication_delivery_channel_recovery",
+            "channel",
+            "lease_expires_at",
+            "created_at",
+            "delivery_id",
+            postgresql_where=text("status = 'running'"),
         ),
         Index("ix_communication_delivery_event_id", "event_id"),
     )

--- a/services/communications/delivery_service.py
+++ b/services/communications/delivery_service.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from types import MappingProxyType
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CommunicationDelivery
+from services.communications.providers.base import (
+    ProviderDeliveryDisposition,
+    ProviderDeliveryResult,
+)
+
+
+DELIVERY_STATUS_QUEUED = "queued"
+DELIVERY_STATUS_RUNNING = "running"
+DELIVERY_STATUS_RETRY = "retry"
+DELIVERY_STATUS_SENT = "sent"
+DELIVERY_STATUS_DEAD = "dead"
+DELIVERY_STATUS_CANCELED = "canceled"
+
+
+class CommunicationDeliveryNotFound(LookupError):
+    pass
+
+
+class CommunicationDeliveryLeaseLost(RuntimeError):
+    pass
+
+
+def _freeze_json_value(value: object) -> object:
+    if isinstance(value, dict):
+        return MappingProxyType(
+            {str(key): _freeze_json_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
+def _thaw_json_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json_value(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class ClaimedCommunicationDelivery:
+    delivery_id: str
+    event_id: str
+    channel: str
+    recipient_key: str = field(repr=False)
+    destination: str = field(repr=False)
+    template_key: str
+    template_version: int
+    render_context: Mapping[str, object] = field(repr=False)
+    attempts: int
+    max_attempts: int
+    lease_token: str = field(repr=False)
+    lease_expires_at: datetime
+
+    def render_context_dict(self) -> dict[str, object]:
+        thawed = _thaw_json_value(self.render_context)
+        if not isinstance(thawed, dict):
+            raise TypeError("Communication delivery render context must be an object")
+        return thawed
+
+
+@dataclass(frozen=True)
+class ExpiredLeaseRecoveryResult:
+    retry_count: int
+    dead_count: int
+
+
+@dataclass(frozen=True)
+class DeliveryFailureOutcome:
+    status: str
+    attempts: int
+    next_attempt_at: datetime | None
+
+
+class CommunicationDeliveryService:
+    """Transaction-neutral state machine for one immutable recipient delivery."""
+
+    MIN_LEASE_SECONDS = 30
+    MAX_LEASE_SECONDS = 3600
+    MAX_RECOVERY_LIMIT = 1000
+    RETRY_BASE_SECONDS = 30
+    RETRY_MAX_SECONDS = 3600
+    RETRY_JITTER_PERCENT = 20
+
+    @classmethod
+    async def claim_next(
+        cls,
+        session: AsyncSession,
+        *,
+        worker_id: str,
+        channel: str = "telegram",
+        lease_seconds: int = 90,
+        now: datetime | None = None,
+    ) -> ClaimedCommunicationDelivery | None:
+        normalized_worker_id = cls._normalize_worker_id(worker_id)
+        normalized_channel = cls._normalize_channel(channel)
+        lease_duration = cls._normalize_lease_seconds(lease_seconds)
+        claimed_at = await cls._resolve_now(session, now)
+
+        statement = (
+            select(CommunicationDelivery)
+            .where(
+                CommunicationDelivery.channel == normalized_channel,
+                CommunicationDelivery.status.in_(
+                    [DELIVERY_STATUS_QUEUED, DELIVERY_STATUS_RETRY]
+                ),
+                CommunicationDelivery.available_at <= claimed_at,
+                CommunicationDelivery.attempts < CommunicationDelivery.max_attempts,
+            )
+            .order_by(
+                CommunicationDelivery.priority.asc(),
+                CommunicationDelivery.available_at.asc(),
+                CommunicationDelivery.created_at.asc(),
+                CommunicationDelivery.delivery_id.asc(),
+            )
+            .limit(1)
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update(skip_locked=True)
+
+        delivery = (await session.execute(statement)).scalar_one_or_none()
+        if delivery is None:
+            return None
+
+        lease_token = secrets.token_urlsafe(32)
+        lease_expires_at = claimed_at + timedelta(seconds=lease_duration)
+        delivery.status = DELIVERY_STATUS_RUNNING
+        delivery.attempts = int(delivery.attempts) + 1
+        delivery.worker_id = normalized_worker_id
+        delivery.lease_token = lease_token
+        delivery.lease_expires_at = lease_expires_at
+        delivery.last_error_category = None
+        delivery.last_error_code = None
+        delivery.last_error_message = None
+        delivery.sent_at = None
+        delivery.finished_at = None
+        delivery.updated_at = claimed_at
+        session.add(delivery)
+        await session.flush()
+
+        return ClaimedCommunicationDelivery(
+            delivery_id=delivery.delivery_id,
+            event_id=delivery.event_id,
+            channel=delivery.channel,
+            recipient_key=delivery.recipient_key,
+            destination=delivery.destination,
+            template_key=delivery.template_key,
+            template_version=delivery.template_version,
+            render_context=_freeze_json_value(dict(delivery.render_context or {})),
+            attempts=delivery.attempts,
+            max_attempts=delivery.max_attempts,
+            lease_token=lease_token,
+            lease_expires_at=lease_expires_at,
+        )
+
+    @classmethod
+    async def recover_expired_leases(
+        cls,
+        session: AsyncSession,
+        *,
+        channel: str = "telegram",
+        now: datetime | None = None,
+        limit: int = 100,
+    ) -> ExpiredLeaseRecoveryResult:
+        normalized_channel = cls._normalize_channel(channel)
+        recovered_at = await cls._resolve_now(session, now)
+        safe_limit = max(1, min(cls.MAX_RECOVERY_LIMIT, int(limit)))
+        statement = (
+            select(CommunicationDelivery)
+            .where(
+                CommunicationDelivery.channel == normalized_channel,
+                CommunicationDelivery.status == DELIVERY_STATUS_RUNNING,
+                CommunicationDelivery.lease_expires_at.is_not(None),
+                CommunicationDelivery.lease_expires_at <= recovered_at,
+            )
+            .order_by(
+                CommunicationDelivery.lease_expires_at.asc(),
+                CommunicationDelivery.created_at.asc(),
+                CommunicationDelivery.delivery_id.asc(),
+            )
+            .limit(safe_limit)
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update(skip_locked=True)
+
+        deliveries = list((await session.execute(statement)).scalars().all())
+        retry_count = 0
+        dead_count = 0
+        for delivery in deliveries:
+            delivery.worker_id = None
+            delivery.lease_token = None
+            delivery.lease_expires_at = None
+            delivery.last_error_category = "lease"
+            delivery.last_error_code = "lease_expired"
+            delivery.last_error_message = "Delivery worker lease expired before completion"
+            delivery.updated_at = recovered_at
+            if int(delivery.attempts) >= int(delivery.max_attempts):
+                delivery.status = DELIVERY_STATUS_DEAD
+                delivery.sent_at = None
+                delivery.finished_at = recovered_at
+                dead_count += 1
+            else:
+                delivery.status = DELIVERY_STATUS_RETRY
+                delivery.available_at = recovered_at + timedelta(
+                    seconds=cls.retry_delay_seconds(
+                        delivery_id=delivery.delivery_id,
+                        attempts=delivery.attempts,
+                    )
+                )
+                delivery.sent_at = None
+                delivery.finished_at = None
+                retry_count += 1
+            session.add(delivery)
+
+        await session.flush()
+        return ExpiredLeaseRecoveryResult(
+            retry_count=retry_count,
+            dead_count=dead_count,
+        )
+
+    @classmethod
+    async def renew_lease(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        lease_seconds: int = 90,
+        now: datetime | None = None,
+    ) -> datetime:
+        delivery, renewed_at = await cls._lock_owned_delivery(
+            session,
+            delivery_id=delivery_id,
+            worker_id=worker_id,
+            lease_token=lease_token,
+            now=now,
+        )
+        lease_expires_at = renewed_at + timedelta(
+            seconds=cls._normalize_lease_seconds(lease_seconds)
+        )
+        delivery.lease_expires_at = lease_expires_at
+        delivery.updated_at = renewed_at
+        session.add(delivery)
+        await session.flush()
+        return lease_expires_at
+
+    @classmethod
+    async def mark_sent(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        provider_message_id: str,
+        now: datetime | None = None,
+    ) -> None:
+        normalized_message_id = str(provider_message_id or "").strip()
+        if not normalized_message_id:
+            raise ValueError("Provider message ID is required")
+        if len(normalized_message_id) > 255:
+            raise ValueError("Provider message ID exceeds 255 characters")
+
+        delivery, completed_at = await cls._lock_owned_delivery(
+            session,
+            delivery_id=delivery_id,
+            worker_id=worker_id,
+            lease_token=lease_token,
+            now=now,
+        )
+        delivery.status = DELIVERY_STATUS_SENT
+        delivery.provider_message_id = normalized_message_id
+        delivery.last_error_category = None
+        delivery.last_error_code = None
+        delivery.last_error_message = None
+        delivery.sent_at = completed_at
+        delivery.finished_at = completed_at
+        delivery.worker_id = None
+        delivery.lease_token = None
+        delivery.lease_expires_at = None
+        delivery.updated_at = completed_at
+        session.add(delivery)
+        await session.flush()
+
+    @classmethod
+    async def mark_failed(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        result: ProviderDeliveryResult,
+        now: datetime | None = None,
+    ) -> DeliveryFailureOutcome:
+        if result.disposition == ProviderDeliveryDisposition.SENT:
+            raise ValueError("A sent provider result cannot be recorded as a failure")
+
+        delivery, failed_at = await cls._lock_owned_delivery(
+            session,
+            delivery_id=delivery_id,
+            worker_id=worker_id,
+            lease_token=lease_token,
+            now=now,
+        )
+        category, code, message = cls._sanitize_provider_error(result)
+        delivery.last_error_category = category
+        delivery.last_error_code = code
+        delivery.last_error_message = message
+        delivery.provider_message_id = None
+        delivery.sent_at = None
+        delivery.worker_id = None
+        delivery.lease_token = None
+        delivery.lease_expires_at = None
+        delivery.updated_at = failed_at
+
+        terminal = (
+            result.disposition == ProviderDeliveryDisposition.PERMANENT_FAILURE
+            or int(delivery.attempts) >= int(delivery.max_attempts)
+        )
+        next_attempt_at: datetime | None = None
+        if terminal:
+            delivery.status = DELIVERY_STATUS_DEAD
+            delivery.finished_at = failed_at
+        else:
+            retry_delay = cls.retry_delay_seconds(
+                delivery_id=delivery.delivery_id,
+                attempts=delivery.attempts,
+            )
+            if result.retry_after_seconds is not None:
+                retry_delay = max(
+                    retry_delay,
+                    max(1, int(result.retry_after_seconds)),
+                )
+            next_attempt_at = failed_at + timedelta(seconds=retry_delay)
+            delivery.status = DELIVERY_STATUS_RETRY
+            delivery.available_at = next_attempt_at
+            delivery.finished_at = None
+
+        session.add(delivery)
+        await session.flush()
+        return DeliveryFailureOutcome(
+            status=delivery.status,
+            attempts=delivery.attempts,
+            next_attempt_at=next_attempt_at,
+        )
+
+    @classmethod
+    async def cancel_owned(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        error_category: str = "recipient",
+        error_code: str = "recipient_inactive",
+        error_message: str = "Communication recipient is no longer eligible",
+        now: datetime | None = None,
+    ) -> None:
+        delivery, canceled_at = await cls._lock_owned_delivery(
+            session,
+            delivery_id=delivery_id,
+            worker_id=worker_id,
+            lease_token=lease_token,
+            now=now,
+        )
+        delivery.status = DELIVERY_STATUS_CANCELED
+        delivery.provider_message_id = None
+        delivery.last_error_category = cls._sanitize_text(error_category, 80, "recipient")
+        delivery.last_error_code = cls._sanitize_text(error_code, 100, "recipient_inactive")
+        delivery.last_error_message = cls._sanitize_text(
+            error_message,
+            1000,
+            "Communication recipient is no longer eligible",
+        )
+        delivery.sent_at = None
+        delivery.finished_at = canceled_at
+        delivery.worker_id = None
+        delivery.lease_token = None
+        delivery.lease_expires_at = None
+        delivery.updated_at = canceled_at
+        session.add(delivery)
+        await session.flush()
+
+    @classmethod
+    def retry_delay_seconds(cls, *, delivery_id: str, attempts: int) -> int:
+        safe_attempts = max(1, int(attempts))
+        exponential_delay = min(
+            cls.RETRY_MAX_SECONDS,
+            cls.RETRY_BASE_SECONDS * (2 ** min(safe_attempts - 1, 16)),
+        )
+        if exponential_delay >= cls.RETRY_MAX_SECONDS:
+            return cls.RETRY_MAX_SECONDS
+        jitter_window = max(
+            1,
+            (exponential_delay * cls.RETRY_JITTER_PERCENT) // 100,
+        )
+        digest = hashlib.sha256(
+            f"{delivery_id}:{safe_attempts}".encode("utf-8")
+        ).digest()
+        return min(
+            cls.RETRY_MAX_SECONDS,
+            exponential_delay + int.from_bytes(digest[:4], "big") % (jitter_window + 1),
+        )
+
+    @classmethod
+    async def _lock_owned_delivery(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        now: datetime | None,
+    ) -> tuple[CommunicationDelivery, datetime]:
+        normalized_delivery_id = cls._normalize_delivery_id(delivery_id)
+        normalized_worker_id = cls._normalize_worker_id(worker_id)
+        normalized_lease_token = cls._normalize_lease_token(lease_token)
+        explicit_now = cls._normalize_now(now) if now is not None else None
+        statement = select(CommunicationDelivery).where(
+            CommunicationDelivery.delivery_id == normalized_delivery_id,
+            CommunicationDelivery.status == DELIVERY_STATUS_RUNNING,
+            CommunicationDelivery.worker_id == normalized_worker_id,
+            CommunicationDelivery.lease_token == normalized_lease_token,
+            CommunicationDelivery.lease_expires_at.is_not(None),
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update()
+        delivery = (await session.execute(statement)).scalar_one_or_none()
+        if delivery is not None:
+            locked_at = explicit_now or await cls._database_now(session)
+            lease_expires_at = cls._coerce_database_datetime(
+                delivery.lease_expires_at
+            )
+            if lease_expires_at <= locked_at:
+                raise CommunicationDeliveryLeaseLost(
+                    f"Communication delivery {normalized_delivery_id!r} lease expired"
+                )
+            return delivery, locked_at
+
+        exists = await session.get(CommunicationDelivery, normalized_delivery_id)
+        if exists is None:
+            raise CommunicationDeliveryNotFound(
+                f"Communication delivery {normalized_delivery_id!r} was not found"
+            )
+        raise CommunicationDeliveryLeaseLost(
+            f"Communication delivery {normalized_delivery_id!r} lease is no longer owned"
+        )
+
+    @classmethod
+    async def _resolve_now(
+        cls,
+        session: AsyncSession,
+        value: datetime | None,
+    ) -> datetime:
+        if value is not None:
+            return cls._normalize_now(value)
+        return await cls._database_now(session)
+
+    @classmethod
+    async def _database_now(cls, session: AsyncSession) -> datetime:
+        clock = (
+            func.clock_timestamp()
+            if session.get_bind().dialect.name == "postgresql"
+            else func.current_timestamp()
+        )
+        value = (await session.execute(select(clock))).scalar_one()
+        return cls._coerce_database_datetime(value)
+
+    @staticmethod
+    def _coerce_database_datetime(value: object) -> datetime:
+        if isinstance(value, str):
+            value = datetime.fromisoformat(value.replace(" ", "T"))
+        if not isinstance(value, datetime):
+            raise TypeError("Database clock did not return a datetime")
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @staticmethod
+    def _normalize_now(value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("Communication delivery timestamps must be timezone-aware")
+        return value.astimezone(timezone.utc)
+
+    @staticmethod
+    def _normalize_delivery_id(delivery_id: str) -> str:
+        normalized = str(delivery_id or "").strip()
+        if not re.fullmatch(r"[0-9a-f]{32}", normalized):
+            raise ValueError("Communication delivery ID must be 32 lowercase hex characters")
+        return normalized
+
+    @staticmethod
+    def _normalize_worker_id(worker_id: str) -> str:
+        normalized = str(worker_id or "").strip()
+        if not normalized:
+            raise ValueError("Communication delivery worker ID is required")
+        if len(normalized) > 128:
+            raise ValueError("Communication delivery worker ID exceeds 128 characters")
+        return normalized
+
+    @staticmethod
+    def _normalize_lease_token(lease_token: str) -> str:
+        normalized = str(lease_token or "").strip()
+        if len(normalized) < 32 or len(normalized) > 255:
+            raise ValueError("Communication delivery lease token is invalid")
+        return normalized
+
+    @staticmethod
+    def _normalize_channel(channel: str) -> str:
+        normalized = str(channel or "").strip().lower()
+        if not normalized or len(normalized) > 32:
+            raise ValueError("Communication delivery channel is invalid")
+        return normalized
+
+    @classmethod
+    def _normalize_lease_seconds(cls, lease_seconds: int) -> int:
+        normalized = int(lease_seconds)
+        if not cls.MIN_LEASE_SECONDS <= normalized <= cls.MAX_LEASE_SECONDS:
+            raise ValueError(
+                f"Communication delivery lease must be between "
+                f"{cls.MIN_LEASE_SECONDS} and {cls.MAX_LEASE_SECONDS} seconds"
+            )
+        return normalized
+
+    @classmethod
+    def _sanitize_provider_error(
+        cls,
+        result: ProviderDeliveryResult,
+    ) -> tuple[str, str, str]:
+        return (
+            cls._sanitize_text(result.error_category, 80, "provider"),
+            cls._sanitize_text(result.error_code, 100, "delivery_failed"),
+            cls._sanitize_text(
+                result.error_message,
+                1000,
+                "Communication delivery failed",
+            ),
+        )
+
+    @staticmethod
+    def _sanitize_text(value: str | None, limit: int, fallback: str) -> str:
+        normalized = re.sub(r"[\x00-\x1f\x7f]+", " ", str(value or ""))
+        normalized = " ".join(normalized.split()).strip()
+        return (normalized or fallback)[:limit]

--- a/services/communications/delivery_worker.py
+++ b/services/communications/delivery_worker.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, TypeVar
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.communications.contracts import CommunicationTemplatePlanV1
+from services.communications.delivery_service import (
+    ClaimedCommunicationDelivery,
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryService,
+    DeliveryFailureOutcome,
+    ExpiredLeaseRecoveryResult,
+)
+from services.communications.providers.base import (
+    CommunicationDeliveryProvider,
+    ProviderDeliveryDisposition,
+    ProviderDeliveryResult,
+)
+from services.communications.recipient_directory import ManagementRecipientDirectory
+from services.communications.template_registry import WebsiteTemplateRegistry
+
+
+logger = logging.getLogger(__name__)
+_TerminalResult = TypeVar("_TerminalResult")
+
+
+class _ProviderResultDuringCancellation(RuntimeError):
+    def __init__(
+        self,
+        *,
+        result: ProviderDeliveryResult,
+        cancellation: asyncio.CancelledError,
+    ) -> None:
+        super().__init__("Provider result completed during worker cancellation")
+        self.result = result
+        self.cancellation = cancellation
+
+
+@dataclass(frozen=True)
+class DeliveryRunOutcome:
+    outcome: Literal[
+        "idle",
+        "sent",
+        "retry",
+        "dead",
+        "canceled",
+        "lease_lost",
+    ]
+    delivery_id: str | None = None
+    attempts: int | None = None
+    next_attempt_at: datetime | None = None
+    recovered_retry_count: int = 0
+    recovered_dead_count: int = 0
+
+
+class CommunicationDeliveryWorker:
+    """One dormant provider-worker iteration with durable per-recipient leases.
+
+    The caller owns scheduling and provider lifecycle. This module deliberately
+    has no runtime imports, feature switches, or producer-side integration.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: Callable[[], AsyncSession],
+        provider: CommunicationDeliveryProvider,
+        worker_id: str,
+        lease_seconds: int = 90,
+        recovery_limit: int = 100,
+    ) -> None:
+        self._session_factory = session_factory
+        self._provider = provider
+        self._worker_id = CommunicationDeliveryService._normalize_worker_id(worker_id)
+        self._channel = CommunicationDeliveryService._normalize_channel(provider.channel)
+        self._lease_seconds = CommunicationDeliveryService._normalize_lease_seconds(
+            lease_seconds
+        )
+        self._recovery_limit = max(
+            1,
+            min(CommunicationDeliveryService.MAX_RECOVERY_LIMIT, int(recovery_limit)),
+        )
+
+    async def run_once(self) -> DeliveryRunOutcome:
+        recovery = await self._recover_expired_leases()
+        claim = await self._claim_and_commit()
+        if claim is None:
+            return DeliveryRunOutcome(
+                outcome="idle",
+                recovered_retry_count=recovery.retry_count,
+                recovered_dead_count=recovery.dead_count,
+            )
+
+        if not await self._recipient_is_current(claim):
+            try:
+                await self._finish_terminal_despite_cancellation(
+                    self._cancel_inactive_recipient(claim),
+                    delivery_id=claim.delivery_id,
+                )
+            except CommunicationDeliveryLeaseLost:
+                return self._lease_lost_outcome(claim, recovery)
+            return DeliveryRunOutcome(
+                outcome="canceled",
+                delivery_id=claim.delivery_id,
+                attempts=claim.attempts,
+                recovered_retry_count=recovery.retry_count,
+                recovered_dead_count=recovery.dead_count,
+            )
+
+        try:
+            rendered_text = self._render(claim)
+        except Exception as exc:
+            logger.warning(
+                "Communication delivery render failed delivery_id=%s error_type=%s",
+                claim.delivery_id,
+                type(exc).__name__,
+            )
+            result = ProviderDeliveryResult.permanent_failure(
+                category="template",
+                code="template_render_failed",
+                message="Communication template could not be rendered",
+            )
+            return await self._finish_terminal_despite_cancellation(
+                self._record_failure(claim, result, recovery),
+                delivery_id=claim.delivery_id,
+            )
+
+        try:
+            await self._renew_before_send(claim)
+        except CommunicationDeliveryLeaseLost:
+            # Rendering and recipient resolution are deliberately outside the
+            # claim transaction. Re-fence immediately before any network I/O.
+            return self._lease_lost_outcome(claim, recovery)
+
+        cancellation_after_finalize: asyncio.CancelledError | None = None
+        try:
+            result = await self._send_with_heartbeat(claim, rendered_text)
+        except _ProviderResultDuringCancellation as exc:
+            result = exc.result
+            cancellation_after_finalize = exc.cancellation
+        except CommunicationDeliveryLeaseLost:
+            return self._lease_lost_outcome(claim, recovery)
+        except asyncio.CancelledError:
+            # The durable running row is intentionally left for lease recovery.
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Communication provider call failed delivery_id=%s error_type=%s",
+                claim.delivery_id,
+                type(exc).__name__,
+            )
+            result = ProviderDeliveryResult.transient_failure(
+                category="provider",
+                code="provider_call_failed",
+                message="Communication provider failed unexpectedly",
+            )
+
+        if result.disposition == ProviderDeliveryDisposition.SENT:
+            if not result.provider_message_id:
+                result = ProviderDeliveryResult.permanent_failure(
+                    category="provider",
+                    code="provider_result_invalid",
+                    message="Communication provider returned an invalid success result",
+                )
+            else:
+                try:
+                    await self._finish_terminal_despite_cancellation(
+                        self._mark_sent(claim, result.provider_message_id),
+                        delivery_id=claim.delivery_id,
+                    )
+                except CommunicationDeliveryLeaseLost:
+                    if cancellation_after_finalize is not None:
+                        raise cancellation_after_finalize
+                    return self._lease_lost_outcome(claim, recovery)
+                outcome = DeliveryRunOutcome(
+                    outcome="sent",
+                    delivery_id=claim.delivery_id,
+                    attempts=claim.attempts,
+                    recovered_retry_count=recovery.retry_count,
+                    recovered_dead_count=recovery.dead_count,
+                )
+                if cancellation_after_finalize is not None:
+                    raise cancellation_after_finalize
+                return outcome
+
+        outcome = await self._finish_terminal_despite_cancellation(
+            self._record_failure(claim, result, recovery),
+            delivery_id=claim.delivery_id,
+        )
+        if cancellation_after_finalize is not None:
+            raise cancellation_after_finalize
+        return outcome
+
+    async def _recover_expired_leases(self) -> ExpiredLeaseRecoveryResult:
+        async with self._session_factory() as session:
+            recovery = await CommunicationDeliveryService.recover_expired_leases(
+                session,
+                channel=self._channel,
+                limit=self._recovery_limit,
+            )
+            await session.commit()
+            return recovery
+
+    async def _claim_and_commit(self) -> ClaimedCommunicationDelivery | None:
+        async with self._session_factory() as session:
+            claim = await CommunicationDeliveryService.claim_next(
+                session,
+                worker_id=self._worker_id,
+                channel=self._channel,
+                lease_seconds=self._lease_seconds,
+            )
+            # This commit is deliberately before recipient lookup, rendering,
+            # and every network operation. An uncommitted claim is never sent.
+            await session.commit()
+            return claim
+
+    async def _recipient_is_current(self, claim: ClaimedCommunicationDelivery) -> bool:
+        async with self._session_factory() as session:
+            recipients = await ManagementRecipientDirectory.list_telegram(session)
+        return any(
+            recipient.recipient_key == claim.recipient_key
+            and recipient.destination == claim.destination
+            and recipient.channel == claim.channel
+            for recipient in recipients
+        )
+
+    async def _cancel_inactive_recipient(self, claim: ClaimedCommunicationDelivery) -> None:
+        async with self._session_factory() as session:
+            await CommunicationDeliveryService.cancel_owned(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id=self._worker_id,
+                lease_token=claim.lease_token,
+            )
+            await session.commit()
+
+    @staticmethod
+    def _render(claim: ClaimedCommunicationDelivery) -> str:
+        plan = CommunicationTemplatePlanV1(
+            channel=claim.channel,
+            audience="management",
+            template_key=claim.template_key,
+            template_version=claim.template_version,
+            render_context=claim.render_context_dict(),
+        )
+        return WebsiteTemplateRegistry.render(plan)
+
+    async def _send_with_heartbeat(
+        self,
+        claim: ClaimedCommunicationDelivery,
+        rendered_text: str,
+    ) -> ProviderDeliveryResult:
+        stop_heartbeat = asyncio.Event()
+        provider_task = asyncio.create_task(
+            self._provider.send(
+                destination=claim.destination,
+                text=rendered_text,
+                delivery_id=claim.delivery_id,
+            )
+        )
+        heartbeat_task = asyncio.create_task(
+            self._heartbeat(claim, stop_heartbeat)
+        )
+        try:
+            done, _ = await asyncio.wait(
+                {provider_task, heartbeat_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if provider_task.done():
+                # A known provider result wins this local race. Heartbeat
+                # errors are advisory now; the subsequent terminal transition
+                # still has to pass the database lease fence.
+                try:
+                    result = await provider_task
+                finally:
+                    stop_heartbeat.set()
+                    if heartbeat_task.done():
+                        if heartbeat_task.cancelled():
+                            logger.warning(
+                                "Communication heartbeat canceled after provider result "
+                                "delivery_id=%s",
+                                claim.delivery_id,
+                            )
+                        else:
+                            heartbeat_error = heartbeat_task.exception()
+                            if heartbeat_error is not None:
+                                logger.warning(
+                                    "Communication heartbeat failed after provider result "
+                                    "delivery_id=%s error_type=%s",
+                                    claim.delivery_id,
+                                    type(heartbeat_error).__name__,
+                                )
+                    else:
+                        try:
+                            await heartbeat_task
+                        except Exception as exc:
+                            logger.warning(
+                                "Communication heartbeat failed after provider result "
+                                "delivery_id=%s error_type=%s",
+                                claim.delivery_id,
+                                type(exc).__name__,
+                            )
+                return result
+
+            if heartbeat_task in done:
+                heartbeat_error = heartbeat_task.exception()
+                if heartbeat_error is not None:
+                    provider_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await provider_task
+                    raise heartbeat_error
+                provider_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await provider_task
+                raise RuntimeError("Communication delivery heartbeat stopped early")
+
+            raise RuntimeError("Communication delivery tasks stopped unexpectedly")
+        except asyncio.CancelledError as cancellation:
+            if provider_task.done() and not provider_task.cancelled():
+                # A managed shutdown raced with a provider response that is
+                # already known locally. Preserve it and let the database
+                # terminal fence decide whether it may be recorded.
+                stop_heartbeat.set()
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+                logger.info(
+                    "Communication cancellation deferred for known provider result "
+                    "delivery_id=%s",
+                    claim.delivery_id,
+                )
+                try:
+                    completed_result = provider_task.result()
+                except Exception as exc:
+                    logger.warning(
+                        "Communication provider raised during worker cancellation "
+                        "delivery_id=%s error_type=%s",
+                        claim.delivery_id,
+                        type(exc).__name__,
+                    )
+                    completed_result = ProviderDeliveryResult.transient_failure(
+                        category="provider",
+                        code="provider_call_failed",
+                        message="Communication provider failed unexpectedly",
+                    )
+                raise _ProviderResultDuringCancellation(
+                    result=completed_result,
+                    cancellation=cancellation,
+                ) from cancellation
+            provider_task.cancel()
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await provider_task
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
+            raise
+        finally:
+            stop_heartbeat.set()
+            if not heartbeat_task.done():
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+
+    async def _renew_before_send(self, claim: ClaimedCommunicationDelivery) -> None:
+        async with self._session_factory() as session:
+            await CommunicationDeliveryService.renew_lease(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id=self._worker_id,
+                lease_token=claim.lease_token,
+                lease_seconds=self._lease_seconds,
+            )
+            await session.commit()
+
+    @staticmethod
+    async def _finish_terminal_despite_cancellation(
+        operation: Coroutine[Any, Any, _TerminalResult],
+        *,
+        delivery_id: str,
+    ) -> _TerminalResult:
+        terminal_task = asyncio.create_task(operation)
+        first_cancellation: asyncio.CancelledError | None = None
+        while not terminal_task.done():
+            try:
+                await asyncio.shield(terminal_task)
+            except asyncio.CancelledError as cancellation:
+                if first_cancellation is None:
+                    first_cancellation = cancellation
+
+        try:
+            result = terminal_task.result()
+        except BaseException as terminal_error:
+            if first_cancellation is None:
+                raise
+            logger.error(
+                "Communication terminal finalize failed during cancellation "
+                "delivery_id=%s error_type=%s",
+                delivery_id,
+                type(terminal_error).__name__,
+            )
+            raise first_cancellation from terminal_error
+
+        if first_cancellation is not None:
+            raise first_cancellation
+        return result
+
+    async def _heartbeat(
+        self,
+        claim: ClaimedCommunicationDelivery,
+        stop: asyncio.Event,
+    ) -> None:
+        interval_seconds = max(1, min(15, self._lease_seconds // 3))
+        while True:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=interval_seconds)
+                return
+            except TimeoutError:
+                pass
+
+            async with self._session_factory() as session:
+                await CommunicationDeliveryService.renew_lease(
+                    session,
+                    delivery_id=claim.delivery_id,
+                    worker_id=self._worker_id,
+                    lease_token=claim.lease_token,
+                    lease_seconds=self._lease_seconds,
+                )
+                await session.commit()
+
+    async def _mark_sent(
+        self,
+        claim: ClaimedCommunicationDelivery,
+        provider_message_id: str,
+    ) -> None:
+        async with self._session_factory() as session:
+            await CommunicationDeliveryService.mark_sent(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id=self._worker_id,
+                lease_token=claim.lease_token,
+                provider_message_id=provider_message_id,
+            )
+            await session.commit()
+
+    async def _record_failure(
+        self,
+        claim: ClaimedCommunicationDelivery,
+        result: ProviderDeliveryResult,
+        recovery: ExpiredLeaseRecoveryResult,
+    ) -> DeliveryRunOutcome:
+        try:
+            async with self._session_factory() as session:
+                failure = await CommunicationDeliveryService.mark_failed(
+                    session,
+                    delivery_id=claim.delivery_id,
+                    worker_id=self._worker_id,
+                    lease_token=claim.lease_token,
+                    result=result,
+                )
+                await session.commit()
+        except CommunicationDeliveryLeaseLost:
+            return self._lease_lost_outcome(claim, recovery)
+        return self._failure_outcome(claim, failure, recovery)
+
+    @staticmethod
+    def _failure_outcome(
+        claim: ClaimedCommunicationDelivery,
+        failure: DeliveryFailureOutcome,
+        recovery: ExpiredLeaseRecoveryResult,
+    ) -> DeliveryRunOutcome:
+        return DeliveryRunOutcome(
+            outcome=failure.status,
+            delivery_id=claim.delivery_id,
+            attempts=failure.attempts,
+            next_attempt_at=failure.next_attempt_at,
+            recovered_retry_count=recovery.retry_count,
+            recovered_dead_count=recovery.dead_count,
+        )
+
+    @staticmethod
+    def _lease_lost_outcome(
+        claim: ClaimedCommunicationDelivery,
+        recovery: ExpiredLeaseRecoveryResult,
+    ) -> DeliveryRunOutcome:
+        return DeliveryRunOutcome(
+            outcome="lease_lost",
+            delivery_id=claim.delivery_id,
+            attempts=claim.attempts,
+            recovered_retry_count=recovery.retry_count,
+            recovered_dead_count=recovery.dead_count,
+        )

--- a/services/communications/providers/__init__.py
+++ b/services/communications/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Network provider contracts for durable communication deliveries."""
+
+from services.communications.providers.base import (
+    CommunicationDeliveryProvider,
+    ProviderDeliveryDisposition,
+    ProviderDeliveryResult,
+)
+from services.communications.providers.telegram import TelegramDeliveryProvider
+
+__all__ = [
+    "CommunicationDeliveryProvider",
+    "ProviderDeliveryDisposition",
+    "ProviderDeliveryResult",
+    "TelegramDeliveryProvider",
+]

--- a/services/communications/providers/base.py
+++ b/services/communications/providers/base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+
+class ProviderDeliveryDisposition(str, Enum):
+    SENT = "sent"
+    TRANSIENT_FAILURE = "transient_failure"
+    PERMANENT_FAILURE = "permanent_failure"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+
+
+@dataclass(frozen=True)
+class ProviderDeliveryResult:
+    disposition: ProviderDeliveryDisposition
+    provider_message_id: str | None = None
+    error_category: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    retry_after_seconds: int | None = None
+
+    @classmethod
+    def sent(cls, provider_message_id: int | str) -> "ProviderDeliveryResult":
+        normalized_message_id = str(provider_message_id or "").strip()
+        if not normalized_message_id:
+            raise ValueError("Provider message ID is required for a sent delivery")
+        return cls(
+            disposition=ProviderDeliveryDisposition.SENT,
+            provider_message_id=normalized_message_id,
+        )
+
+    @classmethod
+    def transient_failure(
+        cls,
+        *,
+        category: str,
+        code: str,
+        message: str,
+        retry_after_seconds: int | None = None,
+    ) -> "ProviderDeliveryResult":
+        return cls(
+            disposition=ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            error_category=category,
+            error_code=code,
+            error_message=message,
+            retry_after_seconds=retry_after_seconds,
+        )
+
+    @classmethod
+    def permanent_failure(
+        cls,
+        *,
+        category: str,
+        code: str,
+        message: str,
+    ) -> "ProviderDeliveryResult":
+        return cls(
+            disposition=ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            error_category=category,
+            error_code=code,
+            error_message=message,
+        )
+
+    @classmethod
+    def provider_unavailable(
+        cls,
+        *,
+        code: str,
+        message: str,
+        retry_after_seconds: int | None = None,
+    ) -> "ProviderDeliveryResult":
+        return cls(
+            disposition=ProviderDeliveryDisposition.PROVIDER_UNAVAILABLE,
+            error_category="provider",
+            error_code=code,
+            error_message=message,
+            retry_after_seconds=retry_after_seconds,
+        )
+
+
+class CommunicationDeliveryProvider(Protocol):
+    channel: str
+
+    async def send(
+        self,
+        *,
+        destination: str,
+        text: str,
+        delivery_id: str,
+    ) -> ProviderDeliveryResult: ...
+
+    async def close(self) -> None: ...

--- a/services/communications/providers/telegram.py
+++ b/services/communications/providers/telegram.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiogram import Bot
+from aiogram.exceptions import (
+    TelegramAPIError,
+    TelegramBadRequest,
+    TelegramConflictError,
+    TelegramEntityTooLarge,
+    TelegramForbiddenError,
+    TelegramMigrateToChat,
+    TelegramNetworkError,
+    TelegramNotFound,
+    TelegramRetryAfter,
+    TelegramServerError,
+    TelegramUnauthorizedError,
+)
+
+from services.communications.providers.base import ProviderDeliveryResult
+
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramDeliveryProvider:
+    """A reusable Telegram adapter with stable, secret-safe error outcomes."""
+
+    channel = "telegram"
+    MAX_MESSAGE_LENGTH = 4096
+
+    def __init__(self, *, token: str, request_timeout_seconds: float = 15.0) -> None:
+        normalized_token = str(token or "").strip()
+        if not normalized_token or normalized_token == "0:disabled-bot-token":
+            raise ValueError("Telegram provider token is required")
+        normalized_timeout = float(request_timeout_seconds)
+        if not 1.0 <= normalized_timeout <= 60.0:
+            raise ValueError("Telegram provider timeout must be between 1 and 60 seconds")
+        self._bot = Bot(token=normalized_token)
+        self._request_timeout_seconds = normalized_timeout
+
+    async def close(self) -> None:
+        await self._bot.session.close()
+
+    async def send(
+        self,
+        *,
+        destination: str,
+        text: str,
+        delivery_id: str,
+    ) -> ProviderDeliveryResult:
+        normalized_delivery_id = str(delivery_id or "").strip()
+        if not normalized_delivery_id:
+            raise ValueError("Communication delivery ID is required")
+        normalized_text = text if isinstance(text, str) else ""
+        if not normalized_text or len(normalized_text) > self.MAX_MESSAGE_LENGTH:
+            return ProviderDeliveryResult.permanent_failure(
+                category="payload",
+                code="telegram_text_invalid",
+                message="Rendered Telegram text is empty or exceeds the provider limit",
+            )
+        try:
+            normalized_destination = int(str(destination).strip())
+        except (TypeError, ValueError):
+            return ProviderDeliveryResult.permanent_failure(
+                category="recipient",
+                code="telegram_destination_invalid",
+                message="Telegram destination is invalid",
+            )
+        if normalized_destination == 0:
+            return ProviderDeliveryResult.permanent_failure(
+                category="recipient",
+                code="telegram_destination_invalid",
+                message="Telegram destination is invalid",
+            )
+
+        try:
+            async with asyncio.timeout(self._request_timeout_seconds):
+                message = await self._bot.send_message(
+                    chat_id=normalized_destination,
+                    text=normalized_text,
+                    parse_mode="HTML",
+                )
+            return ProviderDeliveryResult.sent(message.message_id)
+        except TelegramRetryAfter as exc:
+            return ProviderDeliveryResult.transient_failure(
+                category="rate_limit",
+                code="telegram_retry_after",
+                message="Telegram rate limit requires a delayed retry",
+                retry_after_seconds=max(1, int(exc.retry_after)),
+            )
+        except TelegramEntityTooLarge:
+            return ProviderDeliveryResult.permanent_failure(
+                category="payload",
+                code="telegram_entity_too_large",
+                message="Telegram rejected an oversized entity",
+            )
+        except (TelegramForbiddenError, TelegramNotFound):
+            return ProviderDeliveryResult.permanent_failure(
+                category="recipient",
+                code="telegram_recipient_unavailable",
+                message="Telegram recipient is unavailable",
+            )
+        except TelegramMigrateToChat:
+            return ProviderDeliveryResult.permanent_failure(
+                category="recipient",
+                code="telegram_chat_migrated",
+                message="Telegram destination migrated and requires manual reconciliation",
+            )
+        except TelegramBadRequest:
+            return ProviderDeliveryResult.permanent_failure(
+                category="payload",
+                code="telegram_bad_request",
+                message="Telegram rejected the delivery request",
+            )
+        except (TelegramUnauthorizedError, TelegramConflictError):
+            return ProviderDeliveryResult.provider_unavailable(
+                code="telegram_provider_auth_or_conflict",
+                message="Telegram provider authentication or ownership is unavailable",
+                retry_after_seconds=300,
+            )
+        except (TelegramNetworkError, TelegramServerError, TimeoutError):
+            return ProviderDeliveryResult.transient_failure(
+                category="network",
+                code="telegram_network_error",
+                message="Telegram network request failed",
+            )
+        except TelegramAPIError:
+            return ProviderDeliveryResult.transient_failure(
+                category="provider",
+                code="telegram_api_error",
+                message="Telegram API returned an unexpected error",
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Exception strings from HTTP clients can include a bot-token URL.
+            logger.warning(
+                "Telegram delivery provider failed delivery_id=%s error_type=%s",
+                normalized_delivery_id,
+                type(exc).__name__,
+            )
+            return ProviderDeliveryResult.transient_failure(
+                category="provider",
+                code="telegram_unexpected_error",
+                message="Telegram provider failed unexpectedly",
+            )

--- a/tests/integration/test_communication_delivery_concurrency.py
+++ b/tests/integration/test_communication_delivery_concurrency.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models import CommunicationDelivery
+from services.communications.delivery_service import (
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryService,
+)
+from services.communications.providers.base import ProviderDeliveryResult
+
+
+@pytest.fixture
+async def communication_db_engine():
+    database_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    assert database_url and "test" in database_url.lower()
+    schema_name = f"communication_c1_{uuid.uuid4().hex}"
+    admin_engine = create_async_engine(database_url)
+    async with admin_engine.begin() as connection:
+        await connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+    engine = create_async_engine(
+        database_url,
+        connect_args={"server_settings": {"search_path": schema_name}},
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(CommunicationDelivery.__table__.create)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+        async with admin_engine.begin() as connection:
+            await connection.execute(text(f'DROP SCHEMA "{schema_name}" CASCADE'))
+        await admin_engine.dispose()
+
+
+async def _seed_deliveries(
+    communication_db_engine,
+    count: int,
+    *,
+    expired: bool = False,
+) -> None:
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    now = datetime.now(timezone.utc)
+    async with factory() as session:
+        for sequence in range(1, count + 1):
+            running_values = (
+                {
+                    "status": "running",
+                    "attempts": 1,
+                    "worker_id": f"expired-worker-{sequence}",
+                    "lease_token": f"expired-token-{sequence}".ljust(40, "x"),
+                    "lease_expires_at": now - timedelta(seconds=count - sequence + 1),
+                }
+                if expired
+                else {
+                    "status": "queued",
+                    "attempts": 0,
+                    "worker_id": None,
+                    "lease_token": None,
+                    "lease_expires_at": None,
+                }
+            )
+            session.add(
+                CommunicationDelivery(
+                    delivery_id=f"{sequence:032x}",
+                    event_id=f"{sequence + 1000:032x}",
+                    channel="telegram",
+                    recipient_key=f"staff:{sequence}",
+                    destination=str(100000 + sequence),
+                    template_key="telegram.website_contact_lead_created",
+                    template_version=1,
+                    render_context={"lead_id": sequence},
+                    priority=100,
+                    max_attempts=3,
+                    available_at=now - timedelta(seconds=1),
+                    created_at=now + timedelta(microseconds=sequence),
+                    updated_at=now,
+                    **running_values,
+                )
+            )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_postgres_claim_skips_locked_row_and_claims_distinct_delivery(
+    communication_db_engine,
+):
+    assert communication_db_engine.dialect.name == "postgresql"
+    await _seed_deliveries(communication_db_engine, 2)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with factory() as session_a, factory() as session_b:
+        claim_a = await CommunicationDeliveryService.claim_next(
+            session_a,
+            worker_id="worker-a",
+            lease_seconds=60,
+        )
+        assert claim_a is not None
+
+        claim_b = await asyncio.wait_for(
+            CommunicationDeliveryService.claim_next(
+                session_b,
+                worker_id="worker-b",
+                lease_seconds=60,
+            ),
+            timeout=3,
+        )
+        assert claim_b is not None
+        assert claim_b.delivery_id != claim_a.delivery_id
+        assert claim_b.lease_token != claim_a.lease_token
+        await session_b.commit()
+        await session_a.commit()
+
+    async with factory() as verification:
+        rows = [
+            await verification.get(CommunicationDelivery, f"{sequence:032x}")
+            for sequence in (1, 2)
+        ]
+        assert all(row is not None and row.status == "running" for row in rows)
+        assert [row.attempts for row in rows if row is not None] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_postgres_locked_single_claim_rolls_back_without_consuming_attempt(
+    communication_db_engine,
+):
+    assert communication_db_engine.dialect.name == "postgresql"
+    await _seed_deliveries(communication_db_engine, 1)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with factory() as session_a, factory() as session_b:
+        claim_a = await CommunicationDeliveryService.claim_next(
+            session_a,
+            worker_id="worker-a",
+            lease_seconds=60,
+        )
+        assert claim_a is not None
+        claim_while_locked = await asyncio.wait_for(
+            CommunicationDeliveryService.claim_next(
+                session_b,
+                worker_id="worker-b",
+                lease_seconds=60,
+            ),
+            timeout=3,
+        )
+        assert claim_while_locked is None
+        await session_b.rollback()
+        await session_a.rollback()
+
+        claim_after_rollback = await CommunicationDeliveryService.claim_next(
+            session_b,
+            worker_id="worker-b",
+            lease_seconds=60,
+        )
+        assert claim_after_rollback is not None
+        assert claim_after_rollback.delivery_id == claim_a.delivery_id
+        assert claim_after_rollback.attempts == 1
+        assert claim_after_rollback.lease_token != claim_a.lease_token
+        await session_b.commit()
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_recovery_skips_locked_expired_delivery(
+    communication_db_engine,
+):
+    assert communication_db_engine.dialect.name == "postgresql"
+    await _seed_deliveries(communication_db_engine, 2, expired=True)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with factory() as session_a, factory() as session_b:
+        recovery_a = await CommunicationDeliveryService.recover_expired_leases(
+            session_a,
+            limit=1,
+        )
+        recovery_b = await asyncio.wait_for(
+            CommunicationDeliveryService.recover_expired_leases(
+                session_b,
+                limit=1,
+            ),
+            timeout=3,
+        )
+        assert recovery_a.retry_count == 1
+        assert recovery_b.retry_count == 1
+        await session_b.commit()
+        await session_a.commit()
+
+    async with factory() as verification:
+        rows = [
+            await verification.get(CommunicationDelivery, f"{sequence:032x}")
+            for sequence in (1, 2)
+        ]
+        assert all(row is not None and row.status == "retry" for row in rows)
+        assert [row.attempts for row in rows if row is not None] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_postgres_recovery_rotates_token_and_fences_stale_attempt(
+    communication_db_engine,
+):
+    assert communication_db_engine.dialect.name == "postgresql"
+    await _seed_deliveries(communication_db_engine, 1, expired=True)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    stale_worker = "expired-worker-1"
+    stale_token = "expired-token-1".ljust(40, "x")
+
+    async with factory() as session:
+        recovery = await CommunicationDeliveryService.recover_expired_leases(session)
+        assert recovery.retry_count == 1
+        await session.commit()
+        recovered = await session.get(CommunicationDelivery, f"{1:032x}")
+        assert recovered is not None
+        retry_at = recovered.available_at
+
+    async with factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id=stale_worker,
+            lease_seconds=60,
+            now=retry_at,
+        )
+        assert claim is not None
+        assert claim.lease_token != stale_token
+        assert claim.attempts == 2
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(CommunicationDeliveryLeaseLost):
+            await CommunicationDeliveryService.mark_sent(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id=stale_worker,
+                lease_token=stale_token,
+                provider_message_id="stale-message",
+                now=retry_at + timedelta(seconds=1),
+            )
+        await session.rollback()
+
+    async with factory() as session:
+        await CommunicationDeliveryService.mark_sent(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id=stale_worker,
+            lease_token=claim.lease_token,
+            provider_message_id="current-message",
+            now=retry_at + timedelta(seconds=1),
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_terminal_transitions_have_single_winner(
+    communication_db_engine,
+):
+    assert communication_db_engine.dialect.name == "postgresql"
+    await _seed_deliveries(communication_db_engine, 1)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="terminal-worker",
+            lease_seconds=60,
+        )
+        assert claim is not None
+        await session.commit()
+
+    barrier = asyncio.Barrier(2)
+
+    async def mark_sent():
+        async with factory() as session:
+            await barrier.wait()
+            try:
+                await CommunicationDeliveryService.mark_sent(
+                    session,
+                    delivery_id=claim.delivery_id,
+                    worker_id="terminal-worker",
+                    lease_token=claim.lease_token,
+                    provider_message_id="winner-message",
+                )
+                await session.commit()
+                return "sent"
+            except Exception:
+                await session.rollback()
+                raise
+
+    async def mark_dead():
+        async with factory() as session:
+            await barrier.wait()
+            try:
+                await CommunicationDeliveryService.mark_failed(
+                    session,
+                    delivery_id=claim.delivery_id,
+                    worker_id="terminal-worker",
+                    lease_token=claim.lease_token,
+                    result=ProviderDeliveryResult.permanent_failure(
+                        category="recipient",
+                        code="gone",
+                        message="Recipient is gone",
+                    ),
+                )
+                await session.commit()
+                return "dead"
+            except Exception:
+                await session.rollback()
+                raise
+
+    results = await asyncio.wait_for(
+        asyncio.gather(mark_sent(), mark_dead(), return_exceptions=True),
+        timeout=5,
+    )
+    winners = [result for result in results if isinstance(result, str)]
+    losers = [result for result in results if isinstance(result, BaseException)]
+    assert len(winners) == 1
+    assert len(losers) == 1
+    assert isinstance(losers[0], CommunicationDeliveryLeaseLost)
+
+    async with factory() as verification:
+        row = await verification.get(CommunicationDelivery, claim.delivery_id)
+        assert row is not None
+        assert row.status in {"sent", "dead"}
+        assert row.worker_id is None
+        assert row.lease_token is None
+        assert row.lease_expires_at is None

--- a/tests/integration/test_communication_delivery_concurrency.py
+++ b/tests/integration/test_communication_delivery_concurrency.py
@@ -21,7 +21,9 @@ from services.communications.providers.base import ProviderDeliveryResult
 @pytest.fixture
 async def communication_db_engine():
     database_url = os.environ.get("TEST_DATABASE_URL") or os.environ.get("DATABASE_URL")
-    assert database_url and "test" in database_url.lower()
+    environment = os.environ.get("ENVIRONMENT", "").strip().lower()
+    assert database_url
+    assert "test" in database_url.lower() or environment == "test"
     schema_name = f"communication_c1_{uuid.uuid4().hex}"
     admin_engine = create_async_engine(database_url)
     async with admin_engine.begin() as connection:

--- a/tests/unit/test_communication_delivery_lease_migration.py
+++ b/tests/unit/test_communication_delivery_lease_migration.py
@@ -1,0 +1,208 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+
+FOUNDATION_PATH = Path(
+    "alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py"
+)
+LEASE_REVISION = "4a8b1c2d3e05"
+LEASE_PATH = Path(
+    "alembic/versions/4a8b1c2d3e05_harden_communication_delivery_leases.py"
+)
+
+
+def _load_migration(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _insert_delivery(
+    connection,
+    sequence: int,
+    *,
+    status: str,
+    attempts: int,
+    max_attempts: int = 3,
+    provider_message_id: str | None = None,
+    terminal: bool = False,
+) -> None:
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    stored_now = now.isoformat()
+    connection.execute(
+        text(
+            """
+            INSERT INTO communication_delivery (
+                delivery_id, event_id, channel, recipient_key, destination,
+                template_key, template_version, render_context, status,
+                priority, attempts, max_attempts, available_at,
+                provider_message_id, sent_at, finished_at, created_at, updated_at
+            ) VALUES (
+                :delivery_id, :event_id, 'telegram', :recipient_key, :destination,
+                'telegram.website_contact_lead_created', 1, '{}', :status,
+                100, :attempts, :max_attempts, :available_at,
+                :provider_message_id, :sent_at, :finished_at, :created_at, :updated_at
+            )
+            """
+        ),
+        {
+            "delivery_id": f"{sequence:032x}",
+            "event_id": f"{sequence + 1000:032x}",
+            "recipient_key": f"staff:{sequence}",
+            "destination": str(100000 + sequence),
+            "status": status,
+            "attempts": attempts,
+            "max_attempts": max_attempts,
+            "available_at": stored_now,
+            "provider_message_id": provider_message_id,
+            "sent_at": stored_now if terminal else None,
+            "finished_at": stored_now if terminal else None,
+            "created_at": stored_now,
+            "updated_at": stored_now,
+        },
+    )
+
+
+def test_delivery_lease_hardening_is_the_single_alembic_head():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(LEASE_REVISION)
+
+    assert script.get_heads() == [LEASE_REVISION]
+    assert revision is not None
+    assert revision.down_revision == "3f7a9c1d2e04"
+
+
+def test_delivery_lease_migration_replays_and_downgrades_on_sqlite():
+    foundation = _load_migration("communication_foundation_for_lease", FOUNDATION_PATH)
+    lease = _load_migration("communication_delivery_lease_migration", LEASE_PATH)
+    engine = create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        foundation.op = operations
+        lease.op = operations
+        foundation.upgrade()
+        # Foundation-compatible queued rows must survive the additive C1
+        # hardening migration unchanged.
+        _insert_delivery(connection, 1, status="queued", attempts=0)
+        lease.upgrade()
+
+        inspector = inspect(connection)
+        assert connection.execute(
+            text(
+                "SELECT status, attempts FROM communication_delivery "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": f"{1:032x}"},
+        ).one() == ("queued", 0)
+
+        _insert_delivery(connection, 2, status="retry", attempts=1)
+        _insert_delivery(
+            connection,
+            3,
+            status="sent",
+            attempts=1,
+            provider_message_id="provider-message-3",
+            terminal=True,
+        )
+        with pytest.raises(IntegrityError):
+            with connection.begin_nested():
+                _insert_delivery(
+                    connection,
+                    4,
+                    status="retry",
+                    attempts=3,
+                    max_attempts=3,
+                )
+        with pytest.raises(IntegrityError):
+            with connection.begin_nested():
+                _insert_delivery(
+                    connection,
+                    5,
+                    status="sent",
+                    attempts=1,
+                    provider_message_id=None,
+                    terminal=True,
+                )
+        with pytest.raises(IntegrityError):
+            with connection.begin_nested():
+                _insert_delivery(
+                    connection,
+                    6,
+                    status="retry",
+                    attempts=1,
+                    provider_message_id="not-allowed-before-sent",
+                )
+
+        constraint_names = {
+            item["name"]
+            for item in inspector.get_check_constraints("communication_delivery")
+        }
+        assert {
+            "ck_delivery_active_attempts_remaining",
+            "ck_delivery_attempt_phase",
+            "ck_delivery_attempts_within_max",
+            "ck_delivery_lease_state",
+            "ck_delivery_provider_message_state",
+            "ck_delivery_terminal_timestamps",
+        }.issubset(constraint_names)
+        assert any(
+            item["name"] == "ix_communication_delivery_channel_claim"
+            and item["column_names"]
+            == ["channel", "priority", "available_at", "created_at", "delivery_id"]
+            for item in inspector.get_indexes("communication_delivery")
+        )
+        assert any(
+            item["name"] == "ix_communication_delivery_channel_recovery"
+            and item["column_names"]
+            == ["channel", "lease_expires_at", "created_at", "delivery_id"]
+            for item in inspector.get_indexes("communication_delivery")
+        )
+
+        lease.downgrade()
+        downgraded = inspect(connection)
+        assert not {
+            "ck_delivery_active_attempts_remaining",
+            "ck_delivery_attempt_phase",
+            "ck_delivery_attempts_within_max",
+            "ck_delivery_lease_state",
+            "ck_delivery_provider_message_state",
+            "ck_delivery_terminal_timestamps",
+        }.intersection(
+            item["name"]
+            for item in downgraded.get_check_constraints("communication_delivery")
+        )
+        assert not any(
+            item["name"]
+            in {
+                "ix_communication_delivery_channel_claim",
+                "ix_communication_delivery_channel_recovery",
+            }
+            for item in downgraded.get_indexes("communication_delivery")
+        )
+        assert "communication_delivery" in downgraded.get_table_names()
+        assert any(
+            item["name"] == "ck_delivery_status_valid"
+            for item in downgraded.get_check_constraints("communication_delivery")
+        )
+        assert any(
+            item["name"] == "ix_communication_delivery_claim"
+            for item in downgraded.get_indexes("communication_delivery")
+        )
+        assert connection.execute(
+            text("SELECT count(*) FROM communication_delivery")
+        ).scalar_one() == 3
+
+        foundation.downgrade()
+        assert "communication_delivery" not in inspect(connection).get_table_names()

--- a/tests/unit/test_communication_delivery_service.py
+++ b/tests/unit/test_communication_delivery_service.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import CommunicationDelivery
+from services.communications.delivery_service import (
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryService,
+)
+from services.communications.providers.base import ProviderDeliveryResult
+
+
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def delivery_session_factory(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'delivery.sqlite3'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(CommunicationDelivery.__table__.create)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _delivery(
+    sequence: int,
+    *,
+    status: str = "queued",
+    channel: str = "telegram",
+    priority: int = 100,
+    attempts: int = 0,
+    max_attempts: int = 3,
+    available_at: datetime = NOW,
+    lease_expires_at: datetime | None = None,
+    worker_id: str | None = None,
+    lease_token: str | None = None,
+    provider_message_id: str | None = None,
+) -> CommunicationDelivery:
+    return CommunicationDelivery(
+        delivery_id=f"{sequence:032x}",
+        event_id=f"{sequence + 1000:032x}",
+        channel=channel,
+        recipient_key=f"staff:{sequence}",
+        destination=str(100000 + sequence),
+        template_key="telegram.website_contact_lead_created",
+        template_version=1,
+        render_context={
+            "lead_id": sequence,
+            "customer": {"phone": "+375291112233"},
+            "items": [{"name": "private item"}],
+        },
+        status=status,
+        priority=priority,
+        attempts=attempts,
+        max_attempts=max_attempts,
+        available_at=available_at,
+        worker_id=worker_id,
+        lease_token=lease_token,
+        lease_expires_at=lease_expires_at,
+        provider_message_id=provider_message_id,
+        created_at=NOW + timedelta(microseconds=sequence),
+        updated_at=NOW,
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_next_is_due_channel_scoped_ordered_and_caller_owned(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add_all(
+            [
+                _delivery(1, priority=20),
+                _delivery(2, priority=10),
+                _delivery(3, priority=1, available_at=NOW + timedelta(minutes=1)),
+                _delivery(4, channel="email", priority=1),
+            ]
+        )
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="delivery-worker-a",
+            now=NOW,
+            lease_seconds=60,
+        )
+        assert claim is not None
+        assert claim.delivery_id == f"{2:032x}"
+        assert claim.attempts == 1
+        assert claim.lease_expires_at == NOW + timedelta(seconds=60)
+        assert len(claim.lease_token) >= 32
+
+        independent = await session.get(CommunicationDelivery, claim.delivery_id)
+        assert independent is not None
+        assert independent.status == "running"
+        await session.rollback()
+
+    async with delivery_session_factory() as session:
+        rolled_back = await session.get(CommunicationDelivery, f"{2:032x}")
+        assert rolled_back is not None
+        assert rolled_back.status == "queued"
+        assert rolled_back.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_claim_snapshot_is_frozen_and_redacts_lease_token(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add(_delivery(1))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        assert claim.lease_token not in repr(claim)
+        assert "render_context" not in repr(claim)
+        assert claim.destination not in repr(claim)
+        assert "+375291112233" not in repr(claim)
+        legacy_shaped_key = "legacy-telegram:-100123456"
+        legacy_claim = replace(claim, recipient_key=legacy_shaped_key)
+        assert legacy_shaped_key not in repr(legacy_claim)
+        with pytest.raises(FrozenInstanceError):
+            claim.attempts = 99  # type: ignore[misc]
+        with pytest.raises(TypeError):
+            claim.render_context["lead_id"] = 99  # type: ignore[index]
+        with pytest.raises(TypeError):
+            claim.render_context["customer"]["phone"] = "changed"  # type: ignore[index]
+        with pytest.raises(TypeError):
+            claim.render_context["items"][0]["name"] = "changed"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_expired_running_is_recovered_before_it_can_be_claimed(
+    delivery_session_factory,
+):
+    expired_token = "x" * 43
+    async with delivery_session_factory() as session:
+        session.add(
+            _delivery(
+                1,
+                status="running",
+                attempts=1,
+                worker_id="old-worker",
+                lease_token=expired_token,
+                lease_expires_at=NOW - timedelta(seconds=1),
+            )
+        )
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="new-worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is None
+        recovery = await CommunicationDeliveryService.recover_expired_leases(
+            session,
+            now=NOW,
+        )
+        await session.commit()
+        assert recovery.retry_count == 1
+        assert recovery.dead_count == 0
+
+    async with delivery_session_factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="new-worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is None
+        recovered = await session.get(CommunicationDelivery, f"{1:032x}")
+        assert recovered is not None
+        assert recovered.status == "retry"
+        assert recovered.attempts == 1
+        assert recovered.available_at > NOW.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_renew_and_terminal_transitions_require_exact_unexpired_lease(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add(_delivery(1))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker-a",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        with pytest.raises(CommunicationDeliveryLeaseLost):
+            await CommunicationDeliveryService.renew_lease(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id="worker-b",
+                lease_token=claim.lease_token,
+                lease_seconds=60,
+                now=NOW + timedelta(seconds=1),
+            )
+        await session.rollback()
+
+    async with delivery_session_factory() as session:
+        renewed_until = await CommunicationDeliveryService.renew_lease(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker-a",
+            lease_token=claim.lease_token,
+            lease_seconds=90,
+            now=NOW + timedelta(seconds=1),
+        )
+        assert renewed_until == NOW + timedelta(seconds=91)
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        await CommunicationDeliveryService.mark_sent(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker-a",
+            lease_token=claim.lease_token,
+            provider_message_id="telegram-message-42",
+            now=NOW + timedelta(seconds=2),
+        )
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        sent = await session.get(CommunicationDelivery, claim.delivery_id)
+        assert sent is not None
+        assert sent.status == "sent"
+        assert sent.provider_message_id == "telegram-message-42"
+        assert sent.worker_id is None
+        assert sent.lease_token is None
+        assert sent.lease_expires_at is None
+        assert sent.sent_at == NOW.replace(tzinfo=None) + timedelta(seconds=2)
+        assert sent.finished_at == sent.sent_at
+        with pytest.raises(CommunicationDeliveryLeaseLost):
+            await CommunicationDeliveryService.cancel_owned(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id="worker-a",
+                lease_token=claim.lease_token,
+                now=NOW + timedelta(seconds=3),
+            )
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower_bound(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add(_delivery(1))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    result = ProviderDeliveryResult.transient_failure(
+        category="rate_limit\nsecret",
+        code="retry\tafter",
+        message="Safe\nmessage",
+        retry_after_seconds=900,
+    )
+    async with delivery_session_factory() as session:
+        outcome = await CommunicationDeliveryService.mark_failed(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker",
+            lease_token=claim.lease_token,
+            result=result,
+            now=NOW + timedelta(seconds=1),
+        )
+        await session.commit()
+        assert outcome.status == "retry"
+        assert outcome.next_attempt_at == NOW + timedelta(seconds=901)
+
+    async with delivery_session_factory() as session:
+        row = await session.get(CommunicationDelivery, claim.delivery_id)
+        assert row is not None
+        assert row.status == "retry"
+        assert row.attempts == 1
+        assert row.finished_at is None
+        assert row.last_error_category == "rate_limit secret"
+        assert row.last_error_code == "retry after"
+        assert row.last_error_message == "Safe message"
+        assert row.worker_id is None
+
+    delay = CommunicationDeliveryService.retry_delay_seconds(
+        delivery_id=claim.delivery_id,
+        attempts=1,
+    )
+    assert 30 <= delay <= 36
+    assert delay == CommunicationDeliveryService.retry_delay_seconds(
+        delivery_id=claim.delivery_id,
+        attempts=1,
+    )
+    assert (
+        CommunicationDeliveryService.retry_delay_seconds(
+            delivery_id=claim.delivery_id,
+            attempts=30,
+        )
+        == 3600
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permanent", [True, False])
+async def test_permanent_or_exhausted_failure_is_dead(
+    delivery_session_factory,
+    permanent,
+):
+    max_attempts = 3
+    starting_attempts = 0 if permanent else max_attempts - 1
+    async with delivery_session_factory() as session:
+        session.add(
+                _delivery(
+                    1,
+                    status="queued" if permanent else "retry",
+                    attempts=starting_attempts,
+                    max_attempts=max_attempts,
+                )
+        )
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    result = (
+        ProviderDeliveryResult.permanent_failure(
+            category="recipient",
+            code="gone",
+            message="Recipient is gone",
+        )
+        if permanent
+        else ProviderDeliveryResult.transient_failure(
+            category="network",
+            code="timeout",
+            message="Timed out",
+        )
+    )
+    async with delivery_session_factory() as session:
+        outcome = await CommunicationDeliveryService.mark_failed(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker",
+            lease_token=claim.lease_token,
+            result=result,
+            now=NOW + timedelta(seconds=1),
+        )
+        await session.commit()
+        assert outcome.status == "dead"
+        assert outcome.next_attempt_at is None
+
+        row = await session.get(CommunicationDelivery, claim.delivery_id)
+        assert row is not None
+        assert row.finished_at is not None
+        assert row.worker_id is None
+        assert row.lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_limited_ordered_and_separates_retry_from_dead(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add_all(
+            [
+                _delivery(
+                    1,
+                    status="running",
+                    attempts=1,
+                    worker_id="old-a",
+                    lease_token="a" * 43,
+                    lease_expires_at=NOW - timedelta(seconds=3),
+                ),
+                _delivery(
+                    2,
+                    status="running",
+                    attempts=3,
+                    max_attempts=3,
+                    worker_id="old-b",
+                    lease_token="b" * 43,
+                    lease_expires_at=NOW - timedelta(seconds=2),
+                ),
+                _delivery(
+                    3,
+                    status="running",
+                    attempts=1,
+                    worker_id="old-c",
+                    lease_token="c" * 43,
+                    lease_expires_at=NOW - timedelta(seconds=1),
+                ),
+                _delivery(
+                    4,
+                    status="running",
+                    attempts=1,
+                    worker_id="active",
+                    lease_token="d" * 43,
+                    lease_expires_at=NOW + timedelta(seconds=1),
+                ),
+            ]
+        )
+        await session.commit()
+
+    async with delivery_session_factory() as session:
+        outcome = await CommunicationDeliveryService.recover_expired_leases(
+            session,
+            now=NOW,
+            limit=2,
+        )
+        await session.commit()
+        assert outcome.retry_count == 1
+        assert outcome.dead_count == 1
+
+    async with delivery_session_factory() as session:
+        rows = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery).order_by(
+                        CommunicationDelivery.delivery_id
+                    )
+                )
+            ).scalars()
+        )
+        assert [row.status for row in rows] == ["retry", "dead", "running", "running"]
+        assert [row.attempts for row in rows] == [1, 3, 1, 1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_row",
+    [
+        _delivery(101, status="retry", attempts=3, max_attempts=3),
+        _delivery(102, attempts=1, max_attempts=3),
+        _delivery(103, status="sent", attempts=1, max_attempts=3),
+        _delivery(
+            104,
+            status="retry",
+            attempts=1,
+            max_attempts=3,
+            provider_message_id="not-allowed-before-sent",
+        ),
+    ],
+)
+async def test_delivery_schema_rejects_nonterminal_or_provider_state_drift(
+    delivery_session_factory,
+    invalid_row,
+):
+    if invalid_row.status == "sent":
+        invalid_row.sent_at = NOW
+        invalid_row.finished_at = NOW
+        invalid_row.provider_message_id = None
+
+    async with delivery_session_factory() as session:
+        session.add(invalid_row)
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()

--- a/tests/unit/test_communication_delivery_worker.py
+++ b/tests/unit/test_communication_delivery_worker.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+
+from core.config import settings
+from models import CommunicationDelivery, StaffUser
+from services.communications.contracts import PublicContactLeadCreatedPayloadV1
+from services.communications.delivery_service import (
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryService,
+)
+from services.communications.delivery_worker import CommunicationDeliveryWorker
+from services.communications.providers.base import ProviderDeliveryResult
+from services.communications.template_registry import CONTACT_LEAD_TEMPLATE_KEY
+
+
+@pytest.fixture
+async def worker_session_factory(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'worker.sqlite3'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_delivery(
+    session_factory,
+    *,
+    sequence: int,
+    telegram_id: int,
+    status: str = "active",
+    priority: int = 100,
+    max_attempts: int = 3,
+) -> tuple[int, str]:
+    now = datetime.now(timezone.utc)
+    async with session_factory() as session:
+        owner = StaffUser(
+            display_name=f"Owner {sequence}",
+            status=status,
+            roles=["owner"],
+            primary_role="owner",
+            telegram_id=telegram_id,
+        )
+        session.add(owner)
+        await session.flush()
+        assert owner.id is not None
+        delivery_id = f"{sequence:032x}"
+        session.add(
+            CommunicationDelivery(
+                delivery_id=delivery_id,
+                event_id=f"{sequence + 1000:032x}",
+                channel="telegram",
+                recipient_key=f"staff:{owner.id}",
+                destination=str(telegram_id),
+                template_key=CONTACT_LEAD_TEMPLATE_KEY,
+                template_version=1,
+                render_context=PublicContactLeadCreatedPayloadV1(
+                    lead_id=sequence,
+                    status="new",
+                    name=f"Lead {sequence}",
+                    phone="+375291112233",
+                    message="Нужна консультация",
+                ).model_dump(mode="json"),
+                status="queued",
+                priority=priority,
+                attempts=0,
+                max_attempts=max_attempts,
+                available_at=now - timedelta(seconds=1),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.commit()
+        return owner.id, delivery_id
+
+
+class RecordingProvider:
+    channel = "telegram"
+
+    def __init__(self, session_factory, outcomes):
+        self._session_factory = session_factory
+        self._outcomes = outcomes
+        self.calls: list[tuple[str, str, str]] = []
+        self.claim_was_durable = False
+
+    async def send(self, *, destination: str, text: str, delivery_id: str):
+        async with self._session_factory() as session:
+            row = await session.get(CommunicationDelivery, delivery_id)
+            self.claim_was_durable = bool(
+                row
+                and row.status == "running"
+                and row.worker_id
+                and row.lease_token
+                and row.lease_expires_at
+            )
+        self.calls.append((destination, text, delivery_id))
+        outcome = self._outcomes[destination]
+        return outcome() if callable(outcome) else outcome
+
+    async def close(self):
+        return None
+
+
+class HeartbeatObservingProvider:
+    channel = "telegram"
+
+    def __init__(self, session_factory):
+        self._session_factory = session_factory
+        self.lease_was_extended = False
+
+    async def send(self, *, destination: str, text: str, delivery_id: str):
+        async with self._session_factory() as session:
+            before = await session.get(CommunicationDelivery, delivery_id)
+            assert before is not None
+            initial_expiry = before.lease_expires_at
+        await asyncio.sleep(1.2)
+        async with self._session_factory() as session:
+            after = await session.get(CommunicationDelivery, delivery_id)
+            assert after is not None
+            self.lease_was_extended = bool(
+                initial_expiry
+                and after.lease_expires_at
+                and after.lease_expires_at > initial_expiry
+            )
+        return ProviderDeliveryResult.sent("heartbeat-message")
+
+    async def close(self):
+        return None
+
+
+class ImmediateProvider:
+    channel = "telegram"
+
+    def __init__(self):
+        self.calls = 0
+
+    async def send(self, *, destination: str, text: str, delivery_id: str):
+        self.calls += 1
+        return ProviderDeliveryResult.sent("immediate-message")
+
+    async def close(self):
+        return None
+
+
+class CancellationRaceProvider:
+    channel = "telegram"
+
+    def __init__(self):
+        self.completed = asyncio.Event()
+
+    async def send(self, *, destination: str, text: str, delivery_id: str):
+        self.completed.set()
+        return ProviderDeliveryResult.sent("cancellation-race-message")
+
+    async def close(self):
+        return None
+
+
+class ImmediateFailureProvider:
+    channel = "telegram"
+
+    async def send(self, *, destination: str, text: str, delivery_id: str):
+        return ProviderDeliveryResult.transient_failure(
+            category="network",
+            code="timeout",
+            message="Telegram request timed out",
+        )
+
+    async def close(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_worker_commits_claim_before_provider_and_marks_sent(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=1,
+        telegram_id=101001,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"101001": ProviderDeliveryResult.sent("message-1")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="test-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "sent"
+    assert outcome.delivery_id == delivery_id
+    assert provider.claim_was_durable is True
+    assert len(provider.calls) == 1
+    assert "Lead 1" in provider.calls[0][1]
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "sent"
+        assert row.attempts == 1
+        assert row.provider_message_id == "message-1"
+        assert row.worker_id is None
+        assert row.lease_token is None
+
+
+@pytest.mark.asyncio
+async def test_worker_renews_lease_while_provider_call_is_in_flight(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    monkeypatch.setattr(CommunicationDeliveryService, "MIN_LEASE_SECONDS", 1)
+    await _seed_delivery(
+        worker_session_factory,
+        sequence=10,
+        telegram_id=101010,
+    )
+    provider = HeartbeatObservingProvider(worker_session_factory)
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="heartbeat-worker",
+        lease_seconds=3,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "sent"
+    assert provider.lease_was_extended is True
+
+
+@pytest.mark.asyncio
+async def test_worker_refences_expired_lease_before_network_call(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    await _seed_delivery(
+        worker_session_factory,
+        sequence=11,
+        telegram_id=111011,
+    )
+    provider = ImmediateProvider()
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="preflight-worker",
+        lease_seconds=60,
+    )
+    original_recipient_check = worker._recipient_is_current
+
+    async def expire_after_recipient_check(claim):
+        is_current = await original_recipient_check(claim)
+        async with worker_session_factory() as session:
+            row = await session.get(CommunicationDelivery, claim.delivery_id)
+            assert row is not None
+            row.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            session.add(row)
+            await session.commit()
+        return is_current
+
+    monkeypatch.setattr(worker, "_recipient_is_current", expire_after_recipient_check)
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "lease_lost"
+    assert provider.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_known_provider_result_wins_simultaneous_heartbeat_failure(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=12,
+        telegram_id=121012,
+    )
+    provider = ImmediateProvider()
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="simultaneous-worker",
+        lease_seconds=60,
+    )
+
+    async def fail_heartbeat_immediately(_claim, _stop):
+        raise CommunicationDeliveryLeaseLost("simulated simultaneous lease signal")
+
+    monkeypatch.setattr(worker, "_heartbeat", fail_heartbeat_immediately)
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "sent"
+    assert provider.calls == 1
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "sent"
+        assert row.provider_message_id == "immediate-message"
+
+
+@pytest.mark.asyncio
+async def test_managed_cancellation_preserves_known_provider_result(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=13,
+        telegram_id=131013,
+    )
+    provider = CancellationRaceProvider()
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="cancellation-worker",
+        lease_seconds=60,
+    )
+
+    run_task = asyncio.create_task(worker.run_once())
+    await provider.completed.wait()
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "sent"
+        assert row.provider_message_id == "cancellation-race-message"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_inside_sent_finalizer_commits_then_propagates(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=14,
+        telegram_id=141014,
+    )
+    provider = ImmediateProvider()
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="sent-finalizer-worker",
+        lease_seconds=60,
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_mark_sent = worker._mark_sent
+
+    async def blocked_mark_sent(claim, provider_message_id):
+        entered.set()
+        await release.wait()
+        await original_mark_sent(claim, provider_message_id)
+
+    monkeypatch.setattr(worker, "_mark_sent", blocked_mark_sent)
+    run_task = asyncio.create_task(worker.run_once())
+    await entered.wait()
+    run_task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "sent"
+        assert row.provider_message_id == "immediate-message"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_inside_failure_finalizer_commits_then_propagates(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=15,
+        telegram_id=151015,
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=ImmediateFailureProvider(),
+        worker_id="failure-finalizer-worker",
+        lease_seconds=60,
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_record_failure = worker._record_failure
+
+    async def blocked_record_failure(claim, result, recovery):
+        entered.set()
+        await release.wait()
+        return await original_record_failure(claim, result, recovery)
+
+    monkeypatch.setattr(worker, "_record_failure", blocked_record_failure)
+    run_task = asyncio.create_task(worker.run_once())
+    await entered.wait()
+    run_task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "retry"
+        assert row.last_error_code == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_worker_revalidates_recipient_and_cancels_without_network(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    owner_id, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=2,
+        telegram_id=202002,
+    )
+    async with worker_session_factory() as session:
+        owner = await session.get(StaffUser, owner_id)
+        assert owner is not None
+        owner.status = "blocked"
+        session.add(owner)
+        await session.commit()
+
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"202002": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="test-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "canceled"
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "canceled"
+        assert row.last_error_code == "recipient_inactive"
+        assert row.finished_at is not None
+
+
+@pytest.mark.asyncio
+async def test_worker_keeps_recipient_failures_independent(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, retry_delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=3,
+        telegram_id=303003,
+        priority=1,
+    )
+    _, sent_delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=4,
+        telegram_id=404004,
+        priority=2,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {
+            "303003": ProviderDeliveryResult.transient_failure(
+                category="network",
+                code="timeout",
+                message="Telegram request timed out",
+            ),
+            "404004": ProviderDeliveryResult.sent("message-4"),
+        },
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="test-worker",
+        lease_seconds=60,
+    )
+
+    first = await worker.run_once()
+    second = await worker.run_once()
+
+    assert first.outcome == "retry"
+    assert first.delivery_id == retry_delivery_id
+    assert second.outcome == "sent"
+    assert second.delivery_id == sent_delivery_id
+    async with worker_session_factory() as session:
+        rows = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery).order_by(
+                        CommunicationDelivery.delivery_id
+                    )
+                )
+            ).scalars()
+        )
+        assert [row.status for row in rows] == ["retry", "sent"]
+        assert [row.attempts for row in rows] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_worker_converts_render_error_to_permanent_dead_letter(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=5,
+        telegram_id=505005,
+    )
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        row.template_key = "telegram.unsupported_template"
+        session.add(row)
+        await session.commit()
+
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"505005": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        provider=provider,
+        worker_id="test-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "dead"
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "dead"
+        assert row.last_error_category == "template"
+        assert row.last_error_message == "Communication template could not be rendered"

--- a/tests/unit/test_model_schema_metadata.py
+++ b/tests/unit/test_model_schema_metadata.py
@@ -152,6 +152,22 @@ def test_communication_foundation_metadata_has_durable_uniqueness_and_claim_inde
         for index in delivery.indexes
     )
     assert any(
+        index.name == "ix_communication_delivery_channel_claim"
+        and [column.name for column in index.columns]
+        == ["channel", "priority", "available_at", "created_at", "delivery_id"]
+        and str(index.dialect_options["postgresql"]["where"])
+        == "status IN ('queued', 'retry')"
+        for index in delivery.indexes
+    )
+    assert any(
+        index.name == "ix_communication_delivery_channel_recovery"
+        and [column.name for column in index.columns]
+        == ["channel", "lease_expires_at", "created_at", "delivery_id"]
+        and str(index.dialect_options["postgresql"]["where"])
+        == "status = 'running'"
+        for index in delivery.indexes
+    )
+    assert any(
         isinstance(constraint, CheckConstraint)
         and constraint.name == "ck_outbox_status_valid"
         for constraint in outbox.constraints
@@ -161,3 +177,16 @@ def test_communication_foundation_metadata_has_durable_uniqueness_and_claim_inde
         and constraint.name == "ck_delivery_status_valid"
         for constraint in delivery.constraints
     )
+    for constraint_name in (
+        "ck_delivery_active_attempts_remaining",
+        "ck_delivery_attempt_phase",
+        "ck_delivery_attempts_within_max",
+        "ck_delivery_lease_state",
+        "ck_delivery_provider_message_state",
+        "ck_delivery_terminal_timestamps",
+    ):
+        assert any(
+            isinstance(constraint, CheckConstraint)
+            and constraint.name == constraint_name
+            for constraint in delivery.constraints
+        )

--- a/tests/unit/test_telegram_delivery_provider.py
+++ b/tests/unit/test_telegram_delivery_provider.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from aiogram.exceptions import (
+    TelegramAPIError,
+    TelegramBadRequest,
+    TelegramConflictError,
+    TelegramEntityTooLarge,
+    TelegramForbiddenError,
+    TelegramMigrateToChat,
+    TelegramNetworkError,
+    TelegramNotFound,
+    TelegramRetryAfter,
+    TelegramServerError,
+    TelegramUnauthorizedError,
+)
+from aiogram.methods import SendMessage
+
+from services.communications.providers.base import ProviderDeliveryDisposition
+from services.communications.providers.telegram import TelegramDeliveryProvider
+
+
+class FakeBot:
+    outcome = None
+    calls = []
+
+    def __init__(self, *, token: str):
+        self.token = token
+        self.session = SimpleNamespace(close=self._close)
+
+    async def _close(self):
+        return None
+
+    async def send_message(self, **kwargs):
+        type(self).calls.append(kwargs)
+        if isinstance(type(self).outcome, BaseException):
+            raise type(self).outcome
+        return type(self).outcome
+
+
+@pytest.fixture(autouse=True)
+def fake_bot(monkeypatch):
+    FakeBot.outcome = SimpleNamespace(message_id=42)
+    FakeBot.calls = []
+    monkeypatch.setattr(
+        "services.communications.providers.telegram.Bot",
+        FakeBot,
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_sends_html_and_returns_provider_message_id():
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    result = await provider.send(
+        destination="-100123",
+        text="<b>Новая заявка</b>",
+        delivery_id="1" * 32,
+    )
+
+    assert result.disposition == ProviderDeliveryDisposition.SENT
+    assert result.provider_message_id == "42"
+    assert FakeBot.calls == [
+        {
+            "chat_id": -100123,
+            "text": "<b>Новая заявка</b>",
+            "parse_mode": "HTML",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_preserves_retry_after():
+    method = SendMessage(chat_id=101, text="test")
+    FakeBot.outcome = TelegramRetryAfter(
+        method=method,
+        message="Flood control",
+        retry_after=9876,
+    )
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    result = await provider.send(
+        destination="101",
+        text="test",
+        delivery_id="2" * 32,
+    )
+
+    assert result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
+    assert result.error_code == "telegram_retry_after"
+    assert result.retry_after_seconds == 9876
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception_type", "expected_disposition", "expected_code"),
+    [
+        (
+            TelegramForbiddenError,
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            "telegram_recipient_unavailable",
+        ),
+        (
+            TelegramUnauthorizedError,
+            ProviderDeliveryDisposition.PROVIDER_UNAVAILABLE,
+            "telegram_provider_auth_or_conflict",
+        ),
+    ],
+)
+async def test_telegram_provider_classifies_recipient_and_provider_failures(
+    exception_type,
+    expected_disposition,
+    expected_code,
+):
+    method = SendMessage(chat_id=101, text="test")
+    FakeBot.outcome = exception_type(method=method, message="provider detail")
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    result = await provider.send(
+        destination="101",
+        text="test",
+        delivery_id="3" * 32,
+    )
+
+    assert result.disposition == expected_disposition
+    assert result.error_code == expected_code
+    assert "provider detail" not in (result.error_message or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception_factory", "expected_disposition", "expected_code"),
+    [
+        (
+            lambda method: TelegramEntityTooLarge(method=method, message="too large"),
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            "telegram_entity_too_large",
+        ),
+        (
+            lambda method: TelegramNotFound(method=method, message="not found"),
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            "telegram_recipient_unavailable",
+        ),
+        (
+            lambda method: TelegramMigrateToChat(
+                method=method,
+                message="migrated",
+                migrate_to_chat_id=-100987,
+            ),
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            "telegram_chat_migrated",
+        ),
+        (
+            lambda method: TelegramBadRequest(method=method, message="bad request"),
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            "telegram_bad_request",
+        ),
+        (
+            lambda method: TelegramConflictError(method=method, message="conflict"),
+            ProviderDeliveryDisposition.PROVIDER_UNAVAILABLE,
+            "telegram_provider_auth_or_conflict",
+        ),
+        (
+            lambda method: TelegramNetworkError(method=method, message="network"),
+            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            "telegram_network_error",
+        ),
+        (
+            lambda method: TelegramServerError(method=method, message="server"),
+            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            "telegram_network_error",
+        ),
+        (
+            lambda _method: TimeoutError("timeout"),
+            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            "telegram_network_error",
+        ),
+        (
+            lambda method: TelegramAPIError(method=method, message="generic API"),
+            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            "telegram_api_error",
+        ),
+    ],
+)
+async def test_telegram_provider_classifies_all_provider_error_families(
+    exception_factory,
+    expected_disposition,
+    expected_code,
+):
+    method = SendMessage(chat_id=101, text="test")
+    FakeBot.outcome = exception_factory(method)
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    result = await provider.send(
+        destination="101",
+        text="test",
+        delivery_id="7" * 32,
+    )
+
+    assert result.disposition == expected_disposition
+    assert result.error_code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_propagates_explicit_cancellation():
+    FakeBot.outcome = asyncio.CancelledError()
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.send(
+            destination="101",
+            text="test",
+            delivery_id="8" * 32,
+        )
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_rejects_invalid_payload_without_network():
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    invalid_destination = await provider.send(
+        destination="not-a-chat",
+        text="test",
+        delivery_id="4" * 32,
+    )
+    oversized = await provider.send(
+        destination="101",
+        text="x" * 4097,
+        delivery_id="5" * 32,
+    )
+
+    assert invalid_destination.disposition == ProviderDeliveryDisposition.PERMANENT_FAILURE
+    assert invalid_destination.error_code == "telegram_destination_invalid"
+    assert oversized.disposition == ProviderDeliveryDisposition.PERMANENT_FAILURE
+    assert oversized.error_code == "telegram_text_invalid"
+    assert FakeBot.calls == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_provider_does_not_expose_unknown_exception_message(caplog):
+    FakeBot.outcome = RuntimeError(
+        "request failed at https://api.telegram.org/bot123456:secret-token/sendMessage"
+    )
+    provider = TelegramDeliveryProvider(token="123456:secret-token")
+
+    result = await provider.send(
+        destination="101",
+        text="test",
+        delivery_id="6" * 32,
+    )
+
+    assert result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
+    assert result.error_message == "Telegram provider failed unexpectedly"
+    assert "secret-token" not in caplog.text


### PR DESCRIPTION
## Summary
- add a dormant per-recipient communications delivery worker with leased claims, heartbeats, retry/dead-letter handling, and Telegram provider classification
- harden delivery invariants and PostgreSQL claim/recovery indexes through an additive migration
- preserve the current production notification path: no runtime registration, producer switch, or automatic delivery is enabled in this PR

## Safety and validation
- 84 related unit and integration tests passed
- 5 PostgreSQL concurrency tests passed against an isolated database
- fresh upgrade, downgrade, re-upgrade, and alembic check passed
- full unit suite: 1230 passed; one unrelated macOS wall-clock timing assertion exceeded two seconds, while the same scenario passed in Linux in 0.55 seconds
- independent runtime and schema reviews found no blocking issues

## Rollout
This is the dormant C1 foundation only. C2 must transactionally switch producers, add managed runtime controls and observability, run a canary, and prove delivery to both owners before activation.

Delivery remains at-least-once: an ambiguous provider timeout or process crash after provider acceptance but before the terminal database commit can cause a duplicate.