### PR TITLE
Add durable communication delivery attempt journal

### DIFF
--- a/alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py
+++ b/alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py
@@ -87,6 +87,41 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("delivery_id", "attempt_no"),
     )
+    # A rolling deployment may observe a lease claimed by the dormant C1
+    # worker before this migration is applied. Preserve that open attempt so
+    # the C2 terminal/recovery paths can fence and finalize it normally rather
+    # than repeatedly failing on a missing journal row.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO communication_delivery_attempt (
+                delivery_id,
+                attempt_no,
+                started_at,
+                finished_at,
+                outcome,
+                error_category,
+                error_code,
+                retry_after_seconds,
+                provider_latency_ms,
+                ambiguous
+            )
+            SELECT
+                delivery_id,
+                attempts,
+                updated_at,
+                NULL,
+                'running',
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                false
+            FROM communication_delivery
+            WHERE status = 'running'
+            """
+        )
+    )
     op.create_index(
         "ix_delivery_attempt_outcome_started",
         "communication_delivery_attempt",

--- a/alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py
+++ b/alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py
@@ -1,0 +1,125 @@
+"""add communication delivery attempt journal
+
+Revision ID: 5b9c2d3e4f06
+Revises: 4a8b1c2d3e05
+Create Date: 2026-07-13 20:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "5b9c2d3e4f06"
+down_revision: Union[str, Sequence[str], None] = "4a8b1c2d3e05"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "communication_delivery_attempt",
+        sa.Column("delivery_id", sa.String(length=32), nullable=False),
+        sa.Column("attempt_no", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("outcome", sa.String(length=32), nullable=False),
+        sa.Column("error_category", sa.String(length=80), nullable=True),
+        sa.Column("error_code", sa.String(length=100), nullable=True),
+        sa.Column("retry_after_seconds", sa.BigInteger(), nullable=True),
+        sa.Column("provider_latency_ms", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "ambiguous",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "attempt_no > 0",
+            name="ck_delivery_attempt_no_positive",
+        ),
+        sa.CheckConstraint(
+            "outcome IN ('running', 'sent', 'retry', 'dead', 'canceled')",
+            name="ck_delivery_attempt_outcome_valid",
+        ),
+        sa.CheckConstraint(
+            "(outcome = 'running' AND finished_at IS NULL) "
+            "OR (outcome <> 'running' AND finished_at IS NOT NULL)",
+            name="ck_delivery_attempt_finish_state",
+        ),
+        sa.CheckConstraint(
+            "finished_at IS NULL OR finished_at >= started_at",
+            name="ck_delivery_attempt_finished_after_started",
+        ),
+        sa.CheckConstraint(
+            "(outcome IN ('running', 'sent') AND error_category IS NULL "
+            "AND error_code IS NULL) OR "
+            "(outcome IN ('retry', 'dead', 'canceled') "
+            "AND error_category IS NOT NULL AND length(trim(error_category)) > 0 "
+            "AND error_code IS NOT NULL AND length(trim(error_code)) > 0)",
+            name="ck_delivery_attempt_error_state",
+        ),
+        sa.CheckConstraint(
+            "retry_after_seconds IS NULL OR retry_after_seconds > 0",
+            name="ck_delivery_attempt_retry_after_positive",
+        ),
+        sa.CheckConstraint(
+            "retry_after_seconds IS NULL OR outcome IN ('retry', 'dead')",
+            name="ck_delivery_attempt_retry_after_state",
+        ),
+        sa.CheckConstraint(
+            "provider_latency_ms IS NULL OR provider_latency_ms >= 0",
+            name="ck_delivery_attempt_latency_non_negative",
+        ),
+        sa.CheckConstraint(
+            "provider_latency_ms IS NULL OR outcome IN ('sent', 'retry', 'dead')",
+            name="ck_delivery_attempt_latency_state",
+        ),
+        sa.CheckConstraint(
+            "ambiguous = false OR outcome IN ('retry', 'dead')",
+            name="ck_delivery_attempt_ambiguity_state",
+        ),
+        sa.ForeignKeyConstraint(
+            ["delivery_id"],
+            ["communication_delivery.delivery_id"],
+            name="fk_delivery_attempt_delivery_id",
+        ),
+        sa.PrimaryKeyConstraint("delivery_id", "attempt_no"),
+    )
+    op.create_index(
+        "ix_delivery_attempt_outcome_started",
+        "communication_delivery_attempt",
+        ["outcome", "started_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_delivery_attempt_error_finished",
+        "communication_delivery_attempt",
+        ["error_category", "error_code", "finished_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_delivery_attempt_ambiguous_finished",
+        "communication_delivery_attempt",
+        ["finished_at"],
+        unique=False,
+        postgresql_where=sa.text("ambiguous = true"),
+        sqlite_where=sa.text("ambiguous = 1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_delivery_attempt_ambiguous_finished",
+        table_name="communication_delivery_attempt",
+    )
+    op.drop_index(
+        "ix_delivery_attempt_error_finished",
+        table_name="communication_delivery_attempt",
+    )
+    op.drop_index(
+        "ix_delivery_attempt_outcome_started",
+        table_name="communication_delivery_attempt",
+    )
+    op.drop_table("communication_delivery_attempt")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -20,7 +20,7 @@ from .bot_fsm import BotFsmState
 from .cart import Cart, CartItem
 from .catalog_import import CatalogImportJob
 from .content import Article, GlobalConfig
-from .communication import CommunicationDelivery
+from .communication import CommunicationDelivery, CommunicationDeliveryAttempt
 from .integration_event import ConsumerInbox, IntegrationOutboxEvent
 from .media import MediaAsset, MediaProcessingJob
 from .staff import StaffUser
@@ -84,6 +84,7 @@ __all__ = [
     "BotFsmState",
     "CatalogImportJob",
     "CommunicationDelivery",
+    "CommunicationDeliveryAttempt",
     "ConsumerInbox",
     "Customer",
     "CustomerBranch",

--- a/models/communication.py
+++ b/models/communication.py
@@ -4,9 +4,12 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from sqlalchemy import (
+    BigInteger,
+    Boolean,
     CheckConstraint,
     Column,
     DateTime,
+    ForeignKey,
     Index,
     String,
     UniqueConstraint,
@@ -150,4 +153,112 @@ class CommunicationDelivery(SQLModel, table=True):
     updated_at: datetime = Field(
         default_factory=utc_now,
         sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class CommunicationDeliveryAttempt(SQLModel, table=True):
+    """PII-free lifecycle journal for one provider delivery attempt."""
+
+    __tablename__ = "communication_delivery_attempt"
+    __table_args__ = (
+        CheckConstraint("attempt_no > 0", name="ck_delivery_attempt_no_positive"),
+        CheckConstraint(
+            "outcome IN ('running', 'sent', 'retry', 'dead', 'canceled')",
+            name="ck_delivery_attempt_outcome_valid",
+        ),
+        CheckConstraint(
+            "(outcome = 'running' AND finished_at IS NULL) "
+            "OR (outcome <> 'running' AND finished_at IS NOT NULL)",
+            name="ck_delivery_attempt_finish_state",
+        ),
+        CheckConstraint(
+            "finished_at IS NULL OR finished_at >= started_at",
+            name="ck_delivery_attempt_finished_after_started",
+        ),
+        CheckConstraint(
+            "(outcome IN ('running', 'sent') AND error_category IS NULL "
+            "AND error_code IS NULL) OR "
+            "(outcome IN ('retry', 'dead', 'canceled') "
+            "AND error_category IS NOT NULL AND length(trim(error_category)) > 0 "
+            "AND error_code IS NOT NULL AND length(trim(error_code)) > 0)",
+            name="ck_delivery_attempt_error_state",
+        ),
+        CheckConstraint(
+            "retry_after_seconds IS NULL OR retry_after_seconds > 0",
+            name="ck_delivery_attempt_retry_after_positive",
+        ),
+        CheckConstraint(
+            "retry_after_seconds IS NULL OR outcome IN ('retry', 'dead')",
+            name="ck_delivery_attempt_retry_after_state",
+        ),
+        CheckConstraint(
+            "provider_latency_ms IS NULL OR provider_latency_ms >= 0",
+            name="ck_delivery_attempt_latency_non_negative",
+        ),
+        CheckConstraint(
+            "provider_latency_ms IS NULL OR outcome IN ('sent', 'retry', 'dead')",
+            name="ck_delivery_attempt_latency_state",
+        ),
+        CheckConstraint(
+            "ambiguous = false OR outcome IN ('retry', 'dead')",
+            name="ck_delivery_attempt_ambiguity_state",
+        ),
+        Index(
+            "ix_delivery_attempt_outcome_started",
+            "outcome",
+            "started_at",
+        ),
+        Index(
+            "ix_delivery_attempt_error_finished",
+            "error_category",
+            "error_code",
+            "finished_at",
+        ),
+        Index(
+            "ix_delivery_attempt_ambiguous_finished",
+            "finished_at",
+            postgresql_where=text("ambiguous = true"),
+            sqlite_where=text("ambiguous = 1"),
+        ),
+    )
+
+    delivery_id: str = Field(
+        sa_column=Column(
+            String(32),
+            ForeignKey("communication_delivery.delivery_id"),
+            primary_key=True,
+        ),
+    )
+    attempt_no: int = Field(primary_key=True)
+    started_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    finished_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    outcome: str = Field(sa_column=Column(String(32), nullable=False))
+    error_category: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(80), nullable=True),
+    )
+    error_code: Optional[str] = Field(
+        default=None,
+        sa_column=Column(String(100), nullable=True),
+    )
+    retry_after_seconds: Optional[int] = Field(
+        default=None,
+        sa_column=Column(BigInteger, nullable=True),
+    )
+    provider_latency_ms: Optional[int] = Field(
+        default=None,
+        sa_column=Column(BigInteger, nullable=True),
+    )
+    ambiguous: bool = Field(
+        default=False,
+        sa_column=Column(
+            Boolean,
+            nullable=False,
+            server_default=text("false"),
+        ),
     )

--- a/services/communications/delivery_attempt_service.py
+++ b/services/communications/delivery_attempt_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +29,28 @@ class CommunicationDeliveryAttemptService:
             "recipient",
             "template",
             "unknown",
+        }
+    )
+    ERROR_CODES = frozenset(
+        {
+            "delivery_failed",
+            "lease_expired",
+            "provider_call_failed",
+            "provider_result_invalid",
+            "recipient_inactive",
+            "telegram_api_error",
+            "telegram_bad_request",
+            "telegram_chat_migrated",
+            "telegram_destination_invalid",
+            "telegram_entity_too_large",
+            "telegram_network_error",
+            "telegram_provider_auth_or_conflict",
+            "telegram_recipient_unavailable",
+            "telegram_retry_after",
+            "telegram_text_invalid",
+            "telegram_unexpected_error",
+            "template_render_failed",
+            "timeout",
         }
     )
     FINAL_OUTCOMES = frozenset({"sent", "retry", "dead", "canceled"})
@@ -155,7 +176,7 @@ class CommunicationDeliveryAttemptService:
         if normalized_category not in cls.ERROR_CATEGORIES:
             normalized_category = "unknown"
         normalized_code = str(code or "").strip().lower()
-        if not re.fullmatch(r"[a-z][a-z0-9_]{0,99}", normalized_code):
+        if normalized_code not in cls.ERROR_CODES:
             normalized_code = "delivery_failed"
         return normalized_category, normalized_code
 

--- a/services/communications/delivery_attempt_service.py
+++ b/services/communications/delivery_attempt_service.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from services.communications.providers.base import (
+    ProviderDeliveryDisposition,
+    ProviderDeliveryResult,
+)
+
+
+class CommunicationDeliveryAttemptStateError(RuntimeError):
+    pass
+
+
+class CommunicationDeliveryAttemptService:
+    """Transaction-neutral persistence for the PII-free attempt journal."""
+
+    ERROR_CATEGORIES = frozenset(
+        {
+            "lease",
+            "network",
+            "payload",
+            "provider",
+            "rate_limit",
+            "recipient",
+            "template",
+            "unknown",
+        }
+    )
+    FINAL_OUTCOMES = frozenset({"sent", "retry", "dead", "canceled"})
+    ERROR_OUTCOMES = frozenset({"retry", "dead", "canceled"})
+
+    @classmethod
+    async def start(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery: CommunicationDelivery,
+        attempt_no: int,
+        started_at: datetime,
+    ) -> None:
+        normalized_attempt_no = int(attempt_no)
+        if normalized_attempt_no != int(delivery.attempts) + 1:
+            raise CommunicationDeliveryAttemptStateError(
+                f"Communication delivery {delivery.delivery_id!r} has an invalid attempt number"
+            )
+        existing = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery.delivery_id, normalized_attempt_no),
+        )
+        if existing is not None:
+            raise CommunicationDeliveryAttemptStateError(
+                f"Communication delivery {delivery.delivery_id!r} attempt "
+                f"{normalized_attempt_no} already exists"
+            )
+        session.add(
+            CommunicationDeliveryAttempt(
+                delivery_id=delivery.delivery_id,
+                attempt_no=normalized_attempt_no,
+                started_at=started_at,
+                outcome="running",
+                ambiguous=False,
+            )
+        )
+
+    @classmethod
+    async def finish(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery: CommunicationDelivery,
+        finished_at: datetime,
+        outcome: str,
+        error_category: str | None = None,
+        error_code: str | None = None,
+        retry_after_seconds: int | None = None,
+        provider_latency_ms: int | None = None,
+        ambiguous: bool = False,
+    ) -> None:
+        attempt_no = int(delivery.attempts)
+        statement = select(CommunicationDeliveryAttempt).where(
+            CommunicationDeliveryAttempt.delivery_id == delivery.delivery_id,
+            CommunicationDeliveryAttempt.attempt_no == attempt_no,
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update()
+        attempt = (await session.execute(statement)).scalar_one_or_none()
+        if (
+            attempt is None
+            or attempt.outcome != "running"
+            or attempt.finished_at is not None
+        ):
+            raise CommunicationDeliveryAttemptStateError(
+                f"Communication delivery {delivery.delivery_id!r} attempt "
+                f"{attempt_no} is missing or already finalized"
+            )
+
+        normalized_outcome = str(outcome or "").strip().lower()
+        if normalized_outcome not in cls.FINAL_OUTCOMES:
+            raise ValueError("Communication delivery attempt outcome is invalid")
+        normalized_latency = cls._normalize_provider_latency_ms(provider_latency_ms)
+        normalized_retry_after = cls._normalize_retry_after_seconds(retry_after_seconds)
+        if normalized_outcome not in {"retry", "dead"}:
+            normalized_retry_after = None
+        if normalized_outcome == "canceled":
+            normalized_latency = None
+
+        if normalized_outcome in cls.ERROR_OUTCOMES:
+            normalized_error_category, normalized_error_code = cls._normalize_error(
+                category=error_category,
+                code=error_code,
+            )
+        else:
+            normalized_error_category = None
+            normalized_error_code = None
+
+        attempt.finished_at = finished_at
+        attempt.outcome = normalized_outcome
+        attempt.error_category = normalized_error_category
+        attempt.error_code = normalized_error_code
+        attempt.retry_after_seconds = normalized_retry_after
+        attempt.provider_latency_ms = normalized_latency
+        attempt.ambiguous = bool(ambiguous)
+        session.add(attempt)
+
+    @staticmethod
+    def is_ambiguous_provider_failure(
+        *,
+        result: ProviderDeliveryResult,
+        category: str,
+        code: str,
+    ) -> bool:
+        normalized_category = str(category or "").strip().lower()
+        normalized_code = str(code or "").strip().lower()
+        if normalized_code == "provider_result_invalid":
+            return True
+        return (
+            result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
+            and normalized_category in {"network", "provider"}
+        )
+
+    @classmethod
+    def _normalize_error(
+        cls,
+        *,
+        category: str | None,
+        code: str | None,
+    ) -> tuple[str, str]:
+        normalized_category = str(category or "").strip().lower()
+        if normalized_category not in cls.ERROR_CATEGORIES:
+            normalized_category = "unknown"
+        normalized_code = str(code or "").strip().lower()
+        if not re.fullmatch(r"[a-z][a-z0-9_]{0,99}", normalized_code):
+            normalized_code = "delivery_failed"
+        return normalized_category, normalized_code
+
+    @staticmethod
+    def _normalize_retry_after_seconds(value: int | None) -> int | None:
+        if value is None:
+            return None
+        return max(1, min(int(value), 9_223_372_036_854_775_807))
+
+    @staticmethod
+    def _normalize_provider_latency_ms(value: int | None) -> int | None:
+        if value is None:
+            return None
+        normalized = int(value)
+        if normalized < 0:
+            raise ValueError("Provider latency cannot be negative")
+        return min(normalized, 9_223_372_036_854_775_807)

--- a/services/communications/delivery_service.py
+++ b/services/communications/delivery_service.py
@@ -13,11 +13,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models import CommunicationDelivery
+from services.communications.delivery_attempt_service import (
+    CommunicationDeliveryAttemptService,
+)
 from services.communications.providers.base import (
     ProviderDeliveryDisposition,
     ProviderDeliveryResult,
 )
-
 
 DELIVERY_STATUS_QUEUED = "queued"
 DELIVERY_STATUS_RUNNING = "running"
@@ -140,8 +142,15 @@ class CommunicationDeliveryService:
 
         lease_token = secrets.token_urlsafe(32)
         lease_expires_at = claimed_at + timedelta(seconds=lease_duration)
+        next_attempt_no = int(delivery.attempts) + 1
+        await CommunicationDeliveryAttemptService.start(
+            session,
+            delivery=delivery,
+            attempt_no=next_attempt_no,
+            started_at=claimed_at,
+        )
         delivery.status = DELIVERY_STATUS_RUNNING
-        delivery.attempts = int(delivery.attempts) + 1
+        delivery.attempts = next_attempt_no
         delivery.worker_id = normalized_worker_id
         delivery.lease_token = lease_token
         delivery.lease_expires_at = lease_expires_at
@@ -203,6 +212,19 @@ class CommunicationDeliveryService:
         retry_count = 0
         dead_count = 0
         for delivery in deliveries:
+            await CommunicationDeliveryAttemptService.finish(
+                session,
+                delivery=delivery,
+                finished_at=recovered_at,
+                outcome=(
+                    DELIVERY_STATUS_DEAD
+                    if int(delivery.attempts) >= int(delivery.max_attempts)
+                    else DELIVERY_STATUS_RETRY
+                ),
+                error_category="lease",
+                error_code="lease_expired",
+                ambiguous=True,
+            )
             delivery.worker_id = None
             delivery.lease_token = None
             delivery.lease_expires_at = None
@@ -270,6 +292,7 @@ class CommunicationDeliveryService:
         worker_id: str,
         lease_token: str,
         provider_message_id: str,
+        provider_latency_ms: int | None = None,
         now: datetime | None = None,
     ) -> None:
         normalized_message_id = str(provider_message_id or "").strip()
@@ -284,6 +307,13 @@ class CommunicationDeliveryService:
             worker_id=worker_id,
             lease_token=lease_token,
             now=now,
+        )
+        await CommunicationDeliveryAttemptService.finish(
+            session,
+            delivery=delivery,
+            finished_at=completed_at,
+            outcome=DELIVERY_STATUS_SENT,
+            provider_latency_ms=provider_latency_ms,
         )
         delivery.status = DELIVERY_STATUS_SENT
         delivery.provider_message_id = normalized_message_id
@@ -308,6 +338,7 @@ class CommunicationDeliveryService:
         worker_id: str,
         lease_token: str,
         result: ProviderDeliveryResult,
+        provider_latency_ms: int | None = None,
         now: datetime | None = None,
     ) -> DeliveryFailureOutcome:
         if result.disposition == ProviderDeliveryDisposition.SENT:
@@ -321,24 +352,13 @@ class CommunicationDeliveryService:
             now=now,
         )
         category, code, message = cls._sanitize_provider_error(result)
-        delivery.last_error_category = category
-        delivery.last_error_code = code
-        delivery.last_error_message = message
-        delivery.provider_message_id = None
-        delivery.sent_at = None
-        delivery.worker_id = None
-        delivery.lease_token = None
-        delivery.lease_expires_at = None
-        delivery.updated_at = failed_at
-
         terminal = (
             result.disposition == ProviderDeliveryDisposition.PERMANENT_FAILURE
             or int(delivery.attempts) >= int(delivery.max_attempts)
         )
         next_attempt_at: datetime | None = None
         if terminal:
-            delivery.status = DELIVERY_STATUS_DEAD
-            delivery.finished_at = failed_at
+            failure_status = DELIVERY_STATUS_DEAD
         else:
             retry_delay = cls.retry_delay_seconds(
                 delivery_id=delivery.delivery_id,
@@ -350,10 +370,37 @@ class CommunicationDeliveryService:
                     max(1, int(result.retry_after_seconds)),
                 )
             next_attempt_at = failed_at + timedelta(seconds=retry_delay)
-            delivery.status = DELIVERY_STATUS_RETRY
-            delivery.available_at = next_attempt_at
-            delivery.finished_at = None
+            failure_status = DELIVERY_STATUS_RETRY
 
+        await CommunicationDeliveryAttemptService.finish(
+            session,
+            delivery=delivery,
+            finished_at=failed_at,
+            outcome=failure_status,
+            error_category=category,
+            error_code=code,
+            retry_after_seconds=result.retry_after_seconds,
+            provider_latency_ms=provider_latency_ms,
+            ambiguous=CommunicationDeliveryAttemptService.is_ambiguous_provider_failure(
+                result=result,
+                category=category,
+                code=code,
+            ),
+        )
+
+        delivery.status = failure_status
+        delivery.last_error_category = category
+        delivery.last_error_code = code
+        delivery.last_error_message = message
+        delivery.provider_message_id = None
+        delivery.sent_at = None
+        delivery.finished_at = failed_at if terminal else None
+        delivery.worker_id = None
+        delivery.lease_token = None
+        delivery.lease_expires_at = None
+        delivery.updated_at = failed_at
+        if next_attempt_at is not None:
+            delivery.available_at = next_attempt_at
         session.add(delivery)
         await session.flush()
         return DeliveryFailureOutcome(
@@ -382,10 +429,28 @@ class CommunicationDeliveryService:
             lease_token=lease_token,
             now=now,
         )
+        normalized_error_category = cls._sanitize_text(
+            error_category,
+            80,
+            "recipient",
+        )
+        normalized_error_code = cls._sanitize_text(
+            error_code,
+            100,
+            "recipient_inactive",
+        )
+        await CommunicationDeliveryAttemptService.finish(
+            session,
+            delivery=delivery,
+            finished_at=canceled_at,
+            outcome=DELIVERY_STATUS_CANCELED,
+            error_category=normalized_error_category,
+            error_code=normalized_error_code,
+        )
         delivery.status = DELIVERY_STATUS_CANCELED
         delivery.provider_message_id = None
-        delivery.last_error_category = cls._sanitize_text(error_category, 80, "recipient")
-        delivery.last_error_code = cls._sanitize_text(error_code, 100, "recipient_inactive")
+        delivery.last_error_category = normalized_error_category
+        delivery.last_error_code = normalized_error_code
         delivery.last_error_message = cls._sanitize_text(
             error_message,
             1000,

--- a/services/communications/delivery_worker.py
+++ b/services/communications/delivery_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass
@@ -25,7 +26,6 @@ from services.communications.providers.base import (
 )
 from services.communications.recipient_directory import ManagementRecipientDirectory
 from services.communications.template_registry import WebsiteTemplateRegistry
-
 
 logger = logging.getLogger(__name__)
 _TerminalResult = TypeVar("_TerminalResult")
@@ -140,6 +140,7 @@ class CommunicationDeliveryWorker:
             return self._lease_lost_outcome(claim, recovery)
 
         cancellation_after_finalize: asyncio.CancelledError | None = None
+        provider_started_ns = time.monotonic_ns()
         try:
             result = await self._send_with_heartbeat(claim, rendered_text)
         except _ProviderResultDuringCancellation as exc:
@@ -161,6 +162,10 @@ class CommunicationDeliveryWorker:
                 code="provider_call_failed",
                 message="Communication provider failed unexpectedly",
             )
+        provider_latency_ms = max(
+            0,
+            (time.monotonic_ns() - provider_started_ns) // 1_000_000,
+        )
 
         if result.disposition == ProviderDeliveryDisposition.SENT:
             if not result.provider_message_id:
@@ -172,7 +177,11 @@ class CommunicationDeliveryWorker:
             else:
                 try:
                     await self._finish_terminal_despite_cancellation(
-                        self._mark_sent(claim, result.provider_message_id),
+                        self._mark_sent(
+                            claim,
+                            result.provider_message_id,
+                            provider_latency_ms=provider_latency_ms,
+                        ),
                         delivery_id=claim.delivery_id,
                     )
                 except CommunicationDeliveryLeaseLost:
@@ -191,7 +200,12 @@ class CommunicationDeliveryWorker:
                 return outcome
 
         outcome = await self._finish_terminal_despite_cancellation(
-            self._record_failure(claim, result, recovery),
+            self._record_failure(
+                claim,
+                result,
+                recovery,
+                provider_latency_ms=provider_latency_ms,
+            ),
             delivery_id=claim.delivery_id,
         )
         if cancellation_after_finalize is not None:
@@ -438,6 +452,7 @@ class CommunicationDeliveryWorker:
         self,
         claim: ClaimedCommunicationDelivery,
         provider_message_id: str,
+        provider_latency_ms: int | None = None,
     ) -> None:
         async with self._session_factory() as session:
             await CommunicationDeliveryService.mark_sent(
@@ -446,6 +461,7 @@ class CommunicationDeliveryWorker:
                 worker_id=self._worker_id,
                 lease_token=claim.lease_token,
                 provider_message_id=provider_message_id,
+                provider_latency_ms=provider_latency_ms,
             )
             await session.commit()
 
@@ -454,6 +470,7 @@ class CommunicationDeliveryWorker:
         claim: ClaimedCommunicationDelivery,
         result: ProviderDeliveryResult,
         recovery: ExpiredLeaseRecoveryResult,
+        provider_latency_ms: int | None = None,
     ) -> DeliveryRunOutcome:
         try:
             async with self._session_factory() as session:
@@ -463,6 +480,7 @@ class CommunicationDeliveryWorker:
                     worker_id=self._worker_id,
                     lease_token=claim.lease_token,
                     result=result,
+                    provider_latency_ms=provider_latency_ms,
                 )
                 await session.commit()
         except CommunicationDeliveryLeaseLost:

--- a/tests/integration/test_communication_delivery_concurrency.py
+++ b/tests/integration/test_communication_delivery_concurrency.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-from models import CommunicationDelivery
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
 from services.communications.delivery_service import (
     CommunicationDeliveryLeaseLost,
     CommunicationDeliveryService,
@@ -35,6 +35,7 @@ async def communication_db_engine():
     )
     async with engine.begin() as connection:
         await connection.run_sync(CommunicationDelivery.__table__.create)
+        await connection.run_sync(CommunicationDeliveryAttempt.__table__.create)
     try:
         yield engine
     finally:
@@ -93,6 +94,15 @@ async def _seed_deliveries(
                     **running_values,
                 )
             )
+            if expired:
+                session.add(
+                    CommunicationDeliveryAttempt(
+                        delivery_id=f"{sequence:032x}",
+                        attempt_no=1,
+                        started_at=now - timedelta(minutes=1),
+                        outcome="running",
+                    )
+                )
         await session.commit()
 
 
@@ -137,6 +147,17 @@ async def test_postgres_claim_skips_locked_row_and_claims_distinct_delivery(
         ]
         assert all(row is not None and row.status == "running" for row in rows)
         assert [row.attempts for row in rows if row is not None] == [1, 1]
+        attempts = [
+            await verification.get(
+                CommunicationDeliveryAttempt,
+                (f"{sequence:032x}", 1),
+            )
+            for sequence in (1, 2)
+        ]
+        assert all(
+            attempt is not None and attempt.outcome == "running"
+            for attempt in attempts
+        )
 
 
 @pytest.mark.asyncio
@@ -181,6 +202,14 @@ async def test_postgres_locked_single_claim_rolls_back_without_consuming_attempt
         assert claim_after_rollback.lease_token != claim_a.lease_token
         await session_b.commit()
 
+    async with factory() as verification:
+        attempt = await verification.get(
+            CommunicationDeliveryAttempt,
+            (claim_a.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "running"
+
 
 @pytest.mark.asyncio
 async def test_postgres_concurrent_recovery_skips_locked_expired_delivery(
@@ -218,6 +247,20 @@ async def test_postgres_concurrent_recovery_skips_locked_expired_delivery(
         ]
         assert all(row is not None and row.status == "retry" for row in rows)
         assert [row.attempts for row in rows if row is not None] == [1, 1]
+        attempts = [
+            await verification.get(
+                CommunicationDeliveryAttempt,
+                (f"{sequence:032x}", 1),
+            )
+            for sequence in (1, 2)
+        ]
+        assert all(
+            attempt is not None
+            and attempt.outcome == "retry"
+            and attempt.error_code == "lease_expired"
+            and attempt.ambiguous is True
+            for attempt in attempts
+        )
 
 
 @pytest.mark.asyncio
@@ -276,6 +319,18 @@ async def test_postgres_recovery_rotates_token_and_fences_stale_attempt(
             now=retry_at + timedelta(seconds=1),
         )
         await session.commit()
+        attempts = [
+            await session.get(
+                CommunicationDeliveryAttempt,
+                (claim.delivery_id, attempt_no),
+            )
+            for attempt_no in (1, 2)
+        ]
+        assert [attempt.outcome for attempt in attempts if attempt is not None] == [
+            "retry",
+            "sent",
+        ]
+        assert attempts[0] is not None and attempts[0].ambiguous is True
 
 
 @pytest.mark.asyncio
@@ -355,3 +410,10 @@ async def test_postgres_concurrent_terminal_transitions_have_single_winner(
         assert row.worker_id is None
         assert row.lease_token is None
         assert row.lease_expires_at is None
+        attempt = await verification.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == row.status
+        assert attempt.finished_at is not None

--- a/tests/unit/test_communication_delivery_attempt_migration.py
+++ b/tests/unit/test_communication_delivery_attempt_migration.py
@@ -1,0 +1,251 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+FOUNDATION_PATH = Path(
+    "alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py"
+)
+LEASE_PATH = Path(
+    "alembic/versions/4a8b1c2d3e05_harden_communication_delivery_leases.py"
+)
+ATTEMPT_REVISION = "5b9c2d3e4f06"
+ATTEMPT_PATH = Path(
+    "alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py"
+)
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc).isoformat()
+
+
+def _load_migration(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _insert_queued_delivery(connection, sequence: int) -> str:
+    delivery_id = f"{sequence:032x}"
+    connection.execute(
+        text("""
+            INSERT INTO communication_delivery (
+                delivery_id, event_id, channel, recipient_key, destination,
+                template_key, template_version, render_context, status,
+                priority, attempts, max_attempts, available_at,
+                created_at, updated_at
+            ) VALUES (
+                :delivery_id, :event_id, 'telegram', :recipient_key, :destination,
+                'telegram.website_contact_lead_created', 1, '{}', 'queued',
+                100, 0, 3, :now, :now, :now
+            )
+            """),
+        {
+            "delivery_id": delivery_id,
+            "event_id": f"{sequence + 1000:032x}",
+            "recipient_key": f"staff:{sequence}",
+            "destination": str(100000 + sequence),
+            "now": NOW,
+        },
+    )
+    return delivery_id
+
+
+def _insert_attempt(
+    connection,
+    *,
+    delivery_id: str,
+    attempt_no: int,
+    outcome: str,
+    finished_at: str | None = None,
+    error_category: str | None = None,
+    error_code: str | None = None,
+    retry_after_seconds: int | None = None,
+    provider_latency_ms: int | None = None,
+    ambiguous: bool = False,
+) -> None:
+    connection.execute(
+        text("""
+            INSERT INTO communication_delivery_attempt (
+                delivery_id, attempt_no, started_at, finished_at, outcome,
+                error_category, error_code, retry_after_seconds,
+                provider_latency_ms, ambiguous
+            ) VALUES (
+                :delivery_id, :attempt_no, :started_at, :finished_at, :outcome,
+                :error_category, :error_code, :retry_after_seconds,
+                :provider_latency_ms, :ambiguous
+            )
+            """),
+        {
+            "delivery_id": delivery_id,
+            "attempt_no": attempt_no,
+            "started_at": NOW,
+            "finished_at": finished_at,
+            "outcome": outcome,
+            "error_category": error_category,
+            "error_code": error_code,
+            "retry_after_seconds": retry_after_seconds,
+            "provider_latency_ms": provider_latency_ms,
+            "ambiguous": ambiguous,
+        },
+    )
+
+
+def test_attempt_journal_is_the_single_alembic_head_after_lease_hardening():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(ATTEMPT_REVISION)
+
+    assert script.get_heads() == [ATTEMPT_REVISION]
+    assert revision is not None
+    assert revision.down_revision == "4a8b1c2d3e05"
+
+
+def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
+    foundation = _load_migration("foundation_for_attempt", FOUNDATION_PATH)
+    lease = _load_migration("lease_for_attempt", LEASE_PATH)
+    attempt = _load_migration("attempt_journal_migration", ATTEMPT_PATH)
+    engine = create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        foundation.op = operations
+        lease.op = operations
+        attempt.op = operations
+        foundation.upgrade()
+        delivery_id = _insert_queued_delivery(connection, 1)
+        lease.upgrade()
+        attempt.upgrade()
+
+        inspector = inspect(connection)
+        assert "communication_delivery_attempt" in inspector.get_table_names()
+        assert connection.execute(
+            text(
+                "SELECT status, attempts FROM communication_delivery "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": delivery_id},
+        ).one() == ("queued", 0)
+        assert (
+            connection.execute(
+                text("SELECT count(*) FROM communication_delivery_attempt")
+            ).scalar_one()
+            == 0
+        )
+
+        assert inspector.get_pk_constraint("communication_delivery_attempt")[
+            "constrained_columns"
+        ] == ["delivery_id", "attempt_no"]
+        foreign_keys = inspector.get_foreign_keys("communication_delivery_attempt")
+        assert len(foreign_keys) == 1
+        assert foreign_keys[0]["referred_table"] == "communication_delivery"
+        assert foreign_keys[0]["constrained_columns"] == ["delivery_id"]
+        constraint_names = {
+            item["name"]
+            for item in inspector.get_check_constraints(
+                "communication_delivery_attempt"
+            )
+        }
+        assert {
+            "ck_delivery_attempt_ambiguity_state",
+            "ck_delivery_attempt_error_state",
+            "ck_delivery_attempt_finish_state",
+            "ck_delivery_attempt_finished_after_started",
+            "ck_delivery_attempt_latency_non_negative",
+            "ck_delivery_attempt_latency_state",
+            "ck_delivery_attempt_no_positive",
+            "ck_delivery_attempt_outcome_valid",
+            "ck_delivery_attempt_retry_after_positive",
+            "ck_delivery_attempt_retry_after_state",
+        }.issubset(constraint_names)
+        assert {
+            "ix_delivery_attempt_ambiguous_finished",
+            "ix_delivery_attempt_error_finished",
+            "ix_delivery_attempt_outcome_started",
+        }.issubset(
+            item["name"]
+            for item in inspector.get_indexes("communication_delivery_attempt")
+        )
+
+        _insert_attempt(
+            connection,
+            delivery_id=delivery_id,
+            attempt_no=1,
+            outcome="running",
+        )
+        connection.execute(
+            text(
+                "UPDATE communication_delivery_attempt "
+                "SET outcome = 'sent', finished_at = :now, provider_latency_ms = 12 "
+                "WHERE delivery_id = :delivery_id AND attempt_no = 1"
+            ),
+            {"delivery_id": delivery_id, "now": NOW},
+        )
+        invalid_attempts = [
+            {"attempt_no": 2, "outcome": "sent"},
+            {"attempt_no": 3, "outcome": "retry", "finished_at": NOW},
+            {
+                "attempt_no": 8,
+                "outcome": "retry",
+                "finished_at": NOW,
+                "error_category": " ",
+                "error_code": "timeout",
+            },
+            {
+                "attempt_no": 4,
+                "outcome": "sent",
+                "finished_at": NOW,
+                "ambiguous": True,
+            },
+            {
+                "attempt_no": 5,
+                "outcome": "running",
+                "retry_after_seconds": 30,
+            },
+            {
+                "attempt_no": 6,
+                "outcome": "canceled",
+                "finished_at": NOW,
+                "error_category": "recipient",
+                "error_code": "inactive",
+                "provider_latency_ms": 1,
+            },
+            {
+                "attempt_no": 7,
+                "outcome": "retry",
+                "finished_at": NOW,
+                "error_category": "network",
+                "error_code": "timeout",
+                "provider_latency_ms": -1,
+            },
+        ]
+        for values in invalid_attempts:
+            with pytest.raises(IntegrityError):
+                with connection.begin_nested():
+                    _insert_attempt(
+                        connection,
+                        delivery_id=delivery_id,
+                        **values,
+                    )
+
+        attempt.downgrade()
+        downgraded = inspect(connection)
+        assert "communication_delivery_attempt" not in downgraded.get_table_names()
+        assert "communication_delivery" in downgraded.get_table_names()
+        assert connection.execute(
+            text(
+                "SELECT status, attempts FROM communication_delivery "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": delivery_id},
+        ).one() == ("queued", 0)
+
+        lease.downgrade()
+        assert "communication_delivery" in inspect(connection).get_table_names()
+        foundation.downgrade()
+        assert "communication_delivery" not in inspect(connection).get_table_names()

--- a/tests/unit/test_communication_delivery_attempt_migration.py
+++ b/tests/unit/test_communication_delivery_attempt_migration.py
@@ -9,6 +9,11 @@ from alembic.operations import Operations
 from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from services.communications.delivery_service import CommunicationDeliveryService
 
 FOUNDATION_PATH = Path(
     "alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py"
@@ -21,6 +26,7 @@ ATTEMPT_PATH = Path(
     "alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py"
 )
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc).isoformat()
+SQLITE_RUNNING_NOW = "2026-07-13 12:00:00.000000"
 
 
 def _load_migration(name: str, path: Path):
@@ -52,6 +58,37 @@ def _insert_queued_delivery(connection, sequence: int) -> str:
             "recipient_key": f"staff:{sequence}",
             "destination": str(100000 + sequence),
             "now": NOW,
+        },
+    )
+    return delivery_id
+
+
+def _insert_running_delivery(connection, sequence: int) -> str:
+    delivery_id = f"{sequence:032x}"
+    connection.execute(
+        text("""
+            INSERT INTO communication_delivery (
+                delivery_id, event_id, channel, recipient_key, destination,
+                template_key, template_version, render_context, status,
+                priority, attempts, max_attempts, available_at,
+                worker_id, lease_token, lease_expires_at,
+                created_at, updated_at
+            ) VALUES (
+                :delivery_id, :event_id, 'telegram', :recipient_key, :destination,
+                'telegram.website_contact_lead_created', 1, '{}', 'running',
+                100, 1, 3, :now,
+                'migration-worker', :lease_token, :lease_expires_at,
+                :now, :now
+            )
+            """),
+        {
+            "delivery_id": delivery_id,
+            "event_id": f"{sequence + 1000:032x}",
+            "recipient_key": f"staff:{sequence}",
+            "destination": str(100000 + sequence),
+            "lease_token": "migration-lease-token".ljust(40, "x"),
+            "lease_expires_at": "2026-07-13 12:05:00.000000",
+            "now": SQLITE_RUNNING_NOW,
         },
     )
     return delivery_id
@@ -119,6 +156,7 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
         attempt.op = operations
         foundation.upgrade()
         delivery_id = _insert_queued_delivery(connection, 1)
+        running_delivery_id = _insert_running_delivery(connection, 2)
         lease.upgrade()
         attempt.upgrade()
 
@@ -131,12 +169,21 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
             ),
             {"delivery_id": delivery_id},
         ).one() == ("queued", 0)
-        assert (
-            connection.execute(
-                text("SELECT count(*) FROM communication_delivery_attempt")
-            ).scalar_one()
-            == 0
-        )
+        assert connection.execute(
+            text(
+                "SELECT attempt_no, started_at, finished_at, outcome, ambiguous "
+                "FROM communication_delivery_attempt "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": running_delivery_id},
+        ).one() == (1, SQLITE_RUNNING_NOW, None, "running", False)
+        assert connection.execute(
+            text(
+                "SELECT count(*) FROM communication_delivery_attempt "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": delivery_id},
+        ).scalar_one() == 0
 
         assert inspector.get_pk_constraint("communication_delivery_attempt")[
             "constrained_columns"
@@ -244,8 +291,66 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
             ),
             {"delivery_id": delivery_id},
         ).one() == ("queued", 0)
+        assert connection.execute(
+            text(
+                "SELECT status, attempts FROM communication_delivery "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": running_delivery_id},
+        ).one() == ("running", 1)
 
         lease.downgrade()
         assert "communication_delivery" in inspect(connection).get_table_names()
         foundation.downgrade()
         assert "communication_delivery" not in inspect(connection).get_table_names()
+
+
+@pytest.mark.asyncio
+async def test_attempt_journal_backfills_running_row_for_lease_recovery(tmp_path):
+    foundation = _load_migration("foundation_for_recovery", FOUNDATION_PATH)
+    lease = _load_migration("lease_for_recovery", LEASE_PATH)
+    attempt = _load_migration("attempt_journal_for_recovery", ATTEMPT_PATH)
+    database_path = tmp_path / "attempt-migration-recovery.sqlite3"
+    engine = create_engine(f"sqlite:///{database_path}")
+
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        foundation.op = operations
+        lease.op = operations
+        attempt.op = operations
+        foundation.upgrade()
+        delivery_id = _insert_running_delivery(connection, 9)
+        lease.upgrade()
+        attempt.upgrade()
+    engine.dispose()
+
+    async_engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
+    factory = sessionmaker(
+        async_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    try:
+        async with factory() as session:
+            recovery = await CommunicationDeliveryService.recover_expired_leases(
+                session,
+                now=datetime(2026, 7, 13, 12, 6, tzinfo=timezone.utc),
+            )
+            await session.commit()
+            assert recovery.retry_count == 1
+            assert recovery.dead_count == 0
+
+        async with factory() as session:
+            delivery = await session.get(CommunicationDelivery, delivery_id)
+            journal = await session.get(
+                CommunicationDeliveryAttempt,
+                (delivery_id, 1),
+            )
+            assert delivery is not None and delivery.status == "retry"
+            assert journal is not None and journal.outcome == "retry"
+            assert journal.error_category == "lease"
+            assert journal.error_code == "lease_expired"
+            assert journal.ambiguous is True
+            assert journal.finished_at is not None
+    finally:
+        await async_engine.dispose()

--- a/tests/unit/test_communication_delivery_attempt_service.py
+++ b/tests/unit/test_communication_delivery_attempt_service.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from services.communications.delivery_attempt_service import (
+    CommunicationDeliveryAttemptStateError,
+)
+from services.communications.delivery_service import (
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryService,
+)
+from services.communications.providers.base import ProviderDeliveryResult
+
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def attempt_session_factory(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'attempt.sqlite3'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(CommunicationDelivery.__table__.create)
+        await connection.run_sync(CommunicationDeliveryAttempt.__table__.create)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _delivery(
+    sequence: int,
+    *,
+    status: str = "queued",
+    attempts: int = 0,
+    worker_id: str | None = None,
+    lease_token: str | None = None,
+    lease_expires_at: datetime | None = None,
+) -> CommunicationDelivery:
+    return CommunicationDelivery(
+        delivery_id=f"{sequence:032x}",
+        event_id=f"{sequence + 1000:032x}",
+        channel="telegram",
+        recipient_key=f"staff:{sequence}",
+        destination=str(100000 + sequence),
+        template_key="telegram.website_contact_lead_created",
+        template_version=1,
+        render_context={},
+        status=status,
+        attempts=attempts,
+        max_attempts=3,
+        available_at=NOW,
+        worker_id=worker_id,
+        lease_token=lease_token,
+        lease_expires_at=lease_expires_at,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def test_attempt_model_contains_only_pii_free_operational_fields():
+    assert set(CommunicationDeliveryAttempt.__table__.columns.keys()) == {
+        "delivery_id",
+        "attempt_no",
+        "started_at",
+        "finished_at",
+        "outcome",
+        "error_category",
+        "error_code",
+        "retry_after_seconds",
+        "provider_latency_ms",
+        "ambiguous",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancel_closes_current_attempt_without_provider_telemetry(
+    attempt_session_factory,
+):
+    async with attempt_session_factory() as session:
+        session.add(_delivery(1))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        await CommunicationDeliveryService.cancel_owned(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker",
+            lease_token=claim.lease_token,
+            now=NOW + timedelta(seconds=1),
+        )
+        await session.commit()
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "canceled"
+        assert attempt.error_category == "recipient"
+        assert attempt.error_code == "recipient_inactive"
+        assert attempt.retry_after_seconds is None
+        assert attempt.provider_latency_ms is None
+        assert attempt.ambiguous is False
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_keeps_every_retry_row(attempt_session_factory):
+    async with attempt_session_factory() as session:
+        session.add(_delivery(2))
+        await session.commit()
+        first_claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker-a",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert first_claim is not None
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        failure = await CommunicationDeliveryService.mark_failed(
+            session,
+            delivery_id=first_claim.delivery_id,
+            worker_id="worker-a",
+            lease_token=first_claim.lease_token,
+            result=ProviderDeliveryResult.transient_failure(
+                category="rate_limit",
+                code="telegram_retry_after",
+                message="Retry later",
+                retry_after_seconds=60,
+            ),
+            provider_latency_ms=10,
+            now=NOW + timedelta(seconds=1),
+        )
+        assert failure.next_attempt_at is not None
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        second_claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker-b",
+            lease_seconds=60,
+            now=failure.next_attempt_at,
+        )
+        assert second_claim is not None
+        assert second_claim.attempts == 2
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        await CommunicationDeliveryService.mark_sent(
+            session,
+            delivery_id=second_claim.delivery_id,
+            worker_id="worker-b",
+            lease_token=second_claim.lease_token,
+            provider_message_id="telegram-message-2",
+            provider_latency_ms=12,
+            now=failure.next_attempt_at + timedelta(seconds=1),
+        )
+        await session.commit()
+        attempts = list(
+            (
+                await session.execute(
+                    select(CommunicationDeliveryAttempt)
+                    .where(
+                        CommunicationDeliveryAttempt.delivery_id
+                        == second_claim.delivery_id
+                    )
+                    .order_by(CommunicationDeliveryAttempt.attempt_no)
+                )
+            ).scalars()
+        )
+        assert [attempt.attempt_no for attempt in attempts] == [1, 2]
+        assert [attempt.outcome for attempt in attempts] == ["retry", "sent"]
+        assert [attempt.provider_latency_ms for attempt in attempts] == [10, 12]
+
+
+@pytest.mark.asyncio
+async def test_terminal_transition_and_attempt_are_caller_owned(
+    attempt_session_factory,
+):
+    async with attempt_session_factory() as session:
+        session.add(_delivery(3))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        await CommunicationDeliveryService.mark_sent(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="worker",
+            lease_token=claim.lease_token,
+            provider_message_id="not-committed",
+            provider_latency_ms=4,
+            now=NOW + timedelta(seconds=1),
+        )
+        local_delivery = await session.get(CommunicationDelivery, claim.delivery_id)
+        local_attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert local_delivery is not None and local_delivery.status == "sent"
+        assert local_attempt is not None and local_attempt.outcome == "sent"
+        await session.rollback()
+
+    async with attempt_session_factory() as session:
+        delivery = await session.get(CommunicationDelivery, claim.delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert delivery is not None and delivery.status == "running"
+        assert delivery.provider_message_id is None
+        assert attempt is not None and attempt.outcome == "running"
+        assert attempt.finished_at is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_fence_leaves_attempt_open_for_lease_owner(
+    attempt_session_factory,
+):
+    async with attempt_session_factory() as session:
+        session.add(_delivery(4))
+        await session.commit()
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            worker_id="worker-a",
+            lease_seconds=60,
+            now=NOW,
+        )
+        assert claim is not None
+        await session.commit()
+
+    async with attempt_session_factory() as session:
+        with pytest.raises(CommunicationDeliveryLeaseLost):
+            await CommunicationDeliveryService.mark_sent(
+                session,
+                delivery_id=claim.delivery_id,
+                worker_id="worker-b",
+                lease_token=claim.lease_token,
+                provider_message_id="must-not-persist",
+                now=NOW + timedelta(seconds=1),
+            )
+        await session.rollback()
+
+    async with attempt_session_factory() as session:
+        delivery = await session.get(CommunicationDelivery, claim.delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert delivery is not None and delivery.status == "running"
+        assert delivery.worker_id == "worker-a"
+        assert attempt is not None and attempt.outcome == "running"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_next_attempt_aborts_claim_before_delivery_mutation(
+    attempt_session_factory,
+):
+    delivery = _delivery(7)
+    async with attempt_session_factory() as session:
+        session.add_all(
+            [
+                delivery,
+                CommunicationDeliveryAttempt(
+                    delivery_id=delivery.delivery_id,
+                    attempt_no=1,
+                    started_at=NOW,
+                    outcome="running",
+                ),
+            ]
+        )
+        await session.commit()
+        with pytest.raises(CommunicationDeliveryAttemptStateError):
+            await CommunicationDeliveryService.claim_next(
+                session,
+                worker_id="worker",
+                lease_seconds=60,
+                now=NOW,
+            )
+        unchanged = await session.get(CommunicationDelivery, delivery.delivery_id)
+        assert unchanged is not None
+        assert unchanged.status == "queued"
+        assert unchanged.attempts == 0
+        await session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_missing_running_attempt_aborts_terminal_transition(
+    attempt_session_factory,
+):
+    delivery = _delivery(
+        5,
+        status="running",
+        attempts=1,
+        worker_id="worker",
+        lease_token="z" * 43,
+        lease_expires_at=NOW + timedelta(minutes=1),
+    )
+    delivery_id = delivery.delivery_id
+    async with attempt_session_factory() as session:
+        session.add(delivery)
+        await session.commit()
+        with pytest.raises(CommunicationDeliveryAttemptStateError):
+            await CommunicationDeliveryService.mark_sent(
+                session,
+                delivery_id=delivery_id,
+                worker_id="worker",
+                lease_token="z" * 43,
+                provider_message_id="must-not-persist",
+                now=NOW,
+            )
+        await session.rollback()
+
+    async with attempt_session_factory() as session:
+        unchanged = await session.get(CommunicationDelivery, delivery_id)
+        assert unchanged is not None
+        assert unchanged.status == "running"
+        assert unchanged.provider_message_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attempt_values",
+    [
+        {"attempt_no": 0, "outcome": "running"},
+        {"attempt_no": 1, "outcome": "sent"},
+        {
+            "attempt_no": 1,
+            "outcome": "sent",
+            "finished_at": NOW,
+            "error_category": "provider",
+            "error_code": "not_allowed",
+        },
+        {"attempt_no": 1, "outcome": "retry", "finished_at": NOW},
+        {
+            "attempt_no": 1,
+            "outcome": "retry",
+            "finished_at": NOW,
+            "error_category": " ",
+            "error_code": "timeout",
+        },
+        {
+            "attempt_no": 1,
+            "outcome": "sent",
+            "finished_at": NOW,
+            "ambiguous": True,
+        },
+        {"attempt_no": 1, "outcome": "running", "retry_after_seconds": 30},
+        {
+            "attempt_no": 1,
+            "outcome": "canceled",
+            "finished_at": NOW,
+            "error_category": "recipient",
+            "error_code": "inactive",
+            "provider_latency_ms": 1,
+        },
+        {
+            "attempt_no": 1,
+            "outcome": "retry",
+            "finished_at": NOW,
+            "error_category": "network",
+            "error_code": "timeout",
+            "provider_latency_ms": -1,
+        },
+    ],
+)
+async def test_attempt_schema_rejects_invalid_lifecycle_state(
+    attempt_session_factory,
+    attempt_values,
+):
+    async with attempt_session_factory() as session:
+        delivery = _delivery(6)
+        session.add(delivery)
+        await session.commit()
+        session.add(
+            CommunicationDeliveryAttempt(
+                delivery_id=delivery.delivery_id,
+                started_at=NOW - timedelta(seconds=1),
+                **attempt_values,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()

--- a/tests/unit/test_communication_delivery_lease_migration.py
+++ b/tests/unit/test_communication_delivery_lease_migration.py
@@ -74,11 +74,10 @@ def _insert_delivery(
     )
 
 
-def test_delivery_lease_hardening_is_the_single_alembic_head():
+def test_delivery_lease_hardening_follows_communications_foundation():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(LEASE_REVISION)
 
-    assert script.get_heads() == [LEASE_REVISION]
     assert revision is not None
     assert revision.down_revision == "3f7a9c1d2e04"
 

--- a/tests/unit/test_communication_delivery_service.py
+++ b/tests/unit/test_communication_delivery_service.py
@@ -335,7 +335,7 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
 
     result = ProviderDeliveryResult.transient_failure(
         category="rate_limit\nsecret",
-        code="retry\tafter",
+        code="plaintextsecret123",
         message="Safe\nmessage",
         retry_after_seconds=900,
     )
@@ -360,7 +360,7 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
         assert row.attempts == 1
         assert row.finished_at is None
         assert row.last_error_category == "rate_limit secret"
-        assert row.last_error_code == "retry after"
+        assert row.last_error_code == "plaintextsecret123"
         assert row.last_error_message == "Safe message"
         assert row.worker_id is None
         attempt = await session.get(

--- a/tests/unit/test_communication_delivery_service.py
+++ b/tests/unit/test_communication_delivery_service.py
@@ -9,13 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import select
 
-from models import CommunicationDelivery
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
 from services.communications.delivery_service import (
     CommunicationDeliveryLeaseLost,
     CommunicationDeliveryService,
 )
 from services.communications.providers.base import ProviderDeliveryResult
-
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
 
@@ -25,6 +24,7 @@ async def delivery_session_factory(tmp_path):
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'delivery.sqlite3'}")
     async with engine.begin() as connection:
         await connection.run_sync(CommunicationDelivery.__table__.create)
+        await connection.run_sync(CommunicationDeliveryAttempt.__table__.create)
     factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     try:
         yield factory
@@ -73,6 +73,20 @@ def _delivery(
     )
 
 
+def _running_attempt(
+    sequence: int,
+    *,
+    attempt_no: int = 1,
+    started_at: datetime = NOW - timedelta(minutes=1),
+) -> CommunicationDeliveryAttempt:
+    return CommunicationDeliveryAttempt(
+        delivery_id=f"{sequence:032x}",
+        attempt_no=attempt_no,
+        started_at=started_at,
+        outcome="running",
+    )
+
+
 @pytest.mark.asyncio
 async def test_claim_next_is_due_channel_scoped_ordered_and_caller_owned(
     delivery_session_factory,
@@ -104,6 +118,13 @@ async def test_claim_next_is_due_channel_scoped_ordered_and_caller_owned(
         independent = await session.get(CommunicationDelivery, claim.delivery_id)
         assert independent is not None
         assert independent.status == "running"
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "running"
+        assert attempt.finished_at is None
         await session.rollback()
 
     async with delivery_session_factory() as session:
@@ -111,6 +132,13 @@ async def test_claim_next_is_due_channel_scoped_ordered_and_caller_owned(
         assert rolled_back is not None
         assert rolled_back.status == "queued"
         assert rolled_back.attempts == 0
+        assert (
+            await session.get(
+                CommunicationDeliveryAttempt,
+                (f"{2:032x}", 1),
+            )
+            is None
+        )
 
 
 @pytest.mark.asyncio
@@ -150,15 +178,18 @@ async def test_expired_running_is_recovered_before_it_can_be_claimed(
 ):
     expired_token = "x" * 43
     async with delivery_session_factory() as session:
-        session.add(
-            _delivery(
-                1,
-                status="running",
-                attempts=1,
-                worker_id="old-worker",
-                lease_token=expired_token,
-                lease_expires_at=NOW - timedelta(seconds=1),
-            )
+        session.add_all(
+            [
+                _delivery(
+                    1,
+                    status="running",
+                    attempts=1,
+                    worker_id="old-worker",
+                    lease_token=expired_token,
+                    lease_expires_at=NOW - timedelta(seconds=1),
+                ),
+                _running_attempt(1),
+            ]
         )
         await session.commit()
 
@@ -191,6 +222,15 @@ async def test_expired_running_is_recovered_before_it_can_be_claimed(
         assert recovered.status == "retry"
         assert recovered.attempts == 1
         assert recovered.available_at > NOW.replace(tzinfo=None)
+        recovered_attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (f"{1:032x}", 1),
+        )
+        assert recovered_attempt is not None
+        assert recovered_attempt.outcome == "retry"
+        assert recovered_attempt.error_category == "lease"
+        assert recovered_attempt.error_code == "lease_expired"
+        assert recovered_attempt.ambiguous is True
 
 
 @pytest.mark.asyncio
@@ -240,6 +280,7 @@ async def test_renew_and_terminal_transitions_require_exact_unexpired_lease(
             worker_id="worker-a",
             lease_token=claim.lease_token,
             provider_message_id="telegram-message-42",
+            provider_latency_ms=47,
             now=NOW + timedelta(seconds=2),
         )
         await session.commit()
@@ -254,6 +295,18 @@ async def test_renew_and_terminal_transitions_require_exact_unexpired_lease(
         assert sent.lease_expires_at is None
         assert sent.sent_at == NOW.replace(tzinfo=None) + timedelta(seconds=2)
         assert sent.finished_at == sent.sent_at
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "sent"
+        assert attempt.finished_at == sent.finished_at
+        assert attempt.error_category is None
+        assert attempt.error_code is None
+        assert attempt.retry_after_seconds is None
+        assert attempt.provider_latency_ms == 47
+        assert attempt.ambiguous is False
         with pytest.raises(CommunicationDeliveryLeaseLost):
             await CommunicationDeliveryService.cancel_owned(
                 session,
@@ -293,6 +346,7 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
             worker_id="worker",
             lease_token=claim.lease_token,
             result=result,
+            provider_latency_ms=125,
             now=NOW + timedelta(seconds=1),
         )
         await session.commit()
@@ -309,6 +363,17 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
         assert row.last_error_code == "retry after"
         assert row.last_error_message == "Safe message"
         assert row.worker_id is None
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "retry"
+        assert attempt.error_category == "unknown"
+        assert attempt.error_code == "delivery_failed"
+        assert attempt.retry_after_seconds == 900
+        assert attempt.provider_latency_ms == 125
+        assert attempt.ambiguous is False
 
     delay = CommunicationDeliveryService.retry_delay_seconds(
         delivery_id=claim.delivery_id,
@@ -338,12 +403,12 @@ async def test_permanent_or_exhausted_failure_is_dead(
     starting_attempts = 0 if permanent else max_attempts - 1
     async with delivery_session_factory() as session:
         session.add(
-                _delivery(
-                    1,
-                    status="queued" if permanent else "retry",
-                    attempts=starting_attempts,
-                    max_attempts=max_attempts,
-                )
+            _delivery(
+                1,
+                status="queued" if permanent else "retry",
+                attempts=starting_attempts,
+                max_attempts=max_attempts,
+            )
         )
         await session.commit()
         claim = await CommunicationDeliveryService.claim_next(
@@ -375,6 +440,7 @@ async def test_permanent_or_exhausted_failure_is_dead(
             worker_id="worker",
             lease_token=claim.lease_token,
             result=result,
+            provider_latency_ms=84,
             now=NOW + timedelta(seconds=1),
         )
         await session.commit()
@@ -386,6 +452,14 @@ async def test_permanent_or_exhausted_failure_is_dead(
         assert row.finished_at is not None
         assert row.worker_id is None
         assert row.lease_token is None
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, claim.attempts),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "dead"
+        assert attempt.provider_latency_ms == 84
+        assert attempt.ambiguous is (not permanent)
 
 
 @pytest.mark.asyncio
@@ -428,6 +502,10 @@ async def test_recovery_is_limited_ordered_and_separates_retry_from_dead(
                     lease_token="d" * 43,
                     lease_expires_at=NOW + timedelta(seconds=1),
                 ),
+                _running_attempt(1),
+                _running_attempt(2, attempt_no=3),
+                _running_attempt(3),
+                _running_attempt(4),
             ]
         )
         await session.commit()
@@ -454,6 +532,28 @@ async def test_recovery_is_limited_ordered_and_separates_retry_from_dead(
         )
         assert [row.status for row in rows] == ["retry", "dead", "running", "running"]
         assert [row.attempts for row in rows] == [1, 3, 1, 1]
+        attempts = list(
+            (
+                await session.execute(
+                    select(CommunicationDeliveryAttempt).order_by(
+                        CommunicationDeliveryAttempt.delivery_id
+                    )
+                )
+            ).scalars()
+        )
+        assert [attempt.outcome for attempt in attempts] == [
+            "retry",
+            "dead",
+            "running",
+            "running",
+        ]
+        assert [attempt.error_code for attempt in attempts] == [
+            "lease_expired",
+            "lease_expired",
+            None,
+            None,
+        ]
+        assert [attempt.ambiguous for attempt in attempts] == [True, True, False, False]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_communication_delivery_worker.py
+++ b/tests/unit/test_communication_delivery_worker.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
 from core.config import settings
-from models import CommunicationDelivery, StaffUser
+from models import CommunicationDelivery, CommunicationDeliveryAttempt, StaffUser
 from services.communications.contracts import PublicContactLeadCreatedPayloadV1
 from services.communications.delivery_service import (
     CommunicationDeliveryLeaseLost,
@@ -217,6 +217,14 @@ async def test_worker_commits_claim_before_provider_and_marks_sent(
         assert row.provider_message_id == "message-1"
         assert row.worker_id is None
         assert row.lease_token is None
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "sent"
+        assert attempt.provider_latency_ms is not None
+        assert attempt.provider_latency_ms >= 0
 
 
 @pytest.mark.asyncio
@@ -377,10 +385,18 @@ async def test_cancellation_inside_sent_finalizer_commits_then_propagates(
     release = asyncio.Event()
     original_mark_sent = worker._mark_sent
 
-    async def blocked_mark_sent(claim, provider_message_id):
+    async def blocked_mark_sent(
+        claim,
+        provider_message_id,
+        provider_latency_ms=None,
+    ):
         entered.set()
         await release.wait()
-        await original_mark_sent(claim, provider_message_id)
+        await original_mark_sent(
+            claim,
+            provider_message_id,
+            provider_latency_ms=provider_latency_ms,
+        )
 
     monkeypatch.setattr(worker, "_mark_sent", blocked_mark_sent)
     run_task = asyncio.create_task(worker.run_once())
@@ -419,10 +435,20 @@ async def test_cancellation_inside_failure_finalizer_commits_then_propagates(
     release = asyncio.Event()
     original_record_failure = worker._record_failure
 
-    async def blocked_record_failure(claim, result, recovery):
+    async def blocked_record_failure(
+        claim,
+        result,
+        recovery,
+        provider_latency_ms=None,
+    ):
         entered.set()
         await release.wait()
-        return await original_record_failure(claim, result, recovery)
+        return await original_record_failure(
+            claim,
+            result,
+            recovery,
+            provider_latency_ms=provider_latency_ms,
+        )
 
     monkeypatch.setattr(worker, "_record_failure", blocked_record_failure)
     run_task = asyncio.create_task(worker.run_once())
@@ -437,6 +463,15 @@ async def test_cancellation_inside_failure_finalizer_commits_then_propagates(
         assert row is not None
         assert row.status == "retry"
         assert row.last_error_code == "timeout"
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "retry"
+        assert attempt.provider_latency_ms is not None
+        assert attempt.provider_latency_ms >= 0
+        assert attempt.ambiguous is True
 
 
 @pytest.mark.asyncio
@@ -479,6 +514,13 @@ async def test_worker_revalidates_recipient_and_cancels_without_network(
         assert row.status == "canceled"
         assert row.last_error_code == "recipient_inactive"
         assert row.finished_at is not None
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "canceled"
+        assert attempt.provider_latency_ms is None
 
 
 @pytest.mark.asyncio
@@ -579,3 +621,12 @@ async def test_worker_converts_render_error_to_permanent_dead_letter(
         assert row.status == "dead"
         assert row.last_error_category == "template"
         assert row.last_error_message == "Communication template could not be rendered"
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "dead"
+        assert attempt.error_code == "template_render_failed"
+        assert attempt.provider_latency_ms is None
+        assert attempt.ambiguous is False


### PR DESCRIPTION
## Summary
- add a PII-free per-attempt journal for communication delivery claims and terminal outcomes
- record retry-after, provider latency, and ambiguous lease/provider failures without destination, message body, render context, token, or raw exception text
- backfill any pre-existing running delivery into a synthetic open attempt so recovery remains safe across rolling migration

## Safety
- caller-owned transactions and lease fencing remain intact
- stable error categories and codes are allowlisted; arbitrary secret-like values collapse to safe fallbacks
- this remains dormant: no runtime, compose service, producer switch, canary send, or notification-path behavior is enabled

## Validation
- full unit suite: 1250 passed on an isolated PostgreSQL database
- PostgreSQL delivery concurrency: 5 passed
- targeted journal/delivery suite: 61 passed in independent review
- fresh PostgreSQL upgrade, alembic check, downgrade, and re-upgrade passed
- PostgreSQL C1 running-row migration -> recovery -> downgrade passed
- independent review: PASS with no blocking or high findings after fixes