### PR TITLE
Fix private storage production startup

### DIFF
--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -6,6 +6,9 @@ from .handlers import admin, base, catalog, repair_context, work
 from core.config import settings
 from core.database import async_session_maker
 from core.logger import setup_logging
+from services.private_attachment_storage_service import (
+    verify_private_attachment_storage_startup,
+)
 from services.runtime_lock_service import RuntimeLockService
 
 # Setup logging with session-specific bot.log (cleared on restart)
@@ -37,6 +40,8 @@ async def _setup_bot_commands() -> None:
 
 
 async def main(*, wait_when_disabled: bool = True):
+    await verify_private_attachment_storage_startup(settings)
+
     decision = settings.bot_control_decision
     if not decision.enabled:
         logger.warning("Telegram bot polling disabled: %s.", decision.reason)

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -45,6 +45,14 @@ class SchedulerOwnershipLost(SchedulerRuntimeFatal):
 _detached_scheduler_probe_tasks: set[asyncio.Task] = set()
 
 
+async def _verify_private_attachment_storage() -> None:
+    from services.private_attachment_storage_service import (
+        verify_private_attachment_storage_startup,
+    )
+
+    await verify_private_attachment_storage_startup(settings)
+
+
 def _discard_detached_scheduler_probe(task: asyncio.Task) -> None:
     _detached_scheduler_probe_tasks.discard(task)
     try:
@@ -469,6 +477,7 @@ async def _stop_scheduler_supervisor(app: FastAPI) -> None:
 async def app_lifespan(app: FastAPI):
     logger.info("Starting Application...")
 
+    await _verify_private_attachment_storage()
     await _bootstrap_database()
     _start_scheduler_supervisor(app)
 

--- a/core/config.py
+++ b/core/config.py
@@ -354,16 +354,4 @@ class Settings(BaseSettings):
     )
 
 
-def _run_production_startup_checks(current_settings: Settings) -> None:
-    if not current_settings.is_production:
-        return
-
-    from services.private_attachment_storage_service import (
-        verify_private_attachment_storage_startup,
-    )
-
-    verify_private_attachment_storage_startup(current_settings)
-
-
 settings = Settings()
-_run_production_startup_checks(settings)

--- a/services/private_attachment_storage_service.py
+++ b/services/private_attachment_storage_service.py
@@ -355,7 +355,7 @@ def get_private_attachment_storage(provider: str | None = None) -> PrivateAttach
     return _build_private_attachment_storage(settings, provider)
 
 
-def verify_private_attachment_storage_startup(
+async def verify_private_attachment_storage_startup(
     current_settings: Any,
     *,
     client: Any | None = None,
@@ -381,20 +381,11 @@ def verify_private_attachment_storage_startup(
         )
 
     try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        pass
-    else:
-        raise RuntimeError(
-            "Private attachment startup probe must run before the application event loop"
-        )
-
-    try:
         storage = _build_private_attachment_storage(
             current_settings,
             client=client,
         )
-        asyncio.run(storage.verify_writable())
+        await storage.verify_writable()
     except Exception as exc:
         raise RuntimeError(
             "Private attachment R2 startup probe failed "

--- a/tests/unit/test_private_attachment_storage_security.py
+++ b/tests/unit/test_private_attachment_storage_security.py
@@ -5,9 +5,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from core import config as config_module
 from core.config import Settings
-from services import private_attachment_storage_service as storage_module
 from services.private_attachment_storage_service import (
     S3PrivateAttachmentStorage,
     verify_private_attachment_storage_startup,
@@ -135,7 +133,8 @@ def test_production_private_bucket_must_not_be_shared(public_bucket_setting):
         Settings(_env_file=None, **values)
 
 
-def test_local_settings_do_not_require_r2_or_run_startup_probe(monkeypatch):
+@pytest.mark.asyncio
+async def test_local_settings_do_not_require_r2_or_run_startup_probe():
     local_settings = Settings(
         _env_file=None,
         SECRET_KEY="test",
@@ -144,31 +143,12 @@ def test_local_settings_do_not_require_r2_or_run_startup_probe(monkeypatch):
         ENVIRONMENT="local",
         SERVICE_ATTACHMENT_STORAGE_PROVIDER="local",
     )
-    calls = []
-    monkeypatch.setattr(
-        storage_module,
-        "verify_private_attachment_storage_startup",
-        calls.append,
-    )
+    client = _ProbeS3Client()
 
-    config_module._run_production_startup_checks(local_settings)
+    await verify_private_attachment_storage_startup(local_settings, client=client)
 
     assert local_settings.SERVICE_ATTACHMENT_STORAGE_PROVIDER == "local"
-    assert calls == []
-
-
-def test_production_startup_hook_invokes_private_storage_probe(monkeypatch):
-    configured = _startup_settings()
-    calls = []
-    monkeypatch.setattr(
-        storage_module,
-        "verify_private_attachment_storage_startup",
-        calls.append,
-    )
-
-    config_module._run_production_startup_checks(configured)
-
-    assert calls == [configured]
+    assert client.operations == []
 
 
 def test_s3_storage_rejects_non_https_endpoint():
@@ -183,10 +163,41 @@ def test_s3_storage_rejects_non_https_endpoint():
         )
 
 
-def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
+@pytest.mark.asyncio
+async def test_app_lifespan_checks_private_storage_before_database(monkeypatch):
+    from core import app_lifespan as lifespan_module
+
+    events = []
+
+    async def verify_storage():
+        events.append("storage")
+
+    async def bootstrap_database():
+        events.append("database")
+        return False
+
+    async def stop_scheduler(_app):
+        return None
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "_verify_private_attachment_storage",
+        verify_storage,
+    )
+    monkeypatch.setattr(lifespan_module, "_bootstrap_database", bootstrap_database)
+    monkeypatch.setattr(lifespan_module, "_start_scheduler_supervisor", lambda _app: False)
+    monkeypatch.setattr(lifespan_module, "_stop_scheduler_supervisor", stop_scheduler)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with lifespan_module.app_lifespan(app):
+        assert events == ["storage", "database"]
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
     client = _ProbeS3Client()
 
-    verify_private_attachment_storage_startup(
+    await verify_private_attachment_storage_startup(
         _startup_settings(),
         client=client,
     )
@@ -203,12 +214,13 @@ def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
     assert client.objects == {}
 
 
-def test_startup_probe_fails_closed_when_delete_does_not_remove_object():
+@pytest.mark.asyncio
+async def test_startup_probe_fails_closed_when_delete_does_not_remove_object():
     client = _ProbeS3Client(delete_objects=False)
     configured = _startup_settings()
 
     with pytest.raises(RuntimeError, match="startup probe failed") as error:
-        verify_private_attachment_storage_startup(configured, client=client)
+        await verify_private_attachment_storage_startup(configured, client=client)
 
     assert configured.SERVICE_ATTACHMENT_S3_SECRET_ACCESS_KEY not in str(error.value)
 

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -233,11 +233,18 @@ async def test_bot_main_disabled_does_not_poll(monkeypatch):
     monkeypatch.setattr(bot_main.settings, "BOT_ENABLED", None, raising=False)
     delete_webhook = AsyncMock()
     start_polling = AsyncMock()
+    verify_storage = AsyncMock()
+    monkeypatch.setattr(
+        bot_main,
+        "verify_private_attachment_storage_startup",
+        verify_storage,
+    )
     monkeypatch.setattr(bot_main.bot, "delete_webhook", delete_webhook)
     monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
 
     await bot_main.main(wait_when_disabled=False)
 
+    verify_storage.assert_awaited_once_with(bot_main.settings)
     delete_webhook.assert_not_awaited()
     start_polling.assert_not_awaited()
 


### PR DESCRIPTION
## Summary
- move the private R2 write/read/delete probe out of module import and into the FastAPI async lifespan
- await the same fail-closed probe before Telegram bot polling
- keep production configuration validation at settings load time
- cover startup ordering and bot startup with regression tests

## Root cause
Deploy run 29278020947 failed on the fenced `zakup` replica because Uvicorn imports the application inside its event loop while the old import-time probe rejected any running event loop. The R2 credentials and bucket were valid; the lifecycle placement was not.

## Verification
- `47 passed` across private-storage, runtime-control and scheduler-lifespan tests
- production-configured Docker image reached `Application startup complete` after a real R2 probe
- production-configured bot image completed its R2 probe before the disabled standby decision
- Python compile and diff checks passed
- HA remained healthy after the fenced deploy rollback
