### PR TITLE
Make CI PostgreSQL readiness stable and fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,21 +25,23 @@ jobs:
 
       - name: Create Dummy Env
         run: |
-          echo "POSTGRES_USER=postgres" >> .env
-          echo "POSTGRES_PASSWORD=postgres" >> .env
-          echo "POSTGRES_DB=air_conditioners" >> .env
-          # IMPORTANT: Inside docker network, host is 'db' (service name)
-          echo "POSTGRES_SERVER=db" >> .env
-          echo "POSTGRES_PORT=5432" >> .env
-          # Construct URL explicitly to be safe
-          echo "DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/air_conditioners" >> .env
+          {
+            echo "POSTGRES_USER=postgres"
+            echo "POSTGRES_PASSWORD=postgres"
+            echo "POSTGRES_DB=air_conditioners"
+            # IMPORTANT: Inside docker network, host is 'db' (service name)
+            echo "POSTGRES_SERVER=db"
+            echo "POSTGRES_PORT=5432"
+            # Construct URL explicitly to be safe
+            echo "DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/air_conditioners"
 
-          echo "SECRET_KEY=dummy_secret_for_tests" >> .env
-          echo "BOT_TOKEN=dummy_token" >> .env
-          echo "ADMIN_USERNAME=admin" >> .env
-          echo "ADMIN_PASSWORD=admin" >> .env
-          echo "ENVIRONMENT=test" >> .env
-          echo "WEBSITE_URL=http://localhost:4321" >> .env
+            echo "SECRET_KEY=dummy_secret_for_tests"
+            echo "BOT_TOKEN=dummy_token"
+            echo "ADMIN_USERNAME=admin"
+            echo "ADMIN_PASSWORD=admin"
+            echo "ENVIRONMENT=test"
+            echo "WEBSITE_URL=http://localhost:4321"
+          } >> .env
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -67,19 +69,8 @@ jobs:
 
       - name: Wait for DB
         run: |
-          echo "Waiting for Postgres (main) to be ready..."
-          for i in $(seq 1 60); do
-            docker compose exec -T db pg_isready -U postgres -d air_conditioners >/dev/null 2>&1 && { echo "Postgres (main) ready"; break; }
-            echo "Postgres not ready ($i/60) - sleeping 1s"
-            sleep 1
-          done
-
-          echo "Waiting for Postgres (test) to be ready..."
-          for i in $(seq 1 60); do
-            docker compose exec -T db_test pg_isready -U postgres -d air_conditioners_test >/dev/null 2>&1 && { echo "Postgres (test) ready"; break; }
-            echo "Postgres test not ready ($i/60) - sleeping 1s"
-            sleep 1
-          done
+          scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres
+          scripts/ci/wait_for_stable_postgres.sh db_test air_conditioners_test postgres
 
       - name: Verify Alembic Upgrade From Empty Database
         run: |

--- a/scripts/ci/wait_for_stable_postgres.py
+++ b/scripts/ci/wait_for_stable_postgres.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Sequence
+
+
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_PROBE_TIMEOUT_SECONDS = 5.0
+DEFAULT_STABLE_SAMPLES = 3
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 2.0
+MAX_TERM_GRACE_SECONDS = 0.2
+MAX_REAP_GRACE_SECONDS = 0.05
+POSTMASTER_QUERY = "SELECT pg_postmaster_start_time()::text;"
+
+COMPOSE_SERVICE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+POSTGRES_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class ConfigurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class WaitConfig:
+    service: str
+    database: str
+    user: str
+    timeout_seconds: float
+    probe_timeout_seconds: float
+    stable_samples: int
+    sample_interval_seconds: float
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    returncode: int
+    stdout: str
+    timed_out: bool
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+    except ValueError as exc:
+        raise ConfigurationError(f"{name} must be a positive number") from exc
+    if not math.isfinite(value) or not value > 0:
+        raise ConfigurationError(f"{name} must be a positive number")
+    return value
+
+
+def _stable_samples_env() -> int:
+    raw_value = os.environ.get("POSTGRES_WAIT_STABLE_SAMPLES")
+    if raw_value is None:
+        return DEFAULT_STABLE_SAMPLES
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ConfigurationError(
+            "POSTGRES_WAIT_STABLE_SAMPLES must be an integer of at least 2"
+        ) from exc
+    if value < 2 or str(value) != raw_value:
+        raise ConfigurationError(
+            "POSTGRES_WAIT_STABLE_SAMPLES must be an integer of at least 2"
+        )
+    return value
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Wait for a stable PostgreSQL postmaster in a Compose service."
+    )
+    parser.add_argument("service")
+    parser.add_argument("database")
+    parser.add_argument("user", nargs="?", default="postgres")
+    return parser.parse_args(argv)
+
+
+def _load_config(argv: Sequence[str] | None) -> WaitConfig:
+    args = _parse_args(argv)
+    if not COMPOSE_SERVICE_RE.fullmatch(args.service):
+        raise ConfigurationError(f"invalid Compose service name: {args.service}")
+    if not POSTGRES_IDENTIFIER_RE.fullmatch(args.database):
+        raise ConfigurationError(f"invalid database name: {args.database}")
+    if not POSTGRES_IDENTIFIER_RE.fullmatch(args.user):
+        raise ConfigurationError(f"invalid database user: {args.user}")
+
+    return WaitConfig(
+        service=args.service,
+        database=args.database,
+        user=args.user,
+        timeout_seconds=_positive_float_env(
+            "POSTGRES_WAIT_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS
+        ),
+        probe_timeout_seconds=_positive_float_env(
+            "POSTGRES_WAIT_PROBE_TIMEOUT_SECONDS", DEFAULT_PROBE_TIMEOUT_SECONDS
+        ),
+        stable_samples=_stable_samples_env(),
+        sample_interval_seconds=_positive_float_env(
+            "POSTGRES_WAIT_SAMPLE_INTERVAL_SECONDS",
+            DEFAULT_SAMPLE_INTERVAL_SECONDS,
+        ),
+    )
+
+
+def _signal_process_group(process_group_id: int, sig: signal.Signals) -> None:
+    try:
+        os.killpg(process_group_id, sig)
+    except ProcessLookupError:
+        pass
+    except PermissionError:
+        # A finished group ID may already have been reused by another user.
+        # Refuse to signal a process group that is no longer ours.
+        pass
+
+
+def _drain_after_kill(
+    process: subprocess.Popen[str],
+    *,
+    deadline: float,
+) -> None:
+    remaining = max(0.001, deadline - time.monotonic())
+    try:
+        process.communicate(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        if process.stdout is not None:
+            process.stdout.close()
+        process.kill()
+        try:
+            process.wait(timeout=0.1)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def run_with_process_group_timeout(
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> ProbeResult:
+    started_at = time.monotonic()
+    deadline = started_at + timeout_seconds
+    term_grace = min(MAX_TERM_GRACE_SECONDS, timeout_seconds / 4)
+    reap_grace = min(MAX_REAP_GRACE_SECONDS, timeout_seconds / 4)
+    kill_deadline = deadline - reap_grace
+    term_deadline = kill_deadline - term_grace
+
+    process = subprocess.Popen(
+        list(command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        soft_timeout = max(0.001, term_deadline - time.monotonic())
+        stdout, _ = process.communicate(timeout=soft_timeout)
+        if time.monotonic() > deadline:
+            return ProbeResult(returncode=124, stdout="", timed_out=True)
+        return ProbeResult(
+            returncode=process.returncode,
+            stdout=stdout,
+            timed_out=False,
+        )
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process.pid, signal.SIGTERM)
+        remaining = kill_deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(remaining)
+
+        # The group kill is unconditional after the TERM grace. The original
+        # leader may already be gone while a descendant still owns stdout.
+        _signal_process_group(process.pid, signal.SIGKILL)
+        cleanup_deadline = min(
+            deadline,
+            time.monotonic() + MAX_REAP_GRACE_SECONDS,
+        )
+        _drain_after_kill(process, deadline=cleanup_deadline)
+        return ProbeResult(returncode=124, stdout="", timed_out=True)
+    except BaseException:
+        _signal_process_group(process.pid, signal.SIGKILL)
+        cleanup_deadline = min(
+            deadline,
+            time.monotonic() + MAX_REAP_GRACE_SECONDS,
+        )
+        _drain_after_kill(process, deadline=cleanup_deadline)
+        raise
+
+
+def _timeout_error(config: WaitConfig) -> str:
+    timeout = f"{config.timeout_seconds:g}"
+    return (
+        f"PostgreSQL service {config.service} did not produce "
+        f"{config.stable_samples} stable SQL samples within {timeout}s"
+    )
+
+
+def _probe_command(docker: str, config: WaitConfig) -> list[str]:
+    return [
+        docker,
+        "compose",
+        "exec",
+        "-T",
+        config.service,
+        "psql",
+        "-X",
+        "-w",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-U",
+        config.user,
+        "-d",
+        config.database,
+        "-tAc",
+        POSTMASTER_QUERY,
+    ]
+
+
+def wait_for_stable_postgres(config: WaitConfig, *, docker: str) -> int:
+    started_at = time.monotonic()
+    deadline = started_at + config.timeout_seconds
+    attempt = 0
+    stable_samples = 0
+    last_start_time = ""
+    timeout_label = f"{config.timeout_seconds:g}"
+
+    print(
+        f"Waiting up to {timeout_label}s for PostgreSQL service {config.service} "
+        f"({config.database}) to remain on one postmaster for "
+        f"{config.stable_samples} SQL samples..."
+    )
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(f"ERROR: {_timeout_error(config)}", file=sys.stderr)
+            return 1
+
+        attempt += 1
+        probe_budget = min(config.probe_timeout_seconds, remaining)
+        result = run_with_process_group_timeout(
+            _probe_command(docker, config),
+            timeout_seconds=probe_budget,
+        )
+        sample = result.stdout.rstrip("\r\n")
+        valid_sample = (
+            result.returncode == 0
+            and not result.timed_out
+            and bool(sample)
+            and "\n" not in sample
+            and "\r" not in sample
+        )
+
+        if valid_sample:
+            if sample == last_start_time:
+                stable_samples += 1
+            else:
+                if last_start_time:
+                    print(
+                        f"PostgreSQL service {config.service} restarted; "
+                        "resetting stability samples."
+                    )
+                last_start_time = sample
+                stable_samples = 1
+
+            print(
+                f"PostgreSQL service {config.service} SQL sample "
+                f"{stable_samples}/{config.stable_samples} uses postmaster {sample}."
+            )
+            if stable_samples >= config.stable_samples:
+                elapsed = time.monotonic() - started_at
+                if elapsed > config.timeout_seconds:
+                    print(f"ERROR: {_timeout_error(config)}", file=sys.stderr)
+                    return 1
+                print(
+                    f"PostgreSQL service {config.service} is stable after "
+                    f"{elapsed:.2f}s and {attempt} attempts."
+                )
+                return 0
+        else:
+            if stable_samples:
+                print(
+                    f"PostgreSQL service {config.service} SQL probe failed; "
+                    "resetting stability samples."
+                )
+            else:
+                print(
+                    f"PostgreSQL service {config.service} SQL probe is not ready "
+                    f"(attempt {attempt})."
+                )
+            stable_samples = 0
+            last_start_time = ""
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(f"ERROR: {_timeout_error(config)}", file=sys.stderr)
+            return 1
+        time.sleep(min(config.sample_interval_seconds, remaining))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        config = _load_config(argv)
+    except ConfigurationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    docker = shutil.which("docker")
+    if docker is None:
+        print("ERROR: docker is required", file=sys.stderr)
+        return 1
+    return wait_for_stable_postgres(config, docker=docker)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/wait_for_stable_postgres.sh
+++ b/scripts/ci/wait_for_stable_postgres.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "${script_dir}/wait_for_stable_postgres.py" "$@"

--- a/tests/unit/test_ci_postgres_stability.py
+++ b/tests/unit/test_ci_postgres_stability.py
@@ -15,6 +15,30 @@ def _executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
+def _linux_process_state(pid: int, *, proc_root: Path = Path("/proc")) -> str | None:
+    try:
+        stat = (proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    command_end = stat.rfind(")")
+    if command_end < 0 or command_end + 2 >= len(stat):
+        raise AssertionError(f"malformed proc stat for pid {pid}: {stat!r}")
+    return stat[command_end + 2]
+
+
+def _process_is_live(pid: int, *, proc_root: Path = Path("/proc")) -> bool:
+    if proc_root.is_dir():
+        state = _linux_process_state(pid, proc_root=proc_root)
+        return state is not None and state not in {"Z", "X", "x"}
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def _run_waiter(
     tmp_path: Path,
     fake_docker: str,
@@ -152,16 +176,32 @@ printf '2026-07-13 20:04:00+00\n'
 
     child_pid = int((tmp_path / "docker-child-pid").read_text(encoding="utf-8"))
     cleanup_deadline = time.monotonic() + 0.5
-    while time.monotonic() < cleanup_deadline:
-        try:
-            os.kill(child_pid, 0)
-        except ProcessLookupError:
-            break
+    while _process_is_live(child_pid) and time.monotonic() < cleanup_deadline:
         time.sleep(0.02)
-    else:
+    if _process_is_live(child_pid):
         raise AssertionError(f"timed-out probe child {child_pid} is still running")
 
     assert not (tmp_path / "docker-marker").exists()
+
+
+def test_linux_proc_state_distinguishes_live_process_from_zombie(tmp_path):
+    proc_root = tmp_path / "proc"
+    live_pid = 101
+    zombie_pid = 202
+    (proc_root / str(live_pid)).mkdir(parents=True)
+    (proc_root / str(zombie_pid)).mkdir(parents=True)
+    (proc_root / str(live_pid) / "stat").write_text(
+        "101 (fake ) live child) S 1 2 3\n",
+        encoding="utf-8",
+    )
+    (proc_root / str(zombie_pid) / "stat").write_text(
+        "202 (fake zombie) Z 1 2 3\n",
+        encoding="utf-8",
+    )
+
+    assert _process_is_live(live_pid, proc_root=proc_root) is True
+    assert _process_is_live(zombie_pid, proc_root=proc_root) is False
+    assert _process_is_live(303, proc_root=proc_root) is False
 
 
 def test_ci_waits_for_both_postgres_services_with_sql_stability_gate():

--- a/tests/unit/test_ci_postgres_stability.py
+++ b/tests/unit/test_ci_postgres_stability.py
@@ -1,0 +1,222 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/ci/wait_for_stable_postgres.sh"
+PYTHON_WAITER = REPO_ROOT / "scripts/ci/wait_for_stable_postgres.py"
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_waiter(
+    tmp_path: Path,
+    fake_docker: str,
+    *,
+    service: str = "db",
+    database: str = "air_conditioners",
+    timeout: str = "5",
+    probe_timeout: str = "5",
+    stable_samples: str = "3",
+    interval: str = "0.01",
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "docker", fake_docker)
+
+    return subprocess.run(
+        ["bash", str(SCRIPT), service, database, "postgres"],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "POSTGRES_WAIT_TIMEOUT_SECONDS": timeout,
+            "POSTGRES_WAIT_PROBE_TIMEOUT_SECONDS": probe_timeout,
+            "POSTGRES_WAIT_STABLE_SAMPLES": stable_samples,
+            "POSTGRES_WAIT_SAMPLE_INTERVAL_SECONDS": interval,
+            "FAKE_DOCKER_STATE": str(tmp_path / "docker-state"),
+            "FAKE_DOCKER_CALLS": str(tmp_path / "docker-calls"),
+            "FAKE_DOCKER_MARKER": str(tmp_path / "docker-marker"),
+            "FAKE_DOCKER_PID_FILE": str(tmp_path / "docker-child-pid"),
+            "FAKE_DOCKER_TERM_MARKER": str(tmp_path / "docker-term-marker"),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_temp_postmaster_restart_resets_stability_before_final_server(tmp_path):
+    result = _run_waiter(
+        tmp_path,
+        """#!/usr/bin/env bash
+set -euo pipefail
+state_file="${FAKE_DOCKER_STATE}"
+calls_file="${FAKE_DOCKER_CALLS}"
+count=0
+[[ ! -f "${state_file}" ]] || count="$(cat "${state_file}")"
+count=$((count + 1))
+printf '%s' "${count}" > "${state_file}"
+printf '%s\n' "$*" >> "${calls_file}"
+case "${count}" in
+  1|2) printf '2026-07-13 20:03:50+00\n' ;;
+  *) printf '2026-07-13 20:03:52+00\n' ;;
+esac
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "restarted; resetting stability samples" in result.stdout
+    assert "stable after" in result.stdout
+    assert (tmp_path / "docker-state").read_text(encoding="utf-8") == "5"
+    calls = (tmp_path / "docker-calls").read_text(encoding="utf-8").splitlines()
+    expected_call = (
+        "compose exec -T db psql -X -w -v ON_ERROR_STOP=1 -U postgres "
+        "-d air_conditioners -tAc SELECT pg_postmaster_start_time()::text;"
+    )
+    assert all(call == expected_call for call in calls)
+
+
+def test_never_ready_service_times_out_and_fails_closed(tmp_path):
+    result = _run_waiter(
+        tmp_path,
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_DOCKER_CALLS}"
+printf '\n'
+""",
+        timeout="1",
+        interval="0.05",
+    )
+
+    assert result.returncode != 0
+    assert "did not produce 3 stable SQL samples within 1s" in result.stderr
+    assert "is stable" not in result.stdout
+
+
+def test_failed_sql_query_does_not_count_as_a_stable_sample(tmp_path):
+    result = _run_waiter(
+        tmp_path,
+        """#!/usr/bin/env bash
+set -euo pipefail
+state_file="${FAKE_DOCKER_STATE}"
+count=0
+[[ ! -f "${state_file}" ]] || count="$(cat "${state_file}")"
+count=$((count + 1))
+printf '%s' "${count}" > "${state_file}"
+if (( count == 2 )); then
+  printf 'query failed\n' >&2
+  exit 1
+fi
+printf '2026-07-13 20:04:00+00\n'
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SQL probe failed; resetting stability samples" in result.stdout
+    assert (tmp_path / "docker-state").read_text(encoding="utf-8") == "5"
+
+
+def test_hung_sql_probe_is_killed_within_remaining_global_budget(tmp_path):
+    started = time.monotonic()
+    result = _run_waiter(
+        tmp_path,
+        """#!/usr/bin/env bash
+set -euo pipefail
+trap 'printf terminated > "${FAKE_DOCKER_TERM_MARKER}"; exit 143' TERM
+(
+  trap '' TERM
+  sleep 3
+  printf 'orphaned\n' > "${FAKE_DOCKER_MARKER}"
+) &
+child_pid="$!"
+printf '%s' "${child_pid}" > "${FAKE_DOCKER_PID_FILE}"
+wait "${child_pid}"
+printf '2026-07-13 20:04:00+00\n'
+""",
+        timeout="1",
+        probe_timeout="5",
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode != 0
+    assert elapsed < 1.75
+    assert "within 1s" in result.stderr
+    assert (tmp_path / "docker-term-marker").read_text(encoding="utf-8") == "terminated"
+
+    child_pid = int((tmp_path / "docker-child-pid").read_text(encoding="utf-8"))
+    cleanup_deadline = time.monotonic() + 0.5
+    while time.monotonic() < cleanup_deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.02)
+    else:
+        raise AssertionError(f"timed-out probe child {child_pid} is still running")
+
+    assert not (tmp_path / "docker-marker").exists()
+
+
+def test_ci_waits_for_both_postgres_services_with_sql_stability_gate():
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pg_isready" not in workflow
+    assert (
+        "scripts/ci/wait_for_stable_postgres.sh db air_conditioners postgres"
+        in workflow
+    )
+    assert (
+        "scripts/ci/wait_for_stable_postgres.sh db_test air_conditioners_test postgres"
+        in workflow
+    )
+
+
+def test_waiter_executes_sql_probe_for_each_ci_postgres_service(tmp_path):
+    fake_docker = """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_DOCKER_CALLS}"
+printf '2026-07-13 20:04:00+00\n'
+"""
+
+    for service, database in (
+        ("db", "air_conditioners"),
+        ("db_test", "air_conditioners_test"),
+    ):
+        case_dir = tmp_path / service
+        case_dir.mkdir()
+        result = _run_waiter(
+            case_dir,
+            fake_docker,
+            service=service,
+            database=database,
+            stable_samples="2",
+        )
+
+        assert result.returncode == 0, result.stderr
+        calls = (case_dir / "docker-calls").read_text(encoding="utf-8").splitlines()
+        expected_call = (
+            f"compose exec -T {service} psql -X -w -v ON_ERROR_STOP=1 "
+            f"-U postgres -d {database} -tAc "
+            "SELECT pg_postmaster_start_time()::text;"
+        )
+        assert len(calls) == 2
+        assert all(call == expected_call for call in calls)
+
+
+def test_default_stability_window_uses_three_samples_two_seconds_apart():
+    script = PYTHON_WAITER.read_text(encoding="utf-8")
+
+    assert "DEFAULT_STABLE_SAMPLES = 3" in script
+    assert "DEFAULT_SAMPLE_INTERVAL_SECONDS = 2.0" in script
+    assert "DEFAULT_PROBE_TIMEOUT_SECONDS = 5.0" in script
+    assert "SELECT pg_postmaster_start_time()::text;" in script
+    assert "start_new_session=True" in script
+    assert "os.killpg(process_group_id, sig)" in script
+    assert "signal.SIGKILL" in script


### PR DESCRIPTION
## What changed

- replace one-shot `pg_isready` waits with a stable consecutive-readiness gate for both CI databases
- enforce one end-to-end deadline across probes and cleanup
- run each probe in its own process group and terminate the full group on timeout
- make exhausted readiness attempts fail the workflow explicitly
- add regression coverage for init-time shutdown races, hung probes, and TERM-ignoring descendants

## Why

The previous gate could observe PostgreSQL's temporary init server as ready and then race its shutdown before Alembic. It also silently continued after all retries and could leave descendants holding stdout after a timeout.

## Impact

CI now proceeds only after each database is continuously queryable, and fails within a bounded deadline without orphan processes.

## Validation

- independent review: PASS, no P0/P1/P2 findings
- 9 focused tests passed
- hung-probe regression repeated 20 times
- extra early-leader-exit black-box checks passed
- `bash -n`, ShellCheck, Python compilation, actionlint/YAML parse, and `git diff --check` passed