### PR TITLE
Fix production private storage startup probe

### DIFF
--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -6,6 +6,7 @@ from .handlers import admin, base, catalog, repair_context, work
 from core.config import settings
 from core.database import async_session_maker
 from core.logger import setup_logging
+from core.startup_checks import run_production_startup_checks
 from services.runtime_lock_service import RuntimeLockService
 
 # Setup logging with session-specific bot.log (cleared on restart)
@@ -44,6 +45,8 @@ async def main(*, wait_when_disabled: bool = True):
             logger.info("Bot process is idling without polling to avoid restart loops.")
             await _idle_when_disabled()
         return
+
+    await run_production_startup_checks(settings)
 
     if wait_when_disabled:
         runtime_lock = await RuntimeLockService.wait_until_acquired(

--- a/core/app_lifespan.py
+++ b/core/app_lifespan.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from core.config import settings
 from core.database import async_session_maker, init_db
 from core.logger import logger
+from core.startup_checks import run_production_startup_checks
 from services.runtime_lock_service import RuntimeLockService
 
 
@@ -469,6 +470,7 @@ async def _stop_scheduler_supervisor(app: FastAPI) -> None:
 async def app_lifespan(app: FastAPI):
     logger.info("Starting Application...")
 
+    await run_production_startup_checks(settings)
     await _bootstrap_database()
     _start_scheduler_supervisor(app)
 

--- a/core/config.py
+++ b/core/config.py
@@ -354,16 +354,4 @@ class Settings(BaseSettings):
     )
 
 
-def _run_production_startup_checks(current_settings: Settings) -> None:
-    if not current_settings.is_production:
-        return
-
-    from services.private_attachment_storage_service import (
-        verify_private_attachment_storage_startup,
-    )
-
-    verify_private_attachment_storage_startup(current_settings)
-
-
 settings = Settings()
-_run_production_startup_checks(settings)

--- a/core/startup_checks.py
+++ b/core/startup_checks.py
@@ -1,0 +1,14 @@
+"""Fail-closed checks for production processes before they accept work."""
+
+from typing import Any
+
+
+async def run_production_startup_checks(current_settings: Any) -> None:
+    if not current_settings.is_production:
+        return
+
+    from services.private_attachment_storage_service import (
+        verify_private_attachment_storage_startup,
+    )
+
+    await verify_private_attachment_storage_startup(current_settings)

--- a/services/private_attachment_storage_service.py
+++ b/services/private_attachment_storage_service.py
@@ -355,7 +355,7 @@ def get_private_attachment_storage(provider: str | None = None) -> PrivateAttach
     return _build_private_attachment_storage(settings, provider)
 
 
-def verify_private_attachment_storage_startup(
+async def verify_private_attachment_storage_startup(
     current_settings: Any,
     *,
     client: Any | None = None,
@@ -381,20 +381,11 @@ def verify_private_attachment_storage_startup(
         )
 
     try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        pass
-    else:
-        raise RuntimeError(
-            "Private attachment startup probe must run before the application event loop"
-        )
-
-    try:
         storage = _build_private_attachment_storage(
             current_settings,
             client=client,
         )
-        asyncio.run(storage.verify_writable())
+        await storage.verify_writable()
     except Exception as exc:
         raise RuntimeError(
             "Private attachment R2 startup probe failed "

--- a/tests/unit/test_app_startup_checks.py
+++ b/tests/unit/test_app_startup_checks.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core import app_lifespan as lifespan_module
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_awaits_startup_checks_before_database(monkeypatch):
+    events: list[str] = []
+
+    async def run_startup_checks(_settings):
+        events.append("startup_checks")
+
+    async def bootstrap_database():
+        events.append("database")
+
+    def start_scheduler(_app):
+        events.append("scheduler")
+
+    async def stop_scheduler(_app):
+        events.append("shutdown")
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "run_production_startup_checks",
+        run_startup_checks,
+    )
+    monkeypatch.setattr(lifespan_module, "_bootstrap_database", bootstrap_database)
+    monkeypatch.setattr(
+        lifespan_module,
+        "_start_scheduler_supervisor",
+        start_scheduler,
+    )
+    monkeypatch.setattr(
+        lifespan_module,
+        "_stop_scheduler_supervisor",
+        stop_scheduler,
+    )
+
+    async with lifespan_module.app_lifespan(SimpleNamespace()):
+        events.append("serving")
+
+    assert events == [
+        "startup_checks",
+        "database",
+        "scheduler",
+        "serving",
+        "shutdown",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_app_lifespan_fails_before_database_when_startup_check_fails(
+    monkeypatch,
+):
+    async def fail_startup_checks(_settings):
+        raise RuntimeError("private storage unavailable")
+
+    async def bootstrap_database():
+        raise AssertionError("database bootstrap must not start")
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "run_production_startup_checks",
+        fail_startup_checks,
+    )
+    monkeypatch.setattr(lifespan_module, "_bootstrap_database", bootstrap_database)
+
+    with pytest.raises(RuntimeError, match="private storage unavailable"):
+        async with lifespan_module.app_lifespan(SimpleNamespace()):
+            raise AssertionError("application must not start serving")

--- a/tests/unit/test_private_attachment_storage_security.py
+++ b/tests/unit/test_private_attachment_storage_security.py
@@ -5,8 +5,8 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from core import config as config_module
 from core.config import Settings
+from core import startup_checks as startup_checks_module
 from services import private_attachment_storage_service as storage_module
 from services.private_attachment_storage_service import (
     S3PrivateAttachmentStorage,
@@ -135,7 +135,8 @@ def test_production_private_bucket_must_not_be_shared(public_bucket_setting):
         Settings(_env_file=None, **values)
 
 
-def test_local_settings_do_not_require_r2_or_run_startup_probe(monkeypatch):
+@pytest.mark.asyncio
+async def test_local_settings_do_not_require_r2_or_run_startup_probe(monkeypatch):
     local_settings = Settings(
         _env_file=None,
         SECRET_KEY="test",
@@ -151,22 +152,27 @@ def test_local_settings_do_not_require_r2_or_run_startup_probe(monkeypatch):
         calls.append,
     )
 
-    config_module._run_production_startup_checks(local_settings)
+    await startup_checks_module.run_production_startup_checks(local_settings)
 
     assert local_settings.SERVICE_ATTACHMENT_STORAGE_PROVIDER == "local"
     assert calls == []
 
 
-def test_production_startup_hook_invokes_private_storage_probe(monkeypatch):
+@pytest.mark.asyncio
+async def test_production_startup_hook_invokes_private_storage_probe(monkeypatch):
     configured = _startup_settings()
     calls = []
+
+    async def record_call(current_settings):
+        calls.append(current_settings)
+
     monkeypatch.setattr(
         storage_module,
         "verify_private_attachment_storage_startup",
-        calls.append,
+        record_call,
     )
 
-    config_module._run_production_startup_checks(configured)
+    await startup_checks_module.run_production_startup_checks(configured)
 
     assert calls == [configured]
 
@@ -183,10 +189,11 @@ def test_s3_storage_rejects_non_https_endpoint():
         )
 
 
-def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
+@pytest.mark.asyncio
+async def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
     client = _ProbeS3Client()
 
-    verify_private_attachment_storage_startup(
+    await verify_private_attachment_storage_startup(
         _startup_settings(),
         client=client,
     )
@@ -203,12 +210,13 @@ def test_startup_probe_writes_reads_deletes_and_confirms_cleanup():
     assert client.objects == {}
 
 
-def test_startup_probe_fails_closed_when_delete_does_not_remove_object():
+@pytest.mark.asyncio
+async def test_startup_probe_fails_closed_when_delete_does_not_remove_object():
     client = _ProbeS3Client(delete_objects=False)
     configured = _startup_settings()
 
     with pytest.raises(RuntimeError, match="startup probe failed") as error:
-        verify_private_attachment_storage_startup(configured, client=client)
+        await verify_private_attachment_storage_startup(configured, client=client)
 
     assert configured.SERVICE_ATTACHMENT_S3_SECRET_ACCESS_KEY not in str(error.value)
 


### PR DESCRIPTION
## Root cause

The private R2 write/read/delete startup probe ran during `core.config` import and called `asyncio.run()`. Uvicorn imports the application after its event loop is already running, so every production API container built from `2f5f5f1c` exited with `Private attachment startup probe must run before the application event loop`.

## What changed

- remove network I/O from settings import
- make the live private-storage probe async
- await production startup checks in the API lifespan before DB bootstrap, scheduler startup, or serving traffic
- await the same check in the active Telegram bot before lock acquisition, webhook changes, or polling
- preserve static production config validation and fail-closed probe errors with redacted causes
- add lifecycle ordering and failure regression tests

## Production proof

- reproduced the original crash with the exact failed backend image on the reserve node
- independently verified R2 put/get/delete from that node
- overlaid this patch on the same image in an unpublished one-off container attached to the real standby network
- observed `Application startup complete` with DB bootstrap and scheduler correctly fenced off
- removed the one-off container and temporary files; working production containers were not changed

## Validation

- independent review of exact SHA `bd14a0f1e27a8647689cff98c6127f849ad9ee0b`: PASS, no P0/P1/P2 findings
- full unit suite: 1428 passed
- scoped lifecycle/storage/runtime tests: 49 passed
- production-like API and bot imports inside an active event loop passed
- Python compilation and `git diff --check` passed