### PR TITLE
fix(ha): prevent backend deploys from restarting Patroni

### DIFF
--- a/scripts/ha/patroni_compose_db_contract.py
+++ b/scripts/ha/patroni_compose_db_contract.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Hash the complete Compose contract that can affect the Patroni DB service."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from typing import Any
+
+
+RESOURCE_KINDS = ("volumes", "networks", "configs", "secrets")
+
+
+class ContractError(ValueError):
+    """Raised when Compose output cannot be reduced safely."""
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ContractError(f"{label} must be an object")
+    return value
+
+
+def _named_mount_sources(service: dict[str, Any]) -> set[str]:
+    references: set[str] = set()
+    mounts = service.get("volumes") or []
+    if not isinstance(mounts, list):
+        raise ContractError("services.db.volumes must be an array")
+    for mount in mounts:
+        if isinstance(mount, str):
+            source = mount.split(":", 1)[0]
+            if source and not source.startswith(("/", ".", "~")):
+                references.add(source)
+            continue
+        if not isinstance(mount, dict):
+            raise ContractError("services.db.volumes has an invalid entry")
+        if mount.get("type") == "volume":
+            source = mount.get("source")
+            if not isinstance(source, str) or not source:
+                raise ContractError("services.db volume source is invalid")
+            references.add(source)
+    return references
+
+
+def _network_sources(service: dict[str, Any]) -> set[str]:
+    networks = service.get("networks")
+    if networks is None:
+        return {"default"}
+    if isinstance(networks, dict):
+        return set(networks)
+    if isinstance(networks, list) and all(isinstance(item, str) for item in networks):
+        return set(networks)
+    raise ContractError("services.db.networks has an invalid shape")
+
+
+def _resource_sources(service: dict[str, Any], kind: str) -> set[str]:
+    resources = service.get(kind) or []
+    if not isinstance(resources, list):
+        raise ContractError(f"services.db.{kind} must be an array")
+    references: set[str] = set()
+    for resource in resources:
+        if isinstance(resource, str):
+            references.add(resource)
+            continue
+        if not isinstance(resource, dict):
+            raise ContractError(f"services.db.{kind} has an invalid entry")
+        source = resource.get("source")
+        if not isinstance(source, str) or not source:
+            raise ContractError(f"services.db {kind} source is invalid")
+        references.add(source)
+    return references
+
+
+def _selected_resources(
+    config: dict[str, Any], kind: str, references: set[str]
+) -> dict[str, Any]:
+    available_raw = config.get(kind)
+    if available_raw is None:
+        available: dict[str, Any] = {}
+    else:
+        available = _mapping(available_raw, kind)
+    missing = references.difference(available)
+    if missing:
+        raise ContractError(f"services.db references undefined {kind}")
+    return {name: available[name] for name in sorted(references)}
+
+
+def build_contract(config: dict[str, Any]) -> dict[str, Any]:
+    project_name = config.get("name")
+    if not isinstance(project_name, str) or not project_name:
+        raise ContractError("Compose project name is missing")
+    services = _mapping(config.get("services"), "services")
+    db = _mapping(services.get("db"), "services.db")
+
+    references = {
+        "volumes": _named_mount_sources(db),
+        "networks": _network_sources(db),
+        "configs": _resource_sources(db, "configs"),
+        "secrets": _resource_sources(db, "secrets"),
+    }
+    return {
+        "contract_version": 1,
+        "name": project_name,
+        "service": db,
+        "resources": {
+            kind: _selected_resources(config, kind, references[kind])
+            for kind in RESOURCE_KINDS
+        },
+    }
+
+
+def contract_digest(config: dict[str, Any]) -> str:
+    payload = json.dumps(
+        build_contract(config),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main() -> int:
+    try:
+        config = json.load(sys.stdin)
+        if not isinstance(config, dict):
+            raise ContractError("Compose config root must be an object")
+        print(contract_digest(config))
+    except (ContractError, json.JSONDecodeError) as exc:
+        print(f"invalid Patroni Compose contract: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/patroni_local_identity.py
+++ b/scripts/ha/patroni_local_identity.py
@@ -195,6 +195,22 @@ def reconcile_primary_systemd_units(
         if result.returncode != 0:
             failures.append(unit)
     if role == "standby":
+        # ``systemctl stop`` deliberately does not clear a unit's failed latch.
+        # A failed one-shot PITR service has no running owner, but the strict
+        # steady-state probe still requires ``inactive``.  Clear only the
+        # recorded failure after every stop attempt, then let the exact state
+        # probe below prove that timers are disabled and every unit is inactive.
+        for unit in unique_units:
+            try:
+                subprocess.run(
+                    ["systemctl", "reset-failed", unit],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (OSError, subprocess.SubprocessError):
+                pass
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline and not state_probe(config, role):
             time.sleep(0.1)
@@ -215,6 +231,13 @@ def reconcile_primary_systemd_units(
                 )
                 subprocess.run(
                     ["systemctl", "stop", "--no-block", unit],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                subprocess.run(
+                    ["systemctl", "reset-failed", unit],
                     check=False,
                     capture_output=True,
                     text=True,

--- a/scripts/ha/run_patroni_candidate_transaction.sh
+++ b/scripts/ha/run_patroni_candidate_transaction.sh
@@ -12,6 +12,7 @@ ROLE_AGENT_SOURCE="${PATRONI_ROLE_AGENT_SOURCE:-}"
 ROLE_AGENT_TARGET="${PATRONI_ROLE_AGENT_TARGET:-/usr/local/sbin/mvn-patroni-role-agent}"
 ROLE_IDENTITY_SOURCE="${PATRONI_ROLE_IDENTITY_SOURCE:-}"
 ROLE_IDENTITY_TARGET="${PATRONI_ROLE_IDENTITY_TARGET:-/usr/local/sbin/patroni_local_identity.py}"
+DB_CONTRACT_HELPER="${PATRONI_DB_CONTRACT_HELPER:-/tmp/patroni_compose_db_contract.py}"
 ROLE_AGENT_UNIT="${PATRONI_ROLE_AGENT_UNIT:-mvn-patroni-role-agent.service}"
 RECONCILE_SCRIPT="${API_RECONCILE_SCRIPT:-/tmp/reconcile_backend_compose_runtime.sh}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
@@ -166,6 +167,37 @@ else:
 '
 }
 
+db_contract_digest() {
+  local compose_file="$1"
+  local rendered=""
+
+  rendered="$(
+    docker compose -f "${compose_file}" config \
+      --no-env-resolution --no-interpolate --format json \
+      | python3 "${DB_CONTRACT_HELPER}"
+  )" || {
+    echo "could not render the complete Patroni db contract" >&2
+    return 1
+  }
+  [[ "${rendered}" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "invalid Patroni db contract digest" >&2
+    return 1
+  }
+  printf '%s\n' "${rendered}"
+}
+
+require_unchanged_db_contract() {
+  local canonical_hash=""
+  local candidate_hash=""
+
+  canonical_hash="$(db_contract_digest "${CANONICAL_FILE}")"
+  candidate_hash="$(db_contract_digest "${CANDIDATE_FILE}")"
+  [[ "${canonical_hash}" == "${candidate_hash}" ]] || {
+    echo "candidate changes the Patroni db contract; use the reviewed database rollout controller" >&2
+    return 1
+  }
+}
+
 fence_runtime_for_role_drift() {
   docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
     stop app app-blue app-green bot >/dev/null 2>&1
@@ -266,7 +298,6 @@ CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
   echo "compose transaction helper is missing: ${TRANSACTION_SCRIPT}" >&2
   exit 1
 }
-
 if [[ "${OPERATION}" == "migrate" ]]; then
   trap cleanup_migration_candidate EXIT
   API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" bash "${MIGRATION_SCRIPT}"
@@ -276,11 +307,16 @@ if [[ "${OPERATION}" == "migrate" ]]; then
 fi
 
 trap cleanup_candidate_only EXIT
+[[ -f "${DB_CONTRACT_HELPER}" && ! -L "${DB_CONTRACT_HELPER}" ]] || {
+  echo "Patroni db contract helper is missing or unsafe: ${DB_CONTRACT_HELPER}" >&2
+  exit 1
+}
 exec 9>"${DEPLOY_LOCK_FILE}"
 flock -n 9 || {
   echo "another deployment holds ${DEPLOY_LOCK_FILE}" >&2
   exit 1
 }
+require_unchanged_db_contract
 resolve_previous_backend_image
 backup_role_agent
 trap reconcile_failed_deploy EXIT
@@ -301,6 +337,7 @@ systemctl is-active --quiet "${ROLE_AGENT_UNIT}"
 API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" \
   API_DEPLOY_LOCK_ALREADY_HELD=true \
 bash "${DEPLOY_SCRIPT}"
+require_unchanged_db_contract
 transaction promote
 trap - EXIT
 [[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}" \

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -24,6 +24,9 @@ ROLE_IDENTITY_REMOTE="/tmp/patroni-local-identity-${GITHUB_RUN_ID:-local}-${GITH
 ROLE_IDENTITY_TARGET="/usr/local/sbin/patroni_local_identity.py"
 ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
 CANDIDATE_RUNNER_SOURCE="scripts/ha/run_patroni_candidate_transaction.sh"
+DB_CONTRACT_HELPER_SOURCE="scripts/ha/patroni_compose_db_contract.py"
+DB_CONTRACT_HELPER_REMOTE_DIR=""
+DB_CONTRACT_HELPER_REMOTE=""
 TRANSACTION_SOURCE="scripts/compose_candidate_transaction.sh"
 
 log() {
@@ -36,6 +39,15 @@ usage() {
 
 quote() {
   printf '%q' "$1"
+}
+
+cleanup() {
+  if [[ -n "${DB_CONTRACT_HELPER_REMOTE_DIR}" ]]; then
+    ssh "${SSH_OPTS[@]}" "${REMOTE}" \
+      "rm -f -- $(quote "${DB_CONTRACT_HELPER_REMOTE}"); rmdir -- $(quote "${DB_CONTRACT_HELPER_REMOTE_DIR}")" \
+      >/dev/null 2>&1 || true
+  fi
+  rm -f "${KEY_PATH}" "${KNOWN_HOSTS_PATH}"
 }
 
 [[ "${OPERATION}" == "probe" || "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]] || {
@@ -93,6 +105,13 @@ if [[ "${OPERATION}" != "probe" ]]; then
     exit 1
   }
 fi
+if [[ "${OPERATION}" == "deploy" ]]; then
+  [[ -f "${DB_CONTRACT_HELPER_SOURCE}" \
+    && ! -L "${DB_CONTRACT_HELPER_SOURCE}" ]] || {
+    log error "Patroni db contract helper is missing or unsafe"
+    exit 1
+  }
+fi
 
 required_commands=(ssh ssh-keygen)
 if [[ "${OPERATION}" != "probe" ]]; then
@@ -105,7 +124,7 @@ for command in "${required_commands[@]}"; do
   }
 done
 
-trap 'rm -f "${KEY_PATH}" "${KNOWN_HOSTS_PATH}"' EXIT
+trap cleanup EXIT
 printf '%s\n' "${SSH_PRIVATE_KEY}" > "${KEY_PATH}"
 chmod 600 "${KEY_PATH}"
 : > "${KNOWN_HOSTS_PATH}"
@@ -167,6 +186,19 @@ ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}")"
 CANONICAL_REMOTE_COMPOSE_FILE="docker-compose.patroni.yml"
 candidate_id="$(printf '%s' "${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}-${OPERATION}-$$" | tr -c 'A-Za-z0-9_.-' '-')"
 REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"
+if [[ "${OPERATION}" == "deploy" ]]; then
+  remote_helper_dir="$(
+    ssh "${SSH_OPTS[@]}" "${REMOTE}" \
+      "umask 077; mktemp -d /tmp/mvn-patroni-db-contract.XXXXXXXX"
+  )"
+  [[ "${remote_helper_dir}" \
+    =~ ^/tmp/mvn-patroni-db-contract\.[A-Za-z0-9]{8}$ ]] || {
+    log error "remote Patroni db contract directory is invalid"
+    exit 1
+  }
+  DB_CONTRACT_HELPER_REMOTE_DIR="${remote_helper_dir}"
+  DB_CONTRACT_HELPER_REMOTE="${DB_CONTRACT_HELPER_REMOTE_DIR}/contract.py"
+fi
 scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
   "${REMOTE}:${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}"
 scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
@@ -176,6 +208,8 @@ scp "${SSH_OPTS[@]}" scripts/ha/run_patroni_migrations.sh \
   "${CANDIDATE_RUNNER_SOURCE}" "${TRANSACTION_SOURCE}" \
   "${REMOTE}:/tmp/"
 if [[ "${OPERATION}" == "deploy" ]]; then
+  scp "${SSH_OPTS[@]}" "${DB_CONTRACT_HELPER_SOURCE}" \
+    "${REMOTE}:${DB_CONTRACT_HELPER_REMOTE}"
   scp "${SSH_OPTS[@]}" "${ROLE_AGENT_SOURCE}" \
     "${REMOTE}:${ROLE_AGENT_REMOTE}"
   scp "${SSH_OPTS[@]}" "${ROLE_IDENTITY_SOURCE}" \
@@ -200,10 +234,15 @@ if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
 fi
 
 log "${OPERATION}" "running ${OPERATION} on ${NODE_HOST}"
+remote_helper_cleanup=":"
+if [[ "${OPERATION}" == "deploy" ]]; then
+  remote_helper_cleanup="rm -f -- $(quote "${DB_CONTRACT_HELPER_REMOTE}"); rmdir -- $(quote "${DB_CONTRACT_HELPER_REMOTE_DIR}")"
+fi
 printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   set -euo pipefail
   IFS= read -r GHCR_PAT
   export GHCR_PAT
+  trap $(quote "${remote_helper_cleanup}") EXIT
   chmod 0755 /tmp/run_patroni_migrations.sh /tmp/deploy_patroni_api_node.sh /tmp/deploy_backend_blue_green.sh /tmp/deploy_backend_blue_green_safety.sh /tmp/prepare_google_oauth_token_dir.sh /tmp/reconcile_backend_compose_runtime.sh /tmp/run_patroni_candidate_transaction.sh /tmp/compose_candidate_transaction.sh
   API_PROJECT_DIR=$(quote "${PROJECT_DIR}") \
   API_EXPECTED_PATRONI_ROLE=$(quote "${EXPECTED_ROLE}") \
@@ -224,8 +263,11 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   PATRONI_ROLE_AGENT_TARGET=$(quote "${ROLE_AGENT_TARGET}") \
   PATRONI_ROLE_IDENTITY_SOURCE=$(quote "${ROLE_IDENTITY_REMOTE}") \
   PATRONI_ROLE_IDENTITY_TARGET=$(quote "${ROLE_IDENTITY_TARGET}") \
+  PATRONI_DB_CONTRACT_HELPER=$(quote "${DB_CONTRACT_HELPER_REMOTE}") \
   PATRONI_ROLE_AGENT_UNIT=$(quote "${ROLE_AGENT_UNIT}") \
   ${proxy_env} \
   bash /tmp/run_patroni_candidate_transaction.sh
 "
+DB_CONTRACT_HELPER_REMOTE_DIR=""
+DB_CONTRACT_HELPER_REMOTE=""
 log "done" "${OPERATION} completed on ${NODE_HOST}"

--- a/tests/unit/test_patroni_candidate_transactions.py
+++ b/tests/unit/test_patroni_candidate_transactions.py
@@ -1,3 +1,5 @@
+import copy
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -9,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TRANSACTION = REPO_ROOT / "scripts/compose_candidate_transaction.sh"
 PATRONI_RUNNER = REPO_ROOT / "scripts/ha/run_patroni_candidate_transaction.sh"
 PREVIOUS_IMAGE = "ghcr.io/mvnby/air-api/backend:" + "1" * 40
+DB_CONTRACT_HELPER = REPO_ROOT / "scripts/ha/patroni_compose_db_contract.py"
 
 
 def _executable(path: Path, content: str) -> None:
@@ -28,6 +31,37 @@ def _compose_pair(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     return project
+
+
+def _db_compose_config() -> dict:
+    return {
+        "name": "mvn-api",
+        "services": {
+            "db": {
+                "image": "${PATRONI_IMAGE:?set immutable PATRONI_IMAGE}",
+                "networks": {"default": None},
+                "volumes": [
+                    {
+                        "source": "postgres_data",
+                        "target": "/var/lib/postgresql/data",
+                        "type": "volume",
+                        "volume": {},
+                    }
+                ],
+            }
+        },
+        "networks": {"default": {"name": "mvn-api_default"}},
+        "volumes": {
+            "postgres_data": {
+                "external": True,
+                "name": "air-api_postgres_data",
+            }
+        },
+    }
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
 
 
 def _patroni_runner_env(
@@ -50,12 +84,26 @@ def _patroni_runner_env(
     systemctl_log.touch()
     systemctl_state = tmp_path / "systemctl-state"
     systemctl_state.write_text("active\n", encoding="utf-8")
+    canonical_contract = tmp_path / "canonical-contract.json"
+    candidate_contract = tmp_path / "candidate-contract.json"
+    _write_json(canonical_contract, _db_compose_config())
+    _write_json(candidate_contract, copy.deepcopy(_db_compose_config()))
     _executable(
         fake_bin / "docker",
         """#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$PATRONI_COMMAND_LOG"
-if [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
+if [[ "$1" == "compose" && "$*" == *" config --no-env-resolution --no-interpolate --format json" ]]; then
+  if [[ "$*" == *"compose.yml.candidate"* ]]; then
+    config_path="$CANDIDATE_DB_CONTRACT"
+    if [[ -e "$DEPLOY_CHILD_RAN" && -n "${CANDIDATE_DB_CONTRACT_AFTER_DEPLOY:-}" ]]; then
+      config_path="$CANDIDATE_DB_CONTRACT_AFTER_DEPLOY"
+    fi
+  else
+    config_path="$CANONICAL_DB_CONTRACT"
+  fi
+  exec /bin/cat "$config_path"
+elif [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
   printf 'active-green-container\n'
 elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
   printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
@@ -104,6 +152,7 @@ esac
 set -euo pipefail
 grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
 printf "%s|%s\n" "$API_COMPOSE_FILE" "$API_DEPLOY_LOCK_ALREADY_HELD" > "$CHILD_LOG"
+: > "$DEPLOY_CHILD_RAN"
 exit {child_exit}
 ''',
     )
@@ -139,6 +188,7 @@ exit 0
         "PATRONI_ROLE_AGENT_TARGET": str(tmp_path / "installed-role-agent"),
         "PATRONI_ROLE_IDENTITY_SOURCE": str(role_identity),
         "PATRONI_ROLE_IDENTITY_TARGET": str(tmp_path / "installed-role-identity.py"),
+        "PATRONI_DB_CONTRACT_HELPER": str(DB_CONTRACT_HELPER),
         "PATRONI_ROLE_AGENT_UNIT": "test.service",
         "CHILD_LOG": str(tmp_path / "child.log"),
         "RECONCILE_LOG": str(tmp_path / "reconcile.log"),
@@ -146,6 +196,9 @@ exit 0
         "SYSTEMCTL_LOG": str(systemctl_log),
         "SYSTEMCTL_STATE": str(systemctl_state),
         "SYSTEMCTL_RESTART_COUNT": str(tmp_path / "systemctl-restart-count"),
+        "CANONICAL_DB_CONTRACT": str(canonical_contract),
+        "CANDIDATE_DB_CONTRACT": str(candidate_contract),
+        "DEPLOY_CHILD_RAN": str(tmp_path / "deploy-child-ran"),
         "API_PREVIOUS_BACKEND_IMAGE": "" if discover_previous else PREVIOUS_IMAGE,
         "EXPECTED_PREVIOUS_IMAGE": PREVIOUS_IMAGE,
     }
@@ -189,6 +242,137 @@ def test_patroni_candidate_promotes_only_after_success(tmp_path):
     assert not (tmp_path / "reconcile.log").exists()
     assert Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).read_text() == (
         "# new identity helper\n"
+    )
+
+
+def test_patroni_candidate_rejects_db_service_drift_before_host_mutation(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    candidate = json.loads(Path(env["CANDIDATE_DB_CONTRACT"]).read_text())
+    candidate["services"]["db"]["image"] = "other-patroni-image"
+    _write_json(Path(env["CANDIDATE_DB_CONTRACT"]), candidate)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "candidate changes the Patroni db contract" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "child.log").exists()
+    assert not (tmp_path / "systemctl.log").read_text(encoding="utf-8")
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+    assert not Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).exists()
+
+
+@pytest.mark.parametrize("unsafe_helper", ["missing", "symlink"])
+def test_patroni_candidate_cleans_up_when_db_contract_helper_is_unsafe(
+    tmp_path, unsafe_helper
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    helper = tmp_path / "unsafe-contract-helper.py"
+    if unsafe_helper == "symlink":
+        helper.symlink_to(DB_CONTRACT_HELPER)
+    env["PATRONI_DB_CONTRACT_HELPER"] = str(helper)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "db contract helper is missing or unsafe" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "child.log").exists()
+    assert not (tmp_path / "systemctl.log").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("drift", ["project_name", "external_volume"])
+def test_patroni_candidate_rejects_db_resource_identity_drift_before_host_mutation(
+    tmp_path, drift
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    candidate = json.loads(Path(env["CANDIDATE_DB_CONTRACT"]).read_text())
+    if drift == "project_name":
+        candidate["name"] = "mvn-api-shadow"
+    else:
+        candidate["volumes"]["postgres_data"]["name"] = "other-postgres-data"
+        candidate["volumes"]["postgres_data"]["driver_opts"] = {"type": "tmpfs"}
+    _write_json(Path(env["CANDIDATE_DB_CONTRACT"]), candidate)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "candidate changes the Patroni db contract" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (tmp_path / "child.log").exists()
+    assert not (tmp_path / "systemctl.log").read_text(encoding="utf-8")
+
+
+def test_patroni_candidate_rejects_latent_db_interpolation_drift(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    candidate = json.loads(Path(env["CANDIDATE_DB_CONTRACT"]).read_text())
+    candidate["services"]["db"]["image"] = (
+        "${BACKEND_IMAGE:?set immutable BACKEND_IMAGE}"
+    )
+    _write_json(Path(env["CANDIDATE_DB_CONTRACT"]), candidate)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "candidate changes the Patroni db contract" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (tmp_path / "child.log").exists()
+
+
+def test_patroni_candidate_rechecks_db_contract_immediately_before_promotion(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    drifted_contract = tmp_path / "candidate-contract-after-deploy.json"
+    candidate = json.loads(Path(env["CANDIDATE_DB_CONTRACT"]).read_text())
+    candidate["volumes"]["postgres_data"]["name"] = "late-postgres-data"
+    _write_json(drifted_contract, candidate)
+    env["CANDIDATE_DB_CONTRACT_AFTER_DEPLOY"] = str(drifted_contract)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "candidate changes the Patroni db contract" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert (tmp_path / "child.log").exists()
+    assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == (
+        "compose.yml|app bot"
     )
 
 

--- a/tests/unit/test_patroni_compose_db_contract.py
+++ b/tests/unit/test_patroni_compose_db_contract.py
@@ -1,0 +1,68 @@
+import copy
+
+import pytest
+
+from scripts.ha.patroni_compose_db_contract import ContractError, contract_digest
+
+
+def _config() -> dict:
+    return {
+        "name": "mvn-api",
+        "services": {
+            "db": {
+                "image": "${PATRONI_IMAGE}",
+                "networks": {"default": None},
+                "volumes": [
+                    {
+                        "source": "postgres_data",
+                        "target": "/var/lib/postgresql/data",
+                        "type": "volume",
+                    },
+                    {
+                        "source": "/srv/wal",
+                        "target": "/archive",
+                        "type": "bind",
+                    },
+                ],
+            }
+        },
+        "networks": {"default": {"name": "mvn-api_default"}},
+        "volumes": {
+            "postgres_data": {"external": True, "name": "air-api_postgres_data"}
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(name="other-project"),
+        lambda value: value["services"]["db"].update(image="${BACKEND_IMAGE}"),
+        lambda value: value["volumes"]["postgres_data"].update(
+            name="other-postgres-data"
+        ),
+        lambda value: value["networks"]["default"].update(name="other-network"),
+    ],
+)
+def test_contract_digest_covers_db_project_and_referenced_resources(mutation):
+    canonical = _config()
+    candidate = copy.deepcopy(canonical)
+    mutation(candidate)
+
+    assert contract_digest(candidate) != contract_digest(canonical)
+
+
+def test_contract_digest_ignores_resources_not_referenced_by_db():
+    canonical = _config()
+    candidate = copy.deepcopy(canonical)
+    candidate["volumes"]["app_cache"] = {"name": "mvn-api-app-cache"}
+
+    assert contract_digest(candidate) == contract_digest(canonical)
+
+
+def test_contract_rejects_missing_referenced_resource():
+    value = _config()
+    value["volumes"].clear()
+
+    with pytest.raises(ContractError, match="undefined volumes"):
+        contract_digest(value)

--- a/tests/unit/test_patroni_local_identity.py
+++ b/tests/unit/test_patroni_local_identity.py
@@ -47,6 +47,38 @@ def test_systemd_query_timeout_is_not_treated_as_inactive(monkeypatch):
     assert patroni_local_identity.systemd_units_match(config, "standby") is False
 
 
+def test_standby_reconcile_clears_failed_service_latch(monkeypatch):
+    config = SimpleNamespace(primary_systemd_units=("wal.timer",))
+    active_states = {"wal.timer": "inactive", "wal.service": "failed"}
+    enabled_states = {"wal.timer": "disabled"}
+    calls: list[tuple[str, ...]] = []
+
+    def run(args, **_kwargs):
+        command = tuple(args)
+        calls.append(command)
+        unit = args[-1]
+        if args[1:4] == ["show", "--property=ActiveState", "--value"]:
+            return subprocess.CompletedProcess(args, 0, active_states[unit] + "\n", "")
+        if args[1:2] == ["is-enabled"]:
+            state = enabled_states[unit]
+            return subprocess.CompletedProcess(args, 1, state + "\n", "")
+        if args[1:3] == ["reset-failed", unit]:
+            if active_states[unit] == "failed":
+                active_states[unit] = "inactive"
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[1] in {"disable", "stop"}:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(patroni_local_identity.subprocess, "run", run)
+
+    patroni_local_identity.reconcile_primary_systemd_units(config, "standby")
+
+    assert ("systemctl", "reset-failed", "wal.timer") in calls
+    assert ("systemctl", "reset-failed", "wal.service") in calls
+    assert active_states == {"wal.timer": "inactive", "wal.service": "inactive"}
+
+
 class _PatroniResponse:
     def __init__(self, payload: dict[str, object]):
         self.payload = json.dumps(payload).encode()

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -183,6 +183,10 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert 'candidate_id="$(printf' in text
     assert 'REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"' in text
     assert "run_patroni_candidate_transaction.sh" in text
+    assert "scripts/ha/patroni_compose_db_contract.py" in text
+    assert "PATRONI_DB_CONTRACT_HELPER=" in text
+    assert "mktemp -d /tmp/mvn-patroni-db-contract.XXXXXXXX" in text
+    assert "patroni-compose-db-contract-${GITHUB_RUN_ID" not in text
     assert "compose_candidate_transaction.sh" in text
     assert "reconcile_backend_compose_runtime.sh" in text
     assert (


### PR DESCRIPTION
## What changed

- block ordinary Patroni-aware backend deployments unless the candidate preserves the complete database contract:
  - the non-interpolated normalized `services.db`
  - Compose project identity
  - every referenced top-level volume, network, config, and secret definition
- repeat the database-contract gate immediately before Compose promotion to close late drift
- transfer the contract helper through a root-created random `0700` remote directory and clean it on success or failure
- clear stale systemd failed latches after standby PITR services are stopped, while retaining the strict inactive-state postcondition
- add regression coverage for project/PGDATA/network/interpolation drift, late mutation, unsafe helper cleanup, and failed-unit recovery

## Root cause

PR #743 changed the canonical Patroni Compose contract while the hosts still had an older scheduled PITR runner. The next minute timer used `docker compose run` with dependencies, so Compose reconciled and recreated PostgreSQL first on the active node and then on the promoted node. The resulting double failover exposed a second issue: failed one-shot PITR services remained in systemd's `failed` state, and the role agent treated that safe non-running state as an incomplete fence.

## Production impact and mitigation

The public API returned 502 during the double failover and the concurrent frontend build failed before publication. The database recovered with matching system identifier and synchronous replication.

Both hosts now have the reviewed root-owned PITR maintenance marker. PITR timers/services are disabled and inactive, while the Patroni role agents remain active. Public readiness is 200 and the current topology is one primary plus one synchronous standby.

## Validation

- 169 targeted Patroni/HA tests passed locally
- independent adversarial review: CLEAN, no open P0/P1/P2
- shellcheck and Bash syntax checks passed
- Python compilation passed
- git diff --check passed
- both real production Compose contracts render through the new digest path
- live topology check: one primary, synchronous standby, matching system identifier, healthy three-member etcd