### PR TITLE
fix(ha): validate logical Patroni volume identity

### DIFF
--- a/scripts/ha/patroni_preflight_recovery_remote.py
+++ b/scripts/ha/patroni_preflight_recovery_remote.py
@@ -225,7 +225,7 @@ def prove_compose(project, compose, compose_project, volume, payload):
               if item.get("target") == "/var/lib/postgresql/data"]
     top = config.get("volumes", {}).get("postgres_data", {})
     if (config.get("name") != compose_project or db.get("image") != payload["current_image"]
-            or len(mounts) != 1 or mounts[0].get("source") != volume
+            or len(mounts) != 1 or mounts[0].get("source") != "postgres_data"
             or mounts[0].get("type") != "volume" or top.get("name") != volume
             or top.get("external") is not True):
         die("incident recovery resolved Compose identity drifted")

--- a/scripts/ha/patroni_rollout_remote_executor.py
+++ b/scripts/ha/patroni_rollout_remote_executor.py
@@ -208,7 +208,8 @@ def validate_compose(project, compose, compose_project, volume, expected_image, 
     if db.get("image") != expected_image:
         die("resolved Compose db image drifted")
     mounts = [item for item in db.get("volumes", []) if item.get("target") == "/var/lib/postgresql/data"]
-    if len(mounts) != 1 or mounts[0].get("source") != volume or mounts[0].get("type") != "volume":
+    if (len(mounts) != 1 or mounts[0].get("source") != "postgres_data"
+            or mounts[0].get("type") != "volume"):
         die("reviewed external PGDATA volume drifted")
     top = config.get("volumes", {}).get("postgres_data", {})
     if top.get("name") != volume or top.get("external") is not True:

--- a/tests/unit/test_patroni_preflight_recovery_remote.py
+++ b/tests/unit/test_patroni_preflight_recovery_remote.py
@@ -1,3 +1,6 @@
+import base64
+import copy
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -6,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ha import patroni_preflight_recovery_remote as remote
+from scripts.ha.patroni_rollout_schema import NODE_CONTRACTS
 from scripts.ha.pitr_pinned_ssh import PATRONI_NODES
 
 
@@ -151,3 +155,97 @@ def test_remote_executor_rejects_an_unsafe_existing_receipt_root(tmp_path, monke
 
     with pytest.raises(RuntimeError, match="unsafe incident recovery directory"):
         namespace["ensure_receipt_root"]()
+
+
+def _recovery_compose_case(node):
+    namespace = _remote_namespace()
+    contract = NODE_CONTRACTS[node.alias]
+    project = str(contract["project_dir"])
+    image = "ghcr.io/mvnby/air-api/patroni@sha256:" + "1" * 64
+    source = b"reviewed compose bytes"
+    contract_digest = "2" * 64
+    config = {
+        "name": contract["compose_project"],
+        "services": {
+            "db": {
+                "image": image,
+                "volumes": [
+                    {
+                        "type": "volume",
+                        "source": "postgres_data",
+                        "target": "/var/lib/postgresql/data",
+                    }
+                ],
+            }
+        },
+        "volumes": {
+            "postgres_data": {
+                "external": True,
+                "name": contract["data_volume"],
+            }
+        },
+    }
+    namespace["stable_file"] = lambda *_args, **_kwargs: source
+
+    def fake_run(args, **_kwargs):
+        if args[:3] == ["/usr/bin/python3", "-I", "-c"]:
+            return contract_digest
+        return json.dumps(config)
+
+    namespace["run"] = fake_run
+    payload = {
+        "compose_contract_sha256": contract_digest,
+        "compose_source_sha256": hashlib.sha256(source).hexdigest(),
+        "contract_helper_b64": base64.b64encode(b"pass").decode("ascii"),
+        "current_image": image,
+    }
+    arguments = (
+        project,
+        str(contract["compose_file"]),
+        str(contract["compose_project"]),
+        str(contract["data_volume"]),
+        payload,
+    )
+    return namespace, config, arguments
+
+
+def _mutate_pgdata_identity(config, mutation):
+    mount = config["services"]["db"]["volumes"][0]
+    if mutation == "duplicate-pgdata":
+        config["services"]["db"]["volumes"].append(copy.deepcopy(mount))
+    elif mutation == "bind-pgdata":
+        mount["type"] = "bind"
+    elif mutation == "top-name":
+        config["volumes"]["postgres_data"]["name"] = "wrong-postgres-data"
+    elif mutation == "external-false":
+        config["volumes"]["postgres_data"]["external"] = False
+    elif mutation == "wrong-source":
+        mount["source"] = config["volumes"]["postgres_data"]["name"]
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+
+@pytest.mark.parametrize("node", PATRONI_NODES, ids=lambda node: node.alias)
+def test_recovery_compose_proof_accepts_exact_logical_pgdata_identity(node):
+    namespace, _config, arguments = _recovery_compose_case(node)
+
+    namespace["prove_compose"](*arguments)
+
+
+@pytest.mark.parametrize("node", PATRONI_NODES, ids=lambda node: node.alias)
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "duplicate-pgdata",
+        "bind-pgdata",
+        "top-name",
+        "external-false",
+        "wrong-source",
+    ),
+)
+def test_recovery_compose_proof_rejects_pgdata_identity_drift(node, mutation):
+    namespace, config, arguments = _recovery_compose_case(node)
+    _mutate_pgdata_identity(config, mutation)
+
+    with pytest.raises(RuntimeError, match="resolved Compose identity drifted"):
+        namespace["prove_compose"](*arguments)

--- a/tests/unit/test_patroni_rollout_remote.py
+++ b/tests/unit/test_patroni_rollout_remote.py
@@ -1,3 +1,4 @@
+import base64
 import copy
 import json
 import os
@@ -11,7 +12,7 @@ import pytest
 from scripts.ha.patroni_rollout_remote import build_payload, run_remote_action
 from scripts.ha.patroni_rollout_remote_executor import REMOTE_EXECUTOR
 from scripts.ha.patroni_rollout_local import REVIEWED_ASSETS
-from scripts.ha.patroni_rollout_schema import RolloutInputs
+from scripts.ha.patroni_rollout_schema import NODE_CONTRACTS, RolloutInputs
 from scripts.ha.pitr_pinned_ssh import PATRONI_NODES, PinnedSshContext
 
 
@@ -207,6 +208,107 @@ def test_pitr_fence_is_bound_to_exact_maintenance_transaction(tmp_path):
     namespace["pitr_fence"]("a" * 32)
     with pytest.raises(RuntimeError, match="does not match"):
         namespace["pitr_fence"]("b" * 32)
+
+
+def _rollout_compose_case(node, monkeypatch):
+    namespace = _remote_namespace()
+    contract = NODE_CONTRACTS[node.alias]
+    image = CURRENT
+    contract_digest = "4" * 64
+    config = {
+        "name": contract["compose_project"],
+        "services": {
+            "db": {
+                "image": image,
+                "volumes": [
+                    {
+                        "type": "volume",
+                        "source": "postgres_data",
+                        "target": "/var/lib/postgresql/data",
+                    }
+                ],
+            }
+        },
+        "volumes": {
+            "postgres_data": {
+                "external": True,
+                "name": contract["data_volume"],
+            }
+        },
+    }
+
+    def fake_run(args, **_kwargs):
+        if args[:3] == ["/usr/bin/python3", "-I", "-c"]:
+            return contract_digest
+        return json.dumps(config)
+
+    namespace["run"] = fake_run
+    monkeypatch.setattr(namespace["os"], "chdir", lambda _path: None)
+    payload = {
+        "contract_helper_b64": base64.b64encode(b"pass").decode("ascii"),
+    }
+    arguments = (
+        str(contract["project_dir"]),
+        str(contract["compose_file"]),
+        str(contract["compose_project"]),
+        str(contract["data_volume"]),
+        image,
+        contract_digest,
+        payload,
+    )
+    return namespace, config, arguments, contract_digest
+
+
+def _mutate_rollout_pgdata_identity(config, mutation):
+    mount = config["services"]["db"]["volumes"][0]
+    if mutation == "duplicate-pgdata":
+        config["services"]["db"]["volumes"].append(copy.deepcopy(mount))
+    elif mutation == "bind-pgdata":
+        mount["type"] = "bind"
+    elif mutation == "top-name":
+        config["volumes"]["postgres_data"]["name"] = "wrong-postgres-data"
+    elif mutation == "external-false":
+        config["volumes"]["postgres_data"]["external"] = False
+    elif mutation == "wrong-source":
+        mount["source"] = config["volumes"]["postgres_data"]["name"]
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+
+@pytest.mark.parametrize("node", PATRONI_NODES, ids=lambda node: node.alias)
+def test_rollout_compose_proof_accepts_exact_logical_pgdata_identity(
+    node, monkeypatch
+):
+    namespace, _config, arguments, contract_digest = _rollout_compose_case(
+        node, monkeypatch
+    )
+
+    assert namespace["validate_compose"](
+        *arguments,
+    ) == contract_digest
+
+
+@pytest.mark.parametrize("node", PATRONI_NODES, ids=lambda node: node.alias)
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("duplicate-pgdata", "reviewed external PGDATA volume drifted"),
+        ("bind-pgdata", "reviewed external PGDATA volume drifted"),
+        ("top-name", "PGDATA volume must remain exact and external"),
+        ("external-false", "PGDATA volume must remain exact and external"),
+        ("wrong-source", "reviewed external PGDATA volume drifted"),
+    ),
+)
+def test_rollout_compose_proof_rejects_pgdata_identity_drift(
+    node, mutation, message, monkeypatch
+):
+    namespace, config, arguments, _digest = _rollout_compose_case(
+        node, monkeypatch
+    )
+    _mutate_rollout_pgdata_identity(config, mutation)
+
+    with pytest.raises(RuntimeError, match=message):
+        namespace["validate_compose"](*arguments)
 
 
 def test_completed_marker_cleanup_accepts_missing_but_rejects_wrong_owner(tmp_path):


### PR DESCRIPTION
## Summary
- validate the Compose service mount by its logical resource key `postgres_data`
- keep the separate exact node-specific external volume name and `external=true` proof
- fix the same latent predicate in both incident recovery and the normal rollout executor

## Production evidence
- recovery run `29330467095` failed closed in the first read-only `mvn-api` probe before journal/marker mutation
- live normalized Compose on both nodes reports service source `postgres_data` and exact top-level external names
- public readiness remained 200; Patroni primary/standby, synchronous replication, and etcd quorum remained healthy

## Verification
- `106 passed` focused recovery/rollout suite
- both aliases covered across duplicate PGDATA, bind, wrong source, wrong external name, and external=false
- `actionlint` on both rollout/recovery workflows
- `python3 -m compileall -q scripts/ha tests/unit`
- corrected Compose contract digests remain exact and unchanged
- independent adversarial review: CLEAR (no P0/P1/P2)