### PR TITLE
fix(ha): close PITR role-agent maintenance window

### DIFF
--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -323,15 +323,33 @@ Enable on the current primary after the private bucket/token exist:
 ```bash
 # Host helper installation is a separate reviewed host-assets change. Transfer
 # one exact release bundle through the pinned SSH path; never pipe a root script
-# from the network. Before the first hardened install, stop the Patroni role
-# agent, disable both PITR timers, and stop both PITR services. The installer
-# checks this quiescent state both before and after copying and refuses any
+# from the network. Do not stop or restart the Patroni role agent manually. The
+# cluster controller provisions one node at a time. It first proves the standby
+# runtime is traffic-fenced, stops only that exact attested agent, provisions the
+# standby, and immediately restores and proves the sole main agent. Before the
+# primary's short window, the pinned agent code writes the durable `fencing`
+# state and removes every app, bot, and PITR owner under the deployment lock;
+# only then may the exact main agent stop for primary provisioning. The primary
+# agent is restored and fully converged immediately afterward. Both agents stay
+# active throughout configure, scrub, basebackup, restore, finalize, and verify.
+# The installer checks the short per-node quiescent state and refuses any
 # enabled/running owner, any
 # compose other than docker-compose.patroni.yml, compose digest drift, a mutable
 # backend image, or a running app slot whose image differs from that digest.
 # It never enables timers. A partial install therefore stays inert and must be
 # completed by rerunning the same exact bundle before the pinned enable phase.
-# Restart the role agent only after pinned verify/enable has passed.
+# The pinned executor attests the agent, identity helper, systemd unit, operation
+# guard, and cleanup code by digest before execution and again under both locks.
+# It waits a bounded interval for same-transaction transient work, then may reap
+# or cancel only a record whose operation ID is the exact migration transaction
+# ID; a foreign record is never mutated. On an ambiguous error inside a short
+# stop window, recovery fences both runtimes former-primary first, requires a
+# fresh unchanged topology, and only then restores current standby before
+# current primary. If either fence or fresh topology is unproved, neither node
+# is activated. A node
+# whose maintenance fence was already finalized must prove the matching release
+# manifest before its agent can restart. Never remove a fence or start an agent
+# by hand to work around a failed transaction.
 
 # Put the private R2 credentials in local `.env` using the names above. The
 # helper loads only `POSTGRES_PITR_*` keys from that file. For a live apply it
@@ -366,25 +384,32 @@ python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
 
 # Run the complete two-node transaction. It attests and installs the exact
 # helper bundle standby-first, validates the private destination from both
-# nodes, and then provisions both hosts. Provisioning is the roll-forward
-# boundary because a lost remote response cannot prove that root-owned state was
-# untouched. The transaction then commits resumable root-only config, removes
+# nodes, then runs a separate quiesce/provision/resume window for the standby and
+# a fail-closed-fence/provision/resume window for the primary. The first
+# role-agent stop attempt is the roll-forward boundary because
+# a lost remote response cannot prove the exact service state; the controller
+# runs the strict fenced recovery above before reporting an interrupted window.
+# The transaction then commits resumable root-only config, removes
 # legacy secret copies, stages the final archive env on both nodes, takes and
 # uploads a lineage-bound basebackup on the proved primary, and completes the
 # disposable physical restore drill before either release is finalized. Only
-# then does it finalize both bundles, enable timers on the proved primary, and
-# run the strict final verification.
+# then does it finalize both bundles. Marker removal delegates timer ownership
+# to the already active sole role agents; the controller waits for and proves
+# standby timer fencing and primary timer activation before strict verification.
 python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
   --env-file .env \
   --phase migrate-cluster \
   --transaction-id "${PITR_TRANSACTION_ID}" \
   --no-prompt
 
-# A failure before the first provision attempt rolls the attempted asset bundles
-# back. From the first provision attempt onward the command deliberately enters
-# roll-forward, including an ambiguous timeout or lost SSH response: repair the
-# reported cause and rerun the same command with the same transaction ID. Do not
-# manually roll back files, config, archive state, or timers in that state.
+# A failure before the first pinned role-agent stop attempt rolls the attempted
+# asset bundles back. From that first stop attempt onward the command
+# deliberately enters roll-forward, including an ambiguous timeout or lost SSH
+# response: repair the reported cause and rerun the same command with the same
+# transaction ID. If the interrupted per-node window cannot prove both fences
+# and a fresh unchanged topology, it deliberately leaves the runtime fenced and
+# names the exact failed proof. Do not manually roll back files, config,
+# archive state, agents, fences, or timers in that state.
 
 # PostgreSQL archive parameters are Patroni DCS configuration for an existing
 # cluster. The migration requires the reviewed archive settings to be active on

--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -21,6 +21,7 @@ try:
     from scripts.ha.pitr_remote_execution import (
         run_remote_maintenance_phase,
         run_remote_release_action,
+        run_remote_role_agent_phase,
         run_remote_secret_phase,
     )
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
@@ -36,6 +37,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
     from pitr_remote_execution import (  # type: ignore[no-redef]
         run_remote_maintenance_phase,
         run_remote_release_action,
+        run_remote_role_agent_phase,
         run_remote_secret_phase,
     )
 
@@ -45,6 +47,7 @@ TopologyDiscoverer = Callable[..., ClusterTopology]
 ReleaseAction = Callable[..., str]
 SecretPhase = Callable[..., None]
 MaintenancePhase = Callable[..., None]
+RoleAgentPhase = Callable[..., None]
 
 TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 DEFAULT_BOOTSTRAP_HELPER = "/usr/local/sbin/mvn-postgres-pitr-bootstrap"
@@ -65,6 +68,7 @@ class MigrationDependencies:
     release: ReleaseAction = run_remote_release_action
     secret: SecretPhase = run_remote_secret_phase
     maintenance: MaintenancePhase = run_remote_maintenance_phase
+    role_agent: RoleAgentPhase = run_remote_role_agent_phase
 
 
 def validate_transaction_id(transaction_id: str) -> str:
@@ -101,6 +105,7 @@ class _MigrationOrchestrator:
         self.baseline: ClusterTopology | None = None
         self.roll_forward = False
         self.attempted_bundle_nodes: list[PatroniNode] = []
+        self.role_agent_window_open = False
 
     def _discover(self) -> ClusterTopology:
         return self.dependencies.discover(
@@ -188,6 +193,15 @@ class _MigrationOrchestrator:
             runner=self.runner,
         )
 
+    def _role_agent(self, phase: str, node: PatroniNode) -> None:
+        self.dependencies.role_agent(
+            node=node,
+            context=self.context,
+            phase=phase,
+            transaction_id=self.transaction_id,
+            runner=self.runner,
+        )
+
     def _rollback_attempted_bundles(self, original_error: BaseException) -> None:
         failures: list[str] = []
         for node in reversed(self.attempted_bundle_nodes):
@@ -203,6 +217,73 @@ class _MigrationOrchestrator:
                 f"cluster migration failed before configuration: {original_error}; "
                 "bundle rollback was incomplete: " + "; ".join(failures)
             ) from original_error
+
+    def _resume_role_agents_after_failure(
+        self,
+        baseline: ClusterTopology,
+        original_error: BaseException,
+    ) -> RuntimeError:
+        fence_failures: list[str] = []
+        # Fence the former primary first, then the peer. These local actions do
+        # not trust the baseline role; each removes app, bot, and PITR owners
+        # before the controller attempts to discover a fresh topology.
+        for node in (baseline.primary, baseline.standby):
+            try:
+                self._role_agent("quiesce-fenced", node)
+            except BaseException as exc:
+                fence_failures.append(f"{node.alias}: {exc}")
+
+        if fence_failures:
+            return RuntimeError(
+                "cluster migration entered roll-forward state; do not roll back; "
+                f"resume with the same transaction ID {self.transaction_id}: "
+                f"{original_error}; pinned recovery could not prove both runtime "
+                "fences and therefore did not resume either node: "
+                + "; ".join(fence_failures)
+            )
+
+        try:
+            fresh = self._discover()
+            recovery_nodes = (fresh.standby, fresh.primary)
+            topology_detail = (
+                f"fresh topology standby={fresh.standby.alias} "
+                f"primary={fresh.primary.alias}"
+            )
+        except BaseException as exc:
+            return RuntimeError(
+                "cluster migration entered roll-forward state; do not roll back; "
+                f"resume with the same transaction ID {self.transaction_id}: "
+                f"{original_error}; both runtimes are fenced, but fresh topology "
+                f"is unavailable and neither node was resumed: {exc}"
+            )
+
+        failures: list[str] = []
+        for node in recovery_nodes:
+            try:
+                expected_role = (
+                    "standby" if node.alias == fresh.standby.alias else "primary"
+                )
+                self._role_agent(f"resume-{expected_role}", node)
+                proved = self._discover()
+                if proved != fresh:
+                    raise RuntimeError("fresh topology changed during role-agent recovery")
+            except BaseException as exc:
+                failures.append(f"{node.alias}: {exc}")
+                break
+        recovery_problems = [
+            *(f"resume {failure}" for failure in failures),
+        ]
+        detail = (
+            "; pinned role-agent safety recovery failed: "
+            + "; ".join(recovery_problems)
+            if recovery_problems
+            else "; pinned role agents were safely fenced, freshly ordered, and restarted"
+        )
+        return RuntimeError(
+            "cluster migration entered roll-forward state; do not roll back; "
+            f"resume with the same transaction ID {self.transaction_id}: "
+            f"{original_error}; {topology_detail}{detail}"
+        )
 
     def run(self) -> MigrationResult:
         baseline = self._guard_topology(stage="baseline")
@@ -220,10 +301,27 @@ class _MigrationOrchestrator:
                     action=lambda node=node: self._secret("preflight", node),
                 )
             for node in ordered_nodes:
+                # Provision each node inside its own minimal role-agent window.
+                # The standby is already traffic-fenced. The current primary
+                # is explicitly fenced before its agent is stopped, accepting
+                # a short write outage rather than an unfenced former primary.
+                quiesce_phase = (
+                    "quiesce-standby"
+                    if node.alias == baseline.standby.alias
+                    else "quiesce-fenced"
+                )
+                self.role_agent_window_open = True
+                self._mutate(
+                    stage=f"role-agent quiesce {node.alias}",
+                    action=lambda node=node, phase=quiesce_phase: self._role_agent(
+                        phase, node
+                    ),
+                    enter_roll_forward=True,
+                )
                 # Provisioning mutates root-owned host state. A lost remote
                 # response cannot prove that it made no durable progress, so
-                # every failure from the first provision attempt onward must
-                # resume the same transaction rather than roll assets back.
+                # it remains inside the roll-forward boundary entered before
+                # the first role-agent quiesce attempt.
                 self._mutate(
                     stage=f"provision-node {node.alias}",
                     action=lambda node=node: self._maintenance(
@@ -231,6 +329,18 @@ class _MigrationOrchestrator:
                     ),
                     enter_roll_forward=True,
                 )
+                self._mutate(
+                    stage=f"role-agent resume {node.alias}",
+                    action=lambda node=node: self._role_agent(
+                        (
+                            "resume-standby"
+                            if node.alias == baseline.standby.alias
+                            else "resume-primary"
+                        ),
+                        node,
+                    ),
+                )
+                self.role_agent_window_open = False
             for node in ordered_nodes:
                 self._mutate(
                     stage=f"configure-node {node.alias}",
@@ -261,10 +371,22 @@ class _MigrationOrchestrator:
                     stage=f"bundle finalize {node.alias}",
                     action=lambda node=node: self._release("finalize", node),
                 )
-            self._mutate(
-                stage=f"enable-timers {baseline.primary.alias}",
-                action=lambda: self._maintenance("enable-timers", baseline.primary),
-            )
+            for node in ordered_nodes:
+                # Finalization removes the maintenance marker. The sole active
+                # role agent now owns timer activation/fencing. Re-running its
+                # pinned convergence proof is idempotent and bounded; there is
+                # no second controller timer owner racing systemd.
+                self._mutate(
+                    stage=f"role-agent final convergence {node.alias}",
+                    action=lambda node=node: self._role_agent(
+                        (
+                            "resume-standby"
+                            if node.alias == baseline.standby.alias
+                            else "resume-primary"
+                        ),
+                        node,
+                    ),
+                )
             self._mutate(
                 stage=f"verify {baseline.primary.alias}",
                 action=lambda: self._maintenance("verify", baseline.primary),
@@ -275,6 +397,10 @@ class _MigrationOrchestrator:
                 raise RuntimeError(
                     f"cluster migration failed before configuration and release bundles "
                     f"were rolled back: {exc}"
+                ) from exc
+            if self.role_agent_window_open:
+                raise self._resume_role_agents_after_failure(
+                    baseline, exc
                 ) from exc
             raise RuntimeError(
                 "cluster migration entered roll-forward state; do not roll back; "

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -25,6 +25,7 @@ try:
         LOCKED_MAINTENANCE_WRAPPER,
         REMOTE_ASSET_ATTESTATION,
         REMOTE_MAINTENANCE_EXECUTOR,
+        REMOTE_ROLE_AGENT_EXECUTOR,
         REMOTE_SECRET_EXECUTOR,
     )
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
@@ -43,6 +44,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
         LOCKED_MAINTENANCE_WRAPPER,
         REMOTE_ASSET_ATTESTATION,
         REMOTE_MAINTENANCE_EXECUTOR,
+        REMOTE_ROLE_AGENT_EXECUTOR,
         REMOTE_SECRET_EXECUTOR,
     )
 
@@ -50,6 +52,12 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+ROLE_AGENT_PHASES = {
+    "quiesce-fenced",
+    "quiesce-standby",
+    "resume-primary",
+    "resume-standby",
+}
 
 
 @dataclass(frozen=True)
@@ -227,6 +235,34 @@ PITR_HOST_ASSETS = (
     ),
 )
 
+ROLE_AGENT_ASSETS = (
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/patroni_role_agent.py",
+        "/usr/local/sbin/mvn-patroni-role-agent",
+        0o755,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/patroni_local_identity.py",
+        "/usr/local/sbin/patroni_local_identity.py",
+        0o644,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "deploy/ha/patroni/mvn-patroni-role-agent.service",
+        "/etc/systemd/system/mvn-patroni-role-agent.service",
+        0o644,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/pitr_operation_guard.py",
+        "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py",
+        0o755,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/pitr_operation_cleanup.py",
+        "/usr/local/sbin/mvn_postgres_pitr_operation_cleanup.py",
+        0o755,
+    ),
+)
+
 
 def render_host_asset_manifest(
     node: PatroniNode,
@@ -249,6 +285,26 @@ def render_host_asset_manifest(
             raise RuntimeError(f"PITR host asset has unsafe ownership or mode: {asset.source}")
         if asset.remote_path in manifest:
             raise RuntimeError(f"duplicate PITR host asset path: {asset.remote_path}")
+        manifest[asset.remote_path] = hashlib.sha256(
+            _read_release_asset(asset.source)
+        ).hexdigest()
+    return json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+
+
+def render_role_agent_asset_manifest(
+    assets: Sequence[PitrHostAsset] = ROLE_AGENT_ASSETS,
+) -> str:
+    manifest: dict[str, str] = {}
+    for asset in assets:
+        metadata = asset.source.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError(
+                f"role-agent asset must be a regular non-symlink: {asset.source}"
+            )
+        if metadata.st_uid != os.geteuid() or metadata.st_mode & 0o022:
+            raise RuntimeError(f"role-agent asset has unsafe ownership or mode: {asset.source}")
+        if asset.remote_path in manifest:
+            raise RuntimeError(f"duplicate role-agent asset path: {asset.remote_path}")
         manifest[asset.remote_path] = hashlib.sha256(
             _read_release_asset(asset.source)
         ).hexdigest()
@@ -393,6 +449,35 @@ def run_remote_maintenance_phase(
             shlex.quote(asset_manifest),
             shlex.quote(LOCKED_MAINTENANCE_WRAPPER),
             locked_wrapper_digest,
+        ]
+    )
+    _run_checked([*ssh_args(node, context), command], runner=runner)
+
+
+def run_remote_role_agent_phase(
+    *,
+    node: PatroniNode,
+    context: PinnedSshContext,
+    phase: str,
+    transaction_id: str,
+    runner: Runner | None = None,
+) -> None:
+    """Quiesce or safely reconcile the pinned Patroni role agent."""
+
+    if phase not in ROLE_AGENT_PHASES:
+        raise RuntimeError(f"unsupported role-agent phase: {phase}")
+    if not TRANSACTION_ID_RE.fullmatch(transaction_id):
+        raise RuntimeError("PITR transaction ID must be 32 lowercase hexadecimal characters")
+    command = " ".join(
+        [
+            "/usr/bin/python3",
+            "-I",
+            "-c",
+            shlex.quote(REMOTE_ROLE_AGENT_EXECUTOR),
+            shlex.quote(phase),
+            shlex.quote(node.project_dir),
+            transaction_id,
+            shlex.quote(render_role_agent_asset_manifest()),
         ]
     )
     _run_checked([*ssh_args(node, context), command], runner=runner)

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -7,6 +7,15 @@ host-side helpers by their attested absolute paths.
 
 from __future__ import annotations
 
+try:
+    from scripts.ha.pitr_role_agent_remote_executor import (
+        REMOTE_ROLE_AGENT_EXECUTOR_BODY,
+    )
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_role_agent_remote_executor import (  # type: ignore[no-redef]
+        REMOTE_ROLE_AGENT_EXECUTOR_BODY,
+    )
+
 
 REMOTE_ASSET_ATTESTATION = r'''
 import fcntl
@@ -392,6 +401,11 @@ raise SystemExit(wrapper_main())
 LOCKED_MAINTENANCE_WRAPPER = LOCKED_OPERATION_WRAPPER
 
 
+REMOTE_ROLE_AGENT_EXECUTOR = (
+    REMOTE_ASSET_ATTESTATION + "\n" + REMOTE_ROLE_AGENT_EXECUTOR_BODY
+).strip()
+
+
 REMOTE_SECRET_EXECUTOR = (
     REMOTE_ASSET_ATTESTATION
     + "\n"
@@ -505,6 +519,7 @@ def main():
             record_command=bootstrap_helper,
             stdin_payload=payload_view,
             guard_module=guard,
+            operation_id=transaction_id,
         )
     finally:
         payload_view[:] = b"\0" * len(payload_view)
@@ -629,6 +644,7 @@ def main():
         transient=True,
         record_command=bootstrap_helper,
         guard_module=guard,
+        operation_id=transaction_id,
     )
 
 

--- a/scripts/ha/pitr_role_agent_remote_executor.py
+++ b/scripts/ha/pitr_role_agent_remote_executor.py
@@ -1,0 +1,670 @@
+"""Isolated source body for the pinned PITR role-agent remote executor."""
+
+from __future__ import annotations
+
+
+REMOTE_ROLE_AGENT_EXECUTOR_BODY = r'''
+import json
+import sys
+import types
+
+ROLE_AGENT_UNIT = "mvn-patroni-role-agent.service"
+ROLE_AGENT_PATH = "/usr/local/sbin/mvn-patroni-role-agent"
+ROLE_IDENTITY_PATH = "/usr/local/sbin/patroni_local_identity.py"
+ROLE_UNIT_PATH = "/etc/systemd/system/mvn-patroni-role-agent.service"
+ROLE_ENV_PATH = "/etc/default/mvn-patroni-role-agent"
+OPERATION_GUARD_PATH = "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py"
+OPERATION_CLEANUP_PATH = "/usr/local/sbin/mvn_postgres_pitr_operation_cleanup.py"
+MAINTENANCE_MARKER = "/run/mvn-postgres-pitr-maintenance"
+RELEASE_MANIFEST = "/var/lib/mvn-postgres-pitr/release-manifest.json"
+GLOBAL_LOCK = "/run/lock/mvn-postgres-pitr-prerequisites.lock"
+ROLE_ASSET_MODES = {
+    ROLE_AGENT_PATH: 0o755,
+    ROLE_IDENTITY_PATH: 0o644,
+    ROLE_UNIT_PATH: 0o644,
+    OPERATION_GUARD_PATH: 0o755,
+    OPERATION_CLEANUP_PATH: 0o755,
+}
+ROLE_PROCESS_ASSETS = {
+    ROLE_AGENT_PATH,
+    ROLE_IDENTITY_PATH,
+    ROLE_UNIT_PATH,
+}
+NODE_CONTRACTS = {
+    "/opt/air-api": "mvn-api",
+    "/opt/mvn-reserve": "zakup",
+}
+CLEAN_ENV = {
+    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "HOME": "/root",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "DOCKER_CONTEXT": "default",
+}
+
+
+def fail(message, status=70):
+    print(f"pitr role-agent executor: {message}", file=sys.stderr)
+    return status
+
+
+def read_root_file(path, *, mode, maximum=2097152):
+    metadata = os.lstat(path)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_gid != 0
+        or metadata.st_nlink != 1
+        or stat.S_IMODE(metadata.st_mode) != mode
+    ):
+        raise RuntimeError(f"role-agent file metadata is unsafe: {path}")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        fields = (
+            "st_dev", "st_ino", "st_mode", "st_uid", "st_gid", "st_nlink",
+            "st_size", "st_mtime_ns", "st_ctime_ns",
+        )
+        if tuple(getattr(opened, name) for name in fields) != tuple(
+            getattr(metadata, name) for name in fields
+        ):
+            raise RuntimeError(f"role-agent file changed while opening: {path}")
+        chunks = []
+        size = 0
+        while True:
+            chunk = os.read(descriptor, min(131072, maximum + 1 - size))
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > maximum:
+                raise RuntimeError(f"role-agent file exceeds its size bound: {path}")
+            chunks.append(chunk)
+        finished = os.fstat(descriptor)
+        if tuple(getattr(finished, name) for name in fields) != tuple(
+            getattr(opened, name) for name in fields
+        ):
+            raise RuntimeError(f"role-agent file changed while reading: {path}")
+        return b"".join(chunks), finished
+    finally:
+        os.close(descriptor)
+
+
+def attest_manifest(raw_manifest):
+    try:
+        manifest = json.loads(raw_manifest)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("role-agent asset manifest is invalid") from exc
+    if not isinstance(manifest, dict) or set(manifest) != set(ROLE_ASSET_MODES):
+        raise RuntimeError("role-agent asset manifest has an unexpected path set")
+    sources = {}
+    for path, mode in ROLE_ASSET_MODES.items():
+        digest = manifest.get(path)
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise RuntimeError(f"role-agent digest is invalid: {path}")
+        content, _ = read_root_file(path, mode=mode)
+        if hashlib.sha256(content).hexdigest() != digest:
+            raise RuntimeError(f"role-agent digest mismatch: {path}")
+        sources[path] = content
+    return manifest, sources
+
+
+def expected_role_environment(project_dir):
+    node = NODE_CONTRACTS.get(project_dir)
+    if node is None:
+        raise RuntimeError("unreviewed role-agent project directory")
+    return {
+        "HA_PROJECT_DIR": project_dir,
+        "HA_COMPOSE_FILE": "docker-compose.patroni.yml",
+        "HA_PATRONI_URL": "http://127.0.0.1:8008/patroni",
+        "HA_PATRONI_SCOPE": "mvn-postgres",
+        "HA_PATRONI_NAME": node,
+        "HA_PATRONI_MAX_DCS_AGE_SECONDS": "20",
+        "HA_READY_URL": "http://127.0.0.1:18080/api/ready",
+        "HA_APP_SERVICE": "",
+        "HA_PRIMARY_SYSTEMD_UNITS": (
+            "mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer"
+        ),
+        "HA_ROLE_POLL_SECONDS": "3",
+        "HA_PROMOTION_DELAY_SECONDS": "8",
+        "HA_READY_ATTEMPTS": "30",
+    }
+
+
+def attest_role_environment(project_dir):
+    content, _ = read_root_file(ROLE_ENV_PATH, mode=0o600, maximum=16384)
+    actual = {}
+    try:
+        lines = content.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("role-agent environment is not UTF-8") from exc
+    for line in lines:
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise RuntimeError("role-agent environment contains an invalid line")
+        name, value = line.split("=", 1)
+        if name in actual:
+            raise RuntimeError("role-agent environment contains a duplicate key")
+        actual[name] = value
+    expected = expected_role_environment(project_dir)
+    if actual != expected:
+        raise RuntimeError("role-agent environment differs from the reviewed node contract")
+    return expected
+
+
+def run_command(args, *, environment=CLEAN_ENV, timeout=60):
+    return subprocess.run(
+        list(args),
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def checked(args, *, environment=CLEAN_ENV, timeout=60):
+    result = run_command(args, environment=environment, timeout=timeout)
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(output or "command failed: " + " ".join(args))
+    return result.stdout.strip()
+
+
+def unit_state(kind):
+    result = run_command(["/usr/bin/systemctl", kind, ROLE_AGENT_UNIT])
+    value = result.stdout.strip()
+    allowed = {
+        "is-active": {(0, "active"), (3, "inactive")},
+        "is-enabled": {(0, "enabled"), (1, "disabled")},
+    }
+    if (result.returncode, value) not in allowed[kind]:
+        raise RuntimeError(
+            f"role-agent {kind} state is not exact: "
+            f"rc={result.returncode} value={value}"
+        )
+    return value
+
+
+def attest_loaded_unit():
+    properties = {
+        "FragmentPath": ROLE_UNIT_PATH,
+        "DropInPaths": "",
+        "NeedDaemonReload": "no",
+        "Restart": "always",
+    }
+    for name, expected in properties.items():
+        actual = checked([
+            "/usr/bin/systemctl", "show", f"--property={name}", "--value",
+            ROLE_AGENT_UNIT,
+        ])
+        if actual != expected:
+            raise RuntimeError(f"role-agent loaded unit property drifted: {name}")
+
+
+def marker_value():
+    try:
+        content, _ = read_root_file(MAINTENANCE_MARKER, mode=0o600, maximum=34)
+    except FileNotFoundError:
+        return None
+    if re.fullmatch(rb"[0-9a-f]{32}\n", content) is None:
+        raise RuntimeError("PITR maintenance marker is invalid")
+    return content[:-1].decode("ascii")
+
+
+def finalized_transaction(project_dir, transaction_id):
+    content, _ = read_root_file(RELEASE_MANIFEST, mode=0o600)
+    try:
+        manifest = json.loads(content)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise RuntimeError("PITR release manifest is invalid") from exc
+    canonical = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("ascii")
+        + b"\n"
+    )
+    expected_modes = dict(EXPECTED_ASSET_MODES)
+    expected_modes[os.path.join(project_dir, "docker-compose.patroni.yml")] = 0o644
+    if (
+        content != canonical
+        or not isinstance(manifest, dict)
+        or set(manifest) != {"files", "project_dir", "release_sha256", "txid", "version"}
+        or type(manifest.get("version")) is not int
+        or manifest.get("version") != 1
+        or manifest.get("project_dir") != project_dir
+        or manifest.get("txid") != transaction_id
+        or not re.fullmatch(r"[0-9a-f]{64}", manifest.get("release_sha256", ""))
+        or not isinstance(manifest.get("files"), list)
+    ):
+        raise RuntimeError("PITR release manifest does not prove this transaction")
+    paths = []
+    for item in manifest["files"]:
+        path = item.get("path") if isinstance(item, dict) else None
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"mode", "path", "sha256"}
+            or path not in expected_modes
+            or item.get("mode") != expected_modes[path]
+            or not re.fullmatch(r"[0-9a-f]{64}", item.get("sha256", ""))
+        ):
+            raise RuntimeError("PITR release manifest contains an invalid asset")
+        body, _ = read_root_file(path, mode=item["mode"], maximum=1048576)
+        if hashlib.sha256(body).hexdigest() != item["sha256"]:
+            raise RuntimeError(f"finalized PITR release asset drifted: {path}")
+        paths.append(path)
+    if paths != sorted(expected_modes):
+        raise RuntimeError("PITR release manifest asset set is incomplete")
+
+
+def require_fence(project_dir, transaction_id, *, allow_finalized):
+    current = marker_value()
+    if current == transaction_id:
+        return "maintenance"
+    if current is not None:
+        raise RuntimeError("another transaction owns the PITR maintenance marker")
+    if not allow_finalized:
+        raise RuntimeError("PITR maintenance marker is absent")
+    finalized_transaction(project_dir, transaction_id)
+    return "finalized"
+
+
+def execute_attested_module(name, path, source):
+    module = types.ModuleType(name)
+    module.__file__ = path
+    module.__package__ = name.rpartition(".")[0]
+    sys.modules[name] = module
+    exec(compile(source, path, "exec"), module.__dict__)
+    return module
+
+
+def load_attested_modules(sources, expected_environment):
+    scripts_module = types.ModuleType("scripts")
+    scripts_module.__path__ = []
+    ha_module = types.ModuleType("scripts.ha")
+    ha_module.__path__ = []
+    sys.modules["scripts"] = scripts_module
+    sys.modules["scripts.ha"] = ha_module
+    cleanup = execute_attested_module(
+        "scripts.ha.pitr_operation_cleanup",
+        OPERATION_CLEANUP_PATH,
+        sources[OPERATION_CLEANUP_PATH],
+    )
+    guard = execute_attested_module(
+        "scripts.ha.pitr_operation_guard",
+        OPERATION_GUARD_PATH,
+        sources[OPERATION_GUARD_PATH],
+    )
+    identity = execute_attested_module(
+        "scripts.ha.patroni_local_identity",
+        ROLE_IDENTITY_PATH,
+        sources[ROLE_IDENTITY_PATH],
+    )
+    sys.modules["patroni_local_identity"] = identity
+    role_agent = execute_attested_module(
+        "mvn_pinned_patroni_role_agent",
+        ROLE_AGENT_PATH,
+        sources[ROLE_AGENT_PATH],
+    )
+    os.environ.clear()
+    os.environ.update(CLEAN_ENV)
+    os.environ.update(expected_environment)
+    config = role_agent.load_config()
+    return guard, role_agent, config
+
+
+def attest_contract(raw_manifest, project_dir):
+    manifest, sources = attest_manifest(raw_manifest)
+    expected_environment = attest_role_environment(project_dir)
+    attest_loaded_unit()
+    guard, role_agent, config = load_attested_modules(
+        sources, expected_environment
+    )
+    return manifest, expected_environment, guard, role_agent, config
+
+
+def drain_operations(project_dir, transaction_id, guard, *, wait_seconds=10):
+    deadline = time.monotonic() + wait_seconds
+    while guard.list_records(project_dir=project_dir) and time.monotonic() < deadline:
+        time.sleep(0.25)
+    records = guard.list_records(project_dir=project_dir)
+    foreign = [
+        record.operation_id
+        for record in records
+        if record.operation_id != transaction_id
+    ]
+    if foreign:
+        raise RuntimeError(
+            "foreign PITR operation records remain; refusing cancellation: "
+            + ",".join(foreign)
+        )
+    if not records:
+        return
+    try:
+        guard.reconcile_project_operations(project_dir)
+    except RuntimeError:
+        guard.cancel_project_operations(project_dir)
+        guard.reconcile_project_operations(project_dir)
+    if guard.list_records(project_dir=project_dir):
+        raise RuntimeError("PITR operation records remained after bounded cleanup")
+
+
+def open_global_lock():
+    descriptor = os.open(
+        GLOBAL_LOCK,
+        os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+    )
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_gid != 0
+        or metadata.st_nlink != 1
+    ):
+        os.close(descriptor)
+        raise RuntimeError("shared PITR lock metadata is unsafe")
+    os.fchmod(descriptor, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(descriptor)
+        raise RuntimeError("another PITR operation is active") from exc
+    return descriptor
+
+
+def open_deploy_lock_bounded(project_dir, *, wait_seconds=30):
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        try:
+            return open_deploy_lock(project_dir)
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                raise RuntimeError("project deployment lock remained busy")
+            time.sleep(0.25)
+
+
+def read_project_state(path, expected):
+    content, _ = read_root_file(str(path), mode=0o600, maximum=16384)
+    if content != expected:
+        raise RuntimeError(f"role-agent state is not safely converged: {path}")
+
+
+def readiness_state():
+    result = run_command([
+        "/usr/bin/curl", "-sS", "--max-time", "5", "-w", "\n%{http_code}",
+        "http://127.0.0.1:18080/api/ready",
+    ])
+    if result.returncode != 0:
+        raise RuntimeError("local API readiness proof failed")
+    lines = result.stdout.rstrip().splitlines()
+    if len(lines) < 2 or not lines[-1].isdigit():
+        raise RuntimeError("local API readiness response is invalid")
+    try:
+        payload = json.loads("\n".join(lines[:-1]))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("local API readiness JSON is invalid") from exc
+    return int(lines[-1]), payload
+
+
+def prove_safe_state(role_agent, config, *, required, expected_role=None):
+    if required == "fenced":
+        role = "standby"
+        state = b"fencing\n"
+    else:
+        role = role_agent._fetch_configured_patroni_role(config)
+        if required == "standby" and role != "standby":
+            raise RuntimeError("node is no longer the proved standby")
+        if required == "live" and role != expected_role:
+            raise RuntimeError(
+                f"local Patroni role proof differs: expected={expected_role} actual={role}"
+            )
+        state = (role + "\n").encode("ascii")
+    expected_app = role_agent.role_env(role, bot_process=False).encode("ascii")
+    expected_bot = role_agent.role_env(role, bot_process=True).encode("ascii")
+    read_project_state(config.state_file, state)
+    read_project_state(config.app_role_env, expected_app)
+    read_project_state(config.bot_role_env, expected_bot)
+    running = role_agent._running_services(config)
+    apps = running.intersection(set(role_agent.APP_SERVICE_NAMES))
+    if required == "fenced":
+        if apps or "bot" in running:
+            raise RuntimeError("fenced runtime still owns app or bot")
+    else:
+        if len(apps) != 1 or (("bot" in running) != (role == "primary")):
+            raise RuntimeError("role-agent app/bot ownership did not converge")
+        status, payload = readiness_state()
+        expected_status = 200 if role == "primary" else 503
+        expected_traffic = "enabled" if role == "primary" else "disabled"
+        if status != expected_status or payload.get("traffic") != expected_traffic:
+            raise RuntimeError("API readiness does not match Patroni ownership")
+    timer_role = "standby" if marker_value() is not None else role
+    if not role_agent._systemd_units_match(config, timer_role):
+        raise RuntimeError("PITR timer ownership did not converge")
+    return role
+
+
+def read_proc_file(path, maximum=131072):
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0:
+            raise RuntimeError("role-agent process metadata is unsafe")
+        content = os.read(descriptor, maximum + 1)
+        if len(content) > maximum or os.read(descriptor, 1):
+            raise RuntimeError("role-agent process metadata exceeds limit")
+        return content
+    finally:
+        os.close(descriptor)
+
+
+def process_start_ns(pid):
+    raw = read_proc_file(f"/proc/{pid}/stat", 8192).decode("ascii")
+    boundary = raw.rfind(") ")
+    fields = raw[boundary + 2:].split() if boundary > 0 else []
+    if len(fields) <= 19 or not fields[19].isdigit():
+        raise RuntimeError("role-agent process start metadata is invalid")
+    boot = []
+    for line in read_proc_file("/proc/stat", 1048576).decode("ascii").splitlines():
+        if line.startswith("btime "):
+            boot.append(line.split())
+    if len(boot) != 1 or len(boot[0]) != 2 or not boot[0][1].isdigit():
+        raise RuntimeError("kernel boot-time metadata is invalid")
+    ticks = os.sysconf("SC_CLK_TCK")
+    if not isinstance(ticks, int) or ticks <= 0:
+        raise RuntimeError("kernel clock-tick metadata is invalid")
+    return ((int(boot[0][1]) * ticks + int(fields[19])) * 1000000000) // ticks
+
+
+def attest_live_process(expected_environment, manifest):
+    pid = checked([
+        "/usr/bin/systemctl", "show", "--property=MainPID", "--value",
+        ROLE_AGENT_UNIT,
+    ])
+    if re.fullmatch(r"[1-9][0-9]*", pid) is None:
+        raise RuntimeError("role-agent MainPID is invalid")
+    if read_proc_file(f"/proc/{pid}/cmdline", 4096) != (
+        b"/usr/bin/python3\0/usr/local/sbin/mvn-patroni-role-agent\0"
+    ):
+        raise RuntimeError("live role-agent command line is unreviewed")
+    live = {}
+    for entry in read_proc_file(f"/proc/{pid}/environ").split(b"\0"):
+        if not entry:
+            continue
+        try:
+            name, value = entry.decode("utf-8").split("=", 1)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise RuntimeError("live role-agent environment is invalid") from exc
+        if name.startswith("HA_"):
+            if name in live:
+                raise RuntimeError("live role-agent environment has a duplicate key")
+            live[name] = value
+    if live != expected_environment:
+        raise RuntimeError("live role-agent environment differs from the reviewed contract")
+    newest_asset = 0
+    for path in ROLE_PROCESS_ASSETS:
+        content, metadata = read_root_file(path, mode=ROLE_ASSET_MODES[path])
+        if hashlib.sha256(content).hexdigest() != manifest[path]:
+            raise RuntimeError(f"role-agent digest changed during restart: {path}")
+        newest_asset = max(newest_asset, metadata.st_ctime_ns)
+    _, environment_metadata = read_root_file(ROLE_ENV_PATH, mode=0o600, maximum=16384)
+    newest_asset = max(newest_asset, environment_metadata.st_ctime_ns)
+    if process_start_ns(pid) < newest_asset:
+        raise RuntimeError("live role-agent predates the attested on-disk generation")
+    if checked([
+        "/usr/bin/systemctl", "show", "--property=MainPID", "--value",
+        ROLE_AGENT_UNIT,
+    ]) != pid:
+        raise RuntimeError("role-agent MainPID changed during attestation")
+
+
+def quiesce(phase, project_dir, transaction_id, raw_manifest):
+    manifest, expected, guard, role_agent, config = attest_contract(
+        raw_manifest, project_dir
+    )
+    require_fence(project_dir, transaction_id, allow_finalized=False)
+    drain_operations(project_dir, transaction_id, guard)
+    global_fd = open_global_lock()
+    deploy_fd = None
+    try:
+        deploy_fd = open_deploy_lock_bounded(project_dir)
+        manifest, expected, guard, role_agent, config = attest_contract(
+            raw_manifest, project_dir
+        )
+        drain_operations(
+            project_dir, transaction_id, guard, wait_seconds=0
+        )
+        require_fence(project_dir, transaction_id, allow_finalized=False)
+        if unit_state("is-active") == "active":
+            attest_live_process(expected, manifest)
+        if phase == "quiesce-fenced":
+            role_agent._fence_lost_primary(config)
+            prove_safe_state(role_agent, config, required="fenced")
+        else:
+            prove_safe_state(role_agent, config, required="standby")
+        checked(["/usr/bin/systemctl", "disable", ROLE_AGENT_UNIT])
+        checked(["/usr/bin/systemctl", "stop", ROLE_AGENT_UNIT])
+        checked(["/usr/bin/systemctl", "reset-failed", ROLE_AGENT_UNIT])
+        if unit_state("is-active") != "inactive":
+            raise RuntimeError("role-agent remained active after maintenance quiesce")
+        if unit_state("is-enabled") != "disabled":
+            raise RuntimeError("role-agent remained enabled after maintenance quiesce")
+        required = "fenced" if phase == "quiesce-fenced" else "standby"
+        prove_safe_state(role_agent, config, required=required)
+        require_fence(project_dir, transaction_id, allow_finalized=False)
+    finally:
+        if deploy_fd is not None:
+            os.close(deploy_fd)
+        os.close(global_fd)
+
+
+def wait_for_convergence(role_agent, config, expected_role, *, timeout=90):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            return prove_safe_state(
+                role_agent,
+                config,
+                required="live",
+                expected_role=expected_role,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            last = exc
+            time.sleep(1)
+    raise RuntimeError(f"role-agent did not converge within the bound: {last}")
+
+
+def resume(project_dir, transaction_id, raw_manifest, expected_role):
+    manifest, expected, guard, role_agent, config = attest_contract(
+        raw_manifest, project_dir
+    )
+    initial_fence_state = require_fence(
+        project_dir, transaction_id, allow_finalized=True
+    )
+    drain_operations(project_dir, transaction_id, guard)
+    global_fd = open_global_lock()
+    deploy_fd = None
+    final_deploy_fd = None
+    try:
+        deploy_fd = open_deploy_lock_bounded(project_dir)
+        manifest, expected, guard, role_agent, config = attest_contract(
+            raw_manifest, project_dir
+        )
+        drain_operations(
+            project_dir, transaction_id, guard, wait_seconds=0
+        )
+        fence_state = require_fence(
+            project_dir, transaction_id, allow_finalized=True
+        )
+        if fence_state != initial_fence_state:
+            raise RuntimeError("PITR fence state changed before role-agent resume")
+        checked(["/usr/bin/systemctl", "enable", ROLE_AGENT_UNIT])
+        checked(["/usr/bin/systemctl", "start", ROLE_AGENT_UNIT])
+        if unit_state("is-active") != "active":
+            raise RuntimeError("role-agent did not become active")
+        if unit_state("is-enabled") != "enabled":
+            raise RuntimeError("role-agent did not become enabled")
+        attest_live_process(expected, manifest)
+        os.close(deploy_fd)
+        deploy_fd = None
+        wait_for_convergence(role_agent, config, expected_role)
+        final_deploy_fd = open_deploy_lock_bounded(project_dir)
+        manifest, expected, guard, role_agent, config = attest_contract(
+            raw_manifest, project_dir
+        )
+        attest_live_process(expected, manifest)
+        prove_safe_state(
+            role_agent,
+            config,
+            required="live",
+            expected_role=expected_role,
+        )
+        require_fence(
+            project_dir,
+            transaction_id,
+            allow_finalized=fence_state == "finalized",
+        )
+    finally:
+        if final_deploy_fd is not None:
+            os.close(final_deploy_fd)
+        if deploy_fd is not None:
+            os.close(deploy_fd)
+        os.close(global_fd)
+
+
+def main():
+    if len(sys.argv) != 5:
+        return fail("invalid invocation", 64)
+    if os.geteuid() != 0:
+        return fail("root execution is required", 77)
+    phase, project_dir, transaction_id, raw_manifest = sys.argv[1:]
+    if phase not in {
+        "quiesce-fenced",
+        "quiesce-standby",
+        "resume-primary",
+        "resume-standby",
+    }:
+        return fail("unsupported role-agent phase", 64)
+    if project_dir not in NODE_CONTRACTS:
+        return fail("unreviewed role-agent project directory", 64)
+    if re.fullmatch(r"[0-9a-f]{32}", transaction_id) is None:
+        return fail("invalid PITR transaction ID", 64)
+    try:
+        if phase.startswith("quiesce-"):
+            quiesce(phase, project_dir, transaction_id, raw_manifest)
+        else:
+            resume(
+                project_dir,
+                transaction_id,
+                raw_manifest,
+                phase.removeprefix("resume-"),
+            )
+    except (OSError, RuntimeError, subprocess.SubprocessError, subprocess.TimeoutExpired) as exc:
+        return fail(str(exc))
+    print(f"role_agent_phase={phase} status=proved")
+    return 0
+
+
+raise SystemExit(main())
+'''

--- a/tests/unit/test_pitr_cluster_migration.py
+++ b/tests/unit/test_pitr_cluster_migration.py
@@ -52,10 +52,17 @@ class FakeOperations:
         self.release_failure = None
         self.secret_failure = None
         self.maintenance_failure = None
+        self.role_agent_failure = None
+        self.role_agent_fail_once = set()
         self.release_results = {}
+        self.discover_calls = 0
+        self.discover_failures = set()
 
     def discover(self, *, context, runner):
+        self.discover_calls += 1
         self.events.append(("topology",))
+        if self.discover_calls in self.discover_failures:
+            raise RuntimeError("simulated topology failure")
         if self.topologies:
             return self.topologies.pop(0)
         return _topology()
@@ -102,12 +109,29 @@ class FakeOperations:
         if self.maintenance_failure == (phase, node.alias):
             raise RuntimeError("simulated maintenance phase failure")
 
+    def role_agent(
+        self,
+        *,
+        node,
+        context,
+        phase,
+        transaction_id,
+        runner,
+    ):
+        self.events.append(("role-agent", phase, node.alias, transaction_id))
+        if (phase, node.alias) in self.role_agent_fail_once:
+            self.role_agent_fail_once.remove((phase, node.alias))
+            raise RuntimeError("simulated one-shot role-agent phase failure")
+        if self.role_agent_failure == (phase, node.alias):
+            raise RuntimeError("simulated role-agent phase failure")
+
     def dependencies(self):
         return MigrationDependencies(
             discover=self.discover,
             release=self.release,
             secret=self.secret,
             maintenance=self.maintenance,
+            role_agent=self.role_agent,
         )
 
 
@@ -136,8 +160,12 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("release", "apply", "mvn-api", TXID),
         ("secret", "preflight", "zakup", TXID, ENV_TEXT),
         ("secret", "preflight", "mvn-api", TXID, ENV_TEXT),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
         ("maintenance", "provision-node", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
+        ("role-agent", "quiesce-fenced", "mvn-api", TXID),
         ("maintenance", "provision-node", "mvn-api", TXID),
+        ("role-agent", "resume-primary", "mvn-api", TXID),
         ("secret", "configure-node", "zakup", TXID, ENV_TEXT),
         ("secret", "configure-node", "mvn-api", TXID, ENV_TEXT),
         ("maintenance", "scrub-node", "zakup", TXID),
@@ -148,10 +176,11 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("maintenance", "restore-drill", "mvn-api", TXID),
         ("release", "finalize", "zakup", TXID),
         ("release", "finalize", "mvn-api", TXID),
-        ("maintenance", "enable-timers", "mvn-api", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
+        ("role-agent", "resume-primary", "mvn-api", TXID),
         ("maintenance", "verify", "mvn-api", TXID),
     ]
-    assert len(operations.events) == 1 + 3 * 18
+    assert len(operations.events) == 1 + 3 * 23
     assert operations.events[0] == ("topology",)
     for index in range(1, len(operations.events), 3):
         assert operations.events[index] == ("topology",)
@@ -198,7 +227,7 @@ def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path)
         )
 
     assert not any(
-        event[:2] == ("maintenance", "provision-node")
+        event[:3] == ("maintenance", "provision-node", "mvn-api")
         for event in operations.events
     )
     assert [event[1] for event in operations.events if event[0] == "release"] == [
@@ -246,6 +275,111 @@ def test_ambiguous_failure_during_first_provision_never_rolls_back(tmp_path):
         "apply",
         "apply",
     ]
+    assert [event[1:3] for event in operations.events if event[0] == "role-agent"][-2:] == [
+        ("resume-standby", "zakup"),
+        ("resume-primary", "mvn-api"),
+    ]
+
+
+def test_quiesce_is_standby_first_and_ambiguous_failure_recovers_both_agents(
+    tmp_path,
+):
+    operations = FakeOperations()
+    operations.role_agent_fail_once.add(("quiesce-fenced", "mvn-api"))
+
+    with pytest.raises(
+        RuntimeError,
+        match="safely fenced, freshly ordered, and restarted",
+    ):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    role_events = [event for event in operations.events if event[0] == "role-agent"]
+    assert role_events == [
+        ("role-agent", "quiesce-standby", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
+        ("role-agent", "quiesce-fenced", "mvn-api", TXID),
+        ("role-agent", "quiesce-fenced", "mvn-api", TXID),
+        ("role-agent", "quiesce-fenced", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
+        ("role-agent", "resume-primary", "mvn-api", TXID),
+    ]
+    assert not any(
+        event[:3] == ("maintenance", "provision-node", "mvn-api")
+        for event in operations.events
+    )
+
+
+def test_role_agent_recovery_failure_is_reported_without_rolling_assets_back(
+    tmp_path,
+):
+    operations = FakeOperations()
+    operations.maintenance_failure = ("provision-node", "zakup")
+    operations.role_agent_failure = ("resume-primary", "mvn-api")
+
+    with pytest.raises(
+        RuntimeError,
+        match="pinned role-agent safety recovery failed: resume mvn-api",
+    ):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "apply",
+        "apply",
+    ]
+
+
+def test_recovery_never_resumes_when_either_runtime_fence_is_unproved(tmp_path):
+    operations = FakeOperations()
+    operations.maintenance_failure = ("provision-node", "zakup")
+    operations.role_agent_failure = ("quiesce-fenced", "mvn-api")
+
+    with pytest.raises(RuntimeError, match="did not resume either node"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    recovery = [event for event in operations.events if event[0] == "role-agent"][-2:]
+    assert [event[1] for event in recovery] == [
+        "quiesce-fenced",
+        "quiesce-fenced",
+    ]
+
+
+def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
+    tmp_path,
+):
+    operations = FakeOperations()
+    operations.maintenance_failure = ("provision-node", "zakup")
+    # Baseline + six successful before/after mutations + failed provision proof.
+    operations.discover_failures.add(14)
+
+    with pytest.raises(RuntimeError, match="neither node was resumed"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    role_events = [event for event in operations.events if event[0] == "role-agent"]
+    assert not any(event[1].startswith("resume-") for event in role_events[-2:])
 
 
 def test_topology_failure_before_first_provision_still_rolls_back_assets(tmp_path):

--- a/tests/unit/test_pitr_remote_execution_split.py
+++ b/tests/unit/test_pitr_remote_execution_split.py
@@ -1,6 +1,7 @@
 import ast
 import hashlib
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -14,6 +15,7 @@ from scripts.ha.pitr_pinned_ssh import PATRONI_NODES, PinnedSshContext
 EXECUTORS = (
     pitr_remote_executors.REMOTE_SECRET_EXECUTOR,
     pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR,
+    pitr_remote_executors.REMOTE_ROLE_AGENT_EXECUTOR,
     pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER,
 )
 
@@ -76,6 +78,10 @@ def test_execution_module_preserves_executor_exports():
         is pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR
     )
     assert (
+        pitr_remote_execution.REMOTE_ROLE_AGENT_EXECUTOR
+        is pitr_remote_executors.REMOTE_ROLE_AGENT_EXECUTOR
+    )
+    assert (
         pitr_remote_execution.LOCKED_MAINTENANCE_WRAPPER
         is pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
     )
@@ -129,6 +135,7 @@ def test_secret_executor_uses_transient_cgroup_and_pipe_only_transport():
     assert '"PITR_TRANSACTION_ID": transaction_id' in (
         pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
     )
+    assert "operation_id=transaction_id" in source
     assert 're.fullmatch(r"[0-9a-f]{32}", transaction_id)' in source
     assert 're.fullmatch(r"[0-9a-f]{32}", transaction_id)' in (
         pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
@@ -170,6 +177,9 @@ def test_maintenance_remote_command_contains_exact_nested_programs(tmp_path):
     assert 're.fullmatch(r"[0-9a-f]{32}", transaction_id)' in (
         pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR
     )
+    assert "operation_id=transaction_id" in (
+        pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR
+    )
 
 
 def test_transactional_host_provision_is_an_attested_maintenance_phase(tmp_path):
@@ -194,6 +204,286 @@ def test_transactional_host_provision_is_an_attested_maintenance_phase(tmp_path)
     assert '"provision-node"' in pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
 
 
+def test_role_agent_remote_command_is_pinned_and_attests_exact_assets(tmp_path):
+    captured = []
+
+    def runner(args, stdin):
+        captured.append((list(args), stdin))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    pitr_remote_execution.run_remote_role_agent_phase(
+        node=PATRONI_NODES[1],
+        context=_context(tmp_path),
+        phase="quiesce-standby",
+        transaction_id="0123456789abcdef0123456789abcdef",
+        runner=runner,
+    )
+
+    args, stdin = captured[0]
+    command = shlex.split(args[-1])
+    assert command[:3] == ["/usr/bin/python3", "-I", "-c"]
+    assert command[3] == pitr_remote_executors.REMOTE_ROLE_AGENT_EXECUTOR
+    assert command[4:7] == [
+        "quiesce-standby",
+        "/opt/mvn-reserve",
+        "0123456789abcdef0123456789abcdef",
+    ]
+    manifest = json.loads(command[7])
+    assert set(manifest) == {
+        "/usr/local/sbin/mvn-patroni-role-agent",
+        "/usr/local/sbin/patroni_local_identity.py",
+        "/etc/systemd/system/mvn-patroni-role-agent.service",
+        "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py",
+        "/usr/local/sbin/mvn_postgres_pitr_operation_cleanup.py",
+    }
+    assert all(len(digest) == 64 for digest in manifest.values())
+    assert stdin is None
+
+
+def test_role_agent_executor_keeps_quiesce_fenced_and_resume_fail_closed():
+    source = pitr_remote_executors.REMOTE_ROLE_AGENT_EXECUTOR
+
+    assert 'require_fence(project_dir, transaction_id, allow_finalized=False)' in source
+    assert '["/usr/bin/systemctl", "disable", ROLE_AGENT_UNIT]' in source
+    assert 'unit_state("is-active") != "inactive"' in source
+    assert 'unit_state("is-enabled") != "disabled"' in source
+    assert "role_agent._fence_lost_primary(config)" in source
+    assert "guard.cancel_project_operations(project_dir)" in source
+    assert "execute_attested_module" in source
+    assert "sources[OPERATION_GUARD_PATH]" in source
+    assert 'attest_live_process(expected_environment, manifest)' in source
+    assert "open_deploy_lock_bounded(project_dir)" in source
+    assert "wait_for_convergence(role_agent, config, expected_role)" in source
+
+
+def _role_executor_namespace():
+    source = pitr_remote_executors.REMOTE_ROLE_AGENT_EXECUTOR
+    prefix = source.rsplit("raise SystemExit(main())", 1)[0]
+    namespace = {"__name__": "pitr_role_executor_behavior"}
+    exec(compile(prefix, "<pitr-role-executor>", "exec"), namespace)
+    return namespace
+
+
+def test_record_drain_waits_then_reaps_and_cancels_via_attested_guard():
+    namespace = _role_executor_namespace()
+    events = []
+    record = type("Record", (), {"operation_id": "0" * 32})()
+
+    class Guard:
+        records = [record]
+
+        def list_records(self, **_kwargs):
+            events.append("list")
+            return list(self.records)
+
+        def reconcile_project_operations(self, _project):
+            events.append("reconcile")
+            if self.records:
+                raise RuntimeError("active")
+
+        def cancel_project_operations(self, _project):
+            events.append("cancel")
+            self.records.clear()
+
+    namespace["drain_operations"](
+        "/opt/air-api", "0" * 32, Guard(), wait_seconds=0
+    )
+
+    assert events == [
+        "list", "list", "reconcile", "cancel", "reconcile", "list"
+    ]
+
+
+def test_record_drain_never_reaps_or_cancels_a_foreign_transaction():
+    namespace = _role_executor_namespace()
+    events = []
+    record = type("Record", (), {"operation_id": "f" * 32})()
+
+    class Guard:
+        def list_records(self, **_kwargs):
+            events.append("list")
+            return [record]
+
+        def reconcile_project_operations(self, _project):
+            events.append("reconcile")
+
+        def cancel_project_operations(self, _project):
+            events.append("cancel")
+
+    with pytest.raises(RuntimeError, match="foreign PITR operation"):
+        namespace["drain_operations"](
+            "/opt/air-api", "0" * 32, Guard(), wait_seconds=0
+        )
+
+    assert events == ["list", "list"]
+
+
+def test_primary_quiesce_behavior_fences_before_disabling_main_agent():
+    namespace = _role_executor_namespace()
+    events = []
+    state = {"active": "active", "enabled": "enabled"}
+
+    class Guard:
+        def reconcile_project_operations(self, _project):
+            events.append("reconcile-under-lock")
+
+    class RoleAgent:
+        def _fence_lost_primary(self, _config):
+            events.append("fence-runtime")
+
+    contract = (
+        {"asset": "digest"},
+        {"HA_PROJECT_DIR": "/opt/air-api"},
+        Guard(),
+        RoleAgent(),
+        object(),
+    )
+    namespace["attest_contract"] = lambda *_args: (
+        events.append("attest") or contract
+    )
+    namespace["drain_operations"] = lambda *_args, **_kwargs: events.append(
+        "drain"
+    )
+    namespace["require_fence"] = lambda *_args, **_kwargs: (
+        events.append("fence-proof") or "maintenance"
+    )
+    namespace["open_global_lock"] = lambda: os.open(os.devnull, os.O_RDONLY)
+    namespace["open_deploy_lock_bounded"] = lambda *_args, **_kwargs: os.open(
+        os.devnull, os.O_RDONLY
+    )
+    namespace["attest_live_process"] = lambda *_args: events.append("live-proof")
+    namespace["prove_safe_state"] = lambda *_args, **kwargs: events.append(
+        "safe-" + kwargs["required"]
+    )
+    namespace["unit_state"] = lambda kind: state[
+        "active" if kind == "is-active" else "enabled"
+    ]
+
+    def checked(args, **_kwargs):
+        action = args[1]
+        events.append(action)
+        if action == "disable":
+            state["enabled"] = "disabled"
+        elif action == "stop":
+            state["active"] = "inactive"
+        return ""
+
+    namespace["checked"] = checked
+    namespace["quiesce"](
+        "quiesce-fenced", "/opt/air-api", "0" * 32, "manifest"
+    )
+
+    assert events.index("fence-runtime") < events.index("disable")
+    assert events.index("safe-fenced") < events.index("disable")
+    assert events.count("attest") == 2
+    assert events.count("drain") == 2
+
+
+def test_quiesce_foreign_record_race_fails_before_disabling_agent():
+    namespace = _role_executor_namespace()
+    events = []
+    contract = ({}, {}, object(), object(), object())
+    namespace["attest_contract"] = lambda *_args: contract
+    namespace["require_fence"] = lambda *_args, **_kwargs: "maintenance"
+    namespace["open_global_lock"] = lambda: os.open(os.devnull, os.O_RDONLY)
+    namespace["open_deploy_lock_bounded"] = lambda *_args, **_kwargs: os.open(
+        os.devnull, os.O_RDONLY
+    )
+    calls = 0
+
+    def drain(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        events.append("drain")
+        if calls == 2:
+            raise RuntimeError("foreign PITR operation records remain")
+
+    namespace["drain_operations"] = drain
+    namespace["checked"] = lambda *_args, **_kwargs: events.append("systemctl")
+
+    with pytest.raises(RuntimeError, match="foreign PITR operation"):
+        namespace["quiesce"](
+            "quiesce-standby", "/opt/air-api", "0" * 32, "manifest"
+        )
+
+    assert events == ["drain", "drain"]
+
+
+def test_resume_behavior_holds_lock_for_start_then_reacquires_for_final_proof():
+    namespace = _role_executor_namespace()
+    events = []
+    state = {"active": "inactive", "enabled": "disabled"}
+
+    class Guard:
+        def reconcile_project_operations(self, _project):
+            events.append("reconcile-under-lock")
+
+    contract = (
+        {"asset": "digest"},
+        {"HA_PROJECT_DIR": "/opt/air-api"},
+        Guard(),
+        object(),
+        object(),
+    )
+    namespace["attest_contract"] = lambda *_args: (
+        events.append("attest") or contract
+    )
+    namespace["drain_operations"] = lambda *_args, **_kwargs: events.append(
+        "drain"
+    )
+    namespace["require_fence"] = lambda *_args, **_kwargs: (
+        events.append("fence-proof") or "maintenance"
+    )
+    namespace["open_global_lock"] = lambda: os.open(os.devnull, os.O_RDONLY)
+
+    def deploy_lock(*_args, **_kwargs):
+        events.append("deploy-lock")
+        return os.open(os.devnull, os.O_RDONLY)
+
+    namespace["open_deploy_lock_bounded"] = deploy_lock
+    namespace["attest_live_process"] = lambda *_args: events.append("live-proof")
+    namespace["wait_for_convergence"] = lambda *_args: events.append("converged")
+    namespace["prove_safe_state"] = lambda *_args, **_kwargs: events.append("safe-live")
+    namespace["unit_state"] = lambda kind: state[
+        "active" if kind == "is-active" else "enabled"
+    ]
+
+    def checked(args, **_kwargs):
+        action = args[1]
+        events.append(action)
+        if action == "enable":
+            state["enabled"] = "enabled"
+        elif action == "start":
+            state["active"] = "active"
+        return ""
+
+    namespace["checked"] = checked
+    namespace["resume"](
+        "/opt/air-api", "0" * 32, "manifest", "primary"
+    )
+
+    assert events.count("deploy-lock") == 2
+    assert events.index("start") < events.index("converged")
+    assert events.index("converged") < events.index("safe-live")
+    assert events.count("attest") == 3
+
+
+def test_primary_convergence_never_accepts_unavailable_local_role_proof():
+    namespace = _role_executor_namespace()
+
+    class RoleAgent:
+        def _fetch_configured_patroni_role(self, _config):
+            raise RuntimeError("local Patroni proof unavailable")
+
+    with pytest.raises(RuntimeError, match="local Patroni proof unavailable"):
+        namespace["prove_safe_state"](
+            RoleAgent(),
+            object(),
+            required="live",
+            expected_role="primary",
+        )
+
+
 @pytest.mark.parametrize(
     "transaction_id",
     ["", "A" * 32, "0" * 31, "0" * 33, "g" * 32, "../../unsafe"],
@@ -215,4 +505,11 @@ def test_remote_phases_reject_noncanonical_transaction_id(tmp_path, transaction_
         pitr_remote_execution.run_remote_maintenance_phase(
             **common,
             phase="verify",
+        )
+    with pytest.raises(RuntimeError, match="transaction ID"):
+        pitr_remote_execution.run_remote_role_agent_phase(
+            node=common["node"],
+            context=common["context"],
+            phase="resume-primary",
+            transaction_id=transaction_id,
         )


### PR DESCRIPTION
## Что исправлено
- PITR provisioning выполняется короткими per-node окнами
- primary durable fence до остановки role-agent
- role-specific resume требует свежую локальную Patroni role proof
- recovery fence-ит оба runtime и использует fresh topology
- same-transaction operation records очищаются безопасно; foreign records hard-fail
- timer activation остается у единственного role-agent owner
- guard/cleanup/agent исполняются только после digest attestation

## Проверки
- full unit: 1973 passed, 4 skipped
- broader PITR/Patroni: 472 passed, 4 skipped
- direct behavioral: 47 passed
- adversarial review: CLEAR
- py_compile и git diff --check: green