### PR TITLE
fix(ha): harden PITR migration replay

### DIFF
--- a/scripts/ha/pitr_bundle_executor_source.py
+++ b/scripts/ha/pitr_bundle_executor_source.py
@@ -250,9 +250,14 @@ def file_generation(path, old, new_digest, new_mode):
         return "old" if not old["present"] else "unknown"
     digest = hashlib.sha256(content).hexdigest()
     mode = stat.S_IMODE(metadata.st_mode)
-    if digest == new_digest and mode == new_mode:
+    is_new = digest == new_digest and mode == new_mode
+    is_old = (old["present"] and digest == old["sha256"]
+              and mode == old["mode"])
+    if is_new and is_old:
+        return "both"
+    if is_new:
         return "new"
-    if old["present"] and digest == old["sha256"] and mode == old["mode"]:
+    if is_old:
         return "old"
     return "unknown"
 def write_journal(txdir, journal):
@@ -375,7 +380,7 @@ def rollback_transaction(txdir, journal):
                 fsync_dir(os.path.dirname(entry["path"]))
             else:
                 atomic_write(entry["path"], content, entry["old"]["mode"])
-        if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) != "old":
+        if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) not in {"old", "both"}:
             raise RuntimeError("release rollback verification failed: " + entry["path"])
 def safe_remove_transaction(txdir):
     metadata = os.lstat(txdir)
@@ -610,7 +615,7 @@ def execute(action, txid, project_dir, compose_file, payload):
                 remove_marker(txid)
                 return "rolled-back"
             for entry in journal["entries"]:
-                if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) != "new":
+                if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) not in {"new", "both"}:
                     raise RuntimeError("cannot finalize a non-current release")
             daemon_reload()
             atomic_write(RELEASE_MANIFEST, canonical(release_manifest(journal)) + b"\n", 0o600)

--- a/scripts/ha/pitr_bundle_transport.py
+++ b/scripts/ha/pitr_bundle_transport.py
@@ -167,7 +167,10 @@ def run_remote_release_action(
         raise RuntimeError("unsupported release transaction action")
     if not re.fullmatch(r"[0-9a-f]{32}", txid):
         raise RuntimeError("transaction id must be 32 lowercase hexadecimal characters")
-    stdin = build_release_bundle(node, assets) if action == "apply" else None
+    # An explicit empty payload is required for actions without a bundle.  If
+    # stdin is left as None, subprocess.run() inherits the controller's stdin
+    # and the remote executor blocks forever while waiting for EOF.
+    stdin = build_release_bundle(node, assets) if action == "apply" else ""
     command = " ".join(
         [
             "/usr/bin/python3",

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -121,11 +121,15 @@ def run_bounded(
     record_command,
     stdin_payload=None,
     guard_module=None,
+    operation_id=None,
 ):
     guard = guard_module or load_operation_guard()
     if guard.list_records(project_dir=project_dir):
         raise RuntimeError("another recorded PITR operation requires cleanup")
-    operation_id = secrets.token_hex(16)
+    if operation_id is None:
+        operation_id = secrets.token_hex(16)
+    elif re.fullmatch(r"[0-9a-f]{32}", operation_id) is None:
+        raise RuntimeError("invalid PITR operation ID")
     launch_args = args
     unit = ""
     if transient:

--- a/tests/unit/test_pitr_bundle_transport.py
+++ b/tests/unit/test_pitr_bundle_transport.py
@@ -235,6 +235,37 @@ def test_apply_resumes_mixed_old_new_generation_and_finalize(tmp_path):
     assert not Path(namespace["MAINTENANCE_MARKER"]).exists()
 
 
+def test_apply_and_finalize_accept_identical_old_and_new_generation(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"new-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    txdir = Path(namespace["TRANSACTION_ROOT"]) / TXID
+    journal = json.loads((txdir / "journal.json").read_text())
+    compose_entry = next(
+        entry for entry in journal["entries"] if entry["path"] == str(compose)
+    )
+    assert namespace["file_generation"](
+        str(compose),
+        compose_entry["old"],
+        compose_entry["sha256"],
+        compose_entry["mode"],
+    ) == "both"
+
+    _write(tool, b"old-tool", 0o755)
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert tool.read_bytes() == b"new-tool"
+    assert namespace["execute"](
+        "finalize", TXID, str(project), compose.name, b""
+    ) == "finalized"
+
+
 def test_apply_accepts_only_exact_previous_manifest_missing_new_safe_lock_helper(tmp_path):
     namespace, project, compose, tool = _remote_namespace(tmp_path)
     _write(compose, b"old-compose", 0o644)
@@ -340,6 +371,30 @@ def test_rollback_restores_exact_snapshot_and_absence(tmp_path):
     assert namespace["execute"]("rollback", TXID, str(project), compose.name, b"") == "already-rolled-back"
     with pytest.raises(RuntimeError, match="already has a rollback receipt"):
         namespace["execute"]("apply", TXID, str(project), compose.name, payload)
+
+
+def test_rollback_accepts_identical_old_and_new_generation(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"new-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "rolled-back"
+    assert compose.read_bytes() == b"new-compose"
+    assert tool.read_bytes() == b"old-tool"
+    assert not Path(namespace["MAINTENANCE_MARKER"]).exists()
+    receipt = json.loads(
+        (Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{TXID}.json").read_text()
+    )
+    compose_generation = next(
+        item for item in receipt["old_generations"] if item["path"] == str(compose)
+    )
+    assert compose_generation["sha256"] == hashlib.sha256(b"new-compose").hexdigest()
 
 
 def test_rollback_without_transaction_or_receipt_keeps_marker_fenced(tmp_path):
@@ -453,7 +508,7 @@ def test_hardlink_and_operation_record_block_release(tmp_path):
         namespace["execute"]("apply", TXID, str(project), compose.name, payload)
 
 
-def test_remote_action_uses_pinned_ssh_and_stdin_only_for_apply(tmp_path):
+def test_remote_action_uses_pinned_ssh_and_closes_stdin_without_apply_payload(tmp_path):
     captured = []
 
     def runner(args, stdin):
@@ -490,7 +545,25 @@ def test_remote_action_uses_pinned_ssh_and_stdin_only_for_apply(tmp_path):
         txid=TXID,
         runner=runner,
     )
-    assert captured[-1][1] is None
+    assert captured[-1][1] == ""
+
+
+def test_default_runner_closes_stdin_for_empty_payload(monkeypatch):
+    captured = {}
+
+    def run(args, **kwargs):
+        captured["args"] = args
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args, 0, stdout="finalized\n", stderr="")
+
+    monkeypatch.setattr(bundle.subprocess, "run", run)
+
+    result = bundle._default_runner(["ssh", "node", "command"], "")
+
+    assert result.returncode == 0
+    assert captured["input"] == ""
+    assert captured["text"] is True
+    assert captured["capture_output"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_pitr_remote_execution_split.py
+++ b/tests/unit/test_pitr_remote_execution_split.py
@@ -64,6 +64,74 @@ def test_attestation_loader_uses_an_absolute_path_under_isolated_python(tmp_path
     assert result.returncode == 0, result.stderr
 
 
+def test_bounded_executor_preserves_explicit_transaction_operation_id():
+    namespace = {}
+    exec(
+        compile(
+            pitr_remote_executors.REMOTE_ASSET_ATTESTATION,
+            "<pitr-asset-attestation>",
+            "exec",
+        ),
+        namespace,
+    )
+    operation_id = "0123456789abcdef0123456789abcdef"
+
+    class Guard:
+        def list_records(self, **_kwargs):
+            return []
+
+        def run_guarded_process(self, args, **kwargs):
+            return args, kwargs
+
+    args, kwargs = namespace["run_bounded"](
+        ["/usr/local/sbin/mvn-postgres-pitr-bootstrap"],
+        environment={"PATH": "/usr/bin"},
+        pass_fds=(),
+        phase="configure-node",
+        project_dir="/opt/air-api",
+        timeout_seconds=900,
+        transient=True,
+        record_command="/usr/local/sbin/mvn-postgres-pitr-bootstrap",
+        guard_module=Guard(),
+        operation_id=operation_id,
+    )
+
+    assert kwargs["operation_id"] == operation_id
+    assert kwargs["unit"] == f"mvn-postgres-pitr-manual-{operation_id}.service"
+    assert f"--setenv=PITR_OPERATION_ID={operation_id}" in args
+
+
+@pytest.mark.parametrize("operation_id", ["", "g" * 32, "0" * 31])
+def test_bounded_executor_rejects_invalid_explicit_operation_id(operation_id):
+    namespace = {}
+    exec(
+        compile(
+            pitr_remote_executors.REMOTE_ASSET_ATTESTATION,
+            "<pitr-asset-attestation>",
+            "exec",
+        ),
+        namespace,
+    )
+
+    class Guard:
+        def list_records(self, **_kwargs):
+            return []
+
+    with pytest.raises(RuntimeError, match="invalid PITR operation ID"):
+        namespace["run_bounded"](
+            ["/usr/local/sbin/mvn-postgres-pitr-bootstrap"],
+            environment={"PATH": "/usr/bin"},
+            pass_fds=(),
+            phase="configure-node",
+            project_dir="/opt/air-api",
+            timeout_seconds=900,
+            transient=True,
+            record_command="/usr/local/sbin/mvn-postgres-pitr-bootstrap",
+            guard_module=Guard(),
+            operation_id=operation_id,
+        )
+
+
 def test_execution_module_preserves_executor_exports():
     assert (
         pitr_remote_execution.REMOTE_ASSET_ATTESTATION


### PR DESCRIPTION
## Что изменено

- explicit transaction ID теперь поддерживается и строго проверяется удалённым PITR operation runner;
- release rollback/finalize корректно обрабатывает файлы, у которых старая и новая генерации идентичны;
- rollback/finalize всегда передают явный EOF удалённому executor и не могут зависнуть на унаследованном stdin;
- добавлены поведенческие regression-тесты для всех трёх production-сценариев.

## Причина

Первый реальный fenced migration выявил три скрытых runtime-дефекта: несовпадение сигнатуры `run_bounded`, неоднозначность `old == new` в release journal и наследование controller stdin для действий без payload. Защитные проверки остановили миграцию до конфигурации и сохранили transaction `f3570c4dd678799ebfa53e35e650105d` для безопасного replay.

## Проверки

- `402 passed, 4 skipped` — профильный PITR/Patroni набор;
- полный unit-набор: `1979 passed, 4 skipped`, один несвязанный communications timeout прошёл при изолированном повторе;
- независимый adversarial review: CLEAR, P0–P2 не найдено;
- `git diff --check` clean.