### PR TITLE
fix(pitr): tolerate unloaded quiesced role agent

### DIFF
--- a/scripts/ha/pitr_role_agent_process_attestation.py
+++ b/scripts/ha/pitr_role_agent_process_attestation.py
@@ -140,5 +140,4 @@ def stop_disable_role_agent():
     checked(["/usr/bin/systemctl", "disable", ROLE_AGENT_UNIT])
     if unit_state("is-enabled") != "disabled":
         raise RuntimeError("role-agent remained enabled after maintenance disable")
-    checked(["/usr/bin/systemctl", "reset-failed", ROLE_AGENT_UNIT])
 '''

--- a/tests/unit/test_pitr_role_agent_state_machine.py
+++ b/tests/unit/test_pitr_role_agent_state_machine.py
@@ -38,6 +38,34 @@ def test_role_agent_executor_keeps_quiesce_fenced_and_resume_fail_closed():
     ) < source.index('["/usr/bin/systemctl", "disable", ROLE_AGENT_UNIT]')
     assert "open_deploy_lock_bounded(project_dir)" in source
     assert "wait_for_convergence(role_agent, config, expected_role)" in source
+    assert '"reset-failed"' not in source
+
+
+def test_stop_disable_does_not_reset_an_unloaded_inactive_unit():
+    namespace = _role_executor_namespace()
+    events = []
+    state = {"active": "active", "enabled": "enabled"}
+
+    def checked(args, **_kwargs):
+        action = args[1]
+        events.append(action)
+        if action == "stop":
+            state["active"] = "inactive"
+        elif action == "disable":
+            state["enabled"] = "disabled"
+        else:
+            raise AssertionError(f"unexpected systemctl action: {action}")
+        return ""
+
+    namespace["checked"] = checked
+    namespace["unit_state"] = lambda kind: state[
+        "active" if kind == "is-active" else "enabled"
+    ]
+
+    namespace["stop_disable_role_agent"]()
+
+    assert events == ["stop", "disable"]
+    assert state == {"active": "inactive", "enabled": "disabled"}
 
 
 def _role_executor_namespace():


### PR DESCRIPTION
## Причина

В production replay строгий `stop -> inactive -> disable` успешно завершался, но следующий `systemctl reset-failed <unit>` возвращал `Unit ... not loaded`, потому что отключённый и неактивный unit уже был выгружен systemd. Оркестратор корректно остановился fail-closed.

## Исправление

- удалена избыточная команда `reset-failed` после уже доказанного exact `inactive` и `disabled`;
- добавлен regression test, запрещающий третью systemd-мутацию после `stop/disable`;
- fail-closed сохранён: `failed` не проходит exact-state проверку, `stop` и `disable` остаются checked.

## Проверка

- полный unit suite: `1995 passed, 4 skipped`;
- все PITR/Patroni tests: `658 passed, 4 skipped`;
- независимый adversarial review: CLEAR, P0-P2 нет;
- файлы 143 и 663 строки, `py_compile`/`diff-check` зелёные.

Production восстановлен вручную standby-first/primary-second из аттестованного поколения под тем же maintenance marker; публичный API снова 200. После CI/deploy replay продолжится с тем же transaction ID.