### PR TITLE
Harden HA deploys during PITR maintenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -363,6 +363,7 @@ jobs:
           bundle_sources=(
             scripts/deploy.sh scripts/deploy_backend_blue_green.sh
             scripts/deploy_backend_blue_green_safety.sh
+            scripts/ha/require_deploy_capacity.sh
             scripts/prepare_google_oauth_token_dir.sh
             scripts/post_deploy_smoke_check.sh scripts/compose_candidate_transaction.sh
             scripts/reconcile_backend_compose_runtime.sh
@@ -388,6 +389,7 @@ jobs:
             --env "API_RUN_DEFAULTS=${API_RUN_DEFAULTS}" \
             --env API_BLUE_GREEN_SCRIPT=__MVN_BUNDLE__/deploy_backend_blue_green.sh \
             --env API_BLUE_GREEN_SAFETY_HELPER=__MVN_BUNDLE__/deploy_backend_blue_green_safety.sh \
+            --env API_DEPLOY_CAPACITY_HELPER=__MVN_BUNDLE__/require_deploy_capacity.sh \
             --env API_IN_PLACE_DEPLOY_SCRIPT=__MVN_BUNDLE__/deploy.sh \
             --env API_SMOKE_SCRIPT=__MVN_BUNDLE__/post_deploy_smoke_check.sh \
             --env API_RECONCILE_SCRIPT=__MVN_BUNDLE__/reconcile_backend_compose_runtime.sh \
@@ -463,6 +465,7 @@ jobs:
           bundle_sources=(
             scripts/deploy_backend_blue_green.sh
             scripts/deploy_backend_blue_green_safety.sh
+            scripts/ha/require_deploy_capacity.sh
             scripts/prepare_google_oauth_token_dir.sh scripts/rollback_backend.sh
             scripts/ha/safe_deploy_lock.py
           )
@@ -478,6 +481,7 @@ jobs:
             --env "API_READY_URL=${API_READY_URL}" \
             --env API_BLUE_GREEN_SCRIPT=__MVN_BUNDLE__/deploy_backend_blue_green.sh \
             --env API_BLUE_GREEN_SAFETY_HELPER=__MVN_BUNDLE__/deploy_backend_blue_green_safety.sh \
+            --env API_DEPLOY_CAPACITY_HELPER=__MVN_BUNDLE__/require_deploy_capacity.sh \
             --env API_DEPLOY_LOCK_HELPER=__MVN_BUNDLE__/safe_deploy_lock.py \
             --env "API_DEPLOY_LOCK_HELPER_SHA256=${lock_helper_sha256}" \
             --env GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT=__MVN_BUNDLE__/prepare_google_oauth_token_dir.sh \

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -19,6 +19,7 @@ x-api-app: &api-app
     - ./client_secret.json:/app/client_secret.json:ro
     - ./credentials.json:/app/credentials.json:ro
     - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+  mem_limit: ${MVN_PATRONI_APP_MEMORY:-1024m}
 
 services:
   db:
@@ -101,6 +102,7 @@ services:
       - ./media:/app/media
       - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
     command: python -m bot_app.main
+    mem_limit: ${MVN_PATRONI_BOT_MEMORY:-512m}
 
 volumes:
   postgres_data:

--- a/scripts/deploy_backend_blue_green.sh
+++ b/scripts/deploy_backend_blue_green.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 set -Eeuo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
@@ -15,6 +14,10 @@ DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/ha/safe_deploy_lock.py}"
 DEPLOY_LOCK_HELPER_SHA256="${API_DEPLOY_LOCK_HELPER_SHA256:-}"
+CAPACITY_HELPER="${API_DEPLOY_CAPACITY_HELPER:-${SCRIPT_DIR}/ha/require_deploy_capacity.sh}"
+SAFETY_HELPER="${API_BLUE_GREEN_SAFETY_HELPER:-${SCRIPT_DIR}/deploy_backend_blue_green_safety.sh}"
+PITR_MAINTENANCE_MARKER="/run/mvn-postgres-pitr-maintenance"
+PITR_MARKER_VALIDATOR="${API_PITR_MAINTENANCE_MARKER_VALIDATOR:-${SCRIPT_DIR}/ha/verify_pitr_maintenance_marker.py}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
 ENV_FILE="${PROJECT_DIR}/.env"
@@ -56,7 +59,6 @@ TMP_DIR=""
 log() {
   printf '[blue-green][%s] %s\n' "$1" "$2"
 }
-
 if [[ "${API_DEPLOY_LOCK_ALREADY_HELD:-false}" == "true" && -z "${DEPLOY_LOCK_FD}" ]]; then
   log error "legacy deploy-lock boolean cannot replace an inherited descriptor"
   exit 1
@@ -65,7 +67,6 @@ fi
 summary() {
   printf '%s\n' "$1" >> "${SUMMARY_FILE}"
 }
-
 is_immutable_image() {
   [[ "$1" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]
 }
@@ -477,25 +478,22 @@ PY
   log smoke "candidate API contract checks passed"
 }
 
-wait_service_running() {
-  local service="$1"
-  local running
-
-  for _ in $(seq 1 15); do
-    running="$("${COMPOSE[@]}" ps --status running --services 2>/dev/null || true)"
-    if grep -Fxq "${service}" <<<"${running}"; then
-      return 0
-    fi
-    sleep 1
-  done
-  log error "compose service is not running: ${service}"
-  return 1
-}
-
+if [[ -e "${PITR_MAINTENANCE_MARKER}" || -L "${PITR_MAINTENANCE_MARKER}" ]]; then
+  python3 /usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py pre-source \
+    "${API_PITR_MAINTENANCE_TRANSACTION_ID:-}" "$0" "${DEPLOY_LOCK_HELPER}" "${SAFETY_HELPER}" "${CAPACITY_HELPER}" || {
+    log error "PITR maintenance requires the pinned attested internal scrub runtime"; exit 1;
+  }
+fi
 # shellcheck disable=SC1090,SC1091
-source "${API_BLUE_GREEN_SAFETY_HELPER:-${SCRIPT_DIR}/deploy_backend_blue_green_safety.sh}"
+source "${SAFETY_HELPER}"
+[[ -f "${CAPACITY_HELPER}" && ! -L "${CAPACITY_HELPER}" ]] || {
+  log error "deploy capacity helper is missing or unsafe: ${CAPACITY_HELPER}"
+  exit 1
+}
+# shellcheck disable=SC1090
+source "${CAPACITY_HELPER}"
 
-required_commands=(docker curl python3)
+required_commands=(docker curl python3 awk)
 if [[ "${PROXY_MODE}" == "host_nginx" ]]; then
   required_commands+=(nginx systemctl)
 fi
@@ -568,6 +566,8 @@ fi
   log error "blue-green deploy requires the exact inherited deployment lock fd"; exit 1;
 }
 python3 "${DEPLOY_LOCK_HELPER}" verify "${DEPLOY_LOCK_FILE}" "${DEPLOY_LOCK_FD}"
+require_pitr_maintenance_clear_or_attested_scrub
+require_deploy_capacity
 
 [[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
   log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
@@ -648,15 +648,18 @@ fi
 
 log pull "pulling candidate services ${candidate_service} and bot"
 "${COMPOSE[@]}" pull "${candidate_service}" bot
+require_deploy_capacity
 
 if [[ "${RUN_MIGRATIONS}" == "true" ]]; then
   "${COMPOSE[@]}" run -T --rm --no-deps "${candidate_service}" alembic upgrade head
 fi
 if [[ "${RUN_DEFAULTS}" == "true" ]]; then
+  require_deploy_capacity
   "${COMPOSE[@]}" run -T --rm --no-deps "${candidate_service}" python3 scripts/ensure_global_config_defaults.py
 fi
 
 log start "starting ${candidate_service} on 127.0.0.1:${candidate_port}"
+require_deploy_capacity
 candidate_started=true
 "${COMPOSE[@]}" up -d --no-deps --force-recreate "${candidate_service}"
 smoke_candidate "http://127.0.0.1:${candidate_port}"

--- a/scripts/deploy_backend_blue_green_safety.sh
+++ b/scripts/deploy_backend_blue_green_safety.sh
@@ -11,6 +11,60 @@ rollback_buffer_started=false
 rollback_buffer_routed=false
 ROLLBACK_BUFFER_COMPOSE=()
 
+require_pitr_maintenance_clear_or_attested_scrub() {
+  local transaction_id="${API_PITR_MAINTENANCE_TRANSACTION_ID:-}"
+  local pinned_root="/usr/local/libexec/mvn-pitr"
+
+  if [[ ! -e "${PITR_MAINTENANCE_MARKER}" && ! -L "${PITR_MAINTENANCE_MARKER}" ]]; then
+    if [[ -n "${transaction_id}" ]]; then
+      log error "PITR scrub attestation was supplied without active maintenance"
+      return 1
+    fi
+    return 0
+  fi
+  if [[ -z "${transaction_id}" ]]; then
+    log error "PITR release maintenance is active: ${PITR_MAINTENANCE_MARKER}"
+    return 1
+  fi
+  [[ "${transaction_id}" =~ ^[0-9a-f]{32}$ ]] || {
+    log error "PITR scrub transaction id is invalid"
+    return 1
+  }
+  [[ "$0" == "${pinned_root}/deploy_backend_blue_green.sh" \
+    && "${DEPLOY_LOCK_FD}" == "9" \
+    && "${DEPLOY_LOCK_HELPER}" == "${pinned_root}/safe_deploy_lock.py" \
+    && "${SAFETY_HELPER}" == "${pinned_root}/deploy_backend_blue_green_safety.sh" \
+    && "${CAPACITY_HELPER}" == "${pinned_root}/require_deploy_capacity.sh" \
+    && "${PITR_MARKER_VALIDATOR}" == "${pinned_root}/verify_pitr_maintenance_marker.py" ]] || {
+    log error "PITR scrub helper attestation is not pinned"
+    return 1
+  }
+  [[ -f "${PITR_MARKER_VALIDATOR}" && ! -L "${PITR_MARKER_VALIDATOR}" ]] || {
+    log error "PITR maintenance marker validator is missing or unsafe"
+    return 1
+  }
+  python3 "${PITR_MARKER_VALIDATOR}" marker "${transaction_id}" || {
+    log error "PITR maintenance marker attestation failed"
+    return 1
+  }
+  log pitr "attested internal PITR runtime scrub for transaction ${transaction_id}"
+}
+
+wait_service_running() {
+  local service="$1"
+  local running
+
+  for _ in $(seq 1 15); do
+    running="$("${COMPOSE[@]}" ps --status running --services 2>/dev/null || true)"
+    if grep -Fxq "${service}" <<<"${running}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  log error "compose service is not running: ${service}"
+  return 1
+}
+
 inspect_service_runtime_image() {
   local service="$1"
   local container_ids

--- a/scripts/ha/bootstrap_postgres_pitr.sh
+++ b/scripts/ha/bootstrap_postgres_pitr.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 PROJECT_DIR="${PROJECT_DIR:-}"
 COMPOSE_FILE="${COMPOSE_FILE:-}"
 APP_SERVICE="${APP_SERVICE:-app}"
@@ -18,21 +17,21 @@ RESTORE_DRILL_HELPER="${RESTORE_DRILL_HELPER:-/usr/local/sbin/mvn-postgres-pitr-
 RUNTIME_CHECK_HELPER="${RUNTIME_CHECK_HELPER:-/usr/local/sbin/mvn-postgres-pitr-runtime-check}"
 TOOL_RUNNER_HELPER="${TOOL_RUNNER_HELPER:-/usr/local/sbin/mvn-postgres-pitr-tool-runner}"
 BLUE_GREEN_HELPER="${BLUE_GREEN_HELPER:-/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh}"
+BLUE_GREEN_SAFETY_HELPER="${API_BLUE_GREEN_SAFETY_HELPER:-/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-/usr/local/libexec/mvn-pitr/safe_deploy_lock.py}"
+DEPLOY_CAPACITY_HELPER="${API_DEPLOY_CAPACITY_HELPER:-/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh}"
+PITR_MARKER_VALIDATOR="${API_PITR_MAINTENANCE_MARKER_VALIDATOR:-/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py}"
 DEPLOY_LOCK_HELPER_SHA256="${API_DEPLOY_LOCK_HELPER_SHA256:-}"
 DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 PITR_TRANSACTION_ID="${PITR_TRANSACTION_ID:-${PITR_OPERATION_ID:-}}"
 phase="${1:-preflight}"
-
 log() {
   printf '[pitr-bootstrap] %s\n' "$*"
 }
-
 die() {
   printf '[pitr-bootstrap][fail] %s\n' "$*" >&2
   exit 1
 }
-
 usage() {
   cat <<'EOF'
 Usage:
@@ -58,12 +57,10 @@ Common environment:
   COMPOSE_FILE=docker-compose.patroni.yml
 EOF
 }
-
 if [[ "${phase}" == "help" || "${phase}" == "--help" || "${phase}" == "-h" ]]; then
   usage
   exit 0
 fi
-
 cd_project() {
   [[ -n "${PROJECT_DIR}" ]] || die "PROJECT_DIR must be set explicitly"
   [[ -n "${COMPOSE_FILE}" ]] || die "COMPOSE_FILE must be set explicitly"
@@ -71,19 +68,15 @@ cd_project() {
   [[ -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]] || die "compose file not found: ${PROJECT_DIR}/${COMPOSE_FILE}"
   cd "${PROJECT_DIR}"
 }
-
 compose() {
   docker compose -f "${COMPOSE_FILE}" "$@"
 }
-
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
-
 require_executable() {
   [[ -x "$1" ]] || die "required helper is not executable: $1"
 }
-
 require_active_patroni_compose() {
   local db_container managed_configs runtime_policy target_config
   runtime_policy="${1:-operational}"
@@ -432,7 +425,7 @@ PY
 }
 
 scrub_node() {
-  local active_service in_recovery proxy_mode slot
+  local active_service capacity_profile=primary in_recovery proxy_mode slot
   require_root_for_write_phase
   require_transaction_id
   if BACKEND_IMAGE="$(
@@ -455,12 +448,14 @@ scrub_node() {
         die "unreviewed PITR blue-green helper path"
       [[ "${DEPLOY_LOCK_FD}" == "9" ]] ||
         die "PITR scrub requires inherited deployment lock fd 9"
-      [[ "${DEPLOY_LOCK_HELPER}" == "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py" ]] ||
-        die "unreviewed PITR deploy-lock helper path"
+      [[ "${PITR_MARKER_VALIDATOR}" == "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py" ]] ||
+        die "unreviewed PITR maintenance marker validator path"
       [[ "${DEPLOY_LOCK_HELPER_SHA256}" =~ ^[0-9a-f]{64}$ ]] ||
         die "PITR deploy-lock helper digest is missing"
-      require_executable "${BLUE_GREEN_HELPER}"
-      require_executable "${DEPLOY_LOCK_HELPER}"
+      python3 "${PITR_MARKER_VALIDATOR}" runtime \
+        "${BLUE_GREEN_HELPER}" "${DEPLOY_LOCK_HELPER}" \
+        "${BLUE_GREEN_SAFETY_HELPER}" "${DEPLOY_CAPACITY_HELPER}" ||
+        die "unreviewed PITR scrub runtime helpers"
       python3 "${DEPLOY_LOCK_HELPER}" verify \
         "${PROJECT_DIR}/.deploy.lock" "${DEPLOY_LOCK_FD}" ||
         die "PITR inherited deployment lock verification failed"
@@ -469,6 +464,7 @@ scrub_node() {
       proxy_mode=host_nginx
       if [[ "${PROJECT_DIR}" == "/opt/mvn-reserve" ]]; then
         proxy_mode=container_nginx
+        capacity_profile=reserve
       fi
       API_PROJECT_DIR="${PROJECT_DIR}" \
         API_COMPOSE_FILE="${COMPOSE_FILE}" \
@@ -482,6 +478,11 @@ scrub_node() {
         API_DEPLOY_LOCK_FILE="${PROJECT_DIR}/.deploy.lock" \
         API_DEPLOY_LOCK_HELPER="${DEPLOY_LOCK_HELPER}" \
         API_DEPLOY_LOCK_HELPER_SHA256="${DEPLOY_LOCK_HELPER_SHA256}" \
+        API_BLUE_GREEN_SAFETY_HELPER="${BLUE_GREEN_SAFETY_HELPER}" \
+        API_DEPLOY_CAPACITY_HELPER="${DEPLOY_CAPACITY_HELPER}" \
+        API_DEPLOY_CAPACITY_PROFILE="${capacity_profile}" \
+        API_PITR_MAINTENANCE_MARKER_VALIDATOR="${PITR_MARKER_VALIDATOR}" \
+        API_PITR_MAINTENANCE_TRANSACTION_ID="${PITR_TRANSACTION_ID}" \
         API_BLUE_GREEN_SUMMARY_FILE=/dev/null \
         API_RUN_MIGRATIONS=false \
         API_RUN_DEFAULTS=false \

--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -17,6 +17,8 @@ DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/safe_deploy_lock.py}"
 DEPLOY_LOCK_HELPER_SHA256="${API_DEPLOY_LOCK_HELPER_SHA256:-}"
 MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
+PITR_MAINTENANCE_MARKER="${API_PITR_MAINTENANCE_MARKER:-/run/mvn-postgres-pitr-maintenance}"
+CAPACITY_HELPER="${API_DEPLOY_CAPACITY_HELPER:-${SCRIPT_DIR}/require_deploy_capacity.sh}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
 ENV_FILE="${PROJECT_DIR}/.env"
@@ -150,12 +152,18 @@ rollback_standby() {
   exit "${exit_code}"
 }
 
-for command in docker curl python3; do
+for command in docker curl python3 awk; do
   command -v "${command}" >/dev/null 2>&1 || {
     log error "required command is missing: ${command}"
     exit 1
   }
 done
+[[ -f "${CAPACITY_HELPER}" && ! -L "${CAPACITY_HELPER}" ]] || {
+  log error "deploy capacity helper is missing or unsafe: ${CAPACITY_HELPER}"
+  exit 1
+}
+# shellcheck disable=SC1090
+source "${CAPACITY_HELPER}"
 [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
   log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
   exit 1
@@ -208,7 +216,12 @@ fi
   log error "deploy requires the exact inherited deployment lock fd"; exit 1;
 }
 python3 "${DEPLOY_LOCK_HELPER}" verify "${DEPLOY_LOCK_FILE}" "${DEPLOY_LOCK_FD}"
+[[ ! -e "${PITR_MAINTENANCE_MARKER}" && ! -L "${PITR_MAINTENANCE_MARKER}" ]] || {
+  log error "PITR release maintenance is active: ${PITR_MAINTENANCE_MARKER}"
+  exit 1
+}
 require_expected_role
+require_deploy_capacity
 [[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
   log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
   exit 1
@@ -225,6 +238,7 @@ if [[ "${EXPECTED_ROLE}" == "primary" ]]; then
   API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}" \
     API_DEPLOY_LOCK_HELPER="${DEPLOY_LOCK_HELPER}" \
     API_DEPLOY_LOCK_HELPER_SHA256="${DEPLOY_LOCK_HELPER_SHA256}" \
+    API_DEPLOY_CAPACITY_HELPER="${CAPACITY_HELPER}" \
     API_RUN_MIGRATIONS=false \
     API_RUN_DEFAULTS=false \
     bash "${BLUE_GREEN_SCRIPT}"
@@ -252,6 +266,7 @@ trap rollback_standby ERR
 reconcile_standby_proxy
 log standby "updating fenced service ${active_service}"
 "${COMPOSE[@]}" pull "${active_service}" bot
+require_deploy_capacity
 write_backend_image "${BACKEND_IMAGE}"
 env_updated=true
 "${COMPOSE[@]}" stop bot >/dev/null 2>&1 || true

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -158,6 +158,8 @@ install -o root -g root -m 0755 scripts/ha/pitr_operation_cleanup.py /usr/local/
 install -d -o root -g root -m 0755 /usr/local/libexec/mvn-pitr
 install -o root -g root -m 0755 scripts/deploy_backend_blue_green.sh /usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh
 install -o root -g root -m 0755 scripts/deploy_backend_blue_green_safety.sh /usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh
+install -o root -g root -m 0755 scripts/ha/require_deploy_capacity.sh /usr/local/libexec/mvn-pitr/require_deploy_capacity.sh
+install -o root -g root -m 0755 scripts/ha/verify_pitr_maintenance_marker.py /usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py
 install -o root -g root -m 0755 scripts/prepare_google_oauth_token_dir.sh /usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh
 install -o root -g root -m 0755 scripts/ha/safe_deploy_lock.py /usr/local/libexec/mvn-pitr/safe_deploy_lock.py
 install -o root -g root -m 0644 deploy/ha/systemd/mvn-postgres-wal-upload.service /etc/systemd/system/mvn-postgres-wal-upload.service

--- a/scripts/ha/pitr_bundle_executor_prelude.py
+++ b/scripts/ha/pitr_bundle_executor_prelude.py
@@ -53,6 +53,8 @@ BASE_MODES = {
     LIBEXEC_DIR + "/run_postgres_pitr_install_locked.py": 0o755,
     LIBEXEC_DIR + "/deploy_backend_blue_green.sh": 0o755,
     LIBEXEC_DIR + "/deploy_backend_blue_green_safety.sh": 0o755,
+    LIBEXEC_DIR + "/require_deploy_capacity.sh": 0o755,
+    LIBEXEC_DIR + "/verify_pitr_maintenance_marker.py": 0o755,
     LIBEXEC_DIR + "/safe_deploy_lock.py": 0o755,
     LIBEXEC_DIR + "/prepare_google_oauth_token_dir.sh": 0o755,
     "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,
@@ -60,7 +62,11 @@ BASE_MODES = {
     "/etc/systemd/system/mvn-postgres-basebackup.service": 0o644,
     "/etc/systemd/system/mvn-postgres-basebackup.timer": 0o644,
 }
-PREVIOUS_RELEASE_ADDITIONS = {LIBEXEC_DIR + "/safe_deploy_lock.py"}
+PREVIOUS_RELEASE_ADDITIONS = {
+    LIBEXEC_DIR + "/require_deploy_capacity.sh",
+    LIBEXEC_DIR + "/safe_deploy_lock.py",
+    LIBEXEC_DIR + "/verify_pitr_maintenance_marker.py",
+}
 PROJECT_COMPOSE = {
     "/opt/air-api": "/opt/air-api/docker-compose.patroni.yml",
     "/opt/mvn-reserve": "/opt/mvn-reserve/docker-compose.patroni.yml",

--- a/scripts/ha/pitr_bundle_executor_source.py
+++ b/scripts/ha/pitr_bundle_executor_source.py
@@ -323,6 +323,8 @@ def validate_journal(journal, txid, project_dir, release=None, descriptors=None)
             or set(journal) != {"entries", "project_dir", "release_sha256", "state", "txid", "version"}
             or journal["version"] != 1 or journal["txid"] != txid
             or journal["project_dir"] != project_dir or journal["state"] not in {"prepared", "applied"}
+            or not isinstance(journal["release_sha256"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", journal["release_sha256"])
             or not isinstance(journal["entries"], list)):
         raise RuntimeError("release transaction journal contract is invalid")
     if release is not None and journal["release_sha256"] != release:
@@ -515,8 +517,11 @@ def read_release_manifest(modes, project_dir, allow_previous=False):
             raise RuntimeError("release manifest file contract is invalid")
         files.append(item)
     paths = [item["path"] for item in files]
-    if (paths != sorted(modes) and not
-            (allow_previous and paths == sorted(set(modes) - PREVIOUS_RELEASE_ADDITIONS))):
+    missing = set(modes) - set(paths)
+    previous_is_valid = (allow_previous and missing
+                         and missing <= PREVIOUS_RELEASE_ADDITIONS
+                         and paths == sorted(set(modes) - missing))
+    if paths != sorted(modes) and not previous_is_valid:
         raise RuntimeError("release manifest path set is incomplete")
     for item in files:
         content, _ = read_regular(item["path"], exact_mode=item["mode"])

--- a/scripts/ha/pitr_bundle_transport.py
+++ b/scripts/ha/pitr_bundle_transport.py
@@ -53,6 +53,8 @@ BASE_REMOTE_ASSET_MODES = {
     f"{LIBEXEC_DIR}/run_postgres_pitr_install_locked.py": 0o755,
     f"{LIBEXEC_DIR}/deploy_backend_blue_green.sh": 0o755,
     f"{LIBEXEC_DIR}/deploy_backend_blue_green_safety.sh": 0o755,
+    f"{LIBEXEC_DIR}/require_deploy_capacity.sh": 0o755,
+    f"{LIBEXEC_DIR}/verify_pitr_maintenance_marker.py": 0o755,
     f"{LIBEXEC_DIR}/safe_deploy_lock.py": 0o755,
     f"{LIBEXEC_DIR}/prepare_google_oauth_token_dir.sh": 0o755,
     "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -204,6 +204,16 @@ PITR_HOST_ASSETS = (
         0o755,
     ),
     PitrHostAsset(
+        REPO_ROOT / "scripts/ha/require_deploy_capacity.sh",
+        "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh",
+        0o755,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/verify_pitr_maintenance_marker.py",
+        "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py",
+        0o755,
+    ),
+    PitrHostAsset(
         REPO_ROOT / "scripts/ha/safe_deploy_lock.py",
         "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py",
         0o755,

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -65,6 +65,8 @@ EXPECTED_ASSET_MODES = {
     "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py": 0o755,
     "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py": 0o755,
     "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh": 0o755,
     "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,

--- a/scripts/ha/require_deploy_capacity.sh
+++ b/scripts/ha/require_deploy_capacity.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+DEPLOY_CAPACITY_MEMINFO_FILE="${API_DEPLOY_MEMINFO_FILE:-/proc/meminfo}"
+DEPLOY_CAPACITY_PROFILE="${API_DEPLOY_CAPACITY_PROFILE:-primary}"
+DEPLOY_MIN_FREE_SWAP_KIB="${API_DEPLOY_MIN_FREE_SWAP_KIB:-262144}"
+
+deploy_capacity_error() {
+  printf '[deploy-capacity][error] %s\n' "$1" >&2
+}
+
+case "${DEPLOY_CAPACITY_PROFILE}" in
+  primary) default_min_available_memory_kib=1572864 ;;
+  reserve) default_min_available_memory_kib=1048576 ;;
+  *) deploy_capacity_error "API_DEPLOY_CAPACITY_PROFILE must be primary or reserve"; return 1 2>/dev/null || exit 1 ;;
+esac
+# Keep 512 MiB beyond the node's maximum candidate-app cgroup.
+DEPLOY_MIN_AVAILABLE_MEMORY_KIB="${API_DEPLOY_MIN_AVAILABLE_MEMORY_KIB:-${default_min_available_memory_kib}}"
+
+deploy_capacity_meminfo_value() {
+  local key="$1"
+  awk -v key="${key}:" '
+    $1 == key { value = $2; matches += 1 }
+    END { if (matches != 1 || value !~ /^[0-9]+$/) exit 1; print value }
+  ' "${DEPLOY_CAPACITY_MEMINFO_FILE}"
+}
+
+require_deploy_capacity() {
+  local available_kib=""
+  local swap_total_kib=""
+  local swap_free_kib=""
+
+  [[ "${DEPLOY_MIN_AVAILABLE_MEMORY_KIB}" =~ ^[1-9][0-9]*$ ]] || {
+    deploy_capacity_error "API_DEPLOY_MIN_AVAILABLE_MEMORY_KIB must be a positive integer"
+    return 1
+  }
+  [[ "${DEPLOY_MIN_FREE_SWAP_KIB}" =~ ^[1-9][0-9]*$ ]] || {
+    deploy_capacity_error "API_DEPLOY_MIN_FREE_SWAP_KIB must be a positive integer"
+    return 1
+  }
+  [[ -r "${DEPLOY_CAPACITY_MEMINFO_FILE}" ]] || {
+    deploy_capacity_error "cannot read host memory capacity: ${DEPLOY_CAPACITY_MEMINFO_FILE}"
+    return 1
+  }
+
+  available_kib="$(deploy_capacity_meminfo_value MemAvailable)" || {
+    deploy_capacity_error "MemAvailable is missing or invalid in ${DEPLOY_CAPACITY_MEMINFO_FILE}"
+    return 1
+  }
+  swap_total_kib="$(deploy_capacity_meminfo_value SwapTotal)" || {
+    deploy_capacity_error "SwapTotal is missing or invalid in ${DEPLOY_CAPACITY_MEMINFO_FILE}"
+    return 1
+  }
+  swap_free_kib="$(deploy_capacity_meminfo_value SwapFree)" || {
+    deploy_capacity_error "SwapFree is missing or invalid in ${DEPLOY_CAPACITY_MEMINFO_FILE}"
+    return 1
+  }
+  (( swap_free_kib <= swap_total_kib )) || {
+    deploy_capacity_error "SwapFree exceeds SwapTotal in ${DEPLOY_CAPACITY_MEMINFO_FILE}"
+    return 1
+  }
+  (( available_kib >= DEPLOY_MIN_AVAILABLE_MEMORY_KIB )) || {
+    deploy_capacity_error "insufficient memory headroom: available=${available_kib}KiB required=${DEPLOY_MIN_AVAILABLE_MEMORY_KIB}KiB"
+    return 1
+  }
+  if (( swap_total_kib > 0 && swap_free_kib < DEPLOY_MIN_FREE_SWAP_KIB )); then
+    deploy_capacity_error "insufficient free swap reserve: free=${swap_free_kib}KiB required=${DEPLOY_MIN_FREE_SWAP_KIB}KiB"
+    return 1
+  fi
+}

--- a/scripts/ha/run_patroni_candidate_transaction.sh
+++ b/scripts/ha/run_patroni_candidate_transaction.sh
@@ -6,6 +6,7 @@ OPERATION="${PATRONI_CANDIDATE_OPERATION:-}"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 CANONICAL_FILE="${PATRONI_CANONICAL_COMPOSE_FILE:-${PROJECT_DIR}/docker-compose.patroni.yml}"
 CANDIDATE_FILE="${PATRONI_CANDIDATE_COMPOSE_FILE:-}"
+CANDIDATE_SOURCE="${PATRONI_CANDIDATE_COMPOSE_SOURCE:-}"
 TRANSACTION_SCRIPT="${COMPOSE_CANDIDATE_TRANSACTION_SCRIPT:-/tmp/compose_candidate_transaction.sh}"
 MIGRATION_SCRIPT="${PATRONI_MIGRATION_SCRIPT:-/tmp/run_patroni_migrations.sh}"
 DEPLOY_SCRIPT="${PATRONI_DEPLOY_SCRIPT:-/tmp/deploy_patroni_api_node.sh}"
@@ -21,6 +22,7 @@ DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/safe_deploy_lock.py}"
 DEPLOY_LOCK_HELPER_SHA256="${API_DEPLOY_LOCK_HELPER_SHA256:-}"
 PATRONI_CUTOVER_MARKER="${PATRONI_CUTOVER_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
+PITR_MAINTENANCE_MARKER="${API_PITR_MAINTENANCE_MARKER:-/run/mvn-postgres-pitr-maintenance}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 PREVIOUS_BACKEND_IMAGE="${API_PREVIOUS_BACKEND_IMAGE:-}"
 ROLE_AGENT_BACKUP=""
@@ -29,9 +31,22 @@ ROLE_IDENTITY_BACKUP=""
 ROLE_IDENTITY_PREEXISTED=false
 ROLE_AGENT_CHANGED=false
 CANDIDATE_CHECKSUM=""
+CANDIDATE_OWNED=false
 PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
 CURRENT_ROLE_OVERRIDE="${API_CURRENT_PATRONI_ROLE:-}"
 EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+PROXY_MODE="${API_PROXY_MODE:-host_nginx}"
+PROXY_CONFIG_SOURCE="${PATRONI_PROXY_CONFIG_SOURCE:-}"
+PROXY_CONFIG_TARGET="${API_PROXY_CONFIG_FILE:-${PROJECT_DIR}/api-proxy/nginx.conf}"
+PROXY_UPSTREAM_SOURCE="${PATRONI_PROXY_UPSTREAM_SOURCE:-}"
+PROXY_UPSTREAM_TARGET="${API_NGINX_UPSTREAM_FILE:-${PROJECT_DIR}/api-proxy/upstream.conf}"
+PROXY_SERVICE="${API_PROXY_SERVICE:-api-proxy}"
+PROXY_CONFIG_BACKUP=""
+PROXY_CONFIG_PREEXISTED=false
+PROXY_UPSTREAM_CREATED=false
+PROXY_FILES_CHANGED=false
+PROXY_DIR_CREATED=false
+PROXY_RUNTIME_STATE=not-applicable
 
 [[ "${DEPLOY_LOCK_HELPER_SHA256}" =~ ^[0-9a-f]{64}$ ]] || {
   echo "safe deployment lock helper digest is missing" >&2; exit 1;
@@ -72,17 +87,60 @@ require_no_patroni_cutover() {
   fi
 }
 
+require_no_pitr_maintenance() {
+  if [[ -e "${PITR_MAINTENANCE_MARKER}" || -L "${PITR_MAINTENANCE_MARKER}" ]]; then
+    echo "PITR release maintenance is active: ${PITR_MAINTENANCE_MARKER}" >&2
+    return 1
+  fi
+}
+
 transaction() {
   CANONICAL_COMPOSE_FILE="${CANONICAL_FILE}" \
     CANDIDATE_COMPOSE_FILE="${CANDIDATE_FILE}" \
     bash "${TRANSACTION_SCRIPT}" "$1"
 }
 
+stage_candidate_compose() {
+  local temporary=""
+  [[ "$(dirname "${CANONICAL_FILE}")" == "$(dirname "${CANDIDATE_FILE}")" ]] || {
+    echo "candidate and canonical compose must share a directory" >&2
+    return 1
+  }
+  if [[ -z "${CANDIDATE_SOURCE}" ]]; then
+    [[ -f "${CANDIDATE_FILE}" && ! -L "${CANDIDATE_FILE}" ]] || {
+      echo "candidate compose is missing or unsafe: ${CANDIDATE_FILE}" >&2
+      return 1
+    }
+    CANDIDATE_OWNED=true
+    trap cleanup_candidate_only EXIT
+    return 0
+  fi
+  [[ -f "${CANDIDATE_SOURCE}" && ! -L "${CANDIDATE_SOURCE}" ]] || {
+    echo "candidate compose source is missing or unsafe: ${CANDIDATE_SOURCE}" >&2
+    return 1
+  }
+  [[ ! -e "${CANDIDATE_FILE}" && ! -L "${CANDIDATE_FILE}" ]] || {
+    echo "candidate compose target already exists: ${CANDIDATE_FILE}" >&2
+    return 1
+  }
+  CANDIDATE_OWNED=true
+  trap cleanup_candidate_only EXIT
+  temporary="$(mktemp "${CANDIDATE_FILE}.tmp.XXXXXX")"
+  if ! cp -p -- "${CANDIDATE_SOURCE}" "${temporary}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  if ! mv -- "${temporary}" "${CANDIDATE_FILE}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+}
+
 cleanup_migration_candidate() {
   local status=$?
   trap - EXIT
   set +e
-  transaction cleanup
+  [[ "${CANDIDATE_OWNED}" == "true" ]] && transaction cleanup
   exit "${status}"
 }
 
@@ -90,7 +148,7 @@ cleanup_candidate_only() {
   local status=$?
   trap - EXIT
   set +e
-  transaction cleanup
+  [[ "${CANDIDATE_OWNED}" == "true" ]] && transaction cleanup
   exit "${status}"
 }
 
@@ -189,6 +247,173 @@ restore_role_agent() {
   [[ "${failed}" == "false" ]]
 }
 
+atomic_install_file() {
+  local source="$1"
+  local target="$2"
+  local temporary=""
+  temporary="$(mktemp "${target}.tmp.XXXXXX")"
+  if ! install -m 0644 -- "${source}" "${temporary}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  mv -f -- "${temporary}" "${target}"
+}
+
+atomic_restore_file() {
+  local source="$1"
+  local target="$2"
+  local temporary=""
+  temporary="$(mktemp "${target}.tmp.XXXXXX")"
+  if ! cp -p -- "${source}" "${temporary}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+  mv -f -- "${temporary}" "${target}"
+}
+
+require_safe_proxy_target() {
+  python3 - "$1" <<'PY'
+import os, stat, sys
+metadata = os.lstat(sys.argv[1])
+if (not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid() or metadata.st_nlink != 1
+        or metadata.st_mode & 0o022):
+    raise SystemExit("container proxy target metadata is unsafe: " + sys.argv[1])
+PY
+}
+
+capture_proxy_runtime_state() {
+  local container_ids=""
+  local running=""
+  [[ "${PROXY_MODE}" == "container_nginx" ]] || return 0
+  container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+    ps -a -q "${PROXY_SERVICE}")"
+  if [[ -z "${container_ids}" ]]; then
+    PROXY_RUNTIME_STATE=absent
+    return 0
+  fi
+  [[ "${container_ids}" != *$'\n'* ]] || {
+    echo "container proxy runtime is ambiguous" >&2
+    return 1
+  }
+  running="$(docker inspect --format '{{.State.Running}}' "${container_ids}")"
+  case "${running}" in
+    true) PROXY_RUNTIME_STATE=running ;;
+    false) PROXY_RUNTIME_STATE=stopped ;;
+    *) echo "container proxy runtime state is invalid" >&2; return 1 ;;
+  esac
+}
+
+stage_proxy_files() {
+  local proxy_dir=""
+  [[ "${PROXY_MODE}" == "container_nginx" ]] || return 0
+  [[ -f "${PROXY_CONFIG_SOURCE}" && ! -L "${PROXY_CONFIG_SOURCE}" \
+    && -f "${PROXY_UPSTREAM_SOURCE}" && ! -L "${PROXY_UPSTREAM_SOURCE}" ]] || {
+    echo "container proxy source bundle is incomplete" >&2
+    return 1
+  }
+  proxy_dir="$(dirname "${PROXY_CONFIG_TARGET}")"
+  [[ "${proxy_dir}" == "$(dirname "${PROXY_UPSTREAM_TARGET}")" ]] || {
+    echo "container proxy targets must share one directory" >&2
+    return 1
+  }
+  if [[ -e "${proxy_dir}" || -L "${proxy_dir}" ]]; then
+    [[ -d "${proxy_dir}" && ! -L "${proxy_dir}" ]] || {
+      echo "container proxy directory is unsafe: ${proxy_dir}" >&2
+      return 1
+    }
+  else
+    mkdir -m 0755 -- "${proxy_dir}"
+    PROXY_DIR_CREATED=true
+  fi
+  if [[ -e "${PROXY_CONFIG_TARGET}" || -L "${PROXY_CONFIG_TARGET}" ]]; then
+    [[ -f "${PROXY_CONFIG_TARGET}" && ! -L "${PROXY_CONFIG_TARGET}" ]] || {
+      echo "container proxy config target is unsafe" >&2
+      return 1
+    }
+    require_safe_proxy_target "${PROXY_CONFIG_TARGET}"
+    PROXY_CONFIG_BACKUP="$(mktemp "${PROJECT_DIR}/.patroni-proxy-config.backup.XXXXXX")"
+    if ! cp -p -- "${PROXY_CONFIG_TARGET}" "${PROXY_CONFIG_BACKUP}"; then
+      rm -f -- "${PROXY_CONFIG_BACKUP}"
+      PROXY_CONFIG_BACKUP=""
+      return 1
+    fi
+    PROXY_CONFIG_PREEXISTED=true
+  fi
+  if [[ -e "${PROXY_UPSTREAM_TARGET}" || -L "${PROXY_UPSTREAM_TARGET}" ]]; then
+    [[ -f "${PROXY_UPSTREAM_TARGET}" && ! -L "${PROXY_UPSTREAM_TARGET}" ]] || {
+      echo "container proxy upstream target is unsafe" >&2
+      return 1
+    }
+    require_safe_proxy_target "${PROXY_UPSTREAM_TARGET}"
+  fi
+  PROXY_FILES_CHANGED=true
+  atomic_install_file "${PROXY_CONFIG_SOURCE}" "${PROXY_CONFIG_TARGET}"
+  if [[ ! -e "${PROXY_UPSTREAM_TARGET}" ]]; then
+    atomic_install_file "${PROXY_UPSTREAM_SOURCE}" "${PROXY_UPSTREAM_TARGET}"
+    PROXY_UPSTREAM_CREATED=true
+  fi
+}
+
+restore_proxy_files() {
+  [[ "${PROXY_FILES_CHANGED}" == "true" || "${PROXY_DIR_CREATED}" == "true" ]] || return 0
+  local failed=false
+  if [[ "${PROXY_FILES_CHANGED}" == "true" ]]; then
+    if [[ "${PROXY_CONFIG_PREEXISTED}" == "true" ]]; then
+      atomic_restore_file "${PROXY_CONFIG_BACKUP}" "${PROXY_CONFIG_TARGET}" || failed=true
+    else
+      rm -f -- "${PROXY_CONFIG_TARGET}" || failed=true
+    fi
+    if [[ "${PROXY_UPSTREAM_CREATED}" == "true" ]]; then
+      rm -f -- "${PROXY_UPSTREAM_TARGET}" || failed=true
+    fi
+  fi
+  [[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}" || failed=true
+  if [[ "${PROXY_DIR_CREATED}" == "true" ]]; then
+    rmdir -- "$(dirname "${PROXY_CONFIG_TARGET}")" || failed=true
+  fi
+  [[ "${failed}" == "false" ]]
+}
+
+restore_proxy_runtime() {
+  [[ "${PROXY_MODE}" == "container_nginx" \
+    && "${PROXY_FILES_CHANGED}" == "true" ]] || return 0
+  case "${PROXY_RUNTIME_STATE}" in
+    absent)
+      docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+        rm -s -f "${PROXY_SERVICE}" >/dev/null \
+        && [[ -z "$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+          ps -a -q "${PROXY_SERVICE}")" ]]
+      ;;
+    stopped)
+      docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+        stop "${PROXY_SERVICE}" >/dev/null \
+        && [[ -z "$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+          ps --status running -q "${PROXY_SERVICE}")" ]]
+      ;;
+    running)
+      docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+        up -d --no-deps --force-recreate --wait --wait-timeout 60 "${PROXY_SERVICE}" \
+        && docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+          exec -T "${PROXY_SERVICE}" nginx -t
+      ;;
+    *) echo "container proxy pre-deploy runtime state is unavailable" >&2; return 1 ;;
+  esac
+}
+
+restore_proxy_state() {
+  local failed=false
+  if [[ "${PROXY_RUNTIME_STATE}" == "absent" \
+    || "${PROXY_RUNTIME_STATE}" == "stopped" ]]; then
+    restore_proxy_runtime || failed=true
+    restore_proxy_files || failed=true
+  else
+    restore_proxy_files || failed=true
+    restore_proxy_runtime || failed=true
+  fi
+  [[ "${failed}" == "false" ]]
+}
+
 current_patroni_role() {
   if [[ -n "${CURRENT_ROLE_OVERRIDE}" ]]; then
     [[ "${CURRENT_ROLE_OVERRIDE}" == "primary" || "${CURRENT_ROLE_OVERRIDE}" == "standby" ]] \
@@ -258,9 +483,14 @@ reconcile_failed_deploy() {
     echo "Patroni candidate compose promotion committed; preserving the consistent new runtime" >&2
     [[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}"
     [[ -z "${ROLE_IDENTITY_BACKUP}" ]] || rm -f -- "${ROLE_IDENTITY_BACKUP}"
+    [[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}"
     exit "${status}"
   fi
   transaction cleanup || restoration_failed=true
+  if ! restore_proxy_state; then
+    echo "failed to restore the previous container proxy files and runtime state" >&2
+    restoration_failed=true
+  fi
   if ! restore_role_agent; then
     echo "failed to restore the previous Patroni role agent" >&2
     role_agent_restore_failed=true
@@ -333,16 +563,15 @@ fi
   echo "PATRONI_CANDIDATE_COMPOSE_FILE must name this run's unique candidate" >&2
   exit 1
 }
-[[ -f "${CANDIDATE_FILE}" ]] || {
-  echo "candidate compose is missing: ${CANDIDATE_FILE}" >&2
-  exit 1
-}
-CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
 [[ -f "${TRANSACTION_SCRIPT}" ]] || {
   echo "compose transaction helper is missing: ${TRANSACTION_SCRIPT}" >&2
   exit 1
 }
+require_no_pitr_maintenance
 require_no_patroni_cutover
+stage_candidate_compose
+CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
+trap cleanup_candidate_only EXIT
 if [[ "${OPERATION}" == "migrate" ]]; then
   trap cleanup_migration_candidate EXIT
   API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}" \
@@ -352,7 +581,6 @@ if [[ "${OPERATION}" == "migrate" ]]; then
   exit 0
 fi
 
-trap cleanup_candidate_only EXIT
 [[ -f "${DB_CONTRACT_HELPER}" && ! -L "${DB_CONTRACT_HELPER}" ]] || {
   echo "Patroni db contract helper is missing or unsafe: ${DB_CONTRACT_HELPER}" >&2
   exit 1
@@ -374,6 +602,8 @@ install -m 0755 "${ROLE_AGENT_SOURCE}" "${ROLE_AGENT_TARGET}"
 rm -f -- "${ROLE_AGENT_SOURCE}" "${ROLE_IDENTITY_SOURCE}"
 systemctl restart "${ROLE_AGENT_UNIT}"
 systemctl is-active --quiet "${ROLE_AGENT_UNIT}"
+capture_proxy_runtime_state
+stage_proxy_files
 
 API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" \
   API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}" \
@@ -386,3 +616,5 @@ trap - EXIT
   || echo "warning: stale Patroni role agent backup remains at ${ROLE_AGENT_BACKUP}" >&2
 [[ -z "${ROLE_IDENTITY_BACKUP}" ]] || rm -f -- "${ROLE_IDENTITY_BACKUP}" \
   || echo "warning: stale Patroni identity backup remains at ${ROLE_IDENTITY_BACKUP}" >&2
+[[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}" \
+  || echo "warning: stale Patroni proxy config backup remains at ${PROXY_CONFIG_BACKUP}" >&2

--- a/scripts/ha/run_patroni_migrations.sh
+++ b/scripts/ha/run_patroni_migrations.sh
@@ -9,7 +9,9 @@ MIGRATION_SERVICE="${API_MIGRATION_SERVICE:-app-blue}"
 PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 MAINTENANCE_MARKER="${API_MAINTENANCE_MARKER:-${PROJECT_DIR}/.patroni-cutover-in-progress}"
+PITR_MAINTENANCE_MARKER="${API_PITR_MAINTENANCE_MARKER:-/run/mvn-postgres-pitr-maintenance}"
 RUN_DEFAULTS="${API_RUN_DEFAULTS:-true}"
+CAPACITY_HELPER="${API_DEPLOY_CAPACITY_HELPER:-${SCRIPT_DIR}/require_deploy_capacity.sh}"
 DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/safe_deploy_lock.py}"
 DEPLOY_LOCK_HELPER_SHA256="${API_DEPLOY_LOCK_HELPER_SHA256:-}"
@@ -79,18 +81,28 @@ require_primary() {
   }
 }
 
-for command in docker curl python3; do
+for command in docker curl python3 awk; do
   command -v "${command}" >/dev/null 2>&1 || {
     log error "required command is missing: ${command}"
     exit 1
   }
 done
+[[ -f "${CAPACITY_HELPER}" && ! -L "${CAPACITY_HELPER}" ]] || {
+  log error "deploy capacity helper is missing or unsafe: ${CAPACITY_HELPER}"
+  exit 1
+}
+# shellcheck disable=SC1090
+source "${CAPACITY_HELPER}"
 [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
   log error "BACKEND_IMAGE must be immutable"
   exit 1
 }
 [[ ! -e "${MAINTENANCE_MARKER}" ]] || {
   log error "Patroni maintenance marker exists: ${MAINTENANCE_MARKER}"
+  exit 1
+}
+[[ ! -e "${PITR_MAINTENANCE_MARKER}" && ! -L "${PITR_MAINTENANCE_MARKER}" ]] || {
+  log error "PITR release maintenance is active: ${PITR_MAINTENANCE_MARKER}"
   exit 1
 }
 [[ -f "${PROJECT_DIR}/${COMPOSE_FILE}" ]] || {
@@ -105,6 +117,7 @@ cd "${PROJECT_DIR}"
 }
 
 require_primary
+require_deploy_capacity
 [[ -f "${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}" ]] || {
   log error "Google OAuth token preparation script is missing: ${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT}"
   exit 1
@@ -120,6 +133,7 @@ fi
 log pull "pulling migration image ${BACKEND_IMAGE}"
 "${COMPOSE[@]}" pull "${MIGRATION_SERVICE}"
 require_primary
+require_deploy_capacity
 
 log migrate "running Alembic on the confirmed Patroni primary"
 [[ ! -e "${MAINTENANCE_MARKER}" && ! -L "${MAINTENANCE_MARKER}" ]] || {
@@ -128,6 +142,8 @@ log migrate "running Alembic on the confirmed Patroni primary"
 }
 "${COMPOSE[@]}" run -T --rm --no-deps "${MIGRATION_SERVICE}" alembic upgrade head
 if [[ "${RUN_DEFAULTS}" == "true" ]]; then
+  require_primary
+  require_deploy_capacity
   "${COMPOSE[@]}" run -T --rm --no-deps "${MIGRATION_SERVICE}" \
     python3 scripts/ensure_global_config_defaults.py
 fi

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -11,6 +11,7 @@ PROJECT_DIR="${API_NODE_PROJECT_DIR:-}"
 COMPOSE_SOURCE="${API_NODE_COMPOSE_SOURCE:-}"
 PROXY_MODE="${API_NODE_PROXY_MODE:-host_nginx}"
 EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+PITR_MAINTENANCE_MARKER="${API_PITR_MAINTENANCE_MARKER:-/run/mvn-postgres-pitr-maintenance}"
 BACKEND_IMAGE="${BACKEND_IMAGE:-}"
 SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-}"
 SSH_HOST_KEY_SOURCE="${API_NODE_SSH_HOST_KEY_SOURCE:-}"
@@ -23,11 +24,13 @@ ROLE_IDENTITY_TARGET="/usr/local/sbin/patroni_local_identity.py"
 ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
 CANDIDATE_RUNNER_SOURCE="scripts/ha/run_patroni_candidate_transaction.sh"
 DEPLOY_LOCK_HELPER_SOURCE="scripts/ha/safe_deploy_lock.py"
+DEPLOY_CAPACITY_HELPER_SOURCE="scripts/ha/require_deploy_capacity.sh"
 DEPLOY_LOCK_HELPER_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${DEPLOY_LOCK_HELPER_SOURCE}")"
 DB_CONTRACT_HELPER_SOURCE="scripts/ha/patroni_compose_db_contract.py"
 TRANSACTION_SOURCE="scripts/compose_candidate_transaction.sh"
 BUNDLE_VERIFIER_SOURCE="scripts/ha/verify_patroni_remote_bundle.py"
 REMOTE_BUNDLE_DIR=""
+DEPLOY_CAPACITY_PROFILE=primary
 
 log() {
   printf '[patroni-remote][%s] %s\n' "$1" "$2"
@@ -84,6 +87,9 @@ if [[ "${OPERATION}" != "probe" ]]; then
     exit 1
   }
 fi
+if [[ "${PROJECT_DIR}" == "/opt/mvn-reserve" ]]; then
+  DEPLOY_CAPACITY_PROFILE=reserve
+fi
 if [[ "${OPERATION}" == "deploy" ]]; then
   [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
     log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
@@ -101,6 +107,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 fi
 if [[ "${OPERATION}" != "probe" ]]; then
   [[ -f "${CANDIDATE_RUNNER_SOURCE}" && -f "${TRANSACTION_SOURCE}" \
+    && -f "${DEPLOY_CAPACITY_HELPER_SOURCE}" \
     && -f "${DEPLOY_LOCK_HELPER_SOURCE}" && -f "${BUNDLE_VERIFIER_SOURCE}" ]] || {
     log error "compose candidate transaction scripts are missing"
     exit 1
@@ -171,7 +178,7 @@ REMOTE="${NODE_USER}@${NODE_HOST}"
 
 if [[ "${OPERATION}" == "probe" ]]; then
   role="$(ssh "${SSH_OPTS[@]}" "${REMOTE}" \
-    "curl -fsS --max-time 5 http://127.0.0.1:8008/patroni | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); m={\"leader\":\"primary\",\"master\":\"primary\",\"primary\":\"primary\",\"replica\":\"standby\",\"standby\":\"standby\"}; n=m.get(r); n or sys.exit(1); print(n)'")"
+    "if test -e $(quote "${PITR_MAINTENANCE_MARKER}") || test -L $(quote "${PITR_MAINTENANCE_MARKER}"); then echo 'PITR release maintenance is active; refusing deployment probe' >&2; exit 75; fi; curl -fsS --max-time 5 http://127.0.0.1:8008/patroni | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); m={\"leader\":\"primary\",\"master\":\"primary\",\"primary\":\"primary\",\"replica\":\"standby\",\"standby\":\"standby\"}; n=m.get(r); n or sys.exit(1); print(n)'")"
   [[ "${role}" == "primary" || "${role}" == "standby" ]] || {
     log error "invalid Patroni role from ${NODE_HOST}: ${role}"
     exit 1
@@ -183,7 +190,8 @@ if [[ "${OPERATION}" == "probe" ]]; then
   exit 0
 fi
 
-ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}")"
+ssh "${SSH_OPTS[@]}" "${REMOTE}" \
+  "test -d $(quote "${PROJECT_DIR}"); if test -e $(quote "${PITR_MAINTENANCE_MARKER}") || test -L $(quote "${PITR_MAINTENANCE_MARKER}"); then echo 'PITR release maintenance is active; refusing remote release staging' >&2; exit 75; fi"
 CANONICAL_REMOTE_COMPOSE_FILE="docker-compose.patroni.yml"
 candidate_id="$(printf '%s' "${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}-${OPERATION}-$$" | tr -c 'A-Za-z0-9_.-' '-')"
 REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"
@@ -196,6 +204,7 @@ REMOTE_BUNDLE_DIR="$(
   exit 1
 }
 BUNDLE_SOURCES=(
+  "${COMPOSE_SOURCE}"
   scripts/ha/run_patroni_migrations.sh
   scripts/ha/deploy_patroni_api_node.sh
   scripts/deploy_backend_blue_green.sh
@@ -204,6 +213,7 @@ BUNDLE_SOURCES=(
   scripts/reconcile_backend_compose_runtime.sh
   "${CANDIDATE_RUNNER_SOURCE}"
   "${DEPLOY_LOCK_HELPER_SOURCE}"
+  "${DEPLOY_CAPACITY_HELPER_SOURCE}"
   "${TRANSACTION_SOURCE}"
 )
 if [[ "${OPERATION}" == "deploy" ]]; then
@@ -212,25 +222,20 @@ if [[ "${OPERATION}" == "deploy" ]]; then
     "${ROLE_AGENT_SOURCE}"
     "${ROLE_IDENTITY_SOURCE}"
   )
+  if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
+    BUNDLE_SOURCES+=(
+      deploy/ha/proxy/nginx.conf
+      deploy/ha/proxy/upstream.conf
+    )
+  fi
 fi
 BUNDLE_MANIFEST_B64="$(python3 "${BUNDLE_VERIFIER_SOURCE}" manifest "${BUNDLE_SOURCES[@]}")"
 BUNDLE_VERIFIER_CODE="$(<"${BUNDLE_VERIFIER_SOURCE}")"
 ROLE_AGENT_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_role_agent.py"
 ROLE_IDENTITY_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_local_identity.py"
 DB_CONTRACT_HELPER_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_compose_db_contract.py"
-scp "${SSH_OPTS[@]}" "${COMPOSE_SOURCE}" \
-  "${REMOTE}:${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}"
+REMOTE_COMPOSE_SOURCE="${REMOTE_BUNDLE_DIR}/$(basename "${COMPOSE_SOURCE}")"
 scp "${SSH_OPTS[@]}" "${BUNDLE_SOURCES[@]}" "${REMOTE}:${REMOTE_BUNDLE_DIR}/"
-
-if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
-  ssh "${SSH_OPTS[@]}" "${REMOTE}" "mkdir -p $(quote "${PROJECT_DIR}/api-proxy")"
-  scp "${SSH_OPTS[@]}" deploy/ha/proxy/nginx.conf \
-    "${REMOTE}:${PROJECT_DIR}/api-proxy/nginx.conf"
-  if ! ssh "${SSH_OPTS[@]}" "${REMOTE}" "test -f $(quote "${PROJECT_DIR}/api-proxy/upstream.conf")"; then
-    scp "${SSH_OPTS[@]}" deploy/ha/proxy/upstream.conf \
-      "${REMOTE}:${PROJECT_DIR}/api-proxy/upstream.conf"
-  fi
-fi
 
 proxy_env="API_PROXY_MODE=$(quote "${PROXY_MODE}")"
 if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
@@ -264,8 +269,11 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   PATRONI_CANDIDATE_OPERATION=$(quote "${OPERATION}") \
   PATRONI_CANONICAL_COMPOSE_FILE=$(quote "${PROJECT_DIR}/${CANONICAL_REMOTE_COMPOSE_FILE}") \
   PATRONI_CANDIDATE_COMPOSE_FILE=$(quote "${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}") \
+  PATRONI_CANDIDATE_COMPOSE_SOURCE=$(quote "${REMOTE_COMPOSE_SOURCE}") \
   PATRONI_MIGRATION_SCRIPT=$(quote "${REMOTE_BUNDLE_DIR}/run_patroni_migrations.sh") \
   PATRONI_DEPLOY_SCRIPT=$(quote "${REMOTE_BUNDLE_DIR}/deploy_patroni_api_node.sh") \
+  PATRONI_PROXY_CONFIG_SOURCE=$(quote "${REMOTE_BUNDLE_DIR}/nginx.conf") \
+  PATRONI_PROXY_UPSTREAM_SOURCE=$(quote "${REMOTE_BUNDLE_DIR}/upstream.conf") \
   COMPOSE_CANDIDATE_TRANSACTION_SCRIPT=$(quote "${REMOTE_BUNDLE_DIR}/compose_candidate_transaction.sh") \
   PATRONI_ROLE_AGENT_SOURCE=$(quote "${ROLE_AGENT_REMOTE}") \
   PATRONI_ROLE_AGENT_TARGET=$(quote "${ROLE_AGENT_TARGET}") \
@@ -274,6 +282,8 @@ printf '%s\n' "${GHCR_PAT:-}" | ssh "${SSH_OPTS[@]}" "${REMOTE}" "
   PATRONI_DB_CONTRACT_HELPER=$(quote "${DB_CONTRACT_HELPER_REMOTE}") \
   PATRONI_ROLE_AGENT_UNIT=$(quote "${ROLE_AGENT_UNIT}") \
   API_DEPLOY_LOCK_HELPER=$(quote "${REMOTE_BUNDLE_DIR}/safe_deploy_lock.py") \
+  API_DEPLOY_CAPACITY_HELPER=$(quote "${REMOTE_BUNDLE_DIR}/require_deploy_capacity.sh") \
+  API_DEPLOY_CAPACITY_PROFILE=$(quote "${DEPLOY_CAPACITY_PROFILE}") \
   API_DEPLOY_LOCK_HELPER_SHA256=$(quote "${DEPLOY_LOCK_HELPER_SHA256}") \
   ${proxy_env} \
   bash $(quote "${REMOTE_BUNDLE_DIR}/run_patroni_candidate_transaction.sh")

--- a/scripts/ha/run_postgres_pitr_manual.py
+++ b/scripts/ha/run_postgres_pitr_manual.py
@@ -67,6 +67,8 @@ BASE_RELEASE_MODES = {
     "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py": 0o755,
     "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py": 0o755,
     "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh": 0o755,
     "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,

--- a/scripts/ha/run_postgres_pitr_scheduled.py
+++ b/scripts/ha/run_postgres_pitr_scheduled.py
@@ -89,6 +89,8 @@ BASE_RELEASE_MODES = {
     "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh": 0o755,
     "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py": 0o755,
     "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py": 0o755,
     "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh": 0o755,
     "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,

--- a/scripts/ha/verify_pitr_maintenance_marker.py
+++ b/scripts/ha/verify_pitr_maintenance_marker.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Attest the canonical PITR maintenance marker for an internal scrub."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import sys
+
+
+MARKER_PATH = "/run/mvn-postgres-pitr-maintenance"
+TRANSACTION_RE = re.compile(r"[0-9a-f]{32}")
+PINNED_ROOT = "/usr/local/libexec/mvn-pitr"
+PINNED_VALIDATOR = f"{PINNED_ROOT}/verify_pitr_maintenance_marker.py"
+PINNED_RUNTIME_PATHS = (
+    f"{PINNED_ROOT}/deploy_backend_blue_green.sh",
+    f"{PINNED_ROOT}/safe_deploy_lock.py",
+    f"{PINNED_ROOT}/deploy_backend_blue_green_safety.sh",
+    f"{PINNED_ROOT}/require_deploy_capacity.sh",
+)
+
+
+def _generation(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def verify_marker(
+    path: str,
+    transaction_id: str,
+    *,
+    expected_uid: int = 0,
+    expected_gid: int = 0,
+) -> None:
+    if TRANSACTION_RE.fullmatch(transaction_id) is None:
+        raise RuntimeError("PITR maintenance transaction id is invalid")
+
+    before = os.lstat(path)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or stat.S_IMODE(before.st_mode) != 0o600
+        or before.st_uid != expected_uid
+        or before.st_gid != expected_gid
+        or before.st_nlink != 1
+        or before.st_size != 33
+    ):
+        raise RuntimeError("PITR maintenance marker metadata is unsafe")
+
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if _generation(opened) != _generation(before):
+            raise RuntimeError("PITR maintenance marker changed before open")
+        content = os.read(descriptor, 34)
+        after = os.fstat(descriptor)
+        if _generation(after) != _generation(opened):
+            raise RuntimeError("PITR maintenance marker changed while being read")
+    finally:
+        os.close(descriptor)
+
+    final = os.lstat(path)
+    if _generation(final) != _generation(after):
+        raise RuntimeError("PITR maintenance marker path changed while being read")
+    if content != f"{transaction_id}\n".encode("ascii"):
+        raise RuntimeError("PITR maintenance marker belongs to another transaction")
+
+
+def _verify_runtime_file(path: str) -> None:
+    parent = os.lstat(os.path.dirname(path))
+    if (
+        not stat.S_ISDIR(parent.st_mode)
+        or stat.S_ISLNK(parent.st_mode)
+        or parent.st_uid != 0
+        or parent.st_gid != 0
+        or parent.st_mode & 0o022
+    ):
+        raise RuntimeError(f"PITR scrub runtime helper parent is unsafe: {path}")
+    metadata = os.lstat(path)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_gid != 0
+        or metadata.st_nlink != 1
+        or metadata.st_mode & 0o022
+        or metadata.st_mode & 0o111 == 0
+    ):
+        raise RuntimeError(f"PITR scrub runtime helper is unsafe: {path}")
+
+
+def verify_pinned_runtime(paths: tuple[str, ...]) -> None:
+    if paths != PINNED_RUNTIME_PATHS:
+        raise RuntimeError("PITR scrub runtime helper paths are not pinned")
+    for path in paths:
+        _verify_runtime_file(path)
+
+
+def main() -> int:
+    if os.path.abspath(__file__) != PINNED_VALIDATOR:
+        raise RuntimeError("PITR maintenance marker validator path is not pinned")
+    _verify_runtime_file(PINNED_VALIDATOR)
+    if len(sys.argv) == 3 and sys.argv[1] == "marker":
+        verify_marker(MARKER_PATH, sys.argv[2])
+        return 0
+    if len(sys.argv) == 6 and sys.argv[1] == "runtime":
+        verify_pinned_runtime(tuple(sys.argv[2:]))
+        return 0
+    if len(sys.argv) == 7 and sys.argv[1] == "pre-source":
+        verify_pinned_runtime(tuple(sys.argv[3:]))
+        verify_marker(MARKER_PATH, sys.argv[2])
+        return 0
+    raise RuntimeError(
+        "usage: verify_pitr_maintenance_marker.py marker TRANSACTION_ID | "
+        "runtime RUNTIME LOCK SAFETY CAPACITY | "
+        "pre-source TRANSACTION_ID RUNTIME LOCK SAFETY CAPACITY"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError) as exc:
+        print(f"PITR maintenance marker attestation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/ha/verify_postgres_pitr_runtime.py
+++ b/scripts/ha/verify_postgres_pitr_runtime.py
@@ -27,7 +27,7 @@ PITR_ENV_POLICIES = (*PUBLIC_PITR_ENV_POLICIES, *MIGRATION_PITR_ENV_POLICIES)
 SECRETS_FILE = Path("/etc/mvn-postgres-pitr.secrets.env")
 EXPECTED_COMPOSE_DIGESTS = {
     "/opt/air-api/docker-compose.patroni.yml": (
-        "a10a39f803f6b5683afe2e2fdda6dbda8cbb714edc177ed631b56e7275600428"
+        "f624fe0aad2ce364d1067b34765a54a501281bdca270d43e84045e0d076c4b6a"
     ),
     "/opt/mvn-reserve/docker-compose.patroni.yml": (
         "af02921ab9b4490017002aa08699d758486d858f16a741b72eef33feca27fff4"

--- a/tests/unit/blue_green_deploy_harness.py
+++ b/tests/unit/blue_green_deploy_harness.py
@@ -201,6 +201,11 @@ exit 0
 """,
     )
 
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemAvailable: 2097152 kB\nSwapTotal: 524288 kB\nSwapFree: 524288 kB\n",
+        encoding="utf-8",
+    )
     env = os.environ.copy()
     env.update(
         {
@@ -215,6 +220,7 @@ exit 0
             "API_COMPOSE_FILE": "docker-compose.prod.yml",
             "API_DEPLOY_LOCK_HELPER": str(LOCK_HELPER),
             "API_DEPLOY_LOCK_HELPER_SHA256": LOCK_HELPER_SHA256,
+            "API_DEPLOY_MEMINFO_FILE": str(meminfo),
             "API_NGINX_SITE_FILE": str(site),
             "API_NGINX_UPSTREAM_FILE": str(upstream),
             "API_NGINX_INTERNAL_FILE": str(nginx_dir / "conf.d/mvn-api-internal.conf"),

--- a/tests/unit/test_blue_green_deploy_script.py
+++ b/tests/unit/test_blue_green_deploy_script.py
@@ -162,6 +162,61 @@ def test_first_deploy_activates_blue_without_touching_database(tmp_path):
     assert "include " in site.read_text(encoding="utf-8")
 
 
+def test_deploy_refuses_low_capacity_before_proxy_or_container_mutation(tmp_path):
+    env, project, site, command_log = _environment(tmp_path)
+    Path(env["API_DEPLOY_MEMINFO_FILE"]).write_text(
+        "MemAvailable: 200000 kB\nSwapTotal: 524288 kB\nSwapFree: 1000 kB\n",
+        encoding="utf-8",
+    )
+    original_site = site.read_text(encoding="utf-8")
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "insufficient memory headroom" in result.stderr
+    assert site.read_text(encoding="utf-8") == original_site
+    assert not (project / ".active-api-slot").exists()
+    commands = command_log.read_text(encoding="utf-8")
+    assert " pull " not in commands
+    assert " up " not in commands
+    assert "systemctl reload nginx" not in commands
+
+
+def test_canonical_pitr_marker_has_only_narrow_attested_scrub_exception():
+    deploy_source = SCRIPT.read_text(encoding="utf-8")
+    safety_source = SAFETY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'PITR_MAINTENANCE_MARKER="/run/mvn-postgres-pitr-maintenance"' in deploy_source
+    assert "API_PITR_MAINTENANCE_MARKER:-" not in deploy_source
+    lock_verify = deploy_source.index(
+        'python3 "${DEPLOY_LOCK_HELPER}" verify "${DEPLOY_LOCK_FILE}" "${DEPLOY_LOCK_FD}"'
+    )
+    marker_gate = deploy_source.index(
+        "require_pitr_maintenance_clear_or_attested_scrub"
+    )
+    assert lock_verify < marker_gate
+    pre_source_gate = deploy_source.index(
+        "verify_pitr_maintenance_marker.py pre-source"
+    )
+    safety_source_load = deploy_source.index('source "${SAFETY_HELPER}"')
+    capacity_source_load = deploy_source.index('source "${CAPACITY_HELPER}"')
+    assert pre_source_gate < safety_source_load < capacity_source_load < lock_verify
+    assert 'if [[ -z "${transaction_id}" ]]' in safety_source
+    for pinned_path in (
+        "deploy_backend_blue_green.sh",
+        "deploy_backend_blue_green_safety.sh",
+        "safe_deploy_lock.py",
+        "require_deploy_capacity.sh",
+        "verify_pitr_maintenance_marker.py",
+    ):
+        assert f'"${{pinned_root}}/{pinned_path}"' in safety_source
+    assert '"${DEPLOY_LOCK_FD}" == "9"' in safety_source
+    assert (
+        'python3 "${PITR_MARKER_VALIDATOR}" marker "${transaction_id}"'
+        in safety_source
+    )
+
+
 @pytest.mark.parametrize(
     "stop_timeout",
     ["0", "11", "not-an-int", "999999999999999999999999999999999999999"],

--- a/tests/unit/test_deploy_capacity.py
+++ b/tests/unit/test_deploy_capacity.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "scripts/ha/require_deploy_capacity.sh"
+
+
+def _run(tmp_path: Path, meminfo: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+    meminfo_file = tmp_path / "meminfo"
+    meminfo_file.write_text(meminfo, encoding="utf-8")
+    return subprocess.run(
+        ["bash", "-c", 'source "$1"; require_deploy_capacity', "capacity-test", str(HELPER)],
+        env={
+            **os.environ,
+            "API_DEPLOY_MEMINFO_FILE": str(meminfo_file),
+            **overrides,
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "swap",
+    [
+        "SwapTotal: 0 kB\nSwapFree: 0 kB\n",
+        "SwapTotal: 524288 kB\nSwapFree: 262144 kB\n",
+    ],
+)
+def test_capacity_accepts_exact_primary_memory_boundary_with_safe_swap(tmp_path, swap):
+    result = _run(tmp_path, "MemAvailable: 1572864 kB\n" + swap)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_capacity_reserve_profile_accepts_one_gib_boundary(tmp_path):
+    result = _run(
+        tmp_path,
+        "MemAvailable: 1048576 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n",
+        API_DEPLOY_CAPACITY_PROFILE="reserve",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_capacity_rejects_unknown_profile_before_meminfo_read(tmp_path):
+    result = _run(
+        tmp_path,
+        "MemAvailable: 2097152 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n",
+        API_DEPLOY_CAPACITY_PROFILE="unknown",
+    )
+
+    assert result.returncode != 0
+    assert "must be primary or reserve" in result.stderr
+
+
+def test_capacity_rejects_exhausted_memory_and_swap(tmp_path):
+    result = _run(
+        tmp_path,
+        "MemAvailable: 201868 kB\nSwapTotal: 2621432 kB\nSwapFree: 3804 kB\n",
+    )
+
+    assert result.returncode != 0
+    assert "insufficient memory headroom" in result.stderr
+
+
+def test_capacity_rejects_low_swap_even_with_free_memory(tmp_path):
+    result = _run(
+        tmp_path,
+        "MemAvailable: 2097152 kB\nSwapTotal: 524288 kB\nSwapFree: 131072 kB\n",
+    )
+
+    assert result.returncode != 0
+    assert "insufficient free swap reserve" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "meminfo",
+    [
+        "MemAvailable: 2097152 kB\nMemAvailable: 2097152 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n",
+        "MemAvailable: 2097152 kB\nSwapTotal: 0 kB\n",
+        "MemAvailable: unknown kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n",
+    ],
+)
+def test_capacity_rejects_ambiguous_or_invalid_meminfo(tmp_path, meminfo):
+    result = _run(tmp_path, meminfo)
+
+    assert result.returncode != 0

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -158,6 +158,7 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     assert "scripts/ha/run_verified_remote_bundle.py" in primary_deploy["run"]
     assert "deploy_backend_blue_green.sh" in primary_deploy["run"]
     assert "deploy_backend_blue_green_safety.sh" in primary_deploy["run"]
+    assert "scripts/ha/require_deploy_capacity.sh" in primary_deploy["run"]
     assert "compose_candidate_transaction.sh" in primary_deploy["run"]
     assert "reconcile_backend_compose_runtime.sh" in primary_deploy["run"]
     assert "deploy_backend_candidate_transaction.sh" in primary_deploy["run"]
@@ -176,6 +177,12 @@ def test_backend_release_is_scoped_and_has_guarded_rollback():
     )
     assert safety_helper_env in primary_deploy["run"]
     assert safety_helper_env in rollback["run"]
+    capacity_helper_env = (
+        "API_DEPLOY_CAPACITY_HELPER=__MVN_BUNDLE__/require_deploy_capacity.sh"
+    )
+    assert capacity_helper_env in primary_deploy["run"]
+    assert capacity_helper_env in rollback["run"]
+    assert "scripts/ha/require_deploy_capacity.sh" in rollback["run"]
     assert "scripts/deploy.sh" in standby_deploy["run"]
     assert '.candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}' in standby_deploy["run"]
     assert "scripts/deploy_backend_candidate_transaction.sh" in standby_deploy["run"]

--- a/tests/unit/test_patroni_candidate_release_safety.py
+++ b/tests/unit/test_patroni_candidate_release_safety.py
@@ -1,0 +1,243 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_patroni_candidate_transactions import (
+    PATRONI_RUNNER,
+    _patroni_runner_env,
+)
+
+
+def _run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _proxy_case(tmp_path, *, child_exit: int, runtime_state: str, existing=True):
+    env, project = _patroni_runner_env(tmp_path, child_exit=child_exit)
+    proxy_dir = project / "api-proxy"
+    proxy_config = proxy_dir / "nginx.conf"
+    proxy_upstream = proxy_dir / "upstream.conf"
+    if existing:
+        proxy_dir.mkdir()
+        proxy_config.write_text("old-config\n", encoding="utf-8")
+        proxy_upstream.write_text("active-upstream\n", encoding="utf-8")
+    config_source = tmp_path / "new-nginx.conf"
+    upstream_source = tmp_path / "new-upstream.conf"
+    config_source.write_text("new-config\n", encoding="utf-8")
+    upstream_source.write_text("default-upstream\n", encoding="utf-8")
+    env.update(
+        {
+            "API_PROXY_MODE": "container_nginx",
+            "PATRONI_PROXY_CONFIG_SOURCE": str(config_source),
+            "PATRONI_PROXY_UPSTREAM_SOURCE": str(upstream_source),
+            "API_PROXY_CONFIG_FILE": str(proxy_config),
+            "API_NGINX_UPSTREAM_FILE": str(proxy_upstream),
+            "PROXY_PREVIOUS_RUNTIME_STATE": runtime_state,
+        }
+    )
+    return env, project, proxy_dir, proxy_config, proxy_upstream
+
+
+@pytest.mark.parametrize("marker_kind", ["file", "symlink"])
+def test_patroni_candidate_refuses_pitr_maintenance_before_runtime_mutation(
+    tmp_path, marker_kind
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    marker = tmp_path / "pitr-maintenance"
+    if marker_kind == "file":
+        marker.write_text("owned\n", encoding="utf-8")
+    else:
+        marker.symlink_to(tmp_path / "absent-marker-target")
+    env["API_PITR_MAINTENANCE_MARKER"] = str(marker)
+    proxy_dir = project / "api-proxy"
+    proxy_dir.mkdir()
+    proxy_config = proxy_dir / "nginx.conf"
+    proxy_upstream = proxy_dir / "upstream.conf"
+    proxy_config.write_text("old-config\n", encoding="utf-8")
+    proxy_upstream.write_text("old-upstream\n", encoding="utf-8")
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "PITR release maintenance is active" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert "/app/google-oauth" in (project / "compose.yml.candidate").read_text(
+        encoding="utf-8"
+    )
+    assert not (tmp_path / "child.log").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    assert not (tmp_path / "systemctl.log").read_text(encoding="utf-8")
+    assert not (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert proxy_config.read_text(encoding="utf-8") == "old-config\n"
+    assert proxy_upstream.read_text(encoding="utf-8") == "old-upstream\n"
+
+
+def test_patroni_candidate_rolls_back_proxy_config_and_loaded_runtime(tmp_path):
+    env, project, _, proxy_config, proxy_upstream = _proxy_case(
+        tmp_path, child_exit=42, runtime_state="running"
+    )
+    proxy_config.chmod(0o640)
+    env["PROXY_RUNTIME_CONFIG"] = str(tmp_path / "loaded-nginx.conf")
+
+    result = _run(env)
+
+    assert result.returncode == 42, result.stderr
+    assert proxy_config.read_text(encoding="utf-8") == "old-config\n"
+    assert proxy_config.stat().st_mode & 0o777 == 0o640
+    assert proxy_upstream.read_text(encoding="utf-8") == "active-upstream\n"
+    assert (tmp_path / "loaded-nginx.conf").read_text(encoding="utf-8") == (
+        "old-config\n"
+    )
+    assert not list(project.glob(".patroni-proxy-config.backup.*"))
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert "up -d --no-deps --force-recreate --wait --wait-timeout 60 api-proxy" in commands
+    assert "exec -T api-proxy nginx -t" in commands
+
+
+def test_patroni_candidate_commits_proxy_config_and_preserves_active_upstream(tmp_path):
+    env, project, _, proxy_config, proxy_upstream = _proxy_case(
+        tmp_path, child_exit=0, runtime_state="running"
+    )
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    assert proxy_config.read_text(encoding="utf-8") == "new-config\n"
+    assert proxy_upstream.read_text(encoding="utf-8") == "active-upstream\n"
+    assert not list(project.glob(".patroni-proxy-config.backup.*"))
+
+
+def test_patroni_candidate_rollback_preserves_absent_proxy_runtime_and_directory(
+    tmp_path,
+):
+    env, _, proxy_dir, _, _ = _proxy_case(
+        tmp_path, child_exit=42, runtime_state="absent", existing=False
+    )
+    env["PROXY_RUNTIME_CONFIG"] = str(tmp_path / "loaded-nginx.conf")
+
+    result = _run(env)
+
+    assert result.returncode == 42, result.stderr
+    assert not proxy_dir.exists()
+    assert not (tmp_path / "loaded-nginx.conf").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert "rm -s -f api-proxy" in commands
+    assert "up -d --no-deps --force-recreate --wait" not in commands
+
+
+def test_patroni_candidate_rollback_keeps_previously_stopped_proxy_stopped(tmp_path):
+    env, _, _, proxy_config, _ = _proxy_case(
+        tmp_path, child_exit=42, runtime_state="stopped"
+    )
+
+    result = _run(env)
+
+    assert result.returncode == 42, result.stderr
+    assert proxy_config.read_text(encoding="utf-8") == "old-config\n"
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert "stop api-proxy" in commands
+    assert "ps --status running -q api-proxy" in commands
+    assert "up -d --no-deps --force-recreate --wait" not in commands
+
+
+def test_patroni_candidate_rejects_writable_proxy_target_metadata(tmp_path):
+    env, project, _, proxy_config, _ = _proxy_case(
+        tmp_path, child_exit=0, runtime_state="running"
+    )
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    proxy_config.chmod(0o666)
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "proxy target metadata is unsafe" in result.stderr
+    assert proxy_config.read_text(encoding="utf-8") == "old-config\n"
+    assert proxy_config.stat().st_mode & 0o777 == 0o666
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_patroni_candidate_promotes_only_after_success(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    assert Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).read_text() == (
+        "# new identity helper\n"
+    )
+
+
+def test_patroni_candidate_stages_bundle_compose_only_after_maintenance_guard(
+    tmp_path,
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    candidate = project / "compose.yml.candidate"
+    source = tmp_path / "verified-compose-source.yml"
+    candidate.replace(source)
+    env["PATRONI_CANDIDATE_COMPOSE_SOURCE"] = str(source)
+    marker = tmp_path / "pitr-maintenance"
+    marker.write_text("owned\n", encoding="utf-8")
+    env["API_PITR_MAINTENANCE_MARKER"] = str(marker)
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "PITR release maintenance is active" in result.stderr
+    assert source.is_file()
+    assert not candidate.exists()
+
+
+def test_patroni_candidate_atomically_stages_verified_bundle_source(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    candidate = project / "compose.yml.candidate"
+    source = tmp_path / "verified-compose-source.yml"
+    expected = candidate.read_text(encoding="utf-8")
+    candidate.replace(source)
+    env["PATRONI_CANDIDATE_COMPOSE_SOURCE"] = str(source)
+
+    result = _run(env)
+
+    assert result.returncode == 0, result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == expected
+    assert source.is_file()
+    assert not candidate.exists()
+
+
+@pytest.mark.parametrize("source_kind", ["symlink", "preexisting-target"])
+def test_patroni_candidate_rejects_unowned_bundle_staging_paths(
+    tmp_path, source_kind
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    candidate = project / "compose.yml.candidate"
+    original_candidate = candidate.read_text(encoding="utf-8")
+    source = tmp_path / "verified-compose-source.yml"
+    if source_kind == "symlink":
+        source.symlink_to(candidate)
+    else:
+        source.write_text("services: {}\n", encoding="utf-8")
+    env["PATRONI_CANDIDATE_COMPOSE_SOURCE"] = str(source)
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    expected = (
+        "source is missing or unsafe"
+        if source_kind == "symlink"
+        else "target already exists"
+    )
+    assert expected in result.stderr
+    assert candidate.read_text(encoding="utf-8") == original_candidate
+    assert not (tmp_path / "child.log").exists()

--- a/tests/unit/test_patroni_candidate_transactions.py
+++ b/tests/unit/test_patroni_candidate_transactions.py
@@ -110,6 +110,27 @@ elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
   printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
 elif [[ "$1" == "compose" && "$*" == *" stop app app-blue app-green bot" ]]; then
   exit 0
+elif [[ "$1" == "compose" && "$*" == *" ps -a -q api-proxy" ]]; then
+  if [[ "${PROXY_PREVIOUS_RUNTIME_STATE:-absent}" != "absent" ]]; then
+    printf 'proxy-container\n'
+  fi
+elif [[ "$1" == "inspect" && "$*" == *"proxy-container"* && "$*" == *"State.Running"* ]]; then
+  [[ "${PROXY_PREVIOUS_RUNTIME_STATE:-absent}" == "running" ]] && printf 'true\n' || printf 'false\n'
+elif [[ "$1" == "compose" && "$*" == *" up -d --no-deps --force-recreate --wait --wait-timeout 60 api-proxy" ]]; then
+  if [[ -n "${PROXY_RUNTIME_CONFIG:-}" ]]; then
+    cp "$API_PROXY_CONFIG_FILE" "$PROXY_RUNTIME_CONFIG"
+  fi
+  exit 0
+elif [[ "$1" == "compose" && "$*" == *" exec -T api-proxy nginx -t" ]]; then
+  exit 0
+elif [[ "$1" == "compose" && "$*" == *" rm -s -f api-proxy" ]]; then
+  [[ -z "${PROXY_RUNTIME_CONFIG:-}" ]] || rm -f "$PROXY_RUNTIME_CONFIG"
+  exit 0
+elif [[ "$1" == "compose" && "$*" == *" stop api-proxy" ]]; then
+  exit 0
+elif [[ "$1" == "compose" && "$*" == *" ps --status running -q api-proxy" ]]; then
+  [[ "${PROXY_PREVIOUS_RUNTIME_STATE:-absent}" == "running" ]] && printf 'proxy-container\n' || true
+  exit 0
 else
   exit 91
 fi
@@ -153,6 +174,9 @@ esac
 set -euo pipefail
 grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
 printf "%s|%s\n" "$API_COMPOSE_FILE" "${{API_DEPLOY_LOCK_FD:-}}" > "$CHILD_LOG"
+if [[ -n "${{PROXY_RUNTIME_CONFIG:-}}" ]]; then
+  cp "$API_PROXY_CONFIG_FILE" "$PROXY_RUNTIME_CONFIG"
+fi
 : > "$DEPLOY_CHILD_RAN"
 exit {child_exit}
 ''',
@@ -229,25 +253,6 @@ def test_patroni_candidate_failure_leaves_canonical_old(tmp_path):
     assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == "compose.yml|app bot"
 
 
-def test_patroni_candidate_promotes_only_after_success(tmp_path):
-    env, project = _patroni_runner_env(tmp_path, child_exit=0)
-    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert (project / "compose.yml").read_text(encoding="utf-8") == new
-    assert not (project / "compose.yml.candidate").exists()
-    assert not (tmp_path / "reconcile.log").exists()
-    assert Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).read_text() == (
-        "# new identity helper\n"
-    )
 
 
 def test_patroni_candidate_rejects_db_service_drift_before_host_mutation(tmp_path):

--- a/tests/unit/test_patroni_deploy_scripts.py
+++ b/tests/unit/test_patroni_deploy_scripts.py
@@ -104,7 +104,12 @@ def test_migration_script_requires_primary_and_never_manages_database_service(tm
             "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
             "API_DEPLOY_LOCK_HELPER": str(LOCK_HELPER),
             "API_DEPLOY_LOCK_HELPER_SHA256": LOCK_HELPER_SHA256,
+            "API_DEPLOY_MEMINFO_FILE": str(tmp_path / "meminfo"),
         }
+    )
+    (tmp_path / "meminfo").write_text(
+        "MemAvailable: 1572864 kB\nSwapTotal: 524288 kB\nSwapFree: 524288 kB\n",
+        encoding="utf-8",
     )
 
     result = subprocess.run(
@@ -118,6 +123,103 @@ def test_migration_script_requires_primary_and_never_manages_database_service(tm
     assert "ensure_global_config_defaults.py" in commands
     assert " up " not in commands
     assert " db" not in commands
+
+
+def test_migration_refuses_low_memory_before_docker_mutation(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemAvailable: 201868 kB\nSwapTotal: 2621432 kB\nSwapFree: 3804 kB\n",
+        encoding="utf-8",
+    )
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\nprintf '{\"state\":\"running\",\"role\":\"primary\"}\\n'\n",
+    )
+    _executable(
+        fake_bin / "docker",
+        '#!/usr/bin/env bash\nprintf "docker %s\\n" "$*" >> "$COMMAND_LOG"\n',
+    )
+
+    result = subprocess.run(
+        ["bash", str(MIGRATE)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "compose.yml",
+            "BACKEND_IMAGE": IMAGE,
+            "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
+            "API_DEPLOY_LOCK_HELPER": str(LOCK_HELPER),
+            "API_DEPLOY_LOCK_HELPER_SHA256": LOCK_HELPER_SHA256,
+            "API_DEPLOY_MEMINFO_FILE": str(meminfo),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "insufficient memory headroom" in result.stderr
+    assert not command_log.exists()
+
+
+def test_migration_rechecks_memory_after_image_pull_before_container_start(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemAvailable: 1572864 kB\nSwapTotal: 524288 kB\nSwapFree: 524288 kB\n",
+        encoding="utf-8",
+    )
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\nprintf '{\"state\":\"running\",\"role\":\"primary\"}\\n'\n",
+    )
+    _executable(
+        fake_bin / "docker",
+        "#!/usr/bin/env bash\n"
+        'printf "docker %s\\n" "$*" >> "$COMMAND_LOG"\n'
+        'if [[ "$*" == *" pull app-blue" ]]; then\n'
+        "  printf 'MemAvailable: 200000 kB\\nSwapTotal: 524288 kB\\nSwapFree: 524288 kB\\n' > \"$MEMINFO_FILE\"\n"
+        "fi\n",
+    )
+
+    result = subprocess.run(
+        ["bash", str(MIGRATE)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "COMMAND_LOG": str(command_log),
+            "MEMINFO_FILE": str(meminfo),
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "compose.yml",
+            "BACKEND_IMAGE": IMAGE,
+            "GOOGLE_OAUTH_TOKEN_REQUIRED": "false",
+            "API_DEPLOY_LOCK_HELPER": str(LOCK_HELPER),
+            "API_DEPLOY_LOCK_HELPER_SHA256": LOCK_HELPER_SHA256,
+            "API_DEPLOY_MEMINFO_FILE": str(meminfo),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "insufficient memory headroom" in result.stderr
+    commands = command_log.read_text(encoding="utf-8")
+    assert "pull app-blue" in commands
+    assert " run " not in commands
 
 
 def test_deploy_and_migration_scripts_reject_unknown_running_patroni_role(tmp_path):

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -99,6 +99,7 @@ def _run_probe(
     host_key_source: Path = API_HOST_KEY,
     node_host: str = "example.invalid",
     node_user: str = "deploy",
+    maintenance_marker: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir(parents=True, exist_ok=True)
@@ -150,6 +151,9 @@ def _run_probe(
             "SSH_ARGS_LOG": str(tmp_path / "ssh-args.log"),
             "SSH_FILE_MODES_CAPTURE": str(tmp_path / "ssh-file-modes.capture"),
             "SSH_KNOWN_HOSTS_CAPTURE": str(tmp_path / "known-hosts.capture"),
+            "API_PITR_MAINTENANCE_MARKER": str(
+                maintenance_marker or tmp_path / "absent-maintenance-marker"
+            ),
         },
         text=True,
         capture_output=True,
@@ -177,14 +181,22 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert "docker-compose.patroni.yml" in text
     assert "run_patroni_migrations.sh" in text
     assert "deploy_patroni_api_node.sh" in text
+    assert "scripts/ha/require_deploy_capacity.sh" in text
     assert "deploy_backend_blue_green.sh" in text
     assert "deploy_backend_blue_green_safety.sh" in text
     assert "prepare_google_oauth_token_dir.sh" in text
     assert 'candidate_id="$(printf' in text
     assert 'REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"' in text
+    assert 'PATRONI_CANDIDATE_COMPOSE_SOURCE=$(quote' in text
+    assert '"${REMOTE}:${PROJECT_DIR}/${REMOTE_COMPOSE_FILE}"' not in text
     assert "run_patroni_candidate_transaction.sh" in text
     assert "scripts/ha/patroni_compose_db_contract.py" in text
     assert "PATRONI_DB_CONTRACT_HELPER=" in text
+    assert "PATRONI_PROXY_CONFIG_SOURCE=" in text
+    assert "PATRONI_PROXY_UPSTREAM_SOURCE=" in text
+    assert "API_DEPLOY_CAPACITY_HELPER=" in text
+    assert "API_DEPLOY_CAPACITY_PROFILE=" in text
+    assert 'DEPLOY_CAPACITY_PROFILE=reserve' in text
     assert "mktemp -d /tmp/mvn-patroni-release.XXXXXXXX" in text
     assert "verify_patroni_remote_bundle.py" in text
     assert "BUNDLE_MANIFEST_B64" in text
@@ -212,6 +224,7 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
     assert 'API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")"' in transaction_runner
     assert "API_PROXY_MODE=" in text
     assert "upstream.conf" in text
+    assert 'scp "${SSH_OPTS[@]}" deploy/ha/proxy/nginx.conf' not in text
     assert "up -d db" not in text
     assert "docker compose" not in text
 
@@ -266,6 +279,17 @@ def test_remote_probe_rejects_unknown_running_role(tmp_path):
 
     assert result.returncode != 0
     assert "role=standby" not in result.stdout
+
+
+def test_remote_probe_refuses_active_pitr_maintenance_before_role_lookup(tmp_path):
+    marker = tmp_path / "maintenance"
+    marker.write_text("owned\n", encoding="utf-8")
+
+    result = _run_probe(tmp_path, "primary", maintenance_marker=marker)
+
+    assert result.returncode != 0
+    assert "PITR release maintenance is active" in result.stderr
+    assert "role=primary" not in result.stdout
 
 
 def test_tracked_patroni_host_keys_have_reviewed_ed25519_fingerprints():

--- a/tests/unit/test_pitr_bundle_transport.py
+++ b/tests/unit/test_pitr_bundle_transport.py
@@ -116,6 +116,11 @@ def test_real_bundle_is_deterministic_complete_and_bounded():
     )[0]
     remote = {"__name__": "pitr_bundle_policy_test"}
     exec(compile(source, "<pitr-bundle-policy>", "exec"), remote)
+    assert remote["PREVIOUS_RELEASE_ADDITIONS"] == {
+        "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh",
+        "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py",
+        "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py",
+    }
     for node in PATRONI_NODES:
         first = pitr_remote_execution.build_host_release_bundle(node)
         second = pitr_remote_execution.build_host_release_bundle(node)
@@ -651,6 +656,8 @@ def test_installer_and_blue_green_siblings_are_attested():
         "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py",
         "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh",
         "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh",
+        "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh",
+        "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py",
         "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py",
         "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh",
     }

--- a/tests/unit/test_pitr_maintenance_marker.py
+++ b/tests/unit/test_pitr_maintenance_marker.py
@@ -1,0 +1,94 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.ha import verify_pitr_maintenance_marker as marker_attestation
+
+
+TRANSACTION_ID = "a" * 32
+
+
+def _marker(path: Path, value: str = TRANSACTION_ID) -> Path:
+    path.write_text(f"{value}\n", encoding="ascii")
+    path.chmod(0o600)
+    return path
+
+
+def _verify(path: Path, transaction_id: str = TRANSACTION_ID) -> None:
+    marker_attestation.verify_marker(
+        str(path),
+        transaction_id,
+        expected_uid=os.getuid(),
+        expected_gid=os.getgid(),
+    )
+
+
+def test_marker_attestation_accepts_exact_transaction_and_metadata(tmp_path):
+    _verify(_marker(tmp_path / "maintenance"))
+
+
+@pytest.mark.parametrize(
+    ("value", "transaction_id"),
+    [
+        ("b" * 32, TRANSACTION_ID),
+        (TRANSACTION_ID, "A" * 32),
+        (TRANSACTION_ID, "short"),
+    ],
+)
+def test_marker_attestation_rejects_wrong_or_invalid_transaction(
+    tmp_path, value, transaction_id
+):
+    path = _marker(tmp_path / "maintenance", value)
+
+    with pytest.raises(RuntimeError):
+        _verify(path, transaction_id)
+
+
+def test_marker_attestation_rejects_wrong_mode_symlink_and_hardlink(tmp_path):
+    wrong_mode = _marker(tmp_path / "wrong-mode")
+    wrong_mode.chmod(0o640)
+    with pytest.raises(RuntimeError, match="metadata is unsafe"):
+        _verify(wrong_mode)
+
+    target = _marker(tmp_path / "target")
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(target)
+    with pytest.raises(RuntimeError, match="metadata is unsafe"):
+        _verify(symlink)
+
+    hardlink = tmp_path / "hardlink"
+    os.link(target, hardlink)
+    with pytest.raises(RuntimeError, match="metadata is unsafe"):
+        _verify(target)
+
+
+def test_marker_attestation_rejects_path_replacement_during_read(
+    tmp_path, monkeypatch
+):
+    path = _marker(tmp_path / "maintenance")
+    replacement = _marker(tmp_path / "replacement")
+    real_read = marker_attestation.os.read
+
+    def replace_after_read(descriptor: int, size: int) -> bytes:
+        content = real_read(descriptor, size)
+        os.replace(replacement, path)
+        return content
+
+    monkeypatch.setattr(marker_attestation.os, "read", replace_after_read)
+    with pytest.raises(RuntimeError, match="changed"):
+        _verify(path)
+
+
+def test_cli_is_fixed_to_canonical_root_owned_marker():
+    source = Path(marker_attestation.__file__).read_text(encoding="utf-8")
+
+    assert marker_attestation.MARKER_PATH == "/run/mvn-postgres-pitr-maintenance"
+    assert marker_attestation.PINNED_VALIDATOR == (
+        "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py"
+    )
+    assert "verify_marker(MARKER_PATH, sys.argv[2])" in source
+    assert "verify_pinned_runtime(tuple(sys.argv[3:]))" in source
+    assert "expected_uid: int = 0" in source
+    assert "expected_gid: int = 0" in source
+    assert "os.O_NOFOLLOW" in source

--- a/tests/unit/test_postgres_pitr_activation_safety.py
+++ b/tests/unit/test_postgres_pitr_activation_safety.py
@@ -125,6 +125,8 @@ def test_installer_keeps_blue_green_and_safe_lock_helper_in_one_libexec_generati
     for asset in (
         "deploy_backend_blue_green.sh",
         "deploy_backend_blue_green_safety.sh",
+        "require_deploy_capacity.sh",
+        "verify_pitr_maintenance_marker.py",
         "prepare_google_oauth_token_dir.sh",
         "safe_deploy_lock.py",
     ):
@@ -603,7 +605,22 @@ def test_scrub_node_uses_attested_inherited_deploy_lock_without_tmp_summary():
         "API_DEPLOY_LOCK_FILE",
         "API_DEPLOY_LOCK_HELPER",
         "API_DEPLOY_LOCK_HELPER_SHA256",
+        "API_BLUE_GREEN_SAFETY_HELPER",
+        "API_DEPLOY_CAPACITY_HELPER",
+        "API_DEPLOY_CAPACITY_PROFILE",
+        "API_PITR_MAINTENANCE_MARKER_VALIDATOR",
+        "API_PITR_MAINTENANCE_TRANSACTION_ID",
     ):
         assert variable in scrub
+    for pinned_helper in (
+        "deploy_backend_blue_green.sh",
+        "deploy_backend_blue_green_safety.sh",
+        "safe_deploy_lock.py",
+        "require_deploy_capacity.sh",
+        "verify_pitr_maintenance_marker.py",
+    ):
+        assert f"/usr/local/libexec/mvn-pitr/{pinned_helper}" in source
+    assert 'python3 "${PITR_MARKER_VALIDATOR}" runtime' in scrub
+    assert "capacity_profile=reserve" in scrub
     assert "API_BLUE_GREEN_SUMMARY_FILE=/dev/null" in scrub
     assert "/tmp/backend_blue_green_summary" not in scrub

--- a/tests/unit/test_safe_deploy_lock.py
+++ b/tests/unit/test_safe_deploy_lock.py
@@ -89,9 +89,10 @@ def test_candidate_and_migration_verify_inherited_lock_before_marker_check():
         encoding="utf-8"
     )
     lock_index = candidate.index('"${DEPLOY_LOCK_HELPER}" verify')
-    marker_index = candidate.index("require_no_patroni_cutover", lock_index)
+    pitr_marker_index = candidate.index("require_no_pitr_maintenance", lock_index)
+    marker_index = candidate.index("require_no_patroni_cutover", pitr_marker_index)
     migrate_index = candidate.index('if [[ "${OPERATION}" == "migrate" ]]', marker_index)
-    assert lock_index < marker_index < migrate_index
+    assert lock_index < pitr_marker_index < marker_index < migrate_index
     assert 'API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}"' in candidate
     assert 'DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"' in migration
     assert '"${DEPLOY_LOCK_HELPER}" verify' in migration


### PR DESCRIPTION
## Summary
- block normal deploy paths during an attested PITR maintenance transaction
- add profile-aware memory and swap capacity gates plus API and bot limits
- stage verified Patroni compose and proxy assets only under the deploy lock
- restore proxy files and runtime state exactly on rollback
- propagate new safety helpers through PITR release bundles and runtime verification

## Validation
- 2041 unit tests passed, 4 skipped
- independent P0-P2 review: CLEAR
- shell syntax, Python compile, YAML parse, and git diff checks passed

## Operations
This PR intentionally does not mutate the active f357 PITR journal. The existing transaction will be resumed with its exact prior release, finalized, and only then will this hardening be deployed and verified with a fresh PITR/restore drill.