### PR TITLE
Harden PITR release resume barriers

### DIFF
--- a/scripts/ha/pitr_bundle_executor_source.py
+++ b/scripts/ha/pitr_bundle_executor_source.py
@@ -535,11 +535,41 @@ def clear_completed_marker(txid):
     if marker != txid:
         raise RuntimeError("another release transaction owns the maintenance marker")
     remove_marker(txid)
+def inspect_release(txid, project_dir, modes, release, descriptors):
+    txdir = os.path.join(TRANSACTION_ROOT, txid)
+    has_tx = transaction_exists(txdir)
+    marker = marker_value()
+    expected = [{key: item[key] for key in ("mode", "path", "sha256")} for item in descriptors]
+    try:
+        read_rollback_receipt(txid, project_dir, modes)
+    except FileNotFoundError:
+        pass
+    else:
+        raise RuntimeError("release transaction id already has a rollback receipt")
+    if has_tx:
+        if marker != txid:
+            raise RuntimeError("active release transaction is missing its exact marker")
+        journal = read_journal(txdir)
+        validate_journal(journal, txid, project_dir, release, descriptors)
+        for entry in journal["entries"]:
+            if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) == "unknown":
+                raise RuntimeError("active release transaction has an unknown generation")
+        return "matching-active"
+    completed = read_release_manifest(modes, project_dir, allow_previous=True)
+    if completed is not None and completed["txid"] == txid:
+        if completed["release_sha256"] != release or completed["files"] != expected:
+            raise RuntimeError("transaction id already finalized another release")
+        if marker not in {None, txid}:
+            raise RuntimeError("another release transaction owns the maintenance marker")
+        return "matching-finalized"
+    if marker is not None:
+        raise RuntimeError("maintenance marker has no compatible release transaction")
+    return "fresh"
 def execute(action, txid, project_dir, compose_file, payload):
     validate_txid(txid)
     modes = expected_modes(project_dir, compose_file)
     release = decoded = descriptors = None
-    if action == "apply":
+    if action in {"apply", "inspect"}:
         release, decoded, descriptors = decode_bundle(payload, project_dir, compose_file)
     elif action not in {"rollback", "finalize"}:
         raise RuntimeError("unsupported release transaction action")
@@ -547,6 +577,9 @@ def execute(action, txid, project_dir, compose_file, payload):
     deploy_fd = None
     try:
         deploy_fd = open_lock(os.path.join(project_dir, ".deploy.lock"))
+        if action == "inspect":
+            reject_operation_records()
+            return inspect_release(txid, project_dir, modes, release, descriptors)
         ensure_roots()
         reject_operation_records()
         txdir = os.path.join(TRANSACTION_ROOT, txid)
@@ -603,7 +636,7 @@ def execute(action, txid, project_dir, compose_file, payload):
                 validate_journal(journal, txid, project_dir, release, descriptors)
                 apply_transaction(txdir, journal, decoded)
                 daemon_reload()
-                return "applied"
+                return "resumed" if has_tx else "applied"
             if not has_tx:
                 raise RuntimeError("release transaction does not exist")
             journal = read_journal(txdir)
@@ -644,7 +677,7 @@ def main():
         return 77
     action, txid, project_dir, compose_file = sys.argv[1:]
     try:
-        payload = read_payload(sys.stdin.buffer, action == "apply")
+        payload = read_payload(sys.stdin.buffer, action in {"apply", "inspect"})
         result = execute(action, txid, project_dir, compose_file, payload)
     except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         print("PITR release transport: " + str(exc), file=sys.stderr)

--- a/scripts/ha/pitr_bundle_transport.py
+++ b/scripts/ha/pitr_bundle_transport.py
@@ -106,31 +106,31 @@ def _read_local_asset(path: Path) -> bytes:
         return b"".join(chunks)
     finally:
         os.close(descriptor)
-def build_release_bundle(node: PatroniNode, assets: Sequence[object]) -> str:
-    """Build one canonical, complete node release bundle from reviewed assets."""
+def _render_prepared_bundle(
+    node: PatroniNode,
+    prepared_assets: Sequence[tuple[object, object, bytes]],
+) -> str:
     expected = expected_remote_asset_modes(node)
     node_assets = [
-        *assets,
-        type("NodeComposeAsset", (), {
-            "source": node.compose_source,
-            "remote_path": f"{node.project_dir}/{node.compose_file}",
-            "mode": 0o644,
-        })(),
+        *prepared_assets,
+        (
+            f"{node.project_dir}/{node.compose_file}",
+            0o644,
+            _read_local_asset(Path(node.compose_source)),
+        ),
     ]
-    by_path: dict[str, object] = {}
-    for asset in node_assets:
-        remote_path = getattr(asset, "remote_path", None)
-        mode = getattr(asset, "mode", None)
+    by_path: dict[str, tuple[int, bytes]] = {}
+    for remote_path, mode, content in node_assets:
         if remote_path not in expected or mode != expected.get(remote_path):
             raise RuntimeError(f"unreviewed PITR release asset: {remote_path}")
         if remote_path in by_path:
             raise RuntimeError(f"duplicate PITR release asset: {remote_path}")
-        by_path[remote_path] = asset
+        by_path[remote_path] = (mode, content)
     if set(by_path) != set(expected):
         raise RuntimeError("PITR release bundle has a missing or extra path")
     files = []
     for remote_path in sorted(by_path):
-        content = _read_local_asset(Path(getattr(by_path[remote_path], "source")))
+        _, content = by_path[remote_path]
         files.append(
             {
                 "content": base64.b64encode(content).decode("ascii"),
@@ -145,6 +145,29 @@ def build_release_bundle(node: PatroniNode, assets: Sequence[object]) -> str:
     if not rendered or len(rendered) > MAX_RELEASE_BUNDLE_BYTES:
         raise RuntimeError("PITR release bundle exceeds the transport limit")
     return rendered.decode("ascii")
+def prepare_release_bundles(
+    nodes: Sequence[PatroniNode], assets: Sequence[object]
+) -> dict[str, str]:
+    """Pin shared asset bytes once and render one exact payload per node."""
+    prepared_assets = [
+        (
+            getattr(asset, "remote_path", None),
+            getattr(asset, "mode", None),
+            _read_local_asset(Path(getattr(asset, "source"))),
+        )
+        for asset in assets
+    ]
+    bundles: dict[str, str] = {}
+    for node in nodes:
+        if node.project_dir in bundles:
+            raise RuntimeError("duplicate PITR release node project")
+        bundles[node.project_dir] = _render_prepared_bundle(node, prepared_assets)
+    if not bundles:
+        raise RuntimeError("PITR release requires at least one node")
+    return bundles
+def build_release_bundle(node: PatroniNode, assets: Sequence[object]) -> str:
+    """Build one canonical, complete node release bundle from reviewed assets."""
+    return prepare_release_bundles((node,), assets)[node.project_dir]
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 def _default_runner(args: Sequence[str], stdin: str | None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -162,17 +185,29 @@ def run_remote_release_action(
     action: str,
     txid: str,
     assets: Sequence[object],
+    release_bundle: str | None = None,
     runner: Runner | None = None,
 ) -> str:
     """Apply, roll back, or finalize one release over pinned SSH."""
-    if action not in {"apply", "rollback", "finalize"}:
+    if action not in {"apply", "inspect", "rollback", "finalize"}:
         raise RuntimeError("unsupported release transaction action")
     if not re.fullmatch(r"[0-9a-f]{32}", txid):
         raise RuntimeError("transaction id must be 32 lowercase hexadecimal characters")
     # An explicit empty payload is required for actions without a bundle.  If
     # stdin is left as None, subprocess.run() inherits the controller's stdin
     # and the remote executor blocks forever while waiting for EOF.
-    stdin = build_release_bundle(node, assets) if action == "apply" else ""
+    if action in {"apply", "inspect"}:
+        stdin = (
+            release_bundle
+            if release_bundle is not None
+            else build_release_bundle(node, assets)
+        )
+        if not isinstance(stdin, str) or not stdin or len(stdin.encode()) > MAX_RELEASE_BUNDLE_BYTES:
+            raise RuntimeError("pinned PITR release bundle is invalid")
+    else:
+        if release_bundle is not None:
+            raise RuntimeError("release bundle is only accepted for inspect or apply")
+        stdin = ""
     command = " ".join(
         [
             "/usr/bin/python3",
@@ -190,7 +225,8 @@ def run_remote_release_action(
         detail = (result.stderr or result.stdout or "remote release action failed").strip()
         raise RuntimeError(detail)
     expected = {
-        "apply": {"applied\n", "reopened\n"},
+        "apply": {"applied\n", "resumed\n", "reopened\n"},
+        "inspect": {"fresh\n", "matching-active\n", "matching-finalized\n"},
         "rollback": {"rolled-back\n", "already-rolled-back\n"},
         "finalize": {"finalized\n", "already-finalized\n"},
     }[action]

--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -19,6 +19,7 @@ try:
         ssh_args,
     )
     from scripts.ha.pitr_remote_execution import (
+        prepare_host_release_bundles,
         run_remote_maintenance_phase,
         run_remote_release_action,
         run_remote_role_agent_phase,
@@ -35,6 +36,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
         ssh_args,
     )
     from pitr_remote_execution import (  # type: ignore[no-redef]
+        prepare_host_release_bundles,
         run_remote_maintenance_phase,
         run_remote_release_action,
         run_remote_role_agent_phase,
@@ -45,6 +47,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 TopologyDiscoverer = Callable[..., ClusterTopology]
 ReleaseAction = Callable[..., str]
+ReleaseBundleBuilder = Callable[[Sequence[PatroniNode]], dict[str, str]]
 SecretPhase = Callable[..., None]
 MaintenancePhase = Callable[..., None]
 RoleAgentPhase = Callable[..., None]
@@ -65,6 +68,7 @@ class MigrationResult:
 @dataclass(frozen=True)
 class MigrationDependencies:
     discover: TopologyDiscoverer = discover_cluster_topology
+    bundles: ReleaseBundleBuilder = prepare_host_release_bundles
     release: ReleaseAction = run_remote_release_action
     secret: SecretPhase = run_remote_secret_phase
     maintenance: MaintenancePhase = run_remote_maintenance_phase
@@ -104,7 +108,8 @@ class _MigrationOrchestrator:
         self.bootstrap_helper = bootstrap_helper
         self.baseline: ClusterTopology | None = None
         self.roll_forward = False
-        self.attempted_bundle_nodes: list[PatroniNode] = []
+        self.owned_bundle_nodes: list[PatroniNode] = []
+        self.release_bundles: dict[str, str] = {}
         self.role_agent_window_open = False
 
     def _discover(self) -> ClusterTopology:
@@ -161,16 +166,33 @@ class _MigrationOrchestrator:
         if action_error is not None:
             raise action_error
 
-    def _release(self, action: str, node: PatroniNode) -> None:
-        result = self.dependencies.release(
-            node=node,
-            context=self.context,
-            action=action,
-            txid=self.transaction_id,
-            runner=self.runner,
-        )
-        if action == "apply" and result == "reopened":
-            self.roll_forward = True
+    def _release(self, action: str, node: PatroniNode) -> str:
+        try:
+            result = self.dependencies.release(
+                node=node,
+                context=self.context,
+                action=action,
+                txid=self.transaction_id,
+                release_bundle=(
+                    self.release_bundles[node.project_dir]
+                    if action in {"inspect", "apply"}
+                    else None
+                ),
+                runner=self.runner,
+            )
+        except BaseException:
+            if action == "apply":
+                # A lost response or a rejected pre-existing journal does not
+                # prove that this controller owns a rollback. Preserve every
+                # durable journal and marker for an exact same-tx replay.
+                self.roll_forward = True
+            raise
+        if action == "apply":
+            if result == "applied":
+                self.owned_bundle_nodes.append(node)
+            elif result in {"resumed", "reopened"}:
+                self.roll_forward = True
+        return result
 
     def _secret(self, phase: str, node: PatroniNode) -> None:
         self.dependencies.secret(
@@ -202,9 +224,9 @@ class _MigrationOrchestrator:
             runner=self.runner,
         )
 
-    def _rollback_attempted_bundles(self, original_error: BaseException) -> None:
+    def _rollback_owned_bundles(self, original_error: BaseException) -> None:
         failures: list[str] = []
-        for node in reversed(self.attempted_bundle_nodes):
+        for node in reversed(self.owned_bundle_nodes):
             try:
                 self._mutate(
                     stage=f"bundle rollback {node.alias}",
@@ -288,9 +310,27 @@ class _MigrationOrchestrator:
     def run(self) -> MigrationResult:
         baseline = self._guard_topology(stage="baseline")
         ordered_nodes = (baseline.standby, baseline.primary)
+        self.release_bundles = self.dependencies.bundles(ordered_nodes)
+        if set(self.release_bundles) != {node.project_dir for node in ordered_nodes}:
+            raise RuntimeError("pinned release bundle set does not match cluster nodes")
+        compatibility: dict[str, str] = {}
+        for node in ordered_nodes:
+            self._mutate(
+                stage=f"bundle compatibility {node.alias}",
+                action=lambda node=node: compatibility.__setitem__(
+                    node.alias, self._release("inspect", node)
+                ),
+            )
+        if any(state != "fresh" for state in compatibility.values()):
+            self.roll_forward = True
+        release_nodes = tuple(
+            sorted(
+                ordered_nodes,
+                key=lambda node: compatibility[node.alias] == "fresh",
+            )
+        )
         try:
-            for node in ordered_nodes:
-                self.attempted_bundle_nodes.append(node)
+            for node in release_nodes:
                 self._mutate(
                     stage=f"bundle apply {node.alias}",
                     action=lambda node=node: self._release("apply", node),
@@ -393,7 +433,7 @@ class _MigrationOrchestrator:
             )
         except BaseException as exc:
             if not self.roll_forward:
-                self._rollback_attempted_bundles(exc)
+                self._rollback_owned_bundles(exc)
                 raise RuntimeError(
                     f"cluster migration failed before configuration and release bundles "
                     f"were rolled back: {exc}"

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -17,6 +17,7 @@ try:
     from scripts.ha.pitr_bundle_transport import (
         REMOTE_RELEASE_BUNDLE_EXECUTOR,
         build_release_bundle as _build_release_bundle,
+        prepare_release_bundles as _prepare_release_bundles,
         _read_local_asset as _read_release_asset,
         run_remote_release_action as _run_remote_release_action,
     )
@@ -32,6 +33,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
     from pitr_bundle_transport import (  # type: ignore[no-redef]
         REMOTE_RELEASE_BUNDLE_EXECUTOR,
         build_release_bundle as _build_release_bundle,
+        prepare_release_bundles as _prepare_release_bundles,
         _read_local_asset as _read_release_asset,
         run_remote_release_action as _run_remote_release_action,
     )
@@ -328,6 +330,13 @@ def build_host_release_bundle(
     return _build_release_bundle(node, assets)
 
 
+def prepare_host_release_bundles(
+    nodes: Sequence[PatroniNode],
+    assets: Sequence[PitrHostAsset] = PITR_HOST_ASSETS,
+) -> dict[str, str]:
+    return _prepare_release_bundles(nodes, assets)
+
+
 def run_remote_release_action(
     *,
     node: PatroniNode,
@@ -335,6 +344,7 @@ def run_remote_release_action(
     action: str,
     txid: str,
     assets: Sequence[PitrHostAsset] = PITR_HOST_ASSETS,
+    release_bundle: str | None = None,
     runner: Runner | None = None,
 ) -> str:
     return _run_remote_release_action(
@@ -343,6 +353,7 @@ def run_remote_release_action(
         action=action,
         txid=txid,
         assets=assets,
+        release_bundle=release_bundle,
         runner=runner,
     )
 

--- a/tests/unit/test_pitr_bundle_resume_safety.py
+++ b/tests/unit/test_pitr_bundle_resume_safety.py
@@ -1,0 +1,232 @@
+import base64
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import pitr_bundle_transport as bundle
+from scripts.ha import pitr_remote_execution
+from scripts.ha.pitr_pinned_ssh import PATRONI_NODES
+from tests.unit.test_pitr_bundle_transport import (
+    TXID,
+    _context,
+    _payload,
+    _remote_namespace,
+    _write,
+)
+
+
+def test_existing_transaction_digest_mismatch_preserves_every_generation(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    original, _ = _payload(namespace, project, compose, tool)
+    changed, _ = _payload(
+        namespace,
+        project,
+        compose,
+        tool,
+        tool_content=b"different-release",
+    )
+
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, original
+    ) == "applied"
+    txdir = Path(namespace["TRANSACTION_ROOT"]) / TXID
+    journal = (txdir / "journal.json").read_bytes()
+    marker = Path(namespace["MAINTENANCE_MARKER"]).read_bytes()
+    generations = (compose.read_bytes(), tool.read_bytes())
+
+    with pytest.raises(RuntimeError, match="belongs to another release"):
+        namespace["execute"](
+            "apply", TXID, str(project), compose.name, changed
+        )
+
+    assert (txdir / "journal.json").read_bytes() == journal
+    assert Path(namespace["MAINTENANCE_MARKER"]).read_bytes() == marker
+    assert (compose.read_bytes(), tool.read_bytes()) == generations
+    assert not (Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{TXID}.json").exists()
+
+
+def test_transport_accepts_exact_resumed_result(tmp_path):
+    def runner(args, stdin):
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="resumed\n",
+            stderr="",
+        )
+
+    assert pitr_remote_execution.run_remote_release_action(
+        node=PATRONI_NODES[0],
+        context=_context(tmp_path),
+        action="apply",
+        txid=TXID,
+        runner=runner,
+    ) == "resumed"
+
+
+def test_inspect_barrier_classifies_without_mutating_release_state(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    changed, _ = _payload(
+        namespace,
+        project,
+        compose,
+        tool,
+        tool_content=b"different-release",
+    )
+
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "fresh"
+    assert not Path(namespace["STATE_ROOT"]).exists()
+    assert not Path(namespace["MAINTENANCE_MARKER"]).exists()
+
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    txdir = Path(namespace["TRANSACTION_ROOT"]) / TXID
+    journal = (txdir / "journal.json").read_bytes()
+    marker = Path(namespace["MAINTENANCE_MARKER"]).read_bytes()
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "matching-active"
+    with pytest.raises(RuntimeError, match="belongs to another release"):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, changed
+        )
+    assert (txdir / "journal.json").read_bytes() == journal
+    assert Path(namespace["MAINTENANCE_MARKER"]).read_bytes() == marker
+
+    assert namespace["execute"](
+        "finalize", TXID, str(project), compose.name, b""
+    ) == "finalized"
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "matching-finalized"
+    assert not Path(namespace["MAINTENANCE_MARKER"]).exists()
+
+
+def test_inspect_rejects_receipt_even_when_transaction_directory_remains(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    namespace["execute"]("apply", TXID, str(project), compose.name, payload)
+    remove_transaction = namespace["safe_remove_transaction"]
+    namespace["safe_remove_transaction"] = lambda _path: (_ for _ in ()).throw(
+        RuntimeError("simulated cleanup crash")
+    )
+    with pytest.raises(RuntimeError, match="simulated cleanup crash"):
+        namespace["execute"](
+            "rollback", TXID, str(project), compose.name, b""
+        )
+    namespace["safe_remove_transaction"] = remove_transaction
+
+    assert (Path(namespace["TRANSACTION_ROOT"]) / TXID).exists()
+    assert (Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{TXID}.json").exists()
+    with pytest.raises(RuntimeError, match="already has a rollback receipt"):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, payload
+        )
+
+
+def test_pinned_bundle_bytes_survive_source_changes_between_inspect_and_apply(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    compose = tmp_path / "compose.yml"
+    compose.write_bytes(b"old-compose")
+    source = tmp_path / "tool"
+    source.write_bytes(b"old-tool")
+    source.chmod(0o600)
+    compose_remote = f"{project}/docker-compose.patroni.yml"
+    tool_remote = f"{project}/tool"
+    node = SimpleNamespace(
+        alias="pinned-node",
+        project_dir=str(project),
+        compose_file="docker-compose.patroni.yml",
+        compose_source=compose,
+    )
+    asset = SimpleNamespace(source=source, remote_path=tool_remote, mode=0o755)
+    monkeypatch.setattr(bundle, "PROJECT_COMPOSE_PATHS", {str(project): compose_remote})
+    monkeypatch.setattr(bundle, "BASE_REMOTE_ASSET_MODES", {tool_remote: 0o755})
+    pinned = bundle.prepare_release_bundles((node,), (asset,))[str(project)]
+
+    source.write_bytes(b"changed-tool")
+    compose.write_bytes(b"changed-compose")
+    captured = []
+
+    def runner(args, stdin):
+        captured.append(stdin)
+        output = "fresh\n" if len(captured) == 1 else "applied\n"
+        return subprocess.CompletedProcess(args, 0, stdout=output, stderr="")
+
+    for action in ("inspect", "apply"):
+        bundle.run_remote_release_action(
+            node=node,
+            context=_context(tmp_path),
+            action=action,
+            txid=TXID,
+            assets=(asset,),
+            release_bundle=pinned,
+            runner=runner,
+        )
+
+    assert captured == [pinned, pinned]
+    files = {item["path"]: item for item in json.loads(pinned)["files"]}
+    assert base64.b64decode(files[tool_remote]["content"]) == b"old-tool"
+    assert base64.b64decode(files[compose_remote]["content"]) == b"old-compose"
+
+
+def test_prepare_reads_shared_assets_once_for_every_node(tmp_path, monkeypatch):
+    source = tmp_path / "shared-tool"
+    source.write_bytes(b"one-shared-generation")
+    source.chmod(0o600)
+    tool_remote = "/usr/local/sbin/shared-tool"
+    nodes = []
+    compose_paths = {}
+    for alias in ("first", "second"):
+        project = tmp_path / alias
+        project.mkdir()
+        compose = tmp_path / f"{alias}.yml"
+        compose.write_text(f"name: {alias}\n", encoding="utf-8")
+        compose_remote = f"{project}/docker-compose.patroni.yml"
+        compose_paths[str(project)] = compose_remote
+        nodes.append(
+            SimpleNamespace(
+                alias=alias,
+                project_dir=str(project),
+                compose_file="docker-compose.patroni.yml",
+                compose_source=compose,
+            )
+        )
+    asset = SimpleNamespace(source=source, remote_path=tool_remote, mode=0o755)
+    monkeypatch.setattr(bundle, "PROJECT_COMPOSE_PATHS", compose_paths)
+    monkeypatch.setattr(bundle, "BASE_REMOTE_ASSET_MODES", {tool_remote: 0o755})
+    original_read = bundle._read_local_asset
+    reads = []
+
+    def counted_read(path):
+        reads.append(Path(path))
+        return original_read(Path(path))
+
+    monkeypatch.setattr(bundle, "_read_local_asset", counted_read)
+    prepared = bundle.prepare_release_bundles(tuple(nodes), (asset,))
+
+    assert reads.count(source) == 1
+    shared_digests = {
+        next(
+            item["sha256"]
+            for item in json.loads(payload)["files"]
+            if item["path"] == tool_remote
+        )
+        for payload in prepared.values()
+    }
+    assert len(shared_digests) == 1

--- a/tests/unit/test_pitr_bundle_transport.py
+++ b/tests/unit/test_pitr_bundle_transport.py
@@ -224,7 +224,7 @@ def test_apply_resumes_mixed_old_new_generation_and_finalize(tmp_path):
     assert namespace["execute"]("apply", TXID, str(project), compose.name, payload) == "applied"
     _write(tool, b"old-tool", 0o755)
     assert compose.read_bytes() == b"new-compose"
-    assert namespace["execute"]("apply", TXID, str(project), compose.name, payload) == "applied"
+    assert namespace["execute"]("apply", TXID, str(project), compose.name, payload) == "resumed"
     assert tool.read_bytes() == b"new-tool"
 
     assert namespace["execute"]("finalize", TXID, str(project), compose.name, b"") == "finalized"
@@ -264,7 +264,7 @@ def test_apply_and_finalize_accept_identical_old_and_new_generation(tmp_path):
     _write(tool, b"old-tool", 0o755)
     assert namespace["execute"](
         "apply", TXID, str(project), compose.name, payload
-    ) == "applied"
+    ) == "resumed"
     assert tool.read_bytes() == b"new-tool"
     assert namespace["execute"](
         "finalize", TXID, str(project), compose.name, b""

--- a/tests/unit/test_pitr_cluster_migration.py
+++ b/tests/unit/test_pitr_cluster_migration.py
@@ -55,6 +55,7 @@ class FakeOperations:
         self.role_agent_failure = None
         self.role_agent_fail_once = set()
         self.release_results = {}
+        self.release_payloads = []
         self.discover_calls = 0
         self.discover_failures = set()
 
@@ -67,12 +68,21 @@ class FakeOperations:
             return self.topologies.pop(0)
         return _topology()
 
-    def release(self, *, node, context, action, txid, runner):
+    def bundles(self, nodes):
+        return {node.project_dir: f"pinned:{node.alias}" for node in nodes}
+
+    def release(self, *, node, context, action, txid, release_bundle, runner):
         event = ("release", action, node.alias, txid)
         self.events.append(event)
+        self.release_payloads.append((action, node.alias, release_bundle))
+        if action in {"inspect", "apply"}:
+            assert release_bundle == f"pinned:{node.alias}"
+        else:
+            assert release_bundle is None
         if self.release_failure == (action, node.alias):
             raise RuntimeError("simulated release failure")
         return self.release_results.get((action, node.alias), {
+            "inspect": "fresh",
             "apply": "applied",
             "rollback": "rolled-back",
             "finalize": "finalized",
@@ -128,6 +138,7 @@ class FakeOperations:
     def dependencies(self):
         return MigrationDependencies(
             discover=self.discover,
+            bundles=self.bundles,
             release=self.release,
             secret=self.secret,
             maintenance=self.maintenance,
@@ -156,6 +167,8 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
     assert result.standby_alias == "zakup"
     assert result.transaction_id == TXID
     assert _mutation_events(operations.events) == [
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
         ("release", "apply", "zakup", TXID),
         ("release", "apply", "mvn-api", TXID),
         ("secret", "preflight", "zakup", TXID, ENV_TEXT),
@@ -180,7 +193,7 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("role-agent", "resume-primary", "mvn-api", TXID),
         ("maintenance", "verify", "mvn-api", TXID),
     ]
-    assert len(operations.events) == 1 + 3 * 23
+    assert len(operations.events) == 1 + 3 * 25
     assert operations.events[0] == ("topology",)
     for index in range(1, len(operations.events), 3):
         assert operations.events[index] == ("topology",)
@@ -188,13 +201,13 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         assert operations.events[index + 2] == ("topology",)
 
 
-def test_partial_bundle_apply_failure_rolls_back_all_attempted_nodes_in_reverse(
+def test_bundle_apply_failure_preserves_all_journals_for_exact_resume(
     tmp_path,
 ):
     operations = FakeOperations()
     operations.release_failure = ("apply", "mvn-api")
 
-    with pytest.raises(RuntimeError, match="release bundles were rolled back"):
+    with pytest.raises(RuntimeError, match=f"resume with the same transaction ID {TXID}"):
         migrate_cluster(
             context=_context(tmp_path),
             env_text=ENV_TEXT,
@@ -205,12 +218,32 @@ def test_partial_bundle_apply_failure_rolls_back_all_attempted_nodes_in_reverse(
 
     release_events = [event for event in operations.events if event[0] == "release"]
     assert release_events == [
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
         ("release", "apply", "zakup", TXID),
         ("release", "apply", "mvn-api", TXID),
-        ("release", "rollback", "mvn-api", TXID),
-        ("release", "rollback", "zakup", TXID),
     ]
     assert len([event for event in operations.events if event[0] == "topology"]) == 9
+
+
+def test_first_bundle_digest_rejection_never_authorizes_rollback(tmp_path):
+    operations = FakeOperations()
+    operations.release_failure = ("apply", "zakup")
+
+    with pytest.raises(RuntimeError, match=f"resume with the same transaction ID {TXID}"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event for event in operations.events if event[0] == "release"] == [
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
+        ("release", "apply", "zakup", TXID),
+    ]
 
 
 def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path):
@@ -231,6 +264,8 @@ def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path)
         for event in operations.events
     )
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
         "rollback",
@@ -240,6 +275,7 @@ def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path)
 
 def test_reopened_finalized_node_forces_roll_forward_before_preflight(tmp_path):
     operations = FakeOperations()
+    operations.release_results[("inspect", "zakup")] = "matching-finalized"
     operations.release_results[("apply", "zakup")] = "reopened"
     operations.secret_failure = ("preflight", "mvn-api")
 
@@ -253,6 +289,31 @@ def test_reopened_finalized_node_forces_roll_forward_before_preflight(tmp_path):
         )
 
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
+        "apply",
+        "apply",
+    ]
+
+
+def test_resumed_active_node_forces_roll_forward_before_preflight(tmp_path):
+    operations = FakeOperations()
+    operations.release_results[("inspect", "zakup")] = "matching-active"
+    operations.release_results[("apply", "zakup")] = "resumed"
+    operations.secret_failure = ("preflight", "mvn-api")
+
+    with pytest.raises(RuntimeError, match=f"resume with the same transaction ID {TXID}"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
     ]
@@ -272,6 +333,8 @@ def test_ambiguous_failure_during_first_provision_never_rolls_back(tmp_path):
         )
 
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
     ]
@@ -335,6 +398,8 @@ def test_role_agent_recovery_failure_is_reported_without_rolling_assets_back(
         )
 
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
     ]
@@ -366,8 +431,8 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
 ):
     operations = FakeOperations()
     operations.maintenance_failure = ("provision-node", "zakup")
-    # Baseline + six successful before/after mutations + failed provision proof.
-    operations.discover_failures.add(14)
+    # The compatibility barrier adds two proved read-only operations.
+    operations.discover_failures.add(18)
 
     with pytest.raises(RuntimeError, match="neither node was resumed"):
         migrate_cluster(
@@ -384,7 +449,7 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
 
 def test_topology_failure_before_first_provision_still_rolls_back_assets(tmp_path):
     operations = FakeOperations()
-    operations.topologies = [_topology()] * 9 + [_topology(timeline=10)]
+    operations.topologies = [_topology()] * 13 + [_topology(timeline=10)]
 
     with pytest.raises(RuntimeError, match="release bundles were rolled back"):
         migrate_cluster(
@@ -400,6 +465,8 @@ def test_topology_failure_before_first_provision_still_rolls_back_assets(tmp_pat
         for event in operations.events
     )
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
         "rollback",
@@ -423,7 +490,7 @@ def test_failure_after_first_successful_configuration_never_rolls_back(tmp_path)
     release_actions = [
         event[1] for event in operations.events if event[0] == "release"
     ]
-    assert release_actions == ["apply", "apply"]
+    assert release_actions == ["inspect", "inspect", "apply", "apply"]
 
 
 def test_ambiguous_failure_during_first_configuration_never_rolls_back(tmp_path):
@@ -440,6 +507,8 @@ def test_ambiguous_failure_during_first_configuration_never_rolls_back(tmp_path)
         )
 
     assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
         "apply",
         "apply",
     ]
@@ -475,7 +544,7 @@ def test_lineage_or_primary_drift_aborts_before_another_mutation(
         )
 
     assert [event for event in operations.events if event[0] == "release"] == [
-        ("release", "apply", "zakup", TXID)
+        ("release", "inspect", "zakup", TXID)
     ]
 
 

--- a/tests/unit/test_pitr_cluster_release_barrier.py
+++ b/tests/unit/test_pitr_cluster_release_barrier.py
@@ -1,0 +1,58 @@
+import pytest
+
+from scripts.ha.pitr_cluster_migration import migrate_cluster
+from tests.unit.test_pitr_cluster_migration import (
+    ENV_TEXT,
+    TXID,
+    FakeOperations,
+    _context,
+    _unused_runner,
+)
+
+
+def test_role_swap_mismatch_aborts_barrier_before_any_fresh_apply(tmp_path):
+    operations = FakeOperations()
+    operations.release_failure = ("inspect", "mvn-api")
+
+    with pytest.raises(RuntimeError, match="simulated release failure"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event for event in operations.events if event[0] == "release"] == [
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
+    ]
+
+
+def test_matching_existing_release_is_applied_before_fresh_peer(tmp_path):
+    operations = FakeOperations()
+    operations.release_results[("inspect", "mvn-api")] = "matching-active"
+    operations.release_results[("apply", "mvn-api")] = "resumed"
+
+    migrate_cluster(
+        context=_context(tmp_path),
+        env_text=ENV_TEXT,
+        transaction_id=TXID,
+        runner=_unused_runner,
+        dependencies=operations.dependencies(),
+    )
+
+    release_events = [event for event in operations.events if event[0] == "release"]
+    assert release_events[:4] == [
+        ("release", "inspect", "zakup", TXID),
+        ("release", "inspect", "mvn-api", TXID),
+        ("release", "apply", "mvn-api", TXID),
+        ("release", "apply", "zakup", TXID),
+    ]
+    for alias in ("mvn-api", "zakup"):
+        payloads = [
+            payload
+            for action, node_alias, payload in operations.release_payloads
+            if node_alias == alias and action in {"inspect", "apply"}
+        ]
+        assert payloads == [f"pinned:{alias}", f"pinned:{alias}"]


### PR DESCRIPTION
## Summary
- inspect both cluster nodes against one pinned release generation before the first apply
- reuse the exact same per-node payload bytes for inspect and apply
- distinguish fresh, matching-active, and matching-finalized release state
- never authorize rollback for a pre-existing or ambiguously applied journal
- fail closed when a rollback receipt and transaction directory coexist

## Incident fixed
A resume with a mismatched local release previously registered the pre-existing standby journal as controller-owned and rolled it back. The old f357 transaction was safely aborted symmetrically in production; this PR prevents recurrence.

## Validation
- 2051 unit tests passed, 4 skipped
- 58 focused release/barrier tests passed
- independent P0-P2 review: CLEAR
- Python compile, embedded executor parse, line limits, and diff checks passed