### PR TITLE
Fix fenced primary PITR provisioning

### DIFF
--- a/deploy/ha/patroni/render_patroni_config.py
+++ b/deploy/ha/patroni/render_patroni_config.py
@@ -116,6 +116,15 @@ def render_config() -> dict[str, Any]:
         )
         postgres_parameters["archive_command"] = required("PATRONI_ARCHIVE_COMMAND")
 
+    reviewed_pg_hba = [
+        "local all all trust",
+        "host all all 127.0.0.1/32 scram-sha-256",
+        "host all all 172.16.0.0/12 scram-sha-256",
+        f"host replication {replication_user} 172.16.0.0/12 scram-sha-256",
+        f"host replication {replication_user} 10.77.0.0/24 scram-sha-256",
+        "host all all 10.77.0.0/24 scram-sha-256",
+    ]
+
     watchdog_mode = os.getenv("PATRONI_WATCHDOG_MODE", "off").strip().lower()
     if watchdog_mode not in {"off", "automatic", "required"}:
         raise ValueError("PATRONI_WATCHDOG_MODE must be off, automatic, or required")
@@ -149,14 +158,7 @@ def render_config() -> dict[str, Any]:
                 },
             },
             "initdb": [{"encoding": "UTF8"}, "data-checksums"],
-            "pg_hba": [
-                "local all all trust",
-                "host all all 127.0.0.1/32 scram-sha-256",
-                "host all all 172.16.0.0/12 scram-sha-256",
-                f"host replication {replication_user} 172.16.0.0/12 scram-sha-256",
-                f"host replication {replication_user} 10.77.0.0/24 scram-sha-256",
-                "host all all 10.77.0.0/24 scram-sha-256",
-            ],
+            "pg_hba": list(reviewed_pg_hba),
         },
         "postgresql": {
             "listen": "0.0.0.0:5432",
@@ -175,6 +177,11 @@ def render_config() -> dict[str, Any]:
                 },
             },
             "parameters": {"password_encryption": "scram-sha-256"},
+            # ``bootstrap.pg_hba`` only seeds a newly initialized database
+            # cluster.  Keep the same reviewed rules in local Patroni config
+            # so existing clusters converge too, including replication from
+            # Docker's 172.16.0.0/12 bridge used by the isolated backup helper.
+            "pg_hba": list(reviewed_pg_hba),
         },
         "watchdog": {
             "mode": watchdog_mode,

--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -237,6 +237,29 @@ class _MigrationOrchestrator:
             runner=self.runner,
         )
 
+    def _run_with_standby_agent_quiesced(
+        self,
+        *,
+        node: PatroniNode,
+        stage: str,
+        action: Callable[[], None],
+    ) -> None:
+        baseline = self.baseline
+        if baseline is None or node.alias != baseline.standby.alias:
+            raise RuntimeError("standby role-agent window requires the baseline standby")
+        self.role_agent_window_open = True
+        self._mutate(
+            stage=f"role-agent quiesce {node.alias} before {stage}",
+            action=lambda: self._role_agent("quiesce-standby", node),
+            enter_roll_forward=True,
+        )
+        self._mutate(stage=f"{stage} {node.alias}", action=action)
+        self._mutate(
+            stage=f"role-agent resume {node.alias} after {stage}",
+            action=lambda: self._role_agent("resume-standby", node),
+        )
+        self.role_agent_window_open = False
+
     def _rollback_owned_bundles(self, original_error: BaseException) -> None:
         failures: list[str] = []
         for node in reversed(self.owned_bundle_nodes):
@@ -349,10 +372,18 @@ class _MigrationOrchestrator:
                     action=lambda node=node: self._release("apply", node),
                 )
             for node in ordered_nodes:
-                self._mutate(
-                    stage=f"preflight {node.alias}",
-                    action=lambda node=node: self._secret("preflight", node),
-                )
+                preflight = lambda node=node: self._secret("preflight", node)
+                if node.alias == baseline.standby.alias:
+                    self._run_with_standby_agent_quiesced(
+                        node=node,
+                        stage="preflight",
+                        action=preflight,
+                    )
+                else:
+                    self._mutate(
+                        stage=f"preflight {node.alias}",
+                        action=preflight,
+                    )
             for node in ordered_nodes:
                 # Provision each node inside its own minimal role-agent window.
                 # The standby is already traffic-fenced. The current primary
@@ -363,58 +394,78 @@ class _MigrationOrchestrator:
                     if node.alias == baseline.standby.alias
                     else "quiesce-fenced"
                 )
-                self.role_agent_window_open = True
-                self._mutate(
-                    stage=f"role-agent quiesce {node.alias}",
-                    action=lambda node=node, phase=quiesce_phase: self._role_agent(
-                        phase, node
-                    ),
-                    enter_roll_forward=True,
-                )
-                # Provisioning mutates root-owned host state. A lost remote
-                # response cannot prove that it made no durable progress, so
-                # it remains inside the roll-forward boundary entered before
-                # the first role-agent quiesce attempt.
                 if node.alias == baseline.primary.alias:
-                    provision = lambda node=node: self._fenced_provision(node)
-                else:
-                    provision = lambda node=node: self._maintenance(
-                        "provision-node", node
-                    )
-                self._mutate(
-                    stage=f"provision-node {node.alias}",
-                    action=provision,
-                    enter_roll_forward=True,
-                )
-                self._mutate(
-                    stage=f"role-agent resume {node.alias}",
-                    action=lambda node=node: self._role_agent(
-                        (
-                            "resume-standby"
-                            if node.alias == baseline.standby.alias
-                            else "resume-primary"
+                    self.role_agent_window_open = True
+                    self._mutate(
+                        stage=f"role-agent quiesce {node.alias}",
+                        action=lambda node=node, phase=quiesce_phase: self._role_agent(
+                            phase, node
                         ),
-                        node,
-                    ),
-                )
-                self.role_agent_window_open = False
+                        enter_roll_forward=True,
+                    )
+                    # Provisioning mutates root-owned host state. A lost remote
+                    # response cannot prove that it made no durable progress.
+                    self._mutate(
+                        stage=f"provision-node {node.alias}",
+                        action=lambda node=node: self._fenced_provision(node),
+                        enter_roll_forward=True,
+                    )
+                    self._mutate(
+                        stage=f"role-agent resume {node.alias}",
+                        action=lambda node=node: self._role_agent(
+                            "resume-primary", node
+                        ),
+                    )
+                    self.role_agent_window_open = False
+                else:
+                    self._run_with_standby_agent_quiesced(
+                        node=node,
+                        stage="provision-node",
+                        action=lambda node=node: self._maintenance(
+                            "provision-node", node
+                        ),
+                    )
             for node in ordered_nodes:
-                self._mutate(
-                    stage=f"configure-node {node.alias}",
-                    action=lambda node=node: self._secret("configure-node", node),
-                )
+                configure = lambda node=node: self._secret("configure-node", node)
+                if node.alias == baseline.standby.alias:
+                    self._run_with_standby_agent_quiesced(
+                        node=node,
+                        stage="configure-node",
+                        action=configure,
+                    )
+                else:
+                    self._mutate(
+                        stage=f"configure-node {node.alias}",
+                        action=configure,
+                    )
             for node in ordered_nodes:
-                self._mutate(
-                    stage=f"scrub-node {node.alias}",
-                    action=lambda node=node: self._maintenance("scrub-node", node),
-                )
+                scrub = lambda node=node: self._maintenance("scrub-node", node)
+                if node.alias == baseline.standby.alias:
+                    self._run_with_standby_agent_quiesced(
+                        node=node,
+                        stage="scrub-node",
+                        action=scrub,
+                    )
+                else:
+                    self._mutate(
+                        stage=f"scrub-node {node.alias}",
+                        action=scrub,
+                    )
             for node in ordered_nodes:
-                self._mutate(
-                    stage=f"enable-archive-env {node.alias}",
-                    action=lambda node=node: self._maintenance(
-                        "enable-archive-env", node
-                    ),
+                enable_archive = lambda node=node: self._maintenance(
+                    "enable-archive-env", node
                 )
+                if node.alias == baseline.standby.alias:
+                    self._run_with_standby_agent_quiesced(
+                        node=node,
+                        stage="enable-archive-env",
+                        action=enable_archive,
+                    )
+                else:
+                    self._mutate(
+                        stage=f"enable-archive-env {node.alias}",
+                        action=enable_archive,
+                    )
             self._mutate(
                 stage=f"basebackup {baseline.primary.alias}",
                 action=lambda: self._maintenance("basebackup", baseline.primary),

--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -20,6 +20,7 @@ try:
     )
     from scripts.ha.pitr_remote_execution import (
         prepare_host_release_bundles,
+        run_remote_fenced_provision_phase,
         run_remote_maintenance_phase,
         run_remote_release_action,
         run_remote_role_agent_phase,
@@ -37,6 +38,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
     )
     from pitr_remote_execution import (  # type: ignore[no-redef]
         prepare_host_release_bundles,
+        run_remote_fenced_provision_phase,
         run_remote_maintenance_phase,
         run_remote_release_action,
         run_remote_role_agent_phase,
@@ -50,6 +52,7 @@ ReleaseAction = Callable[..., str]
 ReleaseBundleBuilder = Callable[[Sequence[PatroniNode]], dict[str, str]]
 SecretPhase = Callable[..., None]
 MaintenancePhase = Callable[..., None]
+FencedProvisionPhase = Callable[..., None]
 RoleAgentPhase = Callable[..., None]
 
 TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
@@ -72,6 +75,7 @@ class MigrationDependencies:
     release: ReleaseAction = run_remote_release_action
     secret: SecretPhase = run_remote_secret_phase
     maintenance: MaintenancePhase = run_remote_maintenance_phase
+    fenced_provision: FencedProvisionPhase = run_remote_fenced_provision_phase
     role_agent: RoleAgentPhase = run_remote_role_agent_phase
 
 
@@ -211,6 +215,15 @@ class _MigrationOrchestrator:
             context=self.context,
             bootstrap_helper=self.bootstrap_helper,
             phase=phase,
+            transaction_id=self.transaction_id,
+            runner=self.runner,
+        )
+
+    def _fenced_provision(self, node: PatroniNode) -> None:
+        self.dependencies.fenced_provision(
+            node=node,
+            context=self.context,
+            bootstrap_helper=self.bootstrap_helper,
             transaction_id=self.transaction_id,
             runner=self.runner,
         )
@@ -362,11 +375,15 @@ class _MigrationOrchestrator:
                 # response cannot prove that it made no durable progress, so
                 # it remains inside the roll-forward boundary entered before
                 # the first role-agent quiesce attempt.
+                if node.alias == baseline.primary.alias:
+                    provision = lambda node=node: self._fenced_provision(node)
+                else:
+                    provision = lambda node=node: self._maintenance(
+                        "provision-node", node
+                    )
                 self._mutate(
                     stage=f"provision-node {node.alias}",
-                    action=lambda node=node: self._maintenance(
-                        "provision-node", node
-                    ),
+                    action=provision,
                     enter_roll_forward=True,
                 )
                 self._mutate(

--- a/scripts/ha/pitr_completion_attestation.py
+++ b/scripts/ha/pitr_completion_attestation.py
@@ -1,0 +1,357 @@
+"""Completion-receipt program embedded in privileged PITR SSH calls."""
+
+from __future__ import annotations
+
+
+REMOTE_COMPLETION_ATTESTATION = r'''
+COMPLETION_ROOT = "/run/mvn-postgres-pitr-completions"
+COMPLETION_UID = 0
+COMPLETION_GID = 0
+COMPLETION_NONCE_RE = re.compile(r"^[0-9a-f]{32}$")
+COMPLETION_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+COMPLETION_ALLOWED_PHASES = {
+    "preflight",
+    "provision-node",
+    "configure-node",
+    "scrub-node",
+    "basebackup",
+    "enable-archive-env",
+    "enable-timers",
+    "restore-drill",
+    "verify",
+}
+COMPLETION_STALE_AFTER_NS = 300 * 1_000_000_000
+
+
+def _completion_payload(
+    nonce,
+    transaction_id,
+    phase,
+    project_dir,
+    compose_file,
+    asset_manifest,
+    wrapper_digest,
+):
+    if COMPLETION_NONCE_RE.fullmatch(nonce) is None:
+        raise RuntimeError("PITR completion nonce is invalid")
+    if re.fullmatch(r"[0-9a-f]{32}", transaction_id) is None:
+        raise RuntimeError("PITR completion transaction ID is invalid")
+    if phase not in COMPLETION_ALLOWED_PHASES:
+        raise RuntimeError("PITR completion phase is invalid")
+    if project_dir not in ALLOWED_PROJECT_DIRS:
+        raise RuntimeError("PITR completion project is invalid")
+    if os.path.join(project_dir, compose_file) not in ALLOWED_COMPOSE_PATHS:
+        raise RuntimeError("PITR completion compose file is invalid")
+    if COMPLETION_DIGEST_RE.fullmatch(wrapper_digest) is None:
+        raise RuntimeError("PITR completion wrapper digest is invalid")
+    return (
+        json.dumps(
+            {
+                "asset_manifest_sha256": hashlib.sha256(
+                    asset_manifest.encode()
+                ).hexdigest(),
+                "compose_file": compose_file,
+                "nonce": nonce,
+                "phase": phase,
+                "project_dir": project_dir,
+                "transaction_id": transaction_id,
+                "version": 1,
+                "wrapper_sha256": wrapper_digest,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode()
+
+
+def _completion_root(*, create):
+    if create:
+        try:
+            os.mkdir(COMPLETION_ROOT, 0o700)
+        except FileExistsError:
+            pass
+    metadata = os.lstat(COMPLETION_ROOT)
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != COMPLETION_UID
+        or metadata.st_gid != COMPLETION_GID
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise RuntimeError("PITR completion root metadata is unsafe")
+    return os.listdir(COMPLETION_ROOT)
+
+
+def _validate_stale_receipt(path, name, before):
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != COMPLETION_UID
+        or before.st_gid != COMPLETION_GID
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o600
+        or before.st_size <= 0
+        or before.st_size > 2048
+    ):
+        raise RuntimeError("stale PITR completion receipt metadata is unsafe")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+            raise RuntimeError("stale PITR completion receipt changed while opening")
+        payload = os.read(descriptor, 2049)
+        finished = os.fstat(descriptor)
+        if len(payload) != opened.st_size or os.read(descriptor, 1):
+            raise RuntimeError("stale PITR completion receipt size is invalid")
+        if (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        ) != (
+            finished.st_dev,
+            finished.st_ino,
+            finished.st_size,
+            finished.st_mtime_ns,
+            finished.st_ctime_ns,
+        ):
+            raise RuntimeError("stale PITR completion receipt changed while reading")
+    finally:
+        os.close(descriptor)
+    try:
+        record = json.loads(payload)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("stale PITR completion receipt is invalid") from exc
+    expected_keys = {
+        "asset_manifest_sha256",
+        "compose_file",
+        "nonce",
+        "phase",
+        "project_dir",
+        "transaction_id",
+        "version",
+        "wrapper_sha256",
+    }
+    if not isinstance(record, dict) or set(record) != expected_keys:
+        raise RuntimeError("stale PITR completion receipt schema is invalid")
+    string_keys = expected_keys - {"version"}
+    if (
+        any(not isinstance(record[key], str) for key in string_keys)
+        or type(record["version"]) is not int
+        or record["version"] != 1
+        or name != f'{record["nonce"]}.json'
+        or COMPLETION_NONCE_RE.fullmatch(record["nonce"]) is None
+        or COMPLETION_NONCE_RE.fullmatch(record["transaction_id"]) is None
+        or record["phase"] not in COMPLETION_ALLOWED_PHASES
+        or record["project_dir"] not in ALLOWED_PROJECT_DIRS
+        or os.path.join(record["project_dir"], record["compose_file"])
+        not in ALLOWED_COMPOSE_PATHS
+        or COMPLETION_DIGEST_RE.fullmatch(record["asset_manifest_sha256"]) is None
+        or COMPLETION_DIGEST_RE.fullmatch(record["wrapper_sha256"]) is None
+    ):
+        raise RuntimeError("stale PITR completion receipt contract is invalid")
+    canonical = (
+        json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    if payload != canonical:
+        raise RuntimeError("stale PITR completion receipt is not canonical")
+
+
+def scavenge_completion_receipts(*, now_ns=None):
+    entries = _completion_root(create=True)
+    current_ns = time.time_ns() if now_ns is None else now_ns
+    removed = False
+    for name in entries:
+        receipt_match = re.fullmatch(r"[0-9a-f]{32}\.json", name)
+        temporary_match = re.fullmatch(r"\.[0-9a-f]{32}\.[0-9]+\.tmp", name)
+        if receipt_match is None and temporary_match is None:
+            raise RuntimeError("PITR completion root contains an unknown entry")
+        path = os.path.join(COMPLETION_ROOT, name)
+        before = os.lstat(path)
+        if receipt_match is not None:
+            _validate_stale_receipt(path, name, before)
+        elif (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_ISLNK(before.st_mode)
+            or before.st_uid != COMPLETION_UID
+            or before.st_gid != COMPLETION_GID
+            or before.st_nlink != 1
+            or stat.S_IMODE(before.st_mode) != 0o600
+            or before.st_size > 2048
+        ):
+            raise RuntimeError("stale PITR completion temporary metadata is unsafe")
+        if current_ns < before.st_mtime_ns:
+            raise RuntimeError("PITR completion entry timestamp is in the future")
+        if current_ns - before.st_mtime_ns < COMPLETION_STALE_AFTER_NS:
+            continue
+        final = os.lstat(path)
+        if (final.st_dev, final.st_ino) != (before.st_dev, before.st_ino):
+            raise RuntimeError("stale PITR completion entry changed before removal")
+        os.unlink(path)
+        removed = True
+    remaining = os.listdir(COMPLETION_ROOT)
+    if len(remaining) >= 64:
+        raise RuntimeError("recent PITR completion receipts require bounded retry")
+    if removed:
+        root_fd = os.open(
+            COMPLETION_ROOT, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+        )
+        try:
+            os.fsync(root_fd)
+        finally:
+            os.close(root_fd)
+    return len(entries) - len(remaining)
+
+
+def _read_completion(path, expected):
+    before = os.lstat(path)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != COMPLETION_UID
+        or before.st_gid != COMPLETION_GID
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o600
+        or before.st_size != len(expected)
+    ):
+        raise RuntimeError("PITR completion receipt metadata is unsafe")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+            raise RuntimeError("PITR completion receipt changed while opening")
+        payload = os.read(descriptor, len(expected) + 1)
+        finished = os.fstat(descriptor)
+        if payload != expected or os.read(descriptor, 1):
+            raise RuntimeError("PITR completion receipt content is invalid")
+        if (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        ) != (
+            finished.st_dev,
+            finished.st_ino,
+            finished.st_size,
+            finished.st_mtime_ns,
+            finished.st_ctime_ns,
+        ):
+            raise RuntimeError("PITR completion receipt changed while reading")
+        return opened.st_dev, opened.st_ino
+    finally:
+        os.close(descriptor)
+
+
+def write_completion_receipt(
+    nonce,
+    transaction_id,
+    phase,
+    project_dir,
+    compose_file,
+    asset_manifest,
+    wrapper_digest,
+):
+    expected = _completion_payload(
+        nonce,
+        transaction_id,
+        phase,
+        project_dir,
+        compose_file,
+        asset_manifest,
+        wrapper_digest,
+    )
+    entries = _completion_root(create=True)
+    if len(entries) >= 64:
+        raise RuntimeError("too many recent PITR completion receipts")
+    target = os.path.join(COMPLETION_ROOT, f"{nonce}.json")
+    temporary = os.path.join(COMPLETION_ROOT, f".{nonce}.{os.getpid()}.tmp")
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+    )
+    try:
+        os.fchown(descriptor, COMPLETION_UID, COMPLETION_GID)
+        os.fchmod(descriptor, 0o600)
+        offset = 0
+        while offset < len(expected):
+            written = os.write(descriptor, expected[offset:])
+            if written <= 0:
+                raise RuntimeError("PITR completion receipt write made no progress")
+            offset += written
+        os.fsync(descriptor)
+    except BaseException:
+        os.unlink(temporary)
+        raise
+    finally:
+        os.close(descriptor)
+    try:
+        os.lstat(target)
+    except FileNotFoundError:
+        pass
+    else:
+        os.unlink(temporary)
+        raise RuntimeError("PITR completion nonce already exists")
+    os.replace(temporary, target)
+    root_fd = os.open(COMPLETION_ROOT, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        os.fsync(root_fd)
+    finally:
+        os.close(root_fd)
+    _read_completion(target, expected)
+
+
+def consume_completion_receipt(
+    nonce,
+    transaction_id,
+    phase,
+    project_dir,
+    compose_file,
+    asset_manifest,
+    wrapper_digest,
+):
+    expected = _completion_payload(
+        nonce,
+        transaction_id,
+        phase,
+        project_dir,
+        compose_file,
+        asset_manifest,
+        wrapper_digest,
+    )
+    _completion_root(create=False)
+    target = os.path.join(COMPLETION_ROOT, f"{nonce}.json")
+    identity = _read_completion(target, expected)
+    final = os.lstat(target)
+    if (final.st_dev, final.st_ino) != identity:
+        raise RuntimeError("PITR completion receipt changed before removal")
+    os.unlink(target)
+    root_fd = os.open(COMPLETION_ROOT, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        os.fsync(root_fd)
+    finally:
+        os.close(root_fd)
+
+
+def write_completion_after_status(status, *receipt_fields):
+    if status == 0:
+        write_completion_receipt(*receipt_fields)
+    return status
+
+
+def consume_completion_after_status(status, *receipt_fields):
+    if status == 0:
+        consume_completion_receipt(*receipt_fields)
+    return status
+
+
+def discard_completion_receipt(*receipt_fields):
+    try:
+        consume_completion_receipt(*receipt_fields)
+    except FileNotFoundError:
+        return False
+    return True
+'''.strip()

--- a/scripts/ha/pitr_fenced_provision_remote.py
+++ b/scripts/ha/pitr_fenced_provision_remote.py
@@ -1,0 +1,113 @@
+"""Self-contained fail-closed proof used only for primary PITR provisioning."""
+
+from __future__ import annotations
+
+
+FENCED_PROVISION_HELPERS = r'''
+FENCED_ROLE_AGENT_UNIT = "mvn-patroni-role-agent.service"
+FENCED_RUNTIME_SERVICES = ("app", "app-blue", "app-green", "bot")
+FENCED_CLEAN_ENV = {
+    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "HOME": "/root",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "DOCKER_CONTEXT": "default",
+}
+
+
+def _read_fenced_runtime_state(project_dir):
+    path = os.path.join(project_dir, ".ha-runtime-role")
+    before = os.lstat(path)
+    expected = b"fencing\n"
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != 0
+        or before.st_gid != 0
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o600
+        or before.st_size != len(expected)
+    ):
+        raise RuntimeError("primary fenced runtime state metadata is unsafe")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+            raise RuntimeError("primary fenced runtime state changed while opening")
+        payload = os.read(descriptor, len(expected) + 1)
+        if payload != expected or os.read(descriptor, 1):
+            raise RuntimeError("primary runtime is not in the exact fencing state")
+        finished = os.fstat(descriptor)
+        generation = (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        )
+        if generation != (
+            finished.st_dev,
+            finished.st_ino,
+            finished.st_size,
+            finished.st_mtime_ns,
+            finished.st_ctime_ns,
+        ):
+            raise RuntimeError("primary fenced runtime state changed while reading")
+        return generation
+    finally:
+        os.close(descriptor)
+
+
+def _require_fenced_role_agent_inactive():
+    result = subprocess.run(
+        ["/usr/bin/systemctl", "is-active", FENCED_ROLE_AGENT_UNIT],
+        env=FENCED_CLEAN_ENV,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 3 or result.stdout.strip() != "inactive":
+        raise RuntimeError("primary role agent is not exactly inactive")
+
+
+def _require_fenced_runtime_empty(project_dir, compose_file):
+    compose_path = os.path.join(project_dir, compose_file)
+    result = subprocess.run(
+        [
+            "/usr/bin/docker",
+            "compose",
+            "--profile",
+            "bluegreen",
+            "--project-directory",
+            project_dir,
+            "-f",
+            compose_path,
+            "ps",
+            "--all",
+            "-q",
+            *FENCED_RUNTIME_SERVICES,
+        ],
+        env=FENCED_CLEAN_ENV,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("primary fenced runtime inventory failed")
+    if result.stdout.strip():
+        raise RuntimeError("primary fenced runtime still has API or bot containers")
+
+
+def prove_fenced_provision_state(project_dir, compose_file):
+    first = _read_fenced_runtime_state(project_dir)
+    _require_fenced_role_agent_inactive()
+    _require_fenced_runtime_empty(project_dir, compose_file)
+    second = _read_fenced_runtime_state(project_dir)
+    _require_fenced_role_agent_inactive()
+    if second != first:
+        raise RuntimeError("primary fenced runtime state generation changed")
+'''.strip()

--- a/scripts/ha/pitr_remote_asset_attestation.py
+++ b/scripts/ha/pitr_remote_asset_attestation.py
@@ -1,0 +1,222 @@
+"""Pinned asset-attestation program embedded in privileged PITR SSH calls."""
+
+from __future__ import annotations
+
+
+REMOTE_ASSET_ATTESTATION = r'''
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import secrets
+import signal
+import stat
+import subprocess
+import sys
+import time
+
+EXPECTED_ASSET_MODES = {
+    "/usr/local/sbin/mvn-postgres-pitr-upload": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-immutable-upload": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-upload-wal": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-basebackup": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-configure-env": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-provision-host": 0o755,
+    "/usr/local/sbin/mvn_postgres_pitr_config_transaction.py": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-restore": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-restore-drill": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-status": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-remote-status": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-bootstrap": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
+    "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-artifact-security": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-wal-lineage": 0o755,
+    "/usr/local/sbin/mvn-postgres-pitr-recovery-config": 0o755,
+    "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py": 0o755,
+    "/usr/local/sbin/mvn_postgres_pitr_operation_cleanup.py": 0o755,
+    "/usr/local/libexec/mvn-pitr/install_postgres_pitr_units.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py": 0o755,
+    "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh": 0o755,
+    "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py": 0o755,
+    "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py": 0o755,
+    "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh": 0o755,
+    "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,
+    "/etc/systemd/system/mvn-postgres-wal-upload.timer": 0o644,
+    "/etc/systemd/system/mvn-postgres-basebackup.service": 0o644,
+    "/etc/systemd/system/mvn-postgres-basebackup.timer": 0o644,
+}
+
+
+ALLOWED_COMPOSE_PATHS = {
+    "/opt/air-api/docker-compose.patroni.yml",
+    "/opt/mvn-reserve/docker-compose.patroni.yml",
+}
+ALLOWED_PROJECT_DIRS = {"/opt/air-api", "/opt/mvn-reserve"}
+OPERATION_GUARD_PATH = "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py"
+
+
+def load_operation_guard():
+    specification = importlib.util.spec_from_file_location(
+        "mvn_postgres_pitr_operation_guard",
+        OPERATION_GUARD_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("PITR operation guard could not be loaded")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[specification.name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+def _transient_command(args, environment, operation_id, timeout_seconds):
+    unit = f"mvn-postgres-pitr-manual-{operation_id}.service"
+    command = [
+        "systemd-run",
+        f"--unit={unit}",
+        "--collect",
+        "--wait",
+        "--pipe",
+        "--quiet",
+        "--property=Type=exec",
+        "--property=KillMode=control-group",
+        "--property=SendSIGKILL=yes",
+        "--property=TimeoutStopSec=30s",
+        f"--property=RuntimeMaxSec={timeout_seconds}s",
+    ]
+    for name in sorted(environment):
+        command.append(f"--setenv={name}={environment[name]}")
+    return [*command, "--", *args], unit
+
+
+def run_bounded(
+    args,
+    *,
+    environment,
+    pass_fds,
+    phase,
+    project_dir,
+    timeout_seconds,
+    transient,
+    record_command,
+    stdin_payload=None,
+    guard_module=None,
+    operation_id=None,
+):
+    guard = guard_module or load_operation_guard()
+    if guard.list_records(project_dir=project_dir):
+        raise RuntimeError("another recorded PITR operation requires cleanup")
+    if operation_id is None:
+        operation_id = secrets.token_hex(16)
+    elif re.fullmatch(r"[0-9a-f]{32}", operation_id) is None:
+        raise RuntimeError("invalid PITR operation ID")
+    launch_args = args
+    unit = ""
+    if transient:
+        if pass_fds:
+            raise RuntimeError("transient PITR jobs cannot inherit file descriptors")
+        unit_environment = dict(environment)
+        unit_environment["PITR_OPERATION_ID"] = operation_id
+        launch_args, unit = _transient_command(
+            args,
+            unit_environment,
+            operation_id,
+            timeout_seconds,
+        )
+    return guard.run_guarded_process(
+        launch_args,
+        environment=environment,
+        phase=phase,
+        project_dir=project_dir,
+        kind="manual",
+        unit=unit,
+        record_command=record_command,
+        timeout_seconds=timeout_seconds,
+        pass_fds=tuple(pass_fds),
+        stdin_payload=stdin_payload,
+        operation_id=operation_id,
+    )
+
+
+def open_deploy_lock(project_dir):
+    if project_dir not in ALLOWED_PROJECT_DIRS:
+        raise RuntimeError("unreviewed project directory for deploy lock")
+    path = os.path.join(project_dir, ".deploy.lock")
+    descriptor = os.open(
+        path,
+        os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+    )
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or metadata.st_nlink != 1
+    ):
+        os.close(descriptor)
+        raise RuntimeError("project deploy lock metadata is unsafe")
+    os.fchmod(descriptor, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def attest_assets(raw_manifest, project_dir, compose_file):
+    try:
+        manifest = json.loads(raw_manifest)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("host asset manifest is invalid") from exc
+    compose_path = os.path.join(project_dir, compose_file)
+    if compose_path not in ALLOWED_COMPOSE_PATHS:
+        raise RuntimeError("host asset manifest has an unexpected compose path")
+    expected_modes = dict(EXPECTED_ASSET_MODES)
+    expected_modes[compose_path] = 0o644
+    if not isinstance(manifest, dict) or set(manifest) != set(expected_modes):
+        raise RuntimeError("host asset manifest has an unexpected path set")
+    for path, expected_mode in expected_modes.items():
+        digest = manifest.get(path)
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise RuntimeError(f"host asset digest is invalid: {path}")
+        try:
+            metadata = os.lstat(path)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"host asset is missing: {path}") from exc
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != 0
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != expected_mode
+        ):
+            raise RuntimeError(f"host asset metadata is unsafe: {path}")
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+        try:
+            opened = os.fstat(descriptor)
+            if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+                raise RuntimeError(f"host asset changed during attestation: {path}")
+            hasher = hashlib.sha256()
+            while True:
+                chunk = os.read(descriptor, 131072)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+        finally:
+            os.close(descriptor)
+        if hasher.hexdigest() != digest:
+            raise RuntimeError(f"host asset digest mismatch: {path}")
+    return manifest
+'''.strip()

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -428,13 +428,14 @@ def run_remote_secret_phase(
     )
 
 
-def run_remote_maintenance_phase(
+def _run_remote_maintenance_phase(
     *,
     node: PatroniNode,
     context: PinnedSshContext,
     bootstrap_helper: str,
     phase: str,
     transaction_id: str,
+    confirmation: str,
     runner: Runner | None = None,
 ) -> None:
     if bootstrap_helper != "/usr/local/sbin/mvn-postgres-pitr-bootstrap":
@@ -451,6 +452,10 @@ def run_remote_maintenance_phase(
         raise RuntimeError(f"unsupported maintenance phase: {phase}")
     if not TRANSACTION_ID_RE.fullmatch(transaction_id):
         raise RuntimeError("PITR transaction ID must be 32 lowercase hexadecimal characters")
+    if confirmation not in {"false", "fenced"}:
+        raise RuntimeError("unsupported PITR maintenance confirmation")
+    if confirmation == "fenced" and phase != "provision-node":
+        raise RuntimeError("fenced maintenance is limited to provision-node")
     asset_manifest = render_host_asset_manifest(node)
     locked_wrapper_digest = hashlib.sha256(
         LOCKED_MAINTENANCE_WRAPPER.encode()
@@ -465,7 +470,7 @@ def run_remote_maintenance_phase(
             shlex.quote(phase),
             shlex.quote(node.project_dir),
             shlex.quote(node.compose_file),
-            "false",
+            confirmation,
             transaction_id,
             shlex.quote(asset_manifest),
             shlex.quote(LOCKED_MAINTENANCE_WRAPPER),
@@ -473,6 +478,45 @@ def run_remote_maintenance_phase(
         ]
     )
     _run_checked([*ssh_args(node, context), command], runner=runner)
+
+
+def run_remote_maintenance_phase(
+    *,
+    node: PatroniNode,
+    context: PinnedSshContext,
+    bootstrap_helper: str,
+    phase: str,
+    transaction_id: str,
+    runner: Runner | None = None,
+) -> None:
+    _run_remote_maintenance_phase(
+        node=node,
+        context=context,
+        bootstrap_helper=bootstrap_helper,
+        phase=phase,
+        transaction_id=transaction_id,
+        confirmation="false",
+        runner=runner,
+    )
+
+
+def run_remote_fenced_provision_phase(
+    *,
+    node: PatroniNode,
+    context: PinnedSshContext,
+    bootstrap_helper: str,
+    transaction_id: str,
+    runner: Runner | None = None,
+) -> None:
+    _run_remote_maintenance_phase(
+        node=node,
+        context=context,
+        bootstrap_helper=bootstrap_helper,
+        phase="provision-node",
+        transaction_id=transaction_id,
+        confirmation="fenced",
+        runner=runner,
+    )
 
 
 def run_remote_role_agent_phase(

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -8,6 +8,9 @@ host-side helpers by their attested absolute paths.
 from __future__ import annotations
 
 try:
+    from scripts.ha.pitr_fenced_provision_remote import (
+        FENCED_PROVISION_HELPERS,
+    )
     from scripts.ha.pitr_role_agent_process_attestation import (
         REMOTE_ROLE_AGENT_PROCESS_ATTESTATION,
     )
@@ -15,6 +18,9 @@ try:
         REMOTE_ROLE_AGENT_EXECUTOR_BODY,
     )
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_fenced_provision_remote import (  # type: ignore[no-redef]
+        FENCED_PROVISION_HELPERS,
+    )
     from pitr_role_agent_process_attestation import (  # type: ignore[no-redef]
         REMOTE_ROLE_AGENT_PROCESS_ATTESTATION,
     )
@@ -245,10 +251,13 @@ def attest_assets(raw_manifest, project_dir, compose_file):
 LOCKED_OPERATION_WRAPPER = (
     REMOTE_ASSET_ATTESTATION
     + "\n"
+    + FENCED_PROVISION_HELPERS
+    + "\n"
     + r'''
 import sys
 
 LOCK_PATH = "/run/lock/mvn-postgres-pitr-prerequisites.lock"
+PROVISION_HELPER = "/usr/local/sbin/mvn-postgres-pitr-provision-host"
 MAX_PAYLOAD_BYTES = 65536
 SECRET_PHASES = {"preflight", "configure-node"}
 MAINTENANCE_PHASES = {
@@ -385,8 +394,25 @@ def wrapper_main():
                 )
                 environment["ENV_INPUT_FILE"] = f"/proc/self/fd/{secret_fd}"
                 pass_fds = (deploy_fd, secret_fd)
+            provision_mode = os.environ.get("PITR_PROVISION_MODE", "standard")
+            if provision_mode not in {"standard", "fenced"}:
+                return wrapper_fail("invalid PITR provision mode", 78)
+            if provision_mode == "fenced" and phase != "provision-node":
+                return wrapper_fail("fenced mode requires provision-node", 78)
+            command = [bootstrap_helper, phase]
+            if provision_mode == "fenced":
+                prove_fenced_provision_state(project_dir, compose_file)
+                command = [
+                    PROVISION_HELPER,
+                    "--project-dir",
+                    project_dir,
+                    "--compose-file",
+                    compose_file,
+                    "--transaction-id",
+                    transaction_id,
+                ]
             result = subprocess.run(
-                [bootstrap_helper, phase],
+                command,
                 env=environment,
                 check=False,
                 pass_fds=pass_fds,
@@ -593,8 +619,10 @@ def main():
         return fail("unexpected bootstrap helper path", 64)
     if phase not in ALLOWED_PHASES:
         return fail("unsupported maintenance phase", 64)
-    if confirmed != "false":
+    if confirmed not in {"false", "fenced"}:
         return fail("unexpected maintenance confirmation value", 64)
+    if confirmed == "fenced" and phase != "provision-node":
+        return fail("fenced confirmation requires provision-node", 64)
     if re.fullmatch(r"[0-9a-f]{32}", transaction_id) is None:
         return fail("invalid PITR transaction ID", 64)
     if hashlib.sha256(locked_wrapper.encode()).hexdigest() != locked_wrapper_digest:
@@ -630,6 +658,7 @@ def main():
         "DOCKER_CONTEXT": "default",
         "PROJECT_DIR": project_dir,
         "COMPOSE_FILE": compose_file,
+        "PITR_PROVISION_MODE": "fenced" if confirmed == "fenced" else "standard",
     }
     return run_bounded(
         [

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -8,8 +8,14 @@ host-side helpers by their attested absolute paths.
 from __future__ import annotations
 
 try:
+    from scripts.ha.pitr_completion_attestation import (
+        REMOTE_COMPLETION_ATTESTATION,
+    )
     from scripts.ha.pitr_fenced_provision_remote import (
         FENCED_PROVISION_HELPERS,
+    )
+    from scripts.ha.pitr_remote_asset_attestation import (
+        REMOTE_ASSET_ATTESTATION,
     )
     from scripts.ha.pitr_role_agent_process_attestation import (
         REMOTE_ROLE_AGENT_PROCESS_ATTESTATION,
@@ -18,8 +24,14 @@ try:
         REMOTE_ROLE_AGENT_EXECUTOR_BODY,
     )
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_completion_attestation import (  # type: ignore[no-redef]
+        REMOTE_COMPLETION_ATTESTATION,
+    )
     from pitr_fenced_provision_remote import (  # type: ignore[no-redef]
         FENCED_PROVISION_HELPERS,
+    )
+    from pitr_remote_asset_attestation import (  # type: ignore[no-redef]
+        REMOTE_ASSET_ATTESTATION,
     )
     from pitr_role_agent_process_attestation import (  # type: ignore[no-redef]
         REMOTE_ROLE_AGENT_PROCESS_ATTESTATION,
@@ -29,227 +41,11 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
     )
 
 
-REMOTE_ASSET_ATTESTATION = r'''
-import fcntl
-import hashlib
-import importlib.util
-import json
-import os
-import re
-import secrets
-import signal
-import stat
-import subprocess
-import sys
-import time
-
-EXPECTED_ASSET_MODES = {
-    "/usr/local/sbin/mvn-postgres-pitr-upload": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-immutable-upload": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-upload-wal": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-basebackup": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-configure-env": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-provision-host": 0o755,
-    "/usr/local/sbin/mvn_postgres_pitr_config_transaction.py": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-restore": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-restore-drill": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-status": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-remote-status": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-bootstrap": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
-    "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
-    "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-artifact-security": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-wal-lineage": 0o755,
-    "/usr/local/sbin/mvn-postgres-pitr-recovery-config": 0o755,
-    "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py": 0o755,
-    "/usr/local/sbin/mvn_postgres_pitr_operation_cleanup.py": 0o755,
-    "/usr/local/libexec/mvn-pitr/install_postgres_pitr_units.sh": 0o755,
-    "/usr/local/libexec/mvn-pitr/run_postgres_pitr_install_locked.py": 0o755,
-    "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh": 0o755,
-    "/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh": 0o755,
-    "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh": 0o755,
-    "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py": 0o755,
-    "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py": 0o755,
-    "/usr/local/libexec/mvn-pitr/prepare_google_oauth_token_dir.sh": 0o755,
-    "/etc/systemd/system/mvn-postgres-wal-upload.service": 0o644,
-    "/etc/systemd/system/mvn-postgres-wal-upload.timer": 0o644,
-    "/etc/systemd/system/mvn-postgres-basebackup.service": 0o644,
-    "/etc/systemd/system/mvn-postgres-basebackup.timer": 0o644,
-}
-
-
-ALLOWED_COMPOSE_PATHS = {
-    "/opt/air-api/docker-compose.patroni.yml",
-    "/opt/mvn-reserve/docker-compose.patroni.yml",
-}
-ALLOWED_PROJECT_DIRS = {"/opt/air-api", "/opt/mvn-reserve"}
-OPERATION_GUARD_PATH = "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py"
-
-
-def load_operation_guard():
-    specification = importlib.util.spec_from_file_location(
-        "mvn_postgres_pitr_operation_guard",
-        OPERATION_GUARD_PATH,
-    )
-    if specification is None or specification.loader is None:
-        raise RuntimeError("PITR operation guard could not be loaded")
-    module = importlib.util.module_from_spec(specification)
-    sys.modules[specification.name] = module
-    specification.loader.exec_module(module)
-    return module
-
-
-def _transient_command(args, environment, operation_id, timeout_seconds):
-    unit = f"mvn-postgres-pitr-manual-{operation_id}.service"
-    command = [
-        "systemd-run",
-        f"--unit={unit}",
-        "--collect",
-        "--wait",
-        "--pipe",
-        "--quiet",
-        "--property=Type=exec",
-        "--property=KillMode=control-group",
-        "--property=SendSIGKILL=yes",
-        "--property=TimeoutStopSec=30s",
-        f"--property=RuntimeMaxSec={timeout_seconds}s",
-    ]
-    for name in sorted(environment):
-        command.append(f"--setenv={name}={environment[name]}")
-    return [*command, "--", *args], unit
-
-
-def run_bounded(
-    args,
-    *,
-    environment,
-    pass_fds,
-    phase,
-    project_dir,
-    timeout_seconds,
-    transient,
-    record_command,
-    stdin_payload=None,
-    guard_module=None,
-    operation_id=None,
-):
-    guard = guard_module or load_operation_guard()
-    if guard.list_records(project_dir=project_dir):
-        raise RuntimeError("another recorded PITR operation requires cleanup")
-    if operation_id is None:
-        operation_id = secrets.token_hex(16)
-    elif re.fullmatch(r"[0-9a-f]{32}", operation_id) is None:
-        raise RuntimeError("invalid PITR operation ID")
-    launch_args = args
-    unit = ""
-    if transient:
-        if pass_fds:
-            raise RuntimeError("transient PITR jobs cannot inherit file descriptors")
-        unit_environment = dict(environment)
-        unit_environment["PITR_OPERATION_ID"] = operation_id
-        launch_args, unit = _transient_command(
-            args,
-            unit_environment,
-            operation_id,
-            timeout_seconds,
-        )
-    return guard.run_guarded_process(
-        launch_args,
-        environment=environment,
-        phase=phase,
-        project_dir=project_dir,
-        kind="manual",
-        unit=unit,
-        record_command=record_command,
-        timeout_seconds=timeout_seconds,
-        pass_fds=tuple(pass_fds),
-        stdin_payload=stdin_payload,
-        operation_id=operation_id,
-    )
-
-
-def open_deploy_lock(project_dir):
-    if project_dir not in ALLOWED_PROJECT_DIRS:
-        raise RuntimeError("unreviewed project directory for deploy lock")
-    path = os.path.join(project_dir, ".deploy.lock")
-    descriptor = os.open(
-        path,
-        os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW,
-        0o600,
-    )
-    metadata = os.fstat(descriptor)
-    if (
-        not stat.S_ISREG(metadata.st_mode)
-        or metadata.st_uid != 0
-        or metadata.st_nlink != 1
-    ):
-        os.close(descriptor)
-        raise RuntimeError("project deploy lock metadata is unsafe")
-    os.fchmod(descriptor, 0o600)
-    try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
-        os.close(descriptor)
-        raise
-    return descriptor
-
-
-def attest_assets(raw_manifest, project_dir, compose_file):
-    try:
-        manifest = json.loads(raw_manifest)
-    except (TypeError, ValueError) as exc:
-        raise RuntimeError("host asset manifest is invalid") from exc
-    compose_path = os.path.join(project_dir, compose_file)
-    if compose_path not in ALLOWED_COMPOSE_PATHS:
-        raise RuntimeError("host asset manifest has an unexpected compose path")
-    expected_modes = dict(EXPECTED_ASSET_MODES)
-    expected_modes[compose_path] = 0o644
-    if not isinstance(manifest, dict) or set(manifest) != set(expected_modes):
-        raise RuntimeError("host asset manifest has an unexpected path set")
-    for path, expected_mode in expected_modes.items():
-        digest = manifest.get(path)
-        if (
-            not isinstance(digest, str)
-            or len(digest) != 64
-            or any(character not in "0123456789abcdef" for character in digest)
-        ):
-            raise RuntimeError(f"host asset digest is invalid: {path}")
-        try:
-            metadata = os.lstat(path)
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"host asset is missing: {path}") from exc
-        if (
-            not stat.S_ISREG(metadata.st_mode)
-            or metadata.st_uid != 0
-            or metadata.st_nlink != 1
-            or stat.S_IMODE(metadata.st_mode) != expected_mode
-        ):
-            raise RuntimeError(f"host asset metadata is unsafe: {path}")
-        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
-        try:
-            opened = os.fstat(descriptor)
-            if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
-                raise RuntimeError(f"host asset changed during attestation: {path}")
-            hasher = hashlib.sha256()
-            while True:
-                chunk = os.read(descriptor, 131072)
-                if not chunk:
-                    break
-                hasher.update(chunk)
-        finally:
-            os.close(descriptor)
-        if hasher.hexdigest() != digest:
-            raise RuntimeError(f"host asset digest mismatch: {path}")
-    return manifest
-'''.strip()
-
 
 LOCKED_OPERATION_WRAPPER = (
     REMOTE_ASSET_ATTESTATION
+    + "\n"
+    + REMOTE_COMPLETION_ATTESTATION
     + "\n"
     + FENCED_PROVISION_HELPERS
     + "\n"
@@ -299,7 +95,23 @@ def wrapper_main():
     if phase in SECRET_PHASES and not hasattr(os, "memfd_create"):
         return wrapper_fail("required Linux secret transport is unavailable", 78)
     operation_id = os.environ.get("PITR_OPERATION_ID", "")
+    completion_nonce = os.environ.get("PITR_COMPLETION_NONCE", "")
+    completion_wrapper_digest = os.environ.get(
+        "PITR_COMPLETION_WRAPPER_SHA256", ""
+    )
     expected_unit = f"mvn-postgres-pitr-manual-{operation_id}.service"
+    try:
+        _completion_payload(
+            completion_nonce,
+            transaction_id,
+            phase,
+            project_dir,
+            compose_file,
+            asset_manifest,
+            completion_wrapper_digest,
+        )
+    except RuntimeError as exc:
+        return wrapper_fail(str(exc), 78)
     os.umask(0o077)
     lock_fd = os.open(
         LOCK_PATH,
@@ -417,7 +229,16 @@ def wrapper_main():
                 check=False,
                 pass_fds=pass_fds,
             )
-            return result.returncode
+            return write_completion_after_status(
+                result.returncode,
+                completion_nonce,
+                transaction_id,
+                phase,
+                project_dir,
+                compose_file,
+                asset_manifest,
+                completion_wrapper_digest,
+            )
         finally:
             if payload_view is not None:
                 payload_view[:] = b"\0" * len(payload_view)
@@ -450,6 +271,8 @@ REMOTE_ROLE_AGENT_EXECUTOR = (
 
 REMOTE_SECRET_EXECUTOR = (
     REMOTE_ASSET_ATTESTATION
+    + "\n"
+    + REMOTE_COMPLETION_ATTESTATION
     + "\n"
     + r'''
 import subprocess
@@ -519,7 +342,10 @@ def main():
         try:
             attest_assets(asset_manifest, project_dir, compose_file)
             guard = load_operation_guard()
-        except RuntimeError as exc:
+            if guard.list_records(project_dir=project_dir):
+                return fail("another recorded PITR operation requires cleanup", 75)
+            scavenge_completion_receipts()
+        except (OSError, RuntimeError) as exc:
             return fail(str(exc), 78)
     finally:
         if deploy_fd is not None:
@@ -534,9 +360,12 @@ def main():
         "PROJECT_DIR": project_dir,
         "COMPOSE_FILE": compose_file,
     }
+    completion_nonce = secrets.token_hex(16)
+    environment["PITR_COMPLETION_NONCE"] = completion_nonce
+    environment["PITR_COMPLETION_WRAPPER_SHA256"] = locked_wrapper_digest
     payload_view = memoryview(payload)
     try:
-        return run_bounded(
+        status = run_bounded(
             [
                 "/usr/bin/python3",
                 "-I",
@@ -563,7 +392,35 @@ def main():
             guard_module=guard,
             operation_id=transaction_id,
         )
+        if status != 0:
+            return status
+        try:
+            status = consume_completion_after_status(
+                status,
+                completion_nonce,
+                transaction_id,
+                phase,
+                project_dir,
+                compose_file,
+                asset_manifest,
+                locked_wrapper_digest,
+            )
+        except (OSError, RuntimeError) as exc:
+            return fail(f"completion attestation failed: {exc}", 78)
+        return status
     finally:
+        try:
+            discard_completion_receipt(
+                completion_nonce,
+                transaction_id,
+                phase,
+                project_dir,
+                compose_file,
+                asset_manifest,
+                locked_wrapper_digest,
+            )
+        except (OSError, RuntimeError):
+            pass
         payload_view[:] = b"\0" * len(payload_view)
         payload_view.release()
 
@@ -575,6 +432,8 @@ raise SystemExit(main())
 
 REMOTE_MAINTENANCE_EXECUTOR = (
     REMOTE_ASSET_ATTESTATION
+    + "\n"
+    + REMOTE_COMPLETION_ATTESTATION
     + "\n"
     + r'''
 import subprocess
@@ -646,7 +505,10 @@ def main():
         try:
             attest_assets(asset_manifest, project_dir, compose_file)
             guard = load_operation_guard()
-        except RuntimeError as exc:
+            if guard.list_records(project_dir=project_dir):
+                return fail("another recorded PITR operation requires cleanup", 75)
+            scavenge_completion_receipts()
+        except (OSError, RuntimeError) as exc:
             return fail(str(exc), 78)
     finally:
         os.close(lock_fd)
@@ -660,37 +522,70 @@ def main():
         "COMPOSE_FILE": compose_file,
         "PITR_PROVISION_MODE": "fenced" if confirmed == "fenced" else "standard",
     }
-    return run_bounded(
-        [
-            "/usr/bin/python3",
-            "-I",
-            "-c",
-            locked_wrapper,
-            bootstrap_helper,
-            phase,
-            project_dir,
-            compose_file,
-            transaction_id,
-            asset_manifest,
-        ],
-        environment=environment,
-        pass_fds=(),
-        phase=phase,
-        project_dir=project_dir,
-        timeout_seconds={
-            "provision-node": 900,
-            "scrub-node": 1800,
-            "basebackup": 7200,
-            "enable-archive-env": 900,
-            "enable-timers": 900,
-            "verify": 1200,
-            "restore-drill": 7200,
-        }[phase],
-        transient=True,
-        record_command=bootstrap_helper,
-        guard_module=guard,
-        operation_id=transaction_id,
-    )
+    completion_nonce = secrets.token_hex(16)
+    environment["PITR_COMPLETION_NONCE"] = completion_nonce
+    environment["PITR_COMPLETION_WRAPPER_SHA256"] = locked_wrapper_digest
+    try:
+        status = run_bounded(
+            [
+                "/usr/bin/python3",
+                "-I",
+                "-c",
+                locked_wrapper,
+                bootstrap_helper,
+                phase,
+                project_dir,
+                compose_file,
+                transaction_id,
+                asset_manifest,
+            ],
+            environment=environment,
+            pass_fds=(),
+            phase=phase,
+            project_dir=project_dir,
+            timeout_seconds={
+                "provision-node": 900,
+                "scrub-node": 1800,
+                "basebackup": 7200,
+                "enable-archive-env": 900,
+                "enable-timers": 900,
+                "verify": 1200,
+                "restore-drill": 7200,
+            }[phase],
+            transient=True,
+            record_command=bootstrap_helper,
+            guard_module=guard,
+            operation_id=transaction_id,
+        )
+        if status != 0:
+            return status
+        try:
+            status = consume_completion_after_status(
+                status,
+                completion_nonce,
+                transaction_id,
+                phase,
+                project_dir,
+                compose_file,
+                asset_manifest,
+                locked_wrapper_digest,
+            )
+        except (OSError, RuntimeError) as exc:
+            return fail(f"completion attestation failed: {exc}", 78)
+        return status
+    finally:
+        try:
+            discard_completion_receipt(
+                completion_nonce,
+                transaction_id,
+                phase,
+                project_dir,
+                compose_file,
+                asset_manifest,
+                locked_wrapper_digest,
+            )
+        except (OSError, RuntimeError):
+            pass
 
 
 raise SystemExit(main())

--- a/scripts/ha/postgres_pitr_recovery_config.py
+++ b/scripts/ha/postgres_pitr_recovery_config.py
@@ -50,9 +50,10 @@ def write_recovery_settings(
     if wal_mode == "local":
         # The drill mounts its verified WAL source read-only and deliberately
         # keeps archive members at 0400.  Plain ``cp`` carries that mode to
-        # PostgreSQL's RECOVERYHISTORY staging file, which PostgreSQL must
-        # subsequently reopen for writing.  Install the destination with the
-        # normal server-owned 0600 mode while leaving the archive immutable.
+        # PostgreSQL's RECOVERYHISTORY/RECOVERYXLOG staging file, but the
+        # durable-rename path opens that file O_RDWR before fsync.  Install the
+        # destination with the normal server-owned 0600 mode while leaving the
+        # archive immutable.
         restore_command = (
             "/usr/bin/install -m 0600 "
             f"{shlex.quote(restore_mount_path.rstrip('/') + '/wal/%f')} %p"

--- a/scripts/ha/postgres_pitr_recovery_config.py
+++ b/scripts/ha/postgres_pitr_recovery_config.py
@@ -48,7 +48,15 @@ def write_recovery_settings(
     ):
         raise SystemExit("PITR recovery control directory metadata is unsafe")
     if wal_mode == "local":
-        restore_command = f"cp {shlex.quote(restore_mount_path.rstrip('/') + '/wal/%f')} %p"
+        # The drill mounts its verified WAL source read-only and deliberately
+        # keeps archive members at 0400.  Plain ``cp`` carries that mode to
+        # PostgreSQL's RECOVERYHISTORY staging file, which PostgreSQL must
+        # subsequently reopen for writing.  Install the destination with the
+        # normal server-owned 0600 mode while leaving the archive immutable.
+        restore_command = (
+            "/usr/bin/install -m 0600 "
+            f"{shlex.quote(restore_mount_path.rstrip('/') + '/wal/%f')} %p"
+        )
     elif wal_mode == "remote":
         restore_command = (
             f"python3 {shlex.quote(restore_helper_path)} "

--- a/scripts/ha/postgres_pitr_wal_lineage.py
+++ b/scripts/ha/postgres_pitr_wal_lineage.py
@@ -3,8 +3,13 @@
 
 from __future__ import annotations
 
+import argparse
+import os
 import re
+import stat
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable, Sequence
 
 
@@ -26,6 +31,15 @@ MAX_TIMELINE_HISTORY_BYTES = 64 * 1024
 MAX_TIMELINE_HISTORY_FILES = 1024
 MAX_TIMELINE_HISTORY_ENTRIES = 1024
 MAX_SELECTED_WAL_SEGMENTS = 131072
+MAX_LOCAL_ARCHIVE_ENTRIES = 8192
+LOCAL_HISTORY_UID = 70
+LOCAL_HISTORY_GID = 70
+LOCAL_ARCHIVE_MODE = 0o700
+LOCAL_HISTORY_MODE = 0o600
+ALLOWED_LOCAL_ARCHIVE_DIRS = {
+    Path("/opt/air-api/postgres-wal-archive"),
+    Path("/opt/mvn-reserve/postgres-wal-archive"),
+}
 
 
 @dataclass(frozen=True)
@@ -232,6 +246,113 @@ def _history_lineage(
     return lineage, target_entries, tuple(selected_histories)
 
 
+def _read_local_history(
+    path: Path,
+    *,
+    expected_uid: int,
+    expected_gid: int,
+) -> bytes:
+    before = path.lstat()
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != expected_uid
+        or before.st_gid != expected_gid
+        or stat.S_IMODE(before.st_mode) != LOCAL_HISTORY_MODE
+        or before.st_nlink != 1
+        or before.st_size <= 0
+        or before.st_size > MAX_TIMELINE_HISTORY_BYTES
+    ):
+        raise SystemExit(f"PostgreSQL timeline history metadata is unsafe: {path.name}")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+            raise SystemExit(
+                f"PostgreSQL timeline history changed while opening: {path.name}"
+            )
+        payload = os.read(descriptor, MAX_TIMELINE_HISTORY_BYTES + 1)
+        finished = os.fstat(descriptor)
+        identity = (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_uid",
+            "st_gid",
+            "st_nlink",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        if (
+            len(payload) != opened.st_size
+            or os.read(descriptor, 1)
+            or tuple(getattr(finished, field) for field in identity)
+            != tuple(getattr(opened, field) for field in identity)
+        ):
+            raise SystemExit(
+                f"PostgreSQL timeline history changed while reading: {path.name}"
+            )
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def validate_local_history_chain(
+    archive_dir: Path,
+    *,
+    required_end_wal: str,
+    expected_uid: int = LOCAL_HISTORY_UID,
+    expected_gid: int = LOCAL_HISTORY_GID,
+) -> tuple[str, ...]:
+    """Validate staged local history before any immutable remote upload."""
+
+    if not WAL_SEGMENT_RE.fullmatch(required_end_wal):
+        raise SystemExit("Required end WAL is invalid for local history validation")
+    target_timeline = int(required_end_wal[:8], 16)
+    if target_timeline <= 0:
+        raise SystemExit("Required end WAL timeline is invalid")
+    if not archive_dir.is_absolute() or archive_dir.resolve() != archive_dir:
+        raise SystemExit("Local PostgreSQL WAL archive path is unsafe")
+    metadata = archive_dir.lstat()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != expected_uid
+        or metadata.st_gid != expected_gid
+        or stat.S_IMODE(metadata.st_mode) != LOCAL_ARCHIVE_MODE
+        or metadata.st_nlink < 2
+    ):
+        raise SystemExit("Local PostgreSQL WAL archive metadata is unsafe")
+
+    histories: list[WalObject] = []
+    payloads: dict[str, bytes] = {}
+    for count, entry in enumerate(os.scandir(archive_dir), start=1):
+        if count > MAX_LOCAL_ARCHIVE_ENTRIES:
+            raise SystemExit("Local PostgreSQL WAL archive has too many entries")
+        if WAL_HISTORY_RE.fullmatch(entry.name) is None:
+            continue
+        path = archive_dir / entry.name
+        payload = _read_local_history(
+            path,
+            expected_uid=expected_uid,
+            expected_gid=expected_gid,
+        )
+        timeline = int(entry.name[:8], 16)
+        parse_timeline_history(payload, timeline=timeline)
+        histories.append(WalObject(str(path), entry.name, len(payload)))
+        payloads[entry.name] = payload
+
+    histories.sort(key=lambda item: item.filename)
+    _lineage, _entries, selected = _history_lineage(
+        histories,
+        start_timeline=1,
+        end_timeline=target_timeline,
+        history_loader=lambda item: payloads[item.filename],
+    )
+    return tuple(item.filename for item in selected)
+
+
 def select_wal_objects(
     objects: Sequence[WalObject],
     *,
@@ -320,3 +441,33 @@ def select_wal_objects(
         history_files=histories,
         backup_history_files=tuple(sorted(backup_histories, key=lambda item: item.filename)),
     )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("validate-local-history",),
+    )
+    parser.add_argument("--archive-dir", required=True)
+    parser.add_argument("--required-end-wal", required=True)
+    args = parser.parse_args(argv)
+    archive_dir = Path(args.archive_dir)
+    if archive_dir not in ALLOWED_LOCAL_ARCHIVE_DIRS:
+        print("PostgreSQL WAL lineage: unreviewed local archive path", file=sys.stderr)
+        return 1
+    try:
+        selected = validate_local_history_chain(
+            archive_dir,
+            required_end_wal=args.required_end_wal,
+        )
+    except (OSError, RuntimeError, SystemExit) as exc:
+        print(f"PostgreSQL WAL lineage: {exc}", file=sys.stderr)
+        return 1
+    for name in selected:
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/postgres_pitr_wal_lineage.py
+++ b/scripts/ha/postgres_pitr_wal_lineage.py
@@ -327,11 +327,15 @@ def validate_local_history_chain(
 
     histories: list[WalObject] = []
     payloads: dict[str, bytes] = {}
+    history_count = 0
     for count, entry in enumerate(os.scandir(archive_dir), start=1):
         if count > MAX_LOCAL_ARCHIVE_ENTRIES:
             raise SystemExit("Local PostgreSQL WAL archive has too many entries")
         if WAL_HISTORY_RE.fullmatch(entry.name) is None:
             continue
+        history_count += 1
+        if history_count > MAX_TIMELINE_HISTORY_FILES:
+            raise SystemExit("Too many PostgreSQL timeline history files")
         path = archive_dir / entry.name
         payload = _read_local_history(
             path,

--- a/scripts/ha/restore_postgres_pitr_drill.sh
+++ b/scripts/ha/restore_postgres_pitr_drill.sh
@@ -20,6 +20,7 @@ KEEP_DRILL_CONTAINER="${KEEP_DRILL_CONTAINER:-false}"
 KEEP_DRILL_FILES="${KEEP_DRILL_FILES:-false}"
 RUNTIME_CHECK_HELPER="${RUNTIME_CHECK_HELPER:-/usr/local/sbin/mvn-postgres-pitr-runtime-check}"
 TOOL_RUNNER="/usr/local/sbin/mvn-postgres-pitr-tool-runner"
+WAL_LINEAGE_HELPER="/usr/local/sbin/mvn-postgres-pitr-wal-lineage"
 PITR_OPERATION_ID="${PITR_OPERATION_ID:-}"
 
 umask 077
@@ -202,6 +203,10 @@ if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_DB}" ]]; then
 fi
 
 [[ -x "${TOOL_RUNNER}" ]] || { echo "PITR tool runner is unavailable" >&2; exit 1; }
+[[ -x "${WAL_LINEAGE_HELPER}" ]] || {
+  echo "PITR WAL lineage helper is unavailable" >&2
+  exit 1
+}
 live_state="$(
   "${COMPOSE[@]}" exec -T "${DB_SERVICE}" psql -v ON_ERROR_STOP=1 \
     -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -AtF '|' \
@@ -227,9 +232,13 @@ if [[ "${wal_segment_bytes}" != "16777216" ]]; then
   echo "Live PostgreSQL WAL segment size does not match the reviewed archive contract" >&2
   exit 1
 fi
-
 target_name=""
 target_lsn=""
+archive_dir="${PROJECT_DIR}/postgres-wal-archive"
+[[ -d "${archive_dir}" && ! -L "${archive_dir}" ]] || {
+  echo "Reviewed local WAL archive directory is unavailable" >&2
+  exit 1
+}
 if [[ "${target_mode}" == "time" ]]; then
   if [[ ! "${required_end_wal}" =~ ^[0-9A-F]{24}$ ]] ||
     ! is_unsigned_int "${last_archived_epoch}" || (( last_archived_epoch < target_epoch )); then
@@ -249,11 +258,6 @@ else
     echo "PostgreSQL returned an invalid restore-point proof" >&2
     exit 1
   fi
-  archive_dir="${PROJECT_DIR}/postgres-wal-archive"
-  [[ -d "${archive_dir}" && ! -L "${archive_dir}" ]] || {
-    echo "Reviewed local WAL archive directory is unavailable" >&2
-    exit 1
-  }
   archive_ready=false
   for _ in $(seq 1 "${ARCHIVE_TIMEOUT_SECONDS}"); do
     if [[ -f "${archive_dir}/${required_end_wal}" && ! -L "${archive_dir}/${required_end_wal}" ]] &&
@@ -267,8 +271,51 @@ else
     echo "Restore-point WAL was not archived before timeout" >&2
     exit 1
   }
-  "${TOOL_RUNNER}" --phase wal-upload --data-dir "${archive_dir}"
+
 fi
+
+# PostgreSQL only archives a timeline history file when that timeline is
+# created.  A cluster adopted after earlier promotions can therefore have the
+# original history chain in PGDATA but not in the new remote archive.  Reuse
+# the image-pinned, create-only archive helper to stage every ancestor before
+# the strict remote lineage check.  This is required for both target modes.
+history_output="$(
+  "${COMPOSE[@]}" exec -T --user \
+    "${POSTGRES_CONTAINER_UID}:${POSTGRES_CONTAINER_GID}" \
+    "${DB_SERVICE}" sh -ceu '
+      data_dir="${PGDATA:-/var/lib/postgresql/data}"
+      for source in "${data_dir}"/pg_wal/*.history; do
+        [ -e "${source}" ] || continue
+        name="${source##*/}"
+        /usr/local/bin/mvn-patroni-archive-wal \
+          "${source}" "${name}"
+        printf "%s\n" "${name}"
+      done
+    '
+)" || {
+  echo "Could not stage the complete PostgreSQL timeline history chain" >&2
+  exit 1
+}
+staged_history_count="$(printf '%s\n' "${history_output}" | sed '/^$/d' | wc -l | tr -d ' ')"
+if ! is_unsigned_int "${staged_history_count}"; then
+  echo "PostgreSQL timeline history staging returned an invalid result" >&2
+  exit 1
+fi
+validated_history_output="$(
+  "${WAL_LINEAGE_HELPER}" validate-local-history \
+    --archive-dir "${archive_dir}" \
+    --required-end-wal "${required_end_wal}"
+)" || {
+  echo "Local PostgreSQL timeline history failed strict lineage validation" >&2
+  exit 1
+}
+validated_history_count="$(printf '%s\n' "${validated_history_output}" | sed '/^$/d' | wc -l | tr -d ' ')"
+if ! is_unsigned_int "${validated_history_count}"; then
+  echo "PostgreSQL timeline history validation returned an invalid result" >&2
+  exit 1
+fi
+log "staged_timeline_history_files=${staged_history_count} validated_lineage_history_files=${validated_history_count} required_end_timeline=${required_end_wal:0:8}"
+"${TOOL_RUNNER}" --phase wal-upload --data-dir "${archive_dir}"
 log "target_mode=${target_mode} target_time=${TARGET_TIME:-<none>} target_name=${target_name:-<none>} target_lsn=${target_lsn:-<none>} expected_system_identifier=${live_system_identifier} required_end_wal=${required_end_wal}"
 
 run_dir="${DRILL_DIR}/${PITR_OPERATION_ID}"

--- a/scripts/ha/restore_postgres_pitr_drill.sh
+++ b/scripts/ha/restore_postgres_pitr_drill.sh
@@ -8,6 +8,7 @@ DB_SERVICE="${DB_SERVICE:-db}"
 POSTGRES_IMAGE="postgres:15.18-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f"
 POSTGRES_CONTAINER_UID="70"
 POSTGRES_CONTAINER_GID="70"
+MAX_TIMELINE_HISTORY_FILES="1024"
 DRILL_DIR="/var/lib/mvn-postgres-pitr/restore-drills"
 RESTORE_MOUNT_PATH="${RESTORE_MOUNT_PATH:-/pitr-restore}"
 TARGET_TIME="${TARGET_TIME:-${PITR_RESTORE_TARGET_TIME:-}}"
@@ -283,15 +284,22 @@ history_output="$(
   "${COMPOSE[@]}" exec -T --user \
     "${POSTGRES_CONTAINER_UID}:${POSTGRES_CONTAINER_GID}" \
     "${DB_SERVICE}" sh -ceu '
+      maximum="$1"
       data_dir="${PGDATA:-/var/lib/postgresql/data}"
+      count=0
       for source in "${data_dir}"/pg_wal/*.history; do
         [ -e "${source}" ] || continue
+        count=$((count + 1))
+        if [ "${count}" -gt "${maximum}" ]; then
+          echo "Too many PostgreSQL timeline history files" >&2
+          exit 1
+        fi
         name="${source##*/}"
         /usr/local/bin/mvn-patroni-archive-wal \
           "${source}" "${name}"
         printf "%s\n" "${name}"
       done
-    '
+    ' -- "${MAX_TIMELINE_HISTORY_FILES}"
 )" || {
   echo "Could not stage the complete PostgreSQL timeline history chain" >&2
   exit 1

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -49,6 +49,16 @@ def test_renderer_builds_synchronous_tls_patroni_config(patroni_env):
     assert dcs["synchronous_mode_strict"] is False
     assert dcs["failsafe_mode"] is True
     assert dcs["postgresql"]["use_pg_rewind"] is True
+    expected_pg_hba = [
+        "local all all trust",
+        "host all all 127.0.0.1/32 scram-sha-256",
+        "host all all 172.16.0.0/12 scram-sha-256",
+        "host replication mvn_replicator 172.16.0.0/12 scram-sha-256",
+        "host replication mvn_replicator 10.77.0.0/24 scram-sha-256",
+        "host all all 10.77.0.0/24 scram-sha-256",
+    ]
+    assert config["bootstrap"]["pg_hba"] == expected_pg_hba
+    assert config["postgresql"]["pg_hba"] == expected_pg_hba
     assert config["postgresql"]["authentication"]["superuser"]["password"] == (
         patroni_env["POSTGRES_PASSWORD"]
     )

--- a/tests/unit/test_pitr_cluster_migration.py
+++ b/tests/unit/test_pitr_cluster_migration.py
@@ -52,6 +52,7 @@ class FakeOperations:
         self.release_failure = None
         self.secret_failure = None
         self.maintenance_failure = None
+        self.fenced_provision_failure = False
         self.role_agent_failure = None
         self.role_agent_fail_once = set()
         self.release_results = {}
@@ -135,6 +136,19 @@ class FakeOperations:
         if self.role_agent_failure == (phase, node.alias):
             raise RuntimeError("simulated role-agent phase failure")
 
+    def fenced_provision(
+        self,
+        *,
+        node,
+        context,
+        bootstrap_helper,
+        transaction_id,
+        runner,
+    ):
+        self.events.append(("fenced-provision", node.alias, transaction_id))
+        if self.fenced_provision_failure:
+            raise RuntimeError("simulated fenced provision failure")
+
     def dependencies(self):
         return MigrationDependencies(
             discover=self.discover,
@@ -142,6 +156,7 @@ class FakeOperations:
             release=self.release,
             secret=self.secret,
             maintenance=self.maintenance,
+            fenced_provision=self.fenced_provision,
             role_agent=self.role_agent,
         )
 
@@ -177,7 +192,7 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("maintenance", "provision-node", "zakup", TXID),
         ("role-agent", "resume-standby", "zakup", TXID),
         ("role-agent", "quiesce-fenced", "mvn-api", TXID),
-        ("maintenance", "provision-node", "mvn-api", TXID),
+        ("fenced-provision", "mvn-api", TXID),
         ("role-agent", "resume-primary", "mvn-api", TXID),
         ("secret", "configure-node", "zakup", TXID, ENV_TEXT),
         ("secret", "configure-node", "mvn-api", TXID, ENV_TEXT),
@@ -260,8 +275,7 @@ def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path)
         )
 
     assert not any(
-        event[:3] == ("maintenance", "provision-node", "mvn-api")
-        for event in operations.events
+        event[0] == "fenced-provision" for event in operations.events
     )
     assert [event[1] for event in operations.events if event[0] == "release"] == [
         "inspect",
@@ -344,6 +358,28 @@ def test_ambiguous_failure_during_first_provision_never_rolls_back(tmp_path):
     ]
 
 
+def test_primary_fenced_provision_failure_recovers_agents_for_same_tx(tmp_path):
+    operations = FakeOperations()
+    operations.fenced_provision_failure = True
+
+    with pytest.raises(RuntimeError, match=f"resume with the same transaction ID {TXID}"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert ("fenced-provision", "mvn-api", TXID) in operations.events
+    role_events = [event for event in operations.events if event[0] == "role-agent"]
+    assert [event[1:3] for event in role_events[-2:]] == [
+        ("resume-standby", "zakup"),
+        ("resume-primary", "mvn-api"),
+    ]
+    assert not any(event[0] == "release" and event[1] == "rollback" for event in operations.events)
+
+
 def test_quiesce_is_standby_first_and_ambiguous_failure_recovers_both_agents(
     tmp_path,
 ):
@@ -373,8 +409,7 @@ def test_quiesce_is_standby_first_and_ambiguous_failure_recovers_both_agents(
         ("role-agent", "resume-primary", "mvn-api", TXID),
     ]
     assert not any(
-        event[:3] == ("maintenance", "provision-node", "mvn-api")
-        for event in operations.events
+        event[0] == "fenced-provision" for event in operations.events
     )
 
 

--- a/tests/unit/test_pitr_cluster_migration.py
+++ b/tests/unit/test_pitr_cluster_migration.py
@@ -186,7 +186,9 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("release", "inspect", "mvn-api", TXID),
         ("release", "apply", "zakup", TXID),
         ("release", "apply", "mvn-api", TXID),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
         ("secret", "preflight", "zakup", TXID, ENV_TEXT),
+        ("role-agent", "resume-standby", "zakup", TXID),
         ("secret", "preflight", "mvn-api", TXID, ENV_TEXT),
         ("role-agent", "quiesce-standby", "zakup", TXID),
         ("maintenance", "provision-node", "zakup", TXID),
@@ -194,11 +196,17 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("role-agent", "quiesce-fenced", "mvn-api", TXID),
         ("fenced-provision", "mvn-api", TXID),
         ("role-agent", "resume-primary", "mvn-api", TXID),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
         ("secret", "configure-node", "zakup", TXID, ENV_TEXT),
+        ("role-agent", "resume-standby", "zakup", TXID),
         ("secret", "configure-node", "mvn-api", TXID, ENV_TEXT),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
         ("maintenance", "scrub-node", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
         ("maintenance", "scrub-node", "mvn-api", TXID),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
         ("maintenance", "enable-archive-env", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
         ("maintenance", "enable-archive-env", "mvn-api", TXID),
         ("maintenance", "basebackup", "mvn-api", TXID),
         ("maintenance", "restore-drill", "mvn-api", TXID),
@@ -208,7 +216,7 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("role-agent", "resume-primary", "mvn-api", TXID),
         ("maintenance", "verify", "mvn-api", TXID),
     ]
-    assert len(operations.events) == 1 + 3 * 25
+    assert len(operations.events) == 1 + 3 * 33
     assert operations.events[0] == ("topology",)
     for index in range(1, len(operations.events), 3):
         assert operations.events[index] == ("topology",)
@@ -261,11 +269,13 @@ def test_first_bundle_digest_rejection_never_authorizes_rollback(tmp_path):
     ]
 
 
-def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path):
+def test_primary_preflight_failure_after_standby_window_requires_same_tx_resume(
+    tmp_path,
+):
     operations = FakeOperations()
     operations.secret_failure = ("preflight", "mvn-api")
 
-    with pytest.raises(RuntimeError, match="release bundles were rolled back"):
+    with pytest.raises(RuntimeError, match=f"resume with the same transaction ID {TXID}"):
         migrate_cluster(
             context=_context(tmp_path),
             env_text=ENV_TEXT,
@@ -282,8 +292,6 @@ def test_preflight_failure_rolls_back_assets_before_any_host_provision(tmp_path)
         "inspect",
         "apply",
         "apply",
-        "rollback",
-        "rollback",
     ]
 
 
@@ -402,6 +410,8 @@ def test_quiesce_is_standby_first_and_ambiguous_failure_recovers_both_agents(
     assert role_events == [
         ("role-agent", "quiesce-standby", "zakup", TXID),
         ("role-agent", "resume-standby", "zakup", TXID),
+        ("role-agent", "quiesce-standby", "zakup", TXID),
+        ("role-agent", "resume-standby", "zakup", TXID),
         ("role-agent", "quiesce-fenced", "mvn-api", TXID),
         ("role-agent", "quiesce-fenced", "mvn-api", TXID),
         ("role-agent", "quiesce-fenced", "zakup", TXID),
@@ -467,7 +477,7 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
     operations = FakeOperations()
     operations.maintenance_failure = ("provision-node", "zakup")
     # The compatibility barrier adds two proved read-only operations.
-    operations.discover_failures.add(18)
+    operations.discover_failures.add(22)
 
     with pytest.raises(RuntimeError, match="neither node was resumed"):
         migrate_cluster(
@@ -482,9 +492,9 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
     assert not any(event[1].startswith("resume-") for event in role_events[-2:])
 
 
-def test_topology_failure_before_first_provision_still_rolls_back_assets(tmp_path):
+def test_topology_failure_before_first_agent_quiesce_still_rolls_back_assets(tmp_path):
     operations = FakeOperations()
-    operations.topologies = [_topology()] * 13 + [_topology(timeline=10)]
+    operations.topologies = [_topology()] * 9 + [_topology(timeline=10)]
 
     with pytest.raises(RuntimeError, match="release bundles were rolled back"):
         migrate_cluster(

--- a/tests/unit/test_pitr_completion_attestation.py
+++ b/tests/unit/test_pitr_completion_attestation.py
@@ -1,0 +1,149 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scripts.ha import (
+    pitr_completion_attestation,
+    pitr_remote_asset_attestation,
+    pitr_remote_execution,
+)
+
+
+TXID = "0123456789abcdef0123456789abcdef"
+NONCE = "fedcba9876543210fedcba9876543210"
+WRAPPER_DIGEST = "a" * 64
+FIELDS = (
+    NONCE,
+    TXID,
+    "configure-node",
+    "/opt/mvn-reserve",
+    "docker-compose.patroni.yml",
+    '{"asset":"digest"}',
+    WRAPPER_DIGEST,
+)
+
+
+def _namespace(tmp_path: Path):
+    namespace = {}
+    source = (
+        pitr_remote_asset_attestation.REMOTE_ASSET_ATTESTATION
+        + "\n"
+        + pitr_completion_attestation.REMOTE_COMPLETION_ATTESTATION
+    )
+    exec(compile(source, "<pitr-completion-attestation>", "exec"), namespace)
+    namespace["COMPLETION_ROOT"] = str(tmp_path / "receipts")
+    namespace["COMPLETION_UID"] = os.geteuid()
+    namespace["COMPLETION_GID"] = os.getegid()
+    return namespace
+
+
+def test_completion_receipt_is_exact_atomic_and_consumed(tmp_path):
+    namespace = _namespace(tmp_path)
+
+    namespace["write_completion_receipt"](*FIELDS)
+    receipt = tmp_path / "receipts" / f"{NONCE}.json"
+
+    assert receipt.is_file()
+    assert receipt.stat().st_mode & 0o777 == 0o600
+    namespace["consume_completion_receipt"](*FIELDS)
+    assert not receipt.exists()
+
+
+def test_zero_status_without_completion_receipt_fails_closed(tmp_path):
+    namespace = _namespace(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        namespace["consume_completion_after_status"](0, *FIELDS)
+
+
+def test_nonzero_status_never_accepts_or_writes_a_completion(tmp_path):
+    namespace = _namespace(tmp_path)
+
+    assert namespace["write_completion_after_status"](1, *FIELDS) == 1
+    assert namespace["consume_completion_after_status"](1, *FIELDS) == 1
+    assert not (tmp_path / "receipts").exists()
+
+
+def test_tampered_completion_receipt_is_rejected(tmp_path):
+    namespace = _namespace(tmp_path)
+    namespace["write_completion_receipt"](*FIELDS)
+    receipt = tmp_path / "receipts" / f"{NONCE}.json"
+    payload = receipt.read_bytes()
+    receipt.write_bytes(payload.replace(b"configure-node", b"configure-nodf"))
+    receipt.chmod(0o600)
+
+    with pytest.raises(RuntimeError, match="content is invalid"):
+        namespace["consume_completion_receipt"](*FIELDS)
+
+
+def test_inline_completion_hardening_is_not_part_of_host_release_bundle():
+    bundled_names = {
+        asset.source.name for asset in pitr_remote_execution.PITR_HOST_ASSETS
+    }
+
+    assert "pitr_completion_attestation.py" not in bundled_names
+    assert "pitr_remote_asset_attestation.py" not in bundled_names
+    assert "pitr_remote_executors.py" not in bundled_names
+
+
+def test_stale_receipt_and_partial_temporary_are_scavenged(tmp_path):
+    namespace = _namespace(tmp_path)
+    namespace["write_completion_receipt"](*FIELDS)
+    root = tmp_path / "receipts"
+    receipt = root / f"{NONCE}.json"
+    temporary = root / f".{NONCE}.123.tmp"
+    temporary.write_bytes(b"partial")
+    temporary.chmod(0o600)
+    old = time.time_ns() - namespace["COMPLETION_STALE_AFTER_NS"] - 1
+    os.utime(receipt, ns=(old, old))
+    os.utime(temporary, ns=(old, old))
+
+    assert namespace["scavenge_completion_receipts"]() == 2
+    assert list(root.iterdir()) == []
+
+
+def test_recent_receipt_is_preserved_for_its_outer_executor(tmp_path):
+    namespace = _namespace(tmp_path)
+    namespace["write_completion_receipt"](*FIELDS)
+    receipt = tmp_path / "receipts" / f"{NONCE}.json"
+
+    assert namespace["scavenge_completion_receipts"]() == 0
+    assert receipt.exists()
+    assert namespace["discard_completion_receipt"](*FIELDS) is True
+    assert namespace["discard_completion_receipt"](*FIELDS) is False
+
+
+def test_scavenger_rejects_symlinked_and_hardlinked_entries(tmp_path):
+    symlink_namespace = _namespace(tmp_path / "symlink-case")
+    symlink_root = Path(symlink_namespace["COMPLETION_ROOT"])
+    symlink_root.mkdir(mode=0o700, parents=True)
+    (symlink_root / f"{NONCE}.json").symlink_to("/dev/null")
+
+    with pytest.raises(RuntimeError, match="metadata is unsafe"):
+        symlink_namespace["scavenge_completion_receipts"]()
+
+    hardlink_parent = tmp_path / "hardlink-case"
+    hardlink_parent.mkdir()
+    hardlink_namespace = _namespace(hardlink_parent)
+    hardlink_namespace["write_completion_receipt"](*FIELDS)
+    hardlink_root = Path(hardlink_namespace["COMPLETION_ROOT"])
+    receipt = hardlink_root / f"{NONCE}.json"
+    os.link(receipt, hardlink_root / f"{'1' * 32}.json")
+
+    with pytest.raises(RuntimeError, match="metadata is unsafe"):
+        hardlink_namespace["scavenge_completion_receipts"]()
+
+
+def test_recent_receipt_cap_requires_bounded_retry_not_manual_cleanup(tmp_path):
+    namespace = _namespace(tmp_path)
+    root = Path(namespace["COMPLETION_ROOT"])
+    root.mkdir(mode=0o700)
+    for index in range(64):
+        nonce = f"{index:032x}"
+        fields = (nonce, *FIELDS[1:])
+        namespace["write_completion_receipt"](*fields)
+
+    with pytest.raises(RuntimeError, match="bounded retry"):
+        namespace["scavenge_completion_receipts"]()

--- a/tests/unit/test_pitr_prerequisite_local_security.py
+++ b/tests/unit/test_pitr_prerequisite_local_security.py
@@ -2,6 +2,7 @@ import ast
 import pytest
 
 from scripts.ha import apply_postgres_pitr_primary_prerequisites as module
+from scripts.ha import pitr_remote_executors
 from scripts.ha.pitr_cluster_topology import ClusterTopology
 from scripts.ha.pitr_pinned_ssh import effective_config, ssh_args
 
@@ -89,10 +90,26 @@ def test_remote_maintenance_executor_has_literal_minimal_environment():
         "DOCKER_CONTEXT",
         "PROJECT_DIR",
         "COMPOSE_FILE",
+        "PITR_PROVISION_MODE",
     }
     assert "os.environ" not in module.REMOTE_MAINTENANCE_EXECUTOR
     assert "activate-archive" not in module.REMOTE_MAINTENANCE_EXECUTOR
     assert "docker-compose.prod.yml" not in module.REMOTE_MAINTENANCE_EXECUTOR
+
+
+def test_fenced_primary_provision_has_narrow_fail_closed_proofs():
+    source = pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    ast.parse(source, "<locked-maintenance-wrapper>")
+    assert 'expected = b"fencing\\n"' in source
+    assert "before.st_uid != 0" in source
+    assert "before.st_gid != 0" in source
+    assert "before.st_nlink != 1" in source
+    assert "stat.S_IMODE(before.st_mode) != 0o600" in source
+    assert "os.O_NOFOLLOW" in source
+    assert 'result.stdout.strip() != "inactive"' in source
+    assert '"ps",\n            "--all",\n            "-q"' in source
+    assert "primary fenced runtime still has API or bot containers" in source
+    assert 'if provision_mode == "fenced":' in source
 
 
 @pytest.mark.parametrize("phase", ["restore-drill", "verify"])

--- a/tests/unit/test_pitr_remote_execution_split.py
+++ b/tests/unit/test_pitr_remote_execution_split.py
@@ -273,6 +273,42 @@ def test_transactional_host_provision_is_an_attested_maintenance_phase(tmp_path)
     assert command[5] == "provision-node"
     assert '"provision-node": 900' in pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR
     assert '"provision-node"' in pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    assert (
+        'PROVISION_HELPER = "/usr/local/sbin/mvn-postgres-pitr-provision-host"'
+        in pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    )
+    assert 'if provision_mode == "fenced":' in (
+        pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    )
+    assert "prove_fenced_provision_state(project_dir, compose_file)" in (
+        pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    )
+    assert '"--transaction-id",\n                    transaction_id,' in (
+        pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    )
+
+
+def test_primary_fenced_provision_uses_explicit_attested_mode(tmp_path):
+    captured = []
+
+    def runner(args, stdin):
+        captured.append((list(args), stdin))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    pitr_remote_execution.run_remote_fenced_provision_phase(
+        node=PATRONI_NODES[0],
+        context=_context(tmp_path),
+        bootstrap_helper="/usr/local/sbin/mvn-postgres-pitr-bootstrap",
+        transaction_id="0123456789abcdef0123456789abcdef",
+        runner=runner,
+    )
+
+    command = shlex.split(captured[0][0][-1])
+    assert command[5] == "provision-node"
+    assert command[8] == "fenced"
+    assert command[11] == pitr_remote_executors.LOCKED_MAINTENANCE_WRAPPER
+    assert command[12] == hashlib.sha256(command[11].encode()).hexdigest()
+    assert captured[0][1] is None
 
 
 def test_role_agent_remote_command_is_pinned_and_attests_exact_assets(tmp_path):

--- a/tests/unit/test_postgres_pitr_restore_drill.py
+++ b/tests/unit/test_postgres_pitr_restore_drill.py
@@ -45,6 +45,8 @@ def test_operational_drill_backfills_original_timeline_history_before_upload():
     assert '"${POSTGRES_CONTAINER_UID}:${POSTGRES_CONTAINER_GID}" \\' in source
     assert "/usr/local/bin/mvn-patroni-archive-wal" in source
     assert 'for source in "${data_dir}"/pg_wal/*.history' in source
+    assert 'MAX_TIMELINE_HISTORY_FILES="1024"' in source
+    assert 'if [ "${count}" -gt "${maximum}" ]' in source
     assert '"${WAL_LINEAGE_HELPER}" validate-local-history' in source
     assert '--required-end-wal "${required_end_wal}"' in source
     assert "expected_history_count" not in source

--- a/tests/unit/test_postgres_pitr_restore_drill.py
+++ b/tests/unit/test_postgres_pitr_restore_drill.py
@@ -38,6 +38,25 @@ def test_operational_drill_binds_restore_to_live_lineage_and_archived_wal():
     assert '--required-end-wal "${required_end_wal}"' in source
 
 
+def test_operational_drill_backfills_original_timeline_history_before_upload():
+    source = _source()
+
+    assert '"${COMPOSE[@]}" exec -T --user \\' in source
+    assert '"${POSTGRES_CONTAINER_UID}:${POSTGRES_CONTAINER_GID}" \\' in source
+    assert "/usr/local/bin/mvn-patroni-archive-wal" in source
+    assert 'for source in "${data_dir}"/pg_wal/*.history' in source
+    assert '"${WAL_LINEAGE_HELPER}" validate-local-history' in source
+    assert '--required-end-wal "${required_end_wal}"' in source
+    assert "expected_history_count" not in source
+    assert "pg_control_checkpoint() AS c" not in source
+    assert source.index("mvn-patroni-archive-wal") < source.index(
+        '"${TOOL_RUNNER}" --phase wal-upload'
+    )
+    assert source.index('"${WAL_LINEAGE_HELPER}" validate-local-history') < source.index(
+        '"${TOOL_RUNNER}" --phase wal-upload'
+    )
+
+
 def test_disposable_postgres_has_no_network_or_database_password():
     source = _source()
 

--- a/tests/unit/test_postgres_pitr_restore_wal.py
+++ b/tests/unit/test_postgres_pitr_restore_wal.py
@@ -197,7 +197,11 @@ def test_prepare_verifies_lineage_downloads_exact_chain_and_writes_target(
     ).exists()
     assert (data_dir / "recovery.signal").is_file()
     safe_conf = (target_dir / "control/postgresql.conf").read_text()
-    assert "restore_command = 'cp /pitr-restore/wal/%f %p'" in safe_conf
+    assert (
+        "restore_command = '/usr/bin/install -m 0600 "
+        "/pitr-restore/wal/%f %p'"
+    ) in safe_conf
+    assert "restore_command = 'cp " not in safe_conf
     assert "recovery_target_action = 'pause'" in safe_conf
     assert "recovery_target_inclusive = off" in safe_conf
     assert "recovery_target_time = '2026-07-02T02:30:00+00:00'" in safe_conf

--- a/tests/unit/test_postgres_pitr_wal_lineage.py
+++ b/tests/unit/test_postgres_pitr_wal_lineage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import replace
 
 import pytest
@@ -34,6 +35,80 @@ def _history(timeline: int, payload: bytes) -> lineage.WalObject:
     return lineage.WalObject(
         f"history-{timeline}", f"{timeline:08X}.history", len(payload)
     )
+
+
+def _local_history(archive_dir, timeline: int, payload: bytes):
+    path = archive_dir / f"{timeline:08X}.history"
+    path.write_bytes(payload)
+    path.chmod(0o600)
+    return path
+
+
+def test_local_validation_accepts_sparse_ancestor_chain_before_upload(tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(mode=0o700)
+    history_3 = b"1\t0/300\tpromoted to timeline 3\n"
+    history_5 = history_3 + b"3\t0/580\tpromoted to timeline 5\n"
+    _local_history(archive_dir, 3, history_3)
+    _local_history(archive_dir, 5, history_5)
+
+    selected = lineage.validate_local_history_chain(
+        archive_dir,
+        required_end_wal="000000050000000000000006",
+        expected_uid=os.geteuid(),
+        expected_gid=os.getegid(),
+    )
+
+    assert selected == ("00000003.history", "00000005.history")
+
+
+def test_local_validation_uses_required_end_wal_timeline(tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(mode=0o700)
+    _local_history(archive_dir, 3, b"1\t0/300\tpromoted to timeline 3\n")
+
+    with pytest.raises(SystemExit, match="00000004.history"):
+        lineage.validate_local_history_chain(
+            archive_dir,
+            required_end_wal="000000040000000000000006",
+            expected_uid=os.geteuid(),
+            expected_gid=os.getegid(),
+        )
+
+
+def test_local_validation_rejects_corrupt_unselected_history_before_upload(tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(mode=0o700)
+    _local_history(archive_dir, 3, b"1\t0/300\tpromoted to timeline 3\n")
+    _local_history(archive_dir, 7, b"not a PostgreSQL history file\n")
+
+    with pytest.raises(SystemExit, match="history line is invalid"):
+        lineage.validate_local_history_chain(
+            archive_dir,
+            required_end_wal="000000030000000000000006",
+            expected_uid=os.geteuid(),
+            expected_gid=os.getegid(),
+        )
+
+
+def test_local_validation_rejects_linked_history_before_upload(tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(mode=0o700)
+    original = _local_history(
+        archive_dir,
+        3,
+        b"1\t0/300\tpromoted to timeline 3\n",
+    )
+    linked = archive_dir / "00000005.history"
+    os.link(original, linked)
+
+    with pytest.raises(SystemExit, match="metadata is unsafe"):
+        lineage.validate_local_history_chain(
+            archive_dir,
+            required_end_wal="000000030000000000000006",
+            expected_uid=os.geteuid(),
+            expected_gid=os.getegid(),
+        )
 
 
 def _failover_objects() -> tuple[list[lineage.WalObject], dict[str, bytes]]:

--- a/tests/unit/test_postgres_pitr_wal_lineage.py
+++ b/tests/unit/test_postgres_pitr_wal_lineage.py
@@ -111,6 +111,25 @@ def test_local_validation_rejects_linked_history_before_upload(tmp_path):
         )
 
 
+def test_local_validation_matches_remote_history_count_limit(tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir(mode=0o700)
+    for timeline in range(2, lineage.MAX_TIMELINE_HISTORY_FILES + 3):
+        _local_history(
+            archive_dir,
+            timeline,
+            b"1\t0/100\tvalid sparse branch\n",
+        )
+
+    with pytest.raises(SystemExit, match="Too many PostgreSQL timeline history files"):
+        lineage.validate_local_history_chain(
+            archive_dir,
+            required_end_wal="000000030000000000000006",
+            expected_uid=os.geteuid(),
+            expected_gid=os.getegid(),
+        )
+
+
 def _failover_objects() -> tuple[list[lineage.WalObject], dict[str, bytes]]:
     history_3 = b"1\t0/300\tpromoted to timeline 3\n"
     history_5 = history_3 + b"3\t0/580\tpromoted to timeline 5\n"


### PR DESCRIPTION
## Что исправлено

- сохраняет generic bootstrap provisioning для standby;
- добавляет отдельный fail-closed путь только для primary после `quiesce-fenced`;
- требует exact root-owned `fencing` state, inactive role-agent и пустой all-state API/bot runtime под global + deploy locks;
- вызывает только attested provision helper с canonical аргументами;
- сохраняет topology guards и same-transaction recovery.

## Production incident

Fresh PITR transaction `0a3c8e9b2f1d4a7685c0e3f9b7d2a641` дошла до primary `quiesce-fenced`, после чего generic bootstrap runtime gate закономерно отказал из-за отсутствия live API slot. Controller восстановил оба role-agent и оставил exact same-tx roll-forward state. Этот patch не меняет `PITR_HOST_ASSETS`; вычисленные release digests совпадают с active journal и позволяют безопасный resume.

## Проверки

- `2251 passed, 4 skipped`
- targeted PITR suite: `80 passed`
- embedded executors AST/py_compile/diff-check: passed
- independent review: CLEAR P0-P2
- production during pause: API 200, Patroni streaming/sync, valid markers, timers fenced