### PR TITLE
Fix logical restore resource sizing

### DIFF
--- a/scripts/ha/calculate_logical_restore_resources.py
+++ b/scripts/ha/calculate_logical_restore_resources.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Calculate a bounded resource envelope for a logical PostgreSQL restore."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+
+MIB = 1024**2
+GIB = 1024**3
+
+MAX_SQL_BYTES = 8 * GIB
+MAX_DATA_TMPFS_BYTES = 10 * GIB
+MAX_CONTAINER_MEMORY_BYTES = 12 * GIB
+MAX_PRIMARY_CONTAINER_MEMORY_BYTES = 4 * GIB
+PRIMARY_MEMORY_SHARE_DENOMINATOR = 4
+
+DATA_TMPFS_FLOOR_BYTES = 512 * MIB
+DATA_GROWTH_MULTIPLIER = 2
+WAL_AND_INDEX_ALLOWANCE_BYTES = 256 * MIB
+PROCESS_MEMORY_ALLOWANCE_BYTES = 256 * MIB
+HOST_RESERVE_FLOOR_BYTES = 1 * GIB
+ROUNDING_BYTES = 64 * MIB
+
+
+class ResourceSizingError(ValueError):
+    """Raised when the restore cannot fit the reviewed primary-host envelope."""
+
+
+@dataclass(frozen=True)
+class RestoreResources:
+    data_tmpfs_bytes: int
+    container_memory_bytes: int
+    host_reserve_bytes: int
+    required_available_bytes: int
+    primary_container_limit_bytes: int
+
+
+def _round_up(value: int, quantum: int = ROUNDING_BYTES) -> int:
+    return ((value + quantum - 1) // quantum) * quantum
+
+
+def calculate_resources(
+    *, sql_bytes: int, live_database_bytes: int, host_total_bytes: int
+) -> RestoreResources:
+    for name, value in (
+        ("sql_bytes", sql_bytes),
+        ("live_database_bytes", live_database_bytes),
+        ("host_total_bytes", host_total_bytes),
+    ):
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ResourceSizingError(f"{name} must be a positive integer")
+
+    if sql_bytes > MAX_SQL_BYTES:
+        raise ResourceSizingError("expanded SQL exceeds the absolute anti-bomb limit")
+
+    base_bytes = max(sql_bytes, live_database_bytes)
+    data_tmpfs_bytes = _round_up(
+        max(
+            DATA_TMPFS_FLOOR_BYTES,
+            DATA_GROWTH_MULTIPLIER * base_bytes + WAL_AND_INDEX_ALLOWANCE_BYTES,
+        )
+    )
+    container_memory_bytes = data_tmpfs_bytes + PROCESS_MEMORY_ALLOWANCE_BYTES
+    host_reserve_bytes = max(
+        HOST_RESERVE_FLOOR_BYTES,
+        host_total_bytes // PRIMARY_MEMORY_SHARE_DENOMINATOR,
+    )
+    primary_container_limit_bytes = min(
+        MAX_PRIMARY_CONTAINER_MEMORY_BYTES,
+        host_total_bytes // PRIMARY_MEMORY_SHARE_DENOMINATOR,
+    )
+
+    if data_tmpfs_bytes > MAX_DATA_TMPFS_BYTES:
+        raise ResourceSizingError("derived data tmpfs exceeds the absolute reviewed limit")
+    if container_memory_bytes > MAX_CONTAINER_MEMORY_BYTES:
+        raise ResourceSizingError("derived container memory exceeds the absolute reviewed limit")
+    if container_memory_bytes > primary_container_limit_bytes:
+        raise ResourceSizingError(
+            "logical restore exceeds the reviewed primary-host memory share; "
+            "use a dedicated restore host"
+        )
+
+    required_available_bytes = container_memory_bytes + host_reserve_bytes
+    if required_available_bytes > host_total_bytes:
+        raise ResourceSizingError(
+            "logical restore cannot preserve the reviewed host memory reserve"
+        )
+
+    return RestoreResources(
+        data_tmpfs_bytes=data_tmpfs_bytes,
+        container_memory_bytes=container_memory_bytes,
+        host_reserve_bytes=host_reserve_bytes,
+        required_available_bytes=required_available_bytes,
+        primary_container_limit_bytes=primary_container_limit_bytes,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sql-bytes", type=int, required=True)
+    parser.add_argument("--live-database-bytes", type=int, required=True)
+    parser.add_argument("--host-total-bytes", type=int, required=True)
+    args = parser.parse_args()
+
+    try:
+        resources = calculate_resources(
+            sql_bytes=args.sql_bytes,
+            live_database_bytes=args.live_database_bytes,
+            host_total_bytes=args.host_total_bytes,
+        )
+    except ResourceSizingError as exc:
+        parser.error(str(exc))
+
+    print(
+        resources.data_tmpfs_bytes,
+        resources.container_memory_bytes,
+        resources.host_reserve_bytes,
+        resources.required_available_bytes,
+        resources.primary_container_limit_bytes,
+        sep="\t",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/install_postgres_pitr_units.sh
+++ b/scripts/ha/install_postgres_pitr_units.sh
@@ -147,6 +147,7 @@ install -o root -g root -m 0755 scripts/ha/bootstrap_postgres_pitr.sh /usr/local
 install -o root -g root -m 0755 scripts/ha/verify_postgres_pitr_runtime.py /usr/local/sbin/mvn-postgres-pitr-runtime-check
 install -o root -g root -m 0755 scripts/ha/run_postgres_pitr_scheduled.py /usr/local/sbin/mvn-postgres-pitr-scheduled-runner
 install -o root -g root -m 0755 scripts/ha/run_postgres_pitr_manual.py /usr/local/sbin/mvn-postgres-pitr-manual-runner
+install -o root -g root -m 0755 scripts/ha/calculate_logical_restore_resources.py /usr/local/sbin/mvn-logical-restore-resource-sizer
 install -o root -g root -m 0755 scripts/ha/restore_drill_latest_db.sh /usr/local/sbin/mvn-restore-drill-latest-db
 install -o root -g root -m 0755 scripts/ha/cleanup_restore_drill_runtime.sh /usr/local/sbin/mvn-restore-drill-latest-db-cleanup
 install -o root -g root -m 0755 scripts/ha/run_postgres_pitr_tool.py /usr/local/sbin/mvn-postgres-pitr-tool-runner

--- a/scripts/ha/pitr_bundle_executor_prelude.py
+++ b/scripts/ha/pitr_bundle_executor_prelude.py
@@ -41,6 +41,7 @@ BASE_MODES = {
     "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,

--- a/scripts/ha/pitr_bundle_transport.py
+++ b/scripts/ha/pitr_bundle_transport.py
@@ -41,6 +41,7 @@ BASE_REMOTE_ASSET_MODES = {
     "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,

--- a/scripts/ha/pitr_remote_asset_attestation.py
+++ b/scripts/ha/pitr_remote_asset_attestation.py
@@ -33,6 +33,7 @@ EXPECTED_ASSET_MODES = {
     "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -146,6 +146,11 @@ PITR_HOST_ASSETS = (
         0o755,
     ),
     PitrHostAsset(
+        REPO_ROOT / "scripts/ha/calculate_logical_restore_resources.py",
+        "/usr/local/sbin/mvn-logical-restore-resource-sizer",
+        0o755,
+    ),
+    PitrHostAsset(
         REPO_ROOT / "scripts/ha/restore_drill_latest_db.sh",
         "/usr/local/sbin/mvn-restore-drill-latest-db",
         0o755,

--- a/scripts/ha/restore_drill_latest_db.sh
+++ b/scripts/ha/restore_drill_latest_db.sh
@@ -13,11 +13,9 @@ POSTGRES_IMAGE="postgres:15.18-alpine@sha256:3d0f7584ed7d04e27fa050d6683a7474660
 EXPECTED_DRILL_ROOT="/var/lib/mvn-postgres-pitr/logical-restore-drills"
 EXPECTED_CLEANUP_SCRIPT="/usr/local/sbin/mvn-restore-drill-latest-db-cleanup"
 RUNTIME_CHECK_HELPER="/usr/local/sbin/mvn-postgres-pitr-runtime-check"
+RESOURCE_SIZING_HELPER="/usr/local/sbin/mvn-logical-restore-resource-sizer"
 MIN_PUBLIC_TABLES="64"
 MAX_RESTORED_SQL_BYTES="8589934592"
-POSTGRES_DATA_TMPFS_BYTES="10737418240"
-POSTGRES_MEMORY_BYTES="12884901888"
-POSTGRES_REQUIRED_HOST_MEMORY_BYTES="13958643712"
 RESTORE_TIMEOUT_SECONDS="900"
 POSTGRES_CONTAINER_UID="70"
 POSTGRES_CONTAINER_GID="70"
@@ -57,6 +55,8 @@ esac
   fail "installed restore-drill cleanup helper is unavailable or unsafe"
 [[ -x "${RUNTIME_CHECK_HELPER}" && ! -L "${RUNTIME_CHECK_HELPER}" ]] ||
   fail "installed PITR runtime attestation helper is unavailable or unsafe"
+[[ -x "${RESOURCE_SIZING_HELPER}" && ! -L "${RESOURCE_SIZING_HELPER}" ]] ||
+  fail "installed logical restore resource-sizing helper is unavailable or unsafe"
 [[ -d "${PROJECT_DIR}" && ! -L "${PROJECT_DIR}" ]] ||
   fail "reviewed project directory is unavailable or unsafe"
 [[ -f "${PROJECT_DIR}/${COMPOSE_FILE}" && ! -L "${PROJECT_DIR}/${COMPOSE_FILE}" ]] ||
@@ -74,11 +74,15 @@ BACKEND_IMAGE="$(
 export BACKEND_IMAGE
 COMPOSE=(docker compose -f "${COMPOSE_FILE}")
 
-in_recovery="$(
+database_state="$(
   "${COMPOSE[@]}" exec -T "${DB_SERVICE}" sh -lc \
-    'exec psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -Atqc "SELECT pg_is_in_recovery()"'
-)" || fail "could not prove live PostgreSQL role"
+    'exec psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -AtF "|" -qc "SELECT pg_is_in_recovery(), pg_database_size(current_database())"'
+)" || fail "could not prove live PostgreSQL role and size"
+[[ "${database_state}" != *$'\n'* ]] || fail "live PostgreSQL state is ambiguous"
+IFS='|' read -r in_recovery live_database_bytes unexpected_database_state <<<"${database_state}"
 [[ "${in_recovery}" == "f" ]] || fail "logical restore drill must run on the writable primary"
+[[ "${live_database_bytes}" =~ ^[1-9][0-9]*$ && -z "${unexpected_database_state}" ]] ||
+  fail "live PostgreSQL size attestation is invalid"
 
 run_id="${PITR_OPERATION_ID}"
 drill_dir="${DRILL_ROOT}/${run_id}"
@@ -333,25 +337,47 @@ sed '/^SET transaction_timeout = .*;$/d' "${sql_path}" >"${normalized_sql}"
   fail "normalized logical database backup is empty or unsafe"
 mv -f -- "${normalized_sql}" "${sql_path}"
 
-# The data tmpfs is charged to the container cgroup.  Refuse to start unless
-# the fixed cgroup budget, Docker host capacity, and currently available host
-# memory can all satisfy the reviewed restore envelope.
-(( POSTGRES_DATA_TMPFS_BYTES >= MAX_RESTORED_SQL_BYTES + 2147483648 )) ||
-  fail "logical restore data tmpfs is smaller than the accepted artifact envelope"
-(( POSTGRES_MEMORY_BYTES >= POSTGRES_DATA_TMPFS_BYTES + 2147483648 )) ||
-  fail "logical restore cgroup memory is smaller than the data tmpfs envelope"
-(( POSTGRES_REQUIRED_HOST_MEMORY_BYTES >= POSTGRES_MEMORY_BYTES + 1073741824 )) ||
-  fail "logical restore host memory reserve is inconsistent"
-host_available_kib="$(awk '$1 == "MemAvailable:" {print $2}' /proc/meminfo)"
+sql_bytes="$(stat -Lc '%s' "${sql_path}" 2>/dev/null || true)"
 docker_memory_bytes="$(docker info --format '{{.MemTotal}}')" ||
   fail "could not inspect Docker host memory capacity"
-[[ "${host_available_kib}" =~ ^[1-9][0-9]*$ && "${docker_memory_bytes}" =~ ^[1-9][0-9]*$ ]] ||
+[[ "${sql_bytes}" =~ ^[1-9][0-9]*$ && "${docker_memory_bytes}" =~ ^[1-9][0-9]*$ ]] ||
   fail "logical restore host memory capacity is invalid"
-host_available_bytes=$((host_available_kib * 1024))
-(( host_available_bytes >= POSTGRES_REQUIRED_HOST_MEMORY_BYTES )) ||
-  fail "logical restore host has insufficient currently available memory"
-(( docker_memory_bytes >= POSTGRES_REQUIRED_HOST_MEMORY_BYTES )) ||
-  fail "Docker host memory is below the reviewed logical restore envelope"
+resource_envelope="$(
+  /usr/bin/python3 -I "${RESOURCE_SIZING_HELPER}" \
+    --sql-bytes "${sql_bytes}" \
+    --live-database-bytes "${live_database_bytes}" \
+    --host-total-bytes "${docker_memory_bytes}"
+)" || fail "logical restore does not fit the reviewed primary-host resource envelope"
+[[ "${resource_envelope}" != *$'\n'* ]] ||
+  fail "logical restore resource-sizing output is ambiguous"
+IFS=$'\t' read -r POSTGRES_DATA_TMPFS_BYTES POSTGRES_MEMORY_BYTES \
+  POSTGRES_HOST_RESERVE_BYTES POSTGRES_REQUIRED_HOST_MEMORY_BYTES \
+  POSTGRES_PRIMARY_MEMORY_LIMIT_BYTES unexpected_resource_field <<<"${resource_envelope}"
+for resource_value in \
+  "${POSTGRES_DATA_TMPFS_BYTES}" \
+  "${POSTGRES_MEMORY_BYTES}" \
+  "${POSTGRES_HOST_RESERVE_BYTES}" \
+  "${POSTGRES_REQUIRED_HOST_MEMORY_BYTES}" \
+  "${POSTGRES_PRIMARY_MEMORY_LIMIT_BYTES}"; do
+  [[ "${resource_value}" =~ ^[1-9][0-9]*$ ]] ||
+    fail "logical restore resource-sizing output is invalid"
+done
+[[ -z "${unexpected_resource_field}" ]] ||
+  fail "logical restore resource-sizing output is ambiguous"
+
+check_available_memory() {
+  local host_available_kib=""
+  local host_available_bytes=0
+  host_available_kib="$(awk '$1 == "MemAvailable:" {print $2}' /proc/meminfo)"
+  [[ "${host_available_kib}" =~ ^[1-9][0-9]*$ ]] ||
+    fail "logical restore host available memory is invalid"
+  host_available_bytes=$((host_available_kib * 1024))
+  (( host_available_bytes >= POSTGRES_REQUIRED_HOST_MEMORY_BYTES )) ||
+    fail "logical restore host has insufficient currently available memory"
+}
+
+check_available_memory
+log "resource_envelope sql_bytes=${sql_bytes} live_database_bytes=${live_database_bytes} data_tmpfs_bytes=${POSTGRES_DATA_TMPFS_BYTES} container_memory_bytes=${POSTGRES_MEMORY_BYTES} host_reserve_bytes=${POSTGRES_HOST_RESERVE_BYTES}"
 
 /usr/bin/python3 -I - "${credentials_file}" "${POSTGRES_USER}" "${POSTGRES_DB}" <<'PY'
 import os
@@ -391,6 +417,9 @@ existing_container="$(docker ps -aq --filter "name=^/${container}$")" ||
   fail "could not inventory the logical restore container name"
 [[ -z "${existing_container}" ]] ||
   fail "logical restore runtime name is already in use"
+# Downloading and normalization can change page-cache pressure.  Re-check the
+# exact available-memory gate immediately before Docker creates the cgroup.
+check_available_memory
 docker run --pull never -d \
   --name "${container}" \
   --label com.mvn.purpose=api-restore-drill \

--- a/scripts/ha/run_postgres_pitr_manual.py
+++ b/scripts/ha/run_postgres_pitr_manual.py
@@ -55,6 +55,7 @@ BASE_RELEASE_MODES = {
     "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,

--- a/scripts/ha/run_postgres_pitr_scheduled.py
+++ b/scripts/ha/run_postgres_pitr_scheduled.py
@@ -77,6 +77,7 @@ BASE_RELEASE_MODES = {
     "/usr/local/sbin/mvn-postgres-pitr-runtime-check": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-scheduled-runner": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-manual-runner": 0o755,
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db": 0o755,
     "/usr/local/sbin/mvn-restore-drill-latest-db-cleanup": 0o755,
     "/usr/local/sbin/mvn-postgres-pitr-tool-runner": 0o755,

--- a/tests/unit/test_ha_alert_workflows.py
+++ b/tests/unit/test_ha_alert_workflows.py
@@ -135,7 +135,8 @@ def test_restore_drill_waits_for_stable_sql_and_checks_business_data():
     assert "--env-file" in script
     assert "PGPASSWORD" not in script
     assert "statvfs" in script
-    assert 'POSTGRES_DATA_TMPFS_BYTES="10737418240"' in script
+    assert 'RESOURCE_SIZING_HELPER="/usr/local/sbin/mvn-logical-restore-resource-sizer"' in script
+    assert 'log "resource_envelope sql_bytes=${sql_bytes}' in script
     assert "MediaIoBaseDownload" in script
     assert "download_backup_file" not in script
     assert 'RUNTIME_CHECK_HELPER="/usr/local/sbin/mvn-postgres-pitr-runtime-check"' in script

--- a/tests/unit/test_logical_restore_resource_sizing.py
+++ b/tests/unit/test_logical_restore_resource_sizing.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.ha.calculate_logical_restore_resources import (
+    GIB,
+    MIB,
+    ResourceSizingError,
+    calculate_resources,
+)
+
+
+def test_current_database_uses_a_small_bounded_primary_share():
+    resources = calculate_resources(
+        sql_bytes=20 * MIB,
+        live_database_bytes=62 * MIB,
+        host_total_bytes=3900 * MIB,
+    )
+
+    assert resources.data_tmpfs_bytes == 512 * MIB
+    assert resources.container_memory_bytes == 768 * MIB
+    assert resources.host_reserve_bytes == GIB
+    assert resources.required_available_bytes == 1792 * MIB
+    assert resources.primary_container_limit_bytes == 975 * MIB
+
+
+def test_sizing_rounds_up_from_the_larger_live_database():
+    resources = calculate_resources(
+        sql_bytes=700 * MIB,
+        live_database_bytes=900 * MIB,
+        host_total_bytes=16 * GIB,
+    )
+
+    assert resources.data_tmpfs_bytes == 2112 * MIB
+    assert resources.container_memory_bytes == 2368 * MIB
+    assert resources.host_reserve_bytes == 4 * GIB
+    assert resources.required_available_bytes == 6464 * MIB
+    assert resources.primary_container_limit_bytes == 4 * GIB
+
+
+@pytest.mark.parametrize(
+    ("sql_bytes", "live_database_bytes", "host_total_bytes"),
+    (
+        (0, 1, 1),
+        (1, 0, 1),
+        (1, 1, 0),
+        (-1, 1, 1),
+        (True, 1, 1),
+    ),
+)
+def test_sizing_rejects_invalid_inputs(
+    sql_bytes: int, live_database_bytes: int, host_total_bytes: int
+):
+    with pytest.raises(ResourceSizingError):
+        calculate_resources(
+            sql_bytes=sql_bytes,
+            live_database_bytes=live_database_bytes,
+            host_total_bytes=host_total_bytes,
+        )
+
+
+def test_absolute_sql_cap_remains_independent_from_runtime_sizing():
+    with pytest.raises(ResourceSizingError, match="anti-bomb"):
+        calculate_resources(
+            sql_bytes=8 * GIB + 1,
+            live_database_bytes=62 * MIB,
+            host_total_bytes=64 * GIB,
+        )
+
+
+def test_large_restore_is_routed_away_from_the_primary():
+    with pytest.raises(ResourceSizingError, match="dedicated restore host"):
+        calculate_resources(
+            sql_bytes=2 * GIB,
+            live_database_bytes=2 * GIB,
+            host_total_bytes=16 * GIB,
+        )
+
+
+def test_tiny_host_cannot_preserve_the_minimum_reserve():
+    with pytest.raises(ResourceSizingError, match="primary-host memory share"):
+        calculate_resources(
+            sql_bytes=20 * MIB,
+            live_database_bytes=62 * MIB,
+            host_total_bytes=2 * GIB,
+        )

--- a/tests/unit/test_restore_drill_cleanup.py
+++ b/tests/unit/test_restore_drill_cleanup.py
@@ -74,15 +74,16 @@ def test_logical_drill_uses_root_state_and_isolated_generated_credentials():
     assert '${POSTGRES_IMAGE:-' not in text
     assert '${APP_SERVICE:-' not in text
     assert '${DB_SERVICE:-' not in text
-    assert 'POSTGRES_DATA_TMPFS_BYTES="10737418240"' in text
-    assert 'POSTGRES_MEMORY_BYTES="12884901888"' in text
-    assert 'POSTGRES_REQUIRED_HOST_MEMORY_BYTES="13958643712"' in text
+    assert 'RESOURCE_SIZING_HELPER="/usr/local/sbin/mvn-logical-restore-resource-sizer"' in text
+    assert '--live-database-bytes "${live_database_bytes}"' in text
+    assert '--host-total-bytes "${docker_memory_bytes}"' in text
     assert '--memory "${POSTGRES_MEMORY_BYTES}"' in text
     assert '--memory-swap "${POSTGRES_MEMORY_BYTES}"' in text
     assert 'host.get("Memory") != int(memory)' in text
     assert 'host.get("MemorySwap") != int(memory)' in text
     assert 'docker info --format \'{{.MemTotal}}\'' in text
     assert 'host_available_bytes >= POSTGRES_REQUIRED_HOST_MEMORY_BYTES' in text
+    assert text.count("check_available_memory") >= 3
     assert '--tmpfs "/var/lib/postgresql/data:rw,nosuid,nodev,size=${POSTGRES_DATA_TMPFS_BYTES}' in text
     assert 'type=volume' not in text
     assert 'data tmpfs quota is invalid' in text


### PR DESCRIPTION
## Summary
- derive the disposable PostgreSQL tmpfs/cgroup envelope from the exact SQL and live database sizes
- cap restore memory at 25% of the primary host while preserving at least 25%/1 GiB for production
- keep absolute anti-bomb limits and fail with dedicated-host guidance when the restore outgrows the primary
- ship and attest the isolated sizing helper through the existing PITR release bundle

## Verification
- 2079 unit tests passed, 4 skipped
- 70 focused PITR/restore tests passed
- bash syntax, Python compile, diff checks passed
- independent P0/P1 review: CLEAR

## Production follow-up
After merge/deploy, rerun API Restore Drill and inspect the actual derived envelope and cleanup.