### PR TITLE
Allow logical restore asset release evolution

### DIFF
--- a/scripts/ha/pitr_bundle_executor_prelude.py
+++ b/scripts/ha/pitr_bundle_executor_prelude.py
@@ -64,6 +64,7 @@ BASE_MODES = {
     "/etc/systemd/system/mvn-postgres-basebackup.timer": 0o644,
 }
 PREVIOUS_RELEASE_ADDITIONS = {
+    "/usr/local/sbin/mvn-logical-restore-resource-sizer",
     LIBEXEC_DIR + "/require_deploy_capacity.sh",
     LIBEXEC_DIR + "/safe_deploy_lock.py",
     LIBEXEC_DIR + "/verify_pitr_maintenance_marker.py",

--- a/tests/unit/test_pitr_bundle_transport.py
+++ b/tests/unit/test_pitr_bundle_transport.py
@@ -117,6 +117,7 @@ def test_real_bundle_is_deterministic_complete_and_bounded():
     remote = {"__name__": "pitr_bundle_policy_test"}
     exec(compile(source, "<pitr-bundle-policy>", "exec"), remote)
     assert remote["PREVIOUS_RELEASE_ADDITIONS"] == {
+        "/usr/local/sbin/mvn-logical-restore-resource-sizer",
         "/usr/local/libexec/mvn-pitr/require_deploy_capacity.sh",
         "/usr/local/libexec/mvn-pitr/safe_deploy_lock.py",
         "/usr/local/libexec/mvn-pitr/verify_pitr_maintenance_marker.py",


### PR DESCRIPTION
## Summary
- declare the new logical restore resource sizer as the exact reviewed addition to the previous PITR release manifest
- preserve fail-closed rejection for every other missing path
- update the executable release-policy regression test

## Root cause
The first production drill after #757 correctly refused the 36-file installed PITR manifest because the new 37th asset had not been listed in `PREVIOUS_RELEASE_ADDITIONS`. No restore container was started and production stayed healthy.

## Verification
- 70 focused PITR/restore tests passed
- live nodes confirmed old manifest is intact, marker/operation state is clean, and the sizer is not partially installed

## Rollout
After merge, perform the guarded two-node PITR release migration before rerunning the logical restore drill.