### PR TITLE
fix(ha): route strict readiness PITR through guarded runner

### DIFF
--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -76,6 +76,7 @@ jobs:
           export PRIMARY_COMPOSE_FILE="${API_COMPOSE_FILE}"
           export STANDBY_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
           export STANDBY_COMPOSE_FILE="${API_STANDBY_COMPOSE_FILE}"
+          export PITR_WORKFLOW_IDENTITY_FILE="${HOME}/.ssh/ha_readiness_key"
           bash scripts/ha/check_api_ha_readiness.sh | tee api-ha-readiness.log
 
       - name: Write Summary

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -147,8 +147,18 @@ run_postgres_pitr() {
     soft_blocker "POSTGRES_PITR_REQUIRED is not true; PITR is monitored in soft mode only"
   fi
 
+  if is_true "${pitr_required}"; then
+    if [[ -z "${PITR_WORKFLOW_IDENTITY_FILE:-}" || ! -f "${PITR_WORKFLOW_IDENTITY_FILE}" || -L "${PITR_WORKFLOW_IDENTITY_FILE}" ]]; then
+      log fail "strict PITR proof requires a regular SSH identity file"
+      return 1
+    fi
+    python3 -I scripts/ha/run_postgres_pitr_workflow.py --phase verify \
+      < "${PITR_WORKFLOW_IDENTITY_FILE}"
+    return
+  fi
+
   local remote_cmd
-  remote_cmd="PROJECT_DIR=$(quote_remote "${PRIMARY_PROJECT_DIR}") COMPOSE_FILE=$(quote_remote "${PRIMARY_COMPOSE_FILE}") PITR_REQUIRED=$(quote_remote "${pitr_required}") /usr/local/sbin/mvn-postgres-pitr-status"
+  remote_cmd="PROJECT_DIR=$(quote_remote "${PRIMARY_PROJECT_DIR}") COMPOSE_FILE=$(quote_remote "${PRIMARY_COMPOSE_FILE}") PITR_REQUIRED=false /usr/local/sbin/mvn-postgres-pitr-status"
   # shellcheck disable=SC2029,SC2086
   ssh ${SSH_OPTS:-} "${PRIMARY_SSH}" "${remote_cmd}"
 }

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -43,6 +43,7 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert "scripts/ha/check_api_ha_readiness.sh" in audit_step["run"]
     assert "PRIMARY_SSH" in audit_step["run"]
     assert "STANDBY_SSH" in audit_step["run"]
+    assert "PITR_WORKFLOW_IDENTITY_FILE" in audit_step["run"]
     assert "api-ha-readiness.log" in audit_step["run"]
     assert "strict:" in summary_step["run"]
     assert artifact_step["if"] == "always()"
@@ -58,6 +59,17 @@ def test_ha_readiness_resolves_patroni_primary_and_uses_role_aware_monitor():
     assert "python3 scripts/ha/check_patroni_production.py" in script
     assert 'API_DB_HA_MODE="${API_DB_HA_MODE:-physical}"' in script
     assert 'CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"' in script
+
+
+def test_ha_readiness_routes_required_pitr_through_guarded_workflow():
+    script = (REPO_ROOT / "scripts/ha/check_api_ha_readiness.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'if is_true "${pitr_required}"; then' in script
+    assert "PITR_WORKFLOW_IDENTITY_FILE" in script
+    assert "run_postgres_pitr_workflow.py --phase verify" in script
+    assert "PITR_REQUIRED=false /usr/local/sbin/mvn-postgres-pitr-status" in script
 
 
 def test_ha_invariant_workflow_skips_public_cloudflare_challenge_from_runner():


### PR DESCRIPTION
## Summary
- route required/strict PITR readiness checks through the guarded workflow runner
- retain the direct read-only status path for soft monitoring
- wire the existing ephemeral SSH identity file into the strict proof

## Validation
- `pytest tests/unit/test_ha_readiness_workflow.py tests/unit/test_postgres_pitr_workflow_runner.py tests/unit/test_postgres_pitr_workflows.py -q` (18 passed)
- `bash -n scripts/ha/check_api_ha_readiness.sh`
- live scoped strict proof against the Patroni cluster: passed, exact WAL upload verified, zero PITR failures/warnings