### PR TITLE
fix(ha): make PITR config replay payload-bound

### DIFF
--- a/scripts/ha/bootstrap_postgres_pitr.sh
+++ b/scripts/ha/bootstrap_postgres_pitr.sh
@@ -264,31 +264,6 @@ reviewed_node_alias() {
   esac
 }
 
-config_subtransaction_id() {
-  local stage="$1" node_alias
-  require_transaction_id
-  case "${stage}" in
-    configure-node|enable-archive) ;;
-    *) die "unreviewed PITR config transaction stage" ;;
-  esac
-  node_alias="$(reviewed_node_alias)"
-  /usr/bin/python3 -I - "${PITR_TRANSACTION_ID}" "${node_alias}" "${stage}" <<'PY'
-import hashlib
-import re
-import sys
-
-root_transaction_id, node_alias, stage = sys.argv[1:]
-if re.fullmatch(r"[0-9a-f]{32}", root_transaction_id) is None:
-    raise SystemExit("invalid root PITR transaction ID")
-if node_alias not in {"mvn-api", "zakup"}:
-    raise SystemExit("invalid PITR node alias")
-if stage not in {"configure-node", "enable-archive"}:
-    raise SystemExit("invalid PITR config stage")
-material = "\0".join(("mvn-pitr-config-v1", root_transaction_id, node_alias, stage))
-print(hashlib.sha256(material.encode()).hexdigest()[:32])
-PY
-}
-
 print_archive_settings() {
   compose exec -T "${DB_SERVICE}" sh -lc 'psql -U "$POSTGRES_USER" -d "${POSTGRES_DB:-air_conditioners}" -AtF "|"' <<'SQL' |
 select name, setting
@@ -343,16 +318,18 @@ provision_node() {
 }
 
 configure_node() {
-  local config_transaction_id
+  local node_alias
   require_root_for_write_phase
   require_transaction_id
   require_active_patroni_compose legacy-or-clean
   require_env_input_file
-  config_transaction_id="$(config_subtransaction_id configure-node)"
+  node_alias="$(reviewed_node_alias)"
   "${CONFIGURE_HELPER}" \
     --project-dir "${PROJECT_DIR}" \
     --input-env-file "${ENV_INPUT_FILE}" \
-    --transaction-id "${config_transaction_id}" \
+    --root-transaction-id "${PITR_TRANSACTION_ID}" \
+    --transaction-node "${node_alias}" \
+    --transaction-stage configure-node \
     --enable-archive
   require_active_patroni_compose migration-files-clean
   log "root-only PITR secrets committed and final archive env staged"
@@ -540,14 +517,16 @@ basebackup() {
 }
 
 enable_archive_env() {
-  local config_transaction_id
+  local node_alias
   require_root_for_write_phase
   require_transaction_id
   require_active_patroni_compose configured
-  config_transaction_id="$(config_subtransaction_id enable-archive)"
+  node_alias="$(reviewed_node_alias)"
   "${CONFIGURE_HELPER}" \
     --project-dir "${PROJECT_DIR}" \
-    --transaction-id "${config_transaction_id}" \
+    --root-transaction-id "${PITR_TRANSACTION_ID}" \
+    --transaction-node "${node_alias}" \
+    --transaction-stage enable-archive \
     --enable-archive
   log "PITR archive env staged on the reviewed Patroni node"
 }

--- a/scripts/ha/configure_postgres_pitr_env.py
+++ b/scripts/ha/configure_postgres_pitr_env.py
@@ -344,6 +344,33 @@ def validate_sanitized_environment(payload: bytes) -> None:
         raise RuntimeError("committed project env still exposes PITR credentials")
 
 
+def derive_config_transaction_id(
+    *,
+    root_transaction_id: str,
+    node_alias: str,
+    stage: str,
+    new_env: bytes,
+    new_secrets: bytes,
+) -> str:
+    if not re.fullmatch(r"[0-9a-f]{32}", root_transaction_id):
+        raise RuntimeError("root PITR transaction ID is invalid")
+    if node_alias not in {"mvn-api", "zakup"}:
+        raise RuntimeError("PITR transaction node alias is invalid")
+    if stage not in {"configure-node", "enable-archive"}:
+        raise RuntimeError("PITR configuration transaction stage is invalid")
+    material = "\0".join(
+        (
+            "mvn-pitr-config-v2",
+            root_transaction_id,
+            node_alias,
+            stage,
+            hashlib.sha256(new_env).hexdigest(),
+            hashlib.sha256(new_secrets).hexdigest(),
+        )
+    )
+    return hashlib.sha256(material.encode("ascii")).hexdigest()[:32]
+
+
 def load_transaction_module() -> ModuleType:
     candidates = (
         Path(__file__).resolve().with_name("pitr_config_transaction.py"),
@@ -369,6 +396,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--secrets-file", default="")
     parser.add_argument("--transaction-root", default="")
     parser.add_argument("--transaction-id", default="")
+    parser.add_argument("--root-transaction-id", default="", help=argparse.SUPPRESS)
+    parser.add_argument("--transaction-node", default="", help=argparse.SUPPRESS)
+    parser.add_argument("--transaction-stage", default="", help=argparse.SUPPRESS)
     parser.add_argument("--input-env-file", default="")
     parser.add_argument("--cluster", default="")
     parser.add_argument("--bucket", default="")
@@ -473,13 +503,35 @@ def run(argv: Sequence[str] | None = None) -> int:
     validate_config(config, merged_values, expected_destination_fingerprint=fingerprint)
     new_env = update_env_text(env_payload.decode("utf-8"), config).encode("utf-8")
     new_secrets = render_secrets(config).encode("utf-8")
+    derived_transaction_fields = (
+        args.root_transaction_id,
+        args.transaction_node,
+        args.transaction_stage,
+    )
+    if any(derived_transaction_fields) and (
+        not all(derived_transaction_fields) or args.transaction_id
+    ):
+        raise RuntimeError(
+            "payload-bound PITR transaction identity requires exactly "
+            "root ID, node, and stage"
+        )
     if not args.dry_run:
+        if all(derived_transaction_fields):
+            transaction_id = derive_config_transaction_id(
+                root_transaction_id=args.root_transaction_id,
+                node_alias=args.transaction_node,
+                stage=args.transaction_stage,
+                new_env=new_env,
+                new_secrets=new_secrets,
+            )
+        else:
+            transaction_id = args.transaction_id or uuid.uuid4().hex
         secrets_path.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
         transaction.commit_split_transaction(
             env_path=env_path,
             secrets_path=secrets_path,
             transaction_root=transaction_root,
-            transaction_id=args.transaction_id or uuid.uuid4().hex,
+            transaction_id=transaction_id,
             old_env=env_payload,
             old_secrets=secrets_payload if secrets_exists else None,
             new_env=new_env,

--- a/tests/unit/test_postgres_pitr_activation_safety.py
+++ b/tests/unit/test_postgres_pitr_activation_safety.py
@@ -70,7 +70,9 @@ def test_bootstrap_stages_final_archive_state_and_supports_late_resume():
 
     assert "--enable-archive" in configure_body
     assert "--disable-archive" not in configure_body
-    assert "config_subtransaction_id configure-node" in configure_body
+    assert '--root-transaction-id "${PITR_TRANSACTION_ID}"' in configure_body
+    assert '--transaction-stage configure-node' in configure_body
+    assert '--transaction-node "${node_alias}"' in configure_body
     assert "--pitr-env-policy legacy-migration" in policy_body
     assert "--pitr-env-policy migration-files-clean" in policy_body
     assert "--pitr-env-policy configured" in policy_body

--- a/tests/unit/test_postgres_pitr_env_config.py
+++ b/tests/unit/test_postgres_pitr_env_config.py
@@ -169,3 +169,108 @@ def test_configure_env_dry_run_does_not_write(tmp_path):
     assert env_file.read_text(encoding="utf-8") == "POSTGRES_USER=postgres\n"
     assert not list(tmp_path.glob(".env.bak-pitr-*"))
     assert not (tmp_path / ".mvn-postgres-pitr.secrets.env").exists()
+
+
+def test_payload_bound_transaction_survives_legitimate_project_env_drift(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\nDEPLOY_GENERATION=1\n", encoding="utf-8")
+    env_file.chmod(0o600)
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+    identity = (
+        "--root-transaction-id",
+        "46fb45d80a7e58531bdddb79a6bd5fb3",
+        "--transaction-node",
+        "zakup",
+        "--transaction-stage",
+        "configure-node",
+    )
+
+    first = _run_configure(
+        tmp_path, "--input-env-file", str(input_file), "--enable-archive", *identity
+    )
+    assert first.returncode == 0, first.stderr
+    receipt_root = tmp_path / ".mvn-postgres-pitr-transactions-receipts"
+    first_receipts = sorted(receipt_root.glob("*.json"))
+    assert len(first_receipts) == 1
+
+    env_file.write_text(
+        env_file.read_text(encoding="utf-8").replace(
+            "DEPLOY_GENERATION=1", "DEPLOY_GENERATION=2"
+        ),
+        encoding="utf-8",
+    )
+    second = _run_configure(
+        tmp_path, "--input-env-file", str(input_file), "--enable-archive", *identity
+    )
+    assert second.returncode == 0, second.stderr
+    second_receipts = sorted(receipt_root.glob("*.json"))
+    assert len(second_receipts) == 2
+    assert first_receipts[0] in second_receipts
+    stable_paths = (env_file, tmp_path / ".mvn-postgres-pitr.secrets.env", *second_receipts)
+    stable_metadata = {
+        path: (path.stat().st_ino, path.stat().st_mtime_ns) for path in stable_paths
+    }
+
+    replay = _run_configure(
+        tmp_path, "--input-env-file", str(input_file), "--enable-archive", *identity
+    )
+    assert replay.returncode == 0, replay.stderr
+    assert sorted(receipt_root.glob("*.json")) == second_receipts
+    assert {
+        path: (path.stat().st_ino, path.stat().st_mtime_ns) for path in stable_paths
+    } == stable_metadata
+
+
+def test_payload_bound_transaction_fails_closed_on_completed_target_drift(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+    env_file.chmod(0o600)
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+    identity = (
+        "--root-transaction-id",
+        "46fb45d80a7e58531bdddb79a6bd5fb3",
+        "--transaction-node",
+        "mvn-api",
+        "--transaction-stage",
+        "configure-node",
+    )
+    first = _run_configure(
+        tmp_path, "--input-env-file", str(input_file), "--enable-archive", *identity
+    )
+    assert first.returncode == 0, first.stderr
+
+    env_file.write_text(
+        env_file.read_text(encoding="utf-8").replace(
+            "POSTGRES_PITR_ARCHIVE_MODE=on", "POSTGRES_PITR_ARCHIVE_MODE=off"
+        ),
+        encoding="utf-8",
+    )
+    replay = _run_configure(
+        tmp_path, "--input-env-file", str(input_file), "--enable-archive", *identity
+    )
+
+    assert replay.returncode != 0
+    assert "completed PITR transaction target files drifted" in replay.stderr
+    assert "POSTGRES_PITR_ARCHIVE_MODE=off" in env_file.read_text(encoding="utf-8")
+
+
+def test_payload_bound_transaction_rejects_partial_identity_during_dry_run(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("POSTGRES_USER=postgres\n", encoding="utf-8")
+    env_file.chmod(0o600)
+    input_file = tmp_path / "pitr.env"
+    _write_input_env(input_file)
+
+    result = _run_configure(
+        tmp_path,
+        "--input-env-file",
+        str(input_file),
+        "--root-transaction-id",
+        "46fb45d80a7e58531bdddb79a6bd5fb3",
+        "--dry-run",
+    )
+
+    assert result.returncode != 0
+    assert "requires exactly root ID, node, and stage" in result.stderr


### PR DESCRIPTION
## Summary
- derive immutable PITR config child transactions from the exact desired env/secrets payload
- preserve prior receipts across legitimate deploy-time `.env` changes
- keep exact replay idempotent and fail closed on PITR-managed target drift
- validate coordinated root/node/stage identity even in dry-run mode

## Production failure reproduced
The repeated physical migration for root transaction `46fb45d80a7e58531bdddb79a6bd5fb3` hit `PITR completion receipt conflicts with the requested payload` after a later deploy legitimately changed each node `.env`. The old v1 child IDs were bound only to root/node/stage, so they could not represent a new desired payload.

## Verification
- 89 focused PITR/HA unit tests passed
- full unit suite: 2077 passed, 4 skipped; 3 unrelated PostgreSQL deadlock flakes passed immediately in isolated rerun
- shell syntax and Python compilation passed
- independent review found no blocking defect in the payload-bound replay design