### PR TITLE
fix(ha): guard strict PITR readiness proof

### DIFF
--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -76,6 +76,7 @@ jobs:
           export PRIMARY_COMPOSE_FILE="${API_COMPOSE_FILE}"
           export STANDBY_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
           export STANDBY_COMPOSE_FILE="${API_STANDBY_COMPOSE_FILE}"
+          export PITR_WORKFLOW_IDENTITY_FILE="${HOME}/.ssh/ha_readiness_key"
           bash scripts/ha/check_api_ha_readiness.sh | tee api-ha-readiness.log
 
       - name: Write Summary

--- a/scripts/ha/check_api_ha_readiness.sh
+++ b/scripts/ha/check_api_ha_readiness.sh
@@ -142,7 +142,17 @@ run_media_cdn_db() {
 run_postgres_pitr() {
   local pitr_required="${POSTGRES_PITR_REQUIRED:-false}"
   if is_true "${HA_READINESS_STRICT}"; then
-    pitr_required=true
+    local identity_file="${PITR_WORKFLOW_IDENTITY_FILE:-}"
+    if [[ -z "${identity_file}" || ! -f "${identity_file}" || -L "${identity_file}" || ! -O "${identity_file}" ]]; then
+      log fail "strict PITR proof requires an owner-controlled workflow identity file"
+      return 1
+    fi
+    if [[ "$(stat -c '%a' "${identity_file}")" != "600" ]]; then
+      log fail "strict PITR workflow identity file must have mode 600"
+      return 1
+    fi
+    python3 -I scripts/ha/run_postgres_pitr_workflow.py --phase verify <"${identity_file}"
+    return
   elif ! is_true "${pitr_required}"; then
     soft_blocker "POSTGRES_PITR_REQUIRED is not true; PITR is monitored in soft mode only"
   fi

--- a/tests/unit/test_ha_readiness_workflow.py
+++ b/tests/unit/test_ha_readiness_workflow.py
@@ -43,6 +43,7 @@ def test_ha_readiness_workflow_wires_core_and_soft_blocker_inputs():
     assert "scripts/ha/check_api_ha_readiness.sh" in audit_step["run"]
     assert "PRIMARY_SSH" in audit_step["run"]
     assert "STANDBY_SSH" in audit_step["run"]
+    assert "PITR_WORKFLOW_IDENTITY_FILE" in audit_step["run"]
     assert "api-ha-readiness.log" in audit_step["run"]
     assert "strict:" in summary_step["run"]
     assert artifact_step["if"] == "always()"
@@ -56,6 +57,8 @@ def test_ha_readiness_resolves_patroni_primary_and_uses_role_aware_monitor():
 
     assert "check_patroni_production.py --resolve-primary" in script
     assert "python3 scripts/ha/check_patroni_production.py" in script
+    assert "run_postgres_pitr_workflow.py --phase verify" in script
+    assert 'PITR_WORKFLOW_IDENTITY_FILE' in script
     assert 'API_DB_HA_MODE="${API_DB_HA_MODE:-physical}"' in script
     assert 'CONFIGURED_PRIMARY_ORIGIN="${PRIMARY_ORIGIN}"' in script
 


### PR DESCRIPTION
## Summary
- route strict HA readiness PITR verification through the attested guarded workflow runner
- require the workflow SSH identity to be owner-controlled mode 0600
- keep the existing direct status path only for non-strict monitoring

## Production failure reproduced
Strict readiness run 29476167264 called the installed status helper directly without a guarded `PITR_OPERATION_ID`, so its forced-WAL proof correctly failed closed even though the standalone guarded PITR check and restore drill passed.

## Verification
- `bash -n scripts/ha/check_api_ha_readiness.sh`
- 28 focused HA/PITR workflow tests passed
- `git diff --check` passed