### PR TITLE
fix: serialize final PITR verification

### DIFF
--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -482,8 +482,9 @@ class _MigrationOrchestrator:
             for node in ordered_nodes:
                 # Finalization removes the maintenance marker. The sole active
                 # role agent now owns timer activation/fencing. Re-running its
-                # pinned convergence proof is idempotent and bounded; there is
-                # no second controller timer owner racing systemd.
+                # pinned convergence proof is idempotent and bounded. The
+                # following strict verify uses bounded shared-lock arbitration
+                # if the first recurring WAL upload starts at the same instant.
                 self._mutate(
                     stage=f"role-agent final convergence {node.alias}",
                     action=lambda node=node: self._role_agent(

--- a/scripts/ha/pitr_remote_executors.py
+++ b/scripts/ha/pitr_remote_executors.py
@@ -128,10 +128,20 @@ def wrapper_main():
         ):
             return wrapper_fail("shared PITR lock metadata is unsafe", 78)
         os.fchmod(lock_fd, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            return wrapper_fail("another PITR operation is active", 75)
+        verify_lock_deadline = (
+            time.monotonic() + 30.0 if phase == "verify" else None
+        )
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if verify_lock_deadline is None:
+                    return wrapper_fail("another PITR operation is active", 75)
+                remaining = verify_lock_deadline - time.monotonic()
+                if remaining <= 0:
+                    return wrapper_fail("another PITR operation is active", 75)
+                time.sleep(min(0.5, remaining))
         try:
             deploy_fd = open_deploy_lock(project_dir)
         except BlockingIOError:
@@ -498,10 +508,20 @@ def main():
         ):
             return fail("lock file metadata is unsafe")
         os.fchmod(lock_fd, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            return fail("another PITR prerequisite apply is active", 75)
+        verify_lock_deadline = (
+            time.monotonic() + 30.0 if phase == "verify" else None
+        )
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if verify_lock_deadline is None:
+                    return fail("another PITR prerequisite apply is active", 75)
+                remaining = verify_lock_deadline - time.monotonic()
+                if remaining <= 0:
+                    return fail("another PITR prerequisite apply is active", 75)
+                time.sleep(min(0.5, remaining))
         try:
             attest_assets(asset_manifest, project_dir, compose_file)
             guard = load_operation_guard()

--- a/tests/unit/test_pitr_remote_execution_split.py
+++ b/tests/unit/test_pitr_remote_execution_split.py
@@ -288,6 +288,23 @@ def test_transactional_host_provision_is_an_attested_maintenance_phase(tmp_path)
     )
 
 
+def test_final_verify_waits_boundedly_for_recurring_pitr_lock():
+    outer = pitr_remote_executors.REMOTE_MAINTENANCE_EXECUTOR
+    inner = pitr_remote_executors.LOCKED_OPERATION_WRAPPER
+
+    for source in (outer, inner):
+        assert 'time.monotonic() + 30.0 if phase == "verify" else None' in source
+        assert "while True:" in source
+        assert "remaining = verify_lock_deadline - time.monotonic()" in source
+        assert "time.sleep(min(0.5, remaining))" in source
+    assert outer.count(
+        'return fail("another PITR prerequisite apply is active", 75)'
+    ) >= 2
+    assert inner.count(
+        'return wrapper_fail("another PITR operation is active", 75)'
+    ) >= 2
+
+
 def test_primary_fenced_provision_uses_explicit_attested_mode(tmp_path):
     captured = []
 


### PR DESCRIPTION
## Summary
- let the final strict PITR verify wait boundedly for a concurrently starting recurring WAL upload
- close both the outer executor and inner transient-unit lock acquisition windows
- keep every mutating PITR phase fail-fast and preserve strict timer checks

## Production evidence
Transaction `5d09ec3d661cc172ca373af6a5042a90` completed two physical restore proofs, but final verify twice collided with the one-minute WAL upload timer after final role-agent convergence. Both failures occurred after manifests were safely finalized and returned status 75.

## Verification
- 768 passed, 4 skipped (HA/PITR focused unit suite)
- embedded executor compile checks pass
- independent fail-closed review approved