### PR TITLE
Fix order drawer and supply-linked price updates

### DIFF
--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -74,28 +74,6 @@ const deleteStage = async (stageId: number, stageName: string) => {
     }
 };
 
-const updateEquipmentStatus = async (newStatus: string) => {
-    try {
-        await ManagerOrdersService.patchManagerOrder(props.order.id, {
-            equipment_status: newStatus
-        });
-        emit('refresh');
-    } catch (e: any) {
-        setToast(`Ошибка: ${getApiErrorMessage(e)}`, 'error');
-    }
-};
-
-const toggleKit = async (val: boolean) => {
-    try {
-        await ManagerOrdersService.patchManagerOrder(props.order.id, {
-            standard_install_kit_issued: val
-        });
-        emit('refresh');
-    } catch (e: any) {
-        setToast(`Ошибка: ${getApiErrorMessage(e)}`, 'error');
-    }
-};
-
 const closeDeal = async () => {
     try {
         await ManagerOrdersService.patchManagerOrder(props.order.id, {
@@ -300,34 +278,6 @@ watch(() => props.order.id, () => {
             <button class="btn-mini" :disabled="!newStageName" @click="addStage">Сохранить</button>
         </div>
     </div>
-  </section>
-
-  <!-- ZONE 2: Picking List -->
-  <section class="rounded-2xl bg-white border border-slate-200 p-5 shadow-sm">
-      <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 border-b border-slate-100 pb-3">
-          <h3 class="text-lg font-bold text-slate-800 font-['Space_Grotesk']">Склад и комплектация</h3>
-          
-          <div class="flex flex-wrap items-center gap-2 border border-slate-300 bg-slate-50 rounded-lg p-1 mt-3 md:mt-0 w-full md:w-auto">
-              <button class="px-3 py-1 flex-1 md:flex-none justify-center rounded text-xs font-medium transition-colors" :class="order.equipment_status === 'pending' ? 'bg-red-500 text-white shadow' : 'text-slate-600 hover:bg-slate-200'" @click="updateEquipmentStatus('pending')">🔴 Не собрано</button>
-              <button class="px-3 py-1 flex-1 md:flex-none justify-center rounded text-xs font-medium transition-colors" :class="order.equipment_status === 'reserved' ? 'bg-amber-500 text-white shadow' : 'text-slate-600 hover:bg-slate-200'" @click="updateEquipmentStatus('reserved')">🟡 Забронировано</button>
-              <button class="px-3 py-1 flex-1 md:flex-none justify-center rounded text-xs font-medium transition-colors" :class="order.equipment_status === 'issued' ? 'bg-teal-500 text-white shadow' : 'text-slate-600 hover:bg-slate-200'" @click="updateEquipmentStatus('issued')">🟢 Выдано бригаде</button>
-          </div>
-      </div>
-
-      <div class="bg-slate-50 rounded-xl p-4 border border-slate-200 mb-4">
-          <ul class="space-y-2 text-sm text-slate-700">
-              <li v-for="link in order.product_lines" :key="link.id" class="flex justify-between items-center bg-white p-2 rounded shadow-sm border border-slate-100">
-                  <span class="font-medium flex-1">{{ link.product_title }}</span>
-                  <span class="bg-slate-100 px-2 py-0.5 rounded font-bold text-slate-600">{{ link.quantity }} шт.</span>
-              </li>
-              <li v-if="!order.product_lines?.length" class="text-slate-400 italic py-2">Нет оборудования в смете</li>
-          </ul>
-      </div>
-
-      <label class="flex items-center gap-2 cursor-pointer bg-slate-50 p-3 rounded-lg border border-slate-200 hover:bg-slate-100 transition-colors">
-          <input type="checkbox" :checked="order.standard_install_kit_issued" @change="toggleKit(($event.target as HTMLInputElement).checked)" class="w-5 h-5 rounded border-slate-300 text-teal-600 focus:ring-teal-600" />
-          <span class="font-medium text-slate-800 text-sm">Выдать стандартный монтажный комплект (Кронштейны, труба и т.д.)</span>
-      </label>
   </section>
 
   <!-- ZONE 3: Finance -->

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -2447,9 +2447,21 @@ watch(
             </div>
           </div>
 
-          <button class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600" type="button" @click="closeDrawer" title="Закрыть">
-            <span class="material-icons-round">close</span>
-          </button>
+          <div class="flex shrink-0 items-center gap-1.5">
+            <button
+              v-if="order"
+              type="button"
+              class="inline-flex h-9 items-center gap-1 rounded-lg border px-2.5 text-xs font-semibold transition-colors"
+              :class="order.is_on_hold ? 'border-amber-200 bg-amber-50 text-amber-700' : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'"
+              @click="toggleHold"
+            >
+              <span class="material-icons-round text-[16px]">{{ order.is_on_hold ? 'play_arrow' : 'pause' }}</span>
+              {{ order.is_on_hold ? 'Вернуть' : 'Отложить' }}
+            </button>
+            <button class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600" type="button" @click="closeDrawer" title="Закрыть">
+              <span class="material-icons-round">close</span>
+            </button>
+          </div>
         </div>
 
         <div class="mb-4 rounded-2xl border border-slate-200 bg-slate-50 p-2">
@@ -2579,9 +2591,6 @@ watch(
             <button v-if="status === 'negotiation' && !measurementRequired" type="button" class="btn-mini-outline whitespace-nowrap text-xs" @click="measurementRequired = true">
               <span class="material-icons-round text-[15px]">add_location_alt</span>
               Выезд на замер
-            </button>
-            <button v-if="order" type="button" @click="toggleHold" class="text-xs px-3 py-1.5 rounded-lg border font-medium transition-colors" :class="order.is_on_hold ? 'bg-amber-50 border-amber-200 text-amber-700' : 'bg-white border-gray-200 text-gray-600 hover:bg-gray-50'">
-              {{ order.is_on_hold ? 'Вернуть в работу' : 'Отложить' }}
             </button>
           </div>
         </div>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -3339,16 +3339,9 @@ watch(
         tone="default"
         :has-error="Boolean(getFieldError('products') || getFieldError('services'))"
       >
-      <div class="rounded-2xl border border-gray-200 bg-gray-50/50 p-3 sm:p-4">
+        <div class="min-w-0">
         <div class="mb-4 border-b border-gray-200 pb-3">
-          <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-            <div>
-              <h3 class="text-lg font-bold text-gray-900 sm:text-xl font-['Space_Grotesk']">{{ isRepairWorkflow ? 'Смета ремонта' : 'Предложения' }}</h3>
-              <p class="mt-1 text-xs text-gray-500">{{ activeProposalLineLabel }}</p>
-            </div>
-          </div>
-
-          <div v-if="orderProposals.length" class="mt-3 flex gap-2 overflow-x-auto pb-1">
+          <div v-if="orderProposals.length" class="flex gap-2 overflow-x-auto pb-1">
             <button
               v-for="proposal in orderProposals"
               :key="proposal.id"

--- a/manager_frontend/src/components/orders/OrderEmailHistory.vue
+++ b/manager_frontend/src/components/orders/OrderEmailHistory.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { AlertTriangle, CheckCircle2, Clock3, Copy, ExternalLink, RefreshCw, XCircle } from 'lucide-vue-next';
+import { AlertTriangle, CheckCircle2, ChevronDown, Clock3, Copy, ExternalLink, RefreshCw, XCircle } from 'lucide-vue-next';
 import { ManagerMailService } from '../../client';
 import type { OutgoingEmailResponse } from '../../client';
 import OutgoingEmailDrawer from '../mail/OutgoingEmailDrawer.vue';
@@ -20,6 +20,7 @@ const loading = ref(false);
 const error = ref('');
 const selectedEmailId = ref<number | null>(null);
 const drawerOpen = ref(false);
+const expanded = ref(false);
 
 const failedCount = computed(() => emails.value.filter((item) => item.status === 'failed').length);
 
@@ -123,15 +124,25 @@ watch(
       @toast="emit('toast', $event)"
     />
 
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div>
+    <button
+      type="button"
+      class="flex w-full items-center justify-between gap-3 text-left"
+      :aria-expanded="expanded"
+      @click="expanded = !expanded"
+    >
+      <div class="min-w-0">
         <h4 class="flex items-center gap-2 text-sm font-bold text-slate-900 dark:text-white">
           <span class="material-icons-round text-[18px] text-teal-600">outgoing_mail</span>
           Письма
+          <span v-if="emails.length" class="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-bold text-slate-600 dark:bg-slate-800 dark:text-slate-300">{{ emails.length }}</span>
           <span v-if="failedCount" class="rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700 dark:bg-red-500/10 dark:text-red-300">{{ failedCount }} ошибок</span>
         </h4>
-        <p class="mt-0.5 text-xs text-slate-500 dark:text-slate-400">Что отправлялось клиенту по этому заказу.</p>
+        <p class="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">Что отправлялось клиенту по этому заказу.</p>
       </div>
+      <ChevronDown class="h-4 w-4 shrink-0 text-slate-400 transition-transform" :class="expanded ? 'rotate-180' : ''" />
+    </button>
+
+    <div v-if="expanded" class="mt-3">
       <div class="flex gap-2">
         <button type="button" class="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800" :disabled="loading" @click="loadEmails">
           <RefreshCw class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" />
@@ -142,43 +153,43 @@ watch(
           Все
         </button>
       </div>
-    </div>
 
-    <div v-if="error" class="mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
-      {{ error }}
-    </div>
-    <div v-else-if="loading" class="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900">
-      Загружаю историю писем...
-    </div>
-    <div v-else-if="!emails.length" class="mt-3 rounded-xl border border-dashed border-slate-300 px-3 py-4 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
-      По заказу пока нет отправленных писем.
-    </div>
-    <div v-else class="mt-3 space-y-2">
-      <article
-        v-for="email in emails"
-        :key="email.id"
-        class="cursor-pointer rounded-xl border border-slate-200 bg-white px-3 py-2 transition hover:border-teal-200 hover:bg-teal-50/40 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-teal-500/30 dark:hover:bg-teal-500/10"
-        @click="openEmail(email)"
-      >
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-bold" :class="statusClass(email.status)">
-            <component :is="statusIcon(email.status)" class="h-3 w-3" />
-            {{ statusLabel(email.status) }}
-          </span>
-          <span class="text-xs text-slate-500">{{ formatDate(email.sent_at || email.created_at) }}</span>
-          <span v-if="email.attachments?.length" class="text-xs font-semibold text-slate-500">{{ email.attachments.length }} влож.</span>
-        </div>
-        <div class="mt-1 flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <p class="truncate text-sm font-bold">{{ email.subject }}</p>
-            <p class="truncate text-xs text-slate-500 dark:text-slate-400">{{ email.recipient_email }}</p>
-            <p v-if="email.error" class="mt-1 line-clamp-2 text-xs font-medium text-red-600 dark:text-red-300">{{ email.error }}</p>
+      <div v-if="error" class="mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+        {{ error }}
+      </div>
+      <div v-else-if="loading" class="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900">
+        Загружаю историю писем...
+      </div>
+      <div v-else-if="!emails.length" class="mt-3 rounded-xl border border-dashed border-slate-300 px-3 py-4 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+        По заказу пока нет отправленных писем.
+      </div>
+      <div v-else class="mt-3 space-y-2">
+        <article
+          v-for="email in emails"
+          :key="email.id"
+          class="cursor-pointer rounded-xl border border-slate-200 bg-white px-3 py-2 transition hover:border-teal-200 hover:bg-teal-50/40 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-teal-500/30 dark:hover:bg-teal-500/10"
+          @click="openEmail(email)"
+        >
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-bold" :class="statusClass(email.status)">
+              <component :is="statusIcon(email.status)" class="h-3 w-3" />
+              {{ statusLabel(email.status) }}
+            </span>
+            <span class="text-xs text-slate-500">{{ formatDate(email.sent_at || email.created_at) }}</span>
+            <span v-if="email.attachments?.length" class="text-xs font-semibold text-slate-500">{{ email.attachments.length }} влож.</span>
           </div>
-          <button v-if="email.error" type="button" class="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200" title="Скопировать ошибку" @click.stop="copyText(email.error || '')">
-            <Copy class="h-4 w-4" />
-          </button>
-        </div>
-      </article>
+          <div class="mt-1 flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <p class="truncate text-sm font-bold">{{ email.subject }}</p>
+              <p class="truncate text-xs text-slate-500 dark:text-slate-400">{{ email.recipient_email }}</p>
+              <p v-if="email.error" class="mt-1 line-clamp-2 text-xs font-medium text-red-600 dark:text-red-300">{{ email.error }}</p>
+            </div>
+            <button v-if="email.error" type="button" class="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200" title="Скопировать ошибку" @click.stop="copyText(email.error || '')">
+              <Copy class="h-4 w-4" />
+            </button>
+          </div>
+        </article>
+      </div>
     </div>
   </section>
 </template>

--- a/services/order_product_line_service.py
+++ b/services/order_product_line_service.py
@@ -1,0 +1,97 @@
+from collections import defaultdict
+from typing import Any, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import OrderProductLink, SupplyRequestLine
+
+
+class OrderProductLineService:
+    @staticmethod
+    async def reconcile(
+        session: AsyncSession,
+        *,
+        order_id: int,
+        proposal_id: int,
+        lines: Sequence[dict[str, Any]],
+    ) -> None:
+        result = await session.execute(
+            select(OrderProductLink)
+            .where(
+                OrderProductLink.order_id == order_id,
+                OrderProductLink.proposal_id == proposal_id,
+            )
+            .order_by(OrderProductLink.id)
+        )
+        existing_links = list(result.scalars().all())
+        existing_by_id = {int(link.id): link for link in existing_links if link.id is not None}
+        existing_by_product: dict[int, list[OrderProductLink]] = defaultdict(list)
+        for link in existing_links:
+            if link.product_id is not None:
+                existing_by_product[int(link.product_id)].append(link)
+
+        claimed_ids: set[int] = set()
+        reconciled: list[tuple[dict[str, Any], OrderProductLink | None]] = []
+        for line in lines:
+            link: OrderProductLink | None = None
+            requested_link_id = line.get("link_id")
+            if requested_link_id is not None:
+                link = existing_by_id.get(int(requested_link_id))
+                if link is None:
+                    raise ValueError("Product line does not belong to the selected proposal")
+                if int(link.id) in claimed_ids:
+                    raise ValueError("Product line is duplicated in the request")
+            else:
+                candidates = existing_by_product.get(int(line["product_id"]), [])
+                link = next(
+                    (candidate for candidate in candidates if int(candidate.id) not in claimed_ids),
+                    None,
+                )
+
+            if link is not None and link.id is not None:
+                claimed_ids.add(int(link.id))
+            reconciled.append((line, link))
+
+        existing_ids = set(existing_by_id)
+        removed_ids = existing_ids - claimed_ids
+        referenced_ids: set[int] = set()
+        if existing_ids:
+            reference_result = await session.execute(
+                select(SupplyRequestLine.order_product_link_id).where(
+                    SupplyRequestLine.order_product_link_id.in_(existing_ids)
+                )
+            )
+            referenced_ids = {
+                int(link_id)
+                for link_id in reference_result.scalars().all()
+                if link_id is not None
+            }
+
+        if removed_ids & referenced_ids:
+            raise ValueError(
+                "Товар уже включен в поставку. Сначала удалите его из заявки поставщику."
+            )
+
+        for line, link in reconciled:
+            if link is None:
+                link = OrderProductLink(order_id=order_id, proposal_id=proposal_id)
+            elif link.id is not None and int(link.id) in referenced_ids:
+                if int(link.product_id or 0) != int(line["product_id"]):
+                    raise ValueError(
+                        "Нельзя заменить товар в строке, уже включенной в поставку."
+                    )
+                if int(link.quantity or 0) != int(line["quantity"]):
+                    raise ValueError(
+                        "Нельзя изменить количество товара, уже включенного в поставку."
+                    )
+
+            link.product_id = int(line["product_id"])
+            link.quantity = int(line["quantity"])
+            link.price = int(line["price"])
+            link.cost = int(line["cost"])
+            link.logistics_components = line.get("logistics_components")
+            session.add(link)
+
+        for link_id in removed_ids:
+            await session.delete(existing_by_id[link_id])

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -15,6 +15,7 @@ from models.common import ClosingResult
 from services.customer_contract_service import CustomerContractService
 from services.document_role_service import DocumentRoleService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
+from services.order_product_line_service import OrderProductLineService
 
 logger = logging.getLogger(__name__)
 
@@ -2867,12 +2868,7 @@ class OrderService:
                     if missing_product_ids:
                         raise ValueError(f"Product not found: {missing_product_ids[0]}")
                 product_cost_defaults = await OrderService._build_product_line_cost_defaults(session, list(payload.products))
-                await session.execute(
-                    delete(OrderProductLink).where(
-                        OrderProductLink.order_id == order_id,
-                        OrderProductLink.proposal_id == target_proposal_id,
-                    )
-                )
+                product_line_values = []
                 for product_line in payload.products:
                     logistics_components = OrderService._serialize_order_logistics_components(
                         product_line.logistics_components
@@ -2882,20 +2878,26 @@ class OrderService:
                         product_line.product_id,
                         logistics_components,
                     )
-                    new_product_link = OrderProductLink(
-                        order_id=order_id,
-                        proposal_id=target_proposal_id,
-                        product_id=product_line.product_id,
-                        quantity=product_line.quantity,
-                        price=product_line.price,
-                        cost=(
-                            product_line.cost
-                            if product_line.cost is not None
-                            else product_cost_defaults.get(int(product_line.product_id), 0)
-                        ),
-                        logistics_components=logistics_components,
+                    product_line_values.append(
+                        {
+                            "link_id": product_line.link_id,
+                            "product_id": product_line.product_id,
+                            "quantity": product_line.quantity,
+                            "price": product_line.price,
+                            "cost": (
+                                product_line.cost
+                                if product_line.cost is not None
+                                else product_cost_defaults.get(int(product_line.product_id), 0)
+                            ),
+                            "logistics_components": logistics_components,
+                        }
                     )
-                    session.add(new_product_link)
+                await OrderProductLineService.reconcile(
+                    session,
+                    order_id=order_id,
+                    proposal_id=target_proposal_id,
+                    lines=product_line_values,
+                )
 
             if "services" in fields_set and payload.services is not None:
                 for service_line in payload.services:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -27,6 +27,9 @@ from models import (
     RepairComplaintPreset,
     Service,
     ServiceTariff,
+    Supplier,
+    SupplyRequest,
+    SupplyRequestLine,
 )
 from models.order import OrderWorkStage
 
@@ -1097,6 +1100,79 @@ async def test_manager_order_patch_lines_preserves_installers(async_client, db):
 
     await db.refresh(order, attribute_names=["installers"])
     assert len(order.installers) == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_order_patch_product_price_preserves_supply_request_link(async_client, db):
+    customer = Customer(name="Supply linked", phone="+375296666669", type=CustomerType.individual)
+    product = Product(title="Supply linked product", slug="supply-linked-product", price=2490, area=35)
+    supplier = Supplier(name="Supply linked supplier", code="supply-linked-order-update")
+    db.add(customer)
+    db.add(product)
+    db.add(supplier)
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(product)
+    await db.refresh(supplier)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.EXECUTION)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    order_line = OrderProductLink(
+        order_id=order.id,
+        product_id=product.id,
+        quantity=1,
+        price=1990,
+        cost=1110,
+    )
+    db.add(order_line)
+    await db.commit()
+    await db.refresh(order_line)
+
+    supply_request = SupplyRequest(supplier_id=supplier.id)
+    db.add(supply_request)
+    await db.commit()
+    await db.refresh(supply_request)
+
+    supply_line = SupplyRequestLine(
+        request_id=supply_request.id,
+        order_product_link_id=order_line.id,
+        source_type="order",
+        product_id=product.id,
+        title_snapshot=product.title,
+        qty=1,
+    )
+    db.add(supply_line)
+    await db.commit()
+    await db.refresh(supply_line)
+
+    headers = await _auth_headers(async_client)
+    response = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={
+            "products": [
+                {
+                    "link_id": order_line.id,
+                    "product_id": product.id,
+                    "quantity": 1,
+                    "price": 2090,
+                    "cost": 1110,
+                }
+            ]
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["product_lines"][0]["id"] == order_line.id
+    assert response.json()["product_lines"][0]["price"] == 2090
+
+    await db.refresh(order_line)
+    await db.refresh(supply_line)
+    assert order_line.price == 2090
+    assert supply_line.order_product_link_id == order_line.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что изменено

- скрыт незавершенный блок «Склад и комплектация» без удаления его данных и API
- история писем в карточке заказа теперь свернута по умолчанию
- действие «Отложить / Вернуть» перенесено в шапку рядом с закрытием карточки
- товарные строки теперь обновляются на месте вместо удаления и повторного создания
- для строк, связанных с заявкой поставщику, сохранена стабильная связь; опасное удаление, замена товара или количества возвращают понятную ошибку

## Причина HTTP 500

На production у заказа №145 товарная строка `id=360` связана с `supply_request_line id=1`. Старый PATCH сначала удалял все товарные строки предложения, поэтому PostgreSQL отклонял удаление по внешнему ключу. Новая логика использует `link_id` и сохраняет существующую строку при изменении цены.

## Проверки

- `56 passed` — `tests/integration/test_manager_orders_api.py`
- `28 passed` — затронутые unit-тесты order/supply services
- `vue-tsc -b`
- `vite build`
- `bash scripts/audit_theme_hardcodes.sh`
