### PR TITLE
feat: establish internal bot API gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ GOOGLE_VISION_PROJECT_ID=
  ---
 # --- Bot Settings ---
 BOT_TOKEN=
+# Dedicated service credential for /api/internal/bot/v1. Generate a long,
+# random value and keep it identical in the API and bot runtime environments.
+BOT_API_TOKEN=
+BOT_API_BASE_URL=http://app:8000/api/internal/bot/v1
+BOT_API_TIMEOUT_SECONDS=5
 ADMIN_ID=
 ADMIN_IDS=
 # Public Telegram bot username for the manager login widget, without @.

--- a/api_contracts/__init__.py
+++ b/api_contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Transport contracts shared by independently deployable MVN clients."""

--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -1,0 +1,21 @@
+"""Versioned response contracts for the internal Telegram bot API."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class BotApiHealthResponse(BaseModel):
+    status: Literal["ok"] = "ok"
+    api_version: Literal["v1"] = "v1"
+
+
+class BotStaffContextResponse(BaseModel):
+    telegram_id: int = Field(ge=1)
+    is_staff: bool = False
+    display_name: str = ""
+    primary_role: str = ""
+    roles: list[str] = Field(default_factory=list)
+    legacy_installer_id: int | None = None
+    is_manager: bool = False
+    is_executor: bool = False

--- a/bot_app/api_gateway.py
+++ b/bot_app/api_gateway.py
@@ -1,0 +1,109 @@
+"""Typed HTTP gateway from the Telegram runtime to the MVN internal API."""
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import httpx
+
+from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
+
+
+class BotApiError(RuntimeError):
+    """Base error raised by the bot HTTP gateway."""
+
+
+class BotApiAuthenticationError(BotApiError):
+    """The API rejected the bot service credential."""
+
+
+class BotApiUnavailableError(BotApiError):
+    """The API could not be reached or returned a transient server failure."""
+
+
+class BotApiResponseError(BotApiError):
+    """The API returned an unexpected response."""
+
+
+@dataclass(frozen=True)
+class BotApiGatewayConfig:
+    base_url: str
+    token: str
+    timeout_seconds: float = 5.0
+
+    def __post_init__(self) -> None:
+        normalized_url = self.base_url.strip().rstrip("/")
+        parsed = urlsplit(normalized_url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("Bot API base URL must be a credential-free HTTP(S) URL")
+        if not self.token.strip():
+            raise ValueError("Bot API token is required")
+        if self.timeout_seconds <= 0:
+            raise ValueError("Bot API timeout must be positive")
+        object.__setattr__(self, "base_url", normalized_url)
+        object.__setattr__(self, "token", self.token.strip())
+
+
+class BotApiGateway:
+    """Small use-case client; bot handlers must not know API transport details."""
+
+    def __init__(
+        self,
+        config: BotApiGatewayConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client or httpx.AsyncClient(timeout=config.timeout_seconds)
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def health(self) -> BotApiHealthResponse:
+        payload = await self._get("health")
+        try:
+            return BotApiHealthResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid health contract") from exc
+
+    async def get_staff_context(self, telegram_id: int) -> BotStaffContextResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        payload = await self._get(f"staff/context/{telegram_id}")
+        try:
+            return BotStaffContextResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid staff context contract") from exc
+
+    async def _get(self, path: str) -> dict:
+        url = f"{self._config.base_url}/{path.lstrip('/')}"
+        try:
+            response = await self._client.get(
+                url,
+                headers={"Authorization": f"Bearer {self._config.token}"},
+                timeout=self._config.timeout_seconds,
+            )
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise BotApiUnavailableError("MVN API is temporarily unavailable") from exc
+
+        if response.status_code in {401, 403}:
+            raise BotApiAuthenticationError("MVN API rejected the bot credential")
+        if response.status_code >= 500:
+            raise BotApiUnavailableError(f"MVN API returned HTTP {response.status_code}")
+        if response.status_code >= 400:
+            raise BotApiResponseError(f"MVN API returned HTTP {response.status_code}")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise BotApiResponseError("MVN API returned an invalid response body")
+        return payload

--- a/core/app_routing.py
+++ b/core/app_routing.py
@@ -2,12 +2,14 @@ from fastapi import APIRouter, FastAPI
 
 from routers import api as api_router
 from routers import auth as auth_router
+from routers import internal_bot as internal_bot_router
 from routers import legacy_admin_redirects
 from routers import manager as manager_router
 from routers import system as system_router
 
 APP_ROUTERS: tuple[APIRouter, ...] = (
     auth_router.router,
+    internal_bot_router.router,
     api_router.router,
     manager_router.router,
     legacy_admin_redirects.router,

--- a/core/bot_api_security.py
+++ b/core/bot_api_security.py
@@ -1,0 +1,34 @@
+"""Authentication dependency for the private Telegram bot API."""
+
+import secrets
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from core.config import settings
+
+
+bot_service_bearer = HTTPBearer(
+    auto_error=False,
+    scheme_name="BotServiceBearer",
+    description="Dedicated bearer token used only by the MVN Telegram bot service.",
+)
+
+
+async def require_bot_api_token(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bot_service_bearer),
+) -> None:
+    configured = settings.BOT_API_TOKEN.strip()
+    if not configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Bot API token is not configured",
+        )
+
+    provided = credentials.credentials if credentials is not None else ""
+    if not provided or not secrets.compare_digest(provided, configured):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid bot API token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/core/config.py
+++ b/core/config.py
@@ -26,6 +26,9 @@ def _redact_settings_validation_error(error: ValidationError) -> ValidationError
 class Settings(BaseSettings):
     # Bot Settings
     BOT_TOKEN: str = ""
+    BOT_API_TOKEN: str = ""
+    BOT_API_BASE_URL: str = "http://app:8000/api/internal/bot/v1"
+    BOT_API_TIMEOUT_SECONDS: float = 5.0
     ADMIN_IDS: str = ""
     ADMIN_ID: int = 0
     SECRET_KEY: str

--- a/docs/bot-service-extraction.md
+++ b/docs/bot-service-extraction.md
@@ -1,0 +1,44 @@
+# Telegram bot service extraction
+
+## Target boundary
+
+The Telegram runtime is a client of the versioned MVN internal API. It owns
+Telegram updates, dialogs, buttons, formatting and FSM state. It must not own
+CRM, catalog, staff, repair, warranty, OCR or attachment business logic.
+
+The backend remains the only owner of the main PostgreSQL database. Bot
+requests authenticate with a dedicated service credential; the API then
+authorizes the Telegram user for each use case.
+
+## Migration sequence
+
+1. Establish `/api/internal/bot/v1`, service authentication and the typed HTTP
+   gateway without changing production bot behavior.
+2. Move read-only staff, catalog, selection, calendar and task scenarios.
+3. Move idempotent order/task writes. Never dual-write through local and HTTP
+   paths.
+4. Move attachment, OCR, repair and warranty scenarios.
+5. Move FSM/runtime ownership, remove database access and publish a dedicated
+   bot image.
+6. Move the autonomous bot into a separate repository only after the boundary
+   checks below pass.
+
+## Scope guardrails
+
+- Freeze new bot product features while a scenario is being migrated.
+- Use use-case endpoints instead of exposing generic database CRUD.
+- Keep business rules in backend services; do not copy them into the bot.
+- Cut over one vertical scenario at a time and delete its local path after
+  verification.
+- Do not add an event bus or a generic microservice platform for this split.
+
+## Definition of done
+
+- `bot_app/` has no imports from `core.database`, `models`, `crud` or backend
+  `services`.
+- The bot container has no main-database credential or network access.
+- Repeated Telegram callbacks cannot create duplicate writes.
+- API downtime produces a bounded, staff-readable bot error.
+- Stopping the bot has no effect on the API, web or manager application.
+- HA role changes leave exactly one active Telegram polling runtime.
+- Contract and smoke tests cover every retained staff workflow.

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -30,6 +30,8 @@ export type { Body_upload_manager_customer_contract } from './models/Body_upload
 export type { Body_upload_manager_order_attachment } from './models/Body_upload_manager_order_attachment';
 export type { Body_upload_manager_order_document } from './models/Body_upload_manager_order_document';
 export type { Body_upload_media_assets } from './models/Body_upload_media_assets';
+export type { BotApiHealthResponse } from './models/BotApiHealthResponse';
+export type { BotStaffContextResponse } from './models/BotStaffContextResponse';
 export type { BulkGalleryAddRequest } from './models/BulkGalleryAddRequest';
 export type { BulkGalleryDeleteRequest } from './models/BulkGalleryDeleteRequest';
 export type { BulkProductIdsRequest } from './models/BulkProductIdsRequest';
@@ -416,6 +418,7 @@ export type { WebRebuildStatusResponse } from './models/WebRebuildStatusResponse
 export type { WebRebuildTriggerResponse } from './models/WebRebuildTriggerResponse';
 
 export { ApiService } from './services/ApiService';
+export { InternalBotV1Service } from './services/InternalBotV1Service';
 export { LoginService } from './services/LoginService';
 export { ManagerService } from './services/ManagerService';
 export { ManagerBackupsService } from './services/ManagerBackupsService';

--- a/manager_frontend/src/client/models/BotApiHealthResponse.ts
+++ b/manager_frontend/src/client/models/BotApiHealthResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotApiHealthResponse = {
+    status?: string;
+    api_version?: string;
+};
+

--- a/manager_frontend/src/client/models/BotStaffContextResponse.ts
+++ b/manager_frontend/src/client/models/BotStaffContextResponse.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotStaffContextResponse = {
+    telegram_id: number;
+    is_staff?: boolean;
+    display_name?: string;
+    primary_role?: string;
+    roles?: Array<string>;
+    legacy_installer_id?: (number | null);
+    is_manager?: boolean;
+    is_executor?: boolean;
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -1,0 +1,42 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotApiHealthResponse } from '../models/BotApiHealthResponse';
+import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class InternalBotV1Service {
+    /**
+     * Get Internal Bot Api Health
+     * @returns BotApiHealthResponse Successful Response
+     * @throws ApiError
+     */
+    public static getInternalBotApiHealthV1(): CancelablePromise<BotApiHealthResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/internal/bot/v1/health',
+        });
+    }
+    /**
+     * Get Internal Bot Staff Context
+     * @param telegramId
+     * @returns BotStaffContextResponse Successful Response
+     * @throws ApiError
+     */
+    public static getInternalBotStaffContextV1(
+        telegramId: number,
+    ): CancelablePromise<BotStaffContextResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/internal/bot/v1/staff/context/{telegram_id}',
+            path: {
+                'telegram_id': telegramId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -88,6 +88,80 @@
         }
       }
     },
+    "/api/internal/bot/v1/health": {
+      "get": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Get Internal Bot Api Health",
+        "operationId": "get_internal_bot_api_health_v1",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotApiHealthResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/staff/context/{telegram_id}": {
+      "get": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Get Internal Bot Staff Context",
+        "operationId": "get_internal_bot_staff_context_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "telegram_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Telegram Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotStaffContextResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -18276,6 +18350,81 @@
           "files"
         ],
         "title": "Body_upload_media_assets"
+      },
+      "BotApiHealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "ok",
+            "title": "Status",
+            "default": "ok"
+          },
+          "api_version": {
+            "type": "string",
+            "const": "v1",
+            "title": "Api Version",
+            "default": "v1"
+          }
+        },
+        "type": "object",
+        "title": "BotApiHealthResponse"
+      },
+      "BotStaffContextResponse": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "is_staff": {
+            "type": "boolean",
+            "title": "Is Staff",
+            "default": false
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name",
+            "default": ""
+          },
+          "primary_role": {
+            "type": "string",
+            "title": "Primary Role",
+            "default": ""
+          },
+          "roles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Roles"
+          },
+          "legacy_installer_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Legacy Installer Id"
+          },
+          "is_manager": {
+            "type": "boolean",
+            "title": "Is Manager",
+            "default": false
+          },
+          "is_executor": {
+            "type": "boolean",
+            "title": "Is Executor",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id"
+        ],
+        "title": "BotStaffContextResponse"
       },
       "BulkGalleryAddRequest": {
         "properties": {
@@ -45083,6 +45232,11 @@
       }
     },
     "securitySchemes": {
+      "BotServiceBearer": {
+        "type": "http",
+        "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
+        "scheme": "bearer"
+      },
       "OAuth2PasswordBearer": {
         "type": "oauth2",
         "flows": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -1,0 +1,47 @@
+"""Private, versioned use-case API consumed by the Telegram bot service."""
+
+from fastapi import APIRouter, Depends, Path
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
+from core.bot_api_security import require_bot_api_token
+from core.database import get_session
+from services.bot_access_service import BotAccessService
+
+
+router = APIRouter(
+    prefix="/api/internal/bot/v1",
+    tags=["internal bot v1"],
+    dependencies=[Depends(require_bot_api_token)],
+)
+
+
+@router.get(
+    "/health",
+    response_model=BotApiHealthResponse,
+    operation_id="get_internal_bot_api_health_v1",
+)
+async def get_internal_bot_api_health() -> BotApiHealthResponse:
+    return BotApiHealthResponse()
+
+
+@router.get(
+    "/staff/context/{telegram_id}",
+    response_model=BotStaffContextResponse,
+    operation_id="get_internal_bot_staff_context_v1",
+)
+async def get_internal_bot_staff_context(
+    telegram_id: int = Path(ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> BotStaffContextResponse:
+    context = await BotAccessService.get_context(session, telegram_id)
+    return BotStaffContextResponse(
+        telegram_id=context.telegram_id,
+        is_staff=context.is_staff,
+        display_name=context.display_name,
+        primary_role=context.primary_role,
+        roles=context.roles,
+        legacy_installer_id=context.legacy_installer_id,
+        is_manager=context.is_manager,
+        is_executor=context.is_executor,
+    )

--- a/tests/unit/test_bot_api_gateway.py
+++ b/tests/unit/test_bot_api_gateway.py
@@ -1,0 +1,100 @@
+import httpx
+import pytest
+
+from bot_app.api_gateway import (
+    BotApiAuthenticationError,
+    BotApiGateway,
+    BotApiGatewayConfig,
+    BotApiResponseError,
+    BotApiUnavailableError,
+)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "",
+        "ftp://api.mvn.by/internal",
+        "https://user:password@api.mvn.by/internal",
+        "https://api.mvn.by/internal?token=secret",
+    ],
+)
+def test_bot_api_gateway_rejects_unsafe_base_urls(base_url):
+    with pytest.raises(ValueError):
+        BotApiGatewayConfig(base_url=base_url, token="secret")
+
+
+async def test_bot_api_gateway_sends_bearer_token_and_decodes_context():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://api.mvn.by/api/internal/bot/v1/staff/context/123"
+        assert request.headers["authorization"] == "Bearer service-secret"
+        return httpx.Response(
+            200,
+            json={
+                "telegram_id": 123,
+                "is_staff": True,
+                "display_name": "Менеджер",
+                "primary_role": "manager",
+                "roles": ["manager"],
+                "legacy_installer_id": None,
+                "is_manager": True,
+                "is_executor": False,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(
+                base_url="https://api.mvn.by/api/internal/bot/v1/",
+                token=" service-secret ",
+            ),
+            client=client,
+        )
+        context = await gateway.get_staff_context(123)
+
+    assert context.display_name == "Менеджер"
+    assert context.is_manager is True
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_type"),
+    [
+        (401, BotApiAuthenticationError),
+        (403, BotApiAuthenticationError),
+        (422, BotApiResponseError),
+        (503, BotApiUnavailableError),
+    ],
+)
+async def test_bot_api_gateway_maps_http_failures(status_code, error_type):
+    transport = httpx.MockTransport(lambda _request: httpx.Response(status_code, json={"detail": "failed"}))
+    async with httpx.AsyncClient(transport=transport) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        with pytest.raises(error_type):
+            await gateway.health()
+
+
+async def test_bot_api_gateway_maps_transport_failure():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        with pytest.raises(BotApiUnavailableError, match="temporarily unavailable"):
+            await gateway.health()
+
+
+async def test_bot_api_gateway_rejects_invalid_contract():
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={"status": "wrong"}))
+    async with httpx.AsyncClient(transport=transport) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        with pytest.raises(BotApiResponseError):
+            await gateway.get_staff_context(123)

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -8,3 +8,15 @@ def test_bot_handlers_do_not_use_direct_db_queries():
         assert "from sqlmodel import select" not in source, f"{path} imports select directly"
         assert "session.execute(" not in source, f"{path} executes SQL directly"
         assert "from crud." not in source, f"{path} imports CRUD directly"
+
+
+def test_bot_http_gateway_does_not_import_backend_runtime_layers():
+    source = Path("bot_app/api_gateway.py").read_text(encoding="utf-8")
+    forbidden_imports = (
+        "from core.database",
+        "from models",
+        "from crud",
+        "from services",
+    )
+    for forbidden in forbidden_imports:
+        assert forbidden not in source, f"HTTP gateway imports backend layer: {forbidden}"

--- a/tests/unit/test_communication_runtime_worker_fences.py
+++ b/tests/unit/test_communication_runtime_worker_fences.py
@@ -367,7 +367,11 @@ async def test_terminal_db_timeout_is_recovered_as_ambiguous_attempt(
         provider=provider,
         worker_id="terminal-timeout-worker",
         lease_seconds=60,
-        db_operation_timeout_seconds=0.01,
+        # The timeout must be comfortably above normal SQLite setup/claim
+        # latency so this test deterministically reaches the mocked, blocked
+        # terminal write. Ten milliseconds made the assertion depend on suite
+        # load and could time out before the provider call.
+        db_operation_timeout_seconds=0.5,
     )
 
     with pytest.raises(TimeoutError):

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -1,0 +1,117 @@
+from httpx import ASGITransport, AsyncClient
+
+from core.config import settings
+from core.database import get_session
+from main import app
+from services.bot_access_service import BotAccessContext, BotAccessService
+
+
+async def _request(path: str, *, token: str | None = None):
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(path, headers=headers)
+
+
+async def test_internal_bot_api_fails_closed_when_token_is_not_configured(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "")
+
+    response = await _request("/api/internal/bot/v1/health", token="anything")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Bot API token is not configured"}
+
+
+async def test_internal_bot_api_rejects_missing_and_invalid_tokens(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    missing = await _request("/api/internal/bot/v1/health")
+    invalid = await _request("/api/internal/bot/v1/health", token="wrong-token")
+
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert invalid.headers["www-authenticate"] == "Bearer"
+
+
+async def test_internal_bot_api_rejects_request_before_opening_db_session(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+    session_opened = False
+
+    async def guarded_session():
+        nonlocal session_opened
+        session_opened = True
+        yield object()
+
+    app.dependency_overrides[get_session] = guarded_session
+    try:
+        response = await _request("/api/internal/bot/v1/staff/context/123", token="wrong-token")
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 401
+    assert session_opened is False
+
+
+async def test_internal_bot_api_health_uses_dedicated_bearer_token(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    response = await _request("/api/internal/bot/v1/health", token="expected-token")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "api_version": "v1"}
+
+
+def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
+    schema = app.openapi()
+
+    health = schema["paths"]["/api/internal/bot/v1/health"]["get"]
+    staff_context = schema["paths"]["/api/internal/bot/v1/staff/context/{telegram_id}"]["get"]
+
+    assert health["operationId"] == "get_internal_bot_api_health_v1"
+    assert staff_context["operationId"] == "get_internal_bot_staff_context_v1"
+    assert health["security"] == [{"BotServiceBearer": []}]
+    assert staff_context["security"] == [{"BotServiceBearer": []}]
+    assert schema["components"]["securitySchemes"]["BotServiceBearer"] == {
+        "type": "http",
+        "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
+        "scheme": "bearer",
+    }
+
+
+async def test_internal_bot_staff_context_maps_backend_permissions(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_get_context(_session, telegram_id):
+        assert telegram_id == 123456
+        return BotAccessContext(
+            telegram_id=telegram_id,
+            is_staff=True,
+            display_name="Монтажник",
+            primary_role="installer",
+            roles=["installer", "repair"],
+            legacy_installer_id=42,
+        )
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotAccessService, "get_context", fake_get_context)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/staff/context/123456",
+            token="expected-token",
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "telegram_id": 123456,
+        "is_staff": True,
+        "display_name": "Монтажник",
+        "primary_role": "installer",
+        "roles": ["installer", "repair"],
+        "legacy_installer_id": 42,
+        "is_manager": False,
+        "is_executor": True,
+    }


### PR DESCRIPTION
## Summary

- establish a versioned `/api/internal/bot/v1` boundary for the future autonomous Telegram service
- protect the boundary with a dedicated fail-closed Bearer credential
- add a typed HTTP gateway that has no database, model, CRUD, or backend-service imports
- expose the first staff-access context contract without changing production bot behavior
- document the finite migration sequence, scope guardrails, and definition of done
- regenerate OpenAPI and the manager client
- stabilize the pre-existing terminal-delivery timeout test so it reaches the blocked terminal write instead of racing normal SQLite setup under full-suite load

## Why

The bot currently shares the backend image and calls the main database/services directly. This PR creates the transport and authentication boundary first, so later scenarios can move one at a time without copying business logic into the bot or introducing dual writes.

No production scenario is switched in this PR. With `BOT_API_TOKEN` unset, the private API fails closed with HTTP 503 and the existing bot path remains unchanged.

## Security and behavior

- invalid credentials return 401 before a database session is opened
- missing server configuration returns 503
- credentials are accepted only through a Bearer header
- base URLs containing embedded credentials, query strings, or unsupported schemes are rejected by the gateway
- the secret value is not stored in OpenAPI or generated frontend code

## Validation

- full unit suite: `2102 passed, 4 skipped`
- terminal-timeout regression repeated successfully 10/10 times
- complete communications-worker fence suite: `8 passed`
- Bot API/gateway/architecture contract suite passed
- manager frontend production build passed
- Python compileall passed for contracts, bot, core, and routers
- OpenAPI/client regeneration is deterministic and the commit hook passed

## CI diagnosis

The first GitHub run reached `2304 passed` and failed only because the existing test used a global 10 ms DB timeout. Under full-suite load it timed out during normal setup before the fake provider call. The test now uses a bounded 500 ms timeout, while `mark_sent` remains explicitly blocked, making the intended ambiguous-terminal-write path deterministic. Production communications code is unchanged.

## Next PR

Move read-only staff, catalog, selection, calendar, and task scenarios behind this gateway.