### PR TITLE
feat: route bot staff access through API provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ GOOGLE_VISION_PROJECT_ID=
  ---
 # --- Bot Settings ---
 BOT_TOKEN=
+# Staff authorization backend used by Telegram handlers. Keep database during
+# rollout; switch explicitly to api after BOT_API_TOKEN is deployed and checked.
+BOT_ACCESS_BACKEND=database
 # Dedicated service credential for /api/internal/bot/v1. Generate a long,
 # random value and keep it identical in the API and bot runtime environments.
 BOT_API_TOKEN=

--- a/bot_app/access.py
+++ b/bot_app/access.py
@@ -1,0 +1,28 @@
+"""Bot-owned access context and provider boundary."""
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class BotAccessUnavailableError(RuntimeError):
+    """Staff authorization cannot be checked safely at the moment."""
+
+
+@dataclass(frozen=True)
+class BotAccessContext:
+    telegram_id: int
+    is_staff: bool = False
+    display_name: str = ""
+    primary_role: str = ""
+    roles: list[str] = field(default_factory=list)
+    legacy_installer_id: int | None = None
+    is_manager: bool = False
+    is_executor: bool = False
+
+
+class BotAccessProvider(Protocol):
+    async def health(self) -> None: ...
+
+    async def get_context(self, telegram_id: int | str | None) -> BotAccessContext: ...
+
+    async def aclose(self) -> None: ...

--- a/bot_app/access_api.py
+++ b/bot_app/access_api.py
@@ -1,0 +1,51 @@
+"""HTTP-backed staff access provider for the autonomous bot runtime."""
+
+from api_contracts.bot import BotStaffContextResponse
+
+from .access import BotAccessContext, BotAccessUnavailableError
+from .api_gateway import BotApiError, BotApiGateway
+
+
+def _normalize_telegram_id(value: int | str | None) -> int:
+    try:
+        normalized = int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+    return normalized if normalized > 0 else 0
+
+
+def _context_from_response(response: BotStaffContextResponse) -> BotAccessContext:
+    return BotAccessContext(
+        telegram_id=response.telegram_id,
+        is_staff=response.is_staff,
+        display_name=response.display_name,
+        primary_role=response.primary_role,
+        roles=list(response.roles),
+        legacy_installer_id=response.legacy_installer_id,
+        is_manager=response.is_manager,
+        is_executor=response.is_executor,
+    )
+
+
+class ApiBotAccessProvider:
+    def __init__(self, gateway: BotApiGateway) -> None:
+        self._gateway = gateway
+
+    async def health(self) -> None:
+        try:
+            await self._gateway.health()
+        except BotApiError as exc:
+            raise BotAccessUnavailableError("MVN API staff access is unavailable") from exc
+
+    async def get_context(self, telegram_id: int | str | None) -> BotAccessContext:
+        normalized_id = _normalize_telegram_id(telegram_id)
+        if not normalized_id:
+            return BotAccessContext(telegram_id=0)
+        try:
+            response = await self._gateway.get_staff_context(normalized_id)
+        except BotApiError as exc:
+            raise BotAccessUnavailableError("MVN API staff access is unavailable") from exc
+        return _context_from_response(response)
+
+    async def aclose(self) -> None:
+        await self._gateway.aclose()

--- a/bot_app/access_database.py
+++ b/bot_app/access_database.py
@@ -1,0 +1,28 @@
+"""Temporary database adapter kept only for explicit rollback during extraction."""
+
+from core.database import async_session_maker
+from services.bot_access_service import BotAccessService
+
+from .access import BotAccessContext
+
+
+class DatabaseBotAccessProvider:
+    async def health(self) -> None:
+        return None
+
+    async def get_context(self, telegram_id: int | str | None) -> BotAccessContext:
+        async with async_session_maker() as session:
+            context = await BotAccessService.get_context(session, telegram_id)
+        return BotAccessContext(
+            telegram_id=context.telegram_id,
+            is_staff=context.is_staff,
+            display_name=context.display_name,
+            primary_role=context.primary_role,
+            roles=list(context.roles),
+            legacy_installer_id=context.legacy_installer_id,
+            is_manager=context.is_manager,
+            is_executor=context.is_executor,
+        )
+
+    async def aclose(self) -> None:
+        return None

--- a/bot_app/access_runtime.py
+++ b/bot_app/access_runtime.py
@@ -1,0 +1,54 @@
+"""Select and own the staff-access provider used by Telegram handlers."""
+
+from core.config import settings
+
+from .access import BotAccessContext, BotAccessProvider
+from .access_api import ApiBotAccessProvider
+from .api_gateway import BotApiGateway, BotApiGatewayConfig
+
+
+_provider: BotAccessProvider | None = None
+
+
+def _build_provider() -> BotAccessProvider:
+    if settings.BOT_ACCESS_BACKEND == "api":
+        return ApiBotAccessProvider(
+            BotApiGateway(
+                BotApiGatewayConfig(
+                    base_url=settings.BOT_API_BASE_URL,
+                    token=settings.BOT_API_TOKEN,
+                    timeout_seconds=settings.BOT_API_TIMEOUT_SECONDS,
+                )
+            )
+        )
+
+    if settings.BOT_ACCESS_BACKEND == "database":
+        # Import the temporary adapter only when explicit rollback mode is selected.
+        from .access_database import DatabaseBotAccessProvider
+
+        return DatabaseBotAccessProvider()
+
+    raise RuntimeError(f"Unsupported bot access backend: {settings.BOT_ACCESS_BACKEND}")
+
+
+def get_bot_access_provider() -> BotAccessProvider:
+    global _provider
+    if _provider is None:
+        _provider = _build_provider()
+    return _provider
+
+
+async def get_bot_access_context(telegram_id: int | str | None) -> BotAccessContext:
+    return await get_bot_access_provider().get_context(telegram_id)
+
+
+async def verify_bot_access_startup() -> None:
+    await get_bot_access_provider().health()
+
+
+async def close_bot_access_provider() -> None:
+    global _provider
+    provider = _provider
+    _provider = None
+    if provider is not None:
+        await provider.aclose()

--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -9,14 +9,13 @@ from aiogram.filters import StateFilter
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
-from services.bot_access_service import BotAccessService
 from services.product_service import ProductService
-from services.staff_user_service import StaffUserService
 from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
 from services.bot_task_service import BotTaskService
+from ..access_runtime import get_bot_access_context
 from .repair_context import repair_context_keyboard as _repair_context_keyboard
 from ..config import bot
 from ..states import ShopState
@@ -25,13 +24,12 @@ router = Router()
 
 
 async def _is_admin_user(user_id: int | None) -> bool:
-    async with async_session_maker() as session:
-        return await StaffUserService.is_active_owner_admin_telegram_user(session, user_id)
+    context = await _get_bot_access_context(user_id)
+    return context.is_staff and context.is_manager
 
 
 async def _get_bot_access_context(user_id: int | None):
-    async with async_session_maker() as session:
-        return await BotAccessService.get_context(session, user_id)
+    return await get_bot_access_context(user_id)
 
 
 async def _is_staff_user(user_id: int | None) -> bool:

--- a/bot_app/handlers/base.py
+++ b/bot_app/handlers/base.py
@@ -1,18 +1,16 @@
 from aiogram import Router, types
 from aiogram.filters import Command
-from core.database import async_session_maker
-from services.bot_access_service import BotAccessService
+
+from ..access_runtime import get_bot_access_context
 from ..keyboards import get_staff_main_menu
 
 router = Router()
 
 @router.message(Command("start", "menu", "help"))
 async def cmd_start(message: types.Message):
-    async with async_session_maker() as session:
-        context = await BotAccessService.get_context(
-            session,
-            message.from_user.id if message.from_user else None,
-        )
+    context = await get_bot_access_context(
+        message.from_user.id if message.from_user else None,
+    )
     if not context.is_staff:
         await message.answer("Этот бот теперь только для сотрудников MVN.")
         return

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -8,10 +8,9 @@ from aiogram.filters import Command, StateFilter
 from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
 from core.database import async_session_maker
-from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.product_service import ProductService
-from services.staff_user_service import StaffUserService
+from ..access_runtime import get_bot_access_context
 from ..keyboards import (
     area_selection_kb,
     get_staff_main_menu,
@@ -27,8 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 async def _get_access_context(user_id: int | None):
-    async with async_session_maker() as session:
-        return await BotAccessService.get_context(session, user_id)
+    return await get_bot_access_context(user_id)
 
 
 async def _is_staff_user(user_id: int | None) -> bool:
@@ -93,11 +91,8 @@ async def _render_search_results(message: types.Message, query: str, products: l
         f"🔎 Нашел {len(selected_products)} вариантов по запросу «{html.escape(query)}».",
         parse_mode="HTML",
     )
-    async with async_session_maker() as session:
-        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(
-            session,
-            message.from_user.id if message.from_user else None,
-        )
+    context = await _get_access_context(message.from_user.id if message.from_user else None)
+    is_admin = context.is_staff and context.is_manager
     for product in selected_products:
         await send_product_card(message, product, is_admin)
 
@@ -187,6 +182,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
     )
     
     # Получаем товары с фильтрацией по тегам
+    context = await _get_access_context(callback.from_user.id)
     async with async_session_maker() as session:
         products = await ProductService.get_curated(
             session, 
@@ -195,7 +191,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
             tag_slugs=tag_slugs if tag_slugs else None,
             limit=5  # Максимум 5 результатов
         )
-        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, callback.from_user.id)
+        is_admin = context.is_staff and context.is_manager
     
     if not products:
         await callback.message.answer(
@@ -230,9 +226,10 @@ async def search_details(callback: CallbackQuery):
         await callback.answer("Недостаточно прав", show_alert=True)
         return
     product_id = int(callback.data.split("_")[-1])
+    context = await _get_access_context(callback.from_user.id)
     async with async_session_maker() as session:
         product = await ProductService.get_by_id(session, product_id)
-        is_admin = await StaffUserService.is_active_owner_admin_telegram_user(session, callback.from_user.id)
+        is_admin = context.is_staff and context.is_manager
 
     if not product:
         await callback.answer("Товар не найден", show_alert=True)

--- a/bot_app/handlers/repair_context.py
+++ b/bot_app/handlers/repair_context.py
@@ -5,9 +5,9 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 
 from core.database import async_session_maker
-from services.bot_access_service import BotAccessService
 from services.bot_defect_act_service import BotDefectActService
 
+from ..access_runtime import get_bot_access_context
 from ..states import ShopState
 
 router = Router()
@@ -21,8 +21,7 @@ REPAIR_PRESET_FAULT_TYPES = {
 
 
 async def _access_context(user_id: int | None):
-    async with async_session_maker() as session:
-        return await BotAccessService.get_context(session, user_id)
+    return await get_bot_access_context(user_id)
 
 
 def _parse_order_id(value: object) -> int | None:

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -4,11 +4,11 @@ from aiogram.filters import Command
 from aiogram.types import CallbackQuery, ReplyKeyboardRemove
 
 from core.database import async_session_maker
-from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_service import BotService
 from services.bot_task_service import BotTaskService
+from ..access_runtime import get_bot_access_context
 from ..keyboards import (
     get_staff_main_menu,
     quick_order_confirm_keyboard,
@@ -21,8 +21,7 @@ router = Router()
 
 
 async def _access_context(user_id: int | None):
-    async with async_session_maker() as session:
-        return await BotAccessService.get_context(session, user_id)
+    return await get_bot_access_context(user_id)
 
 
 async def _require_staff(message: types.Message):

--- a/bot_app/keyboards.py
+++ b/bot_app/keyboards.py
@@ -2,7 +2,7 @@ from aiogram.types import (
     ReplyKeyboardMarkup, KeyboardButton, 
     InlineKeyboardMarkup, InlineKeyboardButton
 )
-from services.bot_access_service import BotAccessContext
+from .access import BotAccessContext
 from services.bot_product_selection_service import BotProductSelectionService
 
 

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -1,6 +1,8 @@
 import asyncio
 from aiogram import types
 from aiogram.types import BotCommand
+from .access import BotAccessUnavailableError
+from .access_runtime import close_bot_access_provider, verify_bot_access_startup
 from .config import bot, dp
 from .handlers import admin, base, catalog, repair_context, work
 from core.config import settings
@@ -27,7 +29,20 @@ STAFF_BOT_COMMANDS = [
 # Global Error Handler for Bot
 @dp.error()
 async def error_handler(event: types.ErrorEvent):
-    logger.exception(f"Bot error: {event.exception} for event {event.update}")
+    if isinstance(event.exception, BotAccessUnavailableError):
+        logger.error("Bot staff access unavailable: %s", event.exception)
+        callback = event.update.callback_query
+        if callback is not None:
+            await callback.answer("Сервис авторизации временно недоступен. Попробуйте позже.", show_alert=True)
+        elif event.update.message is not None:
+            await event.update.message.answer("Сервис авторизации временно недоступен. Попробуйте позже.")
+        return True
+    logger.error(
+        "Bot error: %s for event %s",
+        event.exception,
+        event.update,
+        exc_info=(type(event.exception), event.exception, event.exception.__traceback__),
+    )
     return True
 
 async def _idle_when_disabled() -> None:
@@ -73,10 +88,12 @@ async def main(*, wait_when_disabled: bool = True):
     dp.include_router(admin.router)
     
     try:
+        await verify_bot_access_startup()
         await _setup_bot_commands()
         await bot.delete_webhook(drop_pending_updates=settings.BOT_DROP_PENDING_UPDATES)
         await dp.start_polling(bot)
     finally:
+        await close_bot_access_provider()
         await runtime_lock.release()
 
 if __name__ == "__main__":

--- a/core/config.py
+++ b/core/config.py
@@ -26,6 +26,7 @@ def _redact_settings_validation_error(error: ValidationError) -> ValidationError
 class Settings(BaseSettings):
     # Bot Settings
     BOT_TOKEN: str = ""
+    BOT_ACCESS_BACKEND: str = "database"
     BOT_API_TOKEN: str = ""
     BOT_API_BASE_URL: str = "http://app:8000/api/internal/bot/v1"
     BOT_API_TIMEOUT_SECONDS: float = 5.0
@@ -224,6 +225,14 @@ class Settings(BaseSettings):
     READINESS_REQUIRE_WRITABLE_DB: bool = True
     RUNTIME_DB_LOCKS_ENABLED: bool = True
     RUNTIME_LOCK_RETRY_SECONDS: int = 15
+
+    @field_validator("BOT_ACCESS_BACKEND", mode="before")
+    @classmethod
+    def _validate_bot_access_backend(cls, value: object) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in {"database", "api"}:
+            raise ValueError("BOT_ACCESS_BACKEND must be database or api")
+        return normalized
 
     # Durable communications runtime. The process is deliberately inert unless
     # this immutable deployment gate is explicitly enabled. A second, database-

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -35,6 +35,7 @@ services:
     restart: always
     depends_on:
       - db
+      - app
     env_file:
       - .env
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,6 +57,7 @@ services:
     restart: always
     depends_on:
       - db
+      - app
     env_file:
       - .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     restart: always
     depends_on:
       - db
+      - app
     env_file:
       - .env
     environment:

--- a/docs/bot-service-extraction.md
+++ b/docs/bot-service-extraction.md
@@ -23,6 +23,18 @@ authorizes the Telegram user for each use case.
 6. Move the autonomous bot into a separate repository only after the boundary
    checks below pass.
 
+### Staff access cutover
+
+Telegram handlers resolve staff identity and roles through one bot-owned
+provider. `BOT_ACCESS_BACKEND=database` is the explicit rollback mode during
+the rollout. Set `BOT_ACCESS_BACKEND=api` only after deploying the same strong
+`BOT_API_TOKEN` to the API and bot runtimes. API mode performs a startup health
+check and never silently falls back to the database after an HTTP failure.
+
+The temporary database provider is removed after API mode has been verified in
+production. Catalog, orders, repair and FSM database paths remain separate
+migration slices; this switch covers staff authorization only.
+
 ## Scope guardrails
 
 - Freeze new bot product features while a scenario is being migrated.

--- a/tests/unit/test_bot_access_provider.py
+++ b/tests/unit/test_bot_access_provider.py
@@ -1,0 +1,105 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
+from bot_app import access_runtime
+from bot_app.access import BotAccessContext, BotAccessUnavailableError
+from bot_app.access_api import ApiBotAccessProvider
+from bot_app.api_gateway import BotApiUnavailableError
+
+
+async def test_api_access_provider_maps_staff_context():
+    gateway = SimpleNamespace(
+        get_staff_context=AsyncMock(
+            return_value=BotStaffContextResponse(
+                telegram_id=123,
+                is_staff=True,
+                display_name="Менеджер",
+                primary_role="manager",
+                roles=["manager"],
+                is_manager=True,
+                is_executor=False,
+            )
+        ),
+        health=AsyncMock(return_value=BotApiHealthResponse()),
+        aclose=AsyncMock(),
+    )
+    provider = ApiBotAccessProvider(gateway)
+
+    context = await provider.get_context("123")
+
+    assert context == BotAccessContext(
+        telegram_id=123,
+        is_staff=True,
+        display_name="Менеджер",
+        primary_role="manager",
+        roles=["manager"],
+        is_manager=True,
+        is_executor=False,
+    )
+    gateway.get_staff_context.assert_awaited_once_with(123)
+
+
+@pytest.mark.parametrize("telegram_id", [None, "", "invalid", 0, -1])
+async def test_api_access_provider_rejects_invalid_user_without_http_call(telegram_id):
+    gateway = SimpleNamespace(
+        get_staff_context=AsyncMock(),
+        health=AsyncMock(),
+        aclose=AsyncMock(),
+    )
+    provider = ApiBotAccessProvider(gateway)
+
+    context = await provider.get_context(telegram_id)
+
+    assert context == BotAccessContext(telegram_id=0)
+    gateway.get_staff_context.assert_not_awaited()
+
+
+async def test_api_access_provider_fails_closed_when_api_is_unavailable():
+    gateway = SimpleNamespace(
+        get_staff_context=AsyncMock(side_effect=BotApiUnavailableError("offline")),
+        health=AsyncMock(),
+        aclose=AsyncMock(),
+    )
+    provider = ApiBotAccessProvider(gateway)
+
+    with pytest.raises(BotAccessUnavailableError, match="staff access is unavailable"):
+        await provider.get_context(123)
+
+
+async def test_access_runtime_checks_health_and_closes_provider(monkeypatch):
+    provider = SimpleNamespace(
+        health=AsyncMock(),
+        get_context=AsyncMock(return_value=BotAccessContext(telegram_id=7, is_staff=True)),
+        aclose=AsyncMock(),
+    )
+    monkeypatch.setattr(access_runtime, "_provider", provider)
+
+    await access_runtime.verify_bot_access_startup()
+    context = await access_runtime.get_bot_access_context(7)
+    await access_runtime.close_bot_access_provider()
+
+    assert context.is_staff is True
+    provider.health.assert_awaited_once_with()
+    provider.get_context.assert_awaited_once_with(7)
+    provider.aclose.assert_awaited_once_with()
+    assert access_runtime._provider is None
+
+
+def test_api_access_backend_requires_service_token(monkeypatch):
+    monkeypatch.setattr(access_runtime, "_provider", None)
+    monkeypatch.setattr(access_runtime.settings, "BOT_ACCESS_BACKEND", "api")
+    monkeypatch.setattr(access_runtime.settings, "BOT_API_TOKEN", "")
+
+    with pytest.raises(ValueError, match="Bot API token is required"):
+        access_runtime.get_bot_access_provider()
+
+
+def test_access_runtime_never_implicitly_falls_back_to_database(monkeypatch):
+    monkeypatch.setattr(access_runtime, "_provider", None)
+    monkeypatch.setattr(access_runtime.settings, "BOT_ACCESS_BACKEND", "unexpected")
+
+    with pytest.raises(RuntimeError, match="Unsupported bot access backend"):
+        access_runtime.get_bot_access_provider()

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -176,23 +176,12 @@ async def test_delete_item_skips_service_for_non_admin(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_is_admin_user_uses_staff_service(monkeypatch):
-    session = object()
-
-    class _StaticSessionContext:
-        async def __aenter__(self):
-            return session
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    admin_check = AsyncMock(return_value=True)
-    monkeypatch.setattr(admin_handler.StaffUserService, "is_active_owner_admin_telegram_user", admin_check)
-    monkeypatch.setattr(admin_handler, "async_session_maker", lambda: _StaticSessionContext())
+async def test_is_admin_user_uses_shared_access_context(monkeypatch):
+    access_check = AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True))
+    monkeypatch.setattr(admin_handler, "_get_bot_access_context", access_check)
 
     assert await admin_handler._is_admin_user(7)
-    admin_check.assert_awaited_once()
-    assert admin_check.await_args.args == (session, 7)
+    access_check.assert_awaited_once_with(7)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -10,6 +10,18 @@ def test_bot_handlers_do_not_use_direct_db_queries():
         assert "from crud." not in source, f"{path} imports CRUD directly"
 
 
+def test_bot_handlers_resolve_staff_access_only_through_bot_provider():
+    handlers_dir = Path("bot_app/handlers")
+    forbidden_imports = (
+        "services.bot_access_service",
+        "services.staff_user_service",
+    )
+    for path in handlers_dir.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        for forbidden in forbidden_imports:
+            assert forbidden not in source, f"{path} bypasses bot access provider: {forbidden}"
+
+
 def test_bot_http_gateway_does_not_import_backend_runtime_layers():
     source = Path("bot_app/api_gateway.py").read_text(encoding="utf-8")
     forbidden_imports = (

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -97,6 +97,38 @@ def test_empty_runtime_switch_env_values_are_unset(monkeypatch):
     assert settings.db_bootstrap_control_decision.enabled is True
 
 
+@pytest.mark.parametrize(("value", "expected"), [("database", "database"), (" API ", "api")])
+def test_bot_access_backend_is_explicit_and_normalized(monkeypatch, value, expected):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    settings = config.Settings(
+        BOT_TOKEN="123:test",
+        SECRET_KEY="test-secret",
+        ADMIN_USERNAME="admin",
+        ADMIN_PASSWORD="admin",
+        BOT_ACCESS_BACKEND=value,
+        _env_file=None,
+    )
+
+    assert settings.BOT_ACCESS_BACKEND == expected
+
+
+def test_bot_access_backend_rejects_implicit_fallback(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    with pytest.raises(ValueError, match="BOT_ACCESS_BACKEND"):
+        config.Settings(
+            BOT_TOKEN="123:test",
+            SECRET_KEY="test-secret",
+            ADMIN_USERNAME="admin",
+            ADMIN_PASSWORD="admin",
+            BOT_ACCESS_BACKEND="auto",
+            _env_file=None,
+        )
+
+
 @pytest.mark.asyncio
 async def test_database_bootstrap_skips_for_standby(monkeypatch):
     _set_required_env(monkeypatch)
@@ -234,6 +266,7 @@ async def test_bot_main_disabled_does_not_poll(monkeypatch):
     delete_webhook = AsyncMock()
     start_polling = AsyncMock()
     verify_storage = AsyncMock()
+    verify_access = AsyncMock()
     monkeypatch.setattr(
         bot_main,
         "verify_private_attachment_storage_startup",
@@ -241,10 +274,12 @@ async def test_bot_main_disabled_does_not_poll(monkeypatch):
     )
     monkeypatch.setattr(bot_main.bot, "delete_webhook", delete_webhook)
     monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
+    monkeypatch.setattr(bot_main, "verify_bot_access_startup", verify_access)
 
     await bot_main.main(wait_when_disabled=False)
 
     verify_storage.assert_awaited_once_with(bot_main.settings)
+    verify_access.assert_not_awaited()
     delete_webhook.assert_not_awaited()
     start_polling.assert_not_awaited()
 
@@ -263,9 +298,13 @@ async def test_bot_main_preserves_pending_updates_by_default(monkeypatch):
     setup_commands = AsyncMock()
     delete_webhook = AsyncMock()
     start_polling = AsyncMock()
+    verify_access = AsyncMock()
+    close_access = AsyncMock()
     monkeypatch.setattr(bot_main, "_setup_bot_commands", setup_commands)
     monkeypatch.setattr(bot_main.bot, "delete_webhook", delete_webhook)
     monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
+    monkeypatch.setattr(bot_main, "verify_bot_access_startup", verify_access)
+    monkeypatch.setattr(bot_main, "close_bot_access_provider", close_access)
     monkeypatch.setattr(
         bot_main.RuntimeLockService,
         "try_acquire",
@@ -274,6 +313,60 @@ async def test_bot_main_preserves_pending_updates_by_default(monkeypatch):
 
     await bot_main.main(wait_when_disabled=False)
 
+    verify_access.assert_awaited_once_with()
     setup_commands.assert_awaited_once()
     delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
     start_polling.assert_awaited_once_with(bot_main.bot)
+    close_access.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_bot_main_does_not_poll_when_access_preflight_fails(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+    monkeypatch.setattr(config.settings, "BOT_TOKEN", "123:test", raising=False)
+    bot_main = importlib.import_module("bot_app.main")
+
+    monkeypatch.setattr(bot_main.settings, "APP_ROLE", "primary", raising=False)
+    monkeypatch.setattr(bot_main.settings, "BOT_ENABLED", True, raising=False)
+    monkeypatch.setattr(bot_main.dp, "include_router", Mock())
+    runtime_lock = SimpleNamespace(acquired=True, reason="test lock", release=AsyncMock())
+    monkeypatch.setattr(
+        bot_main.RuntimeLockService,
+        "try_acquire",
+        AsyncMock(return_value=runtime_lock),
+    )
+    monkeypatch.setattr(
+        bot_main,
+        "verify_bot_access_startup",
+        AsyncMock(side_effect=bot_main.BotAccessUnavailableError("offline")),
+    )
+    close_access = AsyncMock()
+    start_polling = AsyncMock()
+    monkeypatch.setattr(bot_main, "close_bot_access_provider", close_access)
+    monkeypatch.setattr(bot_main.dp, "start_polling", start_polling)
+
+    with pytest.raises(bot_main.BotAccessUnavailableError, match="offline"):
+        await bot_main.main(wait_when_disabled=False)
+
+    start_polling.assert_not_awaited()
+    close_access.assert_awaited_once_with()
+    runtime_lock.release.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_bot_access_error_is_visible_to_callback(monkeypatch):
+    _set_required_env(monkeypatch)
+    bot_main = importlib.import_module("bot_app.main")
+    callback = SimpleNamespace(answer=AsyncMock())
+    event = SimpleNamespace(
+        exception=bot_main.BotAccessUnavailableError("offline"),
+        update=SimpleNamespace(callback_query=callback, message=None),
+    )
+
+    assert await bot_main.error_handler(event) is True
+
+    callback.answer.assert_awaited_once_with(
+        "Сервис авторизации временно недоступен. Попробуйте позже.",
+        show_alert=True,
+    )


### PR DESCRIPTION
## Что изменено

- все Telegram-обработчики получают staff context через единый bot-owned provider;
- добавлены явные режимы `BOT_ACCESS_BACKEND=database|api`;
- API-режим использует типизированный gateway из PR #767 и никогда не откатывается к БД автоматически;
- перед polling выполняется health-check внутреннего Bot API;
- при недоступности API сотрудник получает понятное ограниченное сообщение;
- временный database provider сохранён как явный rollback до проверки API-режима в production;
- bot compose-сервисы теперь запускаются после `app`;
- документация выделения бота дополнена процедурой staff access cutover.

## Зачем

Проверка Telegram-пользователя и его ролей была продублирована в пяти группах обработчиков и напрямую открывала SQLAlchemy-сессии. Этот PR создаёт один переключаемый вертикальный срез: staff authorization можно перевести на внутренний API без переноса каталога, заказов, ремонтов и FSM в тот же большой PR.

## Безопасность развёртывания

- значение по умолчанию остаётся `database`, поэтому merge сам по себе не меняет production-поведение;
- переключение выполняется явно через `BOT_ACCESS_BACKEND=api` после установки общего `BOT_API_TOKEN`;
- неверный режим и API-режим без токена завершаются ошибкой;
- ошибка HTTP не включает скрытый database fallback;
- неуспешный startup preflight не начинает Telegram polling и освобождает runtime-lock.

## Проверки

- `python3 -m compileall -q bot_app core/config.py`
- bot/runtime/internal API: `188 passed`
- полный unit-набор: `2118 passed, 4 skipped`
- `git diff --check`
- структурная проверка всех трёх compose YAML.

## Следующий шаг после merge

Сгенерировать production service token, установить его для API и bot runtime, переключить `BOT_ACCESS_BACKEND=api`, проверить `/start`, меню менеджера и исполнителя, затем удалить временный database provider отдельным PR после стабильного окна.
