### PR TITLE
fix: guard bot API production routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@ BOT_ACCESS_BACKEND=database
 # Dedicated service credential for /api/internal/bot/v1. Generate a long,
 # random value and keep it identical in the API and bot runtime environments.
 BOT_API_TOKEN=
+# Local Compose can use app. Production blue-green must use the stable HTTPS
+# origin: https://api.mvn.by/api/internal/bot/v1
 BOT_API_BASE_URL=http://app:8000/api/internal/bot/v1
 BOT_API_TIMEOUT_SECONDS=5
 ADMIN_ID=

--- a/core/config.py
+++ b/core/config.py
@@ -234,6 +234,21 @@ class Settings(BaseSettings):
             raise ValueError("BOT_ACCESS_BACKEND must be database or api")
         return normalized
 
+    @model_validator(mode="after")
+    def _validate_bot_api_runtime(self):
+        if self.BOT_ACCESS_BACKEND != "api":
+            return self
+        if not self.BOT_API_TOKEN.strip():
+            raise ValueError("BOT_API_TOKEN is required when BOT_ACCESS_BACKEND=api")
+
+        parsed = urlsplit(self.BOT_API_BASE_URL.strip())
+        if self.ENVIRONMENT == "production":
+            if parsed.scheme != "https":
+                raise ValueError("production Bot API access requires an HTTPS base URL")
+            if parsed.hostname in {"app", "app-blue", "app-green"}:
+                raise ValueError("production Bot API access requires a stable host across blue-green slots")
+        return self
+
     # Durable communications runtime. The process is deliberately inert unless
     # this immutable deployment gate is explicitly enabled. A second, database-
     # backed off/canary/all control is evaluated by the runtime after it proves

--- a/docs/bot-service-extraction.md
+++ b/docs/bot-service-extraction.md
@@ -31,6 +31,12 @@ the rollout. Set `BOT_ACCESS_BACKEND=api` only after deploying the same strong
 `BOT_API_TOKEN` to the API and bot runtimes. API mode performs a startup health
 check and never silently falls back to the database after an HTTP failure.
 
+Production must use `https://api.mvn.by/api/internal/bot/v1`. Blue/green service
+names (`app-blue` and `app-green`) change on every deployment and the inactive
+slot is removed, so they are not valid service-discovery addresses for the bot.
+Settings reject API mode without a token, without HTTPS in production, or with
+a slot-local hostname.
+
 The temporary database provider is removed after API mode has been verified in
 production. Catalog, orders, repair and FSM database paths remain separate
 migration slices; this switch covers staff authorization only.

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -23,6 +23,16 @@ def _set_required_env(monkeypatch):
     monkeypatch.setenv("ADMIN_PASSWORD", "admin")
 
 
+def _production_private_storage_values() -> dict[str, str]:
+    return {
+        "SERVICE_ATTACHMENT_STORAGE_PROVIDER": "r2",
+        "SERVICE_ATTACHMENT_S3_BUCKET": "test-private-service-attachments",
+        "SERVICE_ATTACHMENT_S3_ENDPOINT_URL": "https://account.r2.invalid",
+        "SERVICE_ATTACHMENT_S3_ACCESS_KEY_ID": "test-access-key",
+        "SERVICE_ATTACHMENT_S3_SECRET_ACCESS_KEY": "test-secret-key",
+    }
+
+
 def test_standby_role_disables_scheduler_by_default():
     decision = resolve_single_active_control(
         app_role="standby",
@@ -108,6 +118,7 @@ def test_bot_access_backend_is_explicit_and_normalized(monkeypatch, value, expec
         ADMIN_USERNAME="admin",
         ADMIN_PASSWORD="admin",
         BOT_ACCESS_BACKEND=value,
+        BOT_API_TOKEN="service-token" if expected == "api" else "",
         _env_file=None,
     )
 
@@ -127,6 +138,69 @@ def test_bot_access_backend_rejects_implicit_fallback(monkeypatch):
             BOT_ACCESS_BACKEND="auto",
             _env_file=None,
         )
+
+
+def test_bot_api_backend_requires_service_token(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    with pytest.raises(ValueError, match="BOT_API_TOKEN is required"):
+        config.Settings(
+            BOT_TOKEN="123:test",
+            SECRET_KEY="test-secret",
+            ADMIN_USERNAME="admin",
+            ADMIN_PASSWORD="admin",
+            BOT_ACCESS_BACKEND="api",
+            BOT_API_TOKEN="",
+            _env_file=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://api.mvn.by/api/internal/bot/v1",
+        "https://app/api/internal/bot/v1",
+        "https://app-blue/api/internal/bot/v1",
+    ],
+)
+def test_production_bot_api_backend_requires_stable_https_origin(monkeypatch, base_url):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    with pytest.raises(ValueError, match="production Bot API access"):
+        config.Settings(
+            BOT_TOKEN="123:test",
+            SECRET_KEY="test-secret",
+            ADMIN_USERNAME="admin",
+            ADMIN_PASSWORD="admin",
+            ENVIRONMENT="production",
+            BOT_ACCESS_BACKEND="api",
+            BOT_API_TOKEN="service-token",
+            BOT_API_BASE_URL=base_url,
+            _env_file=None,
+            **_production_private_storage_values(),
+        )
+
+
+def test_production_bot_api_backend_accepts_stable_https_origin(monkeypatch):
+    _set_required_env(monkeypatch)
+    config = importlib.import_module("core.config")
+
+    settings = config.Settings(
+        BOT_TOKEN="123:test",
+        SECRET_KEY="test-secret",
+        ADMIN_USERNAME="admin",
+        ADMIN_PASSWORD="admin",
+        ENVIRONMENT="production",
+        BOT_ACCESS_BACKEND="api",
+        BOT_API_TOKEN="service-token",
+        BOT_API_BASE_URL="https://api.mvn.by/api/internal/bot/v1",
+        _env_file=None,
+        **_production_private_storage_values(),
+    )
+
+    assert settings.BOT_API_BASE_URL == "https://api.mvn.by/api/internal/bot/v1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что изменено

- `BOT_ACCESS_BACKEND=api` теперь требует настроенный `BOT_API_TOKEN`;
- production API mode требует HTTPS base URL;
- slot-local адреса `app`, `app-blue`, `app-green` запрещены в production;
- документация фиксирует стабильный origin `https://api.mvn.by/api/internal/bot/v1`;
- добавлены production-конфигурационные тесты.

## Причина

Live preflight перед переключением Telegram-бота доказал, что имя `app` не резолвится из bot container в blue/green production. Активен только текущий slot (`app-blue` или `app-green`), а его имя меняется при каждом deployment. Включение API mode с default Docker URL привело бы к restart loop бота.

## Влияние

Текущий `BOT_ACCESS_BACKEND=database` не меняется. Guard срабатывает только при явном API cutover и не позволяет запустить production с отсутствующим токеном, HTTP URL или нестабильным slot hostname.

## Проверки

- focused Bot API/settings: `52 passed`;
- полный unit-набор: `2123 passed, 4 skipped`;
- `python3 -m compileall -q core/config.py bot_app`;
- `git diff --check`.

## Live preflight

- `mvn-api` primary, `zakup` synchronous standby;
- public readiness `200`;
- из bot container `app` не резолвится, `app-blue` резолвится только для текущего slot;
- стабильный HTTPS endpoint доступен и до настройки токена корректно возвращал `503`;
- одинаковый новый service token и стабильный URL уже атомарно подготовлены в `.env` обоих узлов, но работающие контейнеры остаются в database mode до штатного deployment.
