### PR TITLE
Route Telegram catalog search through internal API

### DIFF
--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -19,3 +19,33 @@ class BotStaffContextResponse(BaseModel):
     legacy_installer_id: int | None = None
     is_manager: bool = False
     is_executor: bool = False
+
+
+class BotCatalogProductResponse(BaseModel):
+    """Small, stable product projection used by Telegram catalog cards."""
+
+    id: int = Field(ge=1)
+    title: str
+    slug: str = ""
+    description: str = ""
+    price: int
+    area: int = 0
+    main_image: str | None = None
+    categories: list[str] = Field(default_factory=list)
+    vitebsk_qty: int = 0
+    minsk_qty: int = 0
+    availability_status: str = "out_of_stock"
+
+
+class BotCatalogSearchRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    query: str = Field(min_length=1, max_length=100)
+    limit: int = Field(default=5, ge=1, le=10)
+
+
+class BotCatalogSearchResponse(BaseModel):
+    items: list[BotCatalogProductResponse] = Field(default_factory=list)
+
+
+class BotCatalogProductLookupResponse(BaseModel):
+    product: BotCatalogProductResponse | None = None

--- a/bot_app/access_api.py
+++ b/bot_app/access_api.py
@@ -28,8 +28,9 @@ def _context_from_response(response: BotStaffContextResponse) -> BotAccessContex
 
 
 class ApiBotAccessProvider:
-    def __init__(self, gateway: BotApiGateway) -> None:
+    def __init__(self, gateway: BotApiGateway, *, owns_gateway: bool = True) -> None:
         self._gateway = gateway
+        self._owns_gateway = owns_gateway
 
     async def health(self) -> None:
         try:
@@ -48,4 +49,5 @@ class ApiBotAccessProvider:
         return _context_from_response(response)
 
     async def aclose(self) -> None:
-        await self._gateway.aclose()
+        if self._owns_gateway:
+            await self._gateway.aclose()

--- a/bot_app/access_runtime.py
+++ b/bot_app/access_runtime.py
@@ -4,7 +4,7 @@ from core.config import settings
 
 from .access import BotAccessContext, BotAccessProvider
 from .access_api import ApiBotAccessProvider
-from .api_gateway import BotApiGateway, BotApiGatewayConfig
+from .api_runtime import get_bot_api_gateway
 
 
 _provider: BotAccessProvider | None = None
@@ -13,13 +13,8 @@ _provider: BotAccessProvider | None = None
 def _build_provider() -> BotAccessProvider:
     if settings.BOT_ACCESS_BACKEND == "api":
         return ApiBotAccessProvider(
-            BotApiGateway(
-                BotApiGatewayConfig(
-                    base_url=settings.BOT_API_BASE_URL,
-                    token=settings.BOT_API_TOKEN,
-                    timeout_seconds=settings.BOT_API_TIMEOUT_SECONDS,
-                )
-            )
+            get_bot_api_gateway(),
+            owns_gateway=False,
         )
 
     if settings.BOT_ACCESS_BACKEND == "database":

--- a/bot_app/api_gateway.py
+++ b/bot_app/api_gateway.py
@@ -5,7 +5,12 @@ from urllib.parse import urlsplit
 
 import httpx
 
-from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
+from api_contracts.bot import (
+    BotApiHealthResponse,
+    BotCatalogProductLookupResponse,
+    BotCatalogSearchResponse,
+    BotStaffContextResponse,
+)
 
 
 class BotApiError(RuntimeError):
@@ -14,6 +19,10 @@ class BotApiError(RuntimeError):
 
 class BotApiAuthenticationError(BotApiError):
     """The API rejected the bot service credential."""
+
+
+class BotApiAuthorizationError(BotApiError):
+    """The Telegram identity cannot use the requested staff action."""
 
 
 class BotApiUnavailableError(BotApiError):
@@ -83,19 +92,85 @@ class BotApiGateway:
         except ValueError as exc:
             raise BotApiResponseError("MVN API returned an invalid staff context contract") from exc
 
-    async def _get(self, path: str) -> dict:
+    async def search_catalog(
+        self,
+        *,
+        telegram_id: int,
+        query: str,
+        limit: int = 5,
+    ) -> BotCatalogSearchResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise ValueError("Catalog query must not be empty")
+        if len(normalized_query) > 100:
+            raise ValueError("Catalog query must not exceed 100 characters")
+        if limit < 1 or limit > 10:
+            raise ValueError("Catalog search limit must be between 1 and 10")
+        payload = await self._post(
+            "catalog/search",
+            json={
+                "telegram_id": telegram_id,
+                "query": normalized_query,
+                "limit": limit,
+            },
+        )
+        try:
+            return BotCatalogSearchResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid catalog search contract") from exc
+
+    async def get_catalog_product(
+        self,
+        *,
+        telegram_id: int,
+        product_id: int,
+    ) -> BotCatalogProductLookupResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if product_id <= 0:
+            raise ValueError("Product ID must be positive")
+        payload = await self._get(
+            f"catalog/products/{product_id}",
+            params={"telegram_id": telegram_id},
+        )
+        try:
+            return BotCatalogProductLookupResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid catalog product contract") from exc
+
+    async def _get(self, path: str, *, params: dict[str, object] | None = None) -> dict:
+        return await self._request("GET", path, params=params)
+
+    async def _post(self, path: str, *, json: dict[str, object]) -> dict:
+        return await self._request("POST", path, json=json)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        json: dict[str, object] | None = None,
+    ) -> dict:
         url = f"{self._config.base_url}/{path.lstrip('/')}"
         try:
-            response = await self._client.get(
+            response = await self._client.request(
+                method,
                 url,
                 headers={"Authorization": f"Bearer {self._config.token}"},
+                params=params,
+                json=json,
                 timeout=self._config.timeout_seconds,
             )
         except (httpx.TimeoutException, httpx.TransportError) as exc:
             raise BotApiUnavailableError("MVN API is temporarily unavailable") from exc
 
-        if response.status_code in {401, 403}:
+        if response.status_code == 401:
             raise BotApiAuthenticationError("MVN API rejected the bot credential")
+        if response.status_code == 403:
+            raise BotApiAuthorizationError("MVN API denied the staff action")
         if response.status_code >= 500:
             raise BotApiUnavailableError(f"MVN API returned HTTP {response.status_code}")
         if response.status_code >= 400:

--- a/bot_app/api_runtime.py
+++ b/bot_app/api_runtime.py
@@ -1,0 +1,29 @@
+"""Process-wide MVN API gateway shared by autonomous bot use cases."""
+
+from core.config import settings
+
+from .api_gateway import BotApiGateway, BotApiGatewayConfig
+
+
+_gateway: BotApiGateway | None = None
+
+
+def get_bot_api_gateway() -> BotApiGateway:
+    global _gateway
+    if _gateway is None:
+        _gateway = BotApiGateway(
+            BotApiGatewayConfig(
+                base_url=settings.BOT_API_BASE_URL,
+                token=settings.BOT_API_TOKEN,
+                timeout_seconds=settings.BOT_API_TIMEOUT_SECONDS,
+            )
+        )
+    return _gateway
+
+
+async def close_bot_api_gateway() -> None:
+    global _gateway
+    gateway = _gateway
+    _gateway = None
+    if gateway is not None:
+        await gateway.aclose()

--- a/bot_app/catalog_presenter.py
+++ b/bot_app/catalog_presenter.py
@@ -1,0 +1,53 @@
+"""Pure Telegram-side formatting for catalog products."""
+
+from typing import Any
+
+from core.config import settings
+
+
+def product_url(product: dict[str, Any]) -> str:
+    slug = str(product.get("slug") or "").strip()
+    base = settings.PUBLIC_SITE_URL.rstrip("/") if settings.PUBLIC_SITE_URL else "https://mvn.by"
+    return f"{base}/product/{slug}/" if slug else base
+
+
+def availability_text(product: dict[str, Any]) -> str:
+    vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+    minsk_qty = int(product.get("minsk_qty") or 0)
+    availability = str(product.get("availability_status") or "").strip().lower()
+    if vitebsk_qty > 0:
+        return f"Витебск: {vitebsk_qty} шт."
+    if minsk_qty > 0:
+        return f"Минск: {minsk_qty} шт., обычно 2-3 дня"
+    if availability == "in_stock_now":
+        return "В наличии"
+    if availability == "available_2_3_days":
+        return "Доступно 2-3 дня"
+    if availability == "check_availability":
+        return "Наличие уточнить"
+    return "Нет в наличии"
+
+
+def client_availability_text(product: dict[str, Any]) -> str:
+    vitebsk_qty = int(product.get("vitebsk_qty") or 0)
+    minsk_qty = int(product.get("minsk_qty") or 0)
+    availability = str(product.get("availability_status") or "").strip().lower()
+    if vitebsk_qty > 0 or availability == "in_stock_now":
+        return "в наличии"
+    if minsk_qty > 0 or availability == "available_2_3_days":
+        return "в наличии в Минске, срок поставки 2-4 дня"
+    return "наличие уточняем"
+
+
+def format_client_product(product: dict[str, Any]) -> str:
+    title = str(product.get("title") or "Кондиционер").strip()
+    price = product.get("price")
+    price_text = f"{price} руб." if price not in (None, "") else "цену уточним"
+    return "\n".join(
+        (
+            title,
+            f"Цена: {price_text}",
+            client_availability_text(product),
+            product_url(product),
+        )
+    )

--- a/bot_app/handlers/catalog.py
+++ b/bot_app/handlers/catalog.py
@@ -11,6 +11,9 @@ from core.database import async_session_maker
 from services.bot_product_selection_service import BotProductSelectionService
 from services.product_service import ProductService
 from ..access_runtime import get_bot_access_context
+from ..api_gateway import BotApiError
+from ..api_runtime import get_bot_api_gateway
+from ..catalog_presenter import format_client_product
 from ..keyboards import (
     area_selection_kb,
     get_staff_main_menu,
@@ -39,14 +42,21 @@ async def _is_manager_user(user_id: int | None) -> bool:
     return context.is_staff and context.is_manager
 
 
-async def _answer_with_staff_menu(message: types.Message, user_id: int | None) -> None:
-    context = await _get_access_context(user_id)
+async def _answer_with_staff_menu(
+    message: types.Message,
+    user_id: int | None,
+    *,
+    context=None,
+) -> None:
+    context = context or await _get_access_context(user_id)
     if context.is_staff:
         await message.answer("Можно продолжить работу из меню.", reply_markup=get_staff_main_menu(context))
 
 
 def _is_inline_search_query(text: str) -> bool:
     if not text:
+        return False
+    if len(text.strip()) > 100:
         return False
     # 1..3 tokens, each token contains only latin letters/digits.
     return bool(re.fullmatch(r"[A-Za-z0-9]+(?:\s+[A-Za-z0-9]+){0,2}", text.strip()))
@@ -74,7 +84,11 @@ def _choose_search_products(products: list[dict]) -> tuple[list[dict], str | Non
     return [], None
 
 
-async def _render_search_results(message: types.Message, query: str, products: list[dict]) -> None:
+async def _render_search_results(
+    message: types.Message,
+    query: str,
+    products: list[dict],
+) -> None:
     selected_products, warning_text = _choose_search_products(products)
     if not selected_products:
         await message.answer(
@@ -91,10 +105,30 @@ async def _render_search_results(message: types.Message, query: str, products: l
         f"🔎 Нашел {len(selected_products)} вариантов по запросу «{html.escape(query)}».",
         parse_mode="HTML",
     )
-    context = await _get_access_context(message.from_user.id if message.from_user else None)
-    is_admin = context.is_staff and context.is_manager
     for product in selected_products:
-        await send_product_card(message, product, is_admin)
+        await send_product_card(message, product, False)
+
+
+async def _search_products_via_api(
+    *,
+    telegram_id: int,
+    query: str,
+    limit: int = 5,
+) -> list[dict]:
+    response = await get_bot_api_gateway().search_catalog(
+        telegram_id=telegram_id,
+        query=query,
+        limit=limit,
+    )
+    return [item.model_dump(mode="json") for item in response.items]
+
+
+async def _get_product_via_api(*, telegram_id: int, product_id: int) -> dict | None:
+    response = await get_bot_api_gateway().get_catalog_product(
+        telegram_id=telegram_id,
+        product_id=product_id,
+    )
+    return response.product.model_dump(mode="json") if response.product else None
 
 
 # ==================== УМНЫЙ ПОДБОР ====================
@@ -204,7 +238,7 @@ async def process_wifi_and_show_results(callback: CallbackQuery, state: FSMConte
             await send_product_card(callback, product, is_admin)
             
     await state.clear()
-    await _answer_with_staff_menu(callback.message, callback.from_user.id)
+    await _answer_with_staff_menu(callback.message, callback.from_user.id, context=context)
     await callback.answer()
 
 # ==================== ПОИСК ====================
@@ -216,74 +250,75 @@ async def search_start(message: types.Message, state: FSMContext):
         await message.answer("Этот бот теперь только для сотрудников MVN.")
         return
     await state.set_state(ShopState.waiting_for_search)
-    logger.info("BOT_SEARCH_START user_id=%s", message.from_user.id if message.from_user else None)
+    logger.info("BOT_SEARCH_START")
     await message.answer("Введите бренд и мощность, например: Midea 12")
 
 
 @router.callback_query(F.data.startswith("search_details_"))
 async def search_details(callback: CallbackQuery):
-    if not await _is_staff_user(callback.from_user.id):
+    context = await _get_access_context(callback.from_user.id)
+    if not context.is_staff:
         await callback.answer("Недостаточно прав", show_alert=True)
         return
     product_id = int(callback.data.split("_")[-1])
-    context = await _get_access_context(callback.from_user.id)
-    async with async_session_maker() as session:
-        product = await ProductService.get_by_id(session, product_id)
-        is_admin = context.is_staff and context.is_manager
+    product = await _get_product_via_api(
+        telegram_id=callback.from_user.id,
+        product_id=product_id,
+    )
 
     if not product:
         await callback.answer("Товар не найден", show_alert=True)
         return
 
-    await send_product_card(callback, product, is_admin)
+    await send_product_card(callback, product, False)
     await callback.answer()
 
 
 @router.callback_query(F.data.startswith("product_client_text_"))
 async def product_client_text(callback: CallbackQuery):
-    if not await _is_staff_user(callback.from_user.id):
+    context = await _get_access_context(callback.from_user.id)
+    if not context.is_staff:
         await callback.answer("Недостаточно прав", show_alert=True)
         return
     product_id = int((callback.data or "").split("_")[-1])
-    async with async_session_maker() as session:
-        product = await ProductService.get_by_id(session, product_id)
+    product = await _get_product_via_api(
+        telegram_id=callback.from_user.id,
+        product_id=product_id,
+    )
 
     if not product:
         await callback.answer("Товар не найден", show_alert=True)
         return
 
-    await callback.message.answer(BotProductSelectionService.format_client_product(product))
+    await callback.message.answer(format_client_product(product))
     await callback.answer("Можно переслать клиенту")
 
 
 @router.message(ShopState.waiting_for_search)
 async def search_process(message: types.Message, state: FSMContext):
-    if not await _is_staff_user(message.from_user.id if message.from_user else None):
+    user_id = message.from_user.id if message.from_user else None
+    context = await _get_access_context(user_id)
+    if not context.is_staff:
         await message.answer("Этот бот теперь только для сотрудников MVN.")
         await state.clear()
         return
     query = (message.text or "").strip()
-    user_id = message.from_user.id if message.from_user else None
     if not query:
-        logger.info("BOT_SEARCH_EMPTY_QUERY user_id=%s", user_id)
+        logger.info("BOT_SEARCH_EMPTY_QUERY")
         await message.answer("Введите бренд и мощность, например: Midea 12")
         return
 
-    async with async_session_maker() as session:
-        products = await ProductService.search_products(session, query=query, limit=5)
-        sample = [f"{item.get('id')}:{(item.get('title') or '')[:40]}" for item in products[:3]]
-        logger.info(
-            "BOT_SEARCH_RESULT user_id=%s query=%r found=%s sample=%s",
-            user_id,
-            query,
-            len(products),
-            sample,
-        )
+    try:
+        products = await _search_products_via_api(telegram_id=user_id, query=query, limit=5)
+    except BotApiError:
+        await state.clear()
+        raise
+    logger.info("BOT_SEARCH_RESULT query_length=%s found=%s", len(query), len(products))
 
     await _render_search_results(message, query, products)
 
     await state.clear()
-    await _answer_with_staff_menu(message, user_id)
+    await _answer_with_staff_menu(message, user_id, context=context)
 
 
 @router.message(StateFilter(None), F.text)
@@ -292,17 +327,10 @@ async def auto_search_process(message: types.Message):
     user_id = message.from_user.id if message.from_user else None
     if not _is_inline_search_query(query):
         raise SkipHandler()
-    if not await _is_staff_user(user_id):
+    context = await _get_access_context(user_id)
+    if not context.is_staff:
         return
 
-    async with async_session_maker() as session:
-        products = await ProductService.search_products(session, query=query, limit=5)
-        sample = [f"{item.get('id')}:{(item.get('title') or '')[:40]}" for item in products[:3]]
-        logger.info(
-            "BOT_AUTO_SEARCH_RESULT user_id=%s query=%r found=%s sample=%s",
-            user_id,
-            query,
-            len(products),
-            sample,
-        )
+    products = await _search_products_via_api(telegram_id=user_id, query=query, limit=5)
+    logger.info("BOT_AUTO_SEARCH_RESULT query_length=%s found=%s", len(query), len(products))
     await _render_search_results(message, query, products)

--- a/bot_app/keyboards.py
+++ b/bot_app/keyboards.py
@@ -3,7 +3,7 @@ from aiogram.types import (
     InlineKeyboardMarkup, InlineKeyboardButton
 )
 from .access import BotAccessContext
-from services.bot_product_selection_service import BotProductSelectionService
+from .catalog_presenter import product_url
 
 
 def get_staff_main_menu(context: BotAccessContext) -> ReplyKeyboardMarkup:
@@ -68,7 +68,7 @@ wifi_selection_kb = InlineKeyboardMarkup(
 
 def get_product_keyboard(product_id, is_admin=False, in_favorites=False, product=None, staff_mode=True):
     product = product or {}
-    url = BotProductSelectionService.product_url(product) if product.get("slug") else None
+    url = product_url(product) if product.get("slug") else None
     if staff_mode:
         buttons = []
         if url:

--- a/bot_app/main.py
+++ b/bot_app/main.py
@@ -3,6 +3,8 @@ from aiogram import types
 from aiogram.types import BotCommand
 from .access import BotAccessUnavailableError
 from .access_runtime import close_bot_access_provider, verify_bot_access_startup
+from .api_gateway import BotApiAuthorizationError, BotApiError
+from .api_runtime import close_bot_api_gateway
 from .config import bot, dp
 from .handlers import admin, base, catalog, repair_context, work
 from core.config import settings
@@ -36,6 +38,22 @@ async def error_handler(event: types.ErrorEvent):
             await callback.answer("Сервис авторизации временно недоступен. Попробуйте позже.", show_alert=True)
         elif event.update.message is not None:
             await event.update.message.answer("Сервис авторизации временно недоступен. Попробуйте позже.")
+        return True
+    if isinstance(event.exception, BotApiAuthorizationError):
+        logger.warning("Bot staff action denied: %s", event.exception)
+        callback = event.update.callback_query
+        if callback is not None:
+            await callback.answer("Недостаточно прав для этого действия.", show_alert=True)
+        elif event.update.message is not None:
+            await event.update.message.answer("Недостаточно прав для этого действия.")
+        return True
+    if isinstance(event.exception, BotApiError):
+        logger.error("Bot backend API unavailable: %s", event.exception)
+        callback = event.update.callback_query
+        if callback is not None:
+            await callback.answer("Рабочий сервис временно недоступен. Попробуйте позже.", show_alert=True)
+        elif event.update.message is not None:
+            await event.update.message.answer("Рабочий сервис временно недоступен. Попробуйте позже.")
         return True
     logger.error(
         "Bot error: %s for event %s",
@@ -94,6 +112,7 @@ async def main(*, wait_when_disabled: bool = True):
         await dp.start_polling(bot)
     finally:
         await close_bot_access_provider()
+        await close_bot_api_gateway()
         await runtime_lock.release()
 
 if __name__ == "__main__":

--- a/bot_app/utils.py
+++ b/bot_app/utils.py
@@ -1,10 +1,8 @@
 import logging
 import os
 from html import escape
-from pathlib import Path
 from aiogram import types
-from aiogram.types import FSInputFile
-from services.bot_product_selection_service import BotProductSelectionService
+from .catalog_presenter import availability_text, product_url
 from .keyboards import get_product_keyboard
 
 
@@ -29,7 +27,7 @@ def _availability_badge(product: dict) -> str:
 def _availability_details(product: dict) -> str:
     if not any(key in product for key in ("availability_status", "vitebsk_qty", "minsk_qty")):
         return ""
-    return f"📦 {BotProductSelectionService.availability_text(product)}\n"
+    return f"📦 {availability_text(product)}\n"
 
 
 def format_caption(product):
@@ -47,7 +45,7 @@ def format_caption(product):
         f"🏠 Площадь: {escape(str(product.get('area', '-')))} м²\n"
         f"{specs_str}"
         f"📝 {escape(str(product.get('description', ''))[:200])}\n"
-        f"🔗 {escape(BotProductSelectionService.product_url(product))}"
+        f"🔗 {escape(product_url(product))}"
     )
 
 async def send_product_card(message_or_callback, product, is_admin, *, staff_mode=True):
@@ -65,15 +63,10 @@ async def send_product_card(message_or_callback, product, is_admin, *, staff_mod
             photo = image_url
         else:
             normalized_path = image_url if image_url.startswith("/") else f"/{image_url}"
-            local_path = Path(normalized_path.lstrip("/"))
-            if local_path.exists() and local_path.is_file():
-                photo = FSInputFile(str(local_path))
-            else:
-                logging.warning("Bot image local file not found: %s", local_path)
-                public_api_base = os.getenv("PUBLIC_API_BASE", "https://mvn.by/api/v1").rstrip("/")
-                api_prefix = "/api/"
-                origin = public_api_base.split(api_prefix, 1)[0] if api_prefix in public_api_base else public_api_base
-                photo = f"{origin}{normalized_path}"
+            public_api_base = os.getenv("PUBLIC_API_BASE", "https://mvn.by/api/v1").rstrip("/")
+            api_prefix = "/api/"
+            origin = public_api_base.split(api_prefix, 1)[0] if api_prefix in public_api_base else public_api_base
+            photo = f"{origin}{normalized_path}"
 
     if photo:
         try:

--- a/docs/bot-service-extraction.md
+++ b/docs/bot-service-extraction.md
@@ -41,6 +41,23 @@ The temporary database provider is removed after API mode has been verified in
 production. Catalog, orders, repair and FSM database paths remain separate
 migration slices; this switch covers staff authorization only.
 
+### Catalog search slice
+
+The staff search flow, inline product search, product details and the
+forwardable client text use `/api/internal/bot/v1/catalog/*`. The API repeats
+staff authorization for the Telegram identity and returns a deliberately small
+product-card projection instead of exposing a generic manager or public catalog
+contract.
+
+Search cards are read-only. Price changes and product deletion stay in the
+Manager application and are not exposed by the autonomous bot API. Relative
+media paths are resolved through the public API origin; the bot does not depend
+on the monolith's local media filesystem.
+
+The legacy step-by-step selection and the current multi-room selection remain
+separate migration slices. They must be replaced by one backend-orchestrated
+selection use case rather than many remote product queries.
+
 ## Scope guardrails
 
 - Freeze new bot product features while a scenario is being migrated.

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -31,6 +31,10 @@ export type { Body_upload_manager_order_attachment } from './models/Body_upload_
 export type { Body_upload_manager_order_document } from './models/Body_upload_manager_order_document';
 export type { Body_upload_media_assets } from './models/Body_upload_media_assets';
 export type { BotApiHealthResponse } from './models/BotApiHealthResponse';
+export type { BotCatalogProductLookupResponse } from './models/BotCatalogProductLookupResponse';
+export type { BotCatalogProductResponse } from './models/BotCatalogProductResponse';
+export type { BotCatalogSearchRequest } from './models/BotCatalogSearchRequest';
+export type { BotCatalogSearchResponse } from './models/BotCatalogSearchResponse';
 export type { BotStaffContextResponse } from './models/BotStaffContextResponse';
 export type { BulkGalleryAddRequest } from './models/BulkGalleryAddRequest';
 export type { BulkGalleryDeleteRequest } from './models/BulkGalleryDeleteRequest';

--- a/manager_frontend/src/client/models/BotCatalogProductLookupResponse.ts
+++ b/manager_frontend/src/client/models/BotCatalogProductLookupResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotCatalogProductResponse } from './BotCatalogProductResponse';
+export type BotCatalogProductLookupResponse = {
+    product?: (BotCatalogProductResponse | null);
+};
+

--- a/manager_frontend/src/client/models/BotCatalogProductResponse.ts
+++ b/manager_frontend/src/client/models/BotCatalogProductResponse.ts
@@ -1,0 +1,21 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Small, stable product projection used by Telegram catalog cards.
+ */
+export type BotCatalogProductResponse = {
+    id: number;
+    title: string;
+    slug?: string;
+    description?: string;
+    price: number;
+    area?: number;
+    main_image?: (string | null);
+    categories?: Array<string>;
+    vitebsk_qty?: number;
+    minsk_qty?: number;
+    availability_status?: string;
+};
+

--- a/manager_frontend/src/client/models/BotCatalogSearchRequest.ts
+++ b/manager_frontend/src/client/models/BotCatalogSearchRequest.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotCatalogSearchRequest = {
+    telegram_id: number;
+    query: string;
+    limit?: number;
+};
+

--- a/manager_frontend/src/client/models/BotCatalogSearchResponse.ts
+++ b/manager_frontend/src/client/models/BotCatalogSearchResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotCatalogProductResponse } from './BotCatalogProductResponse';
+export type BotCatalogSearchResponse = {
+    items?: Array<BotCatalogProductResponse>;
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -3,6 +3,9 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { BotApiHealthResponse } from '../models/BotApiHealthResponse';
+import type { BotCatalogProductLookupResponse } from '../models/BotCatalogProductLookupResponse';
+import type { BotCatalogSearchRequest } from '../models/BotCatalogSearchRequest';
+import type { BotCatalogSearchResponse } from '../models/BotCatalogSearchResponse';
 import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -32,6 +35,50 @@ export class InternalBotV1Service {
             method: 'GET',
             url: '/api/internal/bot/v1/staff/context/{telegram_id}',
             path: {
+                'telegram_id': telegramId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Search Internal Bot Catalog
+     * @param requestBody
+     * @returns BotCatalogSearchResponse Successful Response
+     * @throws ApiError
+     */
+    public static searchInternalBotCatalogV1(
+        requestBody: BotCatalogSearchRequest,
+    ): CancelablePromise<BotCatalogSearchResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/catalog/search',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Internal Bot Catalog Product
+     * @param productId
+     * @param telegramId
+     * @returns BotCatalogProductLookupResponse Successful Response
+     * @throws ApiError
+     */
+    public static getInternalBotCatalogProductV1(
+        productId: number,
+        telegramId: number,
+    ): CancelablePromise<BotCatalogProductLookupResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/internal/bot/v1/catalog/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
+            query: {
                 'telegram_id': telegramId,
             },
             errors: {

--- a/openapi.json
+++ b/openapi.json
@@ -162,6 +162,110 @@
         }
       }
     },
+    "/api/internal/bot/v1/catalog/search": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Search Internal Bot Catalog",
+        "operationId": "search_internal_bot_catalog_v1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotCatalogSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCatalogSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/catalog/products/{product_id}": {
+      "get": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Get Internal Bot Catalog Product",
+        "operationId": "get_internal_bot_catalog_product_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Product Id"
+            }
+          },
+          {
+            "name": "telegram_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Telegram Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCatalogProductLookupResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -18368,6 +18472,136 @@
         },
         "type": "object",
         "title": "BotApiHealthResponse"
+      },
+      "BotCatalogProductLookupResponse": {
+        "properties": {
+          "product": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCatalogProductResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "BotCatalogProductLookupResponse"
+      },
+      "BotCatalogProductResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "price": {
+            "type": "integer",
+            "title": "Price"
+          },
+          "area": {
+            "type": "integer",
+            "title": "Area",
+            "default": 0
+          },
+          "main_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Image"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Categories"
+          },
+          "vitebsk_qty": {
+            "type": "integer",
+            "title": "Vitebsk Qty",
+            "default": 0
+          },
+          "minsk_qty": {
+            "type": "integer",
+            "title": "Minsk Qty",
+            "default": 0
+          },
+          "availability_status": {
+            "type": "string",
+            "title": "Availability Status",
+            "default": "out_of_stock"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "price"
+        ],
+        "title": "BotCatalogProductResponse",
+        "description": "Small, stable product projection used by Telegram catalog cards."
+      },
+      "BotCatalogSearchRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 10.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 5
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "query"
+        ],
+        "title": "BotCatalogSearchRequest"
+      },
+      "BotCatalogSearchResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BotCatalogProductResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "title": "BotCatalogSearchResponse"
       },
       "BotStaffContextResponse": {
         "properties": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -1,12 +1,20 @@
 """Private, versioned use-case API consumed by the Telegram bot service."""
 
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
+from api_contracts.bot import (
+    BotApiHealthResponse,
+    BotCatalogProductLookupResponse,
+    BotCatalogProductResponse,
+    BotCatalogSearchRequest,
+    BotCatalogSearchResponse,
+    BotStaffContextResponse,
+)
 from core.bot_api_security import require_bot_api_token
 from core.database import get_session
 from services.bot_access_service import BotAccessService
+from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
 
 
 router = APIRouter(
@@ -44,4 +52,50 @@ async def get_internal_bot_staff_context(
         legacy_installer_id=context.legacy_installer_id,
         is_manager=context.is_manager,
         is_executor=context.is_executor,
+    )
+
+
+@router.post(
+    "/catalog/search",
+    response_model=BotCatalogSearchResponse,
+    operation_id="search_internal_bot_catalog_v1",
+)
+async def search_internal_bot_catalog(
+    payload: BotCatalogSearchRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BotCatalogSearchResponse:
+    try:
+        products = await BotCatalogService.search_for_staff(
+            session,
+            telegram_id=payload.telegram_id,
+            query=payload.query,
+            limit=payload.limit,
+        )
+    except BotCatalogAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return BotCatalogSearchResponse(
+        items=[BotCatalogProductResponse.model_validate(product) for product in products]
+    )
+
+
+@router.get(
+    "/catalog/products/{product_id}",
+    response_model=BotCatalogProductLookupResponse,
+    operation_id="get_internal_bot_catalog_product_v1",
+)
+async def get_internal_bot_catalog_product(
+    product_id: int = Path(ge=1),
+    telegram_id: int = Query(ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> BotCatalogProductLookupResponse:
+    try:
+        product = await BotCatalogService.get_product_for_staff(
+            session,
+            telegram_id=telegram_id,
+            product_id=product_id,
+        )
+    except BotCatalogAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return BotCatalogProductLookupResponse(
+        product=BotCatalogProductResponse.model_validate(product) if product else None
     )

--- a/services/bot_catalog_service.py
+++ b/services/bot_catalog_service.py
@@ -1,0 +1,41 @@
+"""Staff-authorized catalog reads exposed to the Telegram bot API."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.bot_access_service import BotAccessService
+from services.product_service import ProductService
+
+
+class BotCatalogAccessDeniedError(PermissionError):
+    """The Telegram identity cannot use staff catalog scenarios."""
+
+
+class BotCatalogService:
+    @staticmethod
+    async def _require_staff(session: AsyncSession, telegram_id: int) -> None:
+        context = await BotAccessService.get_context(session, telegram_id)
+        if not context.is_staff:
+            raise BotCatalogAccessDeniedError("Staff catalog access is required")
+
+    @classmethod
+    async def search_for_staff(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        query: str,
+        limit: int,
+    ) -> list[dict]:
+        await cls._require_staff(session, telegram_id)
+        return await ProductService.search_products(session, query=query, limit=limit)
+
+    @classmethod
+    async def get_product_for_staff(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        product_id: int,
+    ) -> dict | None:
+        await cls._require_staff(session, telegram_id)
+        return await ProductService.get_by_id(session, product_id)

--- a/services/product_service.py
+++ b/services/product_service.py
@@ -4,21 +4,13 @@ Read/filter methods are inherited from ProductReadService.
 Write/mutation methods are inherited from ProductWriteService.
 Manager-facing methods are inherited from ProductManagerService.
 """
-import logging
-
-from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 from crud.product import ProductDAO
-from models.product import Product
 from services.catalog_revision_service import CatalogRevisionService
 from services.product_manager_service import ProductManagerService
 from services.product_read_service import ProductReadService
 from services.product_write_service import ProductWriteService
-
-logger = logging.getLogger(__name__)
-
 
 class ProductService(ProductReadService, ProductWriteService, ProductManagerService):
     """Backward-compatible facade that combines product service specializations."""
@@ -55,29 +47,10 @@ class ProductService(ProductReadService, ProductWriteService, ProductManagerServ
         if not normalized_query:
             return []
 
-        published_total = (
-            await session.execute(select(func.count(Product.id)).where(Product.is_published.is_(True)))
-        ).scalar_one()
-        title_like_total = (
-            await session.execute(
-                select(func.count(Product.id)).where(
-                    Product.is_published.is_(True),
-                    Product.title.ilike(f"%{normalized_query}%"),
-                )
-            )
-        ).scalar_one()
-
         search_result = await ProductManagerService.smart_search(
             session=session,
             q=normalized_query,
             limit=limit,
         )
         products = search_result.get("items", []) if isinstance(search_result, dict) else list(search_result or [])
-        logger.info(
-            "PRODUCT_SEARCH_DEBUG query=%r published_total=%s title_like_total=%s found=%s",
-            normalized_query,
-            published_total,
-            title_like_total,
-            len(products),
-        )
         return products

--- a/tests/unit/test_bot_access_provider.py
+++ b/tests/unit/test_bot_access_provider.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from api_contracts.bot import BotApiHealthResponse, BotStaffContextResponse
-from bot_app import access_runtime
+from bot_app import access_runtime, api_runtime
 from bot_app.access import BotAccessContext, BotAccessUnavailableError
 from bot_app.access_api import ApiBotAccessProvider
 from bot_app.api_gateway import BotApiUnavailableError
@@ -103,3 +103,23 @@ def test_access_runtime_never_implicitly_falls_back_to_database(monkeypatch):
 
     with pytest.raises(RuntimeError, match="Unsupported bot access backend"):
         access_runtime.get_bot_access_provider()
+
+
+async def test_api_runtime_shares_and_closes_one_gateway(monkeypatch):
+    gateway = SimpleNamespace(aclose=AsyncMock())
+    factory = Mock(return_value=gateway)
+    monkeypatch.setattr(api_runtime, "_gateway", None)
+    monkeypatch.setattr(api_runtime.settings, "BOT_API_BASE_URL", "https://api.example.test/bot")
+    monkeypatch.setattr(api_runtime.settings, "BOT_API_TOKEN", "test-token")
+    monkeypatch.setattr(api_runtime.settings, "BOT_API_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(api_runtime, "BotApiGateway", factory)
+
+    first = api_runtime.get_bot_api_gateway()
+    second = api_runtime.get_bot_api_gateway()
+    await api_runtime.close_bot_api_gateway()
+
+    assert first is gateway
+    assert second is gateway
+    factory.assert_called_once()
+    gateway.aclose.assert_awaited_once_with()
+    assert api_runtime._gateway is None

--- a/tests/unit/test_bot_api_gateway.py
+++ b/tests/unit/test_bot_api_gateway.py
@@ -3,6 +3,7 @@ import pytest
 
 from bot_app.api_gateway import (
     BotApiAuthenticationError,
+    BotApiAuthorizationError,
     BotApiGateway,
     BotApiGatewayConfig,
     BotApiResponseError,
@@ -60,7 +61,7 @@ async def test_bot_api_gateway_sends_bearer_token_and_decodes_context():
     ("status_code", "error_type"),
     [
         (401, BotApiAuthenticationError),
-        (403, BotApiAuthenticationError),
+        (403, BotApiAuthorizationError),
         (422, BotApiResponseError),
         (503, BotApiUnavailableError),
     ],
@@ -98,3 +99,95 @@ async def test_bot_api_gateway_rejects_invalid_contract():
         )
         with pytest.raises(BotApiResponseError):
             await gateway.get_staff_context(123)
+
+
+async def test_bot_api_gateway_posts_catalog_search_without_query_string():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/catalog/search"
+        assert request.method == "POST"
+        assert request.url.query == b""
+        assert request.content == (
+            b'{"telegram_id":123,"query":"Midea 12","limit":5}'
+        )
+        assert request.headers["content-type"] == "application/json"
+        assert request.headers["authorization"] == "Bearer service-secret"
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": 42,
+                        "title": "Midea 12",
+                        "slug": "midea-12",
+                        "price": 3200,
+                        "area": 35,
+                        "vitebsk_qty": 1,
+                        "availability_status": "in_stock_now",
+                    }
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(
+                base_url="https://api.mvn.by/api/internal/bot/v1",
+                token="service-secret",
+            ),
+            client=client,
+        )
+        response = await gateway.search_catalog(telegram_id=123, query=" Midea 12 ")
+
+    assert response.items[0].id == 42
+    assert response.items[0].vitebsk_qty == 1
+
+
+async def test_bot_api_gateway_decodes_missing_catalog_product():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/catalog/products/404"
+        assert request.url.params["telegram_id"] == "123"
+        return httpx.Response(200, json={"product": None})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.get_catalog_product(telegram_id=123, product_id=404)
+
+    assert response.product is None
+
+
+async def test_bot_api_gateway_decodes_catalog_product_detail():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/catalog/products/42"
+        return httpx.Response(
+            200,
+            json={
+                "product": {
+                    "id": 42,
+                    "title": "Midea 12",
+                    "slug": "midea-12",
+                    "description": "Тихий инвертор",
+                    "price": 3200,
+                    "area": 35,
+                    "main_image": "/media/midea.webp",
+                    "categories": ["Настенные"],
+                    "vitebsk_qty": 0,
+                    "minsk_qty": 2,
+                    "availability_status": "available_2_3_days",
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.get_catalog_product(telegram_id=123, product_id=42)
+
+    assert response.product is not None
+    assert response.product.description == "Тихий инвертор"
+    assert response.product.categories == ["Настенные"]
+    assert response.product.minsk_qty == 2

--- a/tests/unit/test_bot_auto_search_query.py
+++ b/tests/unit/test_bot_auto_search_query.py
@@ -5,6 +5,13 @@ import pytest
 from aiogram.dispatcher.event.bases import SkipHandler
 
 from bot_app.handlers import catalog as catalog_handler
+from api_contracts.bot import (
+    BotCatalogProductLookupResponse,
+    BotCatalogProductResponse,
+    BotCatalogSearchResponse,
+)
+from bot_app.access import BotAccessContext
+from bot_app.api_gateway import BotApiUnavailableError
 from bot_app.handlers.catalog import _choose_search_products, _is_inline_search_query
 from bot_app.utils import _availability_badge
 
@@ -21,6 +28,7 @@ def test_inline_search_rejects_non_matching_messages():
     assert not _is_inline_search_query("is chigo 12 good?")
     assert not _is_inline_search_query("midea 12 inverter black")  # 4 tokens
     assert not _is_inline_search_query("lg-9")  # punctuation
+    assert not _is_inline_search_query("m" * 101)
 
 
 def test_choose_search_products_prefers_in_stock():
@@ -61,3 +69,164 @@ async def test_auto_search_skips_non_search_text(monkeypatch):
         await catalog_handler.auto_search_process(message)
 
     staff_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_search_uses_internal_api_gateway(monkeypatch):
+    gateway = SimpleNamespace(
+        search_catalog=AsyncMock(
+            return_value=BotCatalogSearchResponse(
+                items=[
+                    BotCatalogProductResponse(
+                        id=42,
+                        title="Midea 12",
+                        slug="midea-12",
+                        price=3200,
+                        area=35,
+                    )
+                ]
+            )
+        )
+    )
+    render = AsyncMock()
+    monkeypatch.setattr(
+        catalog_handler,
+        "_get_access_context",
+        AsyncMock(return_value=BotAccessContext(telegram_id=5, is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(catalog_handler, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(catalog_handler, "_render_search_results", render)
+    message = SimpleNamespace(text="Midea 12", from_user=SimpleNamespace(id=5))
+
+    await catalog_handler.auto_search_process(message)
+
+    gateway.search_catalog.assert_awaited_once_with(
+        telegram_id=5,
+        query="Midea 12",
+        limit=5,
+    )
+    products = render.await_args.args[2]
+    assert products == [
+        {
+            "id": 42,
+            "title": "Midea 12",
+            "slug": "midea-12",
+            "description": "",
+            "price": 3200,
+            "area": 35,
+            "main_image": None,
+            "categories": [],
+            "vitebsk_qty": 0,
+            "minsk_qty": 0,
+            "availability_status": "out_of_stock",
+        }
+    ]
+    assert render.await_args.kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_explicit_search_clears_fsm_when_catalog_api_is_unavailable(monkeypatch):
+    gateway = SimpleNamespace(
+        search_catalog=AsyncMock(side_effect=BotApiUnavailableError("offline"))
+    )
+    monkeypatch.setattr(
+        catalog_handler,
+        "_get_access_context",
+        AsyncMock(return_value=BotAccessContext(telegram_id=5, is_staff=True)),
+    )
+    monkeypatch.setattr(catalog_handler, "get_bot_api_gateway", lambda: gateway)
+    state = SimpleNamespace(clear=AsyncMock())
+    message = SimpleNamespace(text="Midea 12", from_user=SimpleNamespace(id=5))
+
+    with pytest.raises(BotApiUnavailableError, match="offline"):
+        await catalog_handler.search_process(message, state)
+
+    state.clear.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_search_details_renders_product_from_internal_api(monkeypatch):
+    product = BotCatalogProductResponse(
+        id=42,
+        title="Midea 12",
+        slug="midea-12",
+        description="Тихий инвертор",
+        price=3200,
+        area=35,
+        categories=["Настенные"],
+        minsk_qty=2,
+        availability_status="available_2_3_days",
+    )
+    gateway = SimpleNamespace(
+        get_catalog_product=AsyncMock(
+            return_value=BotCatalogProductLookupResponse(product=product)
+        )
+    )
+    send_card = AsyncMock()
+    monkeypatch.setattr(
+        catalog_handler,
+        "_get_access_context",
+        AsyncMock(return_value=BotAccessContext(telegram_id=5, is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(catalog_handler, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(catalog_handler, "send_product_card", send_card)
+    callback = SimpleNamespace(
+        data="search_details_42",
+        from_user=SimpleNamespace(id=5),
+        answer=AsyncMock(),
+    )
+
+    await catalog_handler.search_details(callback)
+
+    gateway.get_catalog_product.assert_awaited_once_with(telegram_id=5, product_id=42)
+    rendered = send_card.await_args.args[1]
+    assert rendered["description"] == "Тихий инвертор"
+    assert rendered["categories"] == ["Настенные"]
+    assert rendered["minsk_qty"] == 2
+    assert send_card.await_args.args[2] is False
+    callback.answer.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_product_client_text_uses_internal_api_detail(monkeypatch):
+    product = BotCatalogProductResponse(
+        id=42,
+        title="Midea 12",
+        slug="midea-12",
+        price=3200,
+        minsk_qty=2,
+        availability_status="available_2_3_days",
+    )
+    gateway = SimpleNamespace(
+        get_catalog_product=AsyncMock(
+            return_value=BotCatalogProductLookupResponse(product=product)
+        )
+    )
+    monkeypatch.setattr(
+        catalog_handler,
+        "_get_access_context",
+        AsyncMock(return_value=BotAccessContext(telegram_id=5, is_staff=True)),
+    )
+    monkeypatch.setattr(catalog_handler, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(
+        "bot_app.catalog_presenter.settings",
+        SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
+    )
+    message = SimpleNamespace(answer=AsyncMock())
+    callback = SimpleNamespace(
+        data="product_client_text_42",
+        from_user=SimpleNamespace(id=5),
+        message=message,
+        answer=AsyncMock(),
+    )
+
+    await catalog_handler.product_client_text(callback)
+
+    gateway.get_catalog_product.assert_awaited_once_with(telegram_id=5, product_id=42)
+    message.answer.assert_awaited_once_with(
+        "Midea 12\n"
+        "Цена: 3200 руб.\n"
+        "в наличии в Минске, срок поставки 2-4 дня\n"
+        "https://example.test/product/midea-12/"
+    )
+    callback.answer.assert_awaited_once_with("Можно переслать клиенту")

--- a/tests/unit/test_bot_catalog_service.py
+++ b/tests/unit/test_bot_catalog_service.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.bot_access_service import BotAccessService
+from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.product_manager_service import ProductManagerService
+from services.product_service import ProductService
+
+
+async def test_bot_catalog_service_authorizes_staff_before_search(monkeypatch):
+    search = AsyncMock(return_value=[{"id": 1}])
+    monkeypatch.setattr(
+        BotAccessService,
+        "get_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True)),
+    )
+    monkeypatch.setattr(ProductService, "search_products", search)
+    session = object()
+
+    result = await BotCatalogService.search_for_staff(
+        session,
+        telegram_id=123,
+        query="Midea 12",
+        limit=5,
+    )
+
+    assert result == [{"id": 1}]
+    search.assert_awaited_once_with(session, query="Midea 12", limit=5)
+
+
+async def test_bot_catalog_service_denies_non_staff_before_product_read(monkeypatch):
+    search = AsyncMock()
+    monkeypatch.setattr(
+        BotAccessService,
+        "get_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=False)),
+    )
+    monkeypatch.setattr(ProductService, "search_products", search)
+
+    with pytest.raises(BotCatalogAccessDeniedError, match="Staff catalog access"):
+        await BotCatalogService.search_for_staff(
+            object(),
+            telegram_id=123,
+            query="Midea",
+            limit=5,
+        )
+
+    search.assert_not_awaited()
+
+
+async def test_product_search_does_not_run_diagnostic_count_queries(monkeypatch):
+    smart_search = AsyncMock(return_value={"items": [{"id": 1}]})
+    monkeypatch.setattr(ProductManagerService, "smart_search", smart_search)
+    session = SimpleNamespace(execute=AsyncMock(side_effect=AssertionError("unexpected count query")))
+
+    result = await ProductService.search_products(session, query="Midea", limit=5)
+
+    assert result == [{"id": 1}]
+    session.execute.assert_not_awaited()

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -32,3 +32,17 @@ def test_bot_http_gateway_does_not_import_backend_runtime_layers():
     )
     for forbidden in forbidden_imports:
         assert forbidden not in source, f"HTTP gateway imports backend layer: {forbidden}"
+
+
+def test_bot_catalog_search_path_uses_api_instead_of_product_service_reads():
+    source = Path("bot_app/handlers/catalog.py").read_text(encoding="utf-8")
+    assert "ProductService.search_products" not in source
+    assert "ProductService.get_by_id" not in source
+    assert "get_bot_api_gateway().search_catalog" in source
+    assert "get_bot_api_gateway().get_catalog_product" in source
+
+
+def test_bot_catalog_presenter_does_not_import_backend_services():
+    source = Path("bot_app/catalog_presenter.py").read_text(encoding="utf-8")
+    for forbidden in ("from core.database", "from models", "from crud", "from services"):
+        assert forbidden not in source, f"catalog presenter imports backend layer: {forbidden}"

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -19,6 +19,7 @@ from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_task_service import BotTaskService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
+from bot_app.catalog_presenter import format_client_product
 from bot_app.keyboards import get_product_keyboard, get_staff_main_menu, selection_result_keyboard
 from bot_app.handlers import work as work_handlers
 from bot_app.utils import format_caption
@@ -346,7 +347,7 @@ async def test_task_status_update_notifies_admins(monkeypatch):
 
 def test_product_caption_contains_public_product_link(monkeypatch):
     monkeypatch.setattr(
-        "services.bot_product_selection_service.settings",
+        "bot_app.catalog_presenter.settings",
         SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
     )
 
@@ -366,7 +367,7 @@ def test_product_caption_contains_public_product_link(monkeypatch):
 
 def test_product_caption_escapes_html_fields(monkeypatch):
     monkeypatch.setattr(
-        "services.bot_product_selection_service.settings",
+        "bot_app.catalog_presenter.settings",
         SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
     )
 
@@ -392,7 +393,7 @@ def test_product_caption_escapes_html_fields(monkeypatch):
 
 def test_staff_product_keyboard_has_client_text_action(monkeypatch):
     monkeypatch.setattr(
-        "services.bot_product_selection_service.settings",
+        "bot_app.catalog_presenter.settings",
         SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
     )
 
@@ -411,7 +412,7 @@ def test_staff_product_keyboard_has_client_text_action(monkeypatch):
 
 def test_admin_product_keyboard_uses_delete_prompt(monkeypatch):
     monkeypatch.setattr(
-        "services.bot_product_selection_service.settings",
+        "bot_app.catalog_presenter.settings",
         SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
     )
 
@@ -429,11 +430,11 @@ def test_admin_product_keyboard_uses_delete_prompt(monkeypatch):
 
 def test_product_client_text_is_forwardable(monkeypatch):
     monkeypatch.setattr(
-        "services.bot_product_selection_service.settings",
+        "bot_app.catalog_presenter.settings",
         SimpleNamespace(PUBLIC_SITE_URL="https://example.test"),
     )
 
-    text = BotProductSelectionService.format_client_product(
+    text = format_client_product(
         {
             "title": "Midea 12",
             "slug": "midea-12",

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -4,12 +4,19 @@ from core.config import settings
 from core.database import get_session
 from main import app
 from services.bot_access_service import BotAccessContext, BotAccessService
+from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
 
 
-async def _request(path: str, *, token: str | None = None):
+async def _request(
+    path: str,
+    *,
+    token: str | None = None,
+    method: str = "GET",
+    json: dict | None = None,
+):
     headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        return await client.get(path, headers=headers)
+        return await client.request(method, path, headers=headers, json=json)
 
 
 async def test_internal_bot_api_fails_closed_when_token_is_not_configured(monkeypatch):
@@ -65,11 +72,17 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
 
     health = schema["paths"]["/api/internal/bot/v1/health"]["get"]
     staff_context = schema["paths"]["/api/internal/bot/v1/staff/context/{telegram_id}"]["get"]
+    catalog_search = schema["paths"]["/api/internal/bot/v1/catalog/search"]["post"]
+    catalog_product = schema["paths"]["/api/internal/bot/v1/catalog/products/{product_id}"]["get"]
 
     assert health["operationId"] == "get_internal_bot_api_health_v1"
     assert staff_context["operationId"] == "get_internal_bot_staff_context_v1"
+    assert catalog_search["operationId"] == "search_internal_bot_catalog_v1"
+    assert catalog_product["operationId"] == "get_internal_bot_catalog_product_v1"
     assert health["security"] == [{"BotServiceBearer": []}]
     assert staff_context["security"] == [{"BotServiceBearer": []}]
+    assert catalog_search["security"] == [{"BotServiceBearer": []}]
+    assert catalog_product["security"] == [{"BotServiceBearer": []}]
     assert schema["components"]["securitySchemes"]["BotServiceBearer"] == {
         "type": "http",
         "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
@@ -115,3 +128,154 @@ async def test_internal_bot_staff_context_maps_backend_permissions(monkeypatch):
         "is_manager": False,
         "is_executor": True,
     }
+
+
+async def test_internal_bot_catalog_search_returns_stable_product_projection(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_search(_session, *, telegram_id, query, limit):
+        assert (telegram_id, query, limit) == (123456, "Midea 12", 5)
+        return [
+            {
+                "id": 42,
+                "title": "Midea 12",
+                "slug": "midea-12",
+                "price": 3200,
+                "area": 35,
+                "main_image": "/media/midea.webp",
+                "vitebsk_qty": 1,
+                "availability_status": "in_stock_now",
+                "specs": {"private_backend_detail": "not part of bot contract"},
+            }
+        ]
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCatalogService, "search_for_staff", fake_search)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/catalog/search",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "query": "Midea 12", "limit": 5},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": 42,
+                "title": "Midea 12",
+                "slug": "midea-12",
+                "description": "",
+                "price": 3200,
+                "area": 35,
+                "main_image": "/media/midea.webp",
+                "categories": [],
+                "vitebsk_qty": 1,
+                "minsk_qty": 0,
+                "availability_status": "in_stock_now",
+            }
+        ]
+    }
+
+
+async def test_internal_bot_catalog_product_can_report_missing_item(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_get(_session, *, telegram_id, product_id):
+        assert (telegram_id, product_id) == (123456, 404)
+        return None
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCatalogService, "get_product_for_staff", fake_get)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/catalog/products/404?telegram_id=123456",
+            token="expected-token",
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"product": None}
+
+
+async def test_internal_bot_catalog_product_returns_card_detail(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_get(_session, *, telegram_id, product_id):
+        assert (telegram_id, product_id) == (123456, 42)
+        return {
+            "id": 42,
+            "title": "Midea 12",
+            "slug": "midea-12",
+            "description": "Тихий инвертор",
+            "price": 3200,
+            "area": 35,
+            "main_image": "/media/midea.webp",
+            "categories": ["Настенные"],
+            "vitebsk_qty": 0,
+            "minsk_qty": 2,
+            "availability_status": "available_2_3_days",
+        }
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCatalogService, "get_product_for_staff", fake_get)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/catalog/products/42?telegram_id=123456",
+            token="expected-token",
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json()["product"] == {
+        "id": 42,
+        "title": "Midea 12",
+        "slug": "midea-12",
+        "description": "Тихий инвертор",
+        "price": 3200,
+        "area": 35,
+        "main_image": "/media/midea.webp",
+        "categories": ["Настенные"],
+        "vitebsk_qty": 0,
+        "minsk_qty": 2,
+        "availability_status": "available_2_3_days",
+    }
+
+
+async def test_internal_bot_catalog_denies_non_staff_identity(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_search(_session, **_kwargs):
+        raise BotCatalogAccessDeniedError("Staff catalog access is required")
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCatalogService, "search_for_staff", fake_search)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/catalog/search",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "query": "Midea"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Staff catalog access is required"}

--- a/tests/unit/test_runtime_controls.py
+++ b/tests/unit/test_runtime_controls.py
@@ -444,3 +444,42 @@ async def test_bot_access_error_is_visible_to_callback(monkeypatch):
         "Сервис авторизации временно недоступен. Попробуйте позже.",
         show_alert=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_bot_backend_api_error_is_visible_to_message(monkeypatch):
+    _set_required_env(monkeypatch)
+    bot_main = importlib.import_module("bot_app.main")
+    from bot_app.api_gateway import BotApiUnavailableError
+
+    message = SimpleNamespace(answer=AsyncMock())
+    event = SimpleNamespace(
+        exception=BotApiUnavailableError("offline"),
+        update=SimpleNamespace(callback_query=None, message=message),
+    )
+
+    assert await bot_main.error_handler(event) is True
+
+    message.answer.assert_awaited_once_with(
+        "Рабочий сервис временно недоступен. Попробуйте позже."
+    )
+
+
+@pytest.mark.asyncio
+async def test_bot_backend_authorization_error_is_not_reported_as_outage(monkeypatch):
+    _set_required_env(monkeypatch)
+    bot_main = importlib.import_module("bot_app.main")
+    from bot_app.api_gateway import BotApiAuthorizationError
+
+    callback = SimpleNamespace(answer=AsyncMock())
+    event = SimpleNamespace(
+        exception=BotApiAuthorizationError("denied"),
+        update=SimpleNamespace(callback_query=callback, message=None),
+    )
+
+    assert await bot_main.error_handler(event) is True
+
+    callback.answer.assert_awaited_once_with(
+        "Недостаточно прав для этого действия.",
+        show_alert=True,
+    )


### PR DESCRIPTION
## Summary
- add staff-authorized internal Bot API contracts for catalog search and product detail
- route Telegram search, inline search, detail, and client text through the shared HTTP gateway
- keep catalog cards read-only and resolve relative media through the public origin
- remove two diagnostic COUNT queries from every product search
- distinguish service-token failures, staff authorization denial, and backend outages

## Safety
- catalog search uses POST JSON so user-entered text and Telegram ID are not placed in the URL
- API repeats per-user staff authorization for every catalog use case
- no database fallback exists in the migrated search path
- complex selection, tasks, repair, and write scenarios remain outside this PR

## Verification
- `pytest tests/unit -q` -> `2142 passed, 4 skipped`
- focused Bot API/catalog/runtime suite -> `131 passed`
- Manager production build passed after OpenAPI/client regeneration
- `git diff --check` passed before commit
- two independent read-only reviews completed; all P2 findings addressed
