### PR TITLE
Polish the order workspace interactions

### DIFF
--- a/manager_frontend/src/components/equipment/OrderEquipmentPanel.vue
+++ b/manager_frontend/src/components/equipment/OrderEquipmentPanel.vue
@@ -153,6 +153,15 @@ const toggle = () => {
   if (expanded.value) void loadLinks();
 };
 
+const expand = () => {
+  expanded.value = true;
+  return loadLinks();
+};
+
+const collapse = () => {
+  expanded.value = false;
+};
+
 const createFromOrder = async () => {
   if (action.value) return;
   action.value = 'from-order';
@@ -314,6 +323,8 @@ watch(() => [props.customerId, props.customerBranchId], () => {
 });
 
 onMounted(() => void loadLinks());
+
+defineExpose({ expand, collapse });
 </script>
 
 <template>

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -8,9 +8,12 @@ import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { fromLocalDateTimeInput } from '../../utils/datetime';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   order: ManagerOrderDetailResponse;
-}>();
+  section?: 'all' | 'documents' | 'payments';
+}>(), {
+  section: 'all',
+});
 
 const emit = defineEmits<{
   refresh: [];
@@ -281,7 +284,7 @@ watch(() => props.order.id, () => {
   </section>
 
   <!-- ZONE 3: Finance -->
-  <section class="rounded-2xl bg-slate-50 border border-slate-200 p-5 shadow-sm">
+  <section v-if="section === 'all' || section === 'payments'" class="rounded-2xl bg-slate-50 border border-slate-200 p-5 shadow-sm">
           <h3 class="text-lg font-bold text-slate-800 font-['Space_Grotesk'] mb-4">Финансы</h3>
           <div class="mb-4 text-center border border-slate-200 rounded-xl py-6 bg-white shadow-inner">
               <p class="text-sm font-medium text-slate-500 uppercase tracking-wide">Остаток к оплате</p>
@@ -366,12 +369,13 @@ watch(() => props.order.id, () => {
   </section>
 
   <OrderDocumentsPanel
+    v-if="section === 'all' || section === 'documents'"
     :order="order"
     @refresh="emit('refresh')"
     @toast="setToast($event.message, $event.type || 'success')"
   />
 
-  <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+  <section v-if="section === 'all' || section === 'payments'" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
     <button
       class="flex w-full items-center justify-center gap-2 rounded-xl py-4 text-lg font-bold shadow-lg transition-transform active:scale-95"
       :class="(order.balance_due || 0) > 0 ? 'bg-slate-300 text-slate-500 cursor-not-allowed' : 'bg-teal-500 text-white hover:bg-teal-600'"

--- a/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
@@ -84,7 +84,7 @@ const saveObject = () => {
             <a v-if="validEmail" :href="'mailto:' + email" class="inline-flex min-w-0 items-center gap-1 hover:text-teal-700 dark:hover:text-teal-300">
               <Mail :size="13" /> <span class="truncate">{{ email }}</span>
             </a>
-            <button v-else type="button" class="font-medium text-slate-500 hover:text-teal-700 dark:hover:text-teal-300" @click="startCustomerEdit">Email не указан</button>
+            <button v-else type="button" class="font-medium text-slate-500 hover:text-teal-700 dark:hover:text-teal-300" @click="startCustomerEdit">Email не указан · добавить</button>
           </div>
         </div>
         <div class="flex shrink-0 gap-1">

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -33,6 +33,7 @@ import type {
   ManagerEquipmentDetailResponse,
   ManagerEquipmentItemResponse,
   ManagerEquipmentHistoryFromRepairOrderPayload,
+  OutgoingEmailResponse,
 } from '../../client';
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
 import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
@@ -294,6 +295,12 @@ const payments = ref<PaymentResponse[]>([]);
 const bankReceipts = ref<BankReceiptResponse[]>([]);
 const bankReceiptsLoading = ref(false);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
+const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
+const executionWorkspaceSection = ref<'documents' | 'payments' | null>(null);
+const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
+const orderEmails = ref<OutgoingEmailResponse[]>([]);
+const orderEmailsLoaded = ref(false);
+let orderEmailsRequestId = 0;
 
 const executorOptions = computed(() => {
   const selectedIds = new Set<number>();
@@ -312,6 +319,7 @@ const createDefaultDrawerSections = () => ({
   proposals: false,
   documents: false,
   payments: false,
+  execution: false,
 });
 type DrawerSectionsState = ReturnType<typeof createDefaultDrawerSections>;
 const expandedDrawerSections = ref(createDefaultDrawerSections());
@@ -642,6 +650,33 @@ const activeProposalLineLabel = computed(() => {
 const paymentsSectionSummary = computed(() => (
   `оплачено ${formatMoney(totalPaymentsPreview.value)} · остаток ${formatMoney(balanceDuePreview.value)} · итого ${formatMoney(totalPreview.value)} · маржа ${formatMoney(marginPreview.value)}`
 ));
+const documentEmailStatus = computed<'unknown' | 'none' | 'pending' | 'sent' | 'failed'>(() => {
+  if (!orderEmailsLoaded.value) return 'unknown';
+  const latestDocumentEmail = [...orderEmails.value]
+    .filter((email) => Boolean(email.attachments?.length))
+    .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+  if (!latestDocumentEmail) return 'none';
+  if (latestDocumentEmail.status === 'sent') return 'sent';
+  if (latestDocumentEmail.status === 'pending') return 'pending';
+  if (latestDocumentEmail.status === 'failed') return 'failed';
+  return 'none';
+});
+const normalizeDocumentNumber = (value: string) => value.toUpperCase().replace(/[^A-ZА-ЯЁ0-9]/g, '');
+const missingReferencedInvoice = computed(() => {
+  const invoiceNumbers = new Set(
+    orderDocuments.value
+      .filter((document) => document.doc_type === 'invoice')
+      .map((document) => normalizeDocumentNumber(document.number || ''))
+      .filter(Boolean),
+  );
+  for (const payment of payments.value) {
+    const purpose = payment.bank_receipt?.payment_purpose || payment.comment || '';
+    const match = purpose.match(/сч[её]т(?:у|а|ом|е)?\s*(?:№\s*)?([A-ZА-ЯЁ0-9][A-ZА-ЯЁ0-9/-]{2,})/iu);
+    const referencedNumber = match?.[1]?.trim();
+    if (referencedNumber && !invoiceNumbers.has(normalizeDocumentNumber(referencedNumber))) return referencedNumber;
+  }
+  return null;
+});
 const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   status: status.value,
   negotiationStatus: negotiationStatus.value,
@@ -654,6 +689,8 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   serviceCount: serviceLines.value.length,
   linkedEquipmentCount: props.order?.linked_equipment_count || 0,
   documents: orderDocuments.value,
+  documentEmailStatus: documentEmailStatus.value,
+  missingReferencedInvoice: missingReferencedInvoice.value,
   total: totalPreview.value,
   paid: totalPaymentsPreview.value,
   balance: balanceDuePreview.value,
@@ -702,6 +739,21 @@ const loadOrderSupplyRequests = async (orderId: number) => {
   } catch (error) {
     console.warn('Failed to load supply requests for order', error);
     supplyRequests.value = [];
+  }
+};
+
+const loadOrderEmails = async (orderId: number) => {
+  const requestId = ++orderEmailsRequestId;
+  try {
+    const response = await ManagerMailService.listManagerOrderOutgoingEmails(orderId, 20);
+    if (requestId !== orderEmailsRequestId || props.order?.id !== orderId) return;
+    orderEmails.value = response.items || [];
+    orderEmailsLoaded.value = true;
+  } catch (error) {
+    if (requestId !== orderEmailsRequestId) return;
+    console.warn('Failed to load order email summary', error);
+    orderEmails.value = [];
+    orderEmailsLoaded.value = false;
   }
 };
 
@@ -998,10 +1050,14 @@ const beforeDocumentGenerate = async (type: string) => {
 
 const handleDocumentPanelToast = (payload: { message: string; type?: 'success' | 'error' }) => {
   setToast(payload.message, payload.type || 'success');
+  if (props.order?.id) window.setTimeout(() => void loadOrderEmails(props.order!.id), 500);
 };
 
 const refreshOrderFromDocumentsPanel = () => {
-  if (props.order?.id) emit('reload', props.order.id);
+  if (props.order?.id) {
+    emit('reload', props.order.id);
+    void loadOrderEmails(props.order.id);
+  }
 };
 
 const newPaymentAmount = ref<number | null>(null);
@@ -1445,6 +1501,10 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     initializedOrderId.value = order.id;
     expandedDrawerSections.value = restoreDrawerSections();
     linkedEquipmentOptions.value = [];
+    executionWorkspaceSection.value = null;
+    activeWorkspaceTarget.value = null;
+    orderEmails.value = [];
+    orderEmailsLoaded.value = false;
   }
   status.value = order.status;
   orderTitle.value = order.title ?? '';
@@ -1547,7 +1607,10 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   savedFormSnapshot.value = currentFormSnapshot();
   restoreDraft();
   syncProductLookupFromLines();
-  await loadOrderSupplyRequests(order.id);
+  await Promise.all([
+    loadOrderSupplyRequests(order.id),
+    loadOrderEmails(order.id),
+  ]);
 };
 
 watch(
@@ -2408,15 +2471,44 @@ const saveCustomerInline = async (payload: { name: string; phone: string; email:
   }
 };
 
-const openWorkspaceTarget = async (target: OrderWorkspaceTarget) => {
+const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = false) => {
+  const shouldClose = allowToggle && activeWorkspaceTarget.value === target;
+  if (activeWorkspaceTarget.value === 'equipment') equipmentPanelRef.value?.collapse();
+  if (workflowType.value === 'sales_installation' && target !== 'object') {
+    expandedDrawerSections.value.proposals = false;
+    expandedDrawerSections.value.documents = false;
+    expandedDrawerSections.value.payments = false;
+    expandedDrawerSections.value.execution = false;
+    executionWorkspaceSection.value = null;
+  }
+  if (shouldClose) {
+    activeWorkspaceTarget.value = null;
+    return;
+  }
+  if (target !== 'object') activeWorkspaceTarget.value = target;
   if (target === 'object') expandedDrawerSections.value.clientDetails = true;
-  if (target === 'planning') expandedDrawerSections.value.planningDetails = true;
+  if (target === 'planning') {
+    if (workflowType.value === 'sales_installation') expandedDrawerSections.value.proposals = true;
+    if (status.value === 'execution') expandedDrawerSections.value.execution = true;
+    else expandedDrawerSections.value.planningDetails = true;
+  }
   if (target === 'proposal') expandedDrawerSections.value.proposals = true;
-  if (target === 'documents') expandedDrawerSections.value.documents = true;
-  if (target === 'payments') expandedDrawerSections.value.payments = true;
+  if (target === 'documents') {
+    if (status.value === 'execution') executionWorkspaceSection.value = 'documents';
+    else expandedDrawerSections.value.documents = true;
+  }
+  if (target === 'payments') {
+    if (status.value === 'execution') executionWorkspaceSection.value = 'payments';
+    else expandedDrawerSections.value.payments = true;
+  }
   await nextTick();
+  if (target === 'equipment') {
+    expandedDrawerSections.value.proposals = true;
+    await equipmentPanelRef.value?.expand();
+    await nextTick();
+  }
   const elementId = status.value === 'execution' && (target === 'documents' || target === 'payments')
-    ? 'order-workspace-execution'
+    ? 'order-workspace-execution-details'
     : 'order-workspace-' + target;
   document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 };
@@ -2480,6 +2572,7 @@ watch(
         @next="openWorkspaceTarget(orderWorkspace.nextAction.target)"
         @payments="openWorkspaceTarget('payments')"
         @hold="toggleHold"
+        @discard="discardUnsavedChanges"
         @save="handleSave"
         @close="closeDrawer"
       />
@@ -2497,7 +2590,7 @@ watch(
           </button>
         </span>
         <button v-if="!showManagerLabelInput" type="button" class="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 px-2 py-1 text-xs font-medium text-slate-500 hover:border-teal-300 hover:text-teal-700 dark:border-slate-700 dark:text-slate-400" @click="showManagerLabelInput = true">
-          <span class="material-icons-round text-[13px]">add</span> метка
+          <span class="material-icons-round text-[13px]">add</span> Добавить метку
         </button>
         <div v-if="showManagerLabelInput" class="flex min-w-[190px] gap-1.5">
           <input v-model="managerLabelDraft" class="field-input h-8 text-xs" placeholder="Новая метка" @keydown.enter.prevent="addManagerLabel" @keydown.esc.prevent="showManagerLabelInput = false" />
@@ -2505,7 +2598,7 @@ watch(
         </div>
       </div>
       <button v-else type="button" class="mt-2 inline-flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-teal-700 dark:text-slate-400 dark:hover:text-teal-300" @click="showManagerLabelInput = true">
-        <span class="material-icons-round text-[14px]">add</span> метка
+        <span class="material-icons-round text-[14px]">add</span> Добавить метку
       </button>
 
       <OrderCustomerObjectSummary
@@ -2544,7 +2637,8 @@ watch(
       <OrderSalesInstallationWorkspace
         v-if="workflowType === 'sales_installation'"
         :lanes="orderWorkspace.lanes"
-        @open="openWorkspaceTarget"
+        :active-target="activeWorkspaceTarget"
+        @open="openWorkspaceTarget($event, true)"
       />
 
       <p v-if="displayFormError" class="mb-4 rounded-xl border border-red-500/40 bg-red-50 px-3 py-2 text-sm text-red-700">
@@ -2603,6 +2697,7 @@ watch(
 
       <OrderEquipmentPanel
         v-if="order"
+        ref="equipmentPanelRef"
         id="order-workspace-equipment"
         :key="`order-equipment-${order.id}`"
         class="mt-4"
@@ -3710,14 +3805,21 @@ watch(
       </OrderDrawerSection>
 
 
-      <section v-if="status === 'execution'" id="order-workspace-planning" class="mt-4 rounded-2xl border border-teal-100 bg-teal-50/50 p-3">
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h3 class="text-sm font-semibold text-teal-900">Работы</h3>
-            <p class="mt-0.5 text-xs text-teal-700/75">Текущий этап: {{ executionStatusLabel }}</p>
-          </div>
-        </div>
-        <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <OrderDrawerSection
+        v-if="status === 'execution'"
+        id="order-workspace-planning"
+        v-model:expanded="expandedDrawerSections.execution"
+        :title="workflowType === 'sales_installation' ? 'Монтаж' : 'Работы'"
+        :summary="executionStatusLabel"
+        tone="default"
+      >
+        <label v-if="workflowType === 'sales_installation'" class="field-label">
+          Общий этап заказа
+          <select v-model="executionStatus" class="field-input mt-1">
+            <option v-for="option in EXECUTION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+          </select>
+        </label>
+        <div v-else class="grid grid-cols-2 gap-2 sm:grid-cols-3">
           <button
             v-for="option in EXECUTION_STATUS_OPTIONS"
             :key="option.value"
@@ -3733,28 +3835,29 @@ watch(
           </button>
         </div>
         <div class="mt-3 grid gap-2 sm:grid-cols-2">
-          <label class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-teal-900 ring-1 ring-teal-100">
-            <input v-model="executionWithoutPayment" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            Перенос без оплаты
+          <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+            <input v-model="executionWithoutPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+            <span><strong class="block">Разрешить переходы при наличии долга</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Менеджер сможет продолжать работу без полной оплаты.</span></span>
           </label>
-          <label class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-teal-900 ring-1 ring-teal-100">
-            <input v-model="autoCloseOnPayment" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
-            Закрыть после оплаты
+          <label class="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+            <input v-model="autoCloseOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
+            <span><strong class="block">Автоматически завершить после полной оплаты</strong><span class="mt-0.5 block text-slate-500 dark:text-slate-400">Сработает, когда долг станет нулевым.</span></span>
           </label>
         </div>
         <label v-if="executionWithoutPayment" class="field-label mt-3">
-          Причина переноса без оплаты
+          Причина работы при наличии долга
           <textarea v-model="executionWithoutPaymentReason" class="field-input min-h-[60px]" placeholder="Например: постоянный клиент, оплата по факту..." />
         </label>
-      </section>
+      </OrderDrawerSection>
 
       <DealExecutionTab
-        v-if="status === 'execution' && order"
-        id="order-workspace-execution"
+        v-if="status === 'execution' && order && executionWorkspaceSection"
+        id="order-workspace-execution-details"
         :order="order"
+        :section="executionWorkspaceSection"
         @refresh="emit('reload', order.id) /* triggering parent reload without closing drawer */"
         @close="closeDrawer"
-        class="mt-8"
+        class="mt-4"
       />
 
       <!-- Оплаты и Валюта (Объединенный блок) -->
@@ -3910,30 +4013,11 @@ watch(
       </section>
       </OrderDrawerSection>
 
-      <div
-        v-if="hasUnsavedChanges"
-        class="sticky bottom-2 z-30 mt-5 flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50/95 px-3 py-2 shadow-lg backdrop-blur dark:border-amber-500/30 dark:bg-amber-950/90"
-      >
-        <p class="text-xs font-semibold text-amber-900 dark:text-amber-100">Есть несохранённые изменения</p>
-        <div class="flex gap-2">
-          <button type="button" class="btn-mini-outline h-9 text-xs" :disabled="saving" @click="discardUnsavedChanges">Отменить</button>
-          <button type="button" class="btn-mini h-9 text-xs" :disabled="saving" @click="handleSave">{{ saving ? 'Сохраняем...' : 'Сохранить' }}</button>
-        </div>
-      </div>
-
-      <footer class="mt-6 flex flex-col gap-3 border-t border-gray-100 pt-4 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <button class="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100 disabled:opacity-50" :disabled="saving || isDeleting" @click="deleteOrder" title="Безвозвратное удаление">
-            <span class="material-icons-round text-[18px]">delete</span>
-            {{ isDeleting ? 'Удаление...' : 'Удалить заказ' }}
-          </button>
-        </div>
-        <div class="flex flex-row gap-2">
-          <button class="btn-mini-outline flex-1 sm:flex-none" :disabled="saving || isDeleting" @click="closeDrawer">Закрыть</button>
-          <button class="btn-mini flex-1 sm:flex-none" :disabled="saving || isDeleting" @click="handleSave">
-            {{ saving ? 'Сохраняем...' : 'Сохранить' }}
-          </button>
-        </div>
+      <footer class="mt-6 border-t border-gray-100 pt-4 dark:border-slate-800">
+        <button class="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/30" :disabled="saving || isDeleting" @click="deleteOrder" title="Безвозвратное удаление">
+          <span class="material-icons-round text-[16px]">delete</span>
+          {{ isDeleting ? 'Удаление...' : 'Удалить заказ' }}
+        </button>
       </footer>
     </aside>
 

--- a/manager_frontend/src/components/orders/OrderSalesInstallationWorkspace.vue
+++ b/manager_frontend/src/components/orders/OrderSalesInstallationWorkspace.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { CreditCard, FileText, PackageCheck, Wrench } from 'lucide-vue-next';
+import { ArrowRight, CreditCard, FileText, PackageCheck, Wrench } from 'lucide-vue-next';
 import type { OrderWorkspaceLane, OrderWorkspaceTarget } from './order-workspace';
 
-defineProps<{ lanes: OrderWorkspaceLane[] }>();
+defineProps<{
+  lanes: OrderWorkspaceLane[];
+  activeTarget?: OrderWorkspaceTarget | null;
+}>();
 const emit = defineEmits<{ open: [target: OrderWorkspaceTarget] }>();
 
 const icons = {
@@ -26,7 +29,7 @@ const toneClasses = {
   <section class="mt-3">
     <div class="mb-2">
       <h3 class="text-sm font-semibold text-slate-900 dark:text-white">Ход заказа</h3>
-      <p class="text-xs text-slate-500 dark:text-slate-400">Независимые направления продажи и монтажа</p>
+      <p class="text-xs text-slate-500 dark:text-slate-400">Статусы по направлениям</p>
     </div>
     <div class="grid gap-2 sm:grid-cols-2">
       <button
@@ -34,14 +37,19 @@ const toneClasses = {
         :key="lane.id"
         type="button"
         class="flex min-h-[88px] items-start gap-3 rounded-xl border p-3 text-left transition hover:-translate-y-px hover:shadow-sm"
-        :class="toneClasses[lane.tone]"
+        :class="[toneClasses[lane.tone], activeTarget === lane.target ? 'ring-2 ring-teal-500/60 ring-offset-1 dark:ring-offset-slate-950' : '']"
+        :aria-expanded="activeTarget === lane.target"
         @click="emit('open', lane.target)"
       >
         <component :is="icons[lane.id]" :size="18" class="mt-0.5 shrink-0" aria-hidden="true" />
-        <span class="min-w-0">
+        <span class="flex min-w-0 flex-1 flex-col self-stretch">
           <span class="block text-[11px] font-semibold uppercase tracking-[0.08em] opacity-70">{{ lane.label }}</span>
           <span class="mt-0.5 block text-sm font-semibold">{{ lane.status }}</span>
           <span class="mt-1 block text-xs opacity-75">{{ lane.detail }}</span>
+          <span class="mt-auto inline-flex items-center gap-1 pt-2 text-xs font-semibold">
+            {{ lane.actionLabel }}
+            <ArrowRight :size="13" aria-hidden="true" />
+          </span>
         </span>
       </button>
     </div>

--- a/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
+++ b/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { nextTick, ref } from 'vue';
-import { Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, X } from 'lucide-vue-next';
+import { Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Undo2, X } from 'lucide-vue-next';
 import { formatMoney } from './order-utils';
 import { ORDER_WORKFLOW_OPTIONS, type OrderWorkflowType, type OrderWorkspaceViewModel } from './order-workspace';
 
@@ -24,6 +24,7 @@ const emit = defineEmits<{
   next: [];
   payments: [];
   hold: [];
+  discard: [];
   save: [];
   close: [];
 }>();
@@ -118,7 +119,7 @@ const onWorkflowChange = async (event: Event) => {
         </select>
         <ChevronDown :size="14" class="pointer-events-none absolute right-2 text-slate-400" />
       </label>
-      <span class="rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">{{ formatMoney(total) }}</span>
+      <span class="rounded-lg bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">Сумма {{ formatMoney(total) }}</span>
       <span class="text-xs text-slate-500 dark:text-slate-400">оплачено {{ formatMoney(paid) }}</span>
       <span class="text-xs font-semibold" :class="balance > 0 ? 'text-rose-600 dark:text-rose-300' : 'text-emerald-700 dark:text-emerald-300'">
         {{ balance > 0 ? 'долг ' + formatMoney(balance) : 'долга нет' }}
@@ -128,16 +129,20 @@ const onWorkflowChange = async (event: Event) => {
     <div class="mt-2.5 flex items-center gap-2">
       <button type="button" class="btn-mini min-w-0 flex-1 justify-center text-xs sm:flex-none" @click="emit('next')">{{ viewModel.nextAction.label }}</button>
       <button v-if="balance > 0" type="button" class="btn-mini-outline hidden h-9 text-xs sm:inline-flex" @click="emit('payments')">Внести оплату</button>
-      <button
-        type="button"
-        class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg px-3 text-xs font-semibold transition"
-        :class="dirty ? 'bg-amber-100 text-amber-900 hover:bg-amber-200 dark:bg-amber-500/20 dark:text-amber-100' : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'"
-        :disabled="saving"
-        @click="emit('save')"
-      >
-        <Save :size="15" />
-        <span class="hidden sm:inline">{{ saving ? 'Сохраняем' : dirty ? 'Сохранить' : 'Сохранено' }}</span>
-      </button>
+      <span v-if="!dirty" class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-xs font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+        <Check :size="15" />
+        <span class="hidden sm:inline">Сохранено</span>
+      </span>
+      <div v-else class="flex shrink-0 items-center gap-1.5">
+        <span class="hidden text-xs font-semibold text-amber-700 dark:text-amber-200 lg:inline">Есть изменения</span>
+        <button type="button" class="btn-mini-outline h-9 w-9 justify-center p-0" :disabled="saving" title="Отменить изменения" aria-label="Отменить изменения" @click="emit('discard')">
+          <Undo2 :size="15" />
+        </button>
+        <button type="button" class="btn-mini h-9 gap-1.5 px-3 text-xs" :disabled="saving" @click="emit('save')">
+          <Save :size="15" />
+          <span class="hidden sm:inline">{{ saving ? 'Сохраняем' : 'Сохранить' }}</span>
+        </button>
+      </div>
     </div>
   </header>
 </template>

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -21,7 +21,7 @@ export const EXECUTION_STATUS_OPTIONS = [
     { value: 'needs_schedule', label: 'Назначить работы', icon: 'event_available', tone: 'teal' },
     { value: 'scheduled', label: 'Работы назначены', icon: 'event', tone: 'cyan' },
     { value: 'work_done', label: 'Работы выполнены', icon: 'task_alt', tone: 'green' },
-    { value: 'awaiting_documents', label: 'Закрыть документы', icon: 'fact_check', tone: 'indigo' },
+    { value: 'awaiting_documents', label: 'Оформление документов', icon: 'fact_check', tone: 'indigo' },
     { value: 'awaiting_payment', label: 'Ждет оплату', icon: 'payments', tone: 'emerald' },
 ] as const;
 

--- a/manager_frontend/src/components/orders/order-workspace.ts
+++ b/manager_frontend/src/components/orders/order-workspace.ts
@@ -29,6 +29,7 @@ export type OrderWorkspaceLane = {
   label: string;
   status: string;
   detail: string;
+  actionLabel: string;
   tone: OrderWorkspaceTone;
   target: OrderWorkspaceTarget;
 };
@@ -58,22 +59,40 @@ export type OrderWorkspaceInput = {
   serviceCount: number;
   linkedEquipmentCount: number;
   documents: ManagerOrderDocumentItem[];
+  documentEmailStatus?: 'unknown' | 'none' | 'pending' | 'sent' | 'failed';
+  missingReferencedInvoice?: string | null;
   total: number;
   paid: number;
   balance: number;
 };
 
-const documentLabel = (documents: ManagerOrderDocumentItem[]) => {
-  if (!documents.length) return 'Не созданы';
+const plural = (count: number, one: string, few: string, many: string) => {
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  if (mod100 >= 11 && mod100 <= 14) return many;
+  if (mod10 === 1) return one;
+  if (mod10 >= 2 && mod10 <= 4) return few;
+  return many;
+};
+
+const documentTypesLabel = (documents: ManagerOrderDocumentItem[]) => {
   const labels = documents.slice(0, 3).map((item) => {
-    if (item.doc_type === 'contract') return 'договор';
-    if (item.doc_type === 'invoice') return 'счёт';
-    if (item.doc_type === 'act') return 'акт';
+    if (item.doc_type === 'contract') return 'Договор';
+    if (item.doc_type === 'invoice') return 'Счёт';
+    if (item.doc_type === 'act') return 'Акт';
     if (item.doc_type === 'tn2') return 'ТН-2';
     return item.number || item.doc_type || 'документ';
   });
-  return `${documents.length} док. · ${labels.join(', ')}`;
+  return labels.join(', ');
 };
+
+const documentDeliveryLabel = (status: OrderWorkspaceInput['documentEmailStatus']) => ({
+  sent: 'отправлены',
+  pending: 'отправляются',
+  failed: 'ошибка отправки',
+  unknown: 'история отправки недоступна',
+  none: 'нужно проверить и отправить',
+}[status || 'none']);
 
 export const buildOrderWorkspaceViewModel = (input: OrderWorkspaceInput): OrderWorkspaceViewModel => {
   const inExecution = input.status === 'execution';
@@ -84,37 +103,48 @@ export const buildOrderWorkspaceViewModel = (input: OrderWorkspaceInput): OrderW
   const changedAt = inExecution
     ? (input.executionStatusChangedAt || input.statusChangedAt)
     : (input.negotiationStatusChangedAt || input.statusChangedAt);
-  const stageLabel = isClosed
-    ? 'Заказ завершён'
-    : inExecution
-      ? (EXECUTION_STATUS_LABELS[substatus] || 'Работы')
-      : (NEGOTIATION_STATUS_LABELS[substatus] || 'Переговоры');
+  const isDocumentStage = inExecution && (substatus === 'work_done' || substatus === 'awaiting_documents');
+  let stageLabel = NEGOTIATION_STATUS_LABELS[substatus] || 'Переговоры';
+  if (inExecution) stageLabel = EXECUTION_STATUS_LABELS[substatus] || 'Работы';
+  if (inExecution && substatus === 'awaiting_payment') stageLabel = 'Ожидание оплаты';
+  if (isDocumentStage) stageLabel = 'Оформление документов';
+  if (isClosed) stageLabel = 'Заказ завершён';
 
   const blockers: string[] = [];
   if (!input.productCount && !input.serviceCount) blockers.push('Смета не заполнена');
   if (input.balance > 0) blockers.push(`Остаток ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`);
   if (inExecution && substatus === 'work_done' && !input.documents.length) blockers.push('Нет закрывающих документов');
+  if (input.missingReferencedInvoice) blockers.push(`Не найден счёт ${input.missingReferencedInvoice} из назначения платежа`);
 
   let nextAction: OrderWorkspaceViewModel['nextAction'];
   if (isClosed) nextAction = { label: 'Проверить историю', target: 'documents', tone: 'slate' };
   else if (!input.productCount && !input.serviceCount) nextAction = { label: 'Заполнить смету', target: 'proposal', tone: 'sky' };
   else if (!inExecution && substatus === 'awaiting_visit') nextAction = { label: 'Назначить выезд', target: 'planning', tone: 'sky' };
-  else if (!inExecution && substatus === 'awaiting_payment') nextAction = { label: 'Открыть оплаты', target: 'payments', tone: 'emerald' };
+  else if (!inExecution && substatus === 'awaiting_payment') nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
   else if (!inExecution && substatus === 'proposal_sent') nextAction = { label: 'Проверить предложение', target: 'proposal', tone: 'amber' };
   else if (!inExecution) nextAction = { label: 'Подготовить предложение', target: 'proposal', tone: 'sky' };
   else if (substatus === 'order_equipment' || substatus === 'awaiting_equipment') nextAction = { label: 'Проверить товар', target: 'proposal', tone: 'amber' };
   else if (substatus === 'needs_schedule' || substatus === 'scheduled') nextAction = { label: 'Открыть планирование', target: 'planning', tone: 'teal' };
-  else if (substatus === 'work_done' || substatus === 'awaiting_documents') nextAction = { label: 'Закрыть документы', target: 'documents', tone: 'teal' };
-  else nextAction = { label: 'Открыть оплаты', target: 'payments', tone: 'emerald' };
+  else if (substatus === 'work_done' || substatus === 'awaiting_documents') {
+    if (input.missingReferencedInvoice) nextAction = { label: `Проверить счёт ${input.missingReferencedInvoice}`, target: 'documents', tone: 'amber' };
+    else if (!input.documents.length) nextAction = { label: 'Создать комплект документов', target: 'documents', tone: 'teal' };
+    else if (input.documentEmailStatus === 'unknown') nextAction = { label: 'Проверить комплект документов', target: 'documents', tone: 'amber' };
+    else if (input.documentEmailStatus === 'failed') nextAction = { label: 'Повторить отправку документов', target: 'documents', tone: 'rose' };
+    else if (input.documentEmailStatus === 'pending') nextAction = { label: 'Проверить отправку документов', target: 'documents', tone: 'amber' };
+    else if (input.documentEmailStatus !== 'sent') nextAction = { label: 'Отправить документы', target: 'documents', tone: 'teal' };
+    else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
+    else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald' };
+  } else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
+  else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald' };
 
   const productStatus = !input.productCount
     ? 'Товар не выбран'
-    : (substatus === 'order_equipment' ? 'Нужно заказать' : substatus === 'awaiting_equipment' ? 'Ждём оборудование' : `${input.productCount} поз.`);
+    : (substatus === 'order_equipment' ? 'Нужно заказать' : substatus === 'awaiting_equipment' ? 'Ждём оборудование' : `${input.productCount} ${plural(input.productCount, 'товар', 'товара', 'товаров')}`);
   const workStatus = substatus === 'work_done' || substatus === 'awaiting_documents' || substatus === 'awaiting_payment'
-    ? 'Работы выполнены'
+    ? 'Выполнен'
     : input.installationDate
-      ? 'Работы назначены'
-      : 'Работы не назначены';
+      ? 'Назначен'
+      : 'Не назначен';
   const paymentStatus = input.balance <= 0 && input.total > 0
     ? 'Оплачено полностью'
     : `Оплачено ${Math.round(input.paid).toLocaleString('ru-RU')} из ${Math.round(input.total).toLocaleString('ru-RU')} BYN`;
@@ -131,23 +161,32 @@ export const buildOrderWorkspaceViewModel = (input: OrderWorkspaceInput): OrderW
         label: 'Товар',
         status: productStatus,
         detail: input.linkedEquipmentCount ? `Оборудование на объекте: ${input.linkedEquipmentCount}` : 'Оборудование объекта ещё не создано',
+        actionLabel: !input.productCount ? 'Добавить товар' : input.linkedEquipmentCount ? 'Открыть товар и оборудование' : 'Создать оборудование',
         tone: !input.productCount ? 'rose' : (substatus === 'order_equipment' || substatus === 'awaiting_equipment') ? 'amber' : 'teal',
-        target: 'proposal',
+        target: 'equipment',
       },
       {
         id: 'work',
-        label: 'Работы',
+        label: 'Монтаж',
         status: workStatus,
-        detail: input.serviceCount ? `${input.serviceCount} услуг в смете` : 'Услуги не добавлены',
-        tone: workStatus === 'Работы выполнены' ? 'emerald' : input.installationDate ? 'teal' : 'amber',
+        detail: input.serviceCount ? `${input.serviceCount} ${plural(input.serviceCount, 'услуга', 'услуги', 'услуг')} в смете` : 'Услуги не добавлены',
+        actionLabel: workStatus === 'Выполнен' ? 'Открыть результат' : 'Открыть планирование',
+        tone: workStatus === 'Выполнен' ? 'emerald' : input.installationDate ? 'teal' : 'amber',
         target: 'planning',
       },
       {
         id: 'documents',
         label: 'Документы',
-        status: documentLabel(input.documents),
-        detail: input.documents.length ? 'Откройте комплект для проверки и отправки' : 'Создайте документы из актуальной сметы',
-        tone: input.documents.length ? 'teal' : 'amber',
+        status: input.documents.length ? `${input.documents.length} ${plural(input.documents.length, 'документ', 'документа', 'документов')}` : 'Не созданы',
+        detail: input.missingReferencedInvoice
+          ? `Счёт ${input.missingReferencedInvoice} из платежа не найден`
+          : input.documents.length
+            ? `${documentTypesLabel(input.documents)} · ${documentDeliveryLabel(input.documentEmailStatus)}`
+            : 'Создайте документы из актуальной сметы',
+        actionLabel: input.missingReferencedInvoice
+          ? 'Проверить счёт'
+          : input.documents.length ? 'Открыть комплект' : 'Создать документы',
+        tone: input.missingReferencedInvoice || input.documentEmailStatus === 'failed' ? 'rose' : input.documentEmailStatus === 'unknown' || !input.documents.length ? 'amber' : 'teal',
         target: 'documents',
       },
       {
@@ -155,6 +194,7 @@ export const buildOrderWorkspaceViewModel = (input: OrderWorkspaceInput): OrderW
         label: 'Оплата',
         status: paymentStatus,
         detail: input.balance > 0 ? `Долг ${Math.round(input.balance).toLocaleString('ru-RU')} BYN` : 'Долга нет',
+        actionLabel: input.balance > 0 ? 'Внести оплату' : 'Открыть оплаты',
         tone: input.balance > 0 ? 'rose' : 'emerald',
         target: 'payments',
       },

--- a/manager_frontend/src/components/service-attachments/OrderAttachmentsPanel.vue
+++ b/manager_frontend/src/components/service-attachments/OrderAttachmentsPanel.vue
@@ -63,7 +63,11 @@ const audioUrls = reactive<Record<string, string>>({});
 let listRequestId = 0;
 
 const uploading = computed(() => uploadingCount.value > 0);
-const visibleCount = computed(() => loaded.value ? total.value : (props.initialCount ?? total.value));
+const visibleCount = computed<number | null>(() => {
+  if (loaded.value) return total.value;
+  const initial = Number(props.initialCount || 0);
+  return initial > 0 ? initial : null;
+});
 const imageItems = computed(() => items.value.filter(isImageAttachment));
 const fileItems = computed(() => items.value.filter((item) => !isImageAttachment(item)));
 const editingItem = computed(() => items.value.find((item) => item.id === editingId.value) || null);
@@ -386,11 +390,11 @@ defineExpose({ refresh, expand });
       <span class="min-w-0 flex-1">
         <span class="block text-sm font-semibold text-slate-900 dark:text-slate-100">Фото и файлы</span>
         <span class="block truncate text-xs text-slate-500 dark:text-slate-400">
-          {{ loaded ? (total ? `${total} файлов` : 'Файлов пока нет') : (visibleCount ? `${visibleCount} файлов` : 'Загрузятся при открытии') }}
+          {{ loaded ? (total ? `${total} файлов` : 'Файлов пока нет') : (visibleCount ? `${visibleCount} файлов` : 'Откройте, чтобы загрузить') }}
         </span>
       </span>
       <span class="inline-flex min-w-7 items-center justify-center rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-        {{ visibleCount }}
+        {{ visibleCount ?? '—' }}
       </span>
       <span class="material-icons-round text-[21px] text-slate-500" aria-hidden="true">{{ expanded ? 'expand_less' : 'expand_more' }}</span>
     </button>


### PR DESCRIPTION
## Summary
- turn the four sales-and-installation lanes into the real navigation for product/equipment, installation, documents, and payments
- derive the next action from document creation, outgoing email status, debt, and invoice references in bank payment purposes
- collapse legacy detail surfaces by default, replace the seven-button execution grid with a compact selector, and remove duplicate save/close controls
- clarify payment settings and tighten labels, plurals, email/file empty states, and amount captions

## Verification
- `pnpm run build` in `manager_frontend`
- `pytest tests/unit/test_order_service_manager.py tests/unit/test_order_currency_guards.py -q` (30 passed)
- `bash scripts/audit_theme_hardcodes.sh`
- `git diff --check`

## Scope
- frontend-only; no API, schema, or migration changes
- completing a won order with debt remains intentionally unavailable because the backend currently rejects it; that behavior needs a separate explicit policy/API change