### PR TITLE
Route Telegram task reads through internal API

### DIFF
--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -1,5 +1,6 @@
 """Versioned response contracts for the internal Telegram bot API."""
 
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -49,3 +50,27 @@ class BotCatalogSearchResponse(BaseModel):
 
 class BotCatalogProductLookupResponse(BaseModel):
     product: BotCatalogProductResponse | None = None
+
+
+class BotTaskListRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    limit: int = Field(default=10, ge=1, le=20)
+
+
+class BotTaskResponse(BaseModel):
+    """Stable read-only task projection rendered by the Telegram runtime."""
+
+    kind: Literal["stage", "order"]
+    id: int = Field(ge=1)
+    order_id: int = Field(ge=1)
+    title: str
+    status: str
+    start_time: datetime
+    address: str | None = None
+    customer_name: str = "Клиент"
+    customer_phone: str | None = None
+    comment: str | None = None
+
+
+class BotTaskListResponse(BaseModel):
+    items: list[BotTaskResponse] = Field(default_factory=list)

--- a/bot_app/api_gateway.py
+++ b/bot_app/api_gateway.py
@@ -10,6 +10,7 @@ from api_contracts.bot import (
     BotCatalogProductLookupResponse,
     BotCatalogSearchResponse,
     BotStaffContextResponse,
+    BotTaskListResponse,
 )
 
 
@@ -139,6 +140,25 @@ class BotApiGateway:
             return BotCatalogProductLookupResponse.model_validate(payload)
         except ValueError as exc:
             raise BotApiResponseError("MVN API returned an invalid catalog product contract") from exc
+
+    async def list_my_tasks(
+        self,
+        *,
+        telegram_id: int,
+        limit: int = 10,
+    ) -> BotTaskListResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if limit < 1 or limit > 20:
+            raise ValueError("Task list limit must be between 1 and 20")
+        payload = await self._post(
+            "tasks/my",
+            json={"telegram_id": telegram_id, "limit": limit},
+        )
+        try:
+            return BotTaskListResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid task list contract") from exc
 
     async def _get(self, path: str, *, params: dict[str, object] | None = None) -> dict:
         return await self._request("GET", path, params=params)

--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -14,8 +14,9 @@ from services.customer_requisites_recognition_service import CustomerRequisitesR
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
-from services.bot_task_service import BotTaskService
 from ..access_runtime import get_bot_access_context
+from ..api_runtime import get_bot_api_gateway
+from ..task_presenter import task_to_dict
 from .repair_context import repair_context_keyboard as _repair_context_keyboard
 from ..config import bot
 from ..states import ShopState
@@ -698,12 +699,16 @@ async def choose_order_for_pending_file(callback: CallbackQuery, state: FSMConte
         await callback.answer("Файл не найден. Отправьте его еще раз.", show_alert=True)
         return
 
-    async with async_session_maker() as session:
-        if context.is_manager:
+    if context.is_manager:
+        async with async_session_maker() as session:
             orders = await BotOrderAttachmentService.list_recent_orders(session, limit=5)
-        else:
-            tasks = await BotTaskService.list_my_tasks(session, callback.from_user.id, limit=5)
-            orders = _order_choices_from_tasks(tasks)
+    else:
+        response = await get_bot_api_gateway().list_my_tasks(
+            telegram_id=callback.from_user.id,
+            limit=5,
+        )
+        tasks = [task_to_dict(task) for task in response.items]
+        orders = _order_choices_from_tasks(tasks)
 
     if orders:
         await callback.message.edit_text(

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -9,6 +9,7 @@ from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_service import BotService
 from services.bot_task_service import BotTaskService
 from ..access_runtime import get_bot_access_context
+from ..api_runtime import get_bot_api_gateway
 from ..keyboards import (
     get_staff_main_menu,
     quick_order_confirm_keyboard,
@@ -16,6 +17,7 @@ from ..keyboards import (
     task_actions_keyboard,
 )
 from ..states import ShopState
+from ..task_presenter import format_tasks, format_tasks_rich_html, task_to_dict
 
 router = Router()
 
@@ -196,13 +198,14 @@ async def my_tasks(message: types.Message):
     context = await _require_staff(message)
     if not context:
         return
-    async with async_session_maker() as session:
-        tasks = await BotTaskService.list_my_tasks(session, message.from_user.id if message.from_user else None)
+    user_id = message.from_user.id if message.from_user else 0
+    response = await get_bot_api_gateway().list_my_tasks(telegram_id=user_id, limit=10)
+    tasks = [task_to_dict(task) for task in response.items]
     keyboard = task_actions_keyboard(tasks)
-    fallback_text = BotTaskService.format_tasks(tasks)
+    fallback_text = format_tasks(tasks)
     delivered = await BotService.send_rich_message(
         message.chat.id,
-        BotTaskService.format_tasks_rich_html(tasks),
+        format_tasks_rich_html(tasks),
         reply_markup=keyboard,
     )
     if not delivered:

--- a/bot_app/task_presenter.py
+++ b/bot_app/task_presenter.py
@@ -1,0 +1,66 @@
+"""Pure Telegram presentation helpers for read-only task cards."""
+
+from datetime import datetime
+from html import escape
+from typing import Any
+
+
+def _task_value(task: dict[str, Any] | Any, field: str, default: Any = None) -> Any:
+    if isinstance(task, dict):
+        return task.get(field, default)
+    return getattr(task, field, default)
+
+
+def task_to_dict(task: dict[str, Any] | Any) -> dict[str, Any]:
+    if isinstance(task, dict):
+        return task
+    model_dump = getattr(task, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    raise TypeError("Unsupported task contract")
+
+
+def format_tasks(tasks: list[dict[str, Any] | Any]) -> str:
+    if not tasks:
+        return "У вас нет ближайших задач."
+    lines = ["<b>Мои ближайшие задачи</b>"]
+    for task in tasks:
+        dt = _task_value(task, "start_time")
+        date_text = dt.strftime("%d.%m.%Y %H:%M") if isinstance(dt, datetime) else "время не назначено"
+        lines.extend(
+            [
+                "",
+                f"<b>#{_task_value(task, 'order_id')} - {escape(str(_task_value(task, 'title', 'Задача')))}</b>",
+                f"Дата: {escape(date_text)}",
+                f"Клиент: {escape(str(_task_value(task, 'customer_name') or 'Клиент'))}",
+                f"Телефон: {escape(str(_task_value(task, 'customer_phone') or 'не указан'))}",
+                f"Адрес: {escape(str(_task_value(task, 'address') or 'не указан'))}",
+            ]
+        )
+        comment = _task_value(task, "comment")
+        if comment:
+            lines.append(f"Комментарий: {escape(str(comment))}")
+    return "\n".join(lines)
+
+
+def format_tasks_rich_html(tasks: list[dict[str, Any] | Any]) -> str:
+    if not tasks:
+        return "<h3>Мои ближайшие задачи</h3><p>У вас нет ближайших задач.</p>"
+
+    blocks = ["<h3>Мои ближайшие задачи</h3>"]
+    for task in tasks:
+        dt = _task_value(task, "start_time")
+        date_text = dt.strftime("%d.%m.%Y %H:%M") if isinstance(dt, datetime) else "время не назначено"
+        blocks.append(
+            "<p>"
+            f"<b>#{_task_value(task, 'order_id')} - {escape(str(_task_value(task, 'title', 'Задача')))}</b><br/>"
+            f"<b>Дата:</b> {escape(date_text)}<br/>"
+            f"<b>Клиент:</b> {escape(str(_task_value(task, 'customer_name') or 'Клиент'))}<br/>"
+            f"<b>Телефон:</b> {escape(str(_task_value(task, 'customer_phone') or 'не указан'))}<br/>"
+            f"<b>Адрес:</b> {escape(str(_task_value(task, 'address') or 'не указан'))}"
+            "</p>"
+        )
+        comment = _task_value(task, "comment")
+        if comment:
+            blocks.append(f"<blockquote>{escape(str(comment))}</blockquote>")
+    return "".join(blocks)

--- a/docs/bot-service-extraction.md
+++ b/docs/bot-service-extraction.md
@@ -58,6 +58,19 @@ The legacy step-by-step selection and the current multi-room selection remain
 separate migration slices. They must be replaced by one backend-orchestrated
 selection use case rather than many remote product queries.
 
+### Read-only task slice
+
+The staff task list uses `POST /api/internal/bot/v1/tasks/my`. Telegram identity
+and pagination stay in the JSON body so staff identifiers do not enter access
+log URLs. The API authorizes the identity once, then queries by the verified
+legacy installer mapping.
+
+Scheduled work stages and legacy installer assignments are merged, ordered by
+start time and deduplicated by order. A work stage is the source of truth when
+both representations exist; unrelated legacy assignments are still returned.
+Task status changes and reports remain a separate write slice and continue to
+use the existing local path until idempotent API commands are introduced.
+
 ## Scope guardrails
 
 - Freeze new bot product features while a scenario is being migrated.

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -36,6 +36,9 @@ export type { BotCatalogProductResponse } from './models/BotCatalogProductRespon
 export type { BotCatalogSearchRequest } from './models/BotCatalogSearchRequest';
 export type { BotCatalogSearchResponse } from './models/BotCatalogSearchResponse';
 export type { BotStaffContextResponse } from './models/BotStaffContextResponse';
+export type { BotTaskListRequest } from './models/BotTaskListRequest';
+export type { BotTaskListResponse } from './models/BotTaskListResponse';
+export type { BotTaskResponse } from './models/BotTaskResponse';
 export type { BulkGalleryAddRequest } from './models/BulkGalleryAddRequest';
 export type { BulkGalleryDeleteRequest } from './models/BulkGalleryDeleteRequest';
 export type { BulkProductIdsRequest } from './models/BulkProductIdsRequest';

--- a/manager_frontend/src/client/models/BotTaskListRequest.ts
+++ b/manager_frontend/src/client/models/BotTaskListRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskListRequest = {
+    telegram_id: number;
+    limit?: number;
+};
+

--- a/manager_frontend/src/client/models/BotTaskListResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskListResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotTaskResponse } from './BotTaskResponse';
+export type BotTaskListResponse = {
+    items?: Array<BotTaskResponse>;
+};
+

--- a/manager_frontend/src/client/models/BotTaskResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskResponse.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Stable read-only task projection rendered by the Telegram runtime.
+ */
+export type BotTaskResponse = {
+    kind: 'stage' | 'order';
+    id: number;
+    order_id: number;
+    title: string;
+    status: string;
+    start_time: string;
+    address?: (string | null);
+    customer_name?: string;
+    customer_phone?: (string | null);
+    comment?: (string | null);
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -7,6 +7,8 @@ import type { BotCatalogProductLookupResponse } from '../models/BotCatalogProduc
 import type { BotCatalogSearchRequest } from '../models/BotCatalogSearchRequest';
 import type { BotCatalogSearchResponse } from '../models/BotCatalogSearchResponse';
 import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
+import type { BotTaskListRequest } from '../models/BotTaskListRequest';
+import type { BotTaskListResponse } from '../models/BotTaskListResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -81,6 +83,25 @@ export class InternalBotV1Service {
             query: {
                 'telegram_id': telegramId,
             },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * List Internal Bot My Tasks
+     * @param requestBody
+     * @returns BotTaskListResponse Successful Response
+     * @throws ApiError
+     */
+    public static listInternalBotMyTasksV1(
+        requestBody: BotTaskListRequest,
+    ): CancelablePromise<BotTaskListResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/tasks/my',
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/openapi.json
+++ b/openapi.json
@@ -266,6 +266,52 @@
         }
       }
     },
+    "/api/internal/bot/v1/tasks/my": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "List Internal Bot My Tasks",
+        "operationId": "list_internal_bot_my_tasks_v1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotTaskListRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotTaskListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -18659,6 +18705,124 @@
           "telegram_id"
         ],
         "title": "BotStaffContextResponse"
+      },
+      "BotTaskListRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id"
+        ],
+        "title": "BotTaskListRequest"
+      },
+      "BotTaskListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BotTaskResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "title": "BotTaskListResponse"
+      },
+      "BotTaskResponse": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "stage",
+              "order"
+            ],
+            "title": "Kind"
+          },
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Order Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Time"
+          },
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "customer_name": {
+            "type": "string",
+            "title": "Customer Name",
+            "default": "\u041a\u043b\u0438\u0435\u043d\u0442"
+          },
+          "customer_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Phone"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "id",
+          "order_id",
+          "title",
+          "status",
+          "start_time"
+        ],
+        "title": "BotTaskResponse",
+        "description": "Stable read-only task projection rendered by the Telegram runtime."
       },
       "BulkGalleryAddRequest": {
         "properties": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -10,11 +10,15 @@ from api_contracts.bot import (
     BotCatalogSearchRequest,
     BotCatalogSearchResponse,
     BotStaffContextResponse,
+    BotTaskListRequest,
+    BotTaskListResponse,
+    BotTaskResponse,
 )
 from core.bot_api_security import require_bot_api_token
 from core.database import get_session
 from services.bot_access_service import BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
 
 
 router = APIRouter(
@@ -98,4 +102,26 @@ async def get_internal_bot_catalog_product(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
     return BotCatalogProductLookupResponse(
         product=BotCatalogProductResponse.model_validate(product) if product else None
+    )
+
+
+@router.post(
+    "/tasks/my",
+    response_model=BotTaskListResponse,
+    operation_id="list_internal_bot_my_tasks_v1",
+)
+async def list_internal_bot_my_tasks(
+    payload: BotTaskListRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BotTaskListResponse:
+    try:
+        tasks = await BotTaskReadService.list_for_staff(
+            session,
+            telegram_id=payload.telegram_id,
+            limit=payload.limit,
+        )
+    except BotTaskAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return BotTaskListResponse(
+        items=[BotTaskResponse.model_validate(task) for task in tasks]
     )

--- a/services/bot_task_read_service.py
+++ b/services/bot_task_read_service.py
@@ -1,0 +1,30 @@
+"""Staff-authorized task reads exposed to the Telegram bot API."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.bot_access_service import BotAccessService
+from services.bot_task_service import BotTaskService
+
+
+class BotTaskAccessDeniedError(PermissionError):
+    """The Telegram identity cannot use staff task scenarios."""
+
+
+class BotTaskReadService:
+    @staticmethod
+    async def list_for_staff(
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        limit: int,
+    ) -> list[dict]:
+        context = await BotAccessService.get_context(session, telegram_id)
+        if not context.is_staff:
+            raise BotTaskAccessDeniedError("Staff task access is required")
+        if not context.legacy_installer_id:
+            return []
+        return await BotTaskService.list_installer_tasks(
+            session,
+            int(context.legacy_installer_id),
+            limit=limit,
+        )

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime, timedelta
-from html import escape
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -48,31 +47,52 @@ class BotTaskService:
         if not staff or not staff.legacy_installer_id:
             return []
 
-        now = datetime.now() - timedelta(days=1)
-        until = datetime.now() + timedelta(days=30)
-        installer_id = int(staff.legacy_installer_id)
+        return await cls.list_installer_tasks(
+            session,
+            int(staff.legacy_installer_id),
+            limit=limit,
+        )
+
+    @classmethod
+    async def list_installer_tasks(
+        cls,
+        session: AsyncSession,
+        installer_id: int,
+        *,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        safe_limit = max(1, min(int(limit or 10), 20))
+
+        reference_time = datetime.now()
+        now = reference_time - timedelta(days=1)
+        until = reference_time + timedelta(days=30)
+        active_stage_filters = (
+            OrderWorkStage.installer_id == installer_id,
+            Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)),
+            OrderWorkStage.start_time.is_not(None),
+            OrderWorkStage.start_time >= now,
+            OrderWorkStage.start_time <= until,
+            OrderWorkStage.status != OrderStageStatus.COMPLETED,
+            OrderWorkStage.status != OrderStageStatus.CANCELED,
+        )
 
         stage_result = await session.execute(
             select(OrderWorkStage)
             .join(Order, Order.id == OrderWorkStage.order_id)
-            .where(OrderWorkStage.installer_id == installer_id)
-            .where(Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)))
-            .where(OrderWorkStage.start_time.is_not(None))
-            .where(
-                (OrderWorkStage.start_time >= now) & (OrderWorkStage.start_time <= until)
-            )
-            .where(OrderWorkStage.status != OrderStageStatus.COMPLETED)
-            .where(OrderWorkStage.status != OrderStageStatus.CANCELED)
+            .where(*active_stage_filters)
             .options(
                 selectinload(OrderWorkStage.order).selectinload(Order.customer),
-                selectinload(OrderWorkStage.installer),
             )
             .order_by(OrderWorkStage.start_time.asc().nullslast(), OrderWorkStage.id.asc())
-            .limit(limit)
+            .limit(safe_limit)
         )
         tasks = [cls._map_stage(stage) for stage in stage_result.scalars().all()]
-        if tasks:
-            return tasks
+
+        active_stage_order_ids = (
+            select(OrderWorkStage.order_id)
+            .join(Order, Order.id == OrderWorkStage.order_id)
+            .where(*active_stage_filters)
+        )
 
         order_result = await session.execute(
             select(Order)
@@ -83,11 +103,20 @@ class BotTaskService:
             .where(
                 (Order.installation_date >= now) & (Order.installation_date <= until)
             )
-            .options(selectinload(Order.customer), selectinload(Order.installers))
+            .where(Order.id.notin_(active_stage_order_ids))
+            .options(selectinload(Order.customer))
             .order_by(Order.installation_date.asc().nullslast(), Order.id.asc())
-            .limit(limit)
+            .limit(safe_limit)
         )
-        return [cls._map_order(order) for order in order_result.scalars().all()]
+        tasks.extend(cls._map_order(order) for order in order_result.scalars().all())
+        tasks.sort(
+            key=lambda task: (
+                task["start_time"],
+                0 if task["kind"] == "stage" else 1,
+                task["id"],
+            )
+        )
+        return tasks[:safe_limit]
 
     @staticmethod
     def _customer_phone(order: Order) -> str | None:
@@ -129,50 +158,6 @@ class BotTaskService:
             "customer_phone": cls._customer_phone(order),
             "comment": order.comment,
         }
-
-    @staticmethod
-    def format_tasks(tasks: list[dict[str, Any]]) -> str:
-        if not tasks:
-            return "У вас нет ближайших задач."
-        lines = ["<b>Мои ближайшие задачи</b>"]
-        for task in tasks:
-            dt = task.get("start_time")
-            date_text = dt.strftime("%d.%m.%Y %H:%M") if dt else "время не назначено"
-            lines.extend(
-                [
-                    "",
-                    f"<b>#{task['order_id']} - {escape(str(task['title']))}</b>",
-                    f"Дата: {escape(date_text)}",
-                    f"Клиент: {escape(str(task.get('customer_name') or 'Клиент'))}",
-                    f"Телефон: {escape(str(task.get('customer_phone') or 'не указан'))}",
-                    f"Адрес: {escape(str(task.get('address') or 'не указан'))}",
-                ]
-            )
-            if task.get("comment"):
-                lines.append(f"Комментарий: {escape(str(task['comment']))}")
-        return "\n".join(lines)
-
-    @staticmethod
-    def format_tasks_rich_html(tasks: list[dict[str, Any]]) -> str:
-        if not tasks:
-            return "<h3>Мои ближайшие задачи</h3><p>У вас нет ближайших задач.</p>"
-
-        blocks = ["<h3>Мои ближайшие задачи</h3>"]
-        for task in tasks:
-            dt = task.get("start_time")
-            date_text = dt.strftime("%d.%m.%Y %H:%M") if dt else "время не назначено"
-            blocks.append(
-                "<p>"
-                f"<b>#{task['order_id']} - {escape(str(task['title']))}</b><br/>"
-                f"<b>Дата:</b> {escape(date_text)}<br/>"
-                f"<b>Клиент:</b> {escape(str(task.get('customer_name') or 'Клиент'))}<br/>"
-                f"<b>Телефон:</b> {escape(str(task.get('customer_phone') or 'не указан'))}<br/>"
-                f"<b>Адрес:</b> {escape(str(task.get('address') or 'не указан'))}"
-                "</p>"
-            )
-            if task.get("comment"):
-                blocks.append(f"<blockquote>{escape(str(task['comment']))}</blockquote>")
-        return "".join(blocks)
 
     @staticmethod
     def build_stage_report(

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -841,13 +841,12 @@ class OrderService:
                 if stage.start_time and start_date <= stage.start_time <= end_date:
                     st_val = stage.status.value if hasattr(stage.status, "value") else str(stage.status)
                     color = "#0ea5e9" # Sky-500 default
+                    title = stage.name
                     if st_val == "completed":
                         color = "#10b981" # Emerald-500
                     elif st_val == "canceled":
                         color = "#94a3b8" # Slate-400
                         title = f"Отменен: {stage.name}"
-                    else:
-                        title = stage.name
 
                     title += f" - {order.customer.name if order.customer else 'Клиент'}"
                         

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from api_contracts.bot import BotTaskListResponse, BotTaskResponse
+
 os.environ["BOT_TOKEN"] = "123:test"
 
 from core.config import settings
@@ -564,31 +566,42 @@ async def test_requisites_file_attach_callback_shows_executor_tasks(monkeypatch)
 
     list_recent_mock = AsyncMock()
 
-    async def fake_list_tasks(session, telegram_id, *, limit):
-        assert telegram_id == 5
-        assert limit == 5
-        return [
-            {
-                "id": 7,
-                "order_id": 42,
-                "title": "Монтаж",
-                "customer_name": "Иван",
-                "address": "Победы 15",
-            }
-        ]
+    gateway = SimpleNamespace(
+        list_my_tasks=AsyncMock(
+            return_value=BotTaskListResponse(
+                items=[
+                    BotTaskResponse(
+                        kind="stage",
+                        id=7,
+                        order_id=42,
+                        title="Монтаж",
+                        status="planned",
+                        start_time="2026-07-20T12:00:00",
+                        customer_name="Иван",
+                        address="Победы 15",
+                    )
+                ]
+            )
+        )
+    )
 
     monkeypatch.setattr(
         admin_handler,
         "_get_bot_access_context",
         AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=False)),
     )
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    monkeypatch.setattr(
+        admin_handler,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("executor task read must not open a DB session")),
+    )
     monkeypatch.setattr(admin_handler.BotOrderAttachmentService, "list_recent_orders", list_recent_mock)
-    monkeypatch.setattr(admin_handler.BotTaskService, "list_my_tasks", fake_list_tasks)
+    monkeypatch.setattr(admin_handler, "get_bot_api_gateway", lambda: gateway)
 
     await admin_handler.choose_order_for_pending_file(callback, state)
 
     list_recent_mock.assert_not_called()
+    gateway.list_my_tasks.assert_awaited_once_with(telegram_id=5, limit=5)
     args, kwargs = callback.message.edit_text.await_args
     assert "#42" in args[0]
     assert kwargs["reply_markup"].inline_keyboard[0][0].callback_data == "req_file_attach_order_42"

--- a/tests/unit/test_bot_api_gateway.py
+++ b/tests/unit/test_bot_api_gateway.py
@@ -191,3 +191,37 @@ async def test_bot_api_gateway_decodes_catalog_product_detail():
     assert response.product.description == "Тихий инвертор"
     assert response.product.categories == ["Настенные"]
     assert response.product.minsk_qty == 2
+
+
+async def test_bot_api_gateway_posts_task_list_without_staff_id_in_url():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/tasks/my"
+        assert request.method == "POST"
+        assert request.url.query == b""
+        assert request.content == b'{"telegram_id":123,"limit":10}'
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "kind": "stage",
+                        "id": 7,
+                        "order_id": 42,
+                        "title": "Монтаж",
+                        "status": "planned",
+                        "start_time": "2026-07-20T12:00:00",
+                        "customer_name": "Иван",
+                    }
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.list_my_tasks(telegram_id=123)
+
+    assert response.items[0].id == 7
+    assert response.items[0].start_time.isoformat() == "2026-07-20T12:00:00"

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -46,3 +46,16 @@ def test_bot_catalog_presenter_does_not_import_backend_services():
     source = Path("bot_app/catalog_presenter.py").read_text(encoding="utf-8")
     for forbidden in ("from core.database", "from models", "from crud", "from services"):
         assert forbidden not in source, f"catalog presenter imports backend layer: {forbidden}"
+
+
+def test_bot_task_read_paths_use_api_instead_of_task_service_reads():
+    for filename in ("work.py", "admin.py"):
+        source = Path(f"bot_app/handlers/{filename}").read_text(encoding="utf-8")
+        assert "BotTaskService.list_my_tasks" not in source
+        assert "get_bot_api_gateway().list_my_tasks" in source
+
+
+def test_bot_task_presenter_does_not_import_backend_runtime_layers():
+    source = Path("bot_app/task_presenter.py").read_text(encoding="utf-8")
+    for forbidden in ("from core.database", "from models", "from crud", "from services"):
+        assert forbidden not in source, f"task presenter imports backend layer: {forbidden}"

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -17,12 +17,15 @@ from services.bot_access_service import BotAccessService
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_task_service import BotTaskService
+from services.bot_task_read_service import BotTaskReadService
 from services.product_read_service import ProductReadService
 from services.product_service import ProductService
 from bot_app.catalog_presenter import format_client_product
 from bot_app.keyboards import get_product_keyboard, get_staff_main_menu, selection_result_keyboard
+from bot_app.task_presenter import format_tasks, format_tasks_rich_html
 from bot_app.handlers import work as work_handlers
 from bot_app.utils import format_caption
+from api_contracts.bot import BotTaskListResponse, BotTaskResponse
 
 
 @pytest.fixture
@@ -172,8 +175,8 @@ def test_tasks_rich_html_formats_and_escapes_cards():
         }
     ]
 
-    rich = BotTaskService.format_tasks_rich_html(tasks)
-    fallback = BotTaskService.format_tasks(tasks)
+    rich = format_tasks_rich_html(tasks)
+    fallback = format_tasks(tasks)
 
     assert "<h3>Мои ближайшие задачи</h3>" in rich
     assert "#42 - Монтаж &lt;важно&gt;" in rich
@@ -184,7 +187,7 @@ def test_tasks_rich_html_formats_and_escapes_cards():
 
 
 @pytest.mark.asyncio
-async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_session):
+async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_session):
     installer = Installer(name="Иван Монтажник")
     sqlite_staff_session.add(installer)
     await sqlite_staff_session.commit()
@@ -209,6 +212,7 @@ async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_se
         status=OrderStatus.EXECUTION,
         title="Активный заказ",
         delivery_address="Победы 15",
+        installation_date=datetime.now() + timedelta(days=1),
     )
     closed_order = Order(
         customer_id=customer.id,
@@ -222,6 +226,7 @@ async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_se
         status=OrderStatus.EXECUTION,
         title="Старый монтаж без даты",
         delivery_address="Победы 17",
+        installation_date=datetime.now() + timedelta(days=3),
     )
     sqlite_staff_session.add(active_order)
     sqlite_staff_session.add(closed_order)
@@ -255,6 +260,13 @@ async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_se
                 status=OrderStageStatus.PLANNED,
             ),
             OrderWorkStage(
+                order_id=active_order.id,
+                name="Пусконаладка",
+                installer_id=installer.id,
+                start_time=datetime.now() + timedelta(days=2, hours=1),
+                status=OrderStageStatus.PLANNED,
+            ),
+            OrderWorkStage(
                 order_id=closed_order.id,
                 name="Этап закрытого заказа",
                 installer_id=installer.id,
@@ -262,13 +274,99 @@ async def test_task_list_skips_stale_unscheduled_and_closed_work(sqlite_staff_se
                 status=OrderStageStatus.PLANNED,
             ),
             OrderInstaller(order_id=legacy_order.id, installer_id=installer.id),
+            OrderInstaller(order_id=active_order.id, installer_id=installer.id),
         ]
     )
     await sqlite_staff_session.commit()
 
     tasks = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345)
 
-    assert [task["title"] for task in tasks] == ["Ближайший монтаж"]
+    assert [task["title"] for task in tasks] == [
+        "Ближайший монтаж",
+        "Пусконаладка",
+        "Старый монтаж без даты",
+    ]
+    assert [task["kind"] for task in tasks] == ["stage", "stage", "order"]
+    assert not any(
+        task["kind"] == "order" and task["order_id"] == active_order.id
+        for task in tasks
+    )
+
+    limited = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345, limit=2)
+    assert [task["title"] for task in limited] == ["Ближайший монтаж", "Пусконаладка"]
+
+
+@pytest.mark.asyncio
+async def test_my_tasks_handler_uses_gateway_without_opening_database(monkeypatch):
+    task = BotTaskResponse(
+        kind="stage",
+        id=7,
+        order_id=42,
+        title="Монтаж",
+        status="planned",
+        start_time=datetime(2026, 7, 20, 12, 0),
+        customer_name="Иван",
+        customer_phone="+375291234567",
+        address="Победы 15",
+    )
+    gateway = SimpleNamespace(
+        list_my_tasks=AsyncMock(return_value=BotTaskListResponse(items=[task]))
+    )
+    context = SimpleNamespace(is_staff=True, is_manager=False, is_executor=True)
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=777),
+        chat=SimpleNamespace(id=555),
+        answer=AsyncMock(),
+    )
+    send_rich = AsyncMock(return_value=True)
+
+    monkeypatch.setattr(work_handlers, "_require_staff", AsyncMock(return_value=context))
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(work_handlers.BotService, "send_rich_message", send_rich)
+    monkeypatch.setattr(
+        work_handlers,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("task read must not open a DB session")),
+    )
+
+    await work_handlers.my_tasks(message)
+
+    gateway.list_my_tasks.assert_awaited_once_with(telegram_id=777, limit=10)
+    send_rich.assert_awaited_once()
+    assert "#42 - Монтаж" in send_rich.await_args.args[1]
+    keyboard = send_rich.await_args.kwargs["reply_markup"]
+    assert keyboard.inline_keyboard[0][0].callback_data == "task_accept_7"
+    message.answer.assert_awaited_once_with(
+        "Можно продолжить работу из меню.",
+        reply_markup=get_staff_main_menu(context),
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_read_service_reuses_authorized_installer_mapping(monkeypatch):
+    session = object()
+    context = SimpleNamespace(is_staff=True, legacy_installer_id=17)
+    get_context = AsyncMock(return_value=context)
+    list_installer_tasks = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(
+        "services.bot_task_read_service.BotAccessService.get_context",
+        get_context,
+    )
+    monkeypatch.setattr(
+        "services.bot_task_read_service.BotTaskService.list_installer_tasks",
+        list_installer_tasks,
+    )
+
+    tasks = await BotTaskReadService.list_for_staff(
+        session,
+        telegram_id=777,
+        limit=10,
+    )
+
+    assert tasks == []
+    get_context.assert_awaited_once_with(session, 777)
+    list_installer_tasks.assert_awaited_once_with(session, 17, limit=10)
 
 
 def test_task_report_builder_keeps_text_report_plain():

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -5,6 +5,7 @@ from core.database import get_session
 from main import app
 from services.bot_access_service import BotAccessContext, BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
 
 
 async def _request(
@@ -74,15 +75,18 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     staff_context = schema["paths"]["/api/internal/bot/v1/staff/context/{telegram_id}"]["get"]
     catalog_search = schema["paths"]["/api/internal/bot/v1/catalog/search"]["post"]
     catalog_product = schema["paths"]["/api/internal/bot/v1/catalog/products/{product_id}"]["get"]
+    task_list = schema["paths"]["/api/internal/bot/v1/tasks/my"]["post"]
 
     assert health["operationId"] == "get_internal_bot_api_health_v1"
     assert staff_context["operationId"] == "get_internal_bot_staff_context_v1"
     assert catalog_search["operationId"] == "search_internal_bot_catalog_v1"
     assert catalog_product["operationId"] == "get_internal_bot_catalog_product_v1"
+    assert task_list["operationId"] == "list_internal_bot_my_tasks_v1"
     assert health["security"] == [{"BotServiceBearer": []}]
     assert staff_context["security"] == [{"BotServiceBearer": []}]
     assert catalog_search["security"] == [{"BotServiceBearer": []}]
     assert catalog_product["security"] == [{"BotServiceBearer": []}]
+    assert task_list["security"] == [{"BotServiceBearer": []}]
     assert schema["components"]["securitySchemes"]["BotServiceBearer"] == {
         "type": "http",
         "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
@@ -279,3 +283,96 @@ async def test_internal_bot_catalog_denies_non_staff_identity(monkeypatch):
 
     assert response.status_code == 403
     assert response.json() == {"detail": "Staff catalog access is required"}
+
+
+async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_list(_session, *, telegram_id, limit):
+        assert (telegram_id, limit) == (123456, 10)
+        return [
+            {
+                "kind": "stage",
+                "id": 7,
+                "order_id": 42,
+                "title": "Монтаж",
+                "status": "planned",
+                "start_time": "2026-07-20T12:00:00",
+                "address": "Победы 15",
+                "customer_name": "Иван",
+                "customer_phone": "+375291234567",
+                "comment": "Позвонить заранее",
+                "private_field": "must not leak",
+            }
+        ]
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskReadService, "list_for_staff", fake_list)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/tasks/my",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "limit": 10},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "kind": "stage",
+                "id": 7,
+                "order_id": 42,
+                "title": "Монтаж",
+                "status": "planned",
+                "start_time": "2026-07-20T12:00:00",
+                "address": "Победы 15",
+                "customer_name": "Иван",
+                "customer_phone": "+375291234567",
+                "comment": "Позвонить заранее",
+            }
+        ]
+    }
+
+
+async def test_internal_bot_task_list_denies_non_staff_identity(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_list(_session, **_kwargs):
+        raise BotTaskAccessDeniedError("Staff task access is required")
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskReadService, "list_for_staff", fake_list)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/tasks/my",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Staff task access is required"}
+
+
+async def test_internal_bot_task_list_validates_body(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    response = await _request(
+        "/api/internal/bot/v1/tasks/my",
+        token="expected-token",
+        method="POST",
+        json={"telegram_id": 0, "limit": 21},
+    )
+
+    assert response.status_code == 422

--- a/tests/unit/test_order_service_manager.py
+++ b/tests/unit/test_order_service_manager.py
@@ -165,6 +165,65 @@ def test_service_display_order_title_hides_legacy_site_title():
     assert OrderService._display_order_title(order) == "Монтаж магазина"
 
 
+@pytest.mark.asyncio
+async def test_calendar_completed_stages_keep_their_own_titles(sqlite_order_session):
+    customer = Customer(name="Иван", phone="+375291234567")
+    sqlite_order_session.add(customer)
+    await sqlite_order_session.commit()
+    await sqlite_order_session.refresh(customer)
+
+    order = Order(
+        customer_id=customer.id,
+        status=OrderStatus.EXECUTION,
+        title="Монтаж",
+        delivery_address="Победы 15",
+    )
+    sqlite_order_session.add(order)
+    await sqlite_order_session.commit()
+    await sqlite_order_session.refresh(order)
+
+    event_time = datetime(2026, 7, 20, 12, 0)
+    stages = [
+        OrderWorkStage(
+            order_id=order.id,
+            name="Завершенный первый",
+            start_time=event_time,
+            status=OrderStageStatus.COMPLETED,
+        ),
+        OrderWorkStage(
+            order_id=order.id,
+            name="Запланированный",
+            start_time=event_time + timedelta(hours=1),
+            status=OrderStageStatus.PLANNED,
+        ),
+        OrderWorkStage(
+            order_id=order.id,
+            name="Завершенный последний",
+            start_time=event_time + timedelta(hours=2),
+            status=OrderStageStatus.COMPLETED,
+        ),
+    ]
+    sqlite_order_session.add_all(stages)
+    await sqlite_order_session.commit()
+    for stage in stages:
+        await sqlite_order_session.refresh(stage)
+    await sqlite_order_session.refresh(order, ["work_stages"])
+
+    events = await OrderService.get_calendar_events(
+        sqlite_order_session,
+        event_time - timedelta(hours=1),
+        event_time + timedelta(hours=3),
+    )
+    by_id = {event.id: event for event in events}
+
+    first = by_id[f"{order.id}-stage-{stages[0].id}"]
+    last = by_id[f"{order.id}-stage-{stages[2].id}"]
+    assert first.title == "Завершенный первый - Иван"
+    assert first.color == "#10b981"
+    assert last.title == "Завершенный последний - Иван"
+    assert last.color == "#10b981"
+
+
 def test_service_json_text_search_variants_include_escaped_cyrillic():
     assert OrderService._json_text_search_variants("адрес") == [
         "адрес",


### PR DESCRIPTION
Summary:
- add versioned staff-authorized Bot API task list contract and shared gateway method
- merge scheduled stages with distinct legacy installer assignments, deduplicate by order, sort globally, and enforce one limit
- move both Telegram task-list consumers and pure presentation out of backend DB reads
- fix completed work-stage calendar titles and add regression coverage
- regenerate OpenAPI and manager typed client

Verification:
- full unit suite: 2151 passed, 4 skipped
- focused task/API/gateway/handler/calendar suite: 154 passed
- manager production build passed
- git diff check passed

Scope:
Read-only task listing only. Status updates and task reports remain the next idempotent write slice; no DB fallback was added to the migrated read paths.