### PR TITLE
Route Telegram task mutations through API

### DIFF
--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -1,9 +1,9 @@
-"""Versioned response contracts for the internal Telegram bot API."""
+"""Versioned contracts for the internal Telegram bot API."""
 
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class BotApiHealthResponse(BaseModel):
@@ -74,3 +74,32 @@ class BotTaskResponse(BaseModel):
 
 class BotTaskListResponse(BaseModel):
     items: list[BotTaskResponse] = Field(default_factory=list)
+
+
+class BotTaskStatusUpdateRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    status: Literal["in_progress", "completed"]
+
+
+class BotTaskStatusUpdateResponse(BaseModel):
+    stage_id: int = Field(ge=1)
+    status: Literal["in_progress", "completed"]
+    changed: bool
+
+
+class BotTaskReportSaveRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    report: str = Field(min_length=1, max_length=12_000)
+
+    @field_validator("report")
+    @classmethod
+    def normalize_report(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Task report must not be empty")
+        return normalized
+
+
+class BotTaskReportSaveResponse(BaseModel):
+    stage_id: int = Field(ge=1)
+    changed: bool

--- a/bot_app/api_gateway.py
+++ b/bot_app/api_gateway.py
@@ -11,6 +11,8 @@ from api_contracts.bot import (
     BotCatalogSearchResponse,
     BotStaffContextResponse,
     BotTaskListResponse,
+    BotTaskReportSaveResponse,
+    BotTaskStatusUpdateResponse,
 )
 
 
@@ -32,6 +34,10 @@ class BotApiUnavailableError(BotApiError):
 
 class BotApiResponseError(BotApiError):
     """The API returned an unexpected response."""
+
+
+class BotApiConflictError(BotApiError):
+    """The staff action conflicts with the current backend state."""
 
 
 @dataclass(frozen=True)
@@ -160,6 +166,53 @@ class BotApiGateway:
         except ValueError as exc:
             raise BotApiResponseError("MVN API returned an invalid task list contract") from exc
 
+    async def update_task_status(
+        self,
+        *,
+        telegram_id: int,
+        stage_id: int,
+        status: str,
+    ) -> BotTaskStatusUpdateResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if stage_id <= 0:
+            raise ValueError("Task stage ID must be positive")
+        if status not in {"in_progress", "completed"}:
+            raise ValueError("Task status must be in_progress or completed")
+        payload = await self._post(
+            f"tasks/stages/{stage_id}/status",
+            json={"telegram_id": telegram_id, "status": status},
+        )
+        try:
+            return BotTaskStatusUpdateResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid task status contract") from exc
+
+    async def save_task_report(
+        self,
+        *,
+        telegram_id: int,
+        stage_id: int,
+        report: str,
+    ) -> BotTaskReportSaveResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if stage_id <= 0:
+            raise ValueError("Task stage ID must be positive")
+        normalized_report = report.strip()
+        if not normalized_report:
+            raise ValueError("Task report must not be empty")
+        if len(normalized_report) > 12_000:
+            raise ValueError("Task report must not exceed 12000 characters")
+        payload = await self._post(
+            f"tasks/stages/{stage_id}/report",
+            json={"telegram_id": telegram_id, "report": normalized_report},
+        )
+        try:
+            return BotTaskReportSaveResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid task report contract") from exc
+
     async def _get(self, path: str, *, params: dict[str, object] | None = None) -> dict:
         return await self._request("GET", path, params=params)
 
@@ -191,6 +244,8 @@ class BotApiGateway:
             raise BotApiAuthenticationError("MVN API rejected the bot credential")
         if response.status_code == 403:
             raise BotApiAuthorizationError("MVN API denied the staff action")
+        if response.status_code == 409:
+            raise BotApiConflictError("MVN API rejected a conflicting staff action")
         if response.status_code >= 500:
             raise BotApiUnavailableError(f"MVN API returned HTTP {response.status_code}")
         if response.status_code >= 400:

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -7,8 +7,8 @@ from core.database import async_session_maker
 from services.bot_product_selection_service import BotProductSelectionService
 from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_service import BotService
-from services.bot_task_service import BotTaskService
 from ..access_runtime import get_bot_access_context
+from ..api_gateway import BotApiAuthorizationError, BotApiConflictError
 from ..api_runtime import get_bot_api_gateway
 from ..keyboards import (
     get_staff_main_menu,
@@ -17,7 +17,7 @@ from ..keyboards import (
     task_actions_keyboard,
 )
 from ..states import ShopState
-from ..task_presenter import format_tasks, format_tasks_rich_html, task_to_dict
+from ..task_presenter import build_stage_report, format_tasks, format_tasks_rich_html, task_to_dict
 
 router = Router()
 
@@ -219,15 +219,17 @@ async def update_task_status(callback: CallbackQuery):
     data = callback.data or ""
     status = "in_progress" if data.startswith("task_accept_") else "completed"
     stage_id = int(data.rsplit("_", 1)[-1])
-    async with async_session_maker() as session:
-        ok = await BotTaskService.update_stage_status(
-            session,
-            stage_id,
-            status,
+    try:
+        await get_bot_api_gateway().update_task_status(
             telegram_id=callback.from_user.id,
+            stage_id=stage_id,
+            status=status,
         )
-    if not ok:
+    except BotApiAuthorizationError:
         await callback.answer("Задача не найдена или нет доступа", show_alert=True)
+        return
+    except BotApiConflictError:
+        await callback.answer("Задача уже завершена или отменена", show_alert=True)
         return
     await callback.answer("Готово")
     await callback.message.answer("Статус задачи обновлен.", reply_markup=get_staff_main_menu(context))
@@ -248,7 +250,7 @@ async def task_report_finish(message: types.Message, state: FSMContext):
     stage_id = int(data.get("task_report_stage_id") or 0)
     photo_file_id = message.photo[-1].file_id if message.photo else None
     document = message.document
-    report = BotTaskService.build_stage_report(
+    report = build_stage_report(
         text=message.text,
         caption=message.caption,
         photo_file_id=photo_file_id,
@@ -258,16 +260,23 @@ async def task_report_finish(message: types.Message, state: FSMContext):
     if not stage_id or not report:
         await message.answer("Отчет пустой, попробуйте еще раз.")
         return
-    async with async_session_maker() as session:
-        ok = await BotTaskService.save_stage_report(
-            session,
-            stage_id,
-            report,
-            telegram_id=message.from_user.id if message.from_user else None,
+    try:
+        await get_bot_api_gateway().save_task_report(
+            telegram_id=message.from_user.id if message.from_user else 0,
+            stage_id=stage_id,
+            report=report,
         )
+    except BotApiAuthorizationError:
+        await state.clear()
+        context = await _access_context(message.from_user.id if message.from_user else None)
+        await message.answer(
+            "Задача не найдена или нет доступа.",
+            reply_markup=get_staff_main_menu(context) if context.is_staff else None,
+        )
+        return
     await state.clear()
     context = await _access_context(message.from_user.id if message.from_user else None)
     await message.answer(
-        "Отчет сохранен." if ok else "Задача не найдена или нет доступа.",
+        "Отчет сохранен.",
         reply_markup=get_staff_main_menu(context) if context.is_staff else None,
     )

--- a/bot_app/task_presenter.py
+++ b/bot_app/task_presenter.py
@@ -1,4 +1,4 @@
-"""Pure Telegram presentation helpers for read-only task cards."""
+"""Pure Telegram presentation helpers for task cards and reports."""
 
 from datetime import datetime
 from html import escape
@@ -18,6 +18,34 @@ def task_to_dict(task: dict[str, Any] | Any) -> dict[str, Any]:
     if callable(model_dump):
         return model_dump()
     raise TypeError("Unsupported task contract")
+
+
+def build_stage_report(
+    *,
+    text: str | None = None,
+    caption: str | None = None,
+    photo_file_id: str | None = None,
+    document_file_id: str | None = None,
+    document_name: str | None = None,
+) -> str:
+    body = (text or caption or "").strip()
+    lines: list[str] = [body] if body else []
+    attachments: list[str] = []
+
+    if photo_file_id:
+        attachments.append(f"Фото: {photo_file_id}")
+
+    if document_file_id:
+        safe_name = " ".join((document_name or "файл").split())[:120] or "файл"
+        attachments.append(f"Документ: {safe_name} ({document_file_id})")
+
+    if attachments:
+        if lines:
+            lines.append("")
+        lines.append("Вложения:")
+        lines.extend(f"- {attachment}" for attachment in attachments)
+
+    return "\n".join(lines).strip()
 
 
 def format_tasks(tasks: list[dict[str, Any] | Any]) -> str:

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -38,7 +38,11 @@ export type { BotCatalogSearchResponse } from './models/BotCatalogSearchResponse
 export type { BotStaffContextResponse } from './models/BotStaffContextResponse';
 export type { BotTaskListRequest } from './models/BotTaskListRequest';
 export type { BotTaskListResponse } from './models/BotTaskListResponse';
+export type { BotTaskReportSaveRequest } from './models/BotTaskReportSaveRequest';
+export type { BotTaskReportSaveResponse } from './models/BotTaskReportSaveResponse';
 export type { BotTaskResponse } from './models/BotTaskResponse';
+export type { BotTaskStatusUpdateRequest } from './models/BotTaskStatusUpdateRequest';
+export type { BotTaskStatusUpdateResponse } from './models/BotTaskStatusUpdateResponse';
 export type { BulkGalleryAddRequest } from './models/BulkGalleryAddRequest';
 export type { BulkGalleryDeleteRequest } from './models/BulkGalleryDeleteRequest';
 export type { BulkProductIdsRequest } from './models/BulkProductIdsRequest';

--- a/manager_frontend/src/client/models/BotTaskReportSaveRequest.ts
+++ b/manager_frontend/src/client/models/BotTaskReportSaveRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskReportSaveRequest = {
+    telegram_id: number;
+    report: string;
+};
+

--- a/manager_frontend/src/client/models/BotTaskReportSaveResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskReportSaveResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskReportSaveResponse = {
+    stage_id: number;
+    changed: boolean;
+};
+

--- a/manager_frontend/src/client/models/BotTaskStatusUpdateRequest.ts
+++ b/manager_frontend/src/client/models/BotTaskStatusUpdateRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskStatusUpdateRequest = {
+    telegram_id: number;
+    status: 'in_progress' | 'completed';
+};
+

--- a/manager_frontend/src/client/models/BotTaskStatusUpdateResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskStatusUpdateResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotTaskStatusUpdateResponse = {
+    stage_id: number;
+    status: 'in_progress' | 'completed';
+    changed: boolean;
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -9,6 +9,10 @@ import type { BotCatalogSearchResponse } from '../models/BotCatalogSearchRespons
 import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
 import type { BotTaskListRequest } from '../models/BotTaskListRequest';
 import type { BotTaskListResponse } from '../models/BotTaskListResponse';
+import type { BotTaskReportSaveRequest } from '../models/BotTaskReportSaveRequest';
+import type { BotTaskReportSaveResponse } from '../models/BotTaskReportSaveResponse';
+import type { BotTaskStatusUpdateRequest } from '../models/BotTaskStatusUpdateRequest';
+import type { BotTaskStatusUpdateResponse } from '../models/BotTaskStatusUpdateResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -100,6 +104,54 @@ export class InternalBotV1Service {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/internal/bot/v1/tasks/my',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Internal Bot Task Status
+     * @param stageId
+     * @param requestBody
+     * @returns BotTaskStatusUpdateResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateInternalBotTaskStatusV1(
+        stageId: number,
+        requestBody: BotTaskStatusUpdateRequest,
+    ): CancelablePromise<BotTaskStatusUpdateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/tasks/stages/{stage_id}/status',
+            path: {
+                'stage_id': stageId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Save Internal Bot Task Report
+     * @param stageId
+     * @param requestBody
+     * @returns BotTaskReportSaveResponse Successful Response
+     * @throws ApiError
+     */
+    public static saveInternalBotTaskReportV1(
+        stageId: number,
+        requestBody: BotTaskReportSaveRequest,
+    ): CancelablePromise<BotTaskReportSaveResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/tasks/stages/{stage_id}/report',
+            path: {
+                'stage_id': stageId,
+            },
             body: requestBody,
             mediaType: 'application/json',
             errors: {

--- a/openapi.json
+++ b/openapi.json
@@ -312,6 +312,122 @@
         ]
       }
     },
+    "/api/internal/bot/v1/tasks/stages/{stage_id}/status": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Update Internal Bot Task Status",
+        "operationId": "update_internal_bot_task_status_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stage_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Stage Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotTaskStatusUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotTaskStatusUpdateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/internal/bot/v1/tasks/stages/{stage_id}/report": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Save Internal Bot Task Report",
+        "operationId": "save_internal_bot_task_report_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stage_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Stage Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotTaskReportSaveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotTaskReportSaveResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -18776,6 +18892,46 @@
         "type": "object",
         "title": "BotTaskListResponse"
       },
+      "BotTaskReportSaveRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "report": {
+            "type": "string",
+            "maxLength": 12000,
+            "minLength": 1,
+            "title": "Report"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "report"
+        ],
+        "title": "BotTaskReportSaveRequest"
+      },
+      "BotTaskReportSaveResponse": {
+        "properties": {
+          "stage_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Stage Id"
+          },
+          "changed": {
+            "type": "boolean",
+            "title": "Changed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stage_id",
+          "changed"
+        ],
+        "title": "BotTaskReportSaveResponse"
+      },
       "BotTaskResponse": {
         "properties": {
           "kind": {
@@ -18859,6 +19015,57 @@
         ],
         "title": "BotTaskResponse",
         "description": "Stable read-only task projection rendered by the Telegram runtime."
+      },
+      "BotTaskStatusUpdateRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed"
+            ],
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "status"
+        ],
+        "title": "BotTaskStatusUpdateRequest"
+      },
+      "BotTaskStatusUpdateResponse": {
+        "properties": {
+          "stage_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Stage Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed"
+            ],
+            "title": "Status"
+          },
+          "changed": {
+            "type": "boolean",
+            "title": "Changed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stage_id",
+          "status",
+          "changed"
+        ],
+        "title": "BotTaskStatusUpdateResponse"
       },
       "BulkGalleryAddRequest": {
         "properties": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -12,12 +12,22 @@ from api_contracts.bot import (
     BotStaffContextResponse,
     BotTaskListRequest,
     BotTaskListResponse,
+    BotTaskReportSaveRequest,
+    BotTaskReportSaveResponse,
     BotTaskResponse,
+    BotTaskStatusUpdateRequest,
+    BotTaskStatusUpdateResponse,
 )
 from core.bot_api_security import require_bot_api_token
 from core.database import get_session
+from models import OrderStageStatus
 from services.bot_access_service import BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.bot_task_mutation_service import (
+    BotTaskMutationAccessDeniedError,
+    BotTaskMutationConflictError,
+    BotTaskMutationService,
+)
 from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
 
 
@@ -124,4 +134,57 @@ async def list_internal_bot_my_tasks(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
     return BotTaskListResponse(
         items=[BotTaskResponse.model_validate(task) for task in tasks]
+    )
+
+
+@router.post(
+    "/tasks/stages/{stage_id}/status",
+    response_model=BotTaskStatusUpdateResponse,
+    operation_id="update_internal_bot_task_status_v1",
+)
+async def update_internal_bot_task_status(
+    payload: BotTaskStatusUpdateRequest,
+    stage_id: int = Path(ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> BotTaskStatusUpdateResponse:
+    try:
+        result = await BotTaskMutationService.update_stage_status(
+            session,
+            telegram_id=payload.telegram_id,
+            stage_id=stage_id,
+            status=OrderStageStatus(payload.status),
+        )
+    except BotTaskMutationAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except BotTaskMutationConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return BotTaskStatusUpdateResponse(
+        stage_id=result.stage_id,
+        status=result.status.value,
+        changed=result.changed,
+    )
+
+
+@router.post(
+    "/tasks/stages/{stage_id}/report",
+    response_model=BotTaskReportSaveResponse,
+    operation_id="save_internal_bot_task_report_v1",
+)
+async def save_internal_bot_task_report(
+    payload: BotTaskReportSaveRequest,
+    stage_id: int = Path(ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> BotTaskReportSaveResponse:
+    try:
+        result = await BotTaskMutationService.save_stage_report(
+            session,
+            telegram_id=payload.telegram_id,
+            stage_id=stage_id,
+            report=payload.report,
+        )
+    except BotTaskMutationAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return BotTaskReportSaveResponse(
+        stage_id=result.stage_id,
+        changed=result.changed,
     )

--- a/services/bot_task_mutation_service.py
+++ b/services/bot_task_mutation_service.py
@@ -1,0 +1,132 @@
+"""Staff-authorized, concurrency-safe task mutations for the Telegram API."""
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import OrderStageStatus, OrderWorkStage
+from services.bot_access_service import BotAccessService
+from services.notification_service import NotificationService
+
+logger = logging.getLogger(__name__)
+
+
+class BotTaskMutationAccessDeniedError(PermissionError):
+    """The Telegram identity cannot mutate the requested stage."""
+
+
+class BotTaskMutationConflictError(RuntimeError):
+    """The requested transition conflicts with a terminal stage state."""
+
+
+@dataclass(frozen=True)
+class BotTaskStatusMutationResult:
+    stage_id: int
+    status: OrderStageStatus
+    changed: bool
+
+
+@dataclass(frozen=True)
+class BotTaskReportMutationResult:
+    stage_id: int
+    changed: bool
+
+
+class BotTaskMutationService:
+    @staticmethod
+    async def _authorized_stage_for_update(
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        stage_id: int,
+    ) -> OrderWorkStage:
+        context = await BotAccessService.get_context(session, telegram_id)
+        if not context.is_staff or not context.legacy_installer_id:
+            raise BotTaskMutationAccessDeniedError("Staff task access is required")
+
+        result = await session.execute(
+            select(OrderWorkStage)
+            .where(OrderWorkStage.id == stage_id)
+            .with_for_update()
+        )
+        stage = result.scalars().first()
+        if not stage or stage.installer_id != context.legacy_installer_id:
+            raise BotTaskMutationAccessDeniedError(
+                "Task was not found or is assigned to another executor"
+            )
+        return stage
+
+    @classmethod
+    async def update_stage_status(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        stage_id: int,
+        status: OrderStageStatus,
+    ) -> BotTaskStatusMutationResult:
+        if status not in {OrderStageStatus.IN_PROGRESS, OrderStageStatus.COMPLETED}:
+            raise ValueError("Bot may only accept or complete a task")
+
+        stage = await cls._authorized_stage_for_update(
+            session,
+            telegram_id=telegram_id,
+            stage_id=stage_id,
+        )
+        current_status = OrderStageStatus(stage.status)
+        if current_status == status:
+            return BotTaskStatusMutationResult(
+                stage_id=stage_id,
+                status=status,
+                changed=False,
+            )
+        if current_status == OrderStageStatus.CANCELED:
+            raise BotTaskMutationConflictError("Canceled task cannot be changed by the bot")
+        if current_status == OrderStageStatus.COMPLETED:
+            raise BotTaskMutationConflictError(
+                "Completed task cannot be reopened by a stale bot action"
+            )
+
+        stage.status = status
+        session.add(stage)
+        await session.commit()
+        try:
+            await NotificationService.notify_admins_work_stage_status_changed(
+                session,
+                stage_id,
+            )
+        except Exception:
+            logger.exception("BOT_TASK_STATUS_NOTIFY_FAILED stage_id=%s", stage_id)
+        return BotTaskStatusMutationResult(
+            stage_id=stage_id,
+            status=status,
+            changed=True,
+        )
+
+    @classmethod
+    async def save_stage_report(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        stage_id: int,
+        report: str,
+    ) -> BotTaskReportMutationResult:
+        normalized_report = report.strip()
+        if not normalized_report:
+            raise ValueError("Task report must not be empty")
+
+        stage = await cls._authorized_stage_for_update(
+            session,
+            telegram_id=telegram_id,
+            stage_id=stage_id,
+        )
+        if (stage.installer_report or "").strip() == normalized_report:
+            return BotTaskReportMutationResult(stage_id=stage_id, changed=False)
+
+        stage.installer_report = normalized_report
+        session.add(stage)
+        await session.commit()
+        return BotTaskReportMutationResult(stage_id=stage_id, changed=True)

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -7,10 +6,7 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from models import Order, OrderInstaller, OrderStageStatus, OrderStatus, OrderWorkStage, StaffUser
-from services.notification_service import NotificationService
 from services.staff_user_service import StaffUserService
-
-logger = logging.getLogger(__name__)
 
 
 class BotTaskService:
@@ -158,69 +154,3 @@ class BotTaskService:
             "customer_phone": cls._customer_phone(order),
             "comment": order.comment,
         }
-
-    @staticmethod
-    def build_stage_report(
-        *,
-        text: str | None = None,
-        caption: str | None = None,
-        photo_file_id: str | None = None,
-        document_file_id: str | None = None,
-        document_name: str | None = None,
-    ) -> str:
-        body = (text or caption or "").strip()
-        lines: list[str] = [body] if body else []
-        attachments: list[str] = []
-
-        if photo_file_id:
-            attachments.append(f"Фото: {photo_file_id}")
-
-        if document_file_id:
-            safe_name = " ".join((document_name or "файл").split())[:120] or "файл"
-            attachments.append(f"Документ: {safe_name} ({document_file_id})")
-
-        if attachments:
-            if lines:
-                lines.append("")
-            lines.append("Вложения:")
-            lines.extend(f"- {attachment}" for attachment in attachments)
-
-        return "\n".join(lines).strip()
-
-    @staticmethod
-    async def update_stage_status(
-        session: AsyncSession,
-        stage_id: int,
-        status: str,
-        *,
-        telegram_id: int | str | None,
-    ) -> bool:
-        staff = await BotTaskService._staff_by_telegram_id(session, telegram_id)
-        stage = await session.get(OrderWorkStage, stage_id)
-        if not staff or not stage or stage.installer_id != staff.legacy_installer_id:
-            return False
-        stage.status = OrderStageStatus(status)
-        session.add(stage)
-        await session.commit()
-        try:
-            await NotificationService.notify_admins_work_stage_status_changed(session, stage_id)
-        except Exception:
-            logger.exception("BOT_TASK_STATUS_NOTIFY_FAILED stage_id=%s", stage_id)
-        return True
-
-    @staticmethod
-    async def save_stage_report(
-        session: AsyncSession,
-        stage_id: int,
-        report: str,
-        *,
-        telegram_id: int | str | None,
-    ) -> bool:
-        staff = await BotTaskService._staff_by_telegram_id(session, telegram_id)
-        stage = await session.get(OrderWorkStage, stage_id)
-        if not staff or not stage or stage.installer_id != staff.legacy_installer_id:
-            return False
-        stage.installer_report = report.strip()
-        session.add(stage)
-        await session.commit()
-        return True

--- a/tests/integration/test_bot_task_mutation_concurrency.py
+++ b/tests/integration/test_bot_task_mutation_concurrency.py
@@ -1,0 +1,104 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from models import Installer, Order, OrderStageStatus, OrderStatus, OrderWorkStage, StaffUser
+from services.bot_task_mutation_service import BotTaskMutationService
+
+
+@pytest.mark.asyncio
+async def test_postgres_duplicate_bot_task_mutations_change_each_value_once(
+    db_engine,
+    monkeypatch,
+):
+    assert db_engine.dialect.name == "postgresql"
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as setup_session:
+        installer = Installer(name="Concurrency installer")
+        setup_session.add(installer)
+        await setup_session.flush()
+        setup_session.add(
+            StaffUser(
+                display_name="Concurrency staff",
+                status="active",
+                roles=["installer"],
+                telegram_id=987654321,
+                legacy_installer_id=installer.id,
+            )
+        )
+        order = Order(status=OrderStatus.EXECUTION, title="Concurrency order")
+        setup_session.add(order)
+        await setup_session.flush()
+        status_stage = OrderWorkStage(
+            order_id=order.id,
+            name="Status stage",
+            installer_id=installer.id,
+            status=OrderStageStatus.PLANNED,
+        )
+        report_stage = OrderWorkStage(
+            order_id=order.id,
+            name="Report stage",
+            installer_id=installer.id,
+            status=OrderStageStatus.IN_PROGRESS,
+        )
+        setup_session.add_all([status_stage, report_stage])
+        await setup_session.commit()
+
+    notify = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service.NotificationService.notify_admins_work_stage_status_changed",
+        notify,
+    )
+
+    status_barrier = asyncio.Barrier(12)
+
+    async def accept_stage_once() -> bool:
+        async with session_factory() as session:
+            await status_barrier.wait()
+            result = await BotTaskMutationService.update_stage_status(
+                session,
+                telegram_id=987654321,
+                stage_id=status_stage.id,
+                status=OrderStageStatus.IN_PROGRESS,
+            )
+            return result.changed
+
+    status_changes = await asyncio.gather(*(accept_stage_once() for _ in range(12)))
+
+    report_barrier = asyncio.Barrier(12)
+
+    async def save_report_once() -> bool:
+        async with session_factory() as session:
+            await report_barrier.wait()
+            result = await BotTaskMutationService.save_stage_report(
+                session,
+                telegram_id=987654321,
+                stage_id=report_stage.id,
+                report="Один и тот же отчет",
+            )
+            return result.changed
+
+    report_changes = await asyncio.gather(*(save_report_once() for _ in range(12)))
+
+    assert status_changes.count(True) == 1
+    assert report_changes.count(True) == 1
+    notify.assert_awaited_once()
+
+    async with session_factory() as verification_session:
+        persisted_status_stage = await verification_session.get(
+            OrderWorkStage,
+            status_stage.id,
+        )
+        persisted_report_stage = await verification_session.get(
+            OrderWorkStage,
+            report_stage.id,
+        )
+    assert persisted_status_stage.status == OrderStageStatus.IN_PROGRESS
+    assert persisted_report_stage.installer_report == "Один и тот же отчет"

--- a/tests/unit/test_bot_api_gateway.py
+++ b/tests/unit/test_bot_api_gateway.py
@@ -4,6 +4,7 @@ import pytest
 from bot_app.api_gateway import (
     BotApiAuthenticationError,
     BotApiAuthorizationError,
+    BotApiConflictError,
     BotApiGateway,
     BotApiGatewayConfig,
     BotApiResponseError,
@@ -225,3 +226,66 @@ async def test_bot_api_gateway_posts_task_list_without_staff_id_in_url():
 
     assert response.items[0].id == 7
     assert response.items[0].start_time.isoformat() == "2026-07-20T12:00:00"
+
+
+async def test_bot_api_gateway_posts_task_status_mutation():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/tasks/stages/7/status"
+        assert request.method == "POST"
+        assert request.content == b'{"telegram_id":123,"status":"completed"}'
+        return httpx.Response(
+            200,
+            json={"stage_id": 7, "status": "completed", "changed": True},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.update_task_status(
+            telegram_id=123,
+            stage_id=7,
+            status="completed",
+        )
+
+    assert response.stage_id == 7
+    assert response.status == "completed"
+    assert response.changed is True
+
+
+async def test_bot_api_gateway_posts_normalized_task_report():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/internal/bot/v1/tasks/stages/7/report"
+        assert request.content.decode() == '{"telegram_id":123,"report":"Готово"}'
+        return httpx.Response(200, json={"stage_id": 7, "changed": False})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.save_task_report(
+            telegram_id=123,
+            stage_id=7,
+            report="  Готово  ",
+        )
+
+    assert response.stage_id == 7
+    assert response.changed is False
+
+
+async def test_bot_api_gateway_maps_task_conflict():
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(409, json={"detail": "terminal"}))
+    ) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        with pytest.raises(BotApiConflictError):
+            await gateway.update_task_status(
+                telegram_id=123,
+                stage_id=7,
+                status="in_progress",
+            )

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -55,6 +55,13 @@ def test_bot_task_read_paths_use_api_instead_of_task_service_reads():
         assert "get_bot_api_gateway().list_my_tasks" in source
 
 
+def test_bot_task_mutation_paths_use_api_instead_of_backend_task_service():
+    source = Path("bot_app/handlers/work.py").read_text(encoding="utf-8")
+    assert "BotTaskService" not in source
+    assert "get_bot_api_gateway().update_task_status" in source
+    assert "get_bot_api_gateway().save_task_report" in source
+
+
 def test_bot_task_presenter_does_not_import_backend_runtime_layers():
     source = Path("bot_app/task_presenter.py").read_text(encoding="utf-8")
     for forbidden in ("from core.database", "from models", "from crud", "from services"):

--- a/tests/unit/test_bot_task_mutation_service.py
+++ b/tests/unit/test_bot_task_mutation_service.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from models import OrderStageStatus
+from services.bot_task_mutation_service import (
+    BotTaskMutationConflictError,
+    BotTaskMutationService,
+)
+
+
+class _ScalarResult:
+    def __init__(self, stage):
+        self._stage = stage
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._stage
+
+
+class _FakeSession:
+    def __init__(self, stage):
+        self.stage = stage
+        self.statements = []
+        self.added = []
+        self.commit_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _ScalarResult(self.stage)
+
+    def add(self, item):
+        self.added.append(item)
+
+    async def commit(self):
+        self.commit_count += 1
+
+
+@pytest.mark.asyncio
+async def test_task_status_mutation_is_locked_idempotent_and_notifies_once(monkeypatch):
+    stage = SimpleNamespace(
+        id=10,
+        installer_id=7,
+        status=OrderStageStatus.PLANNED,
+        installer_report=None,
+    )
+    session = _FakeSession(stage)
+    get_context = AsyncMock(
+        return_value=SimpleNamespace(is_staff=True, legacy_installer_id=7)
+    )
+    notify = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service.BotAccessService.get_context",
+        get_context,
+    )
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service.NotificationService.notify_admins_work_stage_status_changed",
+        notify,
+    )
+
+    first = await BotTaskMutationService.update_stage_status(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        status=OrderStageStatus.IN_PROGRESS,
+    )
+    repeated = await BotTaskMutationService.update_stage_status(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        status=OrderStageStatus.IN_PROGRESS,
+    )
+
+    assert first.changed is True
+    assert repeated.changed is False
+    assert stage.status == OrderStageStatus.IN_PROGRESS
+    assert session.commit_count == 1
+    notify.assert_awaited_once_with(session, 10)
+    assert len(session.statements) == 2
+    assert all(statement._for_update_arg is not None for statement in session.statements)
+
+
+@pytest.mark.asyncio
+async def test_completed_task_cannot_be_reopened_by_stale_accept(monkeypatch):
+    stage = SimpleNamespace(
+        id=10,
+        installer_id=7,
+        status=OrderStageStatus.COMPLETED,
+        installer_report=None,
+    )
+    session = _FakeSession(stage)
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service.BotAccessService.get_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, legacy_installer_id=7)),
+    )
+
+    with pytest.raises(BotTaskMutationConflictError):
+        await BotTaskMutationService.update_stage_status(
+            session,
+            telegram_id=777,
+            stage_id=10,
+            status=OrderStageStatus.IN_PROGRESS,
+        )
+
+    assert stage.status == OrderStageStatus.COMPLETED
+    assert session.commit_count == 0
+
+
+@pytest.mark.asyncio
+async def test_task_report_mutation_is_normalized_and_idempotent(monkeypatch):
+    stage = SimpleNamespace(
+        id=10,
+        installer_id=7,
+        status=OrderStageStatus.IN_PROGRESS,
+        installer_report=None,
+    )
+    session = _FakeSession(stage)
+    monkeypatch.setattr(
+        "services.bot_task_mutation_service.BotAccessService.get_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, legacy_installer_id=7)),
+    )
+
+    first = await BotTaskMutationService.save_stage_report(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        report="  Монтаж завершен  ",
+    )
+    repeated = await BotTaskMutationService.save_stage_report(
+        session,
+        telegram_id=777,
+        stage_id=10,
+        report="Монтаж завершен",
+    )
+
+    assert first.changed is True
+    assert repeated.changed is False
+    assert stage.installer_report == "Монтаж завершен"
+    assert session.commit_count == 1

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -22,10 +22,15 @@ from services.product_read_service import ProductReadService
 from services.product_service import ProductService
 from bot_app.catalog_presenter import format_client_product
 from bot_app.keyboards import get_product_keyboard, get_staff_main_menu, selection_result_keyboard
-from bot_app.task_presenter import format_tasks, format_tasks_rich_html
+from bot_app.task_presenter import build_stage_report, format_tasks, format_tasks_rich_html
 from bot_app.handlers import work as work_handlers
 from bot_app.utils import format_caption
-from api_contracts.bot import BotTaskListResponse, BotTaskResponse
+from api_contracts.bot import (
+    BotTaskListResponse,
+    BotTaskReportSaveResponse,
+    BotTaskResponse,
+    BotTaskStatusUpdateResponse,
+)
 
 
 @pytest.fixture
@@ -370,13 +375,13 @@ async def test_task_read_service_reuses_authorized_installer_mapping(monkeypatch
 
 
 def test_task_report_builder_keeps_text_report_plain():
-    report = BotTaskService.build_stage_report(text="Фреон дозаправлен, трасса проверена")
+    report = build_stage_report(text="Фреон дозаправлен, трасса проверена")
 
     assert report == "Фреон дозаправлен, трасса проверена"
 
 
 def test_task_report_builder_accepts_photo_with_caption():
-    report = BotTaskService.build_stage_report(
+    report = build_stage_report(
         caption="Фото после обслуживания",
         photo_file_id="AgACAgIAAxkBAAIB_photo",
     )
@@ -390,7 +395,7 @@ def test_task_report_builder_accepts_photo_with_caption():
 
 
 def test_task_report_builder_accepts_document_without_caption():
-    report = BotTaskService.build_stage_report(
+    report = build_stage_report(
         document_file_id="BQACAgIAAxkBAAIB_doc",
         document_name="акт выполненных работ.pdf",
     )
@@ -399,48 +404,87 @@ def test_task_report_builder_accepts_document_without_caption():
 
 
 @pytest.mark.asyncio
-async def test_task_status_update_notifies_admins(monkeypatch):
-    calls = {}
-    stage = SimpleNamespace(id=10, installer_id=7, status=OrderStageStatus.PLANNED)
-    staff = SimpleNamespace(legacy_installer_id=7)
+async def test_task_status_handler_uses_gateway_without_opening_database(monkeypatch):
+    gateway = SimpleNamespace(
+        update_task_status=AsyncMock(
+            return_value=BotTaskStatusUpdateResponse(
+                stage_id=10,
+                status="completed",
+                changed=True,
+            )
+        )
+    )
+    context = SimpleNamespace(is_staff=True, is_manager=False, is_executor=True)
+    callback = SimpleNamespace(
+        data="task_done_10",
+        from_user=SimpleNamespace(id=777),
+        answer=AsyncMock(),
+        message=SimpleNamespace(answer=AsyncMock()),
+    )
 
-    class FakeSession:
-        async def get(self, model, stage_id):
-            calls["get"] = {"model": model, "stage_id": stage_id}
-            return stage
-
-        def add(self, item):
-            calls["add"] = item
-
-        async def commit(self):
-            calls["commit"] = True
-
-    async def fake_staff_by_telegram_id(session, telegram_id):
-        calls["staff_lookup"] = {"session": session, "telegram_id": telegram_id}
-        return staff
-
-    async def fake_notify(session, stage_id):
-        calls["notify"] = {"session": session, "stage_id": stage_id}
-        return 1
-
-    monkeypatch.setattr(BotTaskService, "_staff_by_telegram_id", fake_staff_by_telegram_id)
+    monkeypatch.setattr(work_handlers, "_access_context", AsyncMock(return_value=context))
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
     monkeypatch.setattr(
-        "services.bot_task_service.NotificationService.notify_admins_work_stage_status_changed",
-        fake_notify,
+        work_handlers,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("task mutation must not open a DB session")),
     )
 
-    session = FakeSession()
-    ok = await BotTaskService.update_stage_status(
-        session,
-        10,
-        "completed",
+    await work_handlers.update_task_status(callback)
+
+    gateway.update_task_status.assert_awaited_once_with(
         telegram_id=777,
+        stage_id=10,
+        status="completed",
+    )
+    callback.answer.assert_awaited_once_with("Готово")
+    callback.message.answer.assert_awaited_once_with(
+        "Статус задачи обновлен.",
+        reply_markup=get_staff_main_menu(context),
     )
 
-    assert ok
-    assert stage.status == OrderStageStatus.COMPLETED
-    assert calls["commit"] is True
-    assert calls["notify"] == {"session": session, "stage_id": 10}
+
+@pytest.mark.asyncio
+async def test_task_report_handler_uses_gateway_without_opening_database(monkeypatch):
+    gateway = SimpleNamespace(
+        save_task_report=AsyncMock(
+            return_value=BotTaskReportSaveResponse(stage_id=10, changed=True)
+        )
+    )
+    context = SimpleNamespace(is_staff=True, is_manager=False, is_executor=True)
+    state = SimpleNamespace(
+        get_data=AsyncMock(return_value={"task_report_stage_id": 10}),
+        clear=AsyncMock(),
+    )
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=777),
+        text="Монтаж завершен",
+        caption=None,
+        photo=None,
+        document=None,
+        answer=AsyncMock(),
+    )
+
+    monkeypatch.setattr(work_handlers, "_access_context", AsyncMock(return_value=context))
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(
+        work_handlers,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("task report must not open a DB session")),
+    )
+
+    await work_handlers.task_report_finish(message, state)
+
+    gateway.save_task_report.assert_awaited_once_with(
+        telegram_id=777,
+        stage_id=10,
+        report="Монтаж завершен",
+    )
+    state.clear.assert_awaited_once()
+    message.answer.assert_awaited_once_with(
+        "Отчет сохранен.",
+        reply_markup=get_staff_main_menu(context),
+    )
 
 
 def test_product_caption_contains_public_product_link(monkeypatch):

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -6,6 +6,14 @@ from main import app
 from services.bot_access_service import BotAccessContext, BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
 from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
+from services.bot_task_mutation_service import (
+    BotTaskMutationAccessDeniedError,
+    BotTaskMutationConflictError,
+    BotTaskMutationService,
+    BotTaskReportMutationResult,
+    BotTaskStatusMutationResult,
+)
+from models import OrderStageStatus
 
 
 async def _request(
@@ -76,17 +84,23 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     catalog_search = schema["paths"]["/api/internal/bot/v1/catalog/search"]["post"]
     catalog_product = schema["paths"]["/api/internal/bot/v1/catalog/products/{product_id}"]["get"]
     task_list = schema["paths"]["/api/internal/bot/v1/tasks/my"]["post"]
+    task_status = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/status"]["post"]
+    task_report = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/report"]["post"]
 
     assert health["operationId"] == "get_internal_bot_api_health_v1"
     assert staff_context["operationId"] == "get_internal_bot_staff_context_v1"
     assert catalog_search["operationId"] == "search_internal_bot_catalog_v1"
     assert catalog_product["operationId"] == "get_internal_bot_catalog_product_v1"
     assert task_list["operationId"] == "list_internal_bot_my_tasks_v1"
+    assert task_status["operationId"] == "update_internal_bot_task_status_v1"
+    assert task_report["operationId"] == "save_internal_bot_task_report_v1"
     assert health["security"] == [{"BotServiceBearer": []}]
     assert staff_context["security"] == [{"BotServiceBearer": []}]
     assert catalog_search["security"] == [{"BotServiceBearer": []}]
     assert catalog_product["security"] == [{"BotServiceBearer": []}]
     assert task_list["security"] == [{"BotServiceBearer": []}]
+    assert task_status["security"] == [{"BotServiceBearer": []}]
+    assert task_report["security"] == [{"BotServiceBearer": []}]
     assert schema["components"]["securitySchemes"]["BotServiceBearer"] == {
         "type": "http",
         "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
@@ -376,3 +390,107 @@ async def test_internal_bot_task_list_validates_body(monkeypatch):
     )
 
     assert response.status_code == 422
+
+
+async def test_internal_bot_task_status_mutation_uses_authorized_service(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_update(_session, **kwargs):
+        assert kwargs == {
+            "telegram_id": 123456,
+            "stage_id": 7,
+            "status": OrderStageStatus.COMPLETED,
+        }
+        return BotTaskStatusMutationResult(
+            stage_id=7,
+            status=OrderStageStatus.COMPLETED,
+            changed=True,
+        )
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskMutationService, "update_stage_status", fake_update)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/tasks/stages/7/status",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "status": "completed"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "stage_id": 7,
+        "status": "completed",
+        "changed": True,
+    }
+
+
+async def test_internal_bot_task_status_maps_access_and_conflict(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_session():
+        yield object()
+
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        async def deny(*_args, **_kwargs):
+            raise BotTaskMutationAccessDeniedError("denied")
+
+        monkeypatch.setattr(BotTaskMutationService, "update_stage_status", deny)
+        denied = await _request(
+            "/api/internal/bot/v1/tasks/stages/7/status",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "status": "completed"},
+        )
+
+        async def conflict(*_args, **_kwargs):
+            raise BotTaskMutationConflictError("terminal")
+
+        monkeypatch.setattr(BotTaskMutationService, "update_stage_status", conflict)
+        conflicted = await _request(
+            "/api/internal/bot/v1/tasks/stages/7/status",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "status": "in_progress"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert denied.status_code == 403
+    assert conflicted.status_code == 409
+
+
+async def test_internal_bot_task_report_normalizes_and_saves(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_save(_session, **kwargs):
+        assert kwargs == {
+            "telegram_id": 123456,
+            "stage_id": 7,
+            "report": "Работа выполнена",
+        }
+        return BotTaskReportMutationResult(stage_id=7, changed=False)
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskMutationService, "save_stage_report", fake_save)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/tasks/stages/7/report",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "report": "  Работа выполнена  "},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"stage_id": 7, "changed": False}


### PR DESCRIPTION
## Что изменено

- добавлены versioned Bot API endpoints для смены статуса этапа и сохранения отчёта;
- task callbacks `Принял` / `Выполнено` и FSM отчёта переведены на `BotApiGateway`;
- запись задач вынесена в отдельный `BotTaskMutationService`;
- Telegram handler больше не импортирует backend `BotTaskService` для task-сценария;
- обновлены OpenAPI и типизированный manager client.

## Надёжность

- строка этапа блокируется `SELECT ... FOR UPDATE`;
- одинаковые повторные запросы идемпотентны и не дублируют уведомления;
- завершённый или отменённый этап нельзя вернуть в работу старой Telegram-кнопкой;
- проверяется активный сотрудник и соответствие назначенному исполнителю;
- при недоступности API бот не подтверждает успешное действие, а незавершённый FSM отчёта остаётся для повтора.

## Проверки

- `99 passed` — contract/gateway/handler/architecture tests;
- `2162 passed, 4 skipped` — полный unit-набор;
- PostgreSQL concurrency stress: 12 параллельных статусов и 12 одинаковых отчётов, по одному фактическому изменению;
- manager `vue-tsc -b`;
- manager production build;
- повторная генерация OpenAPI/client без diff.
