### PR TITLE
Unify address suggestions and compact order header

### DIFF
--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "test:ui-logic": "node scripts/run-ui-logic-tests.mjs",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },

--- a/manager_frontend/scripts/run-ui-logic-tests.mjs
+++ b/manager_frontend/scripts/run-ui-logic-tests.mjs
@@ -1,0 +1,26 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'vite';
+
+const outputDirectory = await mkdtemp(join(tmpdir(), 'mvn-manager-ui-tests-'));
+
+try {
+  await build({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: true,
+      outDir: outputDirectory,
+      lib: {
+        entry: new URL('../tests/ui-logic.test.ts', import.meta.url).pathname,
+        formats: ['es'],
+        fileName: 'ui-logic.test',
+      },
+    },
+  });
+  await import(pathToFileURL(join(outputDirectory, 'ui-logic.test.js')).href);
+} finally {
+  await rm(outputDirectory, { recursive: true, force: true });
+}

--- a/manager_frontend/src/client/services/ManagerSettingsService.ts
+++ b/manager_frontend/src/client/services/ManagerSettingsService.ts
@@ -56,17 +56,23 @@ export class ManagerSettingsService {
     /**
      * Suggest Address
      * @param q
+     * @param lat
+     * @param lon
      * @returns AddressSuggestResponse Successful Response
      * @throws ApiError
      */
     public static suggestAddress(
         q: string,
+        lat?: (number | null),
+        lon?: (number | null),
     ): CancelablePromise<AddressSuggestResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/manager/settings/address-suggest',
             query: {
                 'q': q,
+                'lat': lat,
+                'lon': lon,
             },
             errors: {
                 422: `Validation Error`,

--- a/manager_frontend/src/components/leads/LeadQualifyModal.vue
+++ b/manager_frontend/src/components/leads/LeadQualifyModal.vue
@@ -5,6 +5,7 @@ import type { LeadsInboxItemResponse } from '../../api';
 import type { ManagerCustomerBranchItemResponse, ManagerOrderUpdatePayload } from '../../client';
 import { useBelarusPhoneMask } from '../../composables/useBelarusPhoneMask';
 import { useB2BLookup } from '../../composables/useB2BLookup';
+import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 
 const props = defineProps<{
   lead: LeadsInboxItemResponse;
@@ -513,10 +514,13 @@ const submitQualify = async () => {
               Email
               <input v-model="customerEmail" type="email" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm font-medium focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
             </label>
-            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
-              Адрес объекта / доставки
-              <input v-model="customerDeliveryAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Адрес можно добавить позже">
-            </label>
+            <AddressSuggestInput
+              v-model="customerDeliveryAddress"
+              class="md:col-span-2"
+              label="Адрес объекта / доставки"
+              placeholder="Адрес можно добавить позже"
+              input-class="bg-white text-sm dark:bg-slate-900"
+            />
           </div>
 
           <button
@@ -549,10 +553,12 @@ const submitQualify = async () => {
               Полное юридическое название
               <input v-model="companyFullLegalName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
             </label>
-            <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
-              Юридический адрес
-              <input v-model="companyLegalAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900">
-            </label>
+            <AddressSuggestInput
+              v-model="companyLegalAddress"
+              class="md:col-span-2"
+              label="Юридический адрес"
+              input-class="bg-white text-sm dark:bg-slate-900"
+            />
             <label class="block text-xs font-semibold text-slate-500 md:col-span-2">
               IBAN
               <span class="relative mt-1 block">
@@ -605,10 +611,12 @@ const submitQualify = async () => {
                 Новый филиал
                 <input v-model="newBranchName" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Склад / Объект">
               </label>
-              <label class="block text-xs font-semibold text-slate-500">
-                Адрес филиала
-                <input v-model="newBranchAddress" type="text" class="mt-1 w-full rounded-xl border-0 bg-white px-4 py-2.5 text-sm focus:ring-2 focus:ring-teal-500 dark:bg-slate-900" placeholder="Минск, Ленина 1">
-              </label>
+              <AddressSuggestInput
+                v-model="newBranchAddress"
+                label="Адрес филиала"
+                placeholder="Минск, Ленина 1"
+                input-class="bg-white text-sm dark:bg-slate-900"
+              />
               <div class="md:col-span-2">
                 <button
                   type="button"

--- a/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
@@ -2,6 +2,8 @@
 import { computed, ref, watch } from 'vue';
 import { Building2, Copy, Mail, MapPin, Pencil, Phone, Route, UserRound } from 'lucide-vue-next';
 import type { OrderCustomerBrief } from '../../client';
+import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
+import { buildYandexMapUrl } from '../../utils/address';
 
 const props = defineProps<{
   customer?: OrderCustomerBrief | null;
@@ -33,7 +35,7 @@ const email = computed(() => String(props.customer?.email || '').trim());
 const phoneDigits = computed(() => phone.value.replace(/\D/g, ''));
 const validPhone = computed(() => phoneDigits.value.length >= 7);
 const validEmail = computed(() => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value));
-const mapUrl = computed(() => props.address ? 'https://yandex.by/maps/?text=' + encodeURIComponent(props.address) : '');
+const mapUrl = computed(() => buildYandexMapUrl(props.address));
 
 watch(() => props.address, (value) => {
   if (!editingObject.value) objectAddress.value = value;
@@ -129,7 +131,7 @@ const saveObject = () => {
     </div>
 
     <div v-if="editingObject" class="border-t border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-950/50">
-      <label class="field-label">Адрес объекта<input v-model="objectAddress" class="field-input mt-1" autocomplete="street-address" /></label>
+      <AddressSuggestInput v-model="objectAddress" label="Адрес объекта" />
       <div class="mt-2 flex justify-between gap-2">
         <button type="button" class="btn-mini-outline text-xs" @click="emit('toggle-branch')">Выбрать филиал</button>
         <div class="flex gap-2">

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useDebounceFn } from '@vueuse/core';
-import { ManagerContractsService, ManagerDocsService, ManagerOrdersService, ManagerService, ManagerSettingsService } from '../../client';
+import { ManagerContractsService, ManagerDocsService, ManagerOrdersService, ManagerService } from '../../client';
 import { downloadManagerDocBlob } from '../../api';
 import type {
-  AddressSuggestionItem,
   DocumentTemplateItem,
   ManagerCustomerBranchItemResponse,
   ManagerCustomerContractItemResponse,
@@ -18,6 +16,7 @@ import { getApiErrorMessage } from '../../utils/api-errors';
 import AdditionalConditionsLibrary from './AdditionalConditionsLibrary.vue';
 import DocumentSendModal from './DocumentSendModal.vue';
 import OrderEmailHistory from './OrderEmailHistory.vue';
+import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 
 type ToastType = 'success' | 'error';
 type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
@@ -124,9 +123,6 @@ const actScopeTitle = ref(props.order.customer_branch?.name || '');
 const actScopeAddress = ref(props.order.delivery_address || props.order.customer_branch?.delivery_address || '');
 const selectedActServiceLineIds = ref<number[]>([]);
 const selectedActServiceLineQuantities = ref<Record<number, number>>({});
-const actAddressSuggestions = ref<AddressSuggestionItem[]>([]);
-const actAddressSuggestActive = ref(false);
-const actAddressLookupLoading = ref(false);
 const newActBranchName = ref('');
 const newActBranchAddress = ref('');
 const creatingActBranch = ref(false);
@@ -803,45 +799,6 @@ const onActBranchChange = () => {
   if (!branch) return;
   actScopeTitle.value = branch.name || '';
   actScopeAddress.value = branch.delivery_address;
-  actAddressSuggestActive.value = false;
-  actAddressSuggestions.value = [];
-};
-
-const fetchActAddressSuggestions = async (query: string) => {
-  const cleaned = query.trim();
-  if (cleaned.length < 3) {
-    actAddressSuggestions.value = [];
-    return;
-  }
-  actAddressLookupLoading.value = true;
-  try {
-    const res = await ManagerSettingsService.suggestAddress(cleaned);
-    actAddressSuggestions.value = res.items || [];
-  } catch (error) {
-    console.warn('Failed to fetch act address suggestions', error);
-  } finally {
-    actAddressLookupLoading.value = false;
-  }
-};
-
-const debouncedFetchActAddressSuggestions = useDebounceFn(fetchActAddressSuggestions, 400);
-
-const onActAddressInput = () => {
-  actAddressSuggestActive.value = true;
-  selectedActBranchId.value = null;
-  debouncedFetchActAddressSuggestions(actScopeAddress.value);
-};
-
-const selectActAddressSuggestion = (item: AddressSuggestionItem) => {
-  actScopeAddress.value = item.value || item.title || '';
-  actAddressSuggestActive.value = false;
-  actAddressSuggestions.value = [];
-};
-
-const hideActAddressSuggestions = () => {
-  setTimeout(() => {
-    actAddressSuggestActive.value = false;
-  }, 200);
 };
 
 const setActServiceLineQuantity = (line: OrderServiceLineResponse, rawValue: number | string) => {
@@ -1479,32 +1436,12 @@ const registerExternalContract = async () => {
                 class="field-input text-sm"
                 placeholder="Название объекта, если нужно"
               />
-              <label class="relative">
-                <input
-                  v-model="actScopeAddress"
-                  class="field-input text-sm"
-                  placeholder="Адрес объекта"
-                  autocomplete="off"
-                  @input="onActAddressInput"
-                  @focus="actAddressSuggestActive = true"
-                  @blur="hideActAddressSuggestions"
-                />
-                <span v-if="actAddressLookupLoading" class="material-icons-round absolute right-3 top-2.5 animate-spin text-[18px] text-slate-400">refresh</span>
-                <ul
-                  v-if="actAddressSuggestActive && actAddressSuggestions.length > 0"
-                  class="absolute left-0 top-full z-50 mt-1 max-h-56 w-full overflow-auto rounded-xl border border-slate-200 bg-white p-1 shadow-2xl ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900"
-                >
-                  <li
-                    v-for="(item, index) in actAddressSuggestions"
-                    :key="`act-address-suggestion-${index}`"
-                    class="flex cursor-pointer flex-col rounded-lg border-b border-slate-100 px-3 py-2 text-sm transition-colors last:border-0 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-800"
-                    @mousedown.prevent="selectActAddressSuggestion(item)"
-                  >
-                    <span class="font-medium text-slate-900 dark:text-slate-100">{{ item.title || item.value }}</span>
-                    <span v-if="item.subtitle" class="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">{{ item.subtitle }}</span>
-                  </li>
-                </ul>
-              </label>
+              <AddressSuggestInput
+                v-model="actScopeAddress"
+                placeholder="Адрес объекта"
+                input-class="text-sm"
+                @input="selectedActBranchId = null"
+              />
             </div>
 
             <div class="mt-3 grid gap-2 rounded-lg border border-dashed border-slate-300 bg-slate-50/70 p-3 dark:border-slate-700 dark:bg-slate-800/40 md:grid-cols-[1fr_1.4fr_auto]">
@@ -1513,10 +1450,10 @@ const registerExternalContract = async () => {
                 class="field-input text-sm"
                 placeholder="Новый объект"
               />
-              <input
+              <AddressSuggestInput
                 v-model="newActBranchAddress"
-                class="field-input text-sm"
                 placeholder="Адрес нового объекта"
+                input-class="text-sm"
               />
               <button
                 type="button"

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -13,6 +13,7 @@ import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
 import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
 import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
+import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
   ManagerOrderDetailResponse,
@@ -65,6 +66,7 @@ import {
 } from './service-description-mode';
 
 import { getApiErrorMessage } from '../../utils/api-errors';
+import { useSmartStickyHeader } from '../../composables/useSmartStickyHeader';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -81,6 +83,9 @@ const emit = defineEmits<{
   deleted: [orderId: number];
   reload: [orderId: number];
 }>();
+
+const drawerScrollContainer = ref<HTMLElement | null>(null);
+const { compact: compactWorkspaceHeader, reset: resetWorkspaceHeader } = useSmartStickyHeader(drawerScrollContainer);
 
 type ProductOption = {
   id: number;
@@ -159,9 +164,6 @@ const isPaid = ref(false);
 const installerId = ref<number | null>(null);
 
 const customerDeliveryAddress = ref('');
-const addressSuggestions = ref<any[]>([]);
-const addressSuggestActive = ref(false);
-const addressLookupLoading = ref(false);
 const customerBranches = ref<ManagerCustomerBranchItemResponse[]>([]);
 const customerBranchId = ref<number | null>(null);
 const customerBranchesLoading = ref(false);
@@ -1636,40 +1638,9 @@ watch(
   },
 );
 
-const fetchAddressSuggestions = async (query: string) => {
-  if (!query || query.length < 3) {
-    addressSuggestions.value = [];
-    return;
-  }
-  addressLookupLoading.value = true;
-  try {
-    const res = await ManagerSettingsService.suggestAddress(query);
-    addressSuggestions.value = res.items || [];
-  } catch (err) {
-    console.warn('Failed to fetch address suggestions', err);
-  } finally {
-    addressLookupLoading.value = false;
-  }
-};
-
-const debouncedFetchAddressSuggestions = useDebounceFn(fetchAddressSuggestions, 400);
-
-const onAddressInput = () => {
-  addressSuggestActive.value = true;
-  debouncedFetchAddressSuggestions(customerDeliveryAddress.value);
-};
-
-const selectAddressSuggestion = (item: any) => {
-  customerDeliveryAddress.value = item.value || item.title || '';
-  addressSuggestActive.value = false;
-  addressSuggestions.value = [];
-};
-
-const hideAddressSuggestions = () => {
-  setTimeout(() => {
-    addressSuggestActive.value = false;
-  }, 200);
-};
+watch(() => props.modelValue, (open) => {
+  if (open) nextTick(resetWorkspaceHeader);
+});
 
 watch(
   () => props.order,
@@ -2553,7 +2524,7 @@ watch(
       </div>
     </Transition>
     <div class="flex-1 bg-black/60" @click="closeDrawer" />
-    <aside class="h-full w-full min-w-0 max-w-3xl overflow-y-auto bg-white p-4 text-gray-900 shadow-2xl dark:bg-slate-950 dark:text-slate-100 sm:p-6 md:border-l md:border-gray-200 dark:md:border-slate-700">
+    <aside ref="drawerScrollContainer" class="h-full w-full min-w-0 max-w-3xl overflow-y-auto bg-white p-4 text-gray-900 shadow-2xl dark:bg-slate-950 dark:text-slate-100 sm:p-6 md:border-l md:border-gray-200 dark:md:border-slate-700">
       <OrderWorkspaceHeader
         class="-mx-4 -mt-4 sm:-mx-6 sm:-mt-6"
         :order-id="order?.id"
@@ -2567,6 +2538,7 @@ watch(
         :is-on-hold="order?.is_on_hold"
         :dirty="hasUnsavedChanges"
         :saving="saving"
+        :compact="compactWorkspaceHeader"
         @update:title="orderTitle = $event"
         @change-workflow="setWorkflowType"
         @next="openWorkspaceTarget(orderWorkspace.nextAction.target)"
@@ -2626,7 +2598,7 @@ watch(
           </select>
         </label>
         <input v-model="newBranchName" class="field-input" placeholder="Название нового филиала" />
-        <input v-model="newBranchAddress" class="field-input" placeholder="Адрес нового филиала" />
+        <AddressSuggestInput v-model="newBranchAddress" placeholder="Адрес нового филиала" />
         <div class="sm:col-span-2 flex justify-end">
           <button type="button" class="btn-mini-outline text-xs" :disabled="creatingCustomerBranch" @click="createCustomerBranch">
             {{ creatingCustomerBranch ? 'Создаём...' : 'Создать и выбрать' }}
@@ -2654,34 +2626,13 @@ watch(
         :has-error="Boolean(getFieldError('customer_delivery_address') || getFieldError('comment'))"
       >
         <div class="grid gap-3 md:grid-cols-2">
-          <label class="field-label md:col-span-2 relative">
-            Адрес объекта / доставки
-            <input
-              v-model="customerDeliveryAddress"
-              @input="onAddressInput"
-              @blur="hideAddressSuggestions"
-              @focus="addressSuggestActive = true"
-              class="field-input"
-              placeholder="Введите адрес..."
-              autocomplete="off"
-            />
-            <div v-if="addressLookupLoading" class="absolute right-3 top-9">
-              <span class="material-icons-round animate-spin text-gray-400 text-[18px]">refresh</span>
-            </div>
-            <span v-if="getFieldError('customer_delivery_address')" class="text-xs text-red-300">{{ getFieldError('customer_delivery_address') }}</span>
-
-            <ul v-if="addressSuggestActive && addressSuggestions.length > 0" class="absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-auto rounded-xl bg-white flex flex-col p-1 shadow-2xl border border-gray-100 ring-1 ring-black/5">
-              <li
-                v-for="(item, i) in addressSuggestions"
-                :key="i"
-                class="flex cursor-pointer flex-col px-3 py-2 text-sm hover:bg-gray-50 rounded-lg transition-colors border-b border-gray-50 last:border-0"
-                @mousedown.prevent="selectAddressSuggestion(item)"
-              >
-                <div class="font-medium text-gray-900">{{ item.title || item.value }}</div>
-                <div v-if="item.subtitle" class="text-xs text-gray-500 mt-0.5 truncate">{{ item.subtitle }}</div>
-              </li>
-            </ul>
-          </label>
+          <AddressSuggestInput
+            v-model="customerDeliveryAddress"
+            class="md:col-span-2"
+            label="Адрес объекта / доставки"
+            placeholder="Введите адрес..."
+            :error="getFieldError('customer_delivery_address')"
+          />
 
           <label class="field-label md:col-span-2">
             Комментарий

--- a/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
+++ b/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Undo2, X } from 'lucide-vue-next';
 import { formatMoney } from './order-utils';
 import { ORDER_WORKFLOW_OPTIONS, type OrderWorkflowType, type OrderWorkspaceViewModel } from './order-workspace';
@@ -16,6 +16,7 @@ const props = defineProps<{
   isOnHold?: boolean;
   dirty?: boolean;
   saving?: boolean;
+  compact?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -32,6 +33,23 @@ const emit = defineEmits<{
 const editingTitle = ref(false);
 const menuOpen = ref(false);
 const titleDraft = ref('');
+const headerRef = ref<HTMLElement | null>(null);
+const focusLocksCompactMode = ref(false);
+const effectiveCompact = computed(() => Boolean(props.compact && !editingTitle.value && !menuOpen.value && !focusLocksCompactMode.value));
+
+const refreshFocusLock = () => {
+  window.requestAnimationFrame(() => {
+    const activeElement = document.activeElement;
+    focusLocksCompactMode.value = Boolean(
+      activeElement
+      && headerRef.value?.contains(activeElement)
+      && (
+        activeElement.matches('input, select, textarea')
+        || activeElement.hasAttribute('data-sticky-header-lock')
+      )
+    );
+  });
+};
 const startTitleEdit = () => {
   titleDraft.value = props.title;
   editingTitle.value = true;
@@ -51,9 +69,23 @@ const onWorkflowChange = async (event: Event) => {
 </script>
 
 <template>
-  <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/95 px-3 py-3 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-950/95 sm:px-5">
-    <div class="flex items-start gap-3">
+  <header
+    ref="headerRef"
+    class="sticky top-0 z-40 border-b border-slate-200 bg-white/95 px-3 shadow-sm backdrop-blur transition-[padding] duration-200 motion-reduce:transition-none dark:border-slate-700 dark:bg-slate-950/95 sm:px-5"
+    :class="effectiveCompact ? 'py-2' : 'py-3'"
+    @focusin="refreshFocusLock"
+    @focusout="refreshFocusLock"
+  >
+    <div class="flex gap-2 sm:gap-3" :class="effectiveCompact ? 'h-9 items-center' : 'items-start'">
       <div class="min-w-0 flex-1">
+        <div v-if="effectiveCompact" class="flex min-w-0 items-center gap-2">
+          <span class="shrink-0 text-xs font-semibold text-slate-600 dark:text-slate-300">№{{ orderId }}</span>
+          <button type="button" class="min-w-0 flex-1 truncate text-left text-sm font-semibold text-slate-950 dark:text-white" title="Изменить название" @click="startTitleEdit">
+            {{ title || 'Без названия' }}
+          </button>
+          <span class="hidden max-w-32 shrink-0 truncate rounded-md bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:inline">{{ viewModel.stageLabel }}</span>
+        </div>
+        <template v-else>
         <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
           <span class="font-semibold text-slate-700 dark:text-slate-200">Заказ №{{ orderId }}</span>
           <span v-if="isWebsiteOrder" class="rounded-full bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">Сайт</span>
@@ -80,9 +112,35 @@ const onWorkflowChange = async (event: Event) => {
           <span class="truncate text-base font-semibold text-slate-950 dark:text-white sm:text-lg">{{ title || 'Без названия' }}</span>
           <Pencil :size="14" class="mt-1 shrink-0 text-slate-400" aria-hidden="true" />
         </button>
+        </template>
       </div>
 
       <div class="flex shrink-0 items-center gap-1">
+        <button
+          v-if="effectiveCompact"
+          type="button"
+          class="btn-mini h-9 min-w-9 justify-center px-2 text-xs sm:px-3"
+          :title="viewModel.nextAction.label"
+          :aria-label="viewModel.nextAction.label"
+          @click="emit('next')"
+        >
+          <Check :size="15" />
+          <span class="hidden max-w-28 truncate lg:inline">{{ viewModel.nextAction.label }}</span>
+        </button>
+        <button
+          v-if="effectiveCompact && dirty"
+          type="button"
+          class="btn-mini h-9 w-9 justify-center p-0"
+          :disabled="saving"
+          :title="saving ? 'Сохраняем' : 'Не сохранено — сохранить'"
+          :aria-label="saving ? 'Сохраняем изменения' : 'Сохранить изменения'"
+          @click="emit('save')"
+        >
+          <Save :size="15" />
+        </button>
+        <span v-else-if="effectiveCompact" class="flex h-9 w-7 items-center justify-center text-emerald-600 dark:text-emerald-300" title="Сохранено" aria-label="Сохранено">
+          <Check :size="16" />
+        </span>
         <div class="relative">
           <button
             type="button"
@@ -107,7 +165,7 @@ const onWorkflowChange = async (event: Event) => {
       </div>
     </div>
 
-    <div class="mt-2.5 flex flex-wrap items-center gap-2">
+    <div v-if="!effectiveCompact" class="mt-2.5 flex flex-wrap items-center gap-2">
       <label class="relative inline-flex min-w-0 items-center">
         <span class="sr-only">Сценарий заказа</span>
         <select
@@ -126,7 +184,7 @@ const onWorkflowChange = async (event: Event) => {
       </span>
     </div>
 
-    <div class="mt-2.5 flex items-center gap-2">
+    <div v-if="!effectiveCompact" class="mt-2.5 flex items-center gap-2">
       <button type="button" class="btn-mini min-w-0 flex-1 justify-center text-xs sm:flex-none" @click="emit('next')">{{ viewModel.nextAction.label }}</button>
       <button v-if="balance > 0" type="button" class="btn-mini-outline hidden h-9 text-xs sm:inline-flex" @click="emit('payments')">Внести оплату</button>
       <span v-if="!dirty" class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-xs font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">

--- a/manager_frontend/src/components/ui/AddressSuggestInput.vue
+++ b/manager_frontend/src/components/ui/AddressSuggestInput.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, useId, watch } from 'vue';
+import { AlertCircle, CheckCircle2, LoaderCircle, RotateCcw, X } from 'lucide-vue-next';
+import { ManagerSettingsService } from '../../client';
+import type { CancelablePromise } from '../../client/core/CancelablePromise';
+import type { AddressSuggestResponse } from '../../client/models/AddressSuggestResponse';
+import {
+  ADDRESS_SUGGEST_DEBOUNCE_MS,
+  hasEnoughAddressCharacters,
+  normalizeAddressQuery,
+  type NormalizedAddressSuggestion,
+} from '../../utils/address';
+
+type GeoPriority = {
+  latitude?: number | null;
+  longitude?: number | null;
+};
+
+const props = withDefaults(defineProps<{
+  modelValue: string;
+  label?: string;
+  placeholder?: string;
+  error?: string;
+  inputClass?: string | string[] | Record<string, boolean>;
+  disabled?: boolean;
+  readonly?: boolean;
+  required?: boolean;
+  showStatus?: boolean;
+  autocomplete?: string;
+  geoPriority?: GeoPriority | null;
+}>(), {
+  label: '',
+  placeholder: 'Введите адрес',
+  error: '',
+  inputClass: '',
+  disabled: false,
+  readonly: false,
+  required: false,
+  showStatus: true,
+  autocomplete: 'street-address',
+  geoPriority: null,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string];
+  input: [value: string];
+  select: [value: NormalizedAddressSuggestion];
+  'selection-cleared': [];
+}>();
+
+const inputId = `address-${useId()}`;
+const listboxId = `${inputId}-listbox`;
+const statusId = `${inputId}-status`;
+const inputValue = ref(props.modelValue || '');
+const suggestions = ref<NormalizedAddressSuggestion[]>([]);
+const loading = ref(false);
+const serviceError = ref(false);
+const open = ref(false);
+const focused = ref(false);
+const activeIndex = ref(-1);
+const confirmedValue = ref('');
+const touched = ref(false);
+const blurredAfterEdit = ref(false);
+let debounceTimer: number | null = null;
+let activeRequest: CancelablePromise<AddressSuggestResponse> | null = null;
+let requestId = 0;
+
+const suggestionCache = new Map<string, NormalizedAddressSuggestion[]>();
+const MAX_CACHE_SIZE = 30;
+
+const status = computed<'idle' | 'confirmed' | 'manual' | 'error'>(() => {
+  if (serviceError.value && touched.value) return 'error';
+  if (confirmedValue.value && confirmedValue.value === inputValue.value) return 'confirmed';
+  if (touched.value && blurredAfterEdit.value && inputValue.value.trim()) return 'manual';
+  return 'idle';
+});
+
+const statusText = computed(() => {
+  if (status.value === 'confirmed') return 'Адрес выбран из подсказок';
+  if (status.value === 'manual') return 'Адрес введён вручную и не подтверждён подсказками';
+  if (status.value === 'error') return 'Не удалось проверить адрес. Его можно сохранить вручную';
+  return '';
+});
+
+const describedBy = computed(() => [props.error ? `${inputId}-error` : '', statusText.value ? statusId : ''].filter(Boolean).join(' ') || undefined);
+
+const cancelPending = () => {
+  if (debounceTimer !== null) {
+    window.clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  if (activeRequest) {
+    requestId += 1;
+    activeRequest.cancel();
+  }
+  activeRequest = null;
+};
+
+const closeSuggestions = () => {
+  open.value = false;
+  activeIndex.value = -1;
+};
+
+const setSuggestions = (items: NormalizedAddressSuggestion[]) => {
+  suggestions.value = items;
+  open.value = focused.value && items.length > 0;
+  activeIndex.value = items.length ? 0 : -1;
+};
+
+const cacheSuggestions = (query: string, items: NormalizedAddressSuggestion[]) => {
+  if (suggestionCache.size >= MAX_CACHE_SIZE) {
+    const oldestKey = suggestionCache.keys().next().value;
+    if (oldestKey) suggestionCache.delete(oldestKey);
+  }
+  suggestionCache.set(query, items);
+};
+
+const fetchSuggestions = async (rawQuery: string) => {
+  const query = normalizeAddressQuery(rawQuery);
+  if (!hasEnoughAddressCharacters(query)) {
+    setSuggestions([]);
+    return;
+  }
+
+  const cached = suggestionCache.get(query);
+  if (cached) {
+    serviceError.value = false;
+    setSuggestions(cached);
+    return;
+  }
+
+  activeRequest?.cancel();
+  const currentRequestId = ++requestId;
+  loading.value = true;
+  serviceError.value = false;
+  try {
+    const latitude = props.geoPriority?.latitude ?? undefined;
+    const longitude = props.geoPriority?.longitude ?? undefined;
+    const hasCoordinatePriority = Number.isFinite(latitude) && Number.isFinite(longitude);
+    const request = ManagerSettingsService.suggestAddress(
+      query,
+      hasCoordinatePriority ? latitude : undefined,
+      hasCoordinatePriority ? longitude : undefined,
+    );
+    activeRequest = request;
+    const response = await request;
+    if (currentRequestId !== requestId || normalizeAddressQuery(inputValue.value) !== query) return;
+    const items = (response.items || []) as NormalizedAddressSuggestion[];
+    cacheSuggestions(query, items);
+    setSuggestions(items);
+  } catch (error) {
+    if (currentRequestId !== requestId || activeRequest?.isCancelled) return;
+    console.warn('Address suggestions are temporarily unavailable', error);
+    serviceError.value = true;
+    setSuggestions([]);
+  } finally {
+    if (currentRequestId === requestId) {
+      loading.value = false;
+      activeRequest = null;
+    }
+  }
+};
+
+const scheduleSuggestions = () => {
+  cancelPending();
+  const query = inputValue.value;
+  if (!hasEnoughAddressCharacters(query)) {
+    loading.value = false;
+    serviceError.value = false;
+    setSuggestions([]);
+    return;
+  }
+  debounceTimer = window.setTimeout(() => {
+    debounceTimer = null;
+    void fetchSuggestions(query);
+  }, ADDRESS_SUGGEST_DEBOUNCE_MS);
+};
+
+const onInput = (event: Event) => {
+  const value = (event.target as HTMLInputElement).value;
+  inputValue.value = value;
+  emit('update:modelValue', value);
+  emit('input', value);
+  touched.value = true;
+  blurredAfterEdit.value = false;
+  serviceError.value = false;
+  if (confirmedValue.value && value !== confirmedValue.value) {
+    confirmedValue.value = '';
+    emit('selection-cleared');
+  }
+  scheduleSuggestions();
+};
+
+const chooseSuggestion = (item: NormalizedAddressSuggestion) => {
+  const value = item.value || item.title || '';
+  cancelPending();
+  inputValue.value = value;
+  confirmedValue.value = value;
+  touched.value = true;
+  blurredAfterEdit.value = false;
+  serviceError.value = false;
+  emit('update:modelValue', value);
+  emit('select', item);
+  closeSuggestions();
+};
+
+const clear = () => {
+  cancelPending();
+  inputValue.value = '';
+  confirmedValue.value = '';
+  touched.value = true;
+  blurredAfterEdit.value = false;
+  serviceError.value = false;
+  setSuggestions([]);
+  emit('update:modelValue', '');
+  emit('input', '');
+  emit('selection-cleared');
+};
+
+const onFocus = () => {
+  focused.value = true;
+  if (suggestions.value.length) open.value = true;
+};
+
+const onBlur = () => {
+  focused.value = false;
+  blurredAfterEdit.value = touched.value && confirmedValue.value !== inputValue.value;
+  window.setTimeout(closeSuggestions, 120);
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    closeSuggestions();
+    return;
+  }
+  if (event.key === 'Tab') {
+    closeSuggestions();
+    return;
+  }
+  if (!open.value || !suggestions.value.length) return;
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    activeIndex.value = (activeIndex.value + 1) % suggestions.value.length;
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    activeIndex.value = (activeIndex.value - 1 + suggestions.value.length) % suggestions.value.length;
+  } else if (event.key === 'Enter' && activeIndex.value >= 0) {
+    const item = suggestions.value[activeIndex.value];
+    if (item) {
+      event.preventDefault();
+      chooseSuggestion(item);
+    }
+  }
+};
+
+const retry = () => {
+  serviceError.value = false;
+  scheduleSuggestions();
+};
+
+watch(() => props.modelValue, (value) => {
+  const nextValue = value || '';
+  if (nextValue === inputValue.value) return;
+  cancelPending();
+  inputValue.value = nextValue;
+  confirmedValue.value = '';
+  touched.value = false;
+  blurredAfterEdit.value = false;
+  serviceError.value = false;
+  setSuggestions([]);
+});
+
+onBeforeUnmount(() => {
+  requestId += 1;
+  cancelPending();
+});
+
+</script>
+
+<template>
+  <div class="relative min-w-0">
+    <label v-if="label" :for="inputId" class="field-label mb-1 block">{{ label }}</label>
+    <div class="relative">
+      <input
+        :id="inputId"
+        :value="inputValue"
+        type="text"
+        role="combobox"
+        :class="['field-input w-full pr-20', inputClass, error ? 'border-red-500 focus:outline-red-400' : '']"
+        :placeholder="placeholder"
+        :disabled="disabled"
+        :readonly="readonly"
+        :required="required"
+        :autocomplete="autocomplete"
+        :aria-expanded="open"
+        :aria-controls="listboxId"
+        :aria-activedescendant="activeIndex >= 0 ? `${inputId}-option-${activeIndex}` : undefined"
+        :aria-describedby="describedBy"
+        :aria-invalid="Boolean(error)"
+        @input="onInput"
+        @focus="onFocus"
+        @blur="onBlur"
+        @keydown="onKeydown"
+      />
+      <div class="absolute inset-y-0 right-2 flex items-center gap-1">
+        <LoaderCircle v-if="loading" :size="17" class="animate-spin text-teal-600 dark:text-teal-300" aria-label="Проверяем адрес" />
+        <button
+          v-if="inputValue && !disabled && !readonly"
+          type="button"
+          class="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-teal-500 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+          aria-label="Очистить адрес"
+          @mousedown.prevent
+          @click="clear"
+        >
+          <X :size="15" />
+        </button>
+      </div>
+    </div>
+
+    <ul
+      v-if="open && suggestions.length"
+      :id="listboxId"
+      role="listbox"
+      class="absolute left-0 top-full z-[70] mt-1 max-h-60 w-full overflow-auto rounded-xl border border-slate-200 bg-white p-1 shadow-2xl ring-1 ring-black/5 dark:border-slate-700 dark:bg-slate-900"
+    >
+      <li
+        v-for="(item, index) in suggestions"
+        :id="`${inputId}-option-${index}`"
+        :key="`${item.value}-${index}`"
+        role="option"
+        :aria-selected="activeIndex === index"
+        class="cursor-pointer rounded-lg px-3 py-2 text-sm transition-colors"
+        :class="activeIndex === index ? 'bg-teal-50 dark:bg-teal-500/15' : 'hover:bg-slate-50 dark:hover:bg-slate-800'"
+        @mousemove="activeIndex = index"
+        @mousedown.prevent="chooseSuggestion(item)"
+      >
+        <span class="block font-medium text-slate-900 dark:text-slate-100">{{ item.title || item.value }}</span>
+        <span v-if="item.subtitle" class="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">{{ item.subtitle }}</span>
+      </li>
+    </ul>
+
+    <p v-if="error" :id="`${inputId}-error`" class="mt-1 text-xs text-red-600 dark:text-red-300">{{ error }}</p>
+    <div v-else-if="showStatus && statusText" :id="statusId" class="mt-1 flex items-start gap-1.5 text-xs" :class="status === 'confirmed' ? 'text-emerald-700 dark:text-emerald-300' : status === 'error' ? 'text-amber-700 dark:text-amber-300' : 'text-slate-500 dark:text-slate-400'">
+      <CheckCircle2 v-if="status === 'confirmed'" :size="14" class="mt-px shrink-0" />
+      <AlertCircle v-else :size="14" class="mt-px shrink-0" />
+      <span>{{ statusText }}</span>
+      <button v-if="status === 'error'" type="button" class="ml-1 inline-flex items-center gap-1 font-semibold underline underline-offset-2" @click="retry">
+        <RotateCcw :size="12" /> Повторить
+      </button>
+    </div>
+  </div>
+</template>

--- a/manager_frontend/src/composables/useSmartStickyHeader.ts
+++ b/manager_frontend/src/composables/useSmartStickyHeader.ts
@@ -1,0 +1,96 @@
+import { onBeforeUnmount, ref, watch, type Ref } from 'vue';
+
+export const STICKY_HEADER_TOP_ZONE_PX = 80;
+export const STICKY_HEADER_COLLAPSE_TRAVEL_PX = 72;
+export const STICKY_HEADER_EXPAND_TRAVEL_PX = 32;
+const MIN_SCROLL_DELTA_PX = 2;
+
+export type StickyHeaderMotionState = {
+  compact: boolean;
+  lastScrollTop: number;
+  downwardTravel: number;
+  upwardTravel: number;
+};
+export const initialStickyHeaderState = (scrollTop = 0): StickyHeaderMotionState => ({
+  compact: false,
+  lastScrollTop: Math.max(0, scrollTop),
+  downwardTravel: 0,
+  upwardTravel: 0,
+});
+
+export const reduceStickyHeaderScroll = (
+  state: StickyHeaderMotionState,
+  rawScrollTop: number,
+): StickyHeaderMotionState => {
+  const scrollTop = Math.max(0, rawScrollTop);
+  const delta = scrollTop - state.lastScrollTop;
+
+  if (scrollTop <= STICKY_HEADER_TOP_ZONE_PX) {
+    return initialStickyHeaderState(scrollTop);
+  }
+  if (Math.abs(delta) < MIN_SCROLL_DELTA_PX) {
+    return { ...state, lastScrollTop: scrollTop };
+  }
+
+  if (delta > 0) {
+    const downwardTravel = state.downwardTravel + delta;
+    return {
+      compact: state.compact || downwardTravel >= STICKY_HEADER_COLLAPSE_TRAVEL_PX,
+      lastScrollTop: scrollTop,
+      downwardTravel,
+      upwardTravel: 0,
+    };
+  }
+
+  const upwardTravel = state.upwardTravel + Math.abs(delta);
+  return {
+    compact: state.compact && upwardTravel < STICKY_HEADER_EXPAND_TRAVEL_PX,
+    lastScrollTop: scrollTop,
+    downwardTravel: 0,
+    upwardTravel,
+  };
+};
+
+export const useSmartStickyHeader = (scrollContainer: Ref<HTMLElement | null>) => {
+  const compact = ref(false);
+  let motionState = initialStickyHeaderState();
+  let frameId: number | null = null;
+  let currentContainer: HTMLElement | null = null;
+
+  const updateFromScroll = () => {
+    frameId = null;
+    if (!currentContainer) return;
+    motionState = reduceStickyHeaderScroll(motionState, currentContainer.scrollTop);
+    compact.value = motionState.compact;
+  };
+
+  const onScroll = () => {
+    if (frameId === null) frameId = window.requestAnimationFrame(updateFromScroll);
+  };
+
+  const detach = () => {
+    currentContainer?.removeEventListener('scroll', onScroll);
+    currentContainer = null;
+    if (frameId !== null) {
+      window.cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+  };
+
+  const reset = () => {
+    const scrollTop = currentContainer?.scrollTop || 0;
+    motionState = initialStickyHeaderState(scrollTop);
+    compact.value = false;
+  };
+
+  watch(scrollContainer, (container) => {
+    detach();
+    currentContainer = container;
+    reset();
+    currentContainer?.addEventListener('scroll', onScroll, { passive: true });
+  }, { immediate: true, flush: 'post' });
+
+  onBeforeUnmount(detach);
+
+  return { compact, reset };
+};

--- a/manager_frontend/src/utils/address.ts
+++ b/manager_frontend/src/utils/address.ts
@@ -1,0 +1,30 @@
+import type { AddressSuggestionItem } from '../client';
+
+export const ADDRESS_SUGGEST_DEBOUNCE_MS = 800;
+export const ADDRESS_SUGGEST_MIN_SIGNIFICANT_CHARS = 3;
+
+export type AddressCoordinates = {
+  latitude: number;
+  longitude: number;
+};
+export type NormalizedAddressSuggestion = AddressSuggestionItem & {
+  coordinates?: AddressCoordinates | null;
+  components?: Record<string, string> | null;
+};
+
+export const normalizeAddressQuery = (value: string) => value.trim().replace(/\s+/g, ' ');
+
+export const hasEnoughAddressCharacters = (value: string) => (
+  normalizeAddressQuery(value).replace(/\s/g, '').length >= ADDRESS_SUGGEST_MIN_SIGNIFICANT_CHARS
+);
+
+export const buildYandexMapUrl = (
+  address: string,
+  coordinates?: AddressCoordinates | null,
+) => {
+  if (coordinates && Number.isFinite(coordinates.latitude) && Number.isFinite(coordinates.longitude)) {
+    return `https://yandex.by/maps/?ll=${coordinates.longitude},${coordinates.latitude}&z=17`;
+  }
+  const normalizedAddress = normalizeAddressQuery(address);
+  return normalizedAddress ? `https://yandex.by/maps/?text=${encodeURIComponent(normalizedAddress)}` : '';
+};

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { useDebounceFn } from '@vueuse/core';
 import { computed, onMounted, ref, watch } from 'vue';
 import { ArrowLeft, Building2, Mail, Phone, Plus, ReceiptText, Save, UserRound, X } from 'lucide-vue-next';
 import CreateOrderModal from '../components/CreateOrderModal.vue';
+import AddressSuggestInput from '../components/ui/AddressSuggestInput.vue';
 import EquipmentAttachmentsPanel from '../components/equipment/EquipmentAttachmentsPanel.vue';
 import EquipmentWarrantyPanel from '../components/equipment/EquipmentWarrantyPanel.vue';
 import { equipmentWarrantySummary } from '../components/equipment/equipmentWarrantySummary';
@@ -12,9 +12,7 @@ import {
   ManagerContractsService,
   ManagerDocsService,
   ManagerEquipmentService,
-  ManagerSettingsService,
   ManagerService,
-  type AddressSuggestionItem,
   type DocumentTemplateItem,
   type EquipmentServiceEventType,
   type ManagerCatalogCustomerItemResponse,
@@ -198,12 +196,6 @@ const emailError = ref('');
 const innError = ref('');
 const ibanError = ref('');
 const phoneInputRef = ref<HTMLInputElement | null>(null);
-type CustomerAddressField = 'legal_address' | 'actual_address';
-const customerAddressSuggestions = ref<AddressSuggestionItem[]>([]);
-const activeCustomerAddressField = ref<CustomerAddressField | null>(null);
-const customerAddressLookupLoading = ref(false);
-let customerAddressRequestId = 0;
-
 const form = ref<CustomerForm>({
   name: '',
   phone: '',
@@ -582,46 +574,6 @@ const fieldClass = (key: keyof CustomerForm) => ({
     (key === 'inn' && Boolean(innError.value)) ||
     (key === 'iban' && Boolean(ibanError.value)),
 });
-
-const fetchCustomerAddressSuggestions = async (field: CustomerAddressField, query: string) => {
-  const requestId = ++customerAddressRequestId;
-  if (!query || query.length < 3) {
-    customerAddressSuggestions.value = [];
-    return;
-  }
-  customerAddressLookupLoading.value = true;
-  try {
-    const res = await ManagerSettingsService.suggestAddress(query);
-    if (requestId === customerAddressRequestId && activeCustomerAddressField.value === field) {
-      customerAddressSuggestions.value = res.items || [];
-    }
-  } catch (err) {
-    console.warn('Failed to fetch address suggestions', err);
-  } finally {
-    if (requestId === customerAddressRequestId) {
-      customerAddressLookupLoading.value = false;
-    }
-  }
-};
-
-const debouncedFetchCustomerAddressSuggestions = useDebounceFn(fetchCustomerAddressSuggestions, 400);
-
-const onCustomerAddressInput = (field: CustomerAddressField) => {
-  activeCustomerAddressField.value = field;
-  debouncedFetchCustomerAddressSuggestions(field, form.value[field]);
-};
-
-const selectCustomerAddressSuggestion = (field: CustomerAddressField, item: AddressSuggestionItem) => {
-  form.value[field] = item.value || item.title || '';
-  activeCustomerAddressField.value = null;
-  customerAddressSuggestions.value = [];
-};
-
-const hideCustomerAddressSuggestions = () => {
-  window.setTimeout(() => {
-    activeCustomerAddressField.value = null;
-  }, 200);
-};
 
 const clearFieldErrors = () => {
   serverErrors.value = {};
@@ -1569,33 +1521,13 @@ onMounted(() => {
                   <option value="company">Юр. лицо</option>
                 </select>
                 <input v-model="form.name" type="text" :placeholder="isCompany ? 'Компания' : 'Имя клиента'" :class="fieldClass('name')" />
-                <div v-if="!isCompany" class="relative">
-                  <input
-                    v-model="form.actual_address"
-                    type="text"
-                    placeholder="Адрес объекта / доставки"
-                    autocomplete="off"
-                    :class="fieldClass('actual_address')"
-                    @input="onCustomerAddressInput('actual_address')"
-                    @focus="activeCustomerAddressField = 'actual_address'"
-                    @blur="hideCustomerAddressSuggestions"
-                  />
-                  <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'actual_address'" class="absolute right-3 top-2">
-                    <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                  </div>
-                  <div v-if="activeCustomerAddressField === 'actual_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
-                    <button
-                      v-for="(item, index) in customerAddressSuggestions"
-                      :key="index"
-                      type="button"
-                      class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
-                      @mousedown.prevent="selectCustomerAddressSuggestion('actual_address', item)"
-                    >
-                      <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
-                      <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
-                    </button>
-                  </div>
-                </div>
+                <AddressSuggestInput
+                  v-if="!isCompany"
+                  v-model="form.actual_address"
+                  placeholder="Адрес объекта / доставки"
+                  :input-class="fieldClass('actual_address')"
+                  :error="serverErrors.actual_address"
+                />
                 <input ref="phoneInputRef" v-model="form.phone" type="tel" placeholder="+375 (XX) XXX-XX-XX или +7 XXX XXX-XX-XX" :class="fieldClass('phone')" />
                 <span v-if="phoneError" class="field-error">{{ phoneError }}</span>
                 <input v-model="form.email" type="email" placeholder="Email" :class="fieldClass('email')" />
@@ -1634,60 +1566,18 @@ onMounted(() => {
               <div class="space-y-3 text-sm">
                 <div v-if="isCompany" class="space-y-3">
                   <input v-model="form.full_legal_name" type="text" placeholder="Полное наименование" :class="fieldClass('full_legal_name')" />
-                  <div class="relative">
-                    <input
-                      v-model="form.legal_address"
-                      type="text"
-                      placeholder="Юр. адрес"
-                      autocomplete="off"
-                      :class="fieldClass('legal_address')"
-                      @input="onCustomerAddressInput('legal_address')"
-                      @focus="activeCustomerAddressField = 'legal_address'"
-                      @blur="hideCustomerAddressSuggestions"
-                    />
-                    <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'legal_address'" class="absolute right-3 top-2">
-                      <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                    </div>
-                    <div v-if="activeCustomerAddressField === 'legal_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
-                      <button
-                        v-for="(item, index) in customerAddressSuggestions"
-                        :key="index"
-                        type="button"
-                        class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
-                        @mousedown.prevent="selectCustomerAddressSuggestion('legal_address', item)"
-                      >
-                        <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
-                        <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
-                      </button>
-                    </div>
-                  </div>
-                  <div class="relative">
-                    <input
-                      v-model="form.actual_address"
-                      type="text"
-                      placeholder="Факт. адрес"
-                      autocomplete="off"
-                      :class="fieldClass('actual_address')"
-                      @input="onCustomerAddressInput('actual_address')"
-                      @focus="activeCustomerAddressField = 'actual_address'"
-                      @blur="hideCustomerAddressSuggestions"
-                    />
-                    <div v-if="customerAddressLookupLoading && activeCustomerAddressField === 'actual_address'" class="absolute right-3 top-2">
-                      <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                    </div>
-                    <div v-if="activeCustomerAddressField === 'actual_address' && customerAddressSuggestions.length > 0" class="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-xl">
-                      <button
-                        v-for="(item, index) in customerAddressSuggestions"
-                        :key="index"
-                        type="button"
-                        class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-50"
-                        @mousedown.prevent="selectCustomerAddressSuggestion('actual_address', item)"
-                      >
-                        <span class="block font-medium text-slate-900">{{ item.title || item.value }}</span>
-                        <span v-if="item.subtitle" class="block truncate text-xs text-slate-500">{{ item.subtitle }}</span>
-                      </button>
-                    </div>
-                  </div>
+                  <AddressSuggestInput
+                    v-model="form.legal_address"
+                    placeholder="Юр. адрес"
+                    :input-class="fieldClass('legal_address')"
+                    :error="serverErrors.legal_address"
+                  />
+                  <AddressSuggestInput
+                    v-model="form.actual_address"
+                    placeholder="Факт. адрес"
+                    :input-class="fieldClass('actual_address')"
+                    :error="serverErrors.actual_address"
+                  />
                   <input v-model="form.bank_name" type="text" placeholder="Название банка" :class="fieldClass('bank_name')" />
                   <input v-model="form.bic" type="text" placeholder="BIC" :class="fieldClass('bic')" />
                   <div class="relative">

--- a/manager_frontend/src/views/LeadInbox.vue
+++ b/manager_frontend/src/views/LeadInbox.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue';
-import { useDebounceFn } from '@vueuse/core';
 import { api, type LeadsInboxItemResponse } from '../api';
-import { ManagerMailService, ManagerSettingsService, type EmailLeadImportJobResponse, type EmailLeadImportResponse } from '../client';
+import { ManagerMailService, type EmailLeadImportJobResponse, type EmailLeadImportResponse } from '../client';
 import LeadInboxCard from '../components/leads/LeadInboxCard.vue';
 import LeadQualifyModal from '../components/leads/LeadQualifyModal.vue';
+import AddressSuggestInput from '../components/ui/AddressSuggestInput.vue';
 import { useBelarusPhoneMask } from '../composables/useBelarusPhoneMask';
 import { useB2BLookup } from '../composables/useB2BLookup';
 
@@ -214,46 +214,6 @@ onMounted(async () => {
 });
 watch(scope, load);
 
-// ── Address Suggest ─────────────────────────────────────────────────────────
-const addressSuggestions = ref<any[]>([]);
-const addressSuggestActive = ref(false);
-const addressLookupLoading = ref(false);
-
-const fetchAddressSuggestions = async (query: string) => {
-  if (!query || query.length < 3) {
-    addressSuggestions.value = [];
-    return;
-  }
-  addressLookupLoading.value = true;
-  try {
-    const res = await ManagerSettingsService.suggestAddress(query);
-    addressSuggestions.value = res.items || [];
-  } catch (err) {
-    console.warn('Failed to fetch address suggestions', err);
-  } finally {
-    addressLookupLoading.value = false;
-  }
-};
-
-const debouncedFetchAddressSuggestions = useDebounceFn(fetchAddressSuggestions, 400);
-
-const onAddressInput = () => {
-  addressSuggestActive.value = true;
-  debouncedFetchAddressSuggestions(createForm.value.address);
-};
-
-const selectAddressSuggestion = (item: any) => {
-  createForm.value.address = item.value || item.title || '';
-  addressSuggestActive.value = false;
-  addressSuggestions.value = [];
-};
-
-const hideAddressSuggestions = () => {
-  setTimeout(() => {
-    addressSuggestActive.value = false;
-  }, 200);
-};
-
 // ── Create Lead ───────────────────────────────────────────────────────────────
 const openCreateModal = () => {
   Object.assign(createForm.value, { 
@@ -271,7 +231,6 @@ const openCreateModal = () => {
   phoneModelRef.value = '';
   existingCustomerId.value = null;
   foundCustomers.value = [];
-  addressSuggestions.value = [];
   showCreateModal.value = true;
 };
 
@@ -706,35 +665,12 @@ const scopeOptions: { value: Scope; label: string }[] = [
                   class="w-full rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-800 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                 />
               </div>
-              <div class="relative">
-                <label class="block text-xs font-semibold text-slate-500 dark:text-slate-400 mb-1 uppercase tracking-wide">Адрес объекта</label>
-                <div class="relative">
-                  <input
-                    v-model="createForm.address"
-                    @input="onAddressInput"
-                    @blur="hideAddressSuggestions"
-                    type="text"
-                    placeholder="г. Минск, ул. ..."
-                    class="w-full rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 px-3 py-2 text-sm text-slate-800 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500"
-                  />
-                  <div v-if="addressLookupLoading" class="absolute right-3 top-2.5">
-                    <span class="material-icons-round animate-spin text-teal-500 text-sm">refresh</span>
-                  </div>
-                </div>
-
-                <!-- Autocomplete Dropdown for Address -->
-                <div v-if="addressSuggestActive && addressSuggestions.length > 0" class="absolute z-10 w-full left-0 top-[100%] bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl shadow-lg mt-1 max-h-48 overflow-y-auto">
-                  <button
-                    v-for="(sug, sidx) in addressSuggestions"
-                    :key="sidx"
-                    @click.prevent="selectAddressSuggestion(sug)"
-                    class="w-full text-left px-4 py-2 hover:bg-slate-50 dark:hover:bg-slate-700 border-b border-slate-100 dark:border-slate-700 last:border-0"
-                  >
-                    <div class="text-sm font-semibold text-slate-800 dark:text-white">{{ sug.title || sug.value }}</div>
-                    <div v-if="sug.subtitle" class="text-xs text-slate-500 dark:text-slate-400">{{ sug.subtitle }}</div>
-                  </button>
-                </div>
-              </div>
+              <AddressSuggestInput
+                v-model="createForm.address"
+                label="Адрес объекта"
+                placeholder="г. Минск, ул. ..."
+                input-class="bg-white text-sm dark:bg-slate-700"
+              />
             </div>
           </template>
           <div>

--- a/manager_frontend/src/views/SettingsView.vue
+++ b/manager_frontend/src/views/SettingsView.vue
@@ -14,6 +14,7 @@ import type {
 } from '../client';
 import { ManagerDocsService, ManagerRepairComplaintsService, ManagerSettingsService } from '../client';
 import { getApiErrorMessage } from '../utils/api-errors';
+import AddressSuggestInput from '../components/ui/AddressSuggestInput.vue';
 
 const settings = ref<ManagerSettingResponse[]>([]);
 const loading = ref(false);
@@ -1674,7 +1675,7 @@ onMounted(() => {
                     </label>
                     <label class="block text-sm">
                         <span class="mb-1 block text-xs font-medium text-gray-500 dark:text-slate-400">Юридический адрес</span>
-                        <input v-model="companyRequisites.company_legal_address" class="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-gray-900 shadow-sm transition-colors focus:border-teal-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" />
+                        <AddressSuggestInput v-model="companyRequisites.company_legal_address" input-class="bg-gray-50 dark:bg-slate-900" />
                     </label>
                     <label class="block text-sm">
                         <span class="mb-1 block text-xs font-medium text-gray-500 dark:text-slate-400">IBAN</span>

--- a/manager_frontend/src/views/SupplierFeedsView.vue
+++ b/manager_frontend/src/views/SupplierFeedsView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { api } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
+import AddressSuggestInput from '../components/ui/AddressSuggestInput.vue';
 import {
   Building2,
   CheckCircle2,
@@ -585,8 +586,8 @@ onMounted(loadData);
               <label class="space-y-1 text-sm font-medium text-slate-600 md:col-span-2">Google Spreadsheet URL/ID<input v-model="supplierForm.spreadsheet_id_or_url" class="field-input" placeholder="https://docs.google.com/spreadsheets/..." /></label>
               <label class="space-y-1 text-sm font-medium text-slate-600">Юридическое название<input v-model="supplierForm.legal_name" class="field-input" placeholder="ООО / УП..." /></label>
               <label class="space-y-1 text-sm font-medium text-slate-600">УНП / рег. номер<input v-model="supplierForm.tax_id" class="field-input" /></label>
-              <label class="space-y-1 text-sm font-medium text-slate-600">Юр. адрес<textarea v-model="supplierForm.legal_address" class="field-input min-h-[76px]" /></label>
-              <label class="space-y-1 text-sm font-medium text-slate-600">Почтовый адрес / документы<textarea v-model="supplierForm.postal_address" class="field-input min-h-[76px]" /></label>
+              <AddressSuggestInput v-model="supplierForm.legal_address" label="Юр. адрес" />
+              <AddressSuggestInput v-model="supplierForm.postal_address" label="Почтовый адрес / документы" />
               <label class="space-y-1 text-sm font-medium text-slate-600">
                 Оплата по умолчанию
                 <select v-model="supplierForm.default_payment_method" class="field-input">
@@ -681,7 +682,7 @@ onMounted(loadData);
               <h3 class="mb-3 font-semibold text-slate-900">{{ editingWarehouseId ? 'Редактировать склад' : 'Новый склад' }}</h3>
               <div class="space-y-2">
                 <input v-model="warehouseForm.name" required class="field-input bg-white" placeholder="Название склада" />
-                <textarea v-model="warehouseForm.address" required class="field-input min-h-[80px] bg-white" placeholder="Адрес склада / точки отгрузки" />
+                <AddressSuggestInput v-model="warehouseForm.address" required placeholder="Адрес склада / точки отгрузки" input-class="bg-white" />
                 <select v-model="warehouseForm.contact_id" class="field-input bg-white">
                   <option :value="null">Контакт из справочника не выбран</option>
                   <option v-for="contact in contacts" :key="contact.id" :value="contact.id">{{ contact.name }}</option>

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -1,0 +1,45 @@
+import {
+  ADDRESS_SUGGEST_DEBOUNCE_MS,
+  buildYandexMapUrl,
+  hasEnoughAddressCharacters,
+} from '../src/utils/address';
+import {
+  STICKY_HEADER_COLLAPSE_TRAVEL_PX,
+  STICKY_HEADER_EXPAND_TRAVEL_PX,
+  initialStickyHeaderState,
+  reduceStickyHeaderScroll,
+} from '../src/composables/useSmartStickyHeader';
+
+const assert = (condition: unknown, message: string) => {
+  if (!condition) throw new Error(message);
+};
+
+assert(ADDRESS_SUGGEST_DEBOUNCE_MS === 800, 'address debounce must remain 800 ms');
+assert(!hasEnoughAddressCharacters('  а б  '), 'spaces must not count as significant address characters');
+assert(hasEnoughAddressCharacters('Мин'), 'three significant characters must enable suggestions');
+assert(buildYandexMapUrl('') === '', 'empty address must not create a map link');
+assert(
+  buildYandexMapUrl('Минск, Ленина 1').includes(encodeURIComponent('Минск, Ленина 1')),
+  'manual address must create a text-based map link',
+);
+assert(
+  buildYandexMapUrl('old address', { latitude: 53.9, longitude: 27.56 }).includes('ll=27.56,53.9'),
+  'trusted coordinates must take priority in the map link',
+);
+
+let header = initialStickyHeaderState();
+assert(!header.compact, 'header must open expanded');
+header = reduceStickyHeaderScroll(header, 60);
+assert(!header.compact, 'header must stay expanded in the top zone');
+header = reduceStickyHeaderScroll(header, 90);
+assert(!header.compact, 'one short downward movement must not collapse the header');
+header = reduceStickyHeaderScroll(header, 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX);
+assert(header.compact, 'sustained downward movement must collapse the header');
+header = reduceStickyHeaderScroll(header, 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX - 8);
+assert(header.compact, 'minor upward jitter must not expand the header');
+header = reduceStickyHeaderScroll(header, 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX - STICKY_HEADER_EXPAND_TRAVEL_PX);
+assert(!header.compact, 'meaningful upward movement must expand the header');
+header = reduceStickyHeaderScroll(header, 20);
+assert(!header.compact, 'returning to the top must keep the header expanded');
+
+console.log('Address and sticky header UI logic tests passed');

--- a/manager_frontend/vite.config.ts
+++ b/manager_frontend/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
         target: 'http://localhost:8000',
         changeOrigin: true,
       },
+      '/login': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
       '/media': {
         target: 'http://localhost:8000',
         changeOrigin: true,

--- a/openapi.json
+++ b/openapi.json
@@ -13390,6 +13390,42 @@
               "minLength": 2,
               "title": "Q"
             }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "maximum": 90,
+                  "minimum": -90
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lat"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "maximum": 180,
+                  "minimum": -180
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lon"
+            }
           }
         ],
         "responses": {

--- a/routers/manager_settings.py
+++ b/routers/manager_settings.py
@@ -56,9 +56,16 @@ async def get_fx_rate(session: AsyncSession = Depends(get_session)):
 
 
 @router.get("/address-suggest", response_model=AddressSuggestResponse, operation_id=SUGGEST_ADDRESS)
-async def suggest_address(q: str = Query(..., min_length=2)):
+async def suggest_address(
+    q: str = Query(..., min_length=2),
+    lat: float | None = Query(default=None, ge=-90, le=90),
+    lon: float | None = Query(default=None, ge=-180, le=180),
+):
     try:
-        return AddressSuggestResponse(items=await AddressSuggestService.suggest(q))
+        ull = f"{lon},{lat}" if lat is not None and lon is not None else None
+        return AddressSuggestResponse(
+            items=await AddressSuggestService.suggest(q, ull=ull)
+        )
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except httpx.HTTPError as exc:

--- a/services/address_suggest_service.py
+++ b/services/address_suggest_service.py
@@ -54,12 +54,30 @@ class AddressSuggestService:
             return {}
 
     @classmethod
-    async def suggest(cls, query: str) -> list[dict[str, str | None]]:
+    async def suggest(
+        cls,
+        query: str,
+        *,
+        ull: str | None = None,
+    ) -> list[dict[str, str | None]]:
         items: list[dict[str, str | None]] = []
         seen_values: set[str] = set()
 
-        for bbox in (cls.VITEBSK_REGION_BBOX, cls.BELARUS_BBOX):
-            payload = await cls.fetch_raw(query, bbox=bbox, strict_bounds=True)
+        scopes = (
+            [(cls.BELARUS_BBOX, ull)]
+            if ull
+            else [
+                (cls.VITEBSK_REGION_BBOX, None),
+                (cls.BELARUS_BBOX, None),
+            ]
+        )
+        for bbox, scope_ull in scopes:
+            payload = await cls.fetch_raw(
+                query,
+                bbox=bbox,
+                ull=scope_ull,
+                strict_bounds=True,
+            )
             scoped_items = cls.normalize_results(payload)
             for item in scoped_items:
                 value = item.get("value")

--- a/tests/unit/test_address_suggest_service.py
+++ b/tests/unit/test_address_suggest_service.py
@@ -7,7 +7,13 @@ from services.address_suggest_service import AddressSuggestService
 async def test_suggest_prefers_vitebsk_region_then_falls_back(monkeypatch):
     calls: list[str] = []
 
-    async def fake_fetch_raw(query: str, *, bbox: str | None = None, ull: str | None = None, strict_bounds: bool = True):
+    async def fake_fetch_raw(
+        query: str,
+        *,
+        bbox: str | None = None,
+        ull: str | None = None,
+        strict_bounds: bool = True,
+    ):
         assert query == "Ленина 1"
         assert strict_bounds is True
         assert ull is None
@@ -46,6 +52,31 @@ async def test_suggest_prefers_vitebsk_region_then_falls_back(monkeypatch):
         "Витебск, улица Ленина, д. 1",
         "Минск, улица Ленина, д. 1",
     ]
+
+
+@pytest.mark.asyncio
+async def test_suggest_uses_coordinate_priority_without_vitebsk_scope(monkeypatch):
+    calls: list[tuple[str | None, str | None]] = []
+
+    async def fake_fetch_raw(query: str, *, bbox: str | None = None, ull: str | None = None, strict_bounds: bool = True):
+        assert query == "Кирова 1"
+        assert strict_bounds is True
+        calls.append((bbox, ull))
+        return {
+            "results": [
+                {
+                    "title": {"text": "улица Кирова, 1"},
+                    "subtitle": {"text": "Гомель"},
+                }
+            ]
+        }
+
+    monkeypatch.setattr(AddressSuggestService, "fetch_raw", fake_fetch_raw)
+
+    items = await AddressSuggestService.suggest("Кирова 1", ull="30.9754,52.4345")
+
+    assert calls == [(AddressSuggestService.BELARUS_BBOX, "30.9754,52.4345")]
+    assert items[0]["value"] == "Гомель, улица Кирова, д. 1"
 
 
 def test_normalize_results_deduplicates_and_skips_invalid_entries():


### PR DESCRIPTION
## Summary
- replace duplicated manager address autocomplete implementations with one accessible AddressSuggestInput using the existing backend proxy
- add cancellation, stale-response protection, 800 ms debounce, manual fallback, error/retry states, and optional geo priority
- add direction-aware compact order header for the real drawer scroll container with hysteresis and interaction locks
- keep OpenAPI and the generated manager client synchronized

## Address audit
Converted order objects and branches, act objects, customer legal/actual addresses, lead qualification and quick creation, supplier legal/postal addresses and warehouses, plus company requisites. The equipment registry address field remains unchanged because it is a multi-entity search filter, not physical address entry.

## Verification
- pnpm run test:ui-logic
- pnpm run build
- 17 scoped backend tests passed
- bash scripts/audit_theme_hardcodes.sh
- git diff --check
- visual QA: desktop and mobile, full and compact header, light and dark themes

## UX details
- address requests start after 800 ms and 3 significant characters
- compact header: 80 px top zone, 72 px downward travel, 32 px upward travel
- compact height measured at 53 px in the real order drawer