### PR TITLE
Fix sticky order header flicker

### DIFF
--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -2524,9 +2524,8 @@ watch(
       </div>
     </Transition>
     <div class="flex-1 bg-black/60" @click="closeDrawer" />
-    <aside ref="drawerScrollContainer" class="h-full w-full min-w-0 max-w-3xl overflow-y-auto bg-white p-4 text-gray-900 shadow-2xl dark:bg-slate-950 dark:text-slate-100 sm:p-6 md:border-l md:border-gray-200 dark:md:border-slate-700">
+    <aside ref="drawerScrollContainer" class="h-full w-full min-w-0 max-w-3xl overflow-y-auto bg-white text-gray-900 shadow-2xl dark:bg-slate-950 dark:text-slate-100 md:border-l md:border-gray-200 dark:md:border-slate-700">
       <OrderWorkspaceHeader
-        class="-mx-4 -mt-4 sm:-mx-6 sm:-mt-6"
         :order-id="order?.id"
         :title="displayOrderTitle"
         :workflow="workflowType"
@@ -2549,7 +2548,7 @@ watch(
         @close="closeDrawer"
       />
 
-
+      <div class="p-4 sm:p-6">
       <div v-if="managerLabels.length || showManagerLabelInput" class="mt-3 flex flex-wrap items-center gap-1.5">
         <span
           v-for="label in managerLabels"
@@ -3970,6 +3969,7 @@ watch(
           {{ isDeleting ? 'Удаление...' : 'Удалить заказ' }}
         </button>
       </footer>
+      </div>
     </aside>
 
     <div

--- a/manager_frontend/src/composables/useSmartStickyHeader.ts
+++ b/manager_frontend/src/composables/useSmartStickyHeader.ts
@@ -1,4 +1,4 @@
-import { onBeforeUnmount, ref, watch, type Ref } from 'vue';
+import { nextTick, onBeforeUnmount, ref, watch, type Ref } from 'vue';
 
 export const STICKY_HEADER_TOP_ZONE_PX = 80;
 export const STICKY_HEADER_COLLAPSE_TRAVEL_PX = 72;
@@ -17,6 +17,27 @@ export const initialStickyHeaderState = (scrollTop = 0): StickyHeaderMotionState
   downwardTravel: 0,
   upwardTravel: 0,
 });
+
+export const syncStickyHeaderAfterLayout = (
+  state: StickyHeaderMotionState,
+  scrollTop: number,
+): StickyHeaderMotionState => ({
+  ...state,
+  lastScrollTop: Math.max(0, scrollTop),
+  downwardTravel: 0,
+  upwardTravel: 0,
+});
+
+export const getStickyHeaderLogicalScrollTop = (
+  rawScrollTop: number,
+  compensation: number,
+) => Math.max(0, rawScrollTop + compensation);
+
+export const getStickyHeaderLayoutCompensation = (
+  logicalScrollTop: number,
+  rawScrollTop: number,
+  compact: boolean,
+) => compact ? logicalScrollTop - rawScrollTop : 0;
 
 export const reduceStickyHeaderScroll = (
   state: StickyHeaderMotionState,
@@ -55,30 +76,77 @@ export const useSmartStickyHeader = (scrollContainer: Ref<HTMLElement | null>) =
   const compact = ref(false);
   let motionState = initialStickyHeaderState();
   let frameId: number | null = null;
+  let layoutFrameId: number | null = null;
+  let layoutSyncGeneration = 0;
+  let layoutSyncPending = false;
+  let scrollCompensation = 0;
   let currentContainer: HTMLElement | null = null;
+
+  const syncAfterLayoutChange = (logicalScrollTop: number, targetCompact: boolean) => {
+    layoutSyncPending = true;
+    const generation = ++layoutSyncGeneration;
+
+    void nextTick(() => {
+      if (generation !== layoutSyncGeneration || !currentContainer) return;
+      layoutFrameId = window.requestAnimationFrame(() => {
+        layoutFrameId = null;
+        if (generation !== layoutSyncGeneration || !currentContainer) return;
+        const rawScrollTop = currentContainer.scrollTop;
+        scrollCompensation = getStickyHeaderLayoutCompensation(
+          logicalScrollTop,
+          rawScrollTop,
+          targetCompact,
+        );
+        motionState = syncStickyHeaderAfterLayout(
+          motionState,
+          targetCompact
+            ? getStickyHeaderLogicalScrollTop(rawScrollTop, scrollCompensation)
+            : rawScrollTop,
+        );
+        layoutSyncPending = false;
+      });
+    });
+  };
 
   const updateFromScroll = () => {
     frameId = null;
-    if (!currentContainer) return;
-    motionState = reduceStickyHeaderScroll(motionState, currentContainer.scrollTop);
+    if (!currentContainer || layoutSyncPending) return;
+    const wasCompact = motionState.compact;
+    const logicalScrollTop = getStickyHeaderLogicalScrollTop(
+      currentContainer.scrollTop,
+      scrollCompensation,
+    );
+    motionState = reduceStickyHeaderScroll(motionState, logicalScrollTop);
     compact.value = motionState.compact;
+    if (wasCompact !== motionState.compact) {
+      syncAfterLayoutChange(motionState.lastScrollTop, motionState.compact);
+    }
   };
 
   const onScroll = () => {
+    if (layoutSyncPending) return;
     if (frameId === null) frameId = window.requestAnimationFrame(updateFromScroll);
   };
 
   const detach = () => {
     currentContainer?.removeEventListener('scroll', onScroll);
     currentContainer = null;
+    layoutSyncPending = false;
+    scrollCompensation = 0;
+    layoutSyncGeneration += 1;
     if (frameId !== null) {
       window.cancelAnimationFrame(frameId);
       frameId = null;
+    }
+    if (layoutFrameId !== null) {
+      window.cancelAnimationFrame(layoutFrameId);
+      layoutFrameId = null;
     }
   };
 
   const reset = () => {
     const scrollTop = currentContainer?.scrollTop || 0;
+    scrollCompensation = 0;
     motionState = initialStickyHeaderState(scrollTop);
     compact.value = false;
   };

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -6,8 +6,11 @@ import {
 import {
   STICKY_HEADER_COLLAPSE_TRAVEL_PX,
   STICKY_HEADER_EXPAND_TRAVEL_PX,
+  getStickyHeaderLayoutCompensation,
+  getStickyHeaderLogicalScrollTop,
   initialStickyHeaderState,
   reduceStickyHeaderScroll,
+  syncStickyHeaderAfterLayout,
 } from '../src/composables/useSmartStickyHeader';
 
 const assert = (condition: unknown, message: string) => {
@@ -41,5 +44,38 @@ header = reduceStickyHeaderScroll(header, 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX 
 assert(!header.compact, 'meaningful upward movement must expand the header');
 header = reduceStickyHeaderScroll(header, 20);
 assert(!header.compact, 'returning to the top must keep the header expanded');
+
+header = reduceStickyHeaderScroll(initialStickyHeaderState(90), 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX);
+assert(header.compact, 'header must collapse before layout synchronization');
+const compactedRawScrollTop = 62;
+const compactedCompensation = getStickyHeaderLayoutCompensation(
+  header.lastScrollTop,
+  compactedRawScrollTop,
+  header.compact,
+);
+header = syncStickyHeaderAfterLayout(
+  header,
+  getStickyHeaderLogicalScrollTop(compactedRawScrollTop, compactedCompensation),
+);
+assert(header.compact, 'layout-induced scroll correction must preserve compact mode');
+assert(
+  header.lastScrollTop === 90 + STICKY_HEADER_COLLAPSE_TRAVEL_PX,
+  'logical scroll position must stay stable after compaction',
+);
+assert(header.upwardTravel === 0, 'layout synchronization must not count as upward user travel');
+header = reduceStickyHeaderScroll(
+  header,
+  getStickyHeaderLogicalScrollTop(54, compactedCompensation),
+);
+assert(header.compact, 'small upward user travel after synchronization must keep compact mode');
+header = reduceStickyHeaderScroll(
+  header,
+  getStickyHeaderLogicalScrollTop(20, compactedCompensation),
+);
+assert(!header.compact, 'meaningful upward user travel must still expand the compensated header');
+assert(
+  getStickyHeaderLayoutCompensation(header.lastScrollTop, 120, header.compact) === 0,
+  'expanded mode must clear layout compensation',
+);
 
 console.log('Address and sticky header UI logic tests passed');


### PR DESCRIPTION
## Summary
- make the order header flush with the drawer top by moving content padding below it
- compensate scroll position changes caused by switching header height
- add regression coverage for collapse, layout correction, and intentional expansion

## Verification
- `pnpm --dir manager_frontend test:ui-logic`
- `pnpm --dir manager_frontend build`
- `bash scripts/audit_theme_hardcodes.sh`
- mobile viewport: header top stayed at 0 px; compact height stayed at 53 px across 16 timed samples