### PR TITLE
Move bot quick orders and requisites behind API

### DIFF
--- a/alembic/versions/7f2b4d6e8a10_add_bot_lead_idempotency_index.py
+++ b/alembic/versions/7f2b4d6e8a10_add_bot_lead_idempotency_index.py
@@ -1,0 +1,134 @@
+"""add Telegram bot idempotency indexes
+
+Revision ID: 7f2b4d6e8a10
+Revises: 6e1a3c5d7f90
+Create Date: 2026-07-17 15:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "7f2b4d6e8a10"
+down_revision: Union[str, Sequence[str], None] = "6e1a3c5d7f90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+LEAD_INDEX_NAME = "uq_lead_bot_source_fingerprint"
+RECOGNITION_INDEX_NAME = "uq_customer_requisites_telegram_message"
+STAGE_INDEX_NAME = "uq_unassigned_order_work_stage_schedule"
+
+
+def _indexes(table_name: str) -> set[str]:
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    duplicate_groups = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT count(*)
+            FROM (
+                SELECT source_fingerprint
+                FROM lead
+                WHERE source = 'bot' AND source_fingerprint IS NOT NULL
+                GROUP BY source_fingerprint
+                HAVING count(*) > 1
+            ) duplicate_bot_fingerprints
+            """
+        )
+    ).scalar_one()
+    if duplicate_groups:
+        raise RuntimeError(
+            "Cannot enforce bot quick-order idempotency: duplicate bot lead fingerprints exist"
+        )
+
+    if LEAD_INDEX_NAME not in _indexes("lead"):
+        op.create_index(
+            LEAD_INDEX_NAME,
+            "lead",
+            ["source_fingerprint"],
+            unique=True,
+            postgresql_where=sa.text("source = 'bot' AND source_fingerprint IS NOT NULL"),
+            sqlite_where=sa.text("source = 'bot' AND source_fingerprint IS NOT NULL"),
+        )
+
+    duplicate_recognitions = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT count(*)
+            FROM (
+                SELECT source, telegram_user_id, telegram_chat_id, telegram_message_id
+                FROM customer_requisites_recognition
+                WHERE source IN ('telegram', 'telegram_text')
+                  AND telegram_user_id IS NOT NULL
+                  AND telegram_chat_id IS NOT NULL
+                  AND telegram_message_id IS NOT NULL
+                GROUP BY source, telegram_user_id, telegram_chat_id, telegram_message_id
+                HAVING count(*) > 1
+            ) duplicate_telegram_recognitions
+            """
+        )
+    ).scalar_one()
+    if duplicate_recognitions:
+        raise RuntimeError(
+            "Cannot enforce requisites idempotency: duplicate Telegram recognitions exist"
+        )
+
+    if RECOGNITION_INDEX_NAME not in _indexes("customer_requisites_recognition"):
+        predicate = sa.text(
+            "source IN ('telegram', 'telegram_text') "
+            "AND telegram_user_id IS NOT NULL "
+            "AND telegram_chat_id IS NOT NULL "
+            "AND telegram_message_id IS NOT NULL"
+        )
+        op.create_index(
+            RECOGNITION_INDEX_NAME,
+            "customer_requisites_recognition",
+            ["source", "telegram_user_id", "telegram_chat_id", "telegram_message_id"],
+            unique=True,
+            postgresql_where=predicate,
+            sqlite_where=predicate,
+        )
+
+    duplicate_stages = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT count(*)
+            FROM (
+                SELECT order_id, name, start_time
+                FROM order_work_stage
+                WHERE installer_id IS NULL AND start_time IS NOT NULL
+                GROUP BY order_id, name, start_time
+                HAVING count(*) > 1
+            ) duplicate_unassigned_stages
+            """
+        )
+    ).scalar_one()
+    if duplicate_stages:
+        raise RuntimeError(
+            "Cannot enforce quick-order stage idempotency: duplicate unassigned stages exist"
+        )
+
+    if STAGE_INDEX_NAME not in _indexes("order_work_stage"):
+        predicate = sa.text("installer_id IS NULL AND start_time IS NOT NULL")
+        op.create_index(
+            STAGE_INDEX_NAME,
+            "order_work_stage",
+            ["order_id", "name", "start_time"],
+            unique=True,
+            postgresql_where=predicate,
+            sqlite_where=predicate,
+        )
+
+
+def downgrade() -> None:
+    if STAGE_INDEX_NAME in _indexes("order_work_stage"):
+        op.drop_index(STAGE_INDEX_NAME, table_name="order_work_stage")
+    if RECOGNITION_INDEX_NAME in _indexes("customer_requisites_recognition"):
+        op.drop_index(RECOGNITION_INDEX_NAME, table_name="customer_requisites_recognition")
+    if LEAD_INDEX_NAME in _indexes("lead"):
+        op.drop_index(LEAD_INDEX_NAME, table_name="lead")

--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -1,9 +1,12 @@
 """Versioned contracts for the internal Telegram bot API."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
+
+
+BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
 
 class BotApiHealthResponse(BaseModel):
@@ -102,4 +105,111 @@ class BotTaskReportSaveRequest(BaseModel):
 
 class BotTaskReportSaveResponse(BaseModel):
     stage_id: int = Field(ge=1)
+    changed: bool
+
+
+BotQuickOrderServiceType = Literal[
+    "turnkey",
+    "install_only",
+    "pre_install",
+    "maintenance",
+    "repair",
+    "dismantling",
+]
+
+
+class BotQuickOrderAddressCheck(BaseModel):
+    status: Literal["unchecked", "not_found", "needs_review", "confirmed"]
+    message: str = Field(min_length=1, max_length=500)
+    suggestion: str | None = Field(default=None, max_length=500)
+
+
+class BotQuickOrderDraft(BaseModel):
+    name: str | None = Field(default=None, max_length=300)
+    phone: str | None = Field(default=None, max_length=64)
+    address: str | None = Field(default=None, max_length=1000)
+    service_type: BotQuickOrderServiceType | None = None
+    service_label: str = Field(min_length=1, max_length=100)
+    target_date: datetime | None = None
+    request_text: str = Field(min_length=1, max_length=12_000)
+    parser: Literal["fallback", "ai"] = "fallback"
+    address_check: BotQuickOrderAddressCheck | None = None
+
+
+class BotQuickOrderParseRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    text: str = Field(min_length=1, max_length=12_000)
+
+    @field_validator("text")
+    @classmethod
+    def normalize_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Quick order text must not be empty")
+        return normalized
+
+
+class BotQuickOrderParseResponse(BaseModel):
+    draft: BotQuickOrderDraft
+
+
+class BotQuickOrderCreateRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    idempotency_key: str = Field(
+        min_length=1,
+        max_length=160,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    )
+    draft: BotQuickOrderDraft
+
+
+class BotQuickOrderCreateResponse(BaseModel):
+    order_id: int = Field(ge=1)
+    customer_id: int = Field(ge=1)
+    created: bool
+
+
+class BotCustomerBriefResponse(BaseModel):
+    id: int = Field(ge=1)
+    name: str
+    inn: str | None = None
+    phone: str | None = None
+    email: str | None = None
+
+
+class BotCustomerRequisitesRecognitionResponse(BaseModel):
+    id: int = Field(ge=1)
+    status: Literal["recognized", "confirmed", "cancelled"]
+    source: str
+    extracted: dict[str, Any] = Field(default_factory=dict)
+    validation_flags: dict[str, Any] = Field(default_factory=dict)
+    duplicate_customer: BotCustomerBriefResponse | None = None
+    confirmed_customer_id: int | None = None
+    confirmed_action: Literal["create", "update"] | None = None
+    created_at: datetime
+
+
+class BotCustomerRequisitesTextRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    text: str = Field(min_length=20, max_length=12_000)
+    telegram_chat_id: int | None = None
+    telegram_message_id: int | None = None
+
+    @field_validator("text")
+    @classmethod
+    def normalize_requisites_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if len(normalized) < 20:
+            raise ValueError("Requisites text is too short")
+        return normalized
+
+
+class BotCustomerRequisitesActionRequest(BaseModel):
+    telegram_id: int = Field(ge=1)
+    action: Literal["create", "update", "cancel"]
+
+
+class BotCustomerRequisitesActionResponse(BaseModel):
+    recognition: BotCustomerRequisitesRecognitionResponse
+    customer: BotCustomerBriefResponse | None = None
     changed: bool

--- a/bot_app/api_gateway.py
+++ b/bot_app/api_gateway.py
@@ -9,6 +9,11 @@ from api_contracts.bot import (
     BotApiHealthResponse,
     BotCatalogProductLookupResponse,
     BotCatalogSearchResponse,
+    BotCustomerRequisitesActionResponse,
+    BotCustomerRequisitesRecognitionResponse,
+    BotQuickOrderCreateResponse,
+    BotQuickOrderDraft,
+    BotQuickOrderParseResponse,
     BotStaffContextResponse,
     BotTaskListResponse,
     BotTaskReportSaveResponse,
@@ -38,6 +43,14 @@ class BotApiResponseError(BotApiError):
 
 class BotApiConflictError(BotApiError):
     """The staff action conflicts with the current backend state."""
+
+
+class BotApiNotFoundError(BotApiResponseError):
+    """The requested backend resource no longer exists."""
+
+
+class BotApiValidationError(BotApiResponseError):
+    """The backend rejected user-provided data."""
 
 
 @dataclass(frozen=True)
@@ -213,11 +226,164 @@ class BotApiGateway:
         except ValueError as exc:
             raise BotApiResponseError("MVN API returned an invalid task report contract") from exc
 
+    async def parse_quick_order(
+        self,
+        *,
+        telegram_id: int,
+        text: str,
+    ) -> BotQuickOrderParseResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        normalized_text = text.strip()
+        if not normalized_text:
+            raise ValueError("Quick order text must not be empty")
+        if len(normalized_text) > 12_000:
+            raise ValueError("Quick order text must not exceed 12000 characters")
+        payload = await self._post(
+            "quick-orders/parse",
+            json={"telegram_id": telegram_id, "text": normalized_text},
+            timeout_seconds=20.0,
+        )
+        try:
+            return BotQuickOrderParseResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid quick-order draft") from exc
+
+    async def create_quick_order(
+        self,
+        *,
+        telegram_id: int,
+        idempotency_key: str,
+        draft: BotQuickOrderDraft | dict,
+    ) -> BotQuickOrderCreateResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        normalized_key = idempotency_key.strip()
+        if not normalized_key:
+            raise ValueError("Quick order idempotency key is required")
+        validated_draft = BotQuickOrderDraft.model_validate(draft)
+        payload = await self._post(
+            "quick-orders",
+            json={
+                "telegram_id": telegram_id,
+                "idempotency_key": normalized_key,
+                "draft": validated_draft.model_dump(mode="json"),
+            },
+            timeout_seconds=20.0,
+        )
+        try:
+            return BotQuickOrderCreateResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid quick-order result") from exc
+
+    async def recognize_customer_requisites_text(
+        self,
+        *,
+        telegram_id: int,
+        text: str,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> BotCustomerRequisitesRecognitionResponse:
+        normalized_text = text.strip()
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if len(normalized_text) < 20:
+            raise ValueError("Requisites text is too short")
+        payload = await self._post(
+            "customers/requisites/recognize-text",
+            json={
+                "telegram_id": telegram_id,
+                "text": normalized_text,
+                "telegram_chat_id": telegram_chat_id,
+                "telegram_message_id": telegram_message_id,
+            },
+            timeout_seconds=60.0,
+        )
+        try:
+            return BotCustomerRequisitesRecognitionResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned invalid customer requisites") from exc
+
+    async def recognize_customer_requisites_file(
+        self,
+        *,
+        telegram_id: int,
+        content: bytes,
+        filename: str,
+        mime_type: str,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> BotCustomerRequisitesRecognitionResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if not content:
+            raise ValueError("Requisites file must not be empty")
+        form_data = {"telegram_id": str(telegram_id)}
+        if telegram_chat_id is not None:
+            form_data["telegram_chat_id"] = str(telegram_chat_id)
+        if telegram_message_id is not None:
+            form_data["telegram_message_id"] = str(telegram_message_id)
+        payload = await self._post_multipart(
+            "customers/requisites/recognize-file",
+            data=form_data,
+            files={"file": (filename, content, mime_type)},
+            timeout_seconds=90.0,
+        )
+        try:
+            return BotCustomerRequisitesRecognitionResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned invalid customer requisites") from exc
+
+    async def apply_customer_requisites_action(
+        self,
+        *,
+        telegram_id: int,
+        recognition_id: int,
+        action: str,
+    ) -> BotCustomerRequisitesActionResponse:
+        if telegram_id <= 0:
+            raise ValueError("Telegram ID must be positive")
+        if recognition_id <= 0:
+            raise ValueError("Recognition ID must be positive")
+        if action not in {"create", "update", "cancel"}:
+            raise ValueError("Recognition action must be create, update or cancel")
+        payload = await self._post(
+            f"customers/requisites/{recognition_id}/action",
+            json={"telegram_id": telegram_id, "action": action},
+            timeout_seconds=20.0,
+        )
+        try:
+            return BotCustomerRequisitesActionResponse.model_validate(payload)
+        except ValueError as exc:
+            raise BotApiResponseError("MVN API returned an invalid customer action result") from exc
+
     async def _get(self, path: str, *, params: dict[str, object] | None = None) -> dict:
         return await self._request("GET", path, params=params)
 
-    async def _post(self, path: str, *, json: dict[str, object]) -> dict:
-        return await self._request("POST", path, json=json)
+    async def _post(
+        self,
+        path: str,
+        *,
+        json: dict[str, object],
+        timeout_seconds: float | None = None,
+    ) -> dict:
+        return await self._request("POST", path, json=json, timeout_seconds=timeout_seconds)
+
+    async def _post_multipart(
+        self,
+        path: str,
+        *,
+        data: dict[str, str],
+        files: dict[str, tuple[str, bytes, str]],
+        timeout_seconds: float,
+    ) -> dict:
+        return await self._request(
+            "POST",
+            path,
+            data=data,
+            files=files,
+            timeout_seconds=timeout_seconds,
+        )
 
     async def _request(
         self,
@@ -226,6 +392,9 @@ class BotApiGateway:
         *,
         params: dict[str, object] | None = None,
         json: dict[str, object] | None = None,
+        data: dict[str, str] | None = None,
+        files: dict[str, tuple[str, bytes, str]] | None = None,
+        timeout_seconds: float | None = None,
     ) -> dict:
         url = f"{self._config.base_url}/{path.lstrip('/')}"
         try:
@@ -235,7 +404,9 @@ class BotApiGateway:
                 headers={"Authorization": f"Bearer {self._config.token}"},
                 params=params,
                 json=json,
-                timeout=self._config.timeout_seconds,
+                data=data,
+                files=files,
+                timeout=timeout_seconds or self._config.timeout_seconds,
             )
         except (httpx.TimeoutException, httpx.TransportError) as exc:
             raise BotApiUnavailableError("MVN API is temporarily unavailable") from exc
@@ -246,6 +417,17 @@ class BotApiGateway:
             raise BotApiAuthorizationError("MVN API denied the staff action")
         if response.status_code == 409:
             raise BotApiConflictError("MVN API rejected a conflicting staff action")
+        if response.status_code == 404:
+            raise BotApiNotFoundError("MVN API resource was not found")
+        if response.status_code in {400, 413, 422}:
+            detail = "MVN API rejected the request"
+            try:
+                response_payload = response.json()
+                if isinstance(response_payload, dict) and isinstance(response_payload.get("detail"), str):
+                    detail = response_payload["detail"]
+            except ValueError:
+                pass
+            raise BotApiValidationError(detail)
         if response.status_code >= 500:
             raise BotApiUnavailableError(f"MVN API returned HTTP {response.status_code}")
         if response.status_code >= 400:

--- a/bot_app/handlers/admin.py
+++ b/bot_app/handlers/admin.py
@@ -8,9 +8,9 @@ from aiogram import Router, types, F
 from aiogram.filters import StateFilter
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.fsm.context import FSMContext
+from api_contracts.bot import BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES
 from core.database import async_session_maker
 from services.product_service import ProductService
-from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 from services.bot_order_attachment_service import BotOrderAttachmentService
 from services.bot_repair_nameplate_service import BotRepairNameplateService
 from services.bot_warranty_nameplate_service import BotWarrantyNameplateService
@@ -444,7 +444,7 @@ def _warranty_nameplate_preview_text(data: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
-def _file_too_large_message(max_bytes: int = CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES) -> str:
+def _file_too_large_message(max_bytes: int = BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES) -> str:
     max_mb = max_bytes / (1024 * 1024)
     return f"Файл слишком большой. Максимум {max_mb:g} МБ."
 
@@ -458,7 +458,7 @@ def _normalize_file_size(value: object) -> int | None:
 
 
 async def _download_telegram_file(file_id: str, *, expected_size: int | None = None) -> bytes:
-    max_bytes = CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES
+    max_bytes = BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES
     if expected_size is not None and expected_size > max_bytes:
         raise ValueError(_file_too_large_message(max_bytes))
 
@@ -493,17 +493,16 @@ async def _run_requisites_recognition(
 ):
     try:
         content = await _download_telegram_file(file_id, expected_size=_normalize_file_size(file_size))
-        async with async_session_maker() as session:
-            data = await CustomerRequisitesRecognitionService.recognize_bytes(
-                session,
+        data = (
+            await get_bot_api_gateway().recognize_customer_requisites_file(
+                telegram_id=int(telegram_user_id or 0),
                 content=content,
                 filename=filename,
                 mime_type=mime_type,
-                source="telegram",
-                telegram_user_id=telegram_user_id,
                 telegram_chat_id=telegram_chat_id,
                 telegram_message_id=telegram_message_id,
             )
+        ).model_dump(mode="json")
     except Exception as exc:
         await progress_message.edit_text(f"❌ Не удалось распознать реквизиты: {escape(str(exc))}")
         return
@@ -520,15 +519,14 @@ async def _run_requisites_text_recognition(
     telegram_message_id: int | None,
 ):
     try:
-        async with async_session_maker() as session:
-            data = await CustomerRequisitesRecognitionService.recognize_text(
-                session,
+        data = (
+            await get_bot_api_gateway().recognize_customer_requisites_text(
+                telegram_id=int(telegram_user_id or 0),
                 text=text,
-                source="telegram_text",
-                telegram_user_id=telegram_user_id,
                 telegram_chat_id=telegram_chat_id,
                 telegram_message_id=telegram_message_id,
             )
+        ).model_dump(mode="json")
     except Exception as exc:
         await progress_message.edit_text(f"❌ Не удалось распознать реквизиты: {escape(str(exc))}")
         return
@@ -581,7 +579,7 @@ async def _ask_requisites_file_action(
         )
         return
     normalized_size = _normalize_file_size(file_size)
-    if normalized_size is not None and normalized_size > CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES:
+    if normalized_size is not None and normalized_size > BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES:
         await message.answer(_file_too_large_message())
         return
     can_extract_requisites = await _is_admin_user(user_id)
@@ -1384,26 +1382,28 @@ async def confirm_requisites_recognition(callback: CallbackQuery):
     action = "create" if data.startswith("ocr_create_") else "update" if data.startswith("ocr_update_") else "cancel"
     recognition_id = int(data.rsplit("_", 1)[-1])
     try:
-        async with async_session_maker() as session:
-            if action == "cancel":
-                await CustomerRequisitesRecognitionService.cancel(session, recognition_id=recognition_id)
-                await callback.message.edit_text("Распознавание отменено.")
-                await callback.answer()
-                return
-            result = await CustomerRequisitesRecognitionService.confirm(
-                session,
-                recognition_id=recognition_id,
-                action=action,
-            )
+        result = await get_bot_api_gateway().apply_customer_requisites_action(
+            telegram_id=callback.from_user.id,
+            recognition_id=recognition_id,
+            action=action,
+        )
     except Exception as exc:
         await callback.answer(str(exc), show_alert=True)
         return
 
-    customer = result["customer"]
-    customer_id = int(customer["id"])
+    if action == "cancel":
+        await callback.message.edit_text("Распознавание отменено.")
+        await callback.answer()
+        return
+
+    customer = result.customer
+    if customer is None:
+        await callback.answer("Клиент не найден", show_alert=True)
+        return
+    customer_id = customer.id
     await callback.message.edit_text(
         f"✅ Клиент {'создан' if action == 'create' else 'обновлен'}: "
-        f"<a href=\"{escape(_manager_customer_url(customer_id))}\">{escape(str(customer.get('name') or customer_id))}</a>",
+        f"<a href=\"{escape(_manager_customer_url(customer_id))}\">{escape(customer.name or str(customer_id))}</a>",
         parse_mode="HTML",
         disable_web_page_preview=True,
     )

--- a/bot_app/handlers/work.py
+++ b/bot_app/handlers/work.py
@@ -5,16 +5,20 @@ from aiogram.types import CallbackQuery, ReplyKeyboardRemove
 
 from core.database import async_session_maker
 from services.bot_product_selection_service import BotProductSelectionService
-from services.bot_quick_order_service import BotQuickOrderService
 from services.bot_service import BotService
 from ..access_runtime import get_bot_access_context
-from ..api_gateway import BotApiAuthorizationError, BotApiConflictError
+from ..api_gateway import BotApiAuthorizationError, BotApiConflictError, BotApiError
 from ..api_runtime import get_bot_api_gateway
 from ..keyboards import (
     get_staff_main_menu,
     quick_order_confirm_keyboard,
     selection_result_keyboard,
     task_actions_keyboard,
+)
+from ..quick_order_presenter import (
+    format_quick_order_preview,
+    format_quick_order_preview_rich_html,
+    quick_order_to_dict,
 )
 from ..states import ShopState
 from ..task_presenter import build_stage_report, format_tasks, format_tasks_rich_html, task_to_dict
@@ -66,13 +70,21 @@ async def quick_order_parse(message: types.Message, state: FSMContext):
     if not text:
         await message.answer("Нужен текст заявки.")
         return
-    draft = await BotQuickOrderService.parse_text(text)
-    await state.update_data(quick_order_draft=draft)
+    response = await get_bot_api_gateway().parse_quick_order(
+        telegram_id=message.from_user.id if message.from_user else 0,
+        text=text,
+    )
+    draft = quick_order_to_dict(response.draft)
+    chat_id = message.chat.id if message.chat else 0
+    await state.update_data(
+        quick_order_draft=draft,
+        quick_order_idempotency_key=f"telegram:{chat_id}:{message.message_id}",
+    )
     keyboard = quick_order_confirm_keyboard()
-    fallback_text = BotQuickOrderService.format_draft_preview(draft)
+    fallback_text = format_quick_order_preview(draft)
     delivered = await BotService.send_rich_message(
         message.chat.id,
-        BotQuickOrderService.format_draft_preview_rich_html(draft),
+        format_quick_order_preview_rich_html(draft),
         reply_markup=keyboard,
     )
     if not delivered:
@@ -90,21 +102,29 @@ async def quick_order_create(callback: CallbackQuery, state: FSMContext):
         await callback.answer("Заказ уже создается", show_alert=False)
         return
     draft = data.get("quick_order_draft")
-    if not isinstance(draft, dict):
+    idempotency_key = str(data.get("quick_order_idempotency_key") or "").strip()
+    if not isinstance(draft, dict) or not idempotency_key:
         await callback.answer("Черновик не найден", show_alert=True)
         return
     await state.update_data(quick_order_creating=True)
     try:
-        async with async_session_maker() as session:
-            order = await BotQuickOrderService.create_order_from_draft(session, draft)
-    except Exception as exc:
+        result = await get_bot_api_gateway().create_quick_order(
+            telegram_id=callback.from_user.id,
+            idempotency_key=idempotency_key,
+            draft=draft,
+        )
+    except BotApiError:
+        await state.update_data(quick_order_creating=False)
+        raise
+    except ValueError as exc:
         await state.update_data(quick_order_creating=False)
         await callback.answer(str(exc), show_alert=True)
         return
 
     await state.clear()
+    created_label = "создан" if result.created else "уже был создан"
     await callback.message.edit_text(
-        f"✅ Заказ #{order['id']} создан.\n"
+        f"✅ Заказ #{result.order_id} {created_label}.\n"
         "Он уже доступен в менеджере и календаре, если дата была указана."
     )
     await _answer_with_staff_menu(callback.message, context)

--- a/bot_app/quick_order_presenter.py
+++ b/bot_app/quick_order_presenter.py
@@ -1,0 +1,63 @@
+"""Pure Telegram presentation helpers for API quick-order contracts."""
+
+from html import escape
+
+from api_contracts.bot import BotQuickOrderDraft
+
+
+def quick_order_to_dict(draft: BotQuickOrderDraft | dict) -> dict:
+    return BotQuickOrderDraft.model_validate(draft).model_dump(mode="json")
+
+
+def _display_target_date(draft: BotQuickOrderDraft) -> str | None:
+    return draft.target_date.strftime("%d.%m.%Y %H:%M") if draft.target_date else None
+
+
+def _address_check_text(draft: BotQuickOrderDraft) -> str | None:
+    check = draft.address_check
+    if check is None:
+        return None
+    if check.status == "confirmed" and check.suggestion:
+        return f"{check.message}: {check.suggestion}"
+    if check.suggestion:
+        return f"{check.message}. Вариант: {check.suggestion}"
+    return check.message
+
+
+def format_quick_order_preview(draft_value: BotQuickOrderDraft | dict) -> str:
+    draft = BotQuickOrderDraft.model_validate(draft_value)
+    address_check_text = _address_check_text(draft)
+    lines = [
+        "<b>Черновик заказа</b>",
+        f"Клиент: {escape(draft.name or 'не указан')}",
+        f"Телефон: {escape(draft.phone or 'не указан')}",
+        f"Адрес: {escape(draft.address or 'не указан')}",
+        f"Услуга: {escape(draft.service_label)}",
+        f"Дата: {escape(_display_target_date(draft) or 'не указана')}",
+        "",
+        f"<i>{escape(draft.request_text)}</i>",
+    ]
+    if address_check_text:
+        lines.insert(4, f"Проверка адреса: {escape(address_check_text)}")
+    return "\n".join(lines)
+
+
+def format_quick_order_preview_rich_html(
+    draft_value: BotQuickOrderDraft | dict,
+) -> str:
+    draft = BotQuickOrderDraft.model_validate(draft_value)
+    address_check_text = _address_check_text(draft)
+    rich_html = (
+        "<h3>Черновик заказа</h3>"
+        "<p>"
+        f"<b>Клиент:</b> {escape(draft.name or 'не указан')}<br/>"
+        f"<b>Телефон:</b> {escape(draft.phone or 'не указан')}<br/>"
+        f"<b>Адрес:</b> {escape(draft.address or 'не указан')}<br/>"
+        f"{('<b>Проверка адреса:</b> ' + escape(address_check_text) + '<br/>') if address_check_text else ''}"
+        f"<b>Услуга:</b> {escape(draft.service_label)}<br/>"
+        f"<b>Дата:</b> {escape(_display_target_date(draft) or 'не указана')}"
+        "</p>"
+    )
+    if draft.request_text:
+        rich_html += f"<blockquote>{escape(draft.request_text)}</blockquote>"
+    return rich_html

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -23,6 +23,7 @@ export type { Body_complete_media_worker_job } from './models/Body_complete_medi
 export type { Body_create_repair_diagnostic_lead } from './models/Body_create_repair_diagnostic_lead';
 export type { Body_import_manager_bank_statement } from './models/Body_import_manager_bank_statement';
 export type { Body_login_access_token } from './models/Body_login_access_token';
+export type { Body_recognize_internal_bot_customer_requisites_file_v1 } from './models/Body_recognize_internal_bot_customer_requisites_file_v1';
 export type { Body_recognize_manager_customer_requisites } from './models/Body_recognize_manager_customer_requisites';
 export type { Body_register_manager_external_contract } from './models/Body_register_manager_external_contract';
 export type { Body_upload_local_images } from './models/Body_upload_local_images';
@@ -35,6 +36,17 @@ export type { BotCatalogProductLookupResponse } from './models/BotCatalogProduct
 export type { BotCatalogProductResponse } from './models/BotCatalogProductResponse';
 export type { BotCatalogSearchRequest } from './models/BotCatalogSearchRequest';
 export type { BotCatalogSearchResponse } from './models/BotCatalogSearchResponse';
+export type { BotCustomerBriefResponse } from './models/BotCustomerBriefResponse';
+export type { BotCustomerRequisitesActionRequest } from './models/BotCustomerRequisitesActionRequest';
+export type { BotCustomerRequisitesActionResponse } from './models/BotCustomerRequisitesActionResponse';
+export type { BotCustomerRequisitesRecognitionResponse } from './models/BotCustomerRequisitesRecognitionResponse';
+export type { BotCustomerRequisitesTextRequest } from './models/BotCustomerRequisitesTextRequest';
+export type { BotQuickOrderAddressCheck } from './models/BotQuickOrderAddressCheck';
+export type { BotQuickOrderCreateRequest } from './models/BotQuickOrderCreateRequest';
+export type { BotQuickOrderCreateResponse } from './models/BotQuickOrderCreateResponse';
+export type { BotQuickOrderDraft } from './models/BotQuickOrderDraft';
+export type { BotQuickOrderParseRequest } from './models/BotQuickOrderParseRequest';
+export type { BotQuickOrderParseResponse } from './models/BotQuickOrderParseResponse';
 export type { BotStaffContextResponse } from './models/BotStaffContextResponse';
 export type { BotTaskListRequest } from './models/BotTaskListRequest';
 export type { BotTaskListResponse } from './models/BotTaskListResponse';

--- a/manager_frontend/src/client/models/Body_recognize_internal_bot_customer_requisites_file_v1.ts
+++ b/manager_frontend/src/client/models/Body_recognize_internal_bot_customer_requisites_file_v1.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Body_recognize_internal_bot_customer_requisites_file_v1 = {
+    telegram_id: number;
+    telegram_chat_id?: (number | null);
+    telegram_message_id?: (number | null);
+    file: Blob;
+};
+

--- a/manager_frontend/src/client/models/BotCustomerBriefResponse.ts
+++ b/manager_frontend/src/client/models/BotCustomerBriefResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotCustomerBriefResponse = {
+    id: number;
+    name: string;
+    inn?: (string | null);
+    phone?: (string | null);
+    email?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/BotCustomerRequisitesActionRequest.ts
+++ b/manager_frontend/src/client/models/BotCustomerRequisitesActionRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotCustomerRequisitesActionRequest = {
+    telegram_id: number;
+    action: 'create' | 'update' | 'cancel';
+};
+

--- a/manager_frontend/src/client/models/BotCustomerRequisitesActionResponse.ts
+++ b/manager_frontend/src/client/models/BotCustomerRequisitesActionResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotCustomerBriefResponse } from './BotCustomerBriefResponse';
+import type { BotCustomerRequisitesRecognitionResponse } from './BotCustomerRequisitesRecognitionResponse';
+export type BotCustomerRequisitesActionResponse = {
+    recognition: BotCustomerRequisitesRecognitionResponse;
+    customer?: (BotCustomerBriefResponse | null);
+    changed: boolean;
+};
+

--- a/manager_frontend/src/client/models/BotCustomerRequisitesRecognitionResponse.ts
+++ b/manager_frontend/src/client/models/BotCustomerRequisitesRecognitionResponse.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotCustomerBriefResponse } from './BotCustomerBriefResponse';
+export type BotCustomerRequisitesRecognitionResponse = {
+    id: number;
+    status: 'recognized' | 'confirmed' | 'cancelled';
+    source: string;
+    extracted?: Record<string, any>;
+    validation_flags?: Record<string, any>;
+    duplicate_customer?: (BotCustomerBriefResponse | null);
+    confirmed_customer_id?: (number | null);
+    confirmed_action?: ('create' | 'update' | null);
+    created_at: string;
+};
+

--- a/manager_frontend/src/client/models/BotCustomerRequisitesTextRequest.ts
+++ b/manager_frontend/src/client/models/BotCustomerRequisitesTextRequest.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotCustomerRequisitesTextRequest = {
+    telegram_id: number;
+    text: string;
+    telegram_chat_id?: (number | null);
+    telegram_message_id?: (number | null);
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderAddressCheck.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderAddressCheck.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotQuickOrderAddressCheck = {
+    status: 'unchecked' | 'not_found' | 'needs_review' | 'confirmed';
+    message: string;
+    suggestion?: (string | null);
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderCreateRequest.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderCreateRequest.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotQuickOrderDraft } from './BotQuickOrderDraft';
+export type BotQuickOrderCreateRequest = {
+    telegram_id: number;
+    idempotency_key: string;
+    draft: BotQuickOrderDraft;
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderCreateResponse.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderCreateResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotQuickOrderCreateResponse = {
+    order_id: number;
+    customer_id: number;
+    created: boolean;
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderDraft.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderDraft.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotQuickOrderAddressCheck } from './BotQuickOrderAddressCheck';
+export type BotQuickOrderDraft = {
+    name?: (string | null);
+    phone?: (string | null);
+    address?: (string | null);
+    service_type?: ('turnkey' | 'install_only' | 'pre_install' | 'maintenance' | 'repair' | 'dismantling' | null);
+    service_label: string;
+    target_date?: (string | null);
+    request_text: string;
+    parser?: 'fallback' | 'ai';
+    address_check?: (BotQuickOrderAddressCheck | null);
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderParseRequest.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderParseRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BotQuickOrderParseRequest = {
+    telegram_id: number;
+    text: string;
+};
+

--- a/manager_frontend/src/client/models/BotQuickOrderParseResponse.ts
+++ b/manager_frontend/src/client/models/BotQuickOrderParseResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { BotQuickOrderDraft } from './BotQuickOrderDraft';
+export type BotQuickOrderParseResponse = {
+    draft: BotQuickOrderDraft;
+};
+

--- a/manager_frontend/src/client/services/InternalBotV1Service.ts
+++ b/manager_frontend/src/client/services/InternalBotV1Service.ts
@@ -2,10 +2,19 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Body_recognize_internal_bot_customer_requisites_file_v1 } from '../models/Body_recognize_internal_bot_customer_requisites_file_v1';
 import type { BotApiHealthResponse } from '../models/BotApiHealthResponse';
 import type { BotCatalogProductLookupResponse } from '../models/BotCatalogProductLookupResponse';
 import type { BotCatalogSearchRequest } from '../models/BotCatalogSearchRequest';
 import type { BotCatalogSearchResponse } from '../models/BotCatalogSearchResponse';
+import type { BotCustomerRequisitesActionRequest } from '../models/BotCustomerRequisitesActionRequest';
+import type { BotCustomerRequisitesActionResponse } from '../models/BotCustomerRequisitesActionResponse';
+import type { BotCustomerRequisitesRecognitionResponse } from '../models/BotCustomerRequisitesRecognitionResponse';
+import type { BotCustomerRequisitesTextRequest } from '../models/BotCustomerRequisitesTextRequest';
+import type { BotQuickOrderCreateRequest } from '../models/BotQuickOrderCreateRequest';
+import type { BotQuickOrderCreateResponse } from '../models/BotQuickOrderCreateResponse';
+import type { BotQuickOrderParseRequest } from '../models/BotQuickOrderParseRequest';
+import type { BotQuickOrderParseResponse } from '../models/BotQuickOrderParseResponse';
 import type { BotStaffContextResponse } from '../models/BotStaffContextResponse';
 import type { BotTaskListRequest } from '../models/BotTaskListRequest';
 import type { BotTaskListResponse } from '../models/BotTaskListResponse';
@@ -151,6 +160,106 @@ export class InternalBotV1Service {
             url: '/api/internal/bot/v1/tasks/stages/{stage_id}/report',
             path: {
                 'stage_id': stageId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Parse Internal Bot Quick Order
+     * @param requestBody
+     * @returns BotQuickOrderParseResponse Successful Response
+     * @throws ApiError
+     */
+    public static parseInternalBotQuickOrderV1(
+        requestBody: BotQuickOrderParseRequest,
+    ): CancelablePromise<BotQuickOrderParseResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/quick-orders/parse',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Internal Bot Quick Order
+     * @param requestBody
+     * @returns BotQuickOrderCreateResponse Successful Response
+     * @throws ApiError
+     */
+    public static createInternalBotQuickOrderV1(
+        requestBody: BotQuickOrderCreateRequest,
+    ): CancelablePromise<BotQuickOrderCreateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/quick-orders',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Recognize Internal Bot Customer Requisites Text
+     * @param requestBody
+     * @returns BotCustomerRequisitesRecognitionResponse Successful Response
+     * @throws ApiError
+     */
+    public static recognizeInternalBotCustomerRequisitesTextV1(
+        requestBody: BotCustomerRequisitesTextRequest,
+    ): CancelablePromise<BotCustomerRequisitesRecognitionResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/customers/requisites/recognize-text',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Recognize Internal Bot Customer Requisites File
+     * @param formData
+     * @returns BotCustomerRequisitesRecognitionResponse Successful Response
+     * @throws ApiError
+     */
+    public static recognizeInternalBotCustomerRequisitesFileV1(
+        formData: Body_recognize_internal_bot_customer_requisites_file_v1,
+    ): CancelablePromise<BotCustomerRequisitesRecognitionResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/customers/requisites/recognize-file',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Apply Internal Bot Customer Requisites Action
+     * @param recognitionId
+     * @param requestBody
+     * @returns BotCustomerRequisitesActionResponse Successful Response
+     * @throws ApiError
+     */
+    public static applyInternalBotCustomerRequisitesActionV1(
+        recognitionId: number,
+        requestBody: BotCustomerRequisitesActionRequest,
+    ): CancelablePromise<BotCustomerRequisitesActionResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/internal/bot/v1/customers/requisites/{recognition_id}/action',
+            path: {
+                'recognition_id': recognitionId,
             },
             body: requestBody,
             mediaType: 'application/json',

--- a/models/customer.py
+++ b/models/customer.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import Column, JSON, String
+from sqlalchemy import Column, Index, JSON, String, text
 from sqlmodel import Field, Relationship, SQLModel
 
 from .common import CustomerType, DocumentRoleType, LeadIntakeSource, LeadLossReason, LeadSegmentHint, LeadStatus
@@ -107,6 +107,28 @@ class CustomerBranch(SQLModel, table=True):
 
 class CustomerRequisitesRecognition(SQLModel, table=True):
     __tablename__ = "customer_requisites_recognition"
+    __table_args__ = (
+        Index(
+            "uq_customer_requisites_telegram_message",
+            "source",
+            "telegram_user_id",
+            "telegram_chat_id",
+            "telegram_message_id",
+            unique=True,
+            postgresql_where=text(
+                "source IN ('telegram', 'telegram_text') "
+                "AND telegram_user_id IS NOT NULL "
+                "AND telegram_chat_id IS NOT NULL "
+                "AND telegram_message_id IS NOT NULL"
+            ),
+            sqlite_where=text(
+                "source IN ('telegram', 'telegram_text') "
+                "AND telegram_user_id IS NOT NULL "
+                "AND telegram_chat_id IS NOT NULL "
+                "AND telegram_message_id IS NOT NULL"
+            ),
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
 
@@ -135,6 +157,16 @@ class CustomerRequisitesRecognition(SQLModel, table=True):
 
 
 class Lead(SQLModel, table=True):
+    __table_args__ = (
+        Index(
+            "uq_lead_bot_source_fingerprint",
+            "source_fingerprint",
+            unique=True,
+            postgresql_where=text("source = 'bot' AND source_fingerprint IS NOT NULL"),
+            sqlite_where=text("source = 'bot' AND source_fingerprint IS NOT NULL"),
+        ),
+    )
+
     id: Optional[int] = Field(default=None, primary_key=True)
 
     status: LeadStatus = Field(default=LeadStatus.new, sa_column=Column(String, index=True))

--- a/models/order.py
+++ b/models/order.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import BigInteger, Column, JSON, String, Text
+from sqlalchemy import BigInteger, Column, Index, JSON, String, Text, text
 from sqlmodel import Field, Relationship, SQLModel
 
 from .common import ClosingResult, DocumentRoleType, EquipmentStatus, LeadSource, OrderStageStatus, OrderStatus, PaymentCurrency, PaymentType
@@ -355,6 +355,18 @@ class DocumentTemplate(SQLModel, table=True):
 
 class OrderWorkStage(SQLModel, table=True):
     __tablename__ = "order_work_stage"
+    __table_args__ = (
+        Index(
+            "uq_unassigned_order_work_stage_schedule",
+            "order_id",
+            "name",
+            "start_time",
+            unique=True,
+            postgresql_where=text("installer_id IS NULL AND start_time IS NOT NULL"),
+            sqlite_where=text("installer_id IS NULL AND start_time IS NOT NULL"),
+        ),
+    )
+
     id: Optional[int] = Field(default=None, primary_key=True)
     order_id: int = Field(foreign_key="order.id", index=True)
 

--- a/openapi.json
+++ b/openapi.json
@@ -428,6 +428,248 @@
         }
       }
     },
+    "/api/internal/bot/v1/quick-orders/parse": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Parse Internal Bot Quick Order",
+        "operationId": "parse_internal_bot_quick_order_v1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotQuickOrderParseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotQuickOrderParseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/quick-orders": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Create Internal Bot Quick Order",
+        "operationId": "create_internal_bot_quick_order_v1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotQuickOrderCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotQuickOrderCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/customers/requisites/recognize-text": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Recognize Internal Bot Customer Requisites Text",
+        "operationId": "recognize_internal_bot_customer_requisites_text_v1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotCustomerRequisitesTextRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCustomerRequisitesRecognitionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/customers/requisites/recognize-file": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Recognize Internal Bot Customer Requisites File",
+        "operationId": "recognize_internal_bot_customer_requisites_file_v1",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_recognize_internal_bot_customer_requisites_file_v1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCustomerRequisitesRecognitionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ]
+      }
+    },
+    "/api/internal/bot/v1/customers/requisites/{recognition_id}/action": {
+      "post": {
+        "tags": [
+          "internal bot v1"
+        ],
+        "summary": "Apply Internal Bot Customer Requisites Action",
+        "operationId": "apply_internal_bot_customer_requisites_action_v1",
+        "security": [
+          {
+            "BotServiceBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "recognition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Recognition Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BotCustomerRequisitesActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BotCustomerRequisitesActionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/products/search": {
       "get": {
         "tags": [
@@ -18412,6 +18654,48 @@
         ],
         "title": "Body_login_access_token"
       },
+      "Body_recognize_internal_bot_customer_requisites_file_v1": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "telegram_chat_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Chat Id"
+          },
+          "telegram_message_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Message Id"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "file"
+        ],
+        "title": "Body_recognize_internal_bot_customer_requisites_file_v1"
+      },
       "Body_recognize_manager_customer_requisites": {
         "properties": {
           "file": {
@@ -18800,6 +19084,463 @@
         },
         "type": "object",
         "title": "BotCatalogSearchResponse"
+      },
+      "BotCustomerBriefResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "inn": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inn"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "BotCustomerBriefResponse"
+      },
+      "BotCustomerRequisitesActionRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "create",
+              "update",
+              "cancel"
+            ],
+            "title": "Action"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "action"
+        ],
+        "title": "BotCustomerRequisitesActionRequest"
+      },
+      "BotCustomerRequisitesActionResponse": {
+        "properties": {
+          "recognition": {
+            "$ref": "#/components/schemas/BotCustomerRequisitesRecognitionResponse"
+          },
+          "customer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCustomerBriefResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "changed": {
+            "type": "boolean",
+            "title": "Changed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "recognition",
+          "changed"
+        ],
+        "title": "BotCustomerRequisitesActionResponse"
+      },
+      "BotCustomerRequisitesRecognitionResponse": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "recognized",
+              "confirmed",
+              "cancelled"
+            ],
+            "title": "Status"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "extracted": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extracted"
+          },
+          "validation_flags": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Validation Flags"
+          },
+          "duplicate_customer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotCustomerBriefResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "confirmed_customer_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmed Customer Id"
+          },
+          "confirmed_action": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confirmed Action"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "source",
+          "created_at"
+        ],
+        "title": "BotCustomerRequisitesRecognitionResponse"
+      },
+      "BotCustomerRequisitesTextRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 12000,
+            "minLength": 20,
+            "title": "Text"
+          },
+          "telegram_chat_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Chat Id"
+          },
+          "telegram_message_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Message Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "text"
+        ],
+        "title": "BotCustomerRequisitesTextRequest"
+      },
+      "BotQuickOrderAddressCheck": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "unchecked",
+              "not_found",
+              "needs_review",
+              "confirmed"
+            ],
+            "title": "Status"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Message"
+          },
+          "suggestion": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestion"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "BotQuickOrderAddressCheck"
+      },
+      "BotQuickOrderCreateRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "idempotency_key": {
+            "type": "string",
+            "maxLength": 160,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._:-]+$",
+            "title": "Idempotency Key"
+          },
+          "draft": {
+            "$ref": "#/components/schemas/BotQuickOrderDraft"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "idempotency_key",
+          "draft"
+        ],
+        "title": "BotQuickOrderCreateRequest"
+      },
+      "BotQuickOrderCreateResponse": {
+        "properties": {
+          "order_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Order Id"
+          },
+          "customer_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Customer Id"
+          },
+          "created": {
+            "type": "boolean",
+            "title": "Created"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_id",
+          "customer_id",
+          "created"
+        ],
+        "title": "BotQuickOrderCreateResponse"
+      },
+      "BotQuickOrderDraft": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 300
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "address": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "service_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "turnkey",
+                  "install_only",
+                  "pre_install",
+                  "maintenance",
+                  "repair",
+                  "dismantling"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Type"
+          },
+          "service_label": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Service Label"
+          },
+          "target_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Date"
+          },
+          "request_text": {
+            "type": "string",
+            "maxLength": 12000,
+            "minLength": 1,
+            "title": "Request Text"
+          },
+          "parser": {
+            "type": "string",
+            "enum": [
+              "fallback",
+              "ai"
+            ],
+            "title": "Parser",
+            "default": "fallback"
+          },
+          "address_check": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotQuickOrderAddressCheck"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "service_label",
+          "request_text"
+        ],
+        "title": "BotQuickOrderDraft"
+      },
+      "BotQuickOrderParseRequest": {
+        "properties": {
+          "telegram_id": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Telegram Id"
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 12000,
+            "minLength": 1,
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram_id",
+          "text"
+        ],
+        "title": "BotQuickOrderParseRequest"
+      },
+      "BotQuickOrderParseResponse": {
+        "properties": {
+          "draft": {
+            "$ref": "#/components/schemas/BotQuickOrderDraft"
+          }
+        },
+        "type": "object",
+        "required": [
+          "draft"
+        ],
+        "title": "BotQuickOrderParseResponse"
       },
       "BotStaffContextResponse": {
         "properties": {

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -1,6 +1,6 @@
 """Private, versioned use-case API consumed by the Telegram bot service."""
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Path, Query, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_contracts.bot import (
@@ -9,6 +9,15 @@ from api_contracts.bot import (
     BotCatalogProductResponse,
     BotCatalogSearchRequest,
     BotCatalogSearchResponse,
+    BotCustomerRequisitesActionRequest,
+    BotCustomerRequisitesActionResponse,
+    BotCustomerRequisitesRecognitionResponse,
+    BotCustomerRequisitesTextRequest,
+    BotQuickOrderCreateRequest,
+    BotQuickOrderCreateResponse,
+    BotQuickOrderDraft,
+    BotQuickOrderParseRequest,
+    BotQuickOrderParseResponse,
     BotStaffContextResponse,
     BotTaskListRequest,
     BotTaskListResponse,
@@ -23,12 +32,23 @@ from core.database import get_session
 from models import OrderStageStatus
 from services.bot_access_service import BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.bot_customer_requisites_api_service import (
+    BotCustomerRequisitesAccessDeniedError,
+    BotCustomerRequisitesApiService,
+    BotCustomerRequisitesConflictError,
+    BotCustomerRequisitesNotFoundError,
+)
+from services.bot_quick_order_api_service import (
+    BotQuickOrderAccessDeniedError,
+    BotQuickOrderApiService,
+)
 from services.bot_task_mutation_service import (
     BotTaskMutationAccessDeniedError,
     BotTaskMutationConflictError,
     BotTaskMutationService,
 )
 from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
+from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
 
 
 router = APIRouter(
@@ -186,5 +206,145 @@ async def save_internal_bot_task_report(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
     return BotTaskReportSaveResponse(
         stage_id=result.stage_id,
+        changed=result.changed,
+    )
+
+
+@router.post(
+    "/quick-orders/parse",
+    response_model=BotQuickOrderParseResponse,
+    operation_id="parse_internal_bot_quick_order_v1",
+)
+async def parse_internal_bot_quick_order(
+    payload: BotQuickOrderParseRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BotQuickOrderParseResponse:
+    try:
+        draft = await BotQuickOrderApiService.parse_for_manager(
+            session,
+            telegram_id=payload.telegram_id,
+            text=payload.text,
+        )
+    except BotQuickOrderAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return BotQuickOrderParseResponse(draft=BotQuickOrderDraft.model_validate(draft))
+
+
+@router.post(
+    "/quick-orders",
+    response_model=BotQuickOrderCreateResponse,
+    operation_id="create_internal_bot_quick_order_v1",
+)
+async def create_internal_bot_quick_order(
+    payload: BotQuickOrderCreateRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BotQuickOrderCreateResponse:
+    try:
+        result = await BotQuickOrderApiService.create_for_manager(
+            session,
+            telegram_id=payload.telegram_id,
+            idempotency_key=payload.idempotency_key,
+            draft=payload.draft,
+        )
+    except BotQuickOrderAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return BotQuickOrderCreateResponse(
+        order_id=result.order_id,
+        customer_id=result.customer_id,
+        created=result.created,
+    )
+
+
+@router.post(
+    "/customers/requisites/recognize-text",
+    response_model=BotCustomerRequisitesRecognitionResponse,
+    operation_id="recognize_internal_bot_customer_requisites_text_v1",
+)
+async def recognize_internal_bot_customer_requisites_text(
+    payload: BotCustomerRequisitesTextRequest,
+    session: AsyncSession = Depends(get_session),
+) -> BotCustomerRequisitesRecognitionResponse:
+    try:
+        recognition = await BotCustomerRequisitesApiService.recognize_text_for_manager(
+            session,
+            telegram_id=payload.telegram_id,
+            text_value=payload.text,
+            telegram_chat_id=payload.telegram_chat_id,
+            telegram_message_id=payload.telegram_message_id,
+        )
+    except BotCustomerRequisitesAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return BotCustomerRequisitesRecognitionResponse.model_validate(recognition)
+
+
+@router.post(
+    "/customers/requisites/recognize-file",
+    response_model=BotCustomerRequisitesRecognitionResponse,
+    operation_id="recognize_internal_bot_customer_requisites_file_v1",
+)
+async def recognize_internal_bot_customer_requisites_file(
+    telegram_id: int = Form(ge=1),
+    telegram_chat_id: int | None = Form(default=None),
+    telegram_message_id: int | None = Form(default=None),
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+) -> BotCustomerRequisitesRecognitionResponse:
+    max_bytes = CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES
+    content = await file.read(max_bytes + 1)
+    await file.close()
+    if len(content) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="Файл слишком большой. Максимальный размер: 10 МБ",
+        )
+    try:
+        recognition = await BotCustomerRequisitesApiService.recognize_file_for_manager(
+            session,
+            telegram_id=telegram_id,
+            content=content,
+            filename=file.filename or "telegram-requisites",
+            mime_type=file.content_type or "application/octet-stream",
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+    except BotCustomerRequisitesAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return BotCustomerRequisitesRecognitionResponse.model_validate(recognition)
+
+
+@router.post(
+    "/customers/requisites/{recognition_id}/action",
+    response_model=BotCustomerRequisitesActionResponse,
+    operation_id="apply_internal_bot_customer_requisites_action_v1",
+)
+async def apply_internal_bot_customer_requisites_action(
+    payload: BotCustomerRequisitesActionRequest,
+    recognition_id: int = Path(ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> BotCustomerRequisitesActionResponse:
+    try:
+        result = await BotCustomerRequisitesApiService.apply_action_for_manager(
+            session,
+            telegram_id=payload.telegram_id,
+            recognition_id=recognition_id,
+            action=payload.action,
+        )
+    except BotCustomerRequisitesAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except BotCustomerRequisitesNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except BotCustomerRequisitesConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    return BotCustomerRequisitesActionResponse(
+        recognition=BotCustomerRequisitesRecognitionResponse.model_validate(result.recognition),
+        customer=result.customer,
         changed=result.changed,
     )

--- a/services/bot_customer_requisites_api_service.py
+++ b/services/bot_customer_requisites_api_service.py
@@ -1,0 +1,279 @@
+"""Authorized API orchestration for customer requisites received from Telegram."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CustomerRequisitesRecognition
+from services.bot_access_service import BotAccessService
+from services.customer_requisites_recognition_service import CustomerRequisitesRecognitionService
+from services.customer_service import CustomerService
+
+
+class BotCustomerRequisitesAccessDeniedError(PermissionError):
+    pass
+
+
+class BotCustomerRequisitesNotFoundError(LookupError):
+    pass
+
+
+class BotCustomerRequisitesConflictError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class BotCustomerRequisitesActionResult:
+    recognition: dict[str, Any]
+    customer: dict[str, Any] | None
+    changed: bool
+
+
+class BotCustomerRequisitesApiService:
+    @staticmethod
+    async def _require_manager(session: AsyncSession, telegram_id: int) -> None:
+        context = await BotAccessService.get_context(session, telegram_id)
+        if not context.is_staff or not context.is_manager:
+            raise BotCustomerRequisitesAccessDeniedError(
+                "Manager customer requisites access is required"
+            )
+
+    @staticmethod
+    async def _lock_message(
+        session: AsyncSession,
+        *,
+        source: str,
+        telegram_user_id: int,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> None:
+        if telegram_chat_id is None or telegram_message_id is None:
+            return
+        bind = session.get_bind()
+        if bind.dialect.name != "postgresql":
+            return
+        lock_key = (
+            f"bot-requisites:{source}:{telegram_user_id}:"
+            f"{telegram_chat_id}:{telegram_message_id}"
+        )
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:lock_key)::bigint)"),
+            {"lock_key": lock_key},
+        )
+
+    @staticmethod
+    async def _find_message_recognition(
+        session: AsyncSession,
+        *,
+        source: str,
+        telegram_user_id: int,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> CustomerRequisitesRecognition | None:
+        if telegram_chat_id is None or telegram_message_id is None:
+            return None
+        return (
+            await session.execute(
+                select(CustomerRequisitesRecognition)
+                .where(
+                    CustomerRequisitesRecognition.source == source,
+                    CustomerRequisitesRecognition.telegram_user_id == telegram_user_id,
+                    CustomerRequisitesRecognition.telegram_chat_id == telegram_chat_id,
+                    CustomerRequisitesRecognition.telegram_message_id == telegram_message_id,
+                )
+                .limit(1)
+            )
+        ).scalars().first()
+
+    @classmethod
+    async def _existing_response(
+        cls,
+        session: AsyncSession,
+        recognition: CustomerRequisitesRecognition,
+    ) -> dict[str, Any]:
+        duplicate = await CustomerRequisitesRecognitionService._find_duplicate(
+            session,
+            (recognition.extracted_json or {}).get("inn"),
+        )
+        return CustomerRequisitesRecognitionService._recognition_response(
+            recognition,
+            duplicate,
+        )
+
+    @classmethod
+    async def recognize_text_for_manager(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        text_value: str,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> dict[str, Any]:
+        await cls._require_manager(session, telegram_id)
+        source = "telegram_text"
+        await cls._lock_message(
+            session,
+            source=source,
+            telegram_user_id=telegram_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+        existing = await cls._find_message_recognition(
+            session,
+            source=source,
+            telegram_user_id=telegram_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+        if existing:
+            return await cls._existing_response(session, existing)
+        try:
+            return await CustomerRequisitesRecognitionService.recognize_text(
+                session,
+                text=text_value,
+                source=source,
+                telegram_user_id=telegram_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+            )
+        except IntegrityError:
+            await session.rollback()
+            existing = await cls._find_message_recognition(
+                session,
+                source=source,
+                telegram_user_id=telegram_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+            )
+            if not existing:
+                raise
+            return await cls._existing_response(session, existing)
+
+    @classmethod
+    async def recognize_file_for_manager(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        content: bytes,
+        filename: str,
+        mime_type: str,
+        telegram_chat_id: int | None,
+        telegram_message_id: int | None,
+    ) -> dict[str, Any]:
+        await cls._require_manager(session, telegram_id)
+        source = "telegram"
+        await cls._lock_message(
+            session,
+            source=source,
+            telegram_user_id=telegram_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+        existing = await cls._find_message_recognition(
+            session,
+            source=source,
+            telegram_user_id=telegram_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+        )
+        if existing:
+            return await cls._existing_response(session, existing)
+        try:
+            return await CustomerRequisitesRecognitionService.recognize_bytes(
+                session,
+                content=content,
+                filename=filename,
+                mime_type=mime_type,
+                source=source,
+                telegram_user_id=telegram_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+            )
+        except IntegrityError:
+            await session.rollback()
+            existing = await cls._find_message_recognition(
+                session,
+                source=source,
+                telegram_user_id=telegram_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_message_id=telegram_message_id,
+            )
+            if not existing:
+                raise
+            return await cls._existing_response(session, existing)
+
+    @classmethod
+    async def apply_action_for_manager(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        recognition_id: int,
+        action: str,
+    ) -> BotCustomerRequisitesActionResult:
+        await cls._require_manager(session, telegram_id)
+        recognition = (
+            await session.execute(
+                select(CustomerRequisitesRecognition)
+                .where(CustomerRequisitesRecognition.id == recognition_id)
+                .with_for_update()
+            )
+        ).scalars().first()
+        if not recognition:
+            raise BotCustomerRequisitesNotFoundError("Recognition not found")
+        if recognition.telegram_user_id not in {None, telegram_id}:
+            raise BotCustomerRequisitesAccessDeniedError(
+                "Recognition belongs to another Telegram user"
+            )
+
+        if recognition.status == CustomerRequisitesRecognitionService.STATUS_CONFIRMED:
+            if action != recognition.confirmed_action:
+                raise BotCustomerRequisitesConflictError(
+                    "Recognition was already confirmed with another action"
+                )
+            customer = await CustomerService.get_for_manager(
+                session=session,
+                customer_id=int(recognition.confirmed_customer_id or 0),
+            )
+            return BotCustomerRequisitesActionResult(
+                recognition=await cls._existing_response(session, recognition),
+                customer=customer,
+                changed=False,
+            )
+
+        if recognition.status == CustomerRequisitesRecognitionService.STATUS_CANCELLED:
+            if action != "cancel":
+                raise BotCustomerRequisitesConflictError("Recognition was already cancelled")
+            return BotCustomerRequisitesActionResult(
+                recognition=await cls._existing_response(session, recognition),
+                customer=None,
+                changed=False,
+            )
+
+        if action == "cancel":
+            cancelled = await CustomerRequisitesRecognitionService.cancel(
+                session,
+                recognition_id=recognition_id,
+            )
+            return BotCustomerRequisitesActionResult(
+                recognition=cancelled,
+                customer=None,
+                changed=True,
+            )
+
+        confirmed = await CustomerRequisitesRecognitionService.confirm(
+            session,
+            recognition_id=recognition_id,
+            action=action,
+        )
+        return BotCustomerRequisitesActionResult(
+            recognition=confirmed["recognition"],
+            customer=confirmed["customer"],
+            changed=True,
+        )

--- a/services/bot_quick_order_api_service.py
+++ b/services/bot_quick_order_api_service.py
@@ -1,0 +1,109 @@
+"""Authorized API orchestration for Telegram quick-order use cases."""
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_contracts.bot import BotQuickOrderDraft
+from models import Order
+from services.bot_access_service import BotAccessService
+from services.bot_quick_order_service import BotQuickOrderService
+
+
+class BotQuickOrderAccessDeniedError(PermissionError):
+    pass
+
+
+@dataclass(frozen=True)
+class BotQuickOrderCreateResult:
+    order_id: int
+    customer_id: int
+    created: bool
+
+
+class BotQuickOrderApiService:
+    @staticmethod
+    async def _require_manager(session: AsyncSession, telegram_id: int) -> None:
+        context = await BotAccessService.get_context(session, telegram_id)
+        if not context.is_staff or not context.is_manager:
+            raise BotQuickOrderAccessDeniedError("Manager quick-order access is required")
+
+    @staticmethod
+    def _request_fingerprint(*, telegram_id: int, idempotency_key: str) -> str:
+        raw = f"v1:{telegram_id}:{idempotency_key}".encode("utf-8")
+        return f"bot_quick_order:v1:{sha256(raw).hexdigest()}"
+
+    @classmethod
+    def _draft_projection(cls, draft: dict[str, Any]) -> dict[str, Any]:
+        normalized = BotQuickOrderService.normalize_draft(draft)
+        service_type = normalized.get("service_type")
+        parser = "ai" if str(normalized.get("parser") or "").strip() == "ai" else "fallback"
+        address_check = normalized.get("address_check")
+        if not isinstance(address_check, dict) or address_check.get("status") not in {
+            "unchecked",
+            "not_found",
+            "needs_review",
+            "confirmed",
+        }:
+            address_check = None
+        return {
+            "name": normalized.get("name"),
+            "phone": normalized.get("phone"),
+            "address": normalized.get("address"),
+            "service_type": service_type,
+            "service_label": BotQuickOrderService.SERVICE_LABELS.get(service_type, "Не указана"),
+            "target_date": normalized.get("target_date"),
+            "request_text": normalized.get("request_text") or "Быстрый заказ из Telegram",
+            "parser": parser,
+            "address_check": address_check,
+        }
+
+    @classmethod
+    async def parse_for_manager(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        text: str,
+    ) -> dict[str, Any]:
+        await cls._require_manager(session, telegram_id)
+        return cls._draft_projection(await BotQuickOrderService.parse_text(text))
+
+    @classmethod
+    async def create_for_manager(
+        cls,
+        session: AsyncSession,
+        *,
+        telegram_id: int,
+        idempotency_key: str,
+        draft: BotQuickOrderDraft,
+    ) -> BotQuickOrderCreateResult:
+        await cls._require_manager(session, telegram_id)
+        source_fingerprint = cls._request_fingerprint(
+            telegram_id=telegram_id,
+            idempotency_key=idempotency_key,
+        )
+        order_data = await BotQuickOrderService.create_order_from_draft(
+            session,
+            draft.model_dump(mode="json", exclude={"service_label"}),
+            source_fingerprint=source_fingerprint,
+        )
+        order_id = int(order_data.get("id") or 0)
+        if not order_id:
+            raise ValueError("Не удалось определить созданный заказ")
+
+        customer = order_data.get("customer") if isinstance(order_data.get("customer"), dict) else {}
+        customer_id = int(customer.get("id") or order_data.get("customer_id") or 0)
+        if not customer_id:
+            order = await session.get(Order, order_id)
+            customer_id = int(order.customer_id or 0) if order else 0
+        if not customer_id:
+            raise ValueError("Не удалось определить клиента заказа")
+
+        return BotQuickOrderCreateResult(
+            order_id=order_id,
+            customer_id=customer_id,
+            created=bool(order_data.get("_bot_order_created", True)),
+        )

--- a/services/bot_quick_order_service.py
+++ b/services/bot_quick_order_service.py
@@ -7,6 +7,7 @@ from html import escape
 from typing import Any, Optional
 
 import httpx
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -427,6 +428,8 @@ class BotQuickOrderService:
         cls,
         session: AsyncSession,
         draft: dict[str, Any],
+        *,
+        source_fingerprint: str | None = None,
     ) -> dict[str, Any]:
         normalized = cls.normalize_draft(draft)
         target_date = None
@@ -434,7 +437,7 @@ class BotQuickOrderService:
             target_date = datetime.fromisoformat(str(normalized["target_date"]).replace("Z", "+00:00"))
 
         request_text = normalized["request_text"] or "Быстрый заказ из Telegram"
-        source_fingerprint = cls._source_fingerprint(normalized)
+        source_fingerprint = source_fingerprint or cls._source_fingerprint(normalized)
         result = await session.execute(
             select(Lead)
             .where(Lead.source == "bot", Lead.source_fingerprint == source_fingerprint)
@@ -450,24 +453,39 @@ class BotQuickOrderService:
                 "lead": LeadService._map_lead(existing_lead),
                 "customer_id": int(converted_order.customer_id or 0),
                 "order_id": int(converted_order.id or 0),
+                "order_created": False,
             }
         else:
             if existing_lead:
                 lead_id = int(existing_lead.id or 0)
             else:
-                lead = await LeadService.create_lead(
-                    session,
-                    LeadCreatePayload(
-                        source="bot",
-                        request_text=request_text,
-                        name=normalized.get("name"),
-                        phone=normalized.get("phone"),
-                        segment_hint="b2c",
-                        source_fingerprint=source_fingerprint,
-                        next_followup_date=target_date,
-                    ),
-                )
-                lead_id = int(lead["id"])
+                try:
+                    lead = await LeadService.create_lead(
+                        session,
+                        LeadCreatePayload(
+                            source="bot",
+                            request_text=request_text,
+                            name=normalized.get("name"),
+                            phone=normalized.get("phone"),
+                            segment_hint="b2c",
+                            source_fingerprint=source_fingerprint,
+                            next_followup_date=target_date,
+                        ),
+                    )
+                    lead_id = int(lead["id"])
+                except IntegrityError:
+                    await session.rollback()
+                    concurrent_lead = (
+                        await session.execute(
+                            select(Lead).where(
+                                Lead.source == "bot",
+                                Lead.source_fingerprint == source_fingerprint,
+                            )
+                        )
+                    ).scalars().first()
+                    if not concurrent_lead:
+                        raise
+                    lead_id = int(concurrent_lead.id or 0)
             qualification = await LeadService.qualify_lead(
                 session,
                 lead_id,
@@ -505,6 +523,17 @@ class BotQuickOrderService:
         if not order:
             raise ValueError("Не удалось создать заказ")
 
+        order_created = bool(qualification.get("order_created", True))
+        if order_created:
+            try:
+                await NotificationService.notify_admins_staff_order_created(
+                    session,
+                    order_id,
+                    source_label="Telegram-бот",
+                )
+            except Exception:
+                logger.exception("BOT_QUICK_ORDER_NOTIFY_FAILED order_id=%s", order_id)
+
         if target_date and service_type != "maintenance":
             stage_payload = OrderWorkStageCreatePayload(
                 name=cls.SERVICE_LABELS.get(service_type, "Рабочая задача"),
@@ -523,16 +552,24 @@ class BotQuickOrderService:
             if existing_stage:
                 order = await OrderService.get_order_detail_for_manager(session, order_id) or order
             else:
-                updated = await OrderService.add_order_stage(session, order_id, stage_payload)
-                order = updated or order
+                try:
+                    updated = await OrderService.add_order_stage(session, order_id, stage_payload)
+                    order = updated or order
+                except IntegrityError:
+                    await session.rollback()
+                    concurrent_stage = (
+                        await session.execute(
+                            select(OrderWorkStage).where(
+                                OrderWorkStage.order_id == order_id,
+                                OrderWorkStage.name == stage_payload.name,
+                                OrderWorkStage.start_time == stage_payload.start_time,
+                                OrderWorkStage.installer_id.is_(None),
+                            )
+                        )
+                    ).scalars().first()
+                    if not concurrent_stage:
+                        raise
+                    order = await OrderService.get_order_detail_for_manager(session, order_id) or order
 
-        try:
-            await NotificationService.notify_admins_staff_order_created(
-                session,
-                order_id,
-                source_label="Telegram-бот",
-            )
-        except Exception:
-            logger.exception("BOT_QUICK_ORDER_NOTIFY_FAILED order_id=%s", order_id)
-
+        order["_bot_order_created"] = order_created
         return order

--- a/services/lead_service.py
+++ b/services/lead_service.py
@@ -380,6 +380,7 @@ class LeadService:
                 "lead": LeadService._map_lead(lead),
                 "customer_id": int(converted_order.customer_id or 0),
                 "order_id": int(converted_order.id),
+                "order_created": False,
             }
 
         name = LeadService._clean_optional(payload.name) or LeadService._clean_optional(lead.name)
@@ -493,6 +494,7 @@ class LeadService:
             "lead": LeadService._map_lead(lead),
             "customer_id": int(customer.id),
             "order_id": int(order.id),
+            "order_created": True,
         }
 
     @staticmethod

--- a/tests/integration/test_bot_quick_order_concurrency.py
+++ b/tests/integration/test_bot_quick_order_concurrency.py
@@ -1,0 +1,124 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from api_contracts.bot import BotQuickOrderDraft
+from models import (
+    Customer,
+    CustomerRequisitesRecognition,
+    Lead,
+    Order,
+    OrderWorkStage,
+    StaffUser,
+)
+from services.bot_customer_requisites_api_service import BotCustomerRequisitesApiService
+from services.bot_quick_order_api_service import BotQuickOrderApiService
+
+
+@pytest.mark.asyncio
+async def test_postgres_bot_order_and_customer_mutations_are_concurrently_idempotent(
+    db_engine,
+    monkeypatch,
+):
+    assert db_engine.dialect.name == "postgresql"
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as setup_session:
+        setup_session.add(
+            StaffUser(
+                display_name="Concurrency manager",
+                status="active",
+                roles=["manager"],
+                primary_role="manager",
+                telegram_id=987650001,
+            )
+        )
+        recognition = CustomerRequisitesRecognition(
+            source="telegram_text",
+            status="recognized",
+            telegram_user_id=987650001,
+            telegram_chat_id=-100,
+            telegram_message_id=77,
+            raw_text="ООО Конкурент УНП 123456789",
+            extracted_json={
+                "name": "ООО Конкурент",
+                "inn": "123456789",
+                "phone": "+375291234567",
+            },
+            validation_flags={"field_errors": {}, "warnings": {}, "is_valid": True},
+        )
+        setup_session.add(recognition)
+        await setup_session.commit()
+
+    notify = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "services.bot_quick_order_service.NotificationService.notify_admins_staff_order_created",
+        notify,
+    )
+    draft = BotQuickOrderDraft(
+        name="Иван",
+        phone="+375291111111",
+        address="Победы 15",
+        service_type="install_only",
+        service_label="Монтаж",
+        target_date="2026-07-20T14:00:00",
+        request_text="Монтаж, Иван, Победы 15",
+    )
+    order_barrier = asyncio.Barrier(12)
+
+    async def create_order_once():
+        async with session_factory() as session:
+            await order_barrier.wait()
+            return await BotQuickOrderApiService.create_for_manager(
+                session,
+                telegram_id=987650001,
+                idempotency_key="telegram:-100:55",
+                draft=draft,
+            )
+
+    order_results = await asyncio.gather(*(create_order_once() for _ in range(12)))
+
+    assert len({result.order_id for result in order_results}) == 1
+    assert len({result.customer_id for result in order_results}) == 1
+    assert sum(result.created for result in order_results) == 1
+    notify.assert_awaited_once()
+
+    action_barrier = asyncio.Barrier(12)
+
+    async def confirm_customer_once():
+        async with session_factory() as session:
+            await action_barrier.wait()
+            return await BotCustomerRequisitesApiService.apply_action_for_manager(
+                session,
+                telegram_id=987650001,
+                recognition_id=int(recognition.id),
+                action="create",
+            )
+
+    action_results = await asyncio.gather(*(confirm_customer_once() for _ in range(12)))
+
+    assert sum(result.changed for result in action_results) == 1
+    assert len({result.customer["id"] for result in action_results}) == 1
+
+    async with session_factory() as verification_session:
+        leads = (await verification_session.execute(select(Lead))).scalars().all()
+        orders = (await verification_session.execute(select(Order))).scalars().all()
+        stages = (await verification_session.execute(select(OrderWorkStage))).scalars().all()
+        customers = (await verification_session.execute(select(Customer))).scalars().all()
+        persisted_recognition = await verification_session.get(
+            CustomerRequisitesRecognition,
+            recognition.id,
+        )
+
+    assert len(leads) == 1
+    assert len(orders) == 1
+    assert len(stages) == 1
+    assert len(customers) == 2
+    assert persisted_recognition.status == "confirmed"

--- a/tests/unit/test_bot_admin_handler.py
+++ b/tests/unit/test_bot_admin_handler.py
@@ -1,11 +1,16 @@
 import os
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from api_contracts.bot import BotTaskListResponse, BotTaskResponse
+from api_contracts.bot import (
+    BotCustomerRequisitesRecognitionResponse,
+    BotTaskListResponse,
+    BotTaskResponse,
+)
 
 os.environ["BOT_TOKEN"] = "123:test"
 
@@ -64,6 +69,18 @@ class _DummySessionContext:
 
 def _fake_async_session_maker():
     return _DummySessionContext()
+
+
+def _recognition_response(*, source: str, extracted: dict) -> BotCustomerRequisitesRecognitionResponse:
+    return BotCustomerRequisitesRecognitionResponse(
+        id=12,
+        status="recognized",
+        source=source,
+        extracted=extracted,
+        validation_flags={"field_errors": {}, "warnings": {}, "is_valid": True},
+        duplicate_customer=None,
+        created_at=datetime(2026, 7, 17, 12, 0),
+    )
 
 
 def test_admin_handler_has_no_direct_dao_import():
@@ -210,27 +227,20 @@ async def test_requisites_file_sends_preview_for_admin(monkeypatch):
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     monkeypatch.setattr(admin_handler, "_download_telegram_file", AsyncMock(return_value=b"image"))
 
-    async def fake_recognize(session, **kwargs):
-        assert kwargs["content"] == b"image"
-        assert kwargs["source"] == "telegram"
-        return {
-            "id": 12,
-            "status": "recognized",
-            "source": "telegram",
-            "raw_text": "raw",
-            "extracted": {
+    recognize = AsyncMock(
+        return_value=_recognition_response(
+            source="telegram",
+            extracted={
                 "name": "ООО Тест",
                 "inn": "123456789",
                 "signer_name": "Иванова Ивана Ивановича",
                 "signer_position": "директора",
                 "acting_basis": "Устава",
             },
-            "validation_flags": {"field_errors": {}, "warnings": {}, "is_valid": True},
-            "duplicate_customer": None,
-        }
-
-    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", fake_recognize)
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+        )
+    )
+    gateway = SimpleNamespace(recognize_customer_requisites_file=recognize)
+    monkeypatch.setattr(admin_handler, "get_bot_api_gateway", lambda: gateway)
 
     await admin_handler._handle_requisites_file(
         message,
@@ -243,6 +253,14 @@ async def test_requisites_file_sends_preview_for_admin(monkeypatch):
     args, kwargs = progress.edit_text.await_args
     assert "ООО Тест" in args[0]
     assert kwargs["parse_mode"] == "HTML"
+    recognize.assert_awaited_once_with(
+        telegram_id=5,
+        content=b"image",
+        filename="req.png",
+        mime_type="image/png",
+        telegram_chat_id=100,
+        telegram_message_id=55,
+    )
 
 
 @pytest.mark.asyncio
@@ -261,29 +279,19 @@ async def test_requisites_text_sends_preview_for_admin(monkeypatch):
 
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
 
-    async def fake_recognize(session, **kwargs):
-        assert "МегаЕвроКлимат" in kwargs["text"]
-        assert kwargs["source"] == "telegram_text"
-        assert kwargs["telegram_user_id"] == 5
-        assert kwargs["telegram_chat_id"] == 100
-        assert kwargs["telegram_message_id"] == 55
-        return {
-            "id": 12,
-            "status": "recognized",
-            "source": "telegram_text",
-            "raw_text": kwargs["text"],
-            "extracted": {
+    recognize = AsyncMock(
+        return_value=_recognition_response(
+            source="telegram_text",
+            extracted={
                 "name": "ЧУП «МегаЕвроКлимат»",
                 "inn": "392053942",
                 "iban": "BY83BPSB30123542950119330000",
                 "bic": "BPSBBY2X",
             },
-            "validation_flags": {"field_errors": {}, "warnings": {}, "is_valid": True},
-            "duplicate_customer": None,
-        }
-
-    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_text", fake_recognize)
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+        )
+    )
+    gateway = SimpleNamespace(recognize_customer_requisites_text=recognize)
+    monkeypatch.setattr(admin_handler, "get_bot_api_gateway", lambda: gateway)
 
     await admin_handler.recognize_requisites_text(message)
 
@@ -293,6 +301,11 @@ async def test_requisites_text_sends_preview_for_admin(monkeypatch):
     assert "МегаЕвроКлимат" in args[0]
     assert "392053942" in args[0]
     assert kwargs["parse_mode"] == "HTML"
+    recognize.assert_awaited_once()
+    assert "МегаЕвроКлимат" in recognize.await_args.kwargs["text"]
+    assert recognize.await_args.kwargs["telegram_id"] == 5
+    assert recognize.await_args.kwargs["telegram_chat_id"] == 100
+    assert recognize.await_args.kwargs["telegram_message_id"] == 55
 
 
 @pytest.mark.asyncio
@@ -319,7 +332,8 @@ async def test_requisites_photo_prompts_for_action_without_recognition(monkeypat
     monkeypatch.setattr(admin_handler, "_is_staff_user", AsyncMock(return_value=True))
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     recognize_mock = AsyncMock()
-    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", recognize_mock)
+    gateway = SimpleNamespace(recognize_customer_requisites_file=recognize_mock)
+    monkeypatch.setattr(admin_handler, "get_bot_api_gateway", lambda: gateway)
 
     await admin_handler.recognize_requisites_photo(message, state)
 
@@ -415,7 +429,7 @@ async def test_requisites_document_rejects_large_file_before_pending(monkeypatch
         file_id="large-pdf-file",
         file_name="large.pdf",
         mime_type="application/pdf",
-        file_size=admin_handler.CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES + 1,
+        file_size=admin_handler.BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES + 1,
     )
     state = _DummyState({})
 
@@ -438,7 +452,7 @@ async def test_download_telegram_file_rejects_large_metadata_before_download(mon
         get_file=AsyncMock(
             return_value=SimpleNamespace(
                 file_path="documents/large.pdf",
-                file_size=admin_handler.CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES + 1,
+                file_size=admin_handler.BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES + 1,
             )
         ),
         download_file=download_file,
@@ -486,25 +500,14 @@ async def test_requisites_file_extract_callback_runs_recognition(monkeypatch):
     monkeypatch.setattr(admin_handler, "_is_admin_user", AsyncMock(return_value=True))
     monkeypatch.setattr(admin_handler, "_download_telegram_file", AsyncMock(return_value=b"image"))
 
-    async def fake_recognize(session, **kwargs):
-        assert kwargs["content"] == b"image"
-        assert kwargs["filename"] == "req.png"
-        assert kwargs["mime_type"] == "image/png"
-        assert kwargs["telegram_user_id"] == 5
-        assert kwargs["telegram_chat_id"] == 200
-        assert kwargs["telegram_message_id"] == 77
-        return {
-            "id": 12,
-            "status": "recognized",
-            "source": "telegram",
-            "raw_text": "raw",
-            "extracted": {"name": "ООО Тест", "inn": "123456789"},
-            "validation_flags": {"field_errors": {}, "warnings": {}, "is_valid": True},
-            "duplicate_customer": None,
-        }
-
-    monkeypatch.setattr(admin_handler.CustomerRequisitesRecognitionService, "recognize_bytes", fake_recognize)
-    monkeypatch.setattr(admin_handler, "async_session_maker", _fake_async_session_maker)
+    recognize = AsyncMock(
+        return_value=_recognition_response(
+            source="telegram",
+            extracted={"name": "ООО Тест", "inn": "123456789"},
+        )
+    )
+    gateway = SimpleNamespace(recognize_customer_requisites_file=recognize)
+    monkeypatch.setattr(admin_handler, "get_bot_api_gateway", lambda: gateway)
 
     await admin_handler.extract_pending_requisites_file(callback, state)
 
@@ -514,6 +517,14 @@ async def test_requisites_file_extract_callback_runs_recognition(monkeypatch):
     final_args, final_kwargs = callback.message.edit_text.await_args
     assert "ООО Тест" in final_args[0]
     assert final_kwargs["parse_mode"] == "HTML"
+    recognize.assert_awaited_once_with(
+        telegram_id=5,
+        content=b"image",
+        filename="req.png",
+        mime_type="image/png",
+        telegram_chat_id=200,
+        telegram_message_id=77,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_api_gateway.py
+++ b/tests/unit/test_bot_api_gateway.py
@@ -289,3 +289,126 @@ async def test_bot_api_gateway_maps_task_conflict():
                 stage_id=7,
                 status="in_progress",
             )
+
+
+async def test_bot_api_gateway_parses_and_creates_quick_order_with_stable_key():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/quick-orders/parse"):
+            assert request.content == '{"telegram_id":123,"text":"ТО Иван"}'.encode()
+            return httpx.Response(
+                200,
+                json={
+                    "draft": {
+                        "name": "Иван",
+                        "phone": "+375291234567",
+                        "service_type": "maintenance",
+                        "service_label": "Обслуживание",
+                        "request_text": "ТО Иван",
+                        "parser": "fallback",
+                    }
+                },
+            )
+        assert request.url.path.endswith("/quick-orders")
+        body = request.content.decode()
+        assert '"idempotency_key":"telegram:-100:55"' in body
+        assert '"service_label":"Обслуживание"' in body
+        return httpx.Response(
+            200,
+            json={"order_id": 42, "customer_id": 7, "created": True},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        parsed = await gateway.parse_quick_order(telegram_id=123, text="  ТО Иван  ")
+        created = await gateway.create_quick_order(
+            telegram_id=123,
+            idempotency_key="telegram:-100:55",
+            draft=parsed.draft,
+        )
+
+    assert len(requests) == 2
+    assert parsed.draft.service_type == "maintenance"
+    assert created.order_id == 42
+    assert created.created is True
+
+
+async def test_bot_api_gateway_sends_requisites_file_as_multipart():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/customers/requisites/recognize-file")
+        assert request.headers["content-type"].startswith("multipart/form-data; boundary=")
+        assert b'name="telegram_id"' in request.content
+        assert b"123" in request.content
+        assert b'filename="req.png"' in request.content
+        assert b"image-bytes" in request.content
+        return httpx.Response(
+            200,
+            json={
+                "id": 12,
+                "status": "recognized",
+                "source": "telegram",
+                "extracted": {"name": "ООО Тест"},
+                "validation_flags": {},
+                "duplicate_customer": None,
+                "created_at": "2026-07-17T12:00:00",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.recognize_customer_requisites_file(
+            telegram_id=123,
+            content=b"image-bytes",
+            filename="req.png",
+            mime_type="image/png",
+            telegram_chat_id=-100,
+            telegram_message_id=55,
+        )
+
+    assert response.id == 12
+    assert response.extracted["name"] == "ООО Тест"
+
+
+async def test_bot_api_gateway_applies_customer_requisites_action():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/customers/requisites/12/action")
+        assert request.content == b'{"telegram_id":123,"action":"create"}'
+        return httpx.Response(
+            200,
+            json={
+                "recognition": {
+                    "id": 12,
+                    "status": "confirmed",
+                    "source": "telegram_text",
+                    "extracted": {"name": "ООО Тест"},
+                    "validation_flags": {},
+                    "confirmed_customer_id": 7,
+                    "confirmed_action": "create",
+                    "created_at": "2026-07-17T12:00:00",
+                },
+                "customer": {"id": 7, "name": "ООО Тест"},
+                "changed": False,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        gateway = BotApiGateway(
+            BotApiGatewayConfig(base_url="https://api.mvn.by/api/internal/bot/v1", token="secret"),
+            client=client,
+        )
+        response = await gateway.apply_customer_requisites_action(
+            telegram_id=123,
+            recognition_id=12,
+            action="create",
+        )
+
+    assert response.customer.id == 7
+    assert response.changed is False

--- a/tests/unit/test_bot_customer_requisites_api_service.py
+++ b/tests/unit/test_bot_customer_requisites_api_service.py
@@ -1,0 +1,103 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlmodel import select
+
+from models import Customer, CustomerRequisitesRecognition, StaffUser
+from services.bot_customer_requisites_api_service import (
+    BotCustomerRequisitesAccessDeniedError,
+    BotCustomerRequisitesApiService,
+)
+
+
+async def _add_manager(db, telegram_id: int) -> None:
+    db.add(
+        StaffUser(
+            display_name=f"Manager {telegram_id}",
+            status="active",
+            roles=["manager"],
+            primary_role="manager",
+            telegram_id=telegram_id,
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_requisites_text_recognition_reuses_same_telegram_message(db, monkeypatch):
+    await _add_manager(db, 2001)
+    extract = AsyncMock(
+        return_value={
+            "name": "ООО Тест",
+            "inn": "123456789",
+            "phone": "+375291234567",
+        }
+    )
+    monkeypatch.setattr(
+        "services.customer_requisites_recognition_service.CustomerRequisitesRecognitionService.extract_requisites",
+        extract,
+    )
+
+    kwargs = {
+        "telegram_id": 2001,
+        "text_value": "ООО Тест, УНП 123456789, банк и расчетный счет",
+        "telegram_chat_id": -100,
+        "telegram_message_id": 55,
+    }
+    first = await BotCustomerRequisitesApiService.recognize_text_for_manager(db, **kwargs)
+    repeated = await BotCustomerRequisitesApiService.recognize_text_for_manager(db, **kwargs)
+
+    assert first["id"] == repeated["id"]
+    assert extract.await_count == 1
+    rows = (await db.execute(select(CustomerRequisitesRecognition))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_requisites_confirmation_is_idempotent_and_bound_to_owner(db):
+    await _add_manager(db, 2002)
+    await _add_manager(db, 2003)
+    recognition = CustomerRequisitesRecognition(
+        source="telegram_text",
+        status="recognized",
+        telegram_user_id=2002,
+        telegram_chat_id=-100,
+        telegram_message_id=77,
+        raw_text="ООО Тест УНП 123456789",
+        extracted_json={
+            "name": "ООО Тест",
+            "inn": "123456789",
+            "phone": "+375291234567",
+        },
+        validation_flags={"field_errors": {}, "warnings": {}, "is_valid": True},
+    )
+    db.add(recognition)
+    await db.commit()
+    await db.refresh(recognition)
+
+    first = await BotCustomerRequisitesApiService.apply_action_for_manager(
+        db,
+        telegram_id=2002,
+        recognition_id=int(recognition.id),
+        action="create",
+    )
+    repeated = await BotCustomerRequisitesApiService.apply_action_for_manager(
+        db,
+        telegram_id=2002,
+        recognition_id=int(recognition.id),
+        action="create",
+    )
+
+    assert first.changed is True
+    assert repeated.changed is False
+    assert repeated.customer["id"] == first.customer["id"]
+    customers = (await db.execute(select(Customer))).scalars().all()
+    assert len(customers) == 1
+
+    with pytest.raises(BotCustomerRequisitesAccessDeniedError):
+        await BotCustomerRequisitesApiService.apply_action_for_manager(
+            db,
+            telegram_id=2003,
+            recognition_id=int(recognition.id),
+            action="create",
+        )

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -66,3 +66,24 @@ def test_bot_task_presenter_does_not_import_backend_runtime_layers():
     source = Path("bot_app/task_presenter.py").read_text(encoding="utf-8")
     for forbidden in ("from core.database", "from models", "from crud", "from services"):
         assert forbidden not in source, f"task presenter imports backend layer: {forbidden}"
+
+
+def test_bot_quick_order_paths_use_api_instead_of_backend_service():
+    source = Path("bot_app/handlers/work.py").read_text(encoding="utf-8")
+    assert "BotQuickOrderService" not in source
+    assert "get_bot_api_gateway().parse_quick_order" in source
+    assert "get_bot_api_gateway().create_quick_order" in source
+
+
+def test_bot_customer_requisites_paths_use_api_instead_of_backend_service():
+    source = Path("bot_app/handlers/admin.py").read_text(encoding="utf-8")
+    assert "CustomerRequisitesRecognitionService" not in source
+    assert "get_bot_api_gateway().recognize_customer_requisites_file" in source
+    assert "get_bot_api_gateway().recognize_customer_requisites_text" in source
+    assert "get_bot_api_gateway().apply_customer_requisites_action" in source
+
+
+def test_bot_quick_order_presenter_does_not_import_backend_runtime_layers():
+    source = Path("bot_app/quick_order_presenter.py").read_text(encoding="utf-8")
+    for forbidden in ("from core.database", "from models", "from crud", "from services"):
+        assert forbidden not in source, f"quick-order presenter imports backend layer: {forbidden}"

--- a/tests/unit/test_bot_quick_order_api_service.py
+++ b/tests/unit/test_bot_quick_order_api_service.py
@@ -1,0 +1,127 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_contracts.bot import BotQuickOrderDraft
+from models import StaffUser
+from services.bot_quick_order_api_service import (
+    BotQuickOrderAccessDeniedError,
+    BotQuickOrderApiService,
+)
+
+
+async def _add_staff(db, *, telegram_id: int, primary_role: str) -> None:
+    db.add(
+        StaffUser(
+            display_name=f"Staff {telegram_id}",
+            status="active",
+            roles=[primary_role],
+            primary_role=primary_role,
+            telegram_id=telegram_id,
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_quick_order_api_parse_authorizes_manager_and_projects_stable_draft(db, monkeypatch):
+    await _add_staff(db, telegram_id=1001, primary_role="manager")
+    parse = AsyncMock(
+        return_value={
+            "name": "Иван",
+            "phone": "+375291234567",
+            "address": "Победы 15",
+            "service_type": "maintenance",
+            "target_date": "2026-07-20T14:00:00",
+            "request_text": "ТО Иван завтра",
+            "parser": "ai",
+            "address_check": {
+                "status": "confirmed",
+                "message": "адрес найден",
+                "suggestion": "проспект Победы, 15",
+            },
+            "private_field": "must not leak",
+        }
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_api_service.BotQuickOrderService.parse_text",
+        parse,
+    )
+
+    draft = await BotQuickOrderApiService.parse_for_manager(
+        db,
+        telegram_id=1001,
+        text="ТО Иван завтра",
+    )
+
+    assert draft["service_label"] == "Обслуживание"
+    assert draft["parser"] == "ai"
+    assert draft["address_check"]["status"] == "confirmed"
+    assert "private_field" not in draft
+
+
+@pytest.mark.asyncio
+async def test_quick_order_api_denies_executor(db):
+    await _add_staff(db, telegram_id=1002, primary_role="installer")
+
+    with pytest.raises(BotQuickOrderAccessDeniedError):
+        await BotQuickOrderApiService.parse_for_manager(
+            db,
+            telegram_id=1002,
+            text="Новый заказ",
+        )
+
+
+@pytest.mark.asyncio
+async def test_quick_order_api_uses_actor_scoped_idempotency_fingerprint(db, monkeypatch):
+    await _add_staff(db, telegram_id=1003, primary_role="manager")
+    create = AsyncMock(
+        return_value={
+            "id": 42,
+            "customer": {"id": 7, "name": "Иван"},
+            "_bot_order_created": False,
+        }
+    )
+    monkeypatch.setattr(
+        "services.bot_quick_order_api_service.BotQuickOrderService.create_order_from_draft",
+        create,
+    )
+    draft = BotQuickOrderDraft(
+        name="Иван",
+        phone="+375291234567",
+        service_type="maintenance",
+        service_label="Обслуживание",
+        request_text="ТО Иван",
+    )
+
+    result = await BotQuickOrderApiService.create_for_manager(
+        db,
+        telegram_id=1003,
+        idempotency_key="telegram:-100:55",
+        draft=draft,
+    )
+
+    assert result.order_id == 42
+    assert result.customer_id == 7
+    assert result.created is False
+    assert create.await_args.kwargs["source_fingerprint"].startswith("bot_quick_order:v1:")
+    sent_draft = create.await_args.args[1]
+    assert "service_label" not in sent_draft
+
+
+def test_quick_order_request_fingerprint_is_stable_and_actor_scoped():
+    first = BotQuickOrderApiService._request_fingerprint(
+        telegram_id=1003,
+        idempotency_key="telegram:-100:55",
+    )
+    repeated = BotQuickOrderApiService._request_fingerprint(
+        telegram_id=1003,
+        idempotency_key="telegram:-100:55",
+    )
+    another_actor = BotQuickOrderApiService._request_fingerprint(
+        telegram_id=1004,
+        idempotency_key="telegram:-100:55",
+    )
+
+    assert first == repeated
+    assert first != another_actor

--- a/tests/unit/test_bot_quick_order_handlers.py
+++ b/tests/unit/test_bot_quick_order_handlers.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_contracts.bot import (
+    BotCustomerBriefResponse,
+    BotCustomerRequisitesActionResponse,
+    BotCustomerRequisitesRecognitionResponse,
+    BotQuickOrderCreateResponse,
+    BotQuickOrderDraft,
+    BotQuickOrderParseResponse,
+)
+from bot_app.handlers import admin as admin_handlers
+from bot_app.handlers import work as work_handlers
+
+
+@pytest.mark.asyncio
+async def test_quick_order_parse_uses_api_and_stores_message_idempotency_key(monkeypatch):
+    draft = BotQuickOrderDraft(
+        name="Иван",
+        phone="+375291234567",
+        address="Победы 15",
+        service_type="maintenance",
+        service_label="Обслуживание",
+        target_date="2026-07-20T14:00:00",
+        request_text="ТО Иван",
+    )
+    gateway = SimpleNamespace(
+        parse_quick_order=AsyncMock(return_value=BotQuickOrderParseResponse(draft=draft))
+    )
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(
+        work_handlers,
+        "_require_staff",
+        AsyncMock(return_value=SimpleNamespace(is_manager=True, is_staff=True)),
+    )
+    monkeypatch.setattr(work_handlers.BotService, "send_rich_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        work_handlers,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("quick order parse must not open DB")),
+    )
+    message = SimpleNamespace(
+        text=" ТО Иван ",
+        from_user=SimpleNamespace(id=123),
+        chat=SimpleNamespace(id=-100),
+        message_id=55,
+        answer=AsyncMock(),
+    )
+    state = SimpleNamespace(update_data=AsyncMock())
+
+    await work_handlers.quick_order_parse(message, state)
+
+    gateway.parse_quick_order.assert_awaited_once_with(telegram_id=123, text="ТО Иван")
+    state.update_data.assert_awaited_once()
+    assert state.update_data.await_args.kwargs["quick_order_idempotency_key"] == "telegram:-100:55"
+    assert state.update_data.await_args.kwargs["quick_order_draft"]["service_label"] == "Обслуживание"
+
+
+@pytest.mark.asyncio
+async def test_quick_order_create_uses_api_and_reports_idempotent_replay(monkeypatch):
+    gateway = SimpleNamespace(
+        create_quick_order=AsyncMock(
+            return_value=BotQuickOrderCreateResponse(
+                order_id=42,
+                customer_id=7,
+                created=False,
+            )
+        )
+    )
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(
+        work_handlers,
+        "_access_context",
+        AsyncMock(return_value=SimpleNamespace(is_staff=True, is_manager=True)),
+    )
+    monkeypatch.setattr(work_handlers, "_answer_with_staff_menu", AsyncMock())
+    draft = BotQuickOrderDraft(
+        service_label="Обслуживание",
+        service_type="maintenance",
+        request_text="ТО Иван",
+    ).model_dump(mode="json")
+
+    class State:
+        async def get_data(self):
+            return {
+                "quick_order_draft": draft,
+                "quick_order_idempotency_key": "telegram:-100:55",
+            }
+
+        update_data = AsyncMock()
+        clear = AsyncMock()
+
+    callback = SimpleNamespace(
+        from_user=SimpleNamespace(id=123),
+        message=SimpleNamespace(edit_text=AsyncMock(), answer=AsyncMock()),
+        answer=AsyncMock(),
+    )
+
+    await work_handlers.quick_order_create(callback, State())
+
+    gateway.create_quick_order.assert_awaited_once_with(
+        telegram_id=123,
+        idempotency_key="telegram:-100:55",
+        draft=draft,
+    )
+    assert "уже был создан" in callback.message.edit_text.await_args.args[0]
+    State.clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_customer_requisites_confirmation_uses_api_without_db(monkeypatch):
+    recognition = BotCustomerRequisitesRecognitionResponse(
+        id=12,
+        status="confirmed",
+        source="telegram_text",
+        extracted={"name": "ООО Тест"},
+        validation_flags={},
+        confirmed_customer_id=7,
+        confirmed_action="create",
+        created_at=datetime(2026, 7, 17, 12, 0),
+    )
+    gateway = SimpleNamespace(
+        apply_customer_requisites_action=AsyncMock(
+            return_value=BotCustomerRequisitesActionResponse(
+                recognition=recognition,
+                customer=BotCustomerBriefResponse(id=7, name="ООО Тест"),
+                changed=True,
+            )
+        )
+    )
+    monkeypatch.setattr(admin_handlers, "get_bot_api_gateway", lambda: gateway)
+    monkeypatch.setattr(admin_handlers, "_is_admin_user", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        admin_handlers,
+        "async_session_maker",
+        lambda: (_ for _ in ()).throw(AssertionError("customer action must not open DB")),
+    )
+    callback = SimpleNamespace(
+        data="ocr_create_12",
+        from_user=SimpleNamespace(id=123),
+        message=SimpleNamespace(edit_text=AsyncMock()),
+        answer=AsyncMock(),
+    )
+
+    await admin_handlers.confirm_requisites_recognition(callback)
+
+    gateway.apply_customer_requisites_action.assert_awaited_once_with(
+        telegram_id=123,
+        recognition_id=12,
+        action="create",
+    )
+    assert "ООО Тест" in callback.message.edit_text.await_args.args[0]

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -1580,12 +1580,11 @@ async def test_quick_order_create_ignores_duplicate_callback(monkeypatch):
         answer=AsyncMock(),
     )
 
-    async def fake_create_order(*args, **kwargs):
-        raise AssertionError("duplicate callback should not create order")
-
     monkeypatch.setattr(work_handlers, "_access_context", fake_access_context)
-    monkeypatch.setattr(work_handlers.BotQuickOrderService, "create_order_from_draft", fake_create_order)
+    gateway = SimpleNamespace(create_quick_order=AsyncMock())
+    monkeypatch.setattr(work_handlers, "get_bot_api_gateway", lambda: gateway)
 
     await work_handlers.quick_order_create(callback, _State())
 
     callback.answer.assert_awaited_once_with("Заказ уже создается", show_alert=False)
+    gateway.create_quick_order.assert_not_called()

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 from httpx import ASGITransport, AsyncClient
 
 from core.config import settings
@@ -5,6 +7,14 @@ from core.database import get_session
 from main import app
 from services.bot_access_service import BotAccessContext, BotAccessService
 from services.bot_catalog_service import BotCatalogAccessDeniedError, BotCatalogService
+from services.bot_customer_requisites_api_service import (
+    BotCustomerRequisitesActionResult,
+    BotCustomerRequisitesApiService,
+)
+from services.bot_quick_order_api_service import (
+    BotQuickOrderApiService,
+    BotQuickOrderCreateResult,
+)
 from services.bot_task_read_service import BotTaskAccessDeniedError, BotTaskReadService
 from services.bot_task_mutation_service import (
     BotTaskMutationAccessDeniedError,
@@ -86,6 +96,11 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     task_list = schema["paths"]["/api/internal/bot/v1/tasks/my"]["post"]
     task_status = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/status"]["post"]
     task_report = schema["paths"]["/api/internal/bot/v1/tasks/stages/{stage_id}/report"]["post"]
+    quick_order_parse = schema["paths"]["/api/internal/bot/v1/quick-orders/parse"]["post"]
+    quick_order_create = schema["paths"]["/api/internal/bot/v1/quick-orders"]["post"]
+    requisites_text = schema["paths"]["/api/internal/bot/v1/customers/requisites/recognize-text"]["post"]
+    requisites_file = schema["paths"]["/api/internal/bot/v1/customers/requisites/recognize-file"]["post"]
+    requisites_action = schema["paths"]["/api/internal/bot/v1/customers/requisites/{recognition_id}/action"]["post"]
 
     assert health["operationId"] == "get_internal_bot_api_health_v1"
     assert staff_context["operationId"] == "get_internal_bot_staff_context_v1"
@@ -94,6 +109,11 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     assert task_list["operationId"] == "list_internal_bot_my_tasks_v1"
     assert task_status["operationId"] == "update_internal_bot_task_status_v1"
     assert task_report["operationId"] == "save_internal_bot_task_report_v1"
+    assert quick_order_parse["operationId"] == "parse_internal_bot_quick_order_v1"
+    assert quick_order_create["operationId"] == "create_internal_bot_quick_order_v1"
+    assert requisites_text["operationId"] == "recognize_internal_bot_customer_requisites_text_v1"
+    assert requisites_file["operationId"] == "recognize_internal_bot_customer_requisites_file_v1"
+    assert requisites_action["operationId"] == "apply_internal_bot_customer_requisites_action_v1"
     assert health["security"] == [{"BotServiceBearer": []}]
     assert staff_context["security"] == [{"BotServiceBearer": []}]
     assert catalog_search["security"] == [{"BotServiceBearer": []}]
@@ -101,6 +121,11 @@ def test_internal_bot_api_openapi_contract_is_versioned_and_secured():
     assert task_list["security"] == [{"BotServiceBearer": []}]
     assert task_status["security"] == [{"BotServiceBearer": []}]
     assert task_report["security"] == [{"BotServiceBearer": []}]
+    assert quick_order_parse["security"] == [{"BotServiceBearer": []}]
+    assert quick_order_create["security"] == [{"BotServiceBearer": []}]
+    assert requisites_text["security"] == [{"BotServiceBearer": []}]
+    assert requisites_file["security"] == [{"BotServiceBearer": []}]
+    assert requisites_action["security"] == [{"BotServiceBearer": []}]
     assert schema["components"]["securitySchemes"]["BotServiceBearer"] == {
         "type": "http",
         "description": "Dedicated bearer token used only by the MVN Telegram bot service.",
@@ -494,3 +519,150 @@ async def test_internal_bot_task_report_normalizes_and_saves(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"stage_id": 7, "changed": False}
+
+
+async def test_internal_bot_quick_order_parse_and_create_use_stable_contract(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_parse(_session, *, telegram_id, text):
+        assert (telegram_id, text) == (123456, "ТО Иван")
+        return {
+            "name": "Иван",
+            "phone": "+375291234567",
+            "address": "Победы 15",
+            "service_type": "maintenance",
+            "service_label": "Обслуживание",
+            "target_date": "2026-07-20T14:00:00",
+            "request_text": text,
+            "parser": "fallback",
+        }
+
+    async def fake_create(_session, *, telegram_id, idempotency_key, draft):
+        assert telegram_id == 123456
+        assert idempotency_key == "telegram:-100:55"
+        assert draft.service_type == "maintenance"
+        return BotQuickOrderCreateResult(order_id=42, customer_id=7, created=True)
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotQuickOrderApiService, "parse_for_manager", fake_parse)
+    monkeypatch.setattr(BotQuickOrderApiService, "create_for_manager", fake_create)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        parsed = await _request(
+            "/api/internal/bot/v1/quick-orders/parse",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "text": " ТО Иван "},
+        )
+        created = await _request(
+            "/api/internal/bot/v1/quick-orders",
+            token="expected-token",
+            method="POST",
+            json={
+                "telegram_id": 123456,
+                "idempotency_key": "telegram:-100:55",
+                "draft": parsed.json()["draft"],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert parsed.status_code == 200
+    assert parsed.json()["draft"]["service_label"] == "Обслуживание"
+    assert created.status_code == 200
+    assert created.json() == {"order_id": 42, "customer_id": 7, "created": True}
+
+
+async def test_internal_bot_requisites_text_and_action_do_not_leak_private_fields(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+    recognition = {
+        "id": 12,
+        "status": "recognized",
+        "source": "telegram_text",
+        "raw_text": "private raw OCR text",
+        "local_file_url": "/private/file.pdf",
+        "extracted": {"name": "ООО Тест", "inn": "123456789"},
+        "validation_flags": {},
+        "duplicate_customer": None,
+        "confirmed_customer_id": None,
+        "confirmed_action": None,
+        "created_at": "2026-07-17T12:00:00",
+    }
+
+    async def fake_recognize(_session, **kwargs):
+        assert kwargs["telegram_id"] == 123456
+        assert kwargs["telegram_chat_id"] == -100
+        return recognition
+
+    async def fake_action(_session, **kwargs):
+        assert kwargs["action"] == "create"
+        confirmed = dict(recognition, status="confirmed", confirmed_customer_id=7, confirmed_action="create")
+        return BotCustomerRequisitesActionResult(
+            recognition=confirmed,
+            customer={"id": 7, "name": "ООО Тест", "inn": "123456789"},
+            changed=True,
+        )
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCustomerRequisitesApiService, "recognize_text_for_manager", fake_recognize)
+    monkeypatch.setattr(BotCustomerRequisitesApiService, "apply_action_for_manager", fake_action)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        recognized = await _request(
+            "/api/internal/bot/v1/customers/requisites/recognize-text",
+            token="expected-token",
+            method="POST",
+            json={
+                "telegram_id": 123456,
+                "text": "ООО Тест УНП 123456789 банковские реквизиты",
+                "telegram_chat_id": -100,
+                "telegram_message_id": 55,
+            },
+        )
+        action = await _request(
+            "/api/internal/bot/v1/customers/requisites/12/action",
+            token="expected-token",
+            method="POST",
+            json={"telegram_id": 123456, "action": "create"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert recognized.status_code == 200
+    assert "raw_text" not in recognized.json()
+    assert "local_file_url" not in recognized.json()
+    assert action.status_code == 200
+    assert action.json()["customer"]["id"] == 7
+    assert action.json()["changed"] is True
+
+
+async def test_internal_bot_requisites_file_enforces_size_before_service(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+    monkeypatch.setattr(
+        "routers.internal_bot.CustomerRequisitesRecognitionService.MAX_FILE_SIZE_BYTES",
+        4,
+    )
+    recognize = AsyncMock()
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotCustomerRequisitesApiService, "recognize_file_for_manager", recognize)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/internal/bot/v1/customers/requisites/recognize-file",
+                headers={"Authorization": "Bearer expected-token"},
+                data={"telegram_id": "123456"},
+                files={"file": ("large.pdf", b"12345", "application/pdf")},
+            )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 413
+    recognize.assert_not_called()

--- a/tests/unit/test_model_schema_metadata.py
+++ b/tests/unit/test_model_schema_metadata.py
@@ -113,6 +113,35 @@ def test_model_indexes_match_current_database_shape():
         for index in bank_receipt.indexes
     )
 
+    lead = SQLModel.metadata.tables["lead"]
+    assert any(
+        index.name == "uq_lead_bot_source_fingerprint"
+        and index.unique
+        and [column.name for column in index.columns] == ["source_fingerprint"]
+        and str(index.dialect_options["postgresql"]["where"])
+        == "source = 'bot' AND source_fingerprint IS NOT NULL"
+        for index in lead.indexes
+    )
+
+    recognition = SQLModel.metadata.tables["customer_requisites_recognition"]
+    assert any(
+        index.name == "uq_customer_requisites_telegram_message"
+        and index.unique
+        and [column.name for column in index.columns]
+        == ["source", "telegram_user_id", "telegram_chat_id", "telegram_message_id"]
+        for index in recognition.indexes
+    )
+
+    work_stage = SQLModel.metadata.tables["order_work_stage"]
+    assert any(
+        index.name == "uq_unassigned_order_work_stage_schedule"
+        and index.unique
+        and [column.name for column in index.columns] == ["order_id", "name", "start_time"]
+        and str(index.dialect_options["postgresql"]["where"])
+        == "installer_id IS NULL AND start_time IS NOT NULL"
+        for index in work_stage.indexes
+    )
+
 
 def test_communication_foundation_metadata_has_durable_uniqueness_and_claim_indexes():
     outbox = SQLModel.metadata.tables["integration_outbox_event"]


### PR DESCRIPTION
## Что изменено
- быстрый заказ Telegram переведён на versioned internal API и API gateway
- распознавание реквизитов из текста/файла, создание, обновление и отмена клиента переведены на API
- добавлена идемпотентность на уровне PostgreSQL для bot leads, OCR-сообщений и календарных этапов
- OpenAPI и типизированный manager client синхронизированы

## Проверки
- 2181 unit tests passed, 4 skipped
- 202 integration tests passed
- 12 параллельных quick-order запросов создают один lead/order/stage/notification
- 12 параллельных подтверждений реквизитов выполняют одно изменение клиента
- Alembic: empty DB upgrade, check, downgrade/upgrade passed
- manager frontend production build passed
- post-rebase focused suite: 171 passed