### PR TITLE
Polish compact order header transitions

### DIFF
--- a/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
+++ b/manager_frontend/src/components/orders/OrderCustomerObjectSummary.vue
@@ -71,13 +71,13 @@ const saveObject = () => {
 <template>
   <section class="mt-3 overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
     <div class="flex flex-col divide-y divide-slate-100 dark:divide-slate-800">
-      <div class="flex min-w-0 items-center gap-3 px-3 py-2.5">
-        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+      <div class="grid min-w-0 grid-cols-[2rem_minmax(0,1fr)] items-start gap-x-3 px-3 py-2.5 sm:grid-cols-[2rem_minmax(0,1fr)_auto]">
+        <span class="row-span-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
           <Building2 v-if="customer?.type === 'company'" :size="17" />
           <UserRound v-else :size="17" />
         </span>
         <div class="min-w-0 flex-1">
-          <p class="truncate text-sm font-semibold text-slate-900 dark:text-white">{{ displayName }}</p>
+          <p class="break-words text-sm font-semibold leading-5 text-slate-900 dark:text-white">{{ displayName }}</p>
           <div class="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
             <a v-if="validPhone" :href="'tel:' + phoneDigits" class="inline-flex items-center gap-1 hover:text-teal-700 dark:hover:text-teal-300">
               <Phone :size="13" /> {{ phone }}
@@ -89,7 +89,7 @@ const saveObject = () => {
             <button v-else type="button" class="font-medium text-slate-500 hover:text-teal-700 dark:hover:text-teal-300" @click="startCustomerEdit">Email не указан · добавить</button>
           </div>
         </div>
-        <div class="flex shrink-0 gap-1">
+        <div class="col-start-2 row-start-2 mt-1 flex shrink-0 gap-1 sm:col-start-3 sm:row-start-1 sm:mt-0">
           <button v-if="validPhone" type="button" class="icon-action" aria-label="Скопировать телефон" @click="emit('copy', phone, 'Телефон')"><Copy :size="15" /></button>
           <button type="button" class="icon-action" aria-label="Редактировать клиента" @click="startCustomerEdit"><Pencil :size="15" /></button>
           <button type="button" class="icon-action hidden sm:flex" aria-label="Открыть полную карточку клиента" @click="emit('open-customer')"><Route :size="15" /></button>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -589,6 +589,11 @@ const recordRepairHistoryFromOrder = async () => {
 };
 
 const customer = computed(() => props.order?.customer ?? null);
+const customerDisplayName = computed(() => (
+  customer.value?.full_legal_name
+  || customer.value?.name
+  || ''
+));
 const isWebsiteOrder = computed(() => props.order?.lead_source === 'site');
 const isB2cCustomer = computed(() => {
   if (!customer.value) return true; // defaults to B2C if unknown
@@ -2528,6 +2533,7 @@ watch(
       <OrderWorkspaceHeader
         :order-id="order?.id"
         :title="displayOrderTitle"
+        :customer-name="customerDisplayName"
         :workflow="workflowType"
         :view-model="orderWorkspace"
         :total="totalPreview"

--- a/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
+++ b/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue';
-import { Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Undo2, X } from 'lucide-vue-next';
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { ArrowRight, Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Undo2, X } from 'lucide-vue-next';
 import { formatMoney } from './order-utils';
 import { ORDER_WORKFLOW_OPTIONS, type OrderWorkflowType, type OrderWorkspaceViewModel } from './order-workspace';
+import { STICKY_HEADER_RESIZE_DURATION_MS } from '../../composables/useSmartStickyHeader';
 
 const props = defineProps<{
   orderId?: number;
   title: string;
+  customerName?: string;
   workflow: OrderWorkflowType;
   viewModel: OrderWorkspaceViewModel;
   total: number;
@@ -34,8 +36,83 @@ const editingTitle = ref(false);
 const menuOpen = ref(false);
 const titleDraft = ref('');
 const headerRef = ref<HTMLElement | null>(null);
+const contentRef = ref<HTMLElement | null>(null);
 const focusLocksCompactMode = ref(false);
 const effectiveCompact = computed(() => Boolean(props.compact && !editingTitle.value && !menuOpen.value && !focusLocksCompactMode.value));
+const showCustomerName = computed(() => {
+  const customerName = String(props.customerName || '').trim();
+  return Boolean(customerName && customerName !== String(props.title || '').trim());
+});
+let resizeAnimation: Animation | null = null;
+let contentAnimation: Animation | null = null;
+let resizeGeneration = 0;
+
+const clearResizeAnimation = () => {
+  resizeGeneration += 1;
+  resizeAnimation?.cancel();
+  resizeAnimation = null;
+  contentAnimation?.cancel();
+  contentAnimation = null;
+  headerRef.value?.style.removeProperty('overflow');
+};
+
+watch(effectiveCompact, async (isCompact) => {
+  const header = headerRef.value;
+  if (!header) return;
+  const generation = ++resizeGeneration;
+  const fromHeight = header.getBoundingClientRect().height;
+  resizeAnimation?.cancel();
+  resizeAnimation = null;
+  contentAnimation?.cancel();
+  contentAnimation = null;
+  header.style.removeProperty('overflow');
+
+  await nextTick();
+  if (generation !== resizeGeneration || headerRef.value !== header) return;
+  const toHeight = header.getBoundingClientRect().height;
+  if (
+    Math.abs(toHeight - fromHeight) < 1
+    || window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    || typeof header.animate !== 'function'
+  ) return;
+
+  header.style.overflow = 'hidden';
+  const animation = header.animate(
+    [{ height: `${fromHeight}px` }, { height: `${toHeight}px` }],
+    {
+      duration: STICKY_HEADER_RESIZE_DURATION_MS,
+      easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    },
+  );
+  resizeAnimation = animation;
+  const content = contentRef.value;
+  if (content && typeof content.animate === 'function') {
+    contentAnimation = content.animate(
+      [
+        {
+          opacity: 0.68,
+          transform: `translateY(${isCompact ? '10px' : '-10px'})`,
+        },
+        { opacity: 1, transform: 'translateY(0)' },
+      ],
+      {
+        duration: Math.round(STICKY_HEADER_RESIZE_DURATION_MS * 0.82),
+        easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+      },
+    );
+    const activeContentAnimation = contentAnimation;
+    activeContentAnimation.addEventListener('finish', () => {
+      if (contentAnimation === activeContentAnimation) contentAnimation = null;
+    }, { once: true });
+  }
+  animation.addEventListener('finish', () => {
+    if (resizeAnimation !== animation) return;
+    resizeAnimation = null;
+    header.style.removeProperty('overflow');
+  }, { once: true });
+}, { flush: 'pre' });
+
+onBeforeUnmount(clearResizeAnimation);
 
 const refreshFocusLock = () => {
   window.requestAnimationFrame(() => {
@@ -71,11 +148,12 @@ const onWorkflowChange = async (event: Event) => {
 <template>
   <header
     ref="headerRef"
-    class="sticky top-0 z-40 border-b border-slate-200 bg-white/95 px-3 shadow-sm backdrop-blur transition-[padding] duration-200 motion-reduce:transition-none dark:border-slate-700 dark:bg-slate-950/95 sm:px-5"
+    class="sticky top-0 z-40 border-b border-slate-200 bg-white/95 px-3 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-950/95 sm:px-5"
     :class="effectiveCompact ? 'py-2' : 'py-3'"
     @focusin="refreshFocusLock"
     @focusout="refreshFocusLock"
   >
+    <div ref="contentRef">
     <div class="flex gap-2 sm:gap-3" :class="effectiveCompact ? 'h-9 items-center' : 'items-start'">
       <div class="min-w-0 flex-1">
         <div v-if="effectiveCompact" class="flex min-w-0 items-center gap-2">
@@ -83,7 +161,6 @@ const onWorkflowChange = async (event: Event) => {
           <button type="button" class="min-w-0 flex-1 truncate text-left text-sm font-semibold text-slate-950 dark:text-white" title="Изменить название" @click="startTitleEdit">
             {{ title || 'Без названия' }}
           </button>
-          <span class="hidden max-w-32 shrink-0 truncate rounded-md bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300 md:inline">{{ viewModel.stageLabel }}</span>
         </div>
         <template v-else>
         <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
@@ -109,24 +186,16 @@ const onWorkflowChange = async (event: Event) => {
           </button>
         </div>
         <button v-else type="button" class="mt-1 flex max-w-full items-start gap-1.5 text-left" title="Изменить название" @click="startTitleEdit">
-          <span class="truncate text-base font-semibold text-slate-950 dark:text-white sm:text-lg">{{ title || 'Без названия' }}</span>
+          <span class="break-words text-base font-semibold leading-5 text-slate-950 dark:text-white sm:text-lg sm:leading-6">{{ title || 'Без названия' }}</span>
           <Pencil :size="14" class="mt-1 shrink-0 text-slate-400" aria-hidden="true" />
         </button>
+        <p v-if="showCustomerName" class="mt-1 break-words text-xs leading-4 text-slate-500 dark:text-slate-400">
+          {{ customerName }}
+        </p>
         </template>
       </div>
 
       <div class="flex shrink-0 items-center gap-1">
-        <button
-          v-if="effectiveCompact"
-          type="button"
-          class="btn-mini h-9 min-w-9 justify-center px-2 text-xs sm:px-3"
-          :title="viewModel.nextAction.label"
-          :aria-label="viewModel.nextAction.label"
-          @click="emit('next')"
-        >
-          <Check :size="15" />
-          <span class="hidden max-w-28 truncate lg:inline">{{ viewModel.nextAction.label }}</span>
-        </button>
         <button
           v-if="effectiveCompact && dirty"
           type="button"
@@ -138,9 +207,6 @@ const onWorkflowChange = async (event: Event) => {
         >
           <Save :size="15" />
         </button>
-        <span v-else-if="effectiveCompact" class="flex h-9 w-7 items-center justify-center text-emerald-600 dark:text-emerald-300" title="Сохранено" aria-label="Сохранено">
-          <Check :size="16" />
-        </span>
         <div class="relative">
           <button
             type="button"
@@ -163,6 +229,25 @@ const onWorkflowChange = async (event: Event) => {
           <X :size="20" />
         </button>
       </div>
+    </div>
+
+    <div v-if="effectiveCompact" class="mt-2 flex h-8 min-w-0 items-center gap-2">
+      <span
+        class="inline-flex min-w-0 max-w-[42%] items-center gap-1.5 rounded-lg bg-slate-100 px-2.5 py-1.5 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+        :title="viewModel.stageLabel"
+      >
+        <Clock3 :size="14" class="shrink-0" aria-hidden="true" />
+        <span class="truncate">{{ viewModel.stageLabel }}</span>
+      </span>
+      <button
+        type="button"
+        class="btn-mini h-8 min-w-0 flex-1 justify-center gap-1.5 px-2.5 text-xs"
+        :title="viewModel.nextAction.label"
+        @click="emit('next')"
+      >
+        <span class="truncate">{{ viewModel.nextAction.label }}</span>
+        <ArrowRight :size="14" class="shrink-0" aria-hidden="true" />
+      </button>
     </div>
 
     <div v-if="!effectiveCompact" class="mt-2.5 flex flex-wrap items-center gap-2">
@@ -201,6 +286,7 @@ const onWorkflowChange = async (event: Event) => {
           <span class="hidden sm:inline">{{ saving ? 'Сохраняем' : 'Сохранить' }}</span>
         </button>
       </div>
+    </div>
     </div>
   </header>
 </template>

--- a/manager_frontend/src/composables/useSmartStickyHeader.ts
+++ b/manager_frontend/src/composables/useSmartStickyHeader.ts
@@ -3,6 +3,7 @@ import { nextTick, onBeforeUnmount, ref, watch, type Ref } from 'vue';
 export const STICKY_HEADER_TOP_ZONE_PX = 80;
 export const STICKY_HEADER_COLLAPSE_TRAVEL_PX = 72;
 export const STICKY_HEADER_EXPAND_TRAVEL_PX = 32;
+export const STICKY_HEADER_RESIZE_DURATION_MS = 360;
 const MIN_SCROLL_DELTA_PX = 2;
 
 export type StickyHeaderMotionState = {
@@ -77,6 +78,7 @@ export const useSmartStickyHeader = (scrollContainer: Ref<HTMLElement | null>) =
   let motionState = initialStickyHeaderState();
   let frameId: number | null = null;
   let layoutFrameId: number | null = null;
+  let layoutTimerId: number | null = null;
   let layoutSyncGeneration = 0;
   let layoutSyncPending = false;
   let scrollCompensation = 0;
@@ -88,23 +90,27 @@ export const useSmartStickyHeader = (scrollContainer: Ref<HTMLElement | null>) =
 
     void nextTick(() => {
       if (generation !== layoutSyncGeneration || !currentContainer) return;
-      layoutFrameId = window.requestAnimationFrame(() => {
-        layoutFrameId = null;
-        if (generation !== layoutSyncGeneration || !currentContainer) return;
-        const rawScrollTop = currentContainer.scrollTop;
-        scrollCompensation = getStickyHeaderLayoutCompensation(
-          logicalScrollTop,
-          rawScrollTop,
-          targetCompact,
-        );
-        motionState = syncStickyHeaderAfterLayout(
-          motionState,
-          targetCompact
-            ? getStickyHeaderLogicalScrollTop(rawScrollTop, scrollCompensation)
-            : rawScrollTop,
-        );
-        layoutSyncPending = false;
-      });
+      const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      layoutTimerId = window.setTimeout(() => {
+        layoutTimerId = null;
+        layoutFrameId = window.requestAnimationFrame(() => {
+          layoutFrameId = null;
+          if (generation !== layoutSyncGeneration || !currentContainer) return;
+          const rawScrollTop = currentContainer.scrollTop;
+          scrollCompensation = getStickyHeaderLayoutCompensation(
+            logicalScrollTop,
+            rawScrollTop,
+            targetCompact,
+          );
+          motionState = syncStickyHeaderAfterLayout(
+            motionState,
+            targetCompact
+              ? getStickyHeaderLogicalScrollTop(rawScrollTop, scrollCompensation)
+              : rawScrollTop,
+          );
+          layoutSyncPending = false;
+        });
+      }, reducedMotion ? 0 : STICKY_HEADER_RESIZE_DURATION_MS);
     });
   };
 
@@ -141,6 +147,10 @@ export const useSmartStickyHeader = (scrollContainer: Ref<HTMLElement | null>) =
     if (layoutFrameId !== null) {
       window.cancelAnimationFrame(layoutFrameId);
       layoutFrameId = null;
+    }
+    if (layoutTimerId !== null) {
+      window.clearTimeout(layoutTimerId);
+      layoutTimerId = null;
     }
   };
 

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   STICKY_HEADER_COLLAPSE_TRAVEL_PX,
   STICKY_HEADER_EXPAND_TRAVEL_PX,
+  STICKY_HEADER_RESIZE_DURATION_MS,
   getStickyHeaderLayoutCompensation,
   getStickyHeaderLogicalScrollTop,
   initialStickyHeaderState,
@@ -18,6 +19,10 @@ const assert = (condition: unknown, message: string) => {
 };
 
 assert(ADDRESS_SUGGEST_DEBOUNCE_MS === 800, 'address debounce must remain 800 ms');
+assert(
+  STICKY_HEADER_RESIZE_DURATION_MS >= 300 && STICKY_HEADER_RESIZE_DURATION_MS <= 450,
+  'sticky header resize must stay quick but perceptible',
+);
 assert(!hasEnoughAddressCharacters('  а б  '), 'spaces must not count as significant address characters');
 assert(hasEnoughAddressCharacters('Мин'), 'three significant characters must enable suggestions');
 assert(buildYandexMapUrl('') === '', 'empty address must not create a map link');

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -2092,7 +2092,10 @@ class OrderService:
         # B2B = explicit company OR customer has non-empty INN.
         # B2C = everything else (including legacy orders without linked customer).
         has_inn = and_(Customer.inn.is_not(None), func.length(func.trim(Customer.inn)) > 0)
-        is_b2b = or_(Customer.type == CustomerType.company, has_inn)
+        is_b2b = or_(
+            cast(Customer.type, String) == CustomerType.company.value,
+            has_inn,
+        )
         base_filters = [Order.status != OrderStatus.NEW_LEAD]
         if segment == "b2b":
             base_filters.append(is_b2b)


### PR DESCRIPTION
## Summary
- make the sticky order header compact state readable on mobile
- animate header resize and content movement without scroll flicker
- show full customer names and keep mobile customer actions from stealing text width
- make B2B filtering tolerant of legacy varchar customer types

## Validation
- manager_frontend: pnpm run test:ui-logic
- manager_frontend: pnpm run build
- pytest tests/unit/test_order_service_manager.py -q (24 passed)
- bash scripts/audit_theme_hardcodes.sh
- local mobile browser review approved