### PR TITLE
Fix Elite Holod stock availability mapping

### DIFF
--- a/services/supplier_availability.py
+++ b/services/supplier_availability.py
@@ -20,9 +20,14 @@ INCOMING_PATTERNS = (
 OUT_PATTERNS = (
     "нет в наличии",
     "нет налич",
+    "нет на складе",
     "out of stock",
     "отсутств",
 )
+EXACT_AVAILABILITY_STATUSES = {
+    "склад": "in_stock",
+    "заказ": "incoming",
+}
 
 
 def classify_availability(raw: str | None) -> str:
@@ -30,6 +35,9 @@ def classify_availability(raw: str | None) -> str:
     if not text:
         return "unknown"
 
+    exact_status = EXACT_AVAILABILITY_STATUSES.get(text)
+    if exact_status:
+        return exact_status
     if any(p in text for p in OUT_PATTERNS):
         return "out_of_stock"
     if any(p in text for p in INCOMING_PATTERNS):

--- a/tests/unit/test_supplier_sync_parsing.py
+++ b/tests/unit/test_supplier_sync_parsing.py
@@ -29,15 +29,22 @@ def test_parse_qty_and_currency_normalization():
     assert _normalize_currency("byn") == "BYN"
     assert _parse_qty("в наличии") == 10
     assert _parse_qty("есть") == 10
+    assert _parse_qty("склад") == 10
+    assert _parse_qty("СКЛАД") == 10
     assert _parse_qty("в наличии 4 шт") == 4
+    assert _parse_qty("заказ") == 0
     assert _parse_qty("ожидается поставка") == 0
     assert _parse_qty("нет в наличии") == 0
+    assert _parse_qty("нет на складе") == 0
 
 
 def test_availability_classification():
     assert classify_availability("в наличии") == "in_stock"
+    assert classify_availability("склад") == "in_stock"
+    assert classify_availability("заказ") == "incoming"
     assert classify_availability("приход июнь-июль") == "incoming"
     assert classify_availability("нет в наличии") == "out_of_stock"
+    assert classify_availability("нет на складе") == "out_of_stock"
 
 
 def test_extract_range_start_row():


### PR DESCRIPTION
## Summary
- map exact supplier availability value `склад` to in-stock quantity fallback
- map exact value `заказ` to incoming with zero stock
- keep `нет на складе` explicitly out of stock

## Verification
- `pytest tests/unit/test_supplier_sync_parsing.py tests/unit/test_product_supply_metrics.py -q` — 8 passed
- `git diff --check`