### PR TITLE
Prevent media uploads from exhausting API memory

### DIFF
--- a/manager_frontend/src/utils/sequential-upload.ts
+++ b/manager_frontend/src/utils/sequential-upload.ts
@@ -1,0 +1,20 @@
+export type SequentialUploadProgress = {
+  completed: number;
+  total: number;
+};
+
+export const uploadSequentially = async <Item, Result>(
+  items: readonly Item[],
+  upload: (item: Item) => Promise<Result>,
+  onCompleted?: (result: Result, progress: SequentialUploadProgress) => void,
+): Promise<Result[]> => {
+  const results: Result[] = [];
+
+  for (const item of items) {
+    const result = await upload(item);
+    results.push(result);
+    onCompleted?.(result, { completed: results.length, total: items.length });
+  }
+
+  return results;
+};

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -26,6 +26,7 @@ import {
   backgroundRemovalProviderOptions,
   type BackgroundRemovalProvider,
 } from '../utils/media-processing';
+import { uploadSequentially } from '../utils/sequential-upload';
 import ImageCropSelector, { type ImageCropSourceSize, type ImageCropValue } from '../components/ImageCropSelector.vue';
 
 type MediaKind = { value: string; label: string };
@@ -49,6 +50,8 @@ const kindOptions: MediaKind[] = [
 const assets = ref<ManagerMediaAssetResponse[]>([]);
 const loading = ref(false);
 const uploading = ref(false);
+const uploadCompleted = ref(0);
+const uploadTotal = ref(0);
 const saving = ref(false);
 const deleting = ref(false);
 const processing = ref<'crop' | 'background' | ''>('');
@@ -114,6 +117,10 @@ const showBackgroundExperimentWarning = computed(() => (
   || backgroundProvider.value === 'ben'
   || (showRembgModelSelect.value && selectedBackgroundModelOption.value?.recommended === false)
 ));
+const uploadProgressLabel = computed(() => {
+  if (!uploading.value || !uploadTotal.value) return '';
+  return `${Math.min(uploadCompleted.value + 1, uploadTotal.value)}/${uploadTotal.value}`;
+});
 const activeSelectedProcessingJob = computed(() => {
   if (!selectedAsset.value) return null;
   return processingJobs.value.find((job) => (
@@ -279,18 +286,32 @@ const uploadFiles = async (files: FileList | File[]) => {
     return;
   }
   uploading.value = true;
+  uploadCompleted.value = 0;
+  uploadTotal.value = imageFiles.length;
   try {
-    const response = await api.uploadMediaAssets({
-      files: imageFiles,
-      kind: uploadKind.value,
-      tags_json: JSON.stringify(parseTags(uploadTags.value)),
-    });
-    appendUploadedAssets(response.items, response.uploaded);
-    setToast(`Загружено: ${response.uploaded}`);
+    const tagsJson = JSON.stringify(parseTags(uploadTags.value));
+    await uploadSequentially(
+      imageFiles,
+      (file) => api.uploadMediaAssets({
+        files: [file],
+        kind: uploadKind.value,
+        tags_json: tagsJson,
+      }),
+      (response, progress) => {
+        appendUploadedAssets(response.items, response.uploaded);
+        uploadCompleted.value = progress.completed;
+      },
+    );
+    setToast(`Загружено: ${uploadCompleted.value}`);
   } catch (err) {
-    setToast(mediaErrorMessage(err, 'Не удалось загрузить файлы'), 'error');
+    const prefix = uploadCompleted.value
+      ? `Загружено ${uploadCompleted.value} из ${uploadTotal.value}. `
+      : '';
+    setToast(`${prefix}${mediaErrorMessage(err, 'Не удалось загрузить файлы')}`, 'error');
   } finally {
     uploading.value = false;
+    uploadCompleted.value = 0;
+    uploadTotal.value = 0;
     dragActive.value = false;
     if (uploadInput.value) uploadInput.value.value = '';
   }
@@ -642,7 +663,7 @@ onUnmounted(() => {
           @click="uploadInput?.click()"
         >
           <UploadCloud class="h-4 w-4" />
-          {{ uploading ? 'Загрузка...' : 'Выбрать' }}
+          {{ uploading ? `Загрузка ${uploadProgressLabel}` : 'Выбрать' }}
         </button>
       </div>
       <div class="mt-2 lg:mt-3">

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -13,6 +13,7 @@ import {
   reduceStickyHeaderScroll,
   syncStickyHeaderAfterLayout,
 } from '../src/composables/useSmartStickyHeader';
+import { uploadSequentially } from '../src/utils/sequential-upload';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -82,5 +83,19 @@ assert(
   getStickyHeaderLayoutCompensation(header.lastScrollTop, 120, header.compact) === 0,
   'expanded mode must clear layout compensation',
 );
+
+const uploadOrder: number[] = [];
+const uploadProgress: string[] = [];
+const uploadResults = await uploadSequentially(
+  [1, 2, 3],
+  async (item) => {
+    uploadOrder.push(item);
+    return item * 10;
+  },
+  (_result, progress) => uploadProgress.push(`${progress.completed}/${progress.total}`),
+);
+assert(uploadOrder.join(',') === '1,2,3', 'media files must upload sequentially in selection order');
+assert(uploadResults.join(',') === '10,20,30', 'sequential upload must return every response');
+assert(uploadProgress.join(',') === '1/3,2/3,3/3', 'sequential upload must report completed file count');
 
 console.log('Address and sticky header UI logic tests passed');

--- a/routers/manager_media_library.py
+++ b/routers/manager_media_library.py
@@ -40,6 +40,7 @@ from services.product_image_processing_provider import (
 
 
 router = APIRouter(prefix="/api/manager/media/assets", tags=["manager media"])
+MAX_UPLOAD_IMAGE_BYTES = 20 * 1024 * 1024
 
 
 @router.get(
@@ -84,14 +85,23 @@ async def upload_media_assets(
         tags = json.loads(tags_json or "[]")
         if not isinstance(tags, list):
             raise ValueError("tags_json must be a JSON array")
-        file_payloads = [(item.filename, await item.read()) for item in files]
-        return await MediaLibraryService.upload_assets(
-            session=session,
-            files=file_payloads,
-            kind=kind,
-            tags=[str(item) for item in tags],
-            created_by=username,
-        )
+        if len(files) != 1:
+            raise ValueError("Upload exactly one image per request")
+
+        upload = files[0]
+        try:
+            content = await upload.read(MAX_UPLOAD_IMAGE_BYTES + 1)
+            if len(content) > MAX_UPLOAD_IMAGE_BYTES:
+                raise ValueError("Uploaded image is too large (maximum 20 MB)")
+            return await MediaLibraryService.upload_assets(
+                session=session,
+                files=[(upload.filename, content)],
+                kind=kind,
+                tags=[str(item) for item in tags],
+                created_by=username,
+            )
+        finally:
+            await upload.close()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/tests/unit/test_manager_media_library_router.py
+++ b/tests/unit/test_manager_media_library_router.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from routers.manager_media_library import MAX_UPLOAD_IMAGE_BYTES, upload_media_assets
+from services.media_library_service import MediaLibraryService
+
+
+@pytest.mark.asyncio
+async def test_upload_media_assets_rejects_batch_before_reading(monkeypatch):
+    first = UploadFile(filename="first.jpg", file=AsyncMock())
+    second = UploadFile(filename="second.jpg", file=AsyncMock())
+    upload_assets = AsyncMock()
+    monkeypatch.setattr(MediaLibraryService, "upload_assets", upload_assets)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload_media_assets(
+            files=[first, second],
+            kind="brand",
+            tags_json="[]",
+            session=AsyncMock(),
+            username="manager",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Upload exactly one image per request"
+    upload_assets.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upload_media_assets_caps_source_file_size(monkeypatch):
+    upload = AsyncMock()
+    upload.filename = "oversized.jpg"
+    upload.read.return_value = b"x" * (MAX_UPLOAD_IMAGE_BYTES + 1)
+    upload_assets = AsyncMock()
+    monkeypatch.setattr(MediaLibraryService, "upload_assets", upload_assets)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await upload_media_assets(
+            files=[upload],
+            kind="brand",
+            tags_json="[]",
+            session=AsyncMock(),
+            username="manager",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Uploaded image is too large (maximum 20 MB)"
+    upload.read.assert_awaited_once_with(MAX_UPLOAD_IMAGE_BYTES + 1)
+    upload.close.assert_awaited_once()
+    upload_assets.assert_not_awaited()


### PR DESCRIPTION
## Что исправлено
- выбранные изображения загружаются последовательно, по одному запросу на файл
- интерфейс показывает прогресс и сохраняет уже загруженные файлы при ошибке следующего
- API отклоняет пакетные multipart-запросы и исходники больше 20 МБ вместо риска OOM
- добавлены backend и UI logic тесты

## Проверка
- `pytest -q tests/unit/test_manager_media_library_router.py tests/unit/test_media_library_service.py` (18 passed)
- `npm run test:ui-logic`
- `npm run build`

## Причина
Продовые kernel/nginx логи показали OOM `uvicorn` при пакетных загрузках; Cloudflare 502 был следствием закрытия upstream, а не первичной причиной.