### PR TITLE
Restrict Telegram bot container environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
 
             echo "SECRET_KEY=dummy_secret_for_tests"
             echo "BOT_TOKEN=dummy_token"
+            echo "BOT_API_TOKEN=dummy_bot_api_token"
+            echo "BOT_API_BASE_URL=http://app:8000/api/internal/bot/v1"
+            echo "BOT_ENABLED=false"
             echo "ADMIN_USERNAME=admin"
             echo "ADMIN_PASSWORD=admin"
             echo "ENVIRONMENT=test"

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -91,10 +91,20 @@ services:
     depends_on:
       - app
     env_file:
-      - .env
       - .ha-bot-role.env
     environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       ENVIRONMENT: production
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
     mem_limit: ${MVN_PATRONI_BOT_MEMORY:-512m}
 

--- a/deploy/ha/mvn-api/docker-compose.primary.yml
+++ b/deploy/ha/mvn-api/docker-compose.primary.yml
@@ -70,18 +70,22 @@ services:
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
     restart: always
     depends_on:
-      - db
-    env_file:
-      - .env
+      - app
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       APP_ROLE: primary
-      SCHEDULER_ENABLED: "false"
       BOT_ENABLED: "true"
-      DB_BOOTSTRAP_ENABLED: "false"
-    volumes:
-      - ./media:/app/media
-      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+      ENVIRONMENT: production
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
 
 volumes:

--- a/deploy/ha/mvn-api/docker-compose.standby.yml
+++ b/deploy/ha/mvn-api/docker-compose.standby.yml
@@ -48,20 +48,22 @@ services:
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
     restart: unless-stopped
     depends_on:
-      - db
-    env_file:
-      - .env
+      - app
     environment:
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       APP_ROLE: standby
-      SCHEDULER_ENABLED: "false"
       BOT_ENABLED: "false"
-      API_READY_ENABLED: "false"
-      DB_BOOTSTRAP_ENABLED: "false"
-      BACKGROUND_REMOVAL_PROVIDER: noop
-    volumes:
-      - ./media:/app/media
-      - ./g-vision-ocr.json:/app/g-vision-ocr.json:ro
+      ENVIRONMENT: production
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
 
 volumes:

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -96,19 +96,23 @@ services:
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
+      - app
     env_file:
-      - ${MVN_RESERVE_ENV_FILE:-.env}
       - .ha-bot-role.env
     environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       ENVIRONMENT: production
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
-      BACKGROUND_REMOVAL_PROVIDER: noop
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
-    volumes:
-      - ./media:/app/media
-      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
     mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
     networks: [reserve]
 

--- a/deploy/ha/zakup/docker-compose.primary.yml
+++ b/deploy/ha/zakup/docker-compose.primary.yml
@@ -78,23 +78,23 @@ services:
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
-    env_file:
-      - ${MVN_RESERVE_ENV_FILE:-.env}
+      - app
     environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       ENVIRONMENT: production
       APP_ROLE: primary
-      SCHEDULER_ENABLED: "false"
       BOT_ENABLED: "true"
-      API_READY_ENABLED: "true"
-      DB_BOOTSTRAP_ENABLED: "false"
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
-      BACKGROUND_REMOVAL_PROVIDER: noop
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
-    volumes:
-      - ./media:/app/media
-      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
     mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
     networks:
       - reserve

--- a/deploy/ha/zakup/docker-compose.standby.yml
+++ b/deploy/ha/zakup/docker-compose.standby.yml
@@ -70,23 +70,23 @@ services:
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
-    env_file:
-      - ${MVN_RESERVE_ENV_FILE:-.env}
+      - app
     environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
       ENVIRONMENT: production
       APP_ROLE: standby
-      SCHEDULER_ENABLED: "false"
       BOT_ENABLED: "false"
-      API_READY_ENABLED: "false"
-      DB_BOOTSTRAP_ENABLED: "false"
-      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
-      BACKGROUND_REMOVAL_PROVIDER: noop
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
-    volumes:
-      - ./media:/app/media
-      - ./secrets/g-vision-ocr.json:/app/g-vision-ocr.json:ro
     mem_limit: ${MVN_RESERVE_BOT_MEMORY:-360m}
     networks:
       - reserve

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -35,8 +35,21 @@ services:
     restart: always
     depends_on:
       - app
-    env_file:
-      - .env
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:-http://app:8000/api/internal/bot/v1}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_ENABLED: ${BOT_ENABLED:-true}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
+      APP_ROLE: ${APP_ROLE:-primary}
+      ENVIRONMENT: ${ENVIRONMENT:-local}
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,10 +57,21 @@ services:
     restart: always
     depends_on:
       - app
-    env_file:
-      - .env
     environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:?set stable HTTPS BOT_API_BASE_URL in .env}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_ENABLED: ${BOT_ENABLED:-true}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
+      APP_ROLE: ${APP_ROLE:-primary}
       ENVIRONMENT: production
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     command: python -m bot_app.main
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,24 @@ services:
     restart: always
     depends_on:
       - app
-    env_file:
-      - .env
+    # Keep the bot runtime on an explicit allowlist. Compose still reads .env
+    # for interpolation, but backend/database credentials never enter the
+    # container environment.
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN:?set BOT_TOKEN in .env}
+      BOT_API_TOKEN: ${BOT_API_TOKEN:?set BOT_API_TOKEN in .env}
+      BOT_API_BASE_URL: ${BOT_API_BASE_URL:-http://app:8000/api/internal/bot/v1}
+      BOT_API_TIMEOUT_SECONDS: ${BOT_API_TIMEOUT_SECONDS:-5}
+      BOT_ENABLED: ${BOT_ENABLED:-true}
+      BOT_DROP_PENDING_UPDATES: ${BOT_DROP_PENDING_UPDATES:-false}
+      APP_ROLE: ${APP_ROLE:-primary}
+      ENVIRONMENT: ${ENVIRONMENT:-local}
+      PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-https://mvn.by}
+      PUBLIC_API_BASE: ${PUBLIC_API_BASE:-https://mvn.by/api/v1}
+      MANAGER_BASE_URL: ${MANAGER_BASE_URL:-}
+      BOT_RUNTIME_LEASE_SECONDS: ${BOT_RUNTIME_LEASE_SECONDS:-45}
+      BOT_RUNTIME_RENEW_SECONDS: ${BOT_RUNTIME_RENEW_SECONDS:-15}
+      BOT_RUNTIME_RETRY_SECONDS: ${BOT_RUNTIME_RETRY_SECONDS:-5}
     # ВАЖНО: Переопределяем команду запуска.
     # Вместо uvicorn (как в Dockerfile) запускаем бота
     command: python -m bot_app.main

--- a/scripts/ha/verify_postgres_pitr_runtime.py
+++ b/scripts/ha/verify_postgres_pitr_runtime.py
@@ -27,10 +27,10 @@ PITR_ENV_POLICIES = (*PUBLIC_PITR_ENV_POLICIES, *MIGRATION_PITR_ENV_POLICIES)
 SECRETS_FILE = Path("/etc/mvn-postgres-pitr.secrets.env")
 EXPECTED_COMPOSE_DIGESTS = {
     "/opt/air-api/docker-compose.patroni.yml": (
-        "2d30b640b36eb3081ee439215d923388d2e542d40ce9c55d0502b4b11682282e"
+        "a441113b33d7cff45d535071edc5e3afa98e7c3ac22c86a422599eb65e7ed1ce"
     ),
     "/opt/mvn-reserve/docker-compose.patroni.yml": (
-        "af02921ab9b4490017002aa08699d758486d858f16a741b72eef33feca27fff4"
+        "e68f422dd85bafa8a75dff9f0d62a904ebcdc578626921ead7b7aa66ae497fa3"
     ),
 }
 EXPECTED_PITR_CLUSTERS = {

--- a/tests/unit/test_bot_handlers_architecture.py
+++ b/tests/unit/test_bot_handlers_architecture.py
@@ -1,6 +1,37 @@
 import ast
 from pathlib import Path
 
+import yaml
+
+
+BOT_COMPOSE_PATHS = (
+    "docker-compose.yml",
+    "docker-compose.api.yml",
+    "docker-compose.prod.yml",
+    "deploy/ha/mvn-api/docker-compose.patroni.yml",
+    "deploy/ha/mvn-api/docker-compose.primary.yml",
+    "deploy/ha/mvn-api/docker-compose.standby.yml",
+    "deploy/ha/zakup/docker-compose.patroni.yml",
+    "deploy/ha/zakup/docker-compose.primary.yml",
+    "deploy/ha/zakup/docker-compose.standby.yml",
+)
+BOT_ALLOWED_ENVIRONMENT = {
+    "APP_ROLE",
+    "BOT_API_BASE_URL",
+    "BOT_API_TIMEOUT_SECONDS",
+    "BOT_API_TOKEN",
+    "BOT_DROP_PENDING_UPDATES",
+    "BOT_ENABLED",
+    "BOT_RUNTIME_LEASE_SECONDS",
+    "BOT_RUNTIME_RENEW_SECONDS",
+    "BOT_RUNTIME_RETRY_SECONDS",
+    "BOT_TOKEN",
+    "ENVIRONMENT",
+    "MANAGER_BASE_URL",
+    "PUBLIC_API_BASE",
+    "PUBLIC_SITE_URL",
+}
+
 
 def test_bot_handlers_do_not_use_direct_db_queries():
     handlers_dir = Path("bot_app/handlers")
@@ -26,16 +57,20 @@ def test_entire_bot_package_has_no_monolith_runtime_imports():
 
 
 def test_bot_compose_services_have_no_database_dependency_or_credentials():
-    for compose_path in (
-        "docker-compose.yml",
-        "docker-compose.api.yml",
-        "docker-compose.prod.yml",
-        "deploy/ha/mvn-api/docker-compose.patroni.yml",
-    ):
-        source = Path(compose_path).read_text(encoding="utf-8")
-        bot_section = source.split("\n  bot:\n", 1)[1].split("\n  ", 1)[0]
-        assert "DATABASE_URL" not in bot_section, compose_path
-        assert "- db" not in bot_section, compose_path
+    for compose_path in BOT_COMPOSE_PATHS:
+        compose = yaml.safe_load(Path(compose_path).read_text(encoding="utf-8"))
+        bot = compose["services"]["bot"]
+        dependencies = bot.get("depends_on", [])
+        dependency_names = set(dependencies if isinstance(dependencies, list) else dependencies)
+        assert "db" not in dependency_names, compose_path
+        assert "volumes" not in bot, compose_path
+
+        env_files = bot.get("env_file", [])
+        assert env_files in ([], [".ha-bot-role.env"]), compose_path
+
+        environment = bot.get("environment", {})
+        assert {"BOT_TOKEN", "BOT_API_TOKEN", "BOT_API_BASE_URL"} <= set(environment)
+        assert set(environment) <= BOT_ALLOWED_ENVIRONMENT, compose_path
 
 
 def test_bot_handlers_resolve_staff_access_only_through_bot_provider():


### PR DESCRIPTION
## Summary
- stop importing the shared backend .env into every bot container
- pass only Telegram/API/runtime settings across all local, production, and HA compose variants
- remove remaining DB dependencies, media/OCR mounts, and backend-only controls from legacy HA bot definitions
- add a repository-wide compose boundary test and refresh reviewed PITR compose digests

## Verification
- 65 focused unit tests passed
- all 9 compose files passed docker compose config --quiet --no-interpolate
- git diff --check passed

## Live finding addressed
PR #780 deployed successfully and the bot used the new API lease/polling path, but runtime inspection showed DATABASE_URL was still inherited via env_file: .env. This PR closes that last credential boundary leak.