### PR TITLE
Sync product and series media galleries

### DIFF
--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -1251,6 +1251,16 @@ export const api = {
         };
     },
 
+    async applyManagerSeriesGalleryToProducts(
+        brandId: number,
+        seriesId: number,
+        sourceUrls: string[],
+    ) {
+        return await ManagerBrandsService.applyManagerSeriesGalleryToProducts(brandId, seriesId, {
+            source_urls: sourceUrls,
+        });
+    },
+
     async deleteManagerBrandSeries(brandId: number, seriesId: number): Promise<{ message: string }> {
         return await ManagerBrandsService.deleteManagerBrandSeries(brandId, seriesId);
     },

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -283,6 +283,8 @@ export type { ManagerRepairComplaintPresetResponse } from './models/ManagerRepai
 export type { ManagerRepairComplaintPresetUpdatePayload } from './models/ManagerRepairComplaintPresetUpdatePayload';
 export type { ManagerRestoreJobStartResponse } from './models/ManagerRestoreJobStartResponse';
 export type { ManagerRestoreJobStatusResponse } from './models/ManagerRestoreJobStatusResponse';
+export type { ManagerSeriesGalleryApplyPayload } from './models/ManagerSeriesGalleryApplyPayload';
+export type { ManagerSeriesGalleryApplyResponse } from './models/ManagerSeriesGalleryApplyResponse';
 export type { ManagerServiceAttachmentAccessResponse } from './models/ManagerServiceAttachmentAccessResponse';
 export type { ManagerServiceAttachmentItemResponse } from './models/ManagerServiceAttachmentItemResponse';
 export type { ManagerServiceAttachmentListResponse } from './models/ManagerServiceAttachmentListResponse';

--- a/manager_frontend/src/client/models/ManagerSeriesGalleryApplyPayload.ts
+++ b/manager_frontend/src/client/models/ManagerSeriesGalleryApplyPayload.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerSeriesGalleryApplyPayload = {
+    source_urls: Array<string>;
+};
+

--- a/manager_frontend/src/client/models/ManagerSeriesGalleryApplyResponse.ts
+++ b/manager_frontend/src/client/models/ManagerSeriesGalleryApplyResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ManagerSeriesGalleryApplyResponse = {
+    message: string;
+    products_count: number;
+    added_links: number;
+    skipped_existing: number;
+    series_id: number;
+    images_applied: number;
+};
+

--- a/manager_frontend/src/client/services/ManagerBrandsService.ts
+++ b/manager_frontend/src/client/services/ManagerBrandsService.ts
@@ -15,6 +15,8 @@ import type { ManagerBrandSeriesListResponse } from '../models/ManagerBrandSerie
 import type { ManagerBrandSeriesResponse } from '../models/ManagerBrandSeriesResponse';
 import type { ManagerBrandSeriesUpdatePayload } from '../models/ManagerBrandSeriesUpdatePayload';
 import type { ManagerBrandUpdatePayload } from '../models/ManagerBrandUpdatePayload';
+import type { ManagerSeriesGalleryApplyPayload } from '../models/ManagerSeriesGalleryApplyPayload';
+import type { ManagerSeriesGalleryApplyResponse } from '../models/ManagerSeriesGalleryApplyResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -276,6 +278,33 @@ export class ManagerBrandsService {
                 'brand_id': brandId,
                 'series_id': seriesId,
             },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Apply Manager Series Gallery To Products
+     * @param brandId
+     * @param seriesId
+     * @param requestBody
+     * @returns ManagerSeriesGalleryApplyResponse Successful Response
+     * @throws ApiError
+     */
+    public static applyManagerSeriesGalleryToProducts(
+        brandId: number,
+        seriesId: number,
+        requestBody: ManagerSeriesGalleryApplyPayload,
+    ): CancelablePromise<ManagerSeriesGalleryApplyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/manager/brands/{brand_id}/series/{series_id}/gallery/apply-to-products',
+            path: {
+                'brand_id': brandId,
+                'series_id': seriesId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/MediaField.vue
+++ b/manager_frontend/src/components/MediaField.vue
@@ -12,6 +12,8 @@ import {
 } from 'lucide-vue-next';
 import { api, type ManagerMediaAssetResponse } from '../api';
 import { getApiErrorMessage } from '../utils/api-errors';
+import { optimizeImageForUpload } from '../utils/image-upload-optimization';
+import { uploadSequentially } from '../utils/sequential-upload';
 
 const props = withDefaults(defineProps<{
     modelValue?: string;
@@ -20,12 +22,14 @@ const props = withDefaults(defineProps<{
     tags?: string[];
     accept?: string;
     placeholder?: string;
+    multiple?: boolean;
 }>(), {
     modelValue: '',
     kind: 'misc',
     tags: () => [],
     accept: 'image/*,.svg',
     placeholder: '/media/library/original/logo.svg',
+    multiple: false,
 });
 
 const emit = defineEmits<{
@@ -41,6 +45,8 @@ type ClipboardImageItem = {
 
 const fileInput = ref<HTMLInputElement | null>(null);
 const uploading = ref(false);
+const uploadCompleted = ref(0);
+const uploadTotal = ref(0);
 const error = ref('');
 const pickerOpen = ref(false);
 const assets = ref<ManagerMediaAssetResponse[]>([]);
@@ -92,34 +98,45 @@ const rememberUploadedAsset = (asset: ManagerMediaAssetResponse) => {
 };
 
 const uploadFile = async (file: File) => {
-    uploading.value = true;
-    error.value = '';
-    try {
-        const response = await api.uploadMediaAssets({
-            files: [file],
-            kind: props.kind,
-            tags_json: JSON.stringify(props.tags || []),
-        });
-        const uploaded = response.items?.[0];
-        if (!uploaded?.url) {
-            throw new Error('Загрузка завершилась без URL файла');
-        }
-        pickedUrl(uploaded.url);
-        emit('uploaded', uploaded.url);
-        rememberUploadedAsset(uploaded);
-    } catch (err) {
-        error.value = mediaErrorMessage(err, 'Не удалось загрузить файл');
-    } finally {
-        uploading.value = false;
-        if (fileInput.value) fileInput.value.value = '';
+    const preparedFile = await optimizeImageForUpload(file);
+    const response = await api.uploadMediaAssets({
+        files: [preparedFile],
+        kind: props.kind,
+        tags_json: JSON.stringify(props.tags || []),
+    });
+    const uploaded = response.items?.[0];
+    if (!uploaded?.url) {
+        throw new Error('Загрузка завершилась без URL файла');
     }
+    pickedUrl(uploaded.url);
+    emit('uploaded', uploaded.url);
+    rememberUploadedAsset(uploaded);
 };
 
 const onFileChange = async (event: Event) => {
     const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    if (!file) return;
-    await uploadFile(file);
+    const files = Array.from(input.files || []);
+    if (!files.length) return;
+    uploading.value = true;
+    uploadCompleted.value = 0;
+    uploadTotal.value = props.multiple ? files.length : 1;
+    error.value = '';
+    try {
+        await uploadSequentially(
+            props.multiple ? files : files.slice(0, 1),
+            uploadFile,
+            (_result, progress) => {
+                uploadCompleted.value = progress.completed;
+            },
+        );
+    } catch (err) {
+        error.value = mediaErrorMessage(err, 'Не удалось загрузить файл');
+    } finally {
+        uploading.value = false;
+        uploadCompleted.value = 0;
+        uploadTotal.value = 0;
+        input.value = '';
+    }
 };
 
 const clearValue = () => {
@@ -208,7 +225,13 @@ const pasteFromClipboard = async () => {
             const imageType = item.types.find((type) => type.startsWith('image/'));
             if (!imageType) continue;
             const blob = await item.getType(imageType);
-            await uploadFile(new File([blob], `clipboard-${Date.now()}.${extensionFromMime(imageType)}`, { type: imageType }));
+            uploading.value = true;
+            error.value = '';
+            try {
+                await uploadFile(new File([blob], `clipboard-${Date.now()}.${extensionFromMime(imageType)}`, { type: imageType }));
+            } finally {
+                uploading.value = false;
+            }
             return;
         }
         error.value = 'В буфере нет изображения';
@@ -271,6 +294,7 @@ const pasteFromClipboard = async () => {
             type="file"
             class="hidden"
             :accept="accept"
+            :multiple="multiple"
             @change="onFileChange"
         />
 
@@ -306,7 +330,7 @@ const pasteFromClipboard = async () => {
                     </button>
                 </span>
                 <span v-if="uploading" class="mt-1 block text-xs font-medium text-teal-700 dark:text-teal-300">
-                    Загрузка...
+                    {{ uploadTotal > 1 ? `Подготовка и загрузка: ${uploadCompleted}/${uploadTotal}` : 'Подготовка и загрузка...' }}
                 </span>
                 <span v-if="error" class="mt-1 block text-xs font-medium text-red-600 dark:text-red-300">
                     {{ error }}

--- a/manager_frontend/src/utils/image-upload-optimization.ts
+++ b/manager_frontend/src/utils/image-upload-optimization.ts
@@ -1,0 +1,62 @@
+const OPTIMIZABLE_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+export const CLIENT_IMAGE_MAX_DIMENSION = 2560;
+export const CLIENT_IMAGE_MIN_OPTIMIZE_BYTES = 750 * 1024;
+export const CLIENT_IMAGE_WEBP_QUALITY = 0.88;
+
+export const shouldOptimizeImageUpload = (file: Pick<File, 'type' | 'size'>): boolean => (
+  OPTIMIZABLE_IMAGE_TYPES.has(file.type.toLowerCase())
+);
+
+export const needsImageOptimization = (width: number, height: number, size: number): boolean => (
+  Math.max(width, height) > CLIENT_IMAGE_MAX_DIMENSION
+  || size >= CLIENT_IMAGE_MIN_OPTIMIZE_BYTES
+);
+
+export const optimizedImageFileName = (name: string): string => {
+  const base = name.replace(/\.[^.]+$/, '') || 'image';
+  return `${base}.webp`;
+};
+
+const canvasToBlob = (canvas: HTMLCanvasElement): Promise<Blob | null> => new Promise((resolve) => {
+  canvas.toBlob(resolve, 'image/webp', CLIENT_IMAGE_WEBP_QUALITY);
+});
+
+export const optimizeImageForUpload = async (file: File): Promise<File> => {
+  if (!shouldOptimizeImageUpload(file) || typeof createImageBitmap !== 'function') {
+    return file;
+  }
+
+  try {
+    const bitmap = await createImageBitmap(file);
+    if (!needsImageOptimization(bitmap.width, bitmap.height, file.size)) {
+      bitmap.close();
+      return file;
+    }
+    const scale = Math.min(1, CLIENT_IMAGE_MAX_DIMENSION / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      bitmap.close();
+      return file;
+    }
+    context.drawImage(bitmap, 0, 0, width, height);
+    bitmap.close();
+
+    const optimized = await canvasToBlob(canvas);
+    if (!optimized || optimized.size >= file.size) {
+      return file;
+    }
+    return new File([optimized], optimizedImageFileName(file.name), {
+      type: 'image/webp',
+      lastModified: file.lastModified,
+    });
+  } catch {
+    // Uploading the original is safer than blocking the user on browser codec support.
+    return file;
+  }
+};

--- a/manager_frontend/src/views/BrandsView.vue
+++ b/manager_frontend/src/views/BrandsView.vue
@@ -73,6 +73,7 @@ const brandFeatures = ref<ManagerBrandFeature[]>([]);
 const seriesLoading = ref(false);
 const brandFeaturesLoading = ref(false);
 const seriesSaving = ref(false);
+const seriesGalleryApplying = ref(false);
 const featureSaving = ref(false);
 const editingBrandFeatureId = ref<number | null>(null);
 const seriesError = ref('');
@@ -664,6 +665,32 @@ const addGalleryImage = (url = pendingGalleryImage.value) => {
 
 const removeGalleryImage = (index: number) => {
     seriesForm.value.galleryImages.splice(index, 1);
+};
+
+const applySeriesGalleryToProducts = async () => {
+    if (!selectedBrandId.value || !editingSeries.value?.id || seriesGalleryApplying.value) return;
+    const galleryUrls = normalizeUrlList(seriesForm.value.galleryImages);
+    if (!galleryUrls.length) {
+        seriesError.value = 'Добавьте хотя бы одно изображение в галерею.';
+        return;
+    }
+
+    seriesGalleryApplying.value = true;
+    seriesError.value = '';
+    try {
+        const result = await api.applyManagerSeriesGalleryToProducts(
+            selectedBrandId.value,
+            editingSeries.value.id,
+            galleryUrls,
+        );
+        seriesForm.value.galleryImages = galleryUrls;
+        await fetchSeries();
+        setToast(`Добавлено товарам: ${result.added_links}, уже было: ${result.skipped_existing}`);
+    } catch (err) {
+        seriesError.value = getApiErrorMessage(err);
+    } finally {
+        seriesGalleryApplying.value = false;
+    }
 };
 
 const isBrandFeatureSelected = (featureId: number) => seriesForm.value.brandFeatureIds.includes(featureId);
@@ -1507,9 +1534,21 @@ onMounted(() => {
                             />
                         </div>
                         <div class="space-y-3">
-                            <div>
-                                <h3 class="text-sm font-medium text-gray-600 dark:text-slate-300">Галерея</h3>
-                                <p class="mt-1 text-xs text-gray-500 dark:text-slate-400">Изображения серии для лендингов, карточек и промо-блоков.</p>
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div>
+                                    <h3 class="text-sm font-medium text-gray-600 dark:text-slate-300">Галерея</h3>
+                                    <p class="mt-1 text-xs text-gray-500 dark:text-slate-400">Изображения серии для лендингов, карточек и промо-блоков.</p>
+                                </div>
+                                <button
+                                    v-if="editingSeries?.id"
+                                    type="button"
+                                    class="inline-flex items-center gap-1 rounded-lg border border-teal-200 px-3 py-1.5 text-xs font-semibold text-teal-700 hover:bg-teal-50 disabled:cursor-wait disabled:opacity-50 dark:border-teal-900/60 dark:text-teal-200 dark:hover:bg-teal-950/30"
+                                    :disabled="seriesGalleryApplying || !seriesForm.galleryImages.length"
+                                    @click="applySeriesGalleryToProducts"
+                                >
+                                    <span class="material-icons-round text-[16px]">library_add</span>
+                                    {{ seriesGalleryApplying ? 'Добавление...' : 'Добавить товарам серии' }}
+                                </button>
                             </div>
                             <div v-if="seriesForm.galleryImages.length" class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                                 <div
@@ -1549,6 +1588,7 @@ onMounted(() => {
                                     kind="brand"
                                     :tags="['series', 'gallery']"
                                     accept="image/png,image/jpeg,image/webp,image/svg+xml,.svg"
+                                    multiple
                                     placeholder="/media/library/original/series-gallery.webp"
                                     @picked="addGalleryImage"
                                 />

--- a/manager_frontend/src/views/MediaLibraryView.vue
+++ b/manager_frontend/src/views/MediaLibraryView.vue
@@ -27,6 +27,7 @@ import {
   type BackgroundRemovalProvider,
 } from '../utils/media-processing';
 import { uploadSequentially } from '../utils/sequential-upload';
+import { optimizeImageForUpload } from '../utils/image-upload-optimization';
 import ImageCropSelector, { type ImageCropSourceSize, type ImageCropValue } from '../components/ImageCropSelector.vue';
 
 type MediaKind = { value: string; label: string };
@@ -292,11 +293,14 @@ const uploadFiles = async (files: FileList | File[]) => {
     const tagsJson = JSON.stringify(parseTags(uploadTags.value));
     await uploadSequentially(
       imageFiles,
-      (file) => api.uploadMediaAssets({
-        files: [file],
-        kind: uploadKind.value,
-        tags_json: tagsJson,
-      }),
+      async (file) => {
+        const preparedFile = await optimizeImageForUpload(file);
+        return api.uploadMediaAssets({
+          files: [preparedFile],
+          kind: uploadKind.value,
+          tags_json: tagsJson,
+        });
+      },
       (response, progress) => {
         appendUploadedAssets(response.items, response.uploaded);
         uploadCompleted.value = progress.completed;

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -26,6 +26,8 @@ import {
     backgroundRemovalProviderOptions,
     type BackgroundRemovalProvider,
 } from '../utils/media-processing';
+import { optimizeImageForUpload } from '../utils/image-upload-optimization';
+import { uploadSequentially } from '../utils/sequential-upload';
 
 // Product state
 const products = ref<Product[]>([]);
@@ -38,6 +40,8 @@ const showEditModal = ref(false);
 const modalMode = ref<'single' | 'bulk'>('single');
 const imageSearchResults = ref<any[]>([]);
 const searchLoading = ref(false);
+const uploadCompleted = ref(0);
+const uploadTotal = ref(0);
 const imageQuery = ref('');
 const cleanupLoading = ref(false);
 const cleanupStats = ref<any>(null);
@@ -525,15 +529,39 @@ const handleDrop = async (e: DragEvent) => {
 
 const uploadFiles = async (files: FileList | File[]) => {
     if (!selectedProduct.value && !isBulkMode.value) return;
+    const imageFiles = Array.from(files);
+    if (!imageFiles.length) return;
     searchLoading.value = true;
+    uploadCompleted.value = 0;
+    uploadTotal.value = imageFiles.length;
     try {
         if (isBulkMode.value) {
-            const res = await api.bulkUploadLocalImages(selectedIdsArray.value, files);
-            setToast(`Загружено ссылок: ${res.uploaded_links}`);
+            let uploadedLinks = 0;
+            await uploadSequentially(
+                imageFiles,
+                async (file) => {
+                    const preparedFile = await optimizeImageForUpload(file);
+                    const response = await api.bulkUploadLocalImages(selectedIdsArray.value, [preparedFile]);
+                    uploadedLinks += response.uploaded_links;
+                    return response;
+                },
+                (_response, progress) => { uploadCompleted.value = progress.completed; },
+            );
+            setToast(`Загружено ссылок: ${uploadedLinks}`);
             await loadCommonGallery();
         } else {
-            const res = await api.uploadLocalImages(selectedProduct.value!.id, files);
-            setToast(`Загружено изображений: ${res.uploaded}`);
+            let uploaded = 0;
+            await uploadSequentially(
+                imageFiles,
+                async (file) => {
+                    const preparedFile = await optimizeImageForUpload(file);
+                    const response = await api.uploadLocalImages(selectedProduct.value!.id, [preparedFile]);
+                    uploaded += response.uploaded;
+                    return response;
+                },
+                (_response, progress) => { uploadCompleted.value = progress.completed; },
+            );
+            setToast(`Загружено изображений: ${uploaded}`);
             refreshSelectedProduct();
         }
         await loadProducts();
@@ -542,6 +570,8 @@ const uploadFiles = async (files: FileList | File[]) => {
         console.error(e);
     } finally {
         searchLoading.value = false;
+        uploadCompleted.value = 0;
+        uploadTotal.value = 0;
         if (fileInput.value) fileInput.value.value = '';
     }
 };
@@ -2164,7 +2194,7 @@ watchDebounced(
                       
                       <div v-if="searchLoading" class="flex items-center gap-2 text-teal-600 font-medium">
                           <div class="w-4 h-4 border-2 border-teal-600 border-t-transparent rounded-full animate-spin"></div>
-                          Загрузка...
+                          {{ uploadTotal > 1 ? `Подготовка и загрузка: ${uploadCompleted}/${uploadTotal}` : 'Подготовка и загрузка...' }}
                       </div>
                   </div>
                   <div class="w-full max-w-2xl rounded-xl border border-gray-200 bg-white p-3 shadow-sm">

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -14,6 +14,12 @@ import {
   syncStickyHeaderAfterLayout,
 } from '../src/composables/useSmartStickyHeader';
 import { uploadSequentially } from '../src/utils/sequential-upload';
+import {
+  CLIENT_IMAGE_MIN_OPTIMIZE_BYTES,
+  needsImageOptimization,
+  optimizedImageFileName,
+  shouldOptimizeImageUpload,
+} from '../src/utils/image-upload-optimization';
 import { compactLegalName } from '../src/components/orders/order-utils';
 
 const assert = (condition: unknown, message: string) => {
@@ -98,6 +104,19 @@ const uploadResults = await uploadSequentially(
 assert(uploadOrder.join(',') === '1,2,3', 'media files must upload sequentially in selection order');
 assert(uploadResults.join(',') === '10,20,30', 'sequential upload must return every response');
 assert(uploadProgress.join(',') === '1/3,2/3,3/3', 'sequential upload must report completed file count');
+assert(
+  shouldOptimizeImageUpload({ type: 'image/png', size: CLIENT_IMAGE_MIN_OPTIMIZE_BYTES }),
+  'raster images must be eligible for browser preparation',
+);
+assert(
+  !shouldOptimizeImageUpload({ type: 'image/svg+xml', size: CLIENT_IMAGE_MIN_OPTIMIZE_BYTES * 4 }),
+  'vector images must not be rasterized by client optimization',
+);
+assert(optimizedImageFileName('outside.unit.PNG') === 'outside.unit.webp', 'optimized files must use WebP names');
+assert(
+  needsImageOptimization(5000, 1200, CLIENT_IMAGE_MIN_OPTIMIZE_BYTES / 2),
+  'oversized pixel dimensions must be optimized even when the encoded file is small',
+);
 
 assert(
   compactLegalName('Общество с ограниченной ответственностью "НПП Юни"') === 'ООО "НПП Юни"',

--- a/openapi.json
+++ b/openapi.json
@@ -14605,6 +14605,72 @@
         }
       }
     },
+    "/api/manager/brands/{brand_id}/series/{series_id}/gallery/apply-to-products": {
+      "post": {
+        "tags": [
+          "manager brands"
+        ],
+        "summary": "Apply Manager Series Gallery To Products",
+        "operationId": "apply_manager_series_gallery_to_products",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Brand Id"
+            }
+          },
+          {
+            "name": "series_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Series Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagerSeriesGalleryApplyPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerSeriesGalleryApplyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/settings": {
       "get": {
         "tags": [
@@ -36938,6 +37004,60 @@
           "stage"
         ],
         "title": "ManagerRestoreJobStatusResponse"
+      },
+      "ManagerSeriesGalleryApplyPayload": {
+        "properties": {
+          "source_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Source Urls"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_urls"
+        ],
+        "title": "ManagerSeriesGalleryApplyPayload"
+      },
+      "ManagerSeriesGalleryApplyResponse": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "products_count": {
+            "type": "integer",
+            "title": "Products Count"
+          },
+          "added_links": {
+            "type": "integer",
+            "title": "Added Links"
+          },
+          "skipped_existing": {
+            "type": "integer",
+            "title": "Skipped Existing"
+          },
+          "series_id": {
+            "type": "integer",
+            "title": "Series Id"
+          },
+          "images_applied": {
+            "type": "integer",
+            "title": "Images Applied"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "products_count",
+          "added_links",
+          "skipped_existing",
+          "series_id",
+          "images_applied"
+        ],
+        "title": "ManagerSeriesGalleryApplyResponse"
       },
       "ManagerServiceAttachmentAccessResponse": {
         "properties": {

--- a/routers/manager_brands.py
+++ b/routers/manager_brands.py
@@ -15,6 +15,7 @@ from routers.manager_operation_ids import (
     LIST_MANAGER_BRANDS,
     UPDATE_MANAGER_BRAND_FEATURE,
     UPDATE_MANAGER_BRAND_SERIES,
+    APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS,
     UPDATE_MANAGER_BRAND,
 )
 from schemas import (
@@ -30,6 +31,8 @@ from schemas import (
     ManagerBrandSeriesListResponse,
     ManagerBrandSeriesResponse,
     ManagerBrandSeriesUpdatePayload,
+    ManagerSeriesGalleryApplyPayload,
+    ManagerSeriesGalleryApplyResponse,
     ManagerBrandUpdatePayload,
 )
 from services.manager_brand_service import ManagerBrandService
@@ -196,6 +199,26 @@ async def update_manager_brand_series(
         payload=payload.model_dump(exclude_unset=True),
     )
     return ManagerBrandSeriesResponse(**updated)
+
+
+@router.post(
+    "/{brand_id}/series/{series_id}/gallery/apply-to-products",
+    response_model=ManagerSeriesGalleryApplyResponse,
+    operation_id=APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS,
+)
+async def apply_manager_series_gallery_to_products(
+    brand_id: int,
+    series_id: int,
+    payload: ManagerSeriesGalleryApplyPayload,
+    session: AsyncSession = Depends(get_session),
+):
+    result = await ManagerBrandService.apply_series_gallery_to_products(
+        session=session,
+        brand_id=brand_id,
+        series_id=series_id,
+        source_urls=payload.source_urls,
+    )
+    return ManagerSeriesGalleryApplyResponse(**result)
 
 
 @router.delete(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -235,6 +235,7 @@ DELETE_MANAGER_BRAND_FEATURE = "delete_manager_brand_feature"
 LIST_MANAGER_BRAND_SERIES = "list_manager_brand_series"
 CREATE_MANAGER_BRAND_SERIES = "create_manager_brand_series"
 UPDATE_MANAGER_BRAND_SERIES = "update_manager_brand_series"
+APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS = "apply_manager_series_gallery_to_products"
 DELETE_MANAGER_BRAND_SERIES = "delete_manager_brand_series"
 LIST_SUPPLIERS = "list_suppliers"
 CREATE_SUPPLIER = "create_supplier"
@@ -492,6 +493,7 @@ ALL_MANAGER_OPERATION_IDS = (
     LIST_MANAGER_BRAND_SERIES,
     CREATE_MANAGER_BRAND_SERIES,
     UPDATE_MANAGER_BRAND_SERIES,
+    APPLY_MANAGER_SERIES_GALLERY_TO_PRODUCTS,
     DELETE_MANAGER_BRAND_SERIES,
     LIST_SUPPLIERS,
     CREATE_SUPPLIER,

--- a/schemas.py
+++ b/schemas.py
@@ -2577,6 +2577,10 @@ class ManagerBrandSeriesUpdatePayload(BaseModel):
     sort_order: Optional[int] = None
 
 
+class ManagerSeriesGalleryApplyPayload(BaseModel):
+    source_urls: List[str]
+
+
 class ManagerBrandFeatureResponse(ProductSeriesBrandFeatureResponse):
     brand_id: int
     created_at: datetime
@@ -2748,6 +2752,11 @@ class ManagerMediaBulkAddResponse(ManagerActionMessageResponse):
     products_count: int
     added_links: int
     skipped_existing: int
+
+
+class ManagerSeriesGalleryApplyResponse(ManagerMediaBulkAddResponse):
+    series_id: int
+    images_applied: int
 
 
 class ManagerMediaBulkDeleteResponse(ManagerActionMessageResponse):

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -568,6 +568,64 @@ class ManagerBrandService:
         )
 
     @staticmethod
+    async def apply_series_gallery_to_products(
+        session: AsyncSession,
+        brand_id: int,
+        series_id: int,
+        source_urls: List[str],
+    ) -> Dict[str, Any]:
+        brand = await session.get(Brand, brand_id)
+        if brand is None:
+            raise HTTPException(status_code=404, detail="Бренд не найден.")
+
+        series = await ManagerBrandService._get_brand_series(session, brand_id, series_id)
+        gallery_urls = ManagerBrandService._normalize_string_list(source_urls)
+        if not gallery_urls:
+            raise HTTPException(status_code=400, detail="Галерея серии пуста.")
+
+        product_ids = list(
+            (
+                await session.execute(
+                    select(Product.id).where(Product.series_id == series.id).order_by(Product.id)
+                )
+            ).scalars().all()
+        )
+        series.gallery_images = gallery_urls
+        session.add(series)
+
+        if product_ids:
+            from services.manager_media_service import ManagerMediaService
+
+            result = await ManagerMediaService.bulk_add_gallery_images(
+                session=session,
+                product_ids=product_ids,
+                source_urls=gallery_urls,
+                is_installation=False,
+                skip_existing=True,
+                set_main=False,
+                commit=False,
+            )
+        else:
+            result = {
+                "message": "Series gallery saved; no products assigned",
+                "products_count": 0,
+                "added_links": 0,
+                "skipped_existing": 0,
+            }
+
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="brand_series_gallery_apply",
+            product_ids=product_ids,
+            brand_slugs=[brand.slug],
+        )
+        return {
+            **result,
+            "series_id": int(series.id or series_id),
+            "images_applied": len(gallery_urls),
+        }
+
+    @staticmethod
     async def delete_brand_series(
         session: AsyncSession,
         brand_id: int,

--- a/services/manager_media_service.py
+++ b/services/manager_media_service.py
@@ -15,6 +15,7 @@ from sqlalchemy import func
 from sqlmodel import select, update
 
 from models import Product, ProductImage, ProductImageVariant, ProductSeries
+from services.catalog_revision_service import CatalogRevisionService
 from services.product_image_processing_contract import ProductImageVariantType
 from services.product_image_processing_provider import (
     ProductImageProcessingContext,
@@ -486,6 +487,7 @@ class ManagerMediaService:
         is_installation: bool,
         skip_existing: bool,
         set_main: bool,
+        commit: bool = True,
     ) -> dict:
         if not product_ids:
             raise ValueError("product_ids is required")
@@ -538,7 +540,8 @@ class ManagerMediaService:
 
             await ManagerMediaService.sync_legacy_images(session, product_id)
 
-        await session.commit()
+        if commit:
+            await session.commit()
         return {
             "message": "Bulk image add completed",
             "products_count": len(unique_product_ids),
@@ -713,6 +716,10 @@ class ManagerMediaService:
                 "deleted_files_count": 0,
             }
 
+        if series:
+            series.gallery_images = list(dict.fromkeys([*(series.gallery_images or []), *source_urls]))
+            session.add(series)
+
         for target_product in target_products:
             target_rows = target_rows_by_product_id[target_product.id]
 
@@ -752,7 +759,11 @@ class ManagerMediaService:
             await ManagerMediaService.sync_legacy_images(session, target_product.id)
             updated_products += 1
 
-        await session.commit()
+        await CatalogRevisionService.bump_commit_and_purge(
+            session,
+            scope="product_series_gallery_apply",
+            product_ids=[source_product.id, *(product.id for product in target_products)],
+        )
 
         deleted_files_count = 0
         if delete_unreferenced:

--- a/tests/integration/test_manager_gallery_bulk.py
+++ b/tests/integration/test_manager_gallery_bulk.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from sqlmodel import select
 
 from core.config import settings
-from models import Product, ProductImage, ProductImageVariant
+from models import Brand, Product, ProductImage, ProductImageVariant, ProductSeries
 
 
 def _make_product(idx: int) -> Product:
@@ -171,6 +171,53 @@ async def test_bulk_delete_common_removes_variants_only_for_deleted_links(async_
     ).scalars().all()
     assert len(remaining_variants) == 1
     assert remaining_variants[0].product_image_id == img3_id
+
+
+@pytest.mark.asyncio
+async def test_series_gallery_can_be_added_to_all_series_products(async_client: AsyncClient, db):
+    brand = Brand(title="Series gallery brand", slug="series-gallery-brand")
+    db.add(brand)
+    await db.flush()
+    series = ProductSeries(
+        brand_id=brand.id,
+        title="Shared gallery series",
+        slug="shared-gallery-series",
+    )
+    db.add(series)
+    await db.flush()
+    first = _make_product(41)
+    first.brand_id = brand.id
+    first.series_id = series.id
+    second = _make_product(42)
+    second.brand_id = brand.id
+    second.series_id = series.id
+    outside = _make_product(43)
+    db.add_all([first, second, outside])
+    await db.commit()
+
+    urls = [
+        "/media/library/original/series-gallery-1.webp",
+        "/media/library/original/series-gallery-2.webp",
+    ]
+    headers = await _auth_headers(async_client)
+    endpoint = f"/api/manager/brands/{brand.id}/series/{series.id}/gallery/apply-to-products"
+    response = await async_client.post(endpoint, json={"source_urls": urls}, headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["products_count"] == 2
+    assert response.json()["added_links"] == 4
+    await db.refresh(series)
+    assert series.gallery_images == urls
+
+    linked_rows = (
+        await db.execute(select(ProductImage).where(ProductImage.url.in_(urls)).order_by(ProductImage.id))
+    ).scalars().all()
+    assert {row.product_id for row in linked_rows} == {first.id, second.id}
+
+    repeated = await async_client.post(endpoint, json={"source_urls": urls}, headers=headers)
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json()["added_links"] == 0
+    assert repeated.json()["skipped_existing"] == 4
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_product_image_variants.py
+++ b/tests/unit/test_product_image_variants.py
@@ -362,6 +362,7 @@ async def test_apply_gallery_to_series_preserves_installation_photos_and_replace
 
     result = await ManagerMediaService.apply_gallery_to_series(sqlite_session, source.id)
 
+    await sqlite_session.refresh(series)
     await sqlite_session.refresh(target)
     await sqlite_session.refresh(outside)
     target_images = (
@@ -383,6 +384,10 @@ async def test_apply_gallery_to_series_preserves_installation_photos_and_replace
     assert result["replaced_links"] == 2
     assert result["deleted_files_count"] == 0
     assert result["preserved_installation_links"] == 1
+    assert series.gallery_images == [
+        "/media/products/shared/source-main.webp",
+        "/media/products/shared/source-extra.webp",
+    ]
     assert target.main_image == source.main_image
     assert [image.url for image in target_images] == [
         "/media/products/shared/target-installation.webp",


### PR DESCRIPTION
## Что изменено
- пакетная загрузка файлов в галерею серии с последовательной отправкой
- клиентское уменьшение крупных raster-изображений до 2560 px и WebP перед загрузкой
- фото товара из действия «Ко всей серии» теперь попадают и в галерею ProductSeries
- явное действие для добавления галереи серии всем товарам без повторной загрузки в R2
- обновление catalog revision и Cloudflare purge после синхронизации

## Проверки
- `pytest tests/unit/test_product_image_variants.py tests/integration/test_manager_gallery_bulk.py tests/integration/test_manager_brands_api.py -q`
- `pytest tests/unit/test_manager_operation_ids_contract.py -q`
- `node scripts/run-ui-logic-tests.mjs`
- `vue-tsc -b`
- `vite build`
- `bash scripts/audit_theme_hardcodes.sh`