### PR TITLE
Polish proposal lifecycle and order card states

### DIFF
--- a/manager_frontend/src/components/equipment/OrderEquipmentPanel.vue
+++ b/manager_frontend/src/components/equipment/OrderEquipmentPanel.vue
@@ -60,6 +60,13 @@ let linksRequestId = 0;
 let customerEquipmentRequestId = 0;
 
 const count = computed(() => loaded.value ? links.value.length : Number(props.initialCount || 0));
+const countLabel = computed(() => {
+  const value = count.value;
+  const mod100 = value % 100;
+  const mod10 = value % 10;
+  const noun = mod100 >= 11 && mod100 <= 14 ? 'единиц' : mod10 === 1 ? 'единица' : mod10 >= 2 && mod10 <= 4 ? 'единицы' : 'единиц';
+  return `Оборудование: ${value} ${noun}`;
+});
 const linkedIds = computed(() => links.value.map((item) => item.equipment.id));
 
 const equipmentTitle = (item: ManagerOrderEquipmentLinkItemResponse['equipment']) => (
@@ -329,18 +336,21 @@ defineExpose({ expand, collapse });
 
 <template>
   <section class="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
-    <button type="button" class="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60 sm:px-4" :aria-expanded="expanded" @click="toggle">
-      <Boxes class="h-5 w-5 shrink-0 text-teal-700 dark:text-teal-300" />
-      <span class="min-w-0 flex-1">
-        <span class="block text-sm font-semibold text-slate-900 dark:text-slate-100">Оборудование на объекте</span>
-        <span class="block truncate text-xs text-slate-500 dark:text-slate-400">
-          {{ count ? `${count} ед.` : 'Пока не привязано' }}
+    <div class="flex items-center gap-1 pr-2">
+      <button type="button" class="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60 sm:px-4" :aria-expanded="expanded" @click="toggle">
+        <Boxes class="h-5 w-5 shrink-0 text-teal-700 dark:text-teal-300" />
+        <span class="min-w-0 flex-1">
+          <span class="block text-sm font-semibold text-slate-900 dark:text-slate-100">Оборудование на объекте</span>
+          <span class="block truncate text-xs text-slate-500 dark:text-slate-400">
+            {{ count ? countLabel : 'Оборудование не привязано' }}
+          </span>
         </span>
-      </span>
-      <span class="inline-flex min-w-7 items-center justify-center rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">{{ count }}</span>
-      <ChevronUp v-if="expanded" class="h-5 w-5 text-slate-500" />
-      <ChevronDown v-else class="h-5 w-5 text-slate-500" />
-    </button>
+        <span v-if="count" class="inline-flex min-w-7 items-center justify-center rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">{{ count }}</span>
+        <ChevronUp v-if="expanded" class="h-5 w-5 text-slate-500" />
+        <ChevronDown v-else class="h-5 w-5 text-slate-500" />
+      </button>
+      <button v-if="!count" type="button" class="btn-mini-outline h-8 shrink-0 px-2 text-xs" :disabled="Boolean(action)" @click="openLinkDialog">Привязать</button>
+    </div>
 
     <div v-if="expanded" class="border-t border-slate-200 px-3 pb-4 pt-3 dark:border-slate-700 sm:px-4">
       <div class="flex flex-wrap items-center gap-2">

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -427,8 +427,12 @@ const inheritedDocumentRoleType = computed(() => normalizeRoleType(
     || props.order.effective_document_role_type
 ));
 const documentSummary = computed(() => {
-  const base = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : (hasClosingBaseDocument.value ? 'есть основание' : 'без основания'));
-  return `${documents.value.length} док. · ${base}`;
+  const count = documents.value.length;
+  if (!count) return 'Документов нет';
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  const noun = mod100 >= 11 && mod100 <= 14 ? 'документов' : mod10 === 1 ? 'документ' : mod10 >= 2 && mod10 <= 4 ? 'документа' : 'документов';
+  return `${count} ${noun}${hasContract.value ? '' : ' · договор не создан'}`;
 });
 const hasDocumentSetupWarning = computed(() => isCompanyOrder.value && !selectedCustomerContractId.value && !hasClosingBaseDocument.value);
 const suggestedDocumentType = computed(() => {
@@ -770,6 +774,11 @@ const openCreatePanel = () => {
     ensureAllWaybillComponents();
   }
 };
+
+defineExpose({
+  openSend: openDocumentSendModal,
+  openCreate: openCreatePanel,
+});
 
 const selectDocumentType = (type: string) => {
   selectedDocumentType.value = type;
@@ -1127,6 +1136,7 @@ const registerExternalContract = async () => {
 
       <div class="flex flex-wrap items-center gap-2 sm:justify-end">
         <button
+          v-if="documents.length"
           class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-teal-600 px-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
           title="Отправить документы"
           :disabled="!documents.length || isUploadingDoc || !!processingDocId || isGeneratingDoc"
@@ -1137,6 +1147,7 @@ const registerExternalContract = async () => {
         </button>
 
         <button
+          v-if="documents.length"
           class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-[#007f80] px-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
           :disabled="isGeneratingDoc || !!processingDocId || isUploadingDoc"
           @click="openCreatePanel"
@@ -1231,8 +1242,12 @@ const registerExternalContract = async () => {
             </div>
           </div>
         </div>
-        <div v-else class="rounded-xl border border-dashed border-slate-300 py-5 text-center text-sm italic text-slate-500 dark:border-slate-700">
-          Нет сформированных документов
+        <div v-else class="flex flex-col items-center gap-2 rounded-xl border border-dashed border-slate-300 px-4 py-5 text-center dark:border-slate-700">
+          <p class="text-sm font-medium text-slate-700 dark:text-slate-200">Документов нет</p>
+          <button type="button" class="btn-mini h-8 text-xs" @click="openCreatePanel">
+            <span class="material-icons-round text-[15px]">add</span>
+            Создать
+          </button>
         </div>
       </div>
 

--- a/manager_frontend/src/components/orders/OrderDrawerSection.vue
+++ b/manager_frontend/src/components/orders/OrderDrawerSection.vue
@@ -13,10 +13,10 @@ const emit = defineEmits<{
 }>();
 
 const toneClasses = {
-  default: 'border-slate-200 bg-slate-50',
-  blue: 'border-blue-100 bg-blue-50/30',
-  amber: 'border-amber-100 bg-amber-50/30',
-  emerald: 'border-emerald-100 bg-emerald-50/40',
+  default: 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900',
+  blue: 'border-blue-100 bg-blue-50/30 dark:border-blue-500/30 dark:bg-blue-500/10',
+  amber: 'border-amber-100 bg-amber-50/30 dark:border-amber-500/30 dark:bg-amber-500/10',
+  emerald: 'border-emerald-100 bg-emerald-50/40 dark:border-emerald-500/30 dark:bg-emerald-500/10',
 };
 </script>
 
@@ -29,16 +29,16 @@ const toneClasses = {
       @click="emit('update:expanded', !expanded)"
     >
       <div class="min-w-0">
-        <h3 class="flex items-center gap-2 text-sm font-semibold text-slate-900">
-          <span v-if="icon" class="material-icons-round text-[18px] text-teal-600" aria-hidden="true">{{ icon }}</span>
+        <h3 class="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+          <span v-if="icon" class="material-icons-round text-[18px] text-teal-600 dark:text-teal-300" aria-hidden="true">{{ icon }}</span>
           {{ title }}
         </h3>
-        <p v-if="summary" class="mt-0.5 truncate text-xs text-slate-500">{{ summary }}</p>
+        <p v-if="summary" class="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">{{ summary }}</p>
       </div>
-      <span class="material-icons-round shrink-0 text-[20px] text-slate-500" aria-hidden="true">{{ expanded ? 'expand_less' : 'expand_more' }}</span>
+      <span class="material-icons-round shrink-0 text-[20px] text-slate-500 dark:text-slate-400" aria-hidden="true">{{ expanded ? 'expand_less' : 'expand_more' }}</span>
     </button>
 
-    <div v-if="expanded" class="border-t border-white/70 px-4 pb-4 pt-3">
+    <div v-if="expanded" class="border-t border-white/70 px-4 pb-4 pt-3 dark:border-slate-700">
       <slot />
     </div>
   </section>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -13,6 +13,7 @@ import OrderEquipmentPanel from '../equipment/OrderEquipmentPanel.vue';
 import OrderWorkspaceHeader from './OrderWorkspaceHeader.vue';
 import OrderCustomerObjectSummary from './OrderCustomerObjectSummary.vue';
 import OrderSalesInstallationWorkspace from './OrderSalesInstallationWorkspace.vue';
+import OrderProposalToolbar from './OrderProposalToolbar.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import type { ServiceAttachmentEquipmentOption } from '../service-attachments/types';
 import type {
@@ -39,11 +40,18 @@ import type {
 import { ManagerOrdersService, ManagerSettingsService, ManagerMailService, ManagerRepairComplaintsService, ManagerEquipmentService } from '../../client';
 import { EXECUTION_STATUS_OPTIONS, NEGOTIATION_STATUS_OPTIONS, formatMoney } from './order-utils';
 import {
+  buildMeasurementSummary,
   buildOrderWorkspaceViewModel,
   normalizeOrderWorkflowType,
   type OrderWorkflowType,
   type OrderWorkspaceTarget,
 } from './order-workspace';
+import {
+  isProposalRevisionLocked,
+  normalizeProposalStatus,
+  proposalStatusLabel,
+  type ProposalLifecycleStatus,
+} from './proposal-lifecycle';
 import {
   CUSTOMER_APPROVAL_STATUS_OPTIONS,
   EQUIPMENT_EVENT_OPTIONS,
@@ -222,7 +230,7 @@ const measurementRequired = ref(false);
 const measurerId = ref<number | null>(null);
 const measurementResult = ref('');
 const additionalConditions = ref('');
-const proposalStatus = ref<'draft' | 'sent' | 'approved' | 'rejected'>('draft');
+const proposalStatus = ref<ProposalLifecycleStatus>('draft');
 const negotiationStatus = ref('awaiting_offer');
 const executionStatus = ref('needs_schedule');
 const executionWithoutPayment = ref(false);
@@ -231,17 +239,12 @@ const autoExecutionOnPayment = ref(false);
 const autoCloseOnPayment = ref(false);
 const activeProposalId = ref<number | null>(null);
 const proposalActionLoading = ref(false);
-const negotiationStatusLabel = computed(() => (
-  NEGOTIATION_STATUS_OPTIONS.find((option) => option.value === negotiationStatus.value)?.label || 'Ждет предложение'
-));
 const executionStatusLabel = computed(() => (
   EXECUTION_STATUS_OPTIONS.find((option) => option.value === executionStatus.value)?.label || 'Назначить работы'
 ));
 
 const setNegotiationStatus = (value: string) => {
   negotiationStatus.value = value;
-  if (value === 'proposal_sent') proposalStatus.value = 'sent';
-  if (value === 'awaiting_payment') proposalStatus.value = 'approved';
 };
 
 const setExecutionStatus = (value: string) => {
@@ -254,6 +257,7 @@ const productLines = ref<ProductLine[]>([]);
 const supplyRequests = ref<any[]>([]);
 const supplyActionLoadingLineId = ref<number | null>(null);
 const serviceLines = ref<ServiceLine[]>([]);
+const editingServiceLineIndex = ref<number | null>(null);
 const savedLinesSnapshot = ref('');
 const savedFormSnapshot = ref('');
 const pendingDraftClearOrderId = ref<number | null>(null);
@@ -298,6 +302,8 @@ const bankReceipts = ref<BankReceiptResponse[]>([]);
 const bankReceiptsLoading = ref(false);
 const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
+const documentsPanelRef = ref<InstanceType<typeof OrderDocumentsPanel> | null>(null);
+const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
 const executionWorkspaceSection = ref<'documents' | 'payments' | null>(null);
 const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
 const orderEmails = ref<OutgoingEmailResponse[]>([]);
@@ -619,10 +625,8 @@ const compactObjectAddress = computed(() => (
   || ''
 ));
 const customerDetailsSummary = computed(() => {
-  const parts = [];
-  if (compactObjectAddress.value) parts.push(compactObjectAddress.value);
-  if (comment.value.trim()) parts.push('есть комментарий');
-  return parts.join(' · ') || 'адрес и комментарий';
+  if (customerBranchId.value) return 'Филиал и дополнительные данные';
+  return 'Адрес и комментарий';
 });
 const filteredEstimateOptions = computed(() => {
   const query = estimateSearchQuery.value.trim().toLowerCase();
@@ -648,11 +652,16 @@ const activeProposal = computed(() => (
   orderProposals.value.find((proposal) => proposal.id === activeProposalId.value)
   || selectedOrderProposal.value
 ));
+const activeProposalStatus = computed(() => normalizeProposalStatus(activeProposal.value?.status || proposalStatus.value));
+const activeProposalLocked = computed(() => isProposalRevisionLocked(activeProposalStatus.value));
 const activeProposalLineLabel = computed(() => {
   const proposal = activeProposal.value;
-  if (!proposal) return 'основной расчет';
+  if (!proposal) return 'Предложение не создано';
   const count = (proposal.product_lines?.length || 0) + (proposal.service_lines?.length || 0);
-  return `${proposal.name} · ${count} поз. · ${formatMoney(proposal.total_amount || 0)}`;
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  const noun = mod100 >= 11 && mod100 <= 14 ? 'позиций' : mod10 === 1 ? 'позиция' : mod10 >= 2 && mod10 <= 4 ? 'позиции' : 'позиций';
+  return `${proposal.name} · ${proposalStatusLabel(proposal.status)} · ${count} ${noun} · ${formatMoney(proposal.total_amount || 0)}`;
 });
 const paymentsSectionSummary = computed(() => (
   `оплачено ${formatMoney(totalPaymentsPreview.value)} · остаток ${formatMoney(balanceDuePreview.value)} · итого ${formatMoney(totalPreview.value)} · маржа ${formatMoney(marginPreview.value)}`
@@ -692,6 +701,11 @@ const orderWorkspace = computed(() => buildOrderWorkspaceViewModel({
   negotiationStatusChangedAt: props.order?.negotiation_status_changed_at,
   executionStatusChangedAt: props.order?.execution_status_changed_at,
   installationDate: installationDate.value,
+  activeProposalId: selectedOrderProposal.value?.id || null,
+  activeProposalStatus: selectedOrderProposal.value?.status || proposalStatus.value,
+  activeProposalLineCount: (selectedOrderProposal.value?.product_lines?.length || 0) + (selectedOrderProposal.value?.service_lines?.length || 0),
+  activeProposalTotal: Number(selectedOrderProposal.value?.total_amount || 0),
+  autoExecutionOnPayment: autoExecutionOnPayment.value,
   productCount: productLines.value.length,
   serviceCount: serviceLines.value.length,
   linkedEquipmentCount: props.order?.linked_equipment_count || 0,
@@ -949,12 +963,14 @@ const websiteOrderSummary = computed(() => {
   return parts.join(' · ');
 });
 const planningSummary = computed(() => {
-  const parts = [];
-  const visitLabel = workflowType.value === 'repair' ? 'диагностика' : 'замер';
-  parts.push(measurementRequired.value ? `${visitLabel} нужна` : `без ${visitLabel}`);
-  if (assessmentDate.value) parts.push(`${visitLabel} ${formatDateTime(assessmentDate.value)}`);
+  const parts = [buildMeasurementSummary({
+    required: measurementRequired.value,
+    date: assessmentDate.value,
+    result: measurementResult.value,
+    kind: workflowType.value === 'repair' ? 'diagnostic' : 'measurement',
+    formatDate: formatDateTime,
+  })];
   if (installationDate.value) parts.push(`${workDateLabel.value.toLowerCase()} ${formatDateTime(installationDate.value)}`);
-  if (customerDeliveryAddress.value) parts.push(customerDeliveryAddress.value);
   return parts.join(' · ');
 });
 const planningDetailsSummary = computed(() => {
@@ -1032,8 +1048,12 @@ const buildRepairMetaPayload = () => normalizeRepairMeta({
   fault_type: repairMeta.value.fault_type || repairAiDefectType.value,
 }, { defaultRepairStatus: isRepairWorkflow.value });
 const documentSectionSummary = computed(() => {
-  const contractText = hasContract.value ? 'договор есть' : (hasOrderInvoice.value ? 'есть счет' : 'без договора');
-  return `${orderDocuments.value.length} док. · ${contractText}`;
+  const count = orderDocuments.value.length;
+  if (!count) return 'Документов нет';
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  const noun = mod100 >= 11 && mod100 <= 14 ? 'документов' : mod10 === 1 ? 'документ' : mod10 >= 2 && mod10 <= 4 ? 'документа' : 'документов';
+  return `${count} ${noun}${hasContract.value ? '' : ' · договор не создан'}`;
 });
 const documentSectionHasError = computed(() => isCompanyOrder.value && !props.order?.customer_contract_id && !hasClosingBaseDocument.value);
 const beforeDocumentGenerate = async (type: string) => {
@@ -1482,15 +1502,16 @@ const mapProductLineFromResponse = (line: OrderProductLineResponse): ProductLine
 const mapServiceLineFromResponse = (line: OrderServiceLineResponse): ServiceLine => ({
   service_id: line.service_id,
   title: line.service_title,
-  quantity: line.quantity,
-  price: line.price,
-  cost: line.cost,
+  quantity: Math.max(1, Number(line.quantity || 1)),
+  price: Number(line.price || 0),
+  cost: Number(line.cost || 0),
 });
 
 const loadProposalLines = (proposal: OrderProposalResponse | null | undefined, fallbackOrder?: ManagerOrderDetailResponse | null) => {
+  editingServiceLineIndex.value = null;
   if (proposal) {
     activeProposalId.value = proposal.id;
-    proposalStatus.value = (proposal.status as any) || proposalStatus.value || 'draft';
+    proposalStatus.value = normalizeProposalStatus(proposal.status);
     productLines.value = (proposal.product_lines || []).map(mapProductLineFromResponse);
     serviceLines.value = (proposal.service_lines || []).map(mapServiceLineFromResponse);
     return;
@@ -1545,7 +1566,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
   measurerId.value = order.measurer_id ?? null;
   measurementResult.value = order.measurement_result ?? '';
   additionalConditions.value = order.additional_conditions ?? '';
-  proposalStatus.value = (order.proposal_status as any) || 'draft';
+  proposalStatus.value = normalizeProposalStatus(order.proposal_status);
   negotiationStatus.value = order.negotiation_status || 'awaiting_offer';
   executionStatus.value = order.execution_status || 'needs_schedule';
   executionWithoutPayment.value = Boolean(order.execution_without_payment);
@@ -1752,6 +1773,7 @@ const addProductLine = () => {
 
 const addServiceLine = () => {
   serviceLines.value.push({ title: '', quantity: 1, price: 0, cost: 0, service_id: null });
+  editingServiceLineIndex.value = serviceLines.value.length - 1;
 };
 
 const applyOrderResponse = async (
@@ -1803,6 +1825,7 @@ const validateProposalLines = () => {
 
 const saveCurrentProposalLines = async () => {
   if (!props.order?.id) return props.order || null;
+  if (activeProposalLocked.value) return props.order;
   const validationError = validateProposalLines();
   if (validationError) {
     localFormError.value = validationError;
@@ -1928,6 +1951,70 @@ const selectProposalForOrder = async (proposal?: OrderProposalResponse) => {
   } finally {
     proposalActionLoading.value = false;
   }
+};
+
+const changeActiveProposalStatus = async (nextStatus: ProposalLifecycleStatus) => {
+  const proposal = activeProposal.value;
+  if (!props.order?.id || !proposal?.id || proposalActionLoading.value) return;
+  if (nextStatus === activeProposalStatus.value) return;
+
+  if (nextStatus === 'ready_to_send') {
+    const validationError = validateProposalLines();
+    if (validationError || totalPreview.value <= 0) {
+      setToast(validationError || 'Добавьте хотя бы одну позицию с ненулевой суммой', 'error');
+      return;
+    }
+  }
+  if (nextStatus === 'sent' && !window.confirm('Отметить предложение отправленным другим способом? Для отправки по email используйте основную кнопку.')) return;
+  if (nextStatus === 'draft' && activeProposalLocked.value && !window.confirm('Вернуть предложение в черновик? После этого его можно будет редактировать.')) return;
+
+  proposalActionLoading.value = true;
+  try {
+    if (nextStatus === 'ready_to_send') await saveCurrentProposalLines();
+    const order = await ManagerOrdersService.patchManagerOrderProposal(props.order.id, proposal.id, { status: nextStatus });
+    proposalStatus.value = nextStatus;
+    negotiationStatus.value = order.negotiation_status || negotiationStatus.value;
+    await applyOrderResponse(order, proposal.id);
+    const label = proposalStatusLabel(nextStatus);
+    setToast(`Статус предложения: ${label}`, 'success');
+  } catch (error) {
+    setToast(`Не удалось изменить статус: ${getApiErrorMessage(error)}`, 'error');
+  } finally {
+    proposalActionLoading.value = false;
+  }
+};
+
+const openProposalSend = async () => {
+  const proposal = activeProposal.value;
+  if (!proposal) return;
+  expandedDrawerSections.value.documents = true;
+  activeWorkspaceTarget.value = 'documents';
+  await nextTick();
+  const offerExists = orderDocuments.value.some((document) => (
+    document.doc_type === 'offer'
+    && (!document.proposal_id || document.proposal_id === proposal.id)
+  ));
+  if (offerExists) documentsPanelRef.value?.openSend();
+  else {
+    documentsPanelRef.value?.openCreate();
+    setToast('Сначала создайте коммерческое предложение для активного варианта', 'error');
+  }
+  document.getElementById('order-workspace-documents')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+};
+
+const handleWorkspaceNextAction = async () => {
+  const action = orderWorkspace.value.nextAction;
+  if (action.command === 'create_proposal') return createProposal();
+  if (action.command === 'finish_proposal') return changeActiveProposalStatus('ready_to_send');
+  if (action.command === 'send_proposal') return openProposalSend();
+  if (action.command === 'record_proposal_response') {
+    openWorkspaceTarget('proposal');
+    await nextTick();
+    proposalToolbarRef.value?.openResponse();
+    return;
+  }
+  if (action.command === 'create_proposal_variant') return duplicateProposal();
+  openWorkspaceTarget(action.target);
 };
 
 const toggleEstimateImport = async () => {
@@ -2203,6 +2290,7 @@ const removeProductLine = (index: number) => {
 const removeServiceLine = (index: number) => {
   if (!window.confirm('Удалить эту услугу из заказа?')) return;
   serviceLines.value.splice(index, 1);
+  editingServiceLineIndex.value = null;
   if (activeServiceSuggestionIndex.value === index) {
     activeServiceSuggestionIndex.value = null;
     serviceTariffOptions.value = [];
@@ -2355,14 +2443,13 @@ const handleSave = () => {
     installer_id: installerId.value,
     customer_branch_id: customerBranchId.value,
     customer_delivery_address: customerDeliveryAddress.value,
-    products: linePayload.products,
-    services: linePayload.services,
+    products: activeProposalLocked.value ? undefined : linePayload.products,
+    services: activeProposalLocked.value ? undefined : linePayload.services,
     measurement_required: measurementRequired.value,
     measurer_id: measurerId.value,
     measurement_result: measurementResult.value,
     additional_conditions: additionalConditions.value,
     negotiation_status: status.value === 'negotiation' ? negotiationStatus.value : undefined,
-    proposal_status: status.value === 'execution' ? 'approved' : proposalStatus.value,
     execution_status: status.value === 'execution' ? executionStatus.value : undefined,
     execution_without_payment: status.value === 'execution' ? executionWithoutPayment.value : false,
     execution_without_payment_reason: status.value === 'execution' && executionWithoutPayment.value ? executionWithoutPaymentReason.value : null,
@@ -2390,7 +2477,8 @@ const closeDrawer = (options?: { force?: boolean } | Event) => {
 const isDeleting = ref(false);
 const deleteOrder = async () => {
   if (!props.order?.id) return;
-  const proceed = window.confirm("Вы уверены? Это безвозвратно удалит заказ и все связанные с ним документы, выезды и платежи.");
+  const orderLabel = `Заказ №${props.order.id}${displayOrderTitle.value ? ` «${displayOrderTitle.value}»` : ''}`;
+  const proceed = window.confirm(`${orderLabel} будет безвозвратно удалён вместе со связанными документами, выездами и платежами. Продолжить?`);
   if (!proceed) return;
 
   isDeleting.value = true;
@@ -2546,9 +2634,10 @@ watch(
         :compact="compactWorkspaceHeader"
         @update:title="orderTitle = $event"
         @change-workflow="setWorkflowType"
-        @next="openWorkspaceTarget(orderWorkspace.nextAction.target)"
+        @next="handleWorkspaceNextAction"
         @payments="openWorkspaceTarget('payments')"
         @hold="toggleHold"
+        @delete="deleteOrder"
         @discard="discardUnsavedChanges"
         @save="handleSave"
         @close="closeDrawer"
@@ -2625,7 +2714,7 @@ watch(
       <OrderDrawerSection
         id="order-workspace-object"
         v-model:expanded="expandedDrawerSections.clientDetails"
-        title="Объект"
+        title="Подробнее об объекте"
         :summary="customerDetailsSummary"
         tone="default"
         :has-error="Boolean(getFieldError('customer_delivery_address') || getFieldError('comment'))"
@@ -2787,11 +2876,11 @@ watch(
 
 
       <!-- Планирование (Measurement & Logistics) -->
-      <section v-if="status === 'negotiation'" id="order-workspace-planning" class="mt-4 rounded-2xl border border-blue-100 bg-blue-50/30 p-3">
+      <section v-if="status === 'negotiation'" id="order-workspace-planning" class="mt-4 rounded-2xl border border-blue-100 bg-blue-50/30 p-3 dark:border-blue-500/30 dark:bg-blue-500/10">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div class="min-w-0">
-            <h3 class="text-sm font-semibold text-blue-900">{{ planningTitle }}</h3>
-            <p class="mt-0.5 truncate text-xs text-blue-700/70">{{ planningSummary }}</p>
+            <h3 class="text-sm font-semibold text-blue-900 dark:text-blue-100">{{ planningTitle }}</h3>
+            <p class="mt-0.5 truncate text-xs text-blue-700/70 dark:text-blue-200/70">{{ planningSummary }}</p>
           </div>
           <button
             v-if="!measurementRequired"
@@ -2800,46 +2889,31 @@ watch(
             @click="measurementRequired = true"
           >
             <span class="material-icons-round text-[15px]">add_location_alt</span>
-            {{ isRepairWorkflow ? 'Выезд на диагностику' : 'Выезд на замер' }}
+            {{ isRepairWorkflow ? 'Назначить диагностику' : 'Назначить замер' }}
           </button>
-          <label v-else class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-blue-900 ring-1 ring-blue-100">
+          <label v-else class="inline-flex items-center gap-2 rounded-xl bg-white px-3 py-2 text-xs font-medium text-blue-900 ring-1 ring-blue-100 dark:bg-slate-900 dark:text-blue-100 dark:ring-blue-500/30">
             <input type="checkbox" v-model="measurementRequired" class="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
             {{ isRepairWorkflow ? 'Диагностика нужна' : 'Замер нужен' }}
           </label>
         </div>
 
-        <div class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm">
-          <div class="flex items-center justify-between gap-3">
-            <p class="text-xs font-semibold uppercase tracking-[0.12em] text-blue-900/70">Состояние переговоров</p>
-            <span class="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold text-blue-800">
-              {{ negotiationStatusLabel }}
-            </span>
-          </div>
-          <div class="mt-3 flex flex-wrap gap-2">
-            <button
-              v-for="option in NEGOTIATION_STATUS_OPTIONS"
-              :key="option.value"
-              type="button"
-              class="inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-semibold transition"
-              :class="negotiationStatus === option.value
-                ? 'border-blue-200 bg-blue-100 text-blue-900 shadow-sm'
-                : 'border-gray-200 bg-white text-gray-600 hover:border-blue-200 hover:bg-blue-50 hover:text-blue-800'"
-              @click="setNegotiationStatus(option.value)"
-            >
-              <span class="material-icons-round text-[15px]">{{ option.icon }}</span>
-              {{ option.label }}
-            </button>
-          </div>
-          <label class="mt-3 flex items-start gap-2 rounded-xl border border-emerald-100 bg-emerald-50/70 px-3 py-2 text-xs text-emerald-900">
+        <div class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
+          <label class="block">
+            <span class="text-xs font-semibold uppercase tracking-[0.12em] text-blue-900/70 dark:text-blue-200/80">Состояние переговоров</span>
+            <select :value="negotiationStatus" class="field-input mt-2 bg-white dark:bg-slate-950" @change="setNegotiationStatus(($event.target as HTMLSelectElement).value)">
+              <option v-for="option in NEGOTIATION_STATUS_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
+            </select>
+          </label>
+          <label class="mt-3 flex items-start gap-2 rounded-xl border border-emerald-100 bg-emerald-50/70 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
             <input v-model="autoExecutionOnPayment" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-600" />
             <span>
-              <span class="block font-semibold">Перевести в работу после полной оплаты</span>
-              <span class="mt-0.5 block text-emerald-700/80">Сработает автоматически, когда долг по заказу станет нулевым.</span>
+              <span class="block font-semibold">После полной оплаты автоматически перевести заказ в этап «Работы»</span>
+              <span class="mt-0.5 block text-emerald-700/80 dark:text-emerald-200/70">Сработает автоматически, когда долг по заказу станет нулевым.</span>
             </span>
           </label>
         </div>
 
-        <div v-if="measurementRequired" class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm">
+        <div v-if="measurementRequired" class="mt-3 rounded-xl border border-blue-100 bg-white p-3 shadow-sm dark:border-blue-500/30 dark:bg-slate-900">
           <DateTimeField v-model="assessmentDate" :label="isRepairWorkflow ? 'Дата и время диагностики' : 'Дата и время замера'" :error="getFieldError('measurement_date')" />
         </div>
 
@@ -3345,76 +3419,31 @@ watch(
         :has-error="Boolean(getFieldError('products') || getFieldError('services'))"
       >
         <div class="min-w-0">
-        <div class="mb-4 border-b border-gray-200 pb-3">
-          <div v-if="orderProposals.length" class="flex gap-2 overflow-x-auto pb-1">
-            <button
-              v-for="proposal in orderProposals"
-              :key="proposal.id"
-              type="button"
-              class="shrink-0 rounded-xl border px-3 py-2 text-left text-xs transition disabled:cursor-not-allowed disabled:opacity-60"
-              :class="proposal.id === activeProposal?.id
-                ? 'border-teal-500 bg-teal-50 text-teal-900 shadow-sm'
-                : 'border-gray-200 bg-white text-gray-600 hover:border-teal-200 hover:text-teal-800'"
-              :disabled="proposalActionLoading"
-              @click="onProposalClick(proposal)"
-              @dblclick.stop="selectProposalForOrder(proposal)"
-            >
-              <span class="flex items-center gap-1 font-semibold">
-                {{ proposal.name }}
-                <span v-if="proposal.is_selected" class="material-icons-round text-[14px] text-teal-600">check_circle</span>
-              </span>
-              <span class="mt-0.5 block whitespace-nowrap text-[11px] opacity-75">{{ formatMoney(proposal.total_amount || 0) }}</span>
-            </button>
-            <button
-              type="button"
-              class="flex min-h-[58px] w-12 shrink-0 items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white text-slate-500 transition hover:border-teal-300 hover:text-teal-700"
-              :disabled="proposalActionLoading"
-              title="Добавить предложение"
-              @click="createProposal"
-            >
-              <span class="material-icons-round text-[20px]">add</span>
-            </button>
-          </div>
+        <OrderProposalToolbar
+          ref="proposalToolbarRef"
+          class="mb-4"
+          :proposals="orderProposals"
+          :active-proposal-id="activeProposal?.id"
+          :loading="proposalActionLoading"
+          @open="onProposalClick"
+          @select="selectProposalForOrder"
+          @create="createProposal"
+          @duplicate="duplicateProposal"
+          @rename="renameProposal"
+          @archive="archiveProposal"
+          @change-status="changeActiveProposalStatus"
+          @send="openProposalSend"
+        />
 
-          <div v-if="activeProposal" class="mt-3 flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              class="btn-mini whitespace-nowrap text-xs"
-              :disabled="proposalActionLoading || activeProposal.is_selected"
-              @click="selectProposalForOrder()"
-            >
-              <span class="material-icons-round text-[15px]">check_circle</span>
-              Выбрать
-            </button>
-            <button
-              type="button"
-              class="btn-mini-outline whitespace-nowrap text-xs"
-              :disabled="proposalActionLoading || !activeProposal"
-              @click="duplicateProposal"
-            >
-              <span class="material-icons-round text-[15px]">content_copy</span>
-              Копия
-            </button>
-            <button
-              type="button"
-              class="btn-mini-outline whitespace-nowrap text-xs"
-              :disabled="proposalActionLoading || !activeProposal"
-              @click="renameProposal"
-            >
-              <span class="material-icons-round text-[15px]">edit</span>
-              Название
-            </button>
-            <button
-              type="button"
-              class="flex h-9 w-9 items-center justify-center rounded-xl border border-red-200 bg-white text-red-600 hover:bg-red-50 disabled:opacity-50"
-              :disabled="proposalActionLoading || orderProposals.length <= 1"
-              @click="archiveProposal"
-              title="В архив"
-            >
-              <span class="material-icons-round text-[18px]">delete</span>
-            </button>
+        <div v-if="activeProposalLocked" class="mb-3 flex flex-col gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between">
+          <span>Эта редакция уже {{ activeProposalStatus === 'approved' ? 'принята клиентом' : 'отправлена' }}. Чтобы изменить состав или стоимость, создайте копию либо верните её в черновик.</span>
+          <div class="flex shrink-0 gap-2">
+            <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="duplicateProposal">Создать копию</button>
+            <button type="button" class="btn-mini-outline h-8 px-2 text-xs" @click="changeActiveProposalStatus('draft')">В черновик</button>
           </div>
         </div>
+
+        <fieldset :disabled="activeProposalLocked" :class="activeProposalLocked ? 'opacity-60' : ''">
 
         <section v-if="showProductLinesSection" class="mt-2">
           <div class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -3564,6 +3593,7 @@ watch(
               class="relative rounded-xl border border-gray-200 bg-white p-3 shadow-sm"
             >
               <button
+                v-if="editingServiceLineIndex === index"
                 type="button"
                 class="absolute -right-2 -top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border border-red-200 bg-red-50 text-lg font-bold text-red-600 shadow-sm transition-colors hover:bg-red-100"
                 :aria-label="`Удалить услугу #${index + 1}`"
@@ -3572,7 +3602,25 @@ watch(
               >
                 ×
               </button>
-              <div class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
+              <div v-if="editingServiceLineIndex !== index" class="flex min-w-0 items-start gap-3">
+                <div class="min-w-0 flex-1">
+                  <p class="break-words text-sm font-semibold leading-snug text-slate-900 dark:text-slate-100">{{ line.title || 'Новая услуга' }}</p>
+                  <div class="mt-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>{{ line.quantity }} × {{ formatMoney(line.price) }}</span>
+                    <span class="font-semibold text-slate-800 dark:text-slate-200">{{ formatMoney(lineTotal(line)) }}</span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  class="btn-mini-outline h-9 w-9 shrink-0 justify-center p-0"
+                  :aria-label="`Редактировать услугу #${index + 1}`"
+                  title="Редактировать"
+                  @click="editingServiceLineIndex = index"
+                >
+                  <span class="material-icons-round text-[17px]">edit</span>
+                </button>
+              </div>
+              <div v-else class="grid grid-cols-6 gap-2 md:grid-cols-12 md:items-start">
                 <div class="relative col-span-6 space-y-1 md:col-span-5">
                   <span class="flex min-h-6 items-center justify-between gap-2 px-1 text-xs font-medium text-gray-500">
                     <span>Название</span>
@@ -3637,6 +3685,9 @@ watch(
                   <div class="rounded-lg bg-gray-50 px-3 py-2">
                     <p class="whitespace-nowrap text-base font-semibold leading-tight text-gray-900">{{ formatMoney(lineTotal(line)) }}</p>
                   </div>
+                </div>
+                <div class="col-span-6 flex justify-end md:col-span-12">
+                  <button type="button" class="btn-mini-outline h-8 px-3 text-xs" @click="editingServiceLineIndex = null">Готово</button>
                 </div>
               </div>
             </div>
@@ -3714,6 +3765,7 @@ watch(
             </p>
           </div>
         </section>
+        </fieldset>
       </div>
       </OrderDrawerSection>
 
@@ -3751,6 +3803,7 @@ watch(
 
         <OrderDocumentsPanel
           v-if="order"
+          ref="documentsPanelRef"
           :order="order"
           :active-proposal-id="activeProposalId"
           :product-lines="productLines"
@@ -3969,12 +4022,6 @@ watch(
       </section>
       </OrderDrawerSection>
 
-      <footer class="mt-6 border-t border-gray-100 pt-4 dark:border-slate-800">
-        <button class="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/30" :disabled="saving || isDeleting" @click="deleteOrder" title="Безвозвратное удаление">
-          <span class="material-icons-round text-[16px]">delete</span>
-          {{ isDeleting ? 'Удаление...' : 'Удалить заказ' }}
-        </button>
-      </footer>
       </div>
     </aside>
 

--- a/manager_frontend/src/components/orders/OrderProposalToolbar.vue
+++ b/manager_frontend/src/components/orders/OrderProposalToolbar.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Archive, Check, Copy, MoreHorizontal, Pencil, Plus, RotateCcw, Send, ThumbsDown, ThumbsUp } from 'lucide-vue-next';
+import type { OrderProposalResponse } from '../../client';
+import {
+  PROPOSAL_STATUS_META,
+  normalizeProposalStatus,
+  proposalPrimaryAction,
+  proposalPrimaryActionLabel,
+} from './proposal-lifecycle';
+import { formatMoney } from './order-utils';
+
+const props = defineProps<{
+  proposals: OrderProposalResponse[];
+  activeProposalId?: number | null;
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  open: [proposal: OrderProposalResponse];
+  select: [proposal: OrderProposalResponse];
+  create: [];
+  duplicate: [];
+  rename: [];
+  archive: [];
+  'change-status': [status: 'draft' | 'ready_to_send' | 'sent' | 'approved' | 'rejected'];
+  send: [];
+}>();
+
+const menuOpen = ref(false);
+const responseOpen = ref(false);
+const activeProposal = computed(() => (
+  props.proposals.find((proposal) => proposal.id === props.activeProposalId)
+  || props.proposals.find((proposal) => proposal.is_selected)
+  || props.proposals[0]
+  || null
+));
+const lineCount = (proposal: OrderProposalResponse) => (proposal.product_lines?.length || 0) + (proposal.service_lines?.length || 0);
+const activeStatus = computed(() => normalizeProposalStatus(activeProposal.value?.status));
+const activeLineCount = computed(() => activeProposal.value ? lineCount(activeProposal.value) : 0);
+const activeCanFinish = computed(() => activeLineCount.value > 0 && Number(activeProposal.value?.total_amount || 0) > 0);
+const primaryAction = computed(() => proposalPrimaryAction(activeStatus.value));
+const primaryLabel = computed(() => (
+  activeStatus.value === 'draft' && !activeCanFinish.value
+    ? 'Заполните предложение'
+    : proposalPrimaryActionLabel(activeStatus.value)
+));
+
+const statusMeta = (proposal: OrderProposalResponse) => PROPOSAL_STATUS_META[normalizeProposalStatus(proposal.status)];
+const lineLabel = (proposal: OrderProposalResponse) => {
+  const count = lineCount(proposal);
+  const mod100 = count % 100;
+  const mod10 = count % 10;
+  const noun = mod100 >= 11 && mod100 <= 14 ? 'позиций' : mod10 === 1 ? 'позиция' : mod10 >= 2 && mod10 <= 4 ? 'позиции' : 'позиций';
+  return `${count} ${noun}`;
+};
+const toneClass = (proposal: OrderProposalResponse) => ({
+  slate: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+  sky: 'bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-200',
+  amber: 'bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-200',
+  emerald: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200',
+  rose: 'bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200',
+}[statusMeta(proposal).tone]);
+
+const runPrimary = () => {
+  if (!activeProposal.value || props.loading) return;
+  if (!activeProposal.value.is_selected) {
+    emit('select', activeProposal.value);
+    return;
+  }
+  if (primaryAction.value === 'finish' && activeCanFinish.value) emit('change-status', 'ready_to_send');
+  else if (primaryAction.value === 'send') emit('send');
+  else if (primaryAction.value === 'record_response') responseOpen.value = !responseOpen.value;
+  else if (primaryAction.value === 'create_variant') emit('duplicate');
+};
+
+const changeResponse = (status: 'approved' | 'rejected') => {
+  responseOpen.value = false;
+  emit('change-status', status);
+};
+
+defineExpose({
+  openResponse: () => { responseOpen.value = true; },
+});
+</script>
+
+<template>
+  <div class="border-b border-slate-200 pb-3 dark:border-slate-700" @keydown.esc="menuOpen = false; responseOpen = false">
+    <div v-if="proposals.length > 1" class="flex gap-2 overflow-x-auto pb-1">
+      <button
+        v-for="proposal in proposals"
+        :key="proposal.id"
+        type="button"
+        class="min-w-[9.5rem] shrink-0 rounded-xl border px-3 py-2 text-left text-xs transition disabled:cursor-not-allowed disabled:opacity-60"
+        :class="proposal.id === activeProposal?.id
+          ? 'border-teal-500 bg-teal-50 text-teal-950 shadow-sm dark:border-teal-400 dark:bg-teal-500/10 dark:text-teal-100'
+          : 'border-slate-200 bg-white text-slate-600 hover:border-teal-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300'"
+        :disabled="loading"
+        @click="emit('open', proposal)"
+      >
+        <span class="flex min-w-0 items-center gap-1 font-semibold">
+          <span class="truncate">{{ proposal.name }}</span>
+          <Check v-if="proposal.is_selected" :size="13" class="shrink-0 text-teal-600" aria-label="Активное предложение" />
+        </span>
+        <span class="mt-1 flex items-center gap-1.5">
+          <span class="rounded-full px-1.5 py-0.5 text-[10px] font-semibold" :class="toneClass(proposal)">{{ statusMeta(proposal).label }}</span>
+          <span class="whitespace-nowrap opacity-70">{{ formatMoney(proposal.total_amount || 0) }}</span>
+        </span>
+      </button>
+    </div>
+
+    <div v-if="activeProposal" class="mt-2 flex min-w-0 items-center gap-2">
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
+          <span class="truncate font-semibold text-slate-900 dark:text-white">{{ activeProposal.name }}</span>
+          <span v-if="activeProposal.is_selected" class="rounded-full bg-teal-50 px-2 py-0.5 font-semibold text-teal-700 dark:bg-teal-500/15 dark:text-teal-200">Активное</span>
+          <span class="rounded-full px-2 py-0.5 font-semibold" :class="toneClass(activeProposal)">{{ statusMeta(activeProposal).label }}</span>
+        </div>
+        <p class="mt-0.5 text-[11px] text-slate-500 dark:text-slate-400">{{ lineLabel(activeProposal) }} · {{ formatMoney(activeProposal.total_amount || 0) }}</p>
+      </div>
+
+      <button
+        v-if="!activeProposal.is_selected || primaryAction"
+        type="button"
+        class="btn-mini h-9 shrink-0 gap-1.5 px-3 text-xs"
+        :disabled="loading"
+        @click="runPrimary"
+      >
+        <Check v-if="!activeProposal.is_selected || primaryAction === 'finish'" :size="15" />
+        <Send v-else-if="primaryAction === 'send'" :size="15" />
+        <Plus v-else-if="primaryAction === 'create_variant'" :size="15" />
+        <span>{{ !activeProposal.is_selected ? 'Сделать активным' : primaryLabel }}</span>
+      </button>
+
+      <div class="relative shrink-0">
+        <button type="button" class="btn-mini-outline h-9 w-9 justify-center p-0" :disabled="loading" aria-label="Действия с предложением" :aria-expanded="menuOpen" @click="menuOpen = !menuOpen">
+          <MoreHorizontal :size="17" />
+        </button>
+        <div v-if="menuOpen" class="absolute right-0 top-11 z-30 w-56 rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+          <button type="button" class="menu-action" @click="emit('rename'); menuOpen = false"><Pencil :size="15" />Переименовать</button>
+          <button type="button" class="menu-action" @click="emit('duplicate'); menuOpen = false"><Copy :size="15" />Создать копию</button>
+          <button type="button" class="menu-action" @click="emit('create'); menuOpen = false"><Plus :size="15" />Альтернативный вариант</button>
+          <button v-if="activeStatus === 'ready_to_send'" type="button" class="menu-action" @click="emit('change-status', 'sent'); menuOpen = false"><Send :size="15" />Отметить отправленным</button>
+          <button v-if="activeStatus !== 'draft'" type="button" class="menu-action" @click="emit('change-status', 'draft'); menuOpen = false"><RotateCcw :size="15" />Вернуть в черновик</button>
+          <button v-if="proposals.length > 1" type="button" class="menu-action danger" @click="emit('archive'); menuOpen = false"><Archive :size="15" />Перенести в архив</button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="responseOpen" class="mt-2 flex flex-wrap items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 p-2 dark:border-amber-500/30 dark:bg-amber-500/10">
+      <span class="mr-auto text-xs font-medium text-amber-900 dark:text-amber-100">Как ответил клиент?</span>
+      <button type="button" class="btn-mini h-8 gap-1.5 px-2.5 text-xs" :disabled="loading" @click="changeResponse('approved')"><ThumbsUp :size="14" />Принято</button>
+      <button type="button" class="btn-mini-outline h-8 gap-1.5 px-2.5 text-xs text-rose-700" :disabled="loading" @click="changeResponse('rejected')"><ThumbsDown :size="14" />Отклонено</button>
+    </div>
+
+    <button v-if="!proposals.length" type="button" class="btn-mini w-full justify-center" :disabled="loading" @click="emit('create')"><Plus :size="16" />Создать предложение</button>
+  </div>
+</template>
+
+<style scoped>
+.menu-action {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.8125rem;
+  color: rgb(51 65 85);
+}
+.menu-action:hover { background: rgb(241 245 249); }
+.menu-action.danger { color: rgb(190 18 60); }
+:global(.dark) .menu-action { color: rgb(226 232 240); }
+:global(.dark) .menu-action.danger { color: rgb(253 164 175); }
+:global(.dark) .menu-action:hover { background: rgb(30 41 59); }
+</style>

--- a/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
+++ b/manager_frontend/src/components/orders/OrderWorkspaceHeader.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
-import { ArrowRight, Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Undo2, X } from 'lucide-vue-next';
+import { ArrowRight, Check, ChevronDown, Clock3, MoreVertical, Pause, Pencil, Play, Save, Trash2, Undo2, X } from 'lucide-vue-next';
 import { formatMoney } from './order-utils';
 import { ORDER_WORKFLOW_OPTIONS, type OrderWorkflowType, type OrderWorkspaceViewModel } from './order-workspace';
 import { STICKY_HEADER_RESIZE_DURATION_MS } from '../../composables/useSmartStickyHeader';
@@ -27,6 +27,7 @@ const emit = defineEmits<{
   next: [];
   payments: [];
   hold: [];
+  delete: [];
   discard: [];
   save: [];
   close: [];
@@ -41,7 +42,7 @@ const focusLocksCompactMode = ref(false);
 const effectiveCompact = computed(() => Boolean(props.compact && !editingTitle.value && !menuOpen.value && !focusLocksCompactMode.value));
 const showCustomerName = computed(() => {
   const customerName = String(props.customerName || '').trim();
-  return Boolean(customerName && customerName !== String(props.title || '').trim());
+  return Boolean(effectiveCompact.value && customerName && customerName !== String(props.title || '').trim());
 });
 let resizeAnimation: Animation | null = null;
 let contentAnimation: Animation | null = null;
@@ -222,6 +223,11 @@ const onWorkflowChange = async (event: Event) => {
               <Play v-if="isOnHold" :size="16" />
               <Pause v-else :size="16" />
               {{ isOnHold ? 'Вернуть в работу' : 'Отложить заказ' }}
+            </button>
+            <div class="my-1 border-t border-slate-200 dark:border-slate-700" />
+            <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/30" @click="emit('delete'); menuOpen = false">
+              <Trash2 :size="16" />
+              Удалить заказ
             </button>
           </div>
         </div>

--- a/manager_frontend/src/components/orders/OrdersDashboard.vue
+++ b/manager_frontend/src/components/orders/OrdersDashboard.vue
@@ -452,7 +452,6 @@ const buildBoardTransitionPayload = (order: ManagerOrderListItemResponse, column
     execution_without_payment: false,
     execution_without_payment_reason: null,
     measurement_required: column === 'awaiting_visit' ? true : undefined,
-    proposal_status: column === 'proposal_sent' ? 'sent' : column === 'awaiting_payment' ? 'approved' : undefined,
   };
 };
 
@@ -464,7 +463,6 @@ const applyStatusLocally = (orderId: number, payload: ManagerOrderUpdatePayload)
   if (payload.execution_status !== undefined && payload.execution_status !== null) item.execution_status = payload.execution_status;
   if (payload.closing_result !== undefined) item.closing_result = payload.closing_result;
   if (payload.reject_reason !== undefined) item.reject_reason = payload.reject_reason;
-  if (payload.proposal_status !== undefined && payload.proposal_status !== null) item.proposal_status = payload.proposal_status;
   if (payload.measurement_required !== undefined && payload.measurement_required !== null) item.measurement_required = payload.measurement_required;
   if (payload.execution_without_payment !== undefined && payload.execution_without_payment !== null) item.execution_without_payment = payload.execution_without_payment;
   if (payload.execution_without_payment_reason !== undefined) item.execution_without_payment_reason = payload.execution_without_payment_reason;

--- a/manager_frontend/src/components/orders/order-utils.ts
+++ b/manager_frontend/src/components/orders/order-utils.ts
@@ -12,7 +12,7 @@ export const NEGOTIATION_STATUS_OPTIONS = [
     { value: 'awaiting_visit', label: 'Ждет выезд', icon: 'location_on', tone: 'violet' },
     { value: 'proposal_sent', label: 'Ожидаем ответ', icon: 'send', tone: 'amber' },
     { value: 'awaiting_payment', label: 'Ожидаем оплату', icon: 'payments', tone: 'emerald' },
-    { value: 'follow_up', label: 'Уточнить', icon: 'contact_phone', tone: 'slate' },
+    { value: 'follow_up', label: 'Требуется уточнение', icon: 'contact_phone', tone: 'slate' },
 ] as const;
 
 export const EXECUTION_STATUS_OPTIONS = [

--- a/manager_frontend/src/components/orders/order-workspace.ts
+++ b/manager_frontend/src/components/orders/order-workspace.ts
@@ -1,9 +1,17 @@
 import type { ManagerOrderDocumentItem } from '../../client';
 import { EXECUTION_STATUS_LABELS, NEGOTIATION_STATUS_LABELS, formatRelativeAge } from './order-utils';
+import { normalizeProposalStatus, type ProposalLifecycleStatus } from './proposal-lifecycle';
 
 export type OrderWorkflowType = 'sales_installation' | 'service_work' | 'maintenance' | 'repair';
 export type OrderWorkspaceTarget = 'object' | 'planning' | 'proposal' | 'documents' | 'payments' | 'equipment';
 export type OrderWorkspaceTone = 'slate' | 'sky' | 'amber' | 'teal' | 'emerald' | 'rose';
+export type OrderWorkspaceCommand =
+  | 'open'
+  | 'create_proposal'
+  | 'finish_proposal'
+  | 'send_proposal'
+  | 'record_proposal_response'
+  | 'create_proposal_variant';
 
 export type OrderWorkflowOption = {
   value: OrderWorkflowType;
@@ -42,6 +50,7 @@ export type OrderWorkspaceViewModel = {
     label: string;
     target: OrderWorkspaceTarget;
     tone: OrderWorkspaceTone;
+    command: OrderWorkspaceCommand;
   };
   blockers: string[];
   lanes: OrderWorkspaceLane[];
@@ -55,6 +64,11 @@ export type OrderWorkspaceInput = {
   negotiationStatusChangedAt?: string | null;
   executionStatusChangedAt?: string | null;
   installationDate?: string | null;
+  activeProposalId?: number | null;
+  activeProposalStatus?: ProposalLifecycleStatus | string | null;
+  activeProposalLineCount?: number;
+  activeProposalTotal?: number;
+  autoExecutionOnPayment?: boolean;
   productCount: number;
   serviceCount: number;
   linkedEquipmentCount: number;
@@ -64,6 +78,24 @@ export type OrderWorkspaceInput = {
   total: number;
   paid: number;
   balance: number;
+};
+
+export const buildMeasurementSummary = (input: {
+  required: boolean;
+  date?: string | null;
+  result?: string | null;
+  kind?: 'measurement' | 'diagnostic';
+  formatDate?: (value: string) => string | null;
+}) => {
+  const diagnostic = input.kind === 'diagnostic';
+  const label = diagnostic ? 'Диагностика' : 'Замер';
+  if (!input.required) return `${label} не требуется`;
+  if (String(input.result || '').trim()) return `${label} выполнен${diagnostic ? 'а' : ''}`;
+  if (input.date) {
+    const renderedDate = (input.formatDate ? input.formatDate(input.date) : input.date) || input.date;
+    return `${label} назначен${diagnostic ? 'а' : ''}: ${renderedDate}`;
+  }
+  return `${label} не назначен${diagnostic ? 'а' : ''}`;
 };
 
 const plural = (count: number, one: string, few: string, many: string) => {
@@ -116,26 +148,36 @@ export const buildOrderWorkspaceViewModel = (input: OrderWorkspaceInput): OrderW
   if (inExecution && substatus === 'work_done' && !input.documents.length) blockers.push('Нет закрывающих документов');
   if (input.missingReferencedInvoice) blockers.push(`Не найден счёт ${input.missingReferencedInvoice} из назначения платежа`);
 
+  const proposalStatus = normalizeProposalStatus(input.activeProposalStatus);
+  const hasActiveProposal = Boolean(input.activeProposalId);
+  const proposalHasValidLines = Number(input.activeProposalLineCount || 0) > 0 && Number(input.activeProposalTotal || 0) > 0;
+
   let nextAction: OrderWorkspaceViewModel['nextAction'];
-  if (isClosed) nextAction = { label: 'Проверить историю', target: 'documents', tone: 'slate' };
-  else if (!input.productCount && !input.serviceCount) nextAction = { label: 'Заполнить смету', target: 'proposal', tone: 'sky' };
-  else if (!inExecution && substatus === 'awaiting_visit') nextAction = { label: 'Назначить выезд', target: 'planning', tone: 'sky' };
-  else if (!inExecution && substatus === 'awaiting_payment') nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
-  else if (!inExecution && substatus === 'proposal_sent') nextAction = { label: 'Проверить предложение', target: 'proposal', tone: 'amber' };
-  else if (!inExecution) nextAction = { label: 'Подготовить предложение', target: 'proposal', tone: 'sky' };
-  else if (substatus === 'order_equipment' || substatus === 'awaiting_equipment') nextAction = { label: 'Проверить товар', target: 'proposal', tone: 'amber' };
-  else if (substatus === 'needs_schedule' || substatus === 'scheduled') nextAction = { label: 'Открыть планирование', target: 'planning', tone: 'teal' };
+  if (isClosed) nextAction = { label: 'Проверить историю', target: 'documents', tone: 'slate', command: 'open' };
+  else if (!inExecution && !hasActiveProposal) nextAction = { label: 'Создать предложение', target: 'proposal', tone: 'sky', command: 'create_proposal' };
+  else if (!inExecution && proposalStatus === 'draft' && !proposalHasValidLines) nextAction = { label: 'Заполнить предложение', target: 'proposal', tone: 'sky', command: 'open' };
+  else if (!inExecution && proposalStatus === 'draft') nextAction = { label: 'Завершить подготовку', target: 'proposal', tone: 'sky', command: 'finish_proposal' };
+  else if (!inExecution && proposalStatus === 'ready_to_send') nextAction = { label: 'Отправить предложение', target: 'proposal', tone: 'sky', command: 'send_proposal' };
+  else if (!inExecution && proposalStatus === 'sent') nextAction = { label: 'Зафиксировать ответ', target: 'proposal', tone: 'amber', command: 'record_proposal_response' };
+  else if (!inExecution && proposalStatus === 'rejected') nextAction = { label: 'Подготовить новый вариант', target: 'proposal', tone: 'rose', command: 'create_proposal_variant' };
+  else if (!inExecution && proposalStatus === 'approved' && input.autoExecutionOnPayment && input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald', command: 'open' };
+  else if (!inExecution && proposalStatus === 'approved' && !input.installationDate) nextAction = { label: 'Назначить работы', target: 'planning', tone: 'teal', command: 'open' };
+  else if (!inExecution && substatus === 'awaiting_visit') nextAction = { label: 'Назначить выезд', target: 'planning', tone: 'sky', command: 'open' };
+  else if (!inExecution && substatus === 'awaiting_payment') nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald', command: 'open' };
+  else if (!inExecution) nextAction = { label: 'Открыть предложение', target: 'proposal', tone: 'sky', command: 'open' };
+  else if (substatus === 'order_equipment' || substatus === 'awaiting_equipment') nextAction = { label: 'Проверить товар', target: 'proposal', tone: 'amber', command: 'open' };
+  else if (substatus === 'needs_schedule' || substatus === 'scheduled') nextAction = { label: 'Открыть планирование', target: 'planning', tone: 'teal', command: 'open' };
   else if (substatus === 'work_done' || substatus === 'awaiting_documents') {
-    if (input.missingReferencedInvoice) nextAction = { label: `Проверить счёт ${input.missingReferencedInvoice}`, target: 'documents', tone: 'amber' };
-    else if (!input.documents.length) nextAction = { label: 'Создать комплект документов', target: 'documents', tone: 'teal' };
-    else if (input.documentEmailStatus === 'unknown') nextAction = { label: 'Проверить комплект документов', target: 'documents', tone: 'amber' };
-    else if (input.documentEmailStatus === 'failed') nextAction = { label: 'Повторить отправку документов', target: 'documents', tone: 'rose' };
-    else if (input.documentEmailStatus === 'pending') nextAction = { label: 'Проверить отправку документов', target: 'documents', tone: 'amber' };
-    else if (input.documentEmailStatus !== 'sent') nextAction = { label: 'Отправить документы', target: 'documents', tone: 'teal' };
-    else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
-    else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald' };
-  } else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald' };
-  else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald' };
+    if (input.missingReferencedInvoice) nextAction = { label: `Проверить счёт ${input.missingReferencedInvoice}`, target: 'documents', tone: 'amber', command: 'open' };
+    else if (!input.documents.length) nextAction = { label: 'Создать комплект документов', target: 'documents', tone: 'teal', command: 'open' };
+    else if (input.documentEmailStatus === 'unknown') nextAction = { label: 'Проверить комплект документов', target: 'documents', tone: 'amber', command: 'open' };
+    else if (input.documentEmailStatus === 'failed') nextAction = { label: 'Повторить отправку документов', target: 'documents', tone: 'rose', command: 'open' };
+    else if (input.documentEmailStatus === 'pending') nextAction = { label: 'Проверить отправку документов', target: 'documents', tone: 'amber', command: 'open' };
+    else if (input.documentEmailStatus !== 'sent') nextAction = { label: 'Отправить документы', target: 'documents', tone: 'teal', command: 'open' };
+    else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald', command: 'open' };
+    else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald', command: 'open' };
+  } else if (input.balance > 0) nextAction = { label: `Ожидать оплату ${Math.round(input.balance).toLocaleString('ru-RU')} BYN`, target: 'payments', tone: 'emerald', command: 'open' };
+  else nextAction = { label: 'Проверить завершение заказа', target: 'payments', tone: 'emerald', command: 'open' };
 
   const productStatus = !input.productCount
     ? 'Товар не выбран'

--- a/manager_frontend/src/components/orders/proposal-lifecycle.ts
+++ b/manager_frontend/src/components/orders/proposal-lifecycle.ts
@@ -1,0 +1,48 @@
+export type ProposalLifecycleStatus = 'draft' | 'ready_to_send' | 'sent' | 'approved' | 'rejected';
+
+export const PROPOSAL_STATUS_META: Record<ProposalLifecycleStatus, {
+  label: string;
+  tone: 'slate' | 'sky' | 'amber' | 'emerald' | 'rose';
+}> = {
+  draft: { label: 'Черновик', tone: 'slate' },
+  ready_to_send: { label: 'Готово к отправке', tone: 'sky' },
+  sent: { label: 'Отправлено', tone: 'amber' },
+  approved: { label: 'Принято клиентом', tone: 'emerald' },
+  rejected: { label: 'Отклонено клиентом', tone: 'rose' },
+};
+
+export const normalizeProposalStatus = (value: unknown): ProposalLifecycleStatus => {
+  const status = String(value || 'draft').trim().toLowerCase();
+  if (status === 'accepted') return 'approved';
+  if (status === 'ready_to_send' || status === 'sent' || status === 'approved' || status === 'rejected') return status;
+  return 'draft';
+};
+
+export const proposalStatusLabel = (value: unknown) => PROPOSAL_STATUS_META[normalizeProposalStatus(value)].label;
+
+export const isProposalRevisionLocked = (value: unknown) => {
+  const status = normalizeProposalStatus(value);
+  return status === 'sent' || status === 'approved';
+};
+
+export type ProposalPrimaryAction = 'finish' | 'send' | 'record_response' | 'create_variant' | null;
+
+export const proposalPrimaryAction = (value: unknown): ProposalPrimaryAction => {
+  const status = normalizeProposalStatus(value);
+  if (status === 'draft') return 'finish';
+  if (status === 'ready_to_send') return 'send';
+  if (status === 'sent') return 'record_response';
+  if (status === 'rejected') return 'create_variant';
+  return null;
+};
+
+export const proposalPrimaryActionLabel = (value: unknown) => {
+  const action = proposalPrimaryAction(value);
+  if (!action) return '';
+  return {
+    finish: 'Завершить подготовку',
+    send: 'Отправить предложение',
+    record_response: 'Зафиксировать ответ',
+    create_variant: 'Подготовить новый вариант',
+  }[action];
+};

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -22,6 +22,15 @@ import {
 } from '../src/utils/image-upload-optimization';
 import { compactLegalName } from '../src/components/orders/order-utils';
 import {
+  buildMeasurementSummary,
+  buildOrderWorkspaceViewModel,
+} from '../src/components/orders/order-workspace';
+import {
+  isProposalRevisionLocked,
+  proposalPrimaryAction,
+  proposalStatusLabel,
+} from '../src/components/orders/proposal-lifecycle';
+import {
   applyCatalogQualityView,
   createDefaultCatalogQualityState,
   parseCatalogQualityState,
@@ -155,5 +164,58 @@ const savedQualityView = applyCatalogQualityView(
 assert(savedQualityView.availability === 'in_stock' && savedQualityView.category === 'media', 'saved catalog view must apply its filters');
 assert(savedQualityView.view === 'table' && savedQualityView.limit === 100, 'saved catalog view must preserve personal display preferences');
 assert(savedQualityView.page === 1, 'saved catalog view must restart pagination');
+
+const workspaceBase = {
+  status: 'negotiation',
+  negotiationStatus: 'awaiting_offer',
+  activeProposalId: 7,
+  activeProposalLineCount: 2,
+  activeProposalTotal: 2400,
+  productCount: 1,
+  serviceCount: 1,
+  linkedEquipmentCount: 0,
+  documents: [],
+  total: 2400,
+  paid: 0,
+  balance: 2400,
+};
+assert(
+  buildOrderWorkspaceViewModel({ ...workspaceBase, activeProposalStatus: 'draft' }).nextAction.command === 'finish_proposal',
+  'valid draft proposal must lead to preparation completion',
+);
+assert(
+  buildOrderWorkspaceViewModel({ ...workspaceBase, activeProposalStatus: 'ready_to_send' }).nextAction.command === 'send_proposal',
+  'ready proposal must lead to sending',
+);
+assert(
+  buildOrderWorkspaceViewModel({ ...workspaceBase, activeProposalStatus: 'sent' }).nextAction.command === 'record_proposal_response',
+  'sent proposal must lead to recording the response',
+);
+assert(
+  buildOrderWorkspaceViewModel({ ...workspaceBase, activeProposalStatus: 'rejected' }).nextAction.command === 'create_proposal_variant',
+  'rejected proposal must lead to a new variant',
+);
+assert(proposalPrimaryAction('approved') === null, 'accepted proposal must not expose another proposal action');
+assert(isProposalRevisionLocked('sent'), 'sent proposal revision must be locked');
+assert(isProposalRevisionLocked('approved'), 'accepted proposal revision must be locked');
+assert(!isProposalRevisionLocked('ready_to_send'), 'ready proposal must remain editable before sending');
+assert(proposalStatusLabel('accepted') === 'Принято клиентом', 'legacy accepted alias must render consistently');
+
+assert(
+  buildMeasurementSummary({ required: false }) === 'Замер не требуется',
+  'optional measurement must be described as not required',
+);
+assert(
+  buildMeasurementSummary({ required: true }) === 'Замер не назначен',
+  'required measurement without a date must be described as not scheduled',
+);
+assert(
+  buildMeasurementSummary({ required: true, date: '2026-07-20', formatDate: () => '20.07.2026' }) === 'Замер назначен: 20.07.2026',
+  'scheduled measurement must show its date',
+);
+assert(
+  buildMeasurementSummary({ required: true, result: 'Осмотр выполнен', kind: 'diagnostic' }) === 'Диагностика выполнена',
+  'completed diagnostic must use the correct wording',
+);
 
 console.log('Manager UI logic tests passed');

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -1056,7 +1056,6 @@ class DocumentService:
                 if order and order.status in ["new_lead", "measurement"]:
                     from models.common import OrderStatus
                     order.status = OrderStatus.NEGOTIATION
-                    order.proposal_status = "sent"
                     session.add(order)
 
             await session.commit()

--- a/services/mail_smtp_service.py
+++ b/services/mail_smtp_service.py
@@ -6,10 +6,12 @@ from email.utils import formataddr
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from core.config import settings
-from models import Order, OrderDocument, OutgoingEmail
+from models import Order, OrderDocument, OrderProposal, OutgoingEmail
 from services.document_service import DocumentService
+from services.order_proposal_lifecycle import PROPOSAL_STATUS_SENT, sync_selected_proposal_status
 
 
 @dataclass(frozen=True)
@@ -158,12 +160,15 @@ class MailSmtpService:
 
         attachments: List[MailAttachment] = []
         has_offer_document = False
+        offer_proposal_ids: set[int] = set()
         for doc_id in document_ids or []:
             doc = await session.get(OrderDocument, doc_id)
             if not doc or doc.order_id != order_id:
                 raise ValueError(f"Document {doc_id} not found on order")
             if doc.doc_type == "offer":
                 has_offer_document = True
+                if doc.proposal_id is not None:
+                    offer_proposal_ids.add(doc.proposal_id)
             stream, filename = await DocumentService.get_download_stream(session, doc_id)
             if not stream:
                 raise ValueError(f"Document {doc_id} cannot be downloaded")
@@ -182,8 +187,39 @@ class MailSmtpService:
             attachments=attachments,
         )
         if has_offer_document:
-            order.proposal_status = "sent"
-            order.proposal_sent_at = datetime.now()
+            sent_at = datetime.now()
+            if offer_proposal_ids:
+                proposals = list(
+                    (
+                        await session.execute(
+                            select(OrderProposal).where(
+                                OrderProposal.order_id == order_id,
+                                OrderProposal.id.in_(offer_proposal_ids),
+                            )
+                        )
+                    ).scalars().all()
+                )
+            else:
+                proposals = list(
+                    (
+                        await session.execute(
+                            select(OrderProposal).where(
+                                OrderProposal.order_id == order_id,
+                                OrderProposal.is_selected == True,
+                                OrderProposal.is_archived == False,
+                            )
+                        )
+                    ).scalars().all()
+                )
+            for proposal in proposals:
+                proposal.status = PROPOSAL_STATUS_SENT
+                sync_selected_proposal_status(order, proposal, now=sent_at)
+                session.add(proposal)
+            if not proposals:
+                order.proposal_status = PROPOSAL_STATUS_SENT
+                order.proposal_sent_at = sent_at
+                order.negotiation_status = "proposal_sent"
+                order.negotiation_status_changed_at = sent_at
             session.add(order)
             await session.commit()
             await session.refresh(email_row)

--- a/services/order_proposal_lifecycle.py
+++ b/services/order_proposal_lifecycle.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from models import Order, OrderProposal
+
+
+PROPOSAL_STATUS_DRAFT = "draft"
+PROPOSAL_STATUS_READY = "ready_to_send"
+PROPOSAL_STATUS_SENT = "sent"
+PROPOSAL_STATUS_APPROVED = "approved"
+PROPOSAL_STATUS_REJECTED = "rejected"
+
+PROPOSAL_STATUSES = {
+    PROPOSAL_STATUS_DRAFT,
+    PROPOSAL_STATUS_READY,
+    PROPOSAL_STATUS_SENT,
+    PROPOSAL_STATUS_APPROVED,
+    PROPOSAL_STATUS_REJECTED,
+}
+
+
+def normalize_proposal_status(value: Optional[str]) -> str:
+    status = str(value or PROPOSAL_STATUS_DRAFT).strip().lower()
+    if status == "accepted":
+        status = PROPOSAL_STATUS_APPROVED
+    if status not in PROPOSAL_STATUSES:
+        raise ValueError(f"Unsupported proposal status: {status}")
+    return status
+
+
+def sync_selected_proposal_status(
+    order: Order,
+    proposal: OrderProposal,
+    *,
+    now: Optional[datetime] = None,
+) -> None:
+    """Keep the order summary in sync without conflating both entities."""
+    if not proposal.is_selected:
+        return
+
+    changed_at = now or datetime.now()
+    status = normalize_proposal_status(proposal.status)
+    order.proposal_status = status
+
+    if status == PROPOSAL_STATUS_SENT:
+        order.proposal_sent_at = changed_at
+        order.negotiation_status = "proposal_sent"
+        order.negotiation_status_changed_at = changed_at
+    elif status == PROPOSAL_STATUS_APPROVED:
+        order.negotiation_status = "awaiting_payment"
+        order.negotiation_status_changed_at = changed_at
+    elif status == PROPOSAL_STATUS_REJECTED:
+        order.negotiation_status = "follow_up"
+        order.negotiation_status_changed_at = changed_at
+    elif order.negotiation_status in {"proposal_sent", "awaiting_payment"}:
+        order.negotiation_status = "awaiting_offer"
+        order.negotiation_status_changed_at = changed_at

--- a/services/order_service.py
+++ b/services/order_service.py
@@ -16,6 +16,13 @@ from services.customer_contract_service import CustomerContractService
 from services.document_role_service import DocumentRoleService
 from services.product_supply_metrics_service import ProductSupplyMetricsService
 from services.order_product_line_service import OrderProductLineService
+from services.order_proposal_lifecycle import (
+    PROPOSAL_STATUS_APPROVED,
+    PROPOSAL_STATUS_READY,
+    PROPOSAL_STATUS_SENT,
+    normalize_proposal_status,
+    sync_selected_proposal_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -690,6 +697,13 @@ class OrderService:
         )
 
     @staticmethod
+    def _legacy_default_proposal_status(order: Order) -> str:
+        """Only carry forward a legacy status when there is evidence of sending."""
+        if order.proposal_status == PROPOSAL_STATUS_SENT and order.proposal_sent_at:
+            return PROPOSAL_STATUS_SENT
+        return "draft"
+
+    @staticmethod
     async def ensure_default_proposal(session: AsyncSession, order: Order) -> OrderProposal:
         proposals = list(getattr(order, "proposals", []) or [])
         active = [proposal for proposal in proposals if not proposal.is_archived]
@@ -705,7 +719,7 @@ class OrderService:
         proposal = OrderProposal(
             order_id=int(order.id),
             name="Основное",
-            status=order.proposal_status or "draft",
+            status=OrderService._legacy_default_proposal_status(order),
             is_selected=True,
             sort_order=0,
         )
@@ -1078,7 +1092,7 @@ class OrderService:
         proposal = OrderProposal(
             order_id=int(order.id),
             name="Основное",
-            status=order.proposal_status or "draft",
+            status="draft",
             is_selected=True,
             sort_order=0,
         )
@@ -2374,11 +2388,23 @@ class OrderService:
         proposal = next((item for item in order.proposals if item.id == proposal_id), None)
         if not proposal:
             raise ValueError("Proposal not found")
-        fields_set = getattr(payload, "model_fields_set", getattr(payload, "__fields_set__", set()))
+        fields_set = getattr(payload, "model_fields_set", None)
+        if fields_set is None:
+            fields_set = getattr(payload, "__fields_set__", set())
         if "name" in fields_set:
             proposal.name = OrderService._clean_proposal_name(payload.name, proposal.name)
-        if "status" in fields_set and payload.status is not None:
-            proposal.status = str(payload.status or "draft")
+        status_changed = "status" in fields_set and payload.status is not None
+        if status_changed:
+            next_status = normalize_proposal_status(payload.status)
+            if next_status == PROPOSAL_STATUS_READY:
+                product_links = [link for link in order.product_links if link.proposal_id == proposal.id]
+                service_links = [link for link in order.service_links if link.proposal_id == proposal.id]
+                total_amount, _, _ = OrderService._proposal_line_totals(product_links, service_links)
+                if not product_links and not service_links:
+                    raise ValueError("Proposal must contain at least one line before it is ready to send")
+                if total_amount <= 0:
+                    raise ValueError("Proposal total must be greater than zero before it is ready to send")
+            proposal.status = next_status
         if "sort_order" in fields_set and payload.sort_order is not None:
             proposal.sort_order = int(payload.sort_order)
         if "is_archived" in fields_set and payload.is_archived is not None:
@@ -2389,8 +2415,12 @@ class OrderService:
                 proposal.is_selected = False
                 if replacement:
                     replacement.is_selected = True
+                    replacement.status = normalize_proposal_status(replacement.status)
+                    sync_selected_proposal_status(order, replacement)
                     session.add(replacement)
         session.add(proposal)
+        if status_changed:
+            sync_selected_proposal_status(order, proposal)
         await session.flush()
         await OrderService._refresh_order_financials(session, order)
         session.add(order)
@@ -2406,7 +2436,8 @@ class OrderService:
         for item in order.proposals:
             item.is_selected = item.id == proposal.id
             session.add(item)
-        order.proposal_status = proposal.status or order.proposal_status or "draft"
+        proposal.status = normalize_proposal_status(proposal.status)
+        sync_selected_proposal_status(order, proposal)
         await session.flush()
         await OrderService._refresh_order_financials(session, order)
         session.add(order)
@@ -2854,6 +2885,8 @@ class OrderService:
             )
             if not target_proposal:
                 raise ValueError("Proposal not found")
+            if normalize_proposal_status(target_proposal.status) in {PROPOSAL_STATUS_SENT, PROPOSAL_STATUS_APPROVED}:
+                raise ValueError("Sent or accepted proposal cannot be edited. Return it to draft or create a copy")
             if "products" in fields_set and payload.products is not None:
                 for product_line in payload.products:
                     if product_line.quantity <= 0:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -1432,6 +1432,92 @@ async def test_manager_order_proposals_can_duplicate_edit_and_select(async_clien
 
 
 @pytest.mark.asyncio
+async def test_manager_proposal_lifecycle_validates_and_protects_sent_revision(async_client, db):
+    customer = Customer(name="Lifecycle Customer", phone="+375296666668", type=CustomerType.individual)
+    product = Product(title="Lifecycle Product", slug="lifecycle-product", price=1200, area=25)
+    db.add_all([customer, product])
+    await db.commit()
+    await db.refresh(customer)
+    await db.refresh(product)
+
+    order = Order(customer_id=customer.id, status=OrderStatus.NEGOTIATION)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+    headers = await _auth_headers(async_client)
+
+    create_lines = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"products": [{"product_id": product.id, "quantity": 1, "price": 1200, "cost": 700}]},
+        headers=headers,
+    )
+    assert create_lines.status_code == 200
+    proposal = create_lines.json()["proposals"][0]
+
+    empty_variant = await async_client.post(
+        f"/api/manager/orders/{order.id}/proposals",
+        json={"name": "Пустой вариант"},
+        headers=headers,
+    )
+    assert empty_variant.status_code == 200
+    empty_proposal = next(item for item in empty_variant.json()["proposals"] if item["name"] == "Пустой вариант")
+    empty_ready = await async_client.patch(
+        f"/api/manager/orders/{order.id}/proposals/{empty_proposal['id']}",
+        json={"status": "ready_to_send"},
+        headers=headers,
+    )
+    assert empty_ready.status_code == 400
+
+    ready = await async_client.patch(
+        f"/api/manager/orders/{order.id}/proposals/{proposal['id']}",
+        json={"status": "ready_to_send"},
+        headers=headers,
+    )
+    assert ready.status_code == 200
+    assert ready.json()["proposal_status"] == "ready_to_send"
+    assert ready.json()["negotiation_status"] == "awaiting_offer"
+
+    invalid = await async_client.patch(
+        f"/api/manager/orders/{order.id}/proposals/{proposal['id']}",
+        json={"status": "unknown"},
+        headers=headers,
+    )
+    assert invalid.status_code == 400
+
+    sent = await async_client.patch(
+        f"/api/manager/orders/{order.id}/proposals/{proposal['id']}",
+        json={"status": "sent"},
+        headers=headers,
+    )
+    assert sent.status_code == 200
+    assert sent.json()["proposal_status"] == "sent"
+    assert sent.json()["negotiation_status"] == "proposal_sent"
+
+    locked_edit = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"products": [{"product_id": product.id, "quantity": 2, "price": 1200, "cost": 700}]},
+        headers=headers,
+    )
+    assert locked_edit.status_code == 400
+    assert "cannot be edited" in str(locked_edit.json())
+
+    draft = await async_client.patch(
+        f"/api/manager/orders/{order.id}/proposals/{proposal['id']}",
+        json={"status": "draft"},
+        headers=headers,
+    )
+    assert draft.status_code == 200
+    assert draft.json()["proposal_status"] == "draft"
+    editable_again = await async_client.patch(
+        f"/api/manager/orders/{order.id}",
+        json={"products": [{"product_id": product.id, "quantity": 2, "price": 1200, "cost": 700}]},
+        headers=headers,
+    )
+    assert editable_again.status_code == 200
+    assert editable_again.json()["total_amount"] == 2400
+
+
+@pytest.mark.asyncio
 async def test_manager_order_export_preview_and_import_creates_new_order(async_client, db):
     customer = Customer(name="Transfer Customer", phone="+375291234000", type=CustomerType.individual)
     product = Product(title="Transfer Product", slug="transfer-product", price=1800, area=25)
@@ -1681,6 +1767,15 @@ async def test_manager_order_offer_generation_uses_requested_proposal_and_create
     assert first_offer["doc_id"] != second_offer["doc_id"]
     assert table_captures[-1][0][1] == "Proposal Doc P1"
     assert table_captures[-1][-1][-1] == "1000.00"
+
+    order_after_generation = await async_client.get(
+        f"/api/manager/orders/{order.id}",
+        headers=headers,
+    )
+    assert order_after_generation.status_code == 200
+    order_payload = order_after_generation.json()
+    assert order_payload["proposal_status"] == "draft"
+    assert {proposal["status"] for proposal in order_payload["proposals"]} == {"draft"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mail_services.py
+++ b/tests/unit/test_mail_services.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
 from core.config import settings
-from models import BankReceipt, Customer, LeadSource, Order, OrderDocument, OrderServiceLink, OrderStatus, OutgoingEmail, Payment, PaymentCurrency
+from models import BankReceipt, Customer, LeadSource, Order, OrderDocument, OrderProposal, OrderServiceLink, OrderStatus, OutgoingEmail, Payment, PaymentCurrency
 from services.bank_email_parser_service import BankEmailParserService
 from services.bank_receipt_service import BankReceiptService
 from services.bank_statement_csv_service import BankStatementCsvService
@@ -1091,8 +1091,14 @@ async def test_send_order_email_attaches_documents_and_marks_offer_sent(sqlite_s
     await sqlite_session.commit()
     await sqlite_session.refresh(order)
 
+    proposal = OrderProposal(order_id=order.id, name="Основное", status="ready_to_send", is_selected=True)
+    sqlite_session.add(proposal)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(proposal)
+
     offer = OrderDocument(
         order_id=order.id,
+        proposal_id=proposal.id,
         doc_type="offer",
         number="КП-2026-001",
         google_file_id="offer-file",
@@ -1138,6 +1144,8 @@ async def test_send_order_email_attaches_documents_and_marks_offer_sent(sqlite_s
     refreshed_order = await sqlite_session.get(Order, order.id)
     assert refreshed_order.proposal_status == "sent"
     assert refreshed_order.proposal_sent_at is not None
+    refreshed_proposal = await sqlite_session.get(OrderProposal, proposal.id)
+    assert refreshed_proposal.status == "sent"
 
     persisted_email = (await sqlite_session.execute(select(OutgoingEmail).where(OutgoingEmail.id == email_row.id))).scalar_one()
     assert persisted_email.recipient_email == "client@example.com"
@@ -1189,3 +1197,57 @@ async def test_send_order_email_without_offer_keeps_proposal_status(sqlite_sessi
     refreshed_order = await sqlite_session.get(Order, order.id)
     assert refreshed_order.proposal_status == "draft"
     assert refreshed_order.proposal_sent_at is None
+
+
+@pytest.mark.asyncio
+async def test_failed_offer_email_keeps_proposal_ready_to_send(sqlite_session, monkeypatch):
+    monkeypatch.setattr(settings, "MAIL_SMTP_USERNAME", "a@mvn.by")
+    monkeypatch.setattr(settings, "MAIL_SMTP_PASSWORD", "super-secret")
+    monkeypatch.setattr(settings, "MAIL_FROM_EMAIL", "a@mvn.by")
+
+    customer = Customer(name="ООО Клиент", phone="+375291111111", type="company", email="client@example.com")
+    sqlite_session.add(customer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(customer)
+
+    order = Order(customer_id=customer.id, status="negotiation", proposal_status="ready_to_send")
+    sqlite_session.add(order)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(order)
+    proposal = OrderProposal(order_id=order.id, name="Основное", status="ready_to_send", is_selected=True)
+    sqlite_session.add(proposal)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(proposal)
+    offer = OrderDocument(
+        order_id=order.id,
+        proposal_id=proposal.id,
+        doc_type="offer",
+        number="КП-2026-FAIL",
+        google_file_id="offer-file",
+        google_edit_url="https://docs.example/offer",
+    )
+    sqlite_session.add(offer)
+    await sqlite_session.commit()
+    await sqlite_session.refresh(offer)
+
+    async def fake_download(_session, doc_id: int):
+        return b"%PDF-1.4", f"document-{doc_id}.pdf"
+
+    monkeypatch.setattr("services.mail_smtp_service.DocumentService.get_download_stream", fake_download)
+    monkeypatch.setattr(MailSmtpService, "send_message", lambda _message: (_ for _ in ()).throw(OSError("SMTP unavailable")))
+
+    with pytest.raises(RuntimeError, match="SMTP unavailable"):
+        await MailSmtpService.send_order_email(
+            sqlite_session,
+            order_id=order.id,
+            to_email="client@example.com",
+            subject="Коммерческое предложение",
+            body_text="Здравствуйте",
+            document_ids=[offer.id],
+        )
+
+    refreshed_order = await sqlite_session.get(Order, order.id)
+    refreshed_proposal = await sqlite_session.get(OrderProposal, proposal.id)
+    assert refreshed_order.proposal_status == "ready_to_send"
+    assert refreshed_order.proposal_sent_at is None
+    assert refreshed_proposal.status == "ready_to_send"


### PR DESCRIPTION
## Summary

- add an explicit persisted proposal lifecycle: draft, ready to send, sent, accepted, rejected
- centralize the order workspace next-action calculation and keep proposal, negotiation, and order stages separate
- protect sent/accepted proposal revisions, while preserving copy and return-to-draft workflows
- compact proposal, negotiation, service-line, equipment, document, and delete-order controls
- preserve the existing smart sticky header and Yandex address suggest implementation

## Lifecycle

| Current state | Primary action | Next state |
| --- | --- | --- |
| Draft | Finish preparation | Ready to send |
| Ready to send | Send through CRM / mark manually | Sent |
| Sent | Record customer response | Accepted or rejected |
| Rejected | Create a new variant / return to draft | Draft copy or draft |

Successful SMTP delivery marks the exact attached proposal as sent. A failed delivery leaves it ready to send. Generating an offer document alone no longer marks a proposal as sent.

Existing orders are handled conservatively: a lazily created legacy proposal inherits `sent` only when the order also has a recorded sent timestamp. No data migration or guessed accepted state is introduced.

## Verification

- `77 passed` in focused backend unit tests
- `57 passed` in the full manager orders integration file
- manager UI logic tests passed, including existing address suggest and sticky-header guards
- `vue-tsc -b` passed
- Vite production build passed
- theme hardcode audit passed
- mobile and desktop visual QA completed in light and dark themes, including compact sticky-header behavior

## Notes

- the existing internal value `approved` is retained and displayed as `Принято клиентом`
- order archival is not available in the current backend model, so only protected deletion was moved into the sticky-header overflow menu
- per-attempt sender/user metadata can be added later when proposal-level audit fields are introduced
