### PR TITLE
Extend Bot API task projection for Today views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ BOT_API_TOKEN=
 # Local Compose can use app. Production blue-green must use the stable HTTPS
 # origin: https://api.mvn.by/api/internal/bot/v1
 BOT_API_BASE_URL=http://app:8000/api/internal/bot/v1
+MANAGER_BASE_URL=https://api.mvn.by/manager
+BOT_TASK_TIMEZONE=Europe/Minsk
 BOT_API_TIMEOUT_SECONDS=5
 BOT_RUNTIME_LEASE_SECONDS=45
 BOT_RUNTIME_RENEW_SECONDS=15

--- a/api_contracts/bot.py
+++ b/api_contracts/bot.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 BOT_CUSTOMER_REQUISITES_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
@@ -59,6 +59,31 @@ class BotCatalogProductLookupResponse(BaseModel):
 class BotTaskListRequest(BaseModel):
     telegram_id: int = Field(ge=1)
     limit: int = Field(default=10, ge=1, le=20)
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+    statuses: list[
+        Literal[
+            "planned",
+            "in_progress",
+            "completed",
+            "canceled",
+            "new_lead",
+            "negotiation",
+            "execution",
+            "closed",
+        ]
+    ] = Field(default_factory=list, max_length=8)
+
+    @model_validator(mode="after")
+    def validate_date_range(self) -> "BotTaskListRequest":
+        if self.date_from and self.date_to:
+            from_is_aware = self.date_from.tzinfo is not None
+            to_is_aware = self.date_to.tzinfo is not None
+            if from_is_aware != to_is_aware:
+                raise ValueError("date_from and date_to must use the same timezone form")
+            if self.date_from > self.date_to:
+                raise ValueError("date_from must not be after date_to")
+        return self
 
 
 class BotTaskResponse(BaseModel):
@@ -67,6 +92,7 @@ class BotTaskResponse(BaseModel):
     kind: Literal["stage", "order"]
     id: int = Field(ge=1)
     order_id: int = Field(ge=1)
+    stage_id: int | None = Field(default=None, ge=1)
     title: str
     status: str
     start_time: datetime
@@ -74,6 +100,7 @@ class BotTaskResponse(BaseModel):
     customer_name: str = "Клиент"
     customer_phone: str | None = None
     comment: str | None = None
+    manager_url: str | None = None
 
 
 class BotTaskListResponse(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -30,6 +30,8 @@ class Settings(BaseSettings):
     BOT_API_TOKEN: str = ""
     BOT_API_BASE_URL: str = "http://app:8000/api/internal/bot/v1"
     BOT_API_TIMEOUT_SECONDS: float = 5.0
+    MANAGER_BASE_URL: str = "https://api.mvn.by/manager"
+    BOT_TASK_TIMEZONE: str = "Europe/Minsk"
     ADMIN_IDS: str = ""
     ADMIN_ID: int = 0
     SECRET_KEY: str

--- a/manager_frontend/src/client/models/BotTaskListRequest.ts
+++ b/manager_frontend/src/client/models/BotTaskListRequest.ts
@@ -5,5 +5,8 @@
 export type BotTaskListRequest = {
     telegram_id: number;
     limit?: number;
+    date_from?: (string | null);
+    date_to?: (string | null);
+    statuses?: Array<'planned' | 'in_progress' | 'completed' | 'canceled' | 'new_lead' | 'negotiation' | 'execution' | 'closed'>;
 };
 

--- a/manager_frontend/src/client/models/BotTaskResponse.ts
+++ b/manager_frontend/src/client/models/BotTaskResponse.ts
@@ -9,6 +9,7 @@ export type BotTaskResponse = {
     kind: 'stage' | 'order';
     id: number;
     order_id: number;
+    stage_id?: (number | null);
     title: string;
     status: string;
     start_time: string;
@@ -16,5 +17,6 @@ export type BotTaskResponse = {
     customer_name?: string;
     customer_phone?: (string | null);
     comment?: (string | null);
+    manager_url?: (string | null);
 };
 

--- a/openapi.json
+++ b/openapi.json
@@ -21877,6 +21877,48 @@
             "minimum": 1.0,
             "title": "Limit",
             "default": 10
+          },
+          "date_from": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date From"
+          },
+          "date_to": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date To"
+          },
+          "statuses": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "planned",
+                "in_progress",
+                "completed",
+                "canceled",
+                "new_lead",
+                "negotiation",
+                "execution",
+                "closed"
+              ]
+            },
+            "type": "array",
+            "maxItems": 8,
+            "title": "Statuses"
           }
         },
         "type": "object",
@@ -21958,6 +22000,18 @@
             "minimum": 1.0,
             "title": "Order Id"
           },
+          "stage_id": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Id"
+          },
           "title": {
             "type": "string",
             "title": "Title"
@@ -22008,6 +22062,17 @@
               }
             ],
             "title": "Comment"
+          },
+          "manager_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manager Url"
           }
         },
         "type": "object",

--- a/routers/internal_bot.py
+++ b/routers/internal_bot.py
@@ -149,6 +149,9 @@ async def list_internal_bot_my_tasks(
             session,
             telegram_id=payload.telegram_id,
             limit=payload.limit,
+            date_from=payload.date_from,
+            date_to=payload.date_to,
+            statuses=payload.statuses,
         )
     except BotTaskAccessDeniedError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/services/bot_task_read_service.py
+++ b/services/bot_task_read_service.py
@@ -1,5 +1,7 @@
 """Staff-authorized task reads exposed to the Telegram bot API."""
 
+from datetime import datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.bot_access_service import BotAccessService
@@ -17,6 +19,9 @@ class BotTaskReadService:
         *,
         telegram_id: int,
         limit: int,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        statuses: list[str] | None = None,
     ) -> list[dict]:
         context = await BotAccessService.get_context(session, telegram_id)
         if not context.is_staff:
@@ -27,4 +32,7 @@ class BotTaskReadService:
             session,
             int(context.legacy_installer_id),
             limit=limit,
+            date_from=date_from,
+            date_to=date_to,
+            statuses=statuses,
         )

--- a/services/bot_task_service.py
+++ b/services/bot_task_service.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 from typing import Any
+from urllib.parse import urlencode
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from core.config import settings
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
@@ -38,6 +41,9 @@ class BotTaskService:
         telegram_id: int | str | None,
         *,
         limit: int = 10,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        statuses: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         staff = await cls._staff_by_telegram_id(session, telegram_id)
         if not staff or not staff.legacy_installer_id:
@@ -47,6 +53,9 @@ class BotTaskService:
             session,
             int(staff.legacy_installer_id),
             limit=limit,
+            date_from=date_from,
+            date_to=date_to,
+            statuses=statuses,
         )
 
     @classmethod
@@ -56,21 +65,44 @@ class BotTaskService:
         installer_id: int,
         *,
         limit: int = 10,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+        statuses: list[str] | None = None,
+        reference_time: datetime | None = None,
     ) -> list[dict[str, Any]]:
         safe_limit = max(1, min(int(limit or 10), 20))
 
-        reference_time = datetime.now()
-        now = reference_time - timedelta(days=1)
-        until = reference_time + timedelta(days=30)
-        active_stage_filters = (
+        current_time = reference_time or datetime.now()
+        range_start = cls._normalize_filter_datetime(
+            date_from
+        ) or current_time - timedelta(days=1)
+        range_end = cls._normalize_filter_datetime(
+            date_to
+        ) or current_time + timedelta(days=30)
+        requested_statuses = {str(value) for value in statuses or []}
+        stage_statuses = requested_statuses.intersection(
+            status.value for status in OrderStageStatus
+        )
+        order_statuses = requested_statuses.intersection(
+            status.value for status in OrderStatus
+        )
+
+        active_stage_filters = [
             OrderWorkStage.installer_id == installer_id,
             Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)),
             OrderWorkStage.start_time.is_not(None),
-            OrderWorkStage.start_time >= now,
-            OrderWorkStage.start_time <= until,
-            OrderWorkStage.status != OrderStageStatus.COMPLETED,
-            OrderWorkStage.status != OrderStageStatus.CANCELED,
-        )
+            OrderWorkStage.start_time >= range_start,
+            OrderWorkStage.start_time <= range_end,
+        ]
+        if requested_statuses:
+            active_stage_filters.append(OrderWorkStage.status.in_(stage_statuses))
+        else:
+            active_stage_filters.extend(
+                [
+                    OrderWorkStage.status != OrderStageStatus.COMPLETED,
+                    OrderWorkStage.status != OrderStageStatus.CANCELED,
+                ]
+            )
 
         stage_result = await session.execute(
             select(OrderWorkStage)
@@ -90,20 +122,24 @@ class BotTaskService:
             .where(*active_stage_filters)
         )
 
-        order_result = await session.execute(
+        order_query = (
             select(Order)
             .join(OrderInstaller, OrderInstaller.order_id == Order.id)
             .where(OrderInstaller.installer_id == installer_id)
             .where(Order.status.in_(list(cls.ACTIVE_ORDER_STATUSES)))
             .where(Order.installation_date.is_not(None))
             .where(
-                (Order.installation_date >= now) & (Order.installation_date <= until)
+                (Order.installation_date >= range_start)
+                & (Order.installation_date <= range_end)
             )
             .where(Order.id.notin_(active_stage_order_ids))
             .options(selectinload(Order.customer))
             .order_by(Order.installation_date.asc().nullslast(), Order.id.asc())
             .limit(safe_limit)
         )
+        if requested_statuses:
+            order_query = order_query.where(Order.status.in_(order_statuses))
+        order_result = await session.execute(order_query)
         tasks.extend(cls._map_order(order) for order in order_result.scalars().all())
         tasks.sort(
             key=lambda task: (
@@ -113,6 +149,23 @@ class BotTaskService:
             )
         )
         return tasks[:safe_limit]
+
+    @staticmethod
+    def _normalize_filter_datetime(value: datetime | None) -> datetime | None:
+        if value is None or value.tzinfo is None:
+            return value
+        try:
+            local_timezone = ZoneInfo(settings.BOT_TASK_TIMEZONE)
+        except ZoneInfoNotFoundError:
+            local_timezone = ZoneInfo("Europe/Minsk")
+        return value.astimezone(local_timezone).replace(tzinfo=None)
+
+    @staticmethod
+    def _manager_url(order_id: int) -> str:
+        base_url = str(
+            settings.MANAGER_BASE_URL or "https://api.mvn.by/manager"
+        ).rstrip("/")
+        return f"{base_url}/orders/kanban?{urlencode({'orderId': order_id})}"
 
     @staticmethod
     def _customer_phone(order: Order) -> str | None:
@@ -131,13 +184,19 @@ class BotTaskService:
             "kind": "stage",
             "id": int(stage.id or 0),
             "order_id": int(stage.order_id),
+            "stage_id": int(stage.id or 0),
             "title": stage.name,
-            "status": stage.status.value if hasattr(stage.status, "value") else str(stage.status),
+            "status": (
+                stage.status.value
+                if hasattr(stage.status, "value")
+                else str(stage.status)
+            ),
             "start_time": stage.start_time,
             "address": order.delivery_address if order else None,
             "customer_name": cls._customer_name(order) if order else "Клиент",
             "customer_phone": cls._customer_phone(order) if order else None,
             "comment": stage.manager_comment,
+            "manager_url": cls._manager_url(int(stage.order_id)),
         }
 
     @classmethod
@@ -146,6 +205,7 @@ class BotTaskService:
             "kind": "order",
             "id": int(order.id or 0),
             "order_id": int(order.id or 0),
+            "stage_id": None,
             "title": order.title or "Монтаж",
             "status": order.status.value if hasattr(order.status, "value") else str(order.status),
             "start_time": order.installation_date,
@@ -153,4 +213,5 @@ class BotTaskService:
             "customer_name": cls._customer_name(order),
             "customer_phone": cls._customer_phone(order),
             "comment": order.comment,
+            "manager_url": cls._manager_url(int(order.id or 0)),
         }

--- a/tests/unit/test_bot_work_services.py
+++ b/tests/unit/test_bot_work_services.py
@@ -292,6 +292,10 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
         "Старый монтаж без даты",
     ]
     assert [task["kind"] for task in tasks] == ["stage", "stage", "order"]
+    assert tasks[0]["stage_id"] == tasks[0]["id"]
+    assert tasks[0]["manager_url"].endswith(
+        f"/orders/kanban?orderId={active_order.id}"
+    )
     assert not any(
         task["kind"] == "order" and task["order_id"] == active_order.id
         for task in tasks
@@ -300,6 +304,16 @@ async def test_task_list_merges_stages_and_distinct_legacy_orders(sqlite_staff_s
     limited = await BotTaskService.list_my_tasks(sqlite_staff_session, 12345, limit=2)
     assert [task["title"] for task in limited] == ["Ближайший монтаж", "Пусконаладка"]
 
+    reference_time = datetime.now()
+    today = await BotTaskService.list_my_tasks(
+        sqlite_staff_session,
+        12345,
+        date_from=reference_time + timedelta(days=1, hours=12),
+        date_to=reference_time + timedelta(days=2, hours=12),
+        statuses=["planned"],
+    )
+    assert [task["title"] for task in today] == ["Ближайший монтаж", "Пусконаладка"]
+
 
 @pytest.mark.asyncio
 async def test_my_tasks_handler_uses_gateway_without_opening_database(monkeypatch):
@@ -307,12 +321,14 @@ async def test_my_tasks_handler_uses_gateway_without_opening_database(monkeypatc
         kind="stage",
         id=7,
         order_id=42,
+        stage_id=7,
         title="Монтаж",
         status="planned",
         start_time=datetime(2026, 7, 20, 12, 0),
         customer_name="Иван",
         customer_phone="+375291234567",
         address="Победы 15",
+        manager_url="https://api.mvn.by/manager/orders/kanban?orderId=42",
     )
     gateway = SimpleNamespace(
         list_my_tasks=AsyncMock(return_value=BotTaskListResponse(items=[task]))
@@ -365,7 +381,14 @@ async def test_task_read_service_reuses_authorized_installer_mapping(monkeypatch
 
     assert tasks == []
     get_context.assert_awaited_once_with(session, 777)
-    list_installer_tasks.assert_awaited_once_with(session, 17, limit=10)
+    list_installer_tasks.assert_awaited_once_with(
+        session,
+        17,
+        limit=10,
+        date_from=None,
+        date_to=None,
+        statuses=None,
+    )
 
 
 def test_task_report_builder_keeps_text_report_plain():

--- a/tests/unit/test_internal_bot_api.py
+++ b/tests/unit/test_internal_bot_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import AsyncMock
 
 from httpx import ASGITransport, AsyncClient
@@ -394,13 +395,25 @@ async def test_internal_bot_catalog_denies_non_staff_identity(monkeypatch):
 async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
     monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
 
-    async def fake_list(_session, *, telegram_id, limit):
+    async def fake_list(
+        _session,
+        *,
+        telegram_id,
+        limit,
+        date_from,
+        date_to,
+        statuses,
+    ):
         assert (telegram_id, limit) == (123456, 10)
+        assert date_from is None
+        assert date_to is None
+        assert statuses == []
         return [
             {
                 "kind": "stage",
                 "id": 7,
                 "order_id": 42,
+                "stage_id": 7,
                 "title": "Монтаж",
                 "status": "planned",
                 "start_time": "2026-07-20T12:00:00",
@@ -408,6 +421,7 @@ async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
                 "customer_name": "Иван",
                 "customer_phone": "+375291234567",
                 "comment": "Позвонить заранее",
+                "manager_url": "https://api.mvn.by/manager/orders/kanban?orderId=42",
                 "private_field": "must not leak",
             }
         ]
@@ -434,6 +448,7 @@ async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
                 "kind": "stage",
                 "id": 7,
                 "order_id": 42,
+                "stage_id": 7,
                 "title": "Монтаж",
                 "status": "planned",
                 "start_time": "2026-07-20T12:00:00",
@@ -441,9 +456,44 @@ async def test_internal_bot_task_list_returns_stable_projection(monkeypatch):
                 "customer_name": "Иван",
                 "customer_phone": "+375291234567",
                 "comment": "Позвонить заранее",
+                "manager_url": "https://api.mvn.by/manager/orders/kanban?orderId=42",
             }
         ]
     }
+
+
+async def test_internal_bot_task_list_forwards_today_filters(monkeypatch):
+    monkeypatch.setattr(settings, "BOT_API_TOKEN", "expected-token")
+
+    async def fake_list(_session, **kwargs):
+        assert kwargs["telegram_id"] == 123456
+        assert kwargs["date_from"] == datetime(2026, 7, 20, 0, 0)
+        assert kwargs["date_to"] == datetime(2026, 7, 20, 23, 59, 59)
+        assert kwargs["statuses"] == ["planned", "in_progress"]
+        return []
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(BotTaskReadService, "list_for_staff", fake_list)
+    app.dependency_overrides[get_session] = fake_session
+    try:
+        response = await _request(
+            "/api/internal/bot/v1/tasks/my",
+            token="expected-token",
+            method="POST",
+            json={
+                "telegram_id": 123456,
+                "date_from": "2026-07-20T00:00:00",
+                "date_to": "2026-07-20T23:59:59",
+                "statuses": ["planned", "in_progress"],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"items": []}
 
 
 async def test_internal_bot_task_list_denies_non_staff_identity(monkeypatch):


### PR DESCRIPTION
## Summary
- extend the additive Bot API v1 task-list request with date range and status filters
- expose explicit stage IDs and manager order links in the stable task projection
- normalize timezone-aware filters to the configured task timezone while preserving the legacy default window
- update OpenAPI, generated manager client models, and contract/service tests

## Compatibility
- existing bot requests remain valid and keep the current default task window
- new response fields are optional in the shared contract for rolling deploy compatibility
- task mutations (accept, complete, report) are unchanged

## Verification
- 114 focused Bot API, gateway, handler architecture, and settings tests passed
- 2 PostgreSQL-backed quick-order tests were deselected because local test PostgreSQL is not available in this isolated worktree
- OpenAPI and generated manager client are synchronized by the pre-commit hook