### PR TITLE
Polish catalog quality workspace

### DIFF
--- a/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
@@ -13,6 +13,7 @@ export type ManagerCatalogQualityReportResponse = {
     total_products: number;
     problem_products: number;
     critical_products: number;
+    fixable_products: number;
     average_score: number;
     items: Array<ManagerCatalogQualityProductResponse>;
     summary: Array<ManagerCatalogQualitySummaryItemResponse>;

--- a/manager_frontend/src/components/catalog-quality/CatalogQualityCards.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualityCards.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { ExternalLink, Image as ImageIcon } from 'lucide-vue-next';
+import { ExternalLink, Image as ImageIcon, Images, Wrench } from 'lucide-vue-next';
 import type { ManagerCatalogQualityReportResponse } from '../../api';
 
 type QualityProduct = ManagerCatalogQualityReportResponse['items'][number];
@@ -10,8 +10,14 @@ const props = defineProps<{
   items: QualityProduct[];
   groups?: ManagerCatalogQualityReportResponse['groups'];
   grouped?: boolean;
+  selectedBrandTitle?: string;
+  hideEquipmentType?: boolean;
+  hideSeries?: boolean;
 }>();
-const emit = defineEmits<{ open: [product: QualityProduct]; selectIssue: [code: string] }>();
+const emit = defineEmits<{
+  open: [product: QualityProduct];
+  openMedia: [product: QualityProduct];
+}>();
 const failedImages = ref(new Set<number>());
 
 const groupedItems = computed(() => {
@@ -28,16 +34,51 @@ const groupedItems = computed(() => {
 
 const groupSummary = (key: string) => props.groups?.find((group) => group.key === key);
 const imageSrc = (url?: string | null) => !url ? '' : url.startsWith('http') || url.startsWith('/') ? url : `/${url}`;
+const publicSiteBaseUrl = (() => {
+  const configured = String(import.meta.env.WEBSITE_URL || '').trim();
+  if (configured) return configured.replace(/\/+$/, '');
+  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    return `${window.location.protocol}//${window.location.hostname}:4321`;
+  }
+  return `${window.location.protocol}//${window.location.host}`;
+})();
+const publicProductUrl = (slug: string) => `${publicSiteBaseUrl}/product/${slug}/`;
 const formatNumber = (value?: number | null) => new Intl.NumberFormat('ru-RU').format(Number(value || 0));
 const scoreTone = (score: number) => score >= 85
-  ? 'bg-emerald-50 text-emerald-700 ring-emerald-200'
-  : score >= 65 ? 'bg-amber-50 text-amber-800 ring-amber-200' : 'bg-red-50 text-red-700 ring-red-200';
+  ? 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950 dark:text-emerald-200 dark:ring-emerald-800'
+  : score >= 65
+    ? 'bg-amber-50 text-amber-800 ring-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:ring-amber-800'
+    : 'bg-red-50 text-red-700 ring-red-200 dark:bg-red-950 dark:text-red-200 dark:ring-red-800';
 const severityTone = (severity: QualityIssue['severity']) => severity === 'critical'
-  ? 'bg-red-50 text-red-700'
-  : severity === 'warning' ? 'bg-amber-50 text-amber-800' : 'bg-sky-50 text-sky-700';
+  ? 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-200'
+  : severity === 'warning'
+    ? 'bg-amber-50 text-amber-800 dark:bg-amber-950 dark:text-amber-200'
+    : 'bg-sky-50 text-sky-700 dark:bg-sky-950 dark:text-sky-200';
 const priorityBorder = (priority?: string) => priority === 'high'
   ? 'border-l-red-500'
   : priority === 'medium' ? 'border-l-amber-400' : 'border-l-gray-300';
+const priorityTone = (priority?: string) => priority === 'high'
+  ? 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-200'
+  : priority === 'medium'
+    ? 'bg-amber-50 text-amber-800 dark:bg-amber-950 dark:text-amber-200'
+    : 'bg-gray-100 text-gray-600 dark:bg-slate-800 dark:text-slate-300';
+const priorityLabel = (priority?: string) => priority === 'high' ? 'Высокий приоритет' : priority === 'medium' ? 'Средний приоритет' : 'Низкий приоритет';
+const hasIssueCategory = (product: QualityProduct, category: string) => (product.issues ?? []).some((issue) => issue.category === category);
+const displayTitle = (product: QualityProduct) => {
+  const brand = props.selectedBrandTitle?.trim();
+  if (!brand) return product.title;
+  const title = product.title.trim();
+  return title.toLocaleLowerCase('ru').startsWith(`${brand.toLocaleLowerCase('ru')} `)
+    ? title.slice(brand.length).trim()
+    : title;
+};
+const identityParts = (product: QualityProduct) => [
+  props.selectedBrandTitle ? '' : product.brand_title || 'Без бренда',
+  props.hideSeries ? '' : product.series_title || 'без серии',
+].filter(Boolean);
+const imageSizeLabel = (product: QualityProduct) => product.main_image_width && product.main_image_height
+  ? `${product.main_image_width} × ${product.main_image_height} px`
+  : '';
 const markImageFailed = (productId: number) => {
   failedImages.value = new Set(failedImages.value).add(productId);
 };
@@ -46,41 +87,50 @@ const markImageFailed = (productId: number) => {
 <template>
   <div class="space-y-5 px-4 py-4 sm:px-5">
     <section v-for="group in groupedItems" :key="group.key">
-      <header v-if="grouped" class="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 pb-2">
-        <div><h2 class="font-bold text-gray-950">{{ group.label }}</h2><p class="text-xs text-gray-500">{{ group.items.length }} на этой странице</p></div>
-        <p v-if="groupSummary(group.key)" class="text-xs font-semibold text-gray-500">
-          Score {{ groupSummary(group.key)?.average_score }} · критичных {{ groupSummary(group.key)?.critical_products || 0 }}
-        </p>
+      <header v-if="grouped" class="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 pb-2 dark:border-slate-700">
+        <div>
+          <h2 class="font-bold text-gray-950 dark:text-slate-100">{{ group.label }}</h2>
+          <p class="text-xs text-gray-500 dark:text-slate-400">{{ formatNumber(groupSummary(group.key)?.count ?? group.items.length) }} товаров · score {{ groupSummary(group.key)?.average_score ?? '—' }} · критичных {{ groupSummary(group.key)?.critical_products || 0 }}</p>
+        </div>
+        <span v-if="groupSummary(group.key)?.media_problem_products" class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-800"><Images class="h-3.5 w-3.5" /> Медиа: {{ groupSummary(group.key)?.media_problem_products }}</span>
       </header>
 
       <div class="grid gap-3 xl:grid-cols-2">
-        <article v-for="product in group.items" :key="product.product_id" class="grid min-h-36 grid-cols-[96px,minmax(0,1fr)] gap-3 rounded-lg border border-l-4 border-gray-200 bg-white p-3 shadow-sm" :class="priorityBorder(product.work_priority)">
-          <button class="relative aspect-[4/3] self-start overflow-hidden rounded-lg bg-gray-100" @click="emit('open', product)">
+        <article v-for="product in group.items" :key="product.product_id" class="grid min-h-36 grid-cols-[92px,minmax(0,1fr)] gap-3 rounded-lg border border-l-4 border-gray-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900" :class="priorityBorder(product.work_priority)">
+          <button class="relative aspect-[4/3] self-start overflow-hidden rounded-lg bg-gray-100 dark:bg-slate-800" @click="emit('open', product)">
             <img v-if="product.main_image && !failedImages.has(product.product_id)" :src="imageSrc(product.main_image)" :alt="product.title" class="h-full w-full object-contain" loading="lazy" @error="markImageFailed(product.product_id)">
             <span v-else class="grid h-full place-items-center text-gray-400"><ImageIcon class="h-7 w-7" /></span>
-            <span class="absolute left-1.5 top-1.5 rounded-md px-1.5 py-1 text-xs font-bold ring-1" :class="scoreTone(product.score)">{{ product.score }}</span>
+            <span class="absolute left-1.5 top-1.5 rounded-md px-1.5 py-1 text-xs font-bold ring-1" :class="scoreTone(product.score)">{{ product.score }} / 100</span>
           </button>
 
           <div class="min-w-0">
             <div class="flex items-start justify-between gap-2">
               <div class="min-w-0">
-                <button class="line-clamp-2 text-left text-sm font-bold leading-5 text-gray-950 hover:text-teal-700" @click="emit('open', product)">{{ product.title }}</button>
-                <p class="mt-1 truncate text-xs text-gray-500">{{ product.brand_title || 'Без бренда' }} / {{ product.series_title || 'без серии' }}</p>
+                <button class="line-clamp-2 text-left text-sm font-bold leading-5 text-gray-950 hover:text-teal-700 dark:text-slate-100 dark:hover:text-teal-300" @click="emit('open', product)">{{ displayTitle(product) }}</button>
+                <p v-if="identityParts(product).length" class="mt-0.5 truncate text-xs font-semibold uppercase text-gray-500 dark:text-slate-400">{{ identityParts(product).join(' / ') }}</p>
               </div>
-              <button class="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-gray-200 text-gray-500 hover:border-teal-300 hover:text-teal-700" title="Открыть товар" @click="emit('open', product)"><ExternalLink class="h-4 w-4" /></button>
+              <span class="shrink-0 rounded-full px-2 py-1 text-[10px] font-bold uppercase" :class="priorityTone(product.work_priority)">{{ priorityLabel(product.work_priority) }}</span>
             </div>
 
-            <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs font-medium text-gray-600">
-              <span>{{ product.equipment_type_label || 'Тип не определен' }}</span>
+            <p class="mt-1.5 text-xs text-gray-500 dark:text-slate-400" :title="product.priority_reason">{{ product.priority_reason }}</p>
+
+            <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs font-medium text-gray-600 dark:text-slate-300">
+              <span v-if="!hideEquipmentType">{{ product.equipment_type_label || 'Тип не определен' }}</span>
               <span>{{ product.available_qty || 0 }} шт.</span>
-              <span>{{ product.image_count || 0 }} фото</span>
               <span>{{ product.supplier_mapping_count || 0 }} поставщ.</span>
               <span :class="product.is_published ? 'text-emerald-700' : 'text-gray-500'">{{ product.is_published ? 'На сайте' : 'Скрыт' }}</span>
+              <span>{{ product.image_count || 0 }} фото<span v-if="imageSizeLabel(product)"> · {{ imageSizeLabel(product) }}</span></span>
             </div>
 
             <div class="mt-2 flex flex-wrap gap-1">
-              <button v-for="issue in (product.issues ?? []).slice(0, 4)" :key="issue.code" class="rounded-md px-1.5 py-1 text-[11px] font-semibold" :class="severityTone(issue.severity)" :title="issue.detail || issue.message" @click="emit('selectIssue', issue.code)">{{ issue.label }}</button>
-              <span v-if="product.issue_count > 4" class="rounded-md bg-gray-100 px-1.5 py-1 text-[11px] font-semibold text-gray-500">+{{ formatNumber(product.issue_count - 4) }}</span>
+              <span v-for="issue in (product.issues ?? []).slice(0, 3)" :key="issue.code" class="rounded-md px-1.5 py-1 text-[11px] font-semibold" :class="severityTone(issue.severity)" :title="issue.detail || issue.message">{{ issue.label }}</span>
+              <span v-if="product.issue_count > 3" class="rounded-md bg-gray-100 px-1.5 py-1 text-[11px] font-semibold text-gray-500 dark:bg-slate-800 dark:text-slate-300">Ещё {{ formatNumber(product.issue_count - 3) }}</span>
+            </div>
+
+            <div class="mt-2 flex flex-wrap gap-2 border-t border-gray-100 pt-2 dark:border-slate-700">
+              <button v-if="hasIssueCategory(product, 'media')" class="inline-flex h-8 items-center gap-1.5 rounded-lg bg-teal-50 px-2.5 text-xs font-semibold text-teal-800 hover:bg-teal-100 dark:bg-teal-950 dark:text-teal-200 dark:hover:bg-teal-900" @click="emit('openMedia', product)"><Images class="h-3.5 w-3.5" />Исправить медиа</button>
+              <button class="inline-flex h-8 items-center gap-1.5 rounded-lg border border-gray-200 px-2.5 text-xs font-semibold text-gray-700 hover:border-teal-300 hover:text-teal-800 dark:border-slate-600 dark:text-slate-200 dark:hover:border-teal-600 dark:hover:text-teal-200" @click="emit('open', product)"><Wrench class="h-3.5 w-3.5" />Открыть карточку</button>
+              <a v-if="product.slug" class="grid h-8 w-8 place-items-center rounded-lg border border-gray-200 text-gray-500 hover:border-teal-300 hover:text-teal-700 dark:border-slate-600 dark:text-slate-300 dark:hover:border-teal-600 dark:hover:text-teal-200" :href="publicProductUrl(product.slug)" target="_blank" rel="noopener noreferrer" title="Открыть на сайте"><ExternalLink class="h-3.5 w-3.5" /></a>
             </div>
           </div>
         </article>

--- a/manager_frontend/src/components/catalog-quality/CatalogQualityFilters.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualityFilters.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import { Bookmark, BookmarkPlus, Search, SlidersHorizontal, X } from 'lucide-vue-next';
+import { computed, ref, watch } from 'vue';
+import { Bookmark, BookmarkPlus, ChevronDown, Search, SlidersHorizontal, X } from 'lucide-vue-next';
 import type { ManagerCatalogQualityFilterOptionsResponse } from '../../client';
-import type {
-  CatalogQualityFilterState,
-  CatalogQualitySavedView,
+import {
+  createDefaultCatalogQualityState,
+  type CatalogQualityFilterState,
+  type CatalogQualitySavedView,
 } from './catalog-quality-state';
 
 const props = defineProps<{
@@ -42,34 +43,64 @@ const findLabel = (group: keyof ManagerCatalogQualityFilterOptionsResponse, valu
 const activeChips = computed(() => {
   const state = props.modelValue;
   const chips: Array<{ key: keyof CatalogQualityFilterState; label: string }> = [];
-  if (state.equipmentType) chips.push({ key: 'equipmentType', label: findLabel('equipment_types', state.equipmentType) });
-  if (state.equipmentSubtype) chips.push({ key: 'equipmentSubtype', label: findLabel('equipment_subtypes', state.equipmentSubtype) });
-  if (state.brandId) chips.push({ key: 'brandId', label: findLabel('brands', state.brandId) });
-  if (state.seriesId) chips.push({ key: 'seriesId', label: findLabel('series', state.seriesId) });
+  if (state.equipmentType) chips.push({ key: 'equipmentType', label: `Тип: ${findLabel('equipment_types', state.equipmentType)}` });
+  if (state.equipmentSubtype) chips.push({ key: 'equipmentSubtype', label: `Подтип: ${findLabel('equipment_subtypes', state.equipmentSubtype)}` });
+  if (state.brandId) chips.push({ key: 'brandId', label: `Бренд: ${findLabel('brands', state.brandId)}` });
+  if (state.seriesId) chips.push({ key: 'seriesId', label: `Серия: ${findLabel('series', state.seriesId)}` });
   if (state.seriesState) chips.push({ key: 'seriesState', label: state.seriesState === 'missing' ? 'Без серии' : 'С серией' });
-  if (state.supplierId) chips.push({ key: 'supplierId', label: findLabel('suppliers', state.supplierId) });
+  if (state.supplierId) chips.push({ key: 'supplierId', label: `Поставщик: ${findLabel('suppliers', state.supplierId)}` });
   if (state.supplierState) chips.push({
     key: 'supplierState',
-    label: { mapped: 'Есть маппинг', in_stock: 'Есть у поставщика', unmapped: 'Без маппинга', multiple: 'Несколько поставщиков' }[state.supplierState],
+    label: `Маппинг: ${{ mapped: 'есть', in_stock: 'есть в наличии', unmapped: 'отсутствует', multiple: 'несколько поставщиков' }[state.supplierState]}`,
   });
   if (state.publication) chips.push({ key: 'publication', label: state.publication === 'published' ? 'Опубликовано' : 'Скрыто' });
   if (state.availability) chips.push({ key: 'availability', label: state.availability === 'in_stock' ? 'В наличии' : 'Нет в наличии' });
   if (state.priority) chips.push({ key: 'priority', label: `Приоритет: ${state.priority === 'high' ? 'высокий' : state.priority === 'medium' ? 'средний' : 'низкий'}` });
-  if (state.category !== 'all') chips.push({ key: 'category', label: { media: 'Медиа', identity: 'Бренд и серия', specs: 'Характеристики', commerce: 'Цена и наличие', supplier: 'Поставщики' }[state.category] });
-  if (state.severity !== 'all') chips.push({ key: 'severity', label: { critical: 'Критично', warning: 'Предупреждение', info: 'Заметка' }[state.severity] });
+  if (state.category !== 'all') chips.push({ key: 'category', label: `Проблема: ${{ media: 'медиа', identity: 'бренд и серия', specs: 'характеристики', commerce: 'цена и наличие', supplier: 'поставщики' }[state.category]}` });
+  if (state.severity !== 'all') chips.push({ key: 'severity', label: `Серьёзность: ${{ critical: 'критично', warning: 'предупреждение', info: 'заметка' }[state.severity]}` });
   if (state.issueCode) chips.push({ key: 'issueCode', label: `Причина: ${state.issueCode}` });
   if (state.scoreMin) chips.push({ key: 'scoreMin', label: `Score от ${state.scoreMin}` });
   if (state.scoreMax) chips.push({ key: 'scoreMax', label: `Score до ${state.scoreMax}` });
-  if (state.onlyFixable) chips.push({ key: 'onlyFixable', label: 'Можно исправить в Manager' });
+  if (state.onlyFixable) chips.push({ key: 'onlyFixable', label: 'Исправимо в Manager' });
   if (!state.onlyProblems) chips.push({ key: 'onlyProblems', label: 'Включая карточки без проблем' });
   return chips;
 });
 
+const advancedActiveCount = computed(() => {
+  const state = props.modelValue;
+  return [
+    state.equipmentSubtype,
+    state.seriesState,
+    state.priority,
+    state.category !== 'all',
+    state.severity !== 'all',
+    state.scoreMin,
+    state.scoreMax,
+    state.onlyFixable,
+    !state.onlyProblems,
+  ].filter(Boolean).length;
+});
+
+const showAdvanced = ref(advancedActiveCount.value > 0);
+watch(advancedActiveCount, (count) => {
+  if (count > 0) showAdvanced.value = true;
+});
+
+const viewComparisonKeys: Array<keyof CatalogQualityFilterState> = [
+  'q', 'equipmentType', 'equipmentSubtype', 'brandId', 'seriesId', 'seriesState',
+  'supplierId', 'supplierState', 'publication', 'availability', 'priority',
+  'scoreMin', 'scoreMax', 'category', 'severity', 'issueCode', 'onlyProblems',
+  'onlyFixable', 'sortBy', 'groupBy',
+];
+
+const isViewActive = (view: CatalogQualitySavedView) => {
+  const target = { ...createDefaultCatalogQualityState(), ...view.filters };
+  return viewComparisonKeys.every((key) => props.modelValue[key] === target[key]);
+};
+
 const clearChip = (key: keyof CatalogQualityFilterState) => {
-  const defaults: Partial<CatalogQualityFilterState> = {
-    category: 'all', severity: 'all', onlyProblems: true, onlyFixable: false,
-  };
-  const patch: Partial<CatalogQualityFilterState> = { [key]: defaults[key] ?? '' };
+  const defaults = createDefaultCatalogQualityState();
+  const patch: Partial<CatalogQualityFilterState> = { [key]: defaults[key] as never };
   if (key === 'equipmentType') patch.equipmentSubtype = '';
   if (key === 'brandId') patch.seriesId = '';
   patchState(patch);
@@ -85,16 +116,21 @@ const submitView = () => {
 </script>
 
 <template>
-  <section class="border-y border-gray-200 bg-white px-4 py-4 sm:px-5">
-    <div class="flex flex-wrap items-center gap-2">
-      <span class="inline-flex items-center gap-1.5 text-xs font-bold uppercase text-gray-500">
+  <section class="border-b border-gray-200 bg-white px-4 py-3 sm:px-5">
+    <div class="flex items-center gap-2 overflow-x-auto pb-1">
+      <span class="inline-flex shrink-0 items-center gap-1.5 text-xs font-bold uppercase text-gray-500">
         <Bookmark class="h-4 w-4" />
         Рабочие виды
       </span>
-      <div v-for="view in savedViews" :key="view.id" class="inline-flex items-center">
+      <div v-for="view in savedViews" :key="view.id" class="inline-flex shrink-0 items-center">
         <button
-          class="h-8 rounded-l-lg border border-gray-200 bg-gray-50 px-2.5 text-xs font-semibold text-gray-700 transition hover:border-teal-300 hover:bg-teal-50 hover:text-teal-800"
-          :class="view.builtin ? 'rounded-r-lg' : ''"
+          class="h-8 rounded-l-lg border px-2.5 text-xs font-semibold transition"
+          :class="[
+            view.builtin ? 'rounded-r-lg' : '',
+            isViewActive(view)
+              ? 'border-teal-600 bg-teal-600 text-white'
+              : 'border-gray-200 bg-gray-50 text-gray-700 hover:border-teal-300 hover:bg-teal-50 hover:text-teal-800',
+          ]"
           @click="emit('apply-view', view)"
         >
           {{ view.name }}
@@ -110,127 +146,108 @@ const submitView = () => {
       </div>
       <button
         v-if="!showSaveInput"
-        class="inline-flex h-8 items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-2.5 text-xs font-semibold text-gray-500 hover:border-teal-300 hover:text-teal-700"
+        class="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-2.5 text-xs font-semibold text-gray-500 hover:border-teal-300 hover:text-teal-700"
         @click="showSaveInput = true"
       >
         <BookmarkPlus class="h-3.5 w-3.5" />
-        Сохранить вид
+        Сохранить текущие фильтры
       </button>
-      <form v-else class="flex items-center gap-1" @submit.prevent="submitView">
-        <input
-          v-model="viewName"
-          class="h-8 w-44 rounded-lg border border-gray-300 px-2 text-xs outline-none focus:border-teal-500"
-          placeholder="Название вида"
-          autofocus
-        >
+      <form v-else class="flex shrink-0 items-center gap-1" @submit.prevent="submitView">
+        <input v-model="viewName" class="h-8 w-44 rounded-lg border border-gray-300 px-2 text-xs outline-none focus:border-teal-500" placeholder="Название вида" autofocus>
         <button class="h-8 rounded-lg bg-teal-600 px-2.5 text-xs font-semibold text-white">Сохранить</button>
-        <button class="grid h-8 w-8 place-items-center rounded-lg text-gray-500 hover:bg-gray-100" type="button" @click="showSaveInput = false">
-          <X class="h-4 w-4" />
-        </button>
+        <button class="grid h-8 w-8 place-items-center rounded-lg text-gray-500 hover:bg-gray-100" type="button" @click="showSaveInput = false"><X class="h-4 w-4" /></button>
       </form>
     </div>
 
-    <div class="mt-4 grid gap-3 xl:grid-cols-[minmax(260px,1.35fr)_repeat(4,minmax(150px,0.8fr))]">
-      <label class="relative block">
-        <span class="sr-only">Поиск</span>
-        <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+    <div class="mt-3 grid grid-cols-2 gap-2 xl:grid-cols-[minmax(280px,1.4fr)_repeat(4,minmax(145px,0.8fr))]">
+      <label class="relative col-span-2 block xl:col-span-1">
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Поиск</span>
+        <Search class="pointer-events-none absolute bottom-3 left-3 h-4 w-4 text-gray-400" />
         <input
           :value="modelValue.q"
-          class="h-10 w-full rounded-lg border border-gray-200 bg-gray-50 pl-9 pr-3 text-sm outline-none focus:border-teal-400 focus:bg-white"
-          placeholder="Название, модель или slug"
+          class="h-10 w-full rounded-lg border border-gray-200 bg-gray-50 pl-9 pr-9 text-sm outline-none focus:border-teal-400 focus:bg-white"
+          placeholder="Модель, артикул или название"
           @input="patchState({ q: ($event.target as HTMLInputElement).value })"
         >
+        <button v-if="modelValue.q" class="absolute bottom-2.5 right-2.5 grid h-5 w-5 place-items-center text-gray-400 hover:text-gray-700" title="Очистить поиск" @click="patchState({ q: '' })"><X class="h-4 w-4" /></button>
       </label>
-      <label class="space-y-1">
-        <span class="sr-only">Тип оборудования</span>
-        <select
-          :value="modelValue.equipmentType"
-          class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm"
-          @change="patchState({ equipmentType: ($event.target as HTMLSelectElement).value, equipmentSubtype: '' })"
-        >
-          <option value="">Все типы</option>
-          <option v-for="item in options?.equipment_types ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
+      <label>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Тип оборудования</span>
+        <select :value="modelValue.equipmentType" class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ equipmentType: ($event.target as HTMLSelectElement).value, equipmentSubtype: '' })">
+          <option value="">Все типы</option><option v-for="item in options?.equipment_types ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
         </select>
       </label>
       <label>
-        <span class="sr-only">Подтип</span>
-        <select
-          :value="modelValue.equipmentSubtype"
-          class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm disabled:bg-gray-100"
-          :disabled="!modelValue.equipmentType"
-          @change="patchState({ equipmentSubtype: ($event.target as HTMLSelectElement).value })"
-        >
-          <option value="">Все подтипы</option>
-          <option v-for="item in equipmentSubtypes" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Бренд</span>
+        <select :value="modelValue.brandId" class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ brandId: ($event.target as HTMLSelectElement).value, seriesId: '' })">
+          <option value="">Все бренды</option><option v-for="item in options?.brands ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
         </select>
       </label>
       <label>
-        <span class="sr-only">Бренд</span>
-        <select
-          :value="modelValue.brandId"
-          class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm"
-          @change="patchState({ brandId: ($event.target as HTMLSelectElement).value, seriesId: '' })"
-        >
-          <option value="">Все бренды</option>
-          <option v-for="item in options?.brands ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Серия</span>
+        <select :value="modelValue.seriesId" class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm disabled:bg-gray-100" :disabled="!modelValue.brandId" @change="patchState({ seriesId: ($event.target as HTMLSelectElement).value })">
+          <option value="">Все серии</option><option v-for="item in seriesOptions" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
         </select>
       </label>
       <label>
-        <span class="sr-only">Серия</span>
-        <select
-          :value="modelValue.seriesId"
-          class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm disabled:bg-gray-100"
-          :disabled="!modelValue.brandId"
-          @change="patchState({ seriesId: ($event.target as HTMLSelectElement).value })"
-        >
-          <option value="">Все серии</option>
-          <option v-for="item in seriesOptions" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Поставщик</span>
+        <select :value="modelValue.supplierId" class="h-10 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ supplierId: ($event.target as HTMLSelectElement).value })">
+          <option value="">Все поставщики</option><option v-for="item in options?.suppliers ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
         </select>
       </label>
     </div>
 
-    <details class="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
-      <summary class="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold text-gray-700">
-        <SlidersHorizontal class="h-4 w-4" />
-        Уточнить выбор
-      </summary>
-      <div class="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
-        <select :value="modelValue.seriesState" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ seriesState: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['seriesState'] })">
-          <option value="">Любая привязка серии</option><option value="assigned">С серией</option><option value="missing">Без серии</option>
+    <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+      <label>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Публикация</span>
+        <select :value="modelValue.publication" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ publication: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['publication'] })">
+          <option value="">Любая</option><option value="published">Опубликовано</option><option value="hidden">Скрыто</option>
         </select>
-        <select :value="modelValue.supplierId" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ supplierId: ($event.target as HTMLSelectElement).value })">
-          <option value="">Все поставщики</option><option v-for="item in options?.suppliers ?? []" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option>
+      </label>
+      <label>
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Наличие</span>
+        <select :value="modelValue.availability" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ availability: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['availability'] })">
+          <option value="">Любое</option><option value="in_stock">В наличии</option><option value="out_of_stock">Нет в наличии</option>
         </select>
-        <select :value="modelValue.supplierState" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ supplierState: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['supplierState'], supplierId: ($event.target as HTMLSelectElement).value === 'unmapped' ? '' : modelValue.supplierId })">
-          <option value="">Любой маппинг</option><option value="mapped">Есть маппинг</option><option value="in_stock">Есть у поставщика</option><option value="unmapped">Без маппинга</option><option value="multiple">Несколько поставщиков</option>
+      </label>
+      <label class="col-span-2 sm:col-span-1">
+        <span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Маппинг прайсов</span>
+        <select :value="modelValue.supplierState" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ supplierState: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['supplierState'], supplierId: ($event.target as HTMLSelectElement).value === 'unmapped' ? '' : modelValue.supplierId })">
+          <option value="">Любой</option><option value="mapped">Есть маппинг</option><option value="in_stock">Есть у поставщика</option><option value="unmapped">Без маппинга</option><option value="multiple">Несколько поставщиков</option>
         </select>
-        <select :value="modelValue.publication" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ publication: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['publication'] })">
-          <option value="">Любая публикация</option><option value="published">Опубликовано</option><option value="hidden">Скрыто</option>
-        </select>
-        <select :value="modelValue.availability" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ availability: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['availability'] })">
-          <option value="">Любое наличие</option><option value="in_stock">В наличии</option><option value="out_of_stock">Нет в наличии</option>
-        </select>
-        <select :value="modelValue.priority" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ priority: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['priority'] })">
-          <option value="">Любой приоритет</option><option value="high">Высокий</option><option value="medium">Средний</option><option value="low">Низкий</option>
-        </select>
-        <select :value="modelValue.category" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ category: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['category'] })">
-          <option value="all">Все группы проблем</option><option value="media">Медиа</option><option value="identity">Бренд и серия</option><option value="specs">Характеристики</option><option value="supplier">Поставщики</option><option value="commerce">Цена и наличие</option>
-        </select>
-        <select :value="modelValue.severity" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ severity: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['severity'] })">
-          <option value="all">Любая серьезность</option><option value="critical">Критично</option><option value="warning">Предупреждение</option><option value="info">Заметка</option>
-        </select>
-        <label class="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2 text-sm"><span class="text-gray-500">Score от</span><input :value="modelValue.scoreMin" class="min-w-0 flex-1 outline-none" inputmode="numeric" @input="patchState({ scoreMin: ($event.target as HTMLInputElement).value })"></label>
-        <label class="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2 text-sm"><span class="text-gray-500">до</span><input :value="modelValue.scoreMax" class="min-w-0 flex-1 outline-none" inputmode="numeric" @input="patchState({ scoreMax: ($event.target as HTMLInputElement).value })"></label>
-        <label class="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2 text-sm"><input :checked="modelValue.onlyProblems" type="checkbox" @change="patchState({ onlyProblems: ($event.target as HTMLInputElement).checked })">Только с проблемами</label>
-        <label class="flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-white px-2 text-sm"><input :checked="modelValue.onlyFixable" type="checkbox" @change="patchState({ onlyFixable: ($event.target as HTMLInputElement).checked })">Исправимо здесь</label>
+      </label>
+    </div>
+
+    <button
+      class="mt-3 inline-flex h-9 items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 text-sm font-semibold text-gray-700 hover:border-teal-300 hover:text-teal-800"
+      :aria-expanded="showAdvanced"
+      @click="showAdvanced = !showAdvanced"
+    >
+      <SlidersHorizontal class="h-4 w-4" />
+      Дополнительные фильтры
+      <span v-if="advancedActiveCount" class="rounded-full bg-teal-100 px-2 py-0.5 text-xs text-teal-800">{{ advancedActiveCount }} активных</span>
+      <ChevronDown class="h-4 w-4 transition-transform" :class="showAdvanced ? 'rotate-180' : ''" />
+    </button>
+
+    <Transition enter-active-class="transition duration-200 ease-out" enter-from-class="-translate-y-1 opacity-0" leave-active-class="transition duration-150 ease-in" leave-to-class="-translate-y-1 opacity-0">
+      <div v-if="showAdvanced" class="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Подтип</span><select :value="modelValue.equipmentSubtype" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm disabled:bg-gray-100" :disabled="!modelValue.equipmentType" @change="patchState({ equipmentSubtype: ($event.target as HTMLSelectElement).value })"><option value="">Все подтипы</option><option v-for="item in equipmentSubtypes" :key="item.value" :value="item.value">{{ item.label }} · {{ item.count }}</option></select></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Привязка серии</span><select :value="modelValue.seriesState" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ seriesState: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['seriesState'] })"><option value="">Любая</option><option value="assigned">С серией</option><option value="missing">Без серии</option></select></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Рабочий приоритет</span><select :value="modelValue.priority" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ priority: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['priority'] })"><option value="">Любой</option><option value="high">Высокий</option><option value="medium">Средний</option><option value="low">Низкий</option></select></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Группа проблем</span><select :value="modelValue.category" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ category: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['category'] })"><option value="all">Все группы</option><option value="media">Медиа</option><option value="identity">Бренд и серия</option><option value="specs">Характеристики</option><option value="supplier">Поставщики</option><option value="commerce">Цена и наличие</option></select></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Серьёзность</span><select :value="modelValue.severity" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm" @change="patchState({ severity: ($event.target as HTMLSelectElement).value as CatalogQualityFilterState['severity'] })"><option value="all">Любая</option><option value="critical">Критично</option><option value="warning">Предупреждение</option><option value="info">Заметка</option></select></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Score от</span><input :value="modelValue.scoreMin" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm outline-none" inputmode="numeric" placeholder="0" @input="patchState({ scoreMin: ($event.target as HTMLInputElement).value })"></label>
+          <label><span class="mb-1 block text-[11px] font-semibold uppercase text-gray-500">Score до</span><input :value="modelValue.scoreMax" class="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm outline-none" inputmode="numeric" placeholder="100" @input="patchState({ scoreMax: ($event.target as HTMLInputElement).value })"></label>
+          <label class="flex h-9 items-center gap-2 self-end rounded-lg border border-gray-200 bg-white px-2 text-sm"><input :checked="modelValue.onlyProblems" type="checkbox" @change="patchState({ onlyProblems: ($event.target as HTMLInputElement).checked })">Только с проблемами</label>
+          <label class="flex h-9 items-center gap-2 self-end rounded-lg border border-gray-200 bg-white px-2 text-sm"><input :checked="modelValue.onlyFixable" type="checkbox" @change="patchState({ onlyFixable: ($event.target as HTMLInputElement).checked })">Исправимо в Manager</label>
+        </div>
       </div>
-    </details>
+    </Transition>
 
     <div v-if="activeChips.length" class="mt-3 flex flex-wrap items-center gap-1.5">
-      <span class="text-xs font-semibold text-gray-400">Выбрано:</span>
-      <button v-for="chip in activeChips" :key="chip.key" class="inline-flex h-7 items-center gap-1 rounded-full bg-teal-50 px-2.5 text-xs font-semibold text-teal-800 hover:bg-teal-100" @click="clearChip(chip.key)">
-        {{ chip.label }} <X class="h-3 w-3" />
-      </button>
+      <span class="text-xs font-semibold text-gray-400">Активно:</span>
+      <button v-for="chip in activeChips" :key="chip.key" class="inline-flex min-h-7 items-center gap-1 rounded-full bg-teal-50 px-2.5 py-1 text-xs font-semibold text-teal-800 hover:bg-teal-100" @click="clearChip(chip.key)">{{ chip.label }} <X class="h-3 w-3" /></button>
     </div>
   </section>
 </template>

--- a/manager_frontend/src/components/catalog-quality/CatalogQualitySummary.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualitySummary.vue
@@ -18,57 +18,39 @@ const categoryIcon = (category: string) => {
   return AlertTriangle;
 };
 const severityTone = (severity: string) => {
-  if (severity === 'critical') return 'bg-red-50 text-red-700 border-red-200';
-  if (severity === 'warning') return 'bg-amber-50 text-amber-800 border-amber-200';
-  return 'bg-sky-50 text-sky-700 border-sky-200';
+  if (severity === 'critical') return 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-200';
+  if (severity === 'warning') return 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200';
+  return 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-200';
 };
 </script>
 
 <template>
-  <section class="border-b border-gray-200 bg-white px-4 py-4 sm:px-5">
-    <div class="grid grid-cols-2 overflow-hidden rounded-lg border border-gray-200 xl:grid-cols-4">
-      <div class="flex items-center gap-3 border-b border-r border-gray-200 px-3 py-3 xl:border-b-0">
-        <ShieldCheck class="h-7 w-7 text-teal-700" />
-        <div><p class="text-xs font-semibold text-gray-500">Средний score</p><p class="text-xl font-bold text-gray-950">{{ report.average_score }}</p></div>
+  <section class="border-b border-gray-200 bg-white px-4 py-3 dark:border-slate-700 dark:bg-slate-900 sm:px-5">
+    <div class="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+      <div class="flex items-center gap-2">
+        <ShieldCheck class="h-6 w-6 shrink-0 text-teal-700" />
+        <div><p class="text-[11px] font-semibold uppercase text-gray-500 dark:text-slate-400">Средний score</p><p class="text-lg font-bold text-gray-950 dark:text-slate-100">{{ report.average_score }} / 100</p></div>
       </div>
-      <div class="border-b border-gray-200 px-3 py-3 xl:border-b-0 xl:border-r">
-        <p class="text-xs font-semibold text-gray-500">Товаров в выборке</p><p class="text-xl font-bold text-gray-950">{{ formatNumber(report.total_products) }}</p>
-      </div>
-      <div class="border-r border-gray-200 px-3 py-3">
-        <p class="text-xs font-semibold text-amber-700">Карточек с проблемами</p><p class="text-xl font-bold text-amber-800">{{ formatNumber(report.problem_products) }}</p>
-      </div>
-      <div class="px-3 py-3">
-        <p class="text-xs font-semibold text-red-700">Критичных карточек</p><p class="text-xl font-bold text-red-800">{{ formatNumber(report.critical_products) }}</p>
-      </div>
+      <div><p class="text-[11px] font-semibold uppercase text-gray-500 dark:text-slate-400">Товаров</p><p class="text-lg font-bold text-gray-950 dark:text-slate-100">{{ formatNumber(report.total_products) }}</p></div>
+      <div><p class="text-[11px] font-semibold uppercase text-red-600">Критичных</p><p class="text-lg font-bold text-red-700">{{ formatNumber(report.critical_products) }}</p></div>
+      <div><p class="text-[11px] font-semibold uppercase text-teal-700">Исправимо здесь</p><p class="text-lg font-bold text-teal-800">{{ formatNumber(report.fixable_products) }}</p></div>
     </div>
 
-    <div class="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-start">
-      <div>
-        <div class="flex items-baseline justify-between gap-3">
-          <h2 class="text-sm font-bold text-gray-900">Главные причины в текущей выборке</h2>
-          <p class="text-xs text-gray-500">Число на причине = количество нарушений</p>
-        </div>
-        <div class="mt-2 flex flex-wrap gap-2">
-          <button
-            v-for="item in report.summary.slice(0, 8)"
-            :key="item.code"
-            class="inline-flex h-9 items-center gap-2 rounded-lg border px-2.5 text-xs font-semibold transition hover:brightness-95"
-            :class="[severityTone(item.severity), selectedIssueCode === item.code ? 'ring-2 ring-teal-500 ring-offset-1' : '']"
-            @click="emit('selectIssue', item.code)"
-          >
-            <component :is="categoryIcon(item.category)" class="h-4 w-4" />
-            <span>{{ item.label }}</span>
-            <strong>{{ formatNumber(item.count) }}</strong>
-          </button>
-          <p v-if="!report.summary.length" class="text-sm font-semibold text-emerald-700">По текущей выборке проблем нет.</p>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-3 gap-2 text-center text-xs">
-        <div class="rounded-lg bg-red-50 px-3 py-2 text-red-800"><strong class="block text-base">{{ formatNumber(report.severity_product_counts?.critical) }}</strong>карточек<br>критично</div>
-        <div class="rounded-lg bg-amber-50 px-3 py-2 text-amber-800"><strong class="block text-base">{{ formatNumber(report.severity_product_counts?.warning) }}</strong>карточек<br>с замечаниями</div>
-        <div class="rounded-lg bg-sky-50 px-3 py-2 text-sky-800"><strong class="block text-base">{{ formatNumber(report.severity_issue_counts?.info) }}</strong>заметок<br>всего</div>
-      </div>
+    <div v-if="report.summary.length" class="mt-3 flex flex-wrap items-center gap-1.5 border-t border-gray-100 pt-3 dark:border-slate-700">
+      <span class="mr-1 text-xs font-semibold text-gray-500 dark:text-slate-400">Главные причины:</span>
+      <button
+        v-for="item in report.summary.slice(0, 6)"
+        :key="item.code"
+        class="inline-flex min-h-8 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs font-semibold transition hover:brightness-95"
+        :class="[severityTone(item.severity), selectedIssueCode === item.code ? 'ring-2 ring-teal-500 ring-offset-1' : '']"
+        :title="`Показать ${formatNumber(item.count)} карточек с этой проблемой`"
+        @click="emit('selectIssue', item.code)"
+      >
+        <component :is="categoryIcon(item.category)" class="h-3.5 w-3.5" />
+        <span>{{ item.label }}</span>
+        <strong>{{ formatNumber(item.count) }}</strong>
+      </button>
     </div>
+    <p v-else class="mt-3 border-t border-gray-100 pt-3 text-sm font-semibold text-emerald-700">По текущей выборке проблем нет.</p>
   </section>
 </template>

--- a/manager_frontend/src/views/CatalogQualityView.vue
+++ b/manager_frontend/src/views/CatalogQualityView.vue
@@ -43,6 +43,14 @@ const currentRelativeUrl = () => `${window.location.pathname}${window.location.s
 const generatedAt = computed(() => report.value?.generated_at
   ? new Intl.DateTimeFormat('ru-RU', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(report.value.generated_at))
   : '');
+const selectedBrandTitle = computed(() => state.value.brandId
+  ? report.value?.filter_options.brands?.find((item) => item.value === state.value.brandId)?.label || ''
+  : '');
+const shouldSuggestSeriesGrouping = computed(() => Boolean(
+  state.value.brandId
+  && state.value.groupBy === 'none'
+  && (report.value?.filter_options.series?.filter((item) => item.parent_value === state.value.brandId).length || 0) > 1,
+));
 const productCountLabel = (value?: number | null) => {
   const count = Number(value || 0);
   const lastTwo = count % 100;
@@ -141,7 +149,7 @@ const deleteSavedView = (id: string) => {
   writeCatalogQualitySavedViews(window.localStorage, next);
 };
 
-const openProduct = (product: QualityProduct) => {
+const openProductPanel = (product: QualityProduct, panel: 'edit' | 'media') => {
   window.sessionStorage.setItem(SCROLL_STORAGE_KEY, JSON.stringify({
     url: currentRelativeUrl(),
     scrollY: window.scrollY,
@@ -149,10 +157,14 @@ const openProduct = (product: QualityProduct) => {
   const params = new URLSearchParams({
     editProductId: String(product.product_id),
     returnTo: currentRelativeUrl(),
+    productPanel: panel,
   });
   if (product.title) params.set('editProductQuery', product.title);
   window.location.href = `/manager/products?${params.toString()}`;
 };
+
+const openProduct = (product: QualityProduct) => openProductPanel(product, 'edit');
+const openProductMedia = (product: QualityProduct) => openProductPanel(product, 'media');
 
 const goToPage = (page: number) => {
   state.value = { ...state.value, page: Math.min(Math.max(1, page), totalPages.value) };
@@ -185,12 +197,12 @@ onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState));
 </script>
 
 <template>
-  <main class="min-h-screen bg-gray-50 pb-8 pt-12 text-gray-950 md:pt-4">
-    <div class="mx-auto max-w-[1600px] overflow-hidden border-y border-gray-200 bg-white shadow-sm md:rounded-xl md:border">
-      <header class="flex flex-col gap-3 border-b border-gray-200 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+  <main class="min-h-screen bg-gray-50 pb-8 pt-12 text-gray-950 dark:bg-slate-950 dark:text-slate-100 md:pt-4">
+    <div class="mx-auto max-w-[1600px] overflow-hidden border-y border-gray-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 md:rounded-xl md:border">
+      <header class="flex flex-col gap-2 border-b border-gray-200 px-4 py-3 dark:border-slate-700 sm:flex-row sm:items-center sm:justify-between sm:px-5">
         <div class="min-w-0">
-          <div class="flex items-center gap-2"><ShieldCheck class="h-6 w-6 text-teal-700" /><h1 class="text-xl font-bold">Качество каталога</h1></div>
-          <p class="mt-1 text-sm text-gray-500">Рабочая очередь карточек: контент, нормализация и готовность предложений.</p>
+          <div class="flex items-center gap-2"><ShieldCheck class="h-6 w-6 text-teal-700" /><h1 class="text-xl font-bold text-gray-950 dark:text-slate-100">Качество каталога</h1></div>
+          <p class="mt-1 hidden text-sm text-gray-500 dark:text-slate-400 sm:block">Рабочая очередь карточек: контент, нормализация и готовность предложений.</p>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <span v-if="generatedAt" class="text-xs text-gray-400">Проверено {{ generatedAt }}</span>
@@ -214,25 +226,28 @@ onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState));
 
       <div v-if="error" class="border-b border-red-200 bg-red-50 px-5 py-3 text-sm font-semibold text-red-700">Не удалось загрузить отчет: {{ error }}</div>
 
-      <section class="flex flex-col gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3 lg:flex-row lg:items-center lg:justify-between sm:px-5">
+      <section class="sticky top-0 z-20 flex flex-col gap-2 border-b border-gray-200 bg-gray-50/95 px-4 py-2 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-950/95 lg:flex-row lg:items-center lg:justify-between sm:px-5">
         <div class="flex flex-wrap items-center gap-2 text-sm">
-          <strong>{{ productCountLabel(meta?.total) }}</strong>
+          <strong v-if="selectedBrandTitle" class="text-teal-800">{{ selectedBrandTitle }}</strong>
+          <span v-if="selectedBrandTitle" class="text-gray-400">·</span>
+          <strong class="text-gray-950 dark:text-slate-100">{{ productCountLabel(meta?.total) }}</strong>
           <span class="text-gray-400">·</span>
-          <span class="text-gray-500">страница {{ meta?.page || 1 }} из {{ totalPages }}</span>
+          <span class="text-gray-500 dark:text-slate-400">страница {{ meta?.page || 1 }} из {{ totalPages }}</span>
           <span v-if="loading" class="font-semibold text-teal-700">обновляем...</span>
+          <button v-if="shouldSuggestSeriesGrouping" class="h-8 rounded-lg bg-teal-50 px-2.5 text-xs font-semibold text-teal-800 hover:bg-teal-100" @click="state.groupBy = 'series'">Сгруппировать по сериям</button>
         </div>
         <div class="flex flex-wrap items-center gap-2">
-          <label class="flex items-center gap-2 text-xs font-semibold text-gray-500">Сортировка
-            <select v-model="state.sortBy" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-800">
+          <label class="flex items-center gap-2 text-xs font-semibold text-gray-500 dark:text-slate-300">Сортировка
+            <select v-model="state.sortBy" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-800 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
               <option value="priority">По рабочему приоритету</option><option value="score_asc">Худший score</option><option value="critical">Критичные сначала</option><option value="stock">С наличием сначала</option><option value="newest">Новые сначала</option><option value="brand">По бренду</option><option value="series">По серии</option><option value="title">По названию</option>
             </select>
           </label>
-          <label class="flex items-center gap-2 text-xs font-semibold text-gray-500">Группа
-            <select v-model="state.groupBy" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-800">
+          <label class="flex items-center gap-2 text-xs font-semibold text-gray-500 dark:text-slate-300">Группа
+            <select v-model="state.groupBy" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-800 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
               <option value="none">Без группировки</option><option value="brand">Бренд</option><option value="series">Серия</option><option value="supplier">Поставщик</option><option value="equipment_type">Тип оборудования</option>
             </select>
           </label>
-          <div class="inline-flex h-9 overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div class="inline-flex h-9 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-slate-600 dark:bg-slate-900">
             <button class="grid w-9 place-items-center" :class="state.view === 'cards' ? 'bg-teal-600 text-white' : 'text-gray-500'" title="Карточки" @click="state.view = 'cards'"><Grid2X2 class="h-4 w-4" /></button>
             <button class="grid w-9 place-items-center" :class="state.view === 'table' ? 'bg-teal-600 text-white' : 'text-gray-500'" title="Таблица" @click="state.view = 'table'"><List class="h-4 w-4" /></button>
           </div>
@@ -242,7 +257,17 @@ onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState));
       <div v-if="loading && !report" class="grid gap-3 p-5 sm:grid-cols-2"><div v-for="index in 6" :key="index" class="h-36 animate-pulse rounded-lg bg-gray-100" /></div>
       <div v-else-if="report && !report.items.length" class="px-5 py-14 text-center"><ShieldCheck class="mx-auto h-10 w-10 text-emerald-600" /><h2 class="mt-3 text-lg font-bold">По этой выборке все чисто</h2><p class="mt-1 text-sm text-gray-500">Измените фильтры или включите карточки без проблем.</p></div>
       <template v-else-if="report">
-        <CatalogQualityCards v-if="state.view === 'cards'" :items="report.items" :groups="report.groups" :grouped="state.groupBy !== 'none'" @open="openProduct" @select-issue="selectIssue" />
+        <CatalogQualityCards
+          v-if="state.view === 'cards'"
+          :items="report.items"
+          :groups="report.groups"
+          :grouped="state.groupBy !== 'none'"
+          :selected-brand-title="selectedBrandTitle"
+          :hide-equipment-type="Boolean(state.equipmentType)"
+          :hide-series="Boolean(state.seriesId) || state.groupBy === 'series'"
+          @open="openProduct"
+          @open-media="openProductMedia"
+        />
         <CatalogQualityTable v-else :items="report.items" @open="openProduct" @select-issue="selectIssue" />
       </template>
 

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -176,6 +176,7 @@ const handleOnlinerImported = async (successCount: number) => {
 const pendingEditProductId = ref<number | null>(null);
 const pendingEditProductQuery = ref('');
 const pendingReturnTo = ref('');
+const pendingProductPanel = ref<'edit' | 'media'>('edit');
 const pendingEditHandled = ref(false);
 
 // Bulk Actions
@@ -723,7 +724,8 @@ const loadProducts = async () => {
           : null);
       if (target) {
         pendingEditHandled.value = true;
-        openEditModal(target);
+        if (pendingProductPanel.value === 'media') openSearchModal(target);
+        else openEditModal(target);
       } else if (searchQuery.value.trim()) {
         pendingEditHandled.value = true;
         setToast(`Товар #${pendingEditProductId.value} не найден`);
@@ -1418,6 +1420,7 @@ onMounted(() => {
     pendingEditProductId.value = Number.isFinite(parsedEditProductId) && parsedEditProductId > 0 ? parsedEditProductId : null;
     pendingEditProductQuery.value = params.get('editProductQuery') || '';
     pendingReturnTo.value = params.get('returnTo') || '';
+    pendingProductPanel.value = params.get('productPanel') === 'media' ? 'media' : 'edit';
     if (!searchQuery.value) {
         if (pendingEditProductQuery.value) {
             searchQuery.value = pendingEditProductQuery.value;

--- a/openapi.json
+++ b/openapi.json
@@ -27854,6 +27854,10 @@
             "type": "integer",
             "title": "Critical Products"
           },
+          "fixable_products": {
+            "type": "integer",
+            "title": "Fixable Products"
+          },
           "average_score": {
             "type": "integer",
             "title": "Average Score"
@@ -27913,6 +27917,7 @@
           "total_products",
           "problem_products",
           "critical_products",
+          "fixable_products",
           "average_score",
           "items",
           "summary",

--- a/schemas.py
+++ b/schemas.py
@@ -1762,6 +1762,7 @@ class ManagerCatalogQualityReportResponse(BaseModel):
     total_products: int
     problem_products: int
     critical_products: int
+    fixable_products: int
     average_score: int
     items: List[ManagerCatalogQualityProductResponse]
     summary: List[ManagerCatalogQualitySummaryItemResponse]

--- a/services/catalog_quality_service.py
+++ b/services/catalog_quality_service.py
@@ -264,6 +264,7 @@ class CatalogQualityService:
             for item in filtered
             if any(issue["severity"] == "critical" for issue in item["issues"])
         )
+        fixable_products = sum(1 for item in filtered if int(item.get("fixable_issue_count") or 0) > 0)
         severity_issue_counts = {severity_key: 0 for severity_key in ("critical", "warning", "info")}
         severity_product_counts = {severity_key: 0 for severity_key in ("critical", "warning", "info")}
         for item in filtered:
@@ -280,6 +281,7 @@ class CatalogQualityService:
             "total_products": total_filtered,
             "problem_products": problem_products,
             "critical_products": critical_products,
+            "fixable_products": fixable_products,
             "average_score": average_score,
             "items": page_items,
             "summary": summary,

--- a/tests/integration/test_manager_catalog_quality_api.py
+++ b/tests/integration/test_manager_catalog_quality_api.py
@@ -64,6 +64,7 @@ async def test_catalog_quality_report_supports_normalized_workspace_filters(asyn
     payload = response.json()
     assert payload["meta"]["total"] == 1
     assert payload["total_products"] == 1
+    assert payload["fixable_products"] == 1
     assert payload["items"][0]["product_id"] == product.id
     assert payload["items"][0]["equipment_type"] == "cat-household"
     assert payload["groups"][0]["key"] == "equipment:cat-household"


### PR DESCRIPTION
## Summary
- reorganize catalog-quality filters into compact primary and advanced groups with labeled controls and saved-view state
- simplify KPIs and quality cards, expose score rationale, media dimensions, and direct edit/media actions
- add full-result fixable product count and preserve it in the generated API client
- improve mobile density, sticky controls, dark theme contrast, and storefront links

## Verification
- manager_frontend: pnpm run build
- manager_frontend: pnpm run test:ui-logic
- pytest tests/integration/test_manager_catalog_quality_api.py -q
- bash scripts/audit_theme_hardcodes.sh
- desktop and 390x844 browser QA in light-responsive layout and dark theme