### PR TITLE
Clarify catalog quality work queue

### DIFF
--- a/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
+++ b/manager_frontend/src/client/models/ManagerCatalogQualityReportResponse.ts
@@ -20,6 +20,7 @@ export type ManagerCatalogQualityReportResponse = {
     categories: Array<ManagerCatalogQualityCategoryResponse>;
     groups?: Array<ManagerCatalogQualityGroupResponse>;
     filter_options: ManagerCatalogQualityFilterOptionsResponse;
+    builtin_view_counts?: Record<string, number>;
     severity_issue_counts?: Record<string, number>;
     severity_product_counts?: Record<string, number>;
     meta: Meta;

--- a/manager_frontend/src/components/catalog-quality/CatalogQualityCards.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualityCards.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { ExternalLink, Image as ImageIcon, Images, Wrench } from 'lucide-vue-next';
 import type { ManagerCatalogQualityReportResponse } from '../../api';
+import { countLabel } from './catalog-quality-copy';
 
 type QualityProduct = ManagerCatalogQualityReportResponse['items'][number];
 type QualityIssue = NonNullable<QualityProduct['issues']>[number];
@@ -17,6 +18,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [product: QualityProduct];
   openMedia: [product: QualityProduct];
+  openSeriesMedia: [product: QualityProduct];
 }>();
 const failedImages = ref(new Set<number>());
 
@@ -33,6 +35,8 @@ const groupedItems = computed(() => {
 });
 
 const groupSummary = (key: string) => props.groups?.find((group) => group.key === key);
+const seriesMediaProduct = (group: { key: string; items: QualityProduct[] }) =>
+  group.key.startsWith('series:') ? group.items.find((product) => product.series_id) : undefined;
 const imageSrc = (url?: string | null) => !url ? '' : url.startsWith('http') || url.startsWith('/') ? url : `/${url}`;
 const publicSiteBaseUrl = (() => {
   const configured = String(import.meta.env.WEBSITE_URL || '').trim();
@@ -82,6 +86,15 @@ const imageSizeLabel = (product: QualityProduct) => product.main_image_width && 
 const markImageFailed = (productId: number) => {
   failedImages.value = new Set(failedImages.value).add(productId);
 };
+const openGroupMedia = (group: { key: string; items: QualityProduct[] }) => {
+  const product = seriesMediaProduct(group);
+  if (product) emit('openSeriesMedia', product);
+};
+const visibleIssues = (product: QualityProduct) => (product.issues ?? []).filter((issue) => !(
+  issue.code === 'out_of_stock'
+  && product.work_priority === 'low'
+  && Number(product.available_qty || 0) === 0
+));
 </script>
 
 <template>
@@ -90,9 +103,12 @@ const markImageFailed = (productId: number) => {
       <header v-if="grouped" class="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 pb-2 dark:border-slate-700">
         <div>
           <h2 class="font-bold text-gray-950 dark:text-slate-100">{{ group.label }}</h2>
-          <p class="text-xs text-gray-500 dark:text-slate-400">{{ formatNumber(groupSummary(group.key)?.count ?? group.items.length) }} товаров · score {{ groupSummary(group.key)?.average_score ?? '—' }} · критичных {{ groupSummary(group.key)?.critical_products || 0 }}</p>
+          <p class="text-xs text-gray-500 dark:text-slate-400">{{ countLabel(groupSummary(group.key)?.count ?? group.items.length, 'товар', 'товара', 'товаров') }} · score {{ groupSummary(group.key)?.average_score ?? '—' }} · критичных {{ groupSummary(group.key)?.critical_products || 0 }}</p>
         </div>
-        <span v-if="groupSummary(group.key)?.media_problem_products" class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-800"><Images class="h-3.5 w-3.5" /> Медиа: {{ groupSummary(group.key)?.media_problem_products }}</span>
+        <div v-if="groupSummary(group.key)?.media_problem_products" class="flex flex-wrap items-center gap-2">
+          <span class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-950 dark:text-amber-200"><Images class="h-3.5 w-3.5" /> Медиа: {{ groupSummary(group.key)?.media_problem_products }}</span>
+          <button v-if="seriesMediaProduct(group)" class="inline-flex h-8 items-center gap-1.5 rounded-lg bg-teal-600 px-2.5 text-xs font-semibold text-white hover:bg-teal-700" @click="openGroupMedia(group)"><Images class="h-3.5 w-3.5" />Исправить медиа серии</button>
+        </div>
       </header>
 
       <div class="grid gap-3 xl:grid-cols-2">
@@ -117,14 +133,14 @@ const markImageFailed = (productId: number) => {
             <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs font-medium text-gray-600 dark:text-slate-300">
               <span v-if="!hideEquipmentType">{{ product.equipment_type_label || 'Тип не определен' }}</span>
               <span>{{ product.available_qty || 0 }} шт.</span>
-              <span>{{ product.supplier_mapping_count || 0 }} поставщ.</span>
+              <span>{{ countLabel(product.supplier_mapping_count || 0, 'поставщик', 'поставщика', 'поставщиков') }}</span>
               <span :class="product.is_published ? 'text-emerald-700' : 'text-gray-500'">{{ product.is_published ? 'На сайте' : 'Скрыт' }}</span>
               <span>{{ product.image_count || 0 }} фото<span v-if="imageSizeLabel(product)"> · {{ imageSizeLabel(product) }}</span></span>
             </div>
 
             <div class="mt-2 flex flex-wrap gap-1">
-              <span v-for="issue in (product.issues ?? []).slice(0, 3)" :key="issue.code" class="rounded-md px-1.5 py-1 text-[11px] font-semibold" :class="severityTone(issue.severity)" :title="issue.detail || issue.message">{{ issue.label }}</span>
-              <span v-if="product.issue_count > 3" class="rounded-md bg-gray-100 px-1.5 py-1 text-[11px] font-semibold text-gray-500 dark:bg-slate-800 dark:text-slate-300">Ещё {{ formatNumber(product.issue_count - 3) }}</span>
+              <span v-for="issue in visibleIssues(product).slice(0, 3)" :key="issue.code" class="rounded-md px-1.5 py-1 text-[11px] font-semibold" :class="severityTone(issue.severity)" :title="issue.detail || issue.message">{{ issue.label }}</span>
+              <span v-if="visibleIssues(product).length > 3" class="rounded-md bg-gray-100 px-1.5 py-1 text-[11px] font-semibold text-gray-500 dark:bg-slate-800 dark:text-slate-300">Ещё {{ formatNumber(visibleIssues(product).length - 3) }}</span>
             </div>
 
             <div class="mt-2 flex flex-wrap gap-2 border-t border-gray-100 pt-2 dark:border-slate-700">

--- a/manager_frontend/src/components/catalog-quality/CatalogQualityFilters.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualityFilters.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   modelValue: CatalogQualityFilterState;
   options?: ManagerCatalogQualityFilterOptionsResponse;
   savedViews: CatalogQualitySavedView[];
+  viewCounts?: Record<string, number>;
   loading?: boolean;
 }>();
 
@@ -133,7 +134,7 @@ const submitView = () => {
           ]"
           @click="emit('apply-view', view)"
         >
-          {{ view.name }}
+          {{ view.name }}<span v-if="viewCounts?.[view.id] !== undefined" class="ml-1 opacity-75">· {{ viewCounts[view.id] }}</span>
         </button>
         <button
           v-if="!view.builtin"
@@ -224,8 +225,7 @@ const submitView = () => {
       @click="showAdvanced = !showAdvanced"
     >
       <SlidersHorizontal class="h-4 w-4" />
-      Дополнительные фильтры
-      <span v-if="advancedActiveCount" class="rounded-full bg-teal-100 px-2 py-0.5 text-xs text-teal-800">{{ advancedActiveCount }} активных</span>
+      Дополнительные фильтры<span v-if="advancedActiveCount"> · {{ advancedActiveCount }}</span>
       <ChevronDown class="h-4 w-4 transition-transform" :class="showAdvanced ? 'rotate-180' : ''" />
     </button>
 

--- a/manager_frontend/src/components/catalog-quality/CatalogQualitySummary.vue
+++ b/manager_frontend/src/components/catalog-quality/CatalogQualitySummary.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AlertTriangle, Image as ImageIcon, ListChecks, PackageCheck, ShieldCheck, Truck } from 'lucide-vue-next';
 import type { ManagerCatalogQualityReportResponse } from '../../api';
+import { countLabel } from './catalog-quality-copy';
 
 const props = defineProps<{
   report: ManagerCatalogQualityReportResponse;
@@ -8,6 +10,19 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{ selectIssue: [code: string] }>();
+
+const summaryGroups = computed(() => [
+  {
+    key: 'content',
+    label: 'Контент',
+    items: props.report.summary.filter((item) => ['media', 'identity', 'specs'].includes(item.category)),
+  },
+  {
+    key: 'commercial',
+    label: 'Коммерческая готовность',
+    items: props.report.summary.filter((item) => ['commerce', 'supplier'].includes(item.category)),
+  },
+].filter((group) => group.items.length));
 
 const formatNumber = (value?: number | null) => new Intl.NumberFormat('ru-RU').format(Number(value || 0));
 const categoryIcon = (category: string) => {
@@ -36,20 +51,22 @@ const severityTone = (severity: string) => {
       <div><p class="text-[11px] font-semibold uppercase text-teal-700">Исправимо здесь</p><p class="text-lg font-bold text-teal-800">{{ formatNumber(report.fixable_products) }}</p></div>
     </div>
 
-    <div v-if="report.summary.length" class="mt-3 flex flex-wrap items-center gap-1.5 border-t border-gray-100 pt-3 dark:border-slate-700">
-      <span class="mr-1 text-xs font-semibold text-gray-500 dark:text-slate-400">Главные причины:</span>
-      <button
-        v-for="item in report.summary.slice(0, 6)"
-        :key="item.code"
-        class="inline-flex min-h-8 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs font-semibold transition hover:brightness-95"
-        :class="[severityTone(item.severity), selectedIssueCode === item.code ? 'ring-2 ring-teal-500 ring-offset-1' : '']"
-        :title="`Показать ${formatNumber(item.count)} карточек с этой проблемой`"
-        @click="emit('selectIssue', item.code)"
-      >
-        <component :is="categoryIcon(item.category)" class="h-3.5 w-3.5" />
-        <span>{{ item.label }}</span>
-        <strong>{{ formatNumber(item.count) }}</strong>
-      </button>
+    <div v-if="report.summary.length" class="mt-3 grid gap-2 border-t border-gray-100 pt-3 dark:border-slate-700 lg:grid-cols-2">
+      <div v-for="group in summaryGroups" :key="group.key" class="flex min-w-0 flex-wrap items-center gap-1.5">
+        <span class="mr-1 text-xs font-semibold text-gray-500 dark:text-slate-400">{{ group.label }}:</span>
+        <button
+          v-for="item in group.items.slice(0, 4)"
+          :key="item.code"
+          class="inline-flex min-h-8 items-center gap-1.5 rounded-lg border px-2 py-1 text-xs font-semibold transition hover:brightness-95"
+          :class="[severityTone(item.severity), selectedIssueCode === item.code ? 'ring-2 ring-teal-500 ring-offset-1' : '']"
+          :title="`Показать ${countLabel(item.count, 'карточку', 'карточки', 'карточек')} с этой проблемой`"
+          @click="emit('selectIssue', item.code)"
+        >
+          <component :is="categoryIcon(item.category)" class="h-3.5 w-3.5" />
+          <span>{{ item.label }}</span>
+          <strong>{{ formatNumber(item.count) }}</strong>
+        </button>
+      </div>
     </div>
     <p v-else class="mt-3 border-t border-gray-100 pt-3 text-sm font-semibold text-emerald-700">По текущей выборке проблем нет.</p>
   </section>

--- a/manager_frontend/src/components/catalog-quality/catalog-quality-copy.ts
+++ b/manager_frontend/src/components/catalog-quality/catalog-quality-copy.ts
@@ -1,0 +1,11 @@
+export const pluralRu = (count: number, one: string, few: string, many: string) => {
+  const absolute = Math.abs(count);
+  const lastTwo = absolute % 100;
+  const last = absolute % 10;
+  if (last === 1 && lastTwo !== 11) return one;
+  if (last >= 2 && last <= 4 && (lastTwo < 12 || lastTwo > 14)) return few;
+  return many;
+};
+
+export const countLabel = (count: number, one: string, few: string, many: string) =>
+  `${new Intl.NumberFormat('ru-RU').format(count)} ${pluralRu(count, one, few, many)}`;

--- a/manager_frontend/src/views/CatalogQualityView.vue
+++ b/manager_frontend/src/views/CatalogQualityView.vue
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   RotateCcw,
   ShieldCheck,
+  SlidersHorizontal,
 } from 'lucide-vue-next';
 import { api, type CatalogQualityReportParams, type ManagerCatalogQualityReportResponse } from '../api';
 import CatalogQualityCards from '../components/catalog-quality/CatalogQualityCards.vue';
@@ -35,6 +36,7 @@ const loading = ref(false);
 const error = ref('');
 const requestId = ref(0);
 const customViews = ref<CatalogQualitySavedView[]>(readCatalogQualitySavedViews(window.localStorage));
+const filtersAnchor = ref<HTMLElement | null>(null);
 
 const savedViews = computed(() => [...catalogQualityBuiltinViews, ...customViews.value]);
 const meta = computed(() => report.value?.meta);
@@ -46,11 +48,15 @@ const generatedAt = computed(() => report.value?.generated_at
 const selectedBrandTitle = computed(() => state.value.brandId
   ? report.value?.filter_options.brands?.find((item) => item.value === state.value.brandId)?.label || ''
   : '');
+const selectedBrandCatalogCount = computed(() => state.value.brandId
+  ? Number(report.value?.filter_options.brands?.find((item) => item.value === state.value.brandId)?.count || 0)
+  : 0);
 const shouldSuggestSeriesGrouping = computed(() => Boolean(
   state.value.brandId
   && state.value.groupBy === 'none'
   && (report.value?.filter_options.series?.filter((item) => item.parent_value === state.value.brandId).length || 0) > 1,
 ));
+const formatNumber = (value?: number | null) => new Intl.NumberFormat('ru-RU').format(Number(value || 0));
 const productCountLabel = (value?: number | null) => {
   const count = Number(value || 0);
   const lastTwo = count % 100;
@@ -165,6 +171,7 @@ const openProductPanel = (product: QualityProduct, panel: 'edit' | 'media') => {
 
 const openProduct = (product: QualityProduct) => openProductPanel(product, 'edit');
 const openProductMedia = (product: QualityProduct) => openProductPanel(product, 'media');
+const scrollToFilters = () => filtersAnchor.value?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
 const goToPage = (page: number) => {
   state.value = { ...state.value, page: Math.min(Math.max(1, page), totalPages.value) };
@@ -211,32 +218,41 @@ onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState));
         </div>
       </header>
 
-      <CatalogQualityFilters
-        :model-value="state"
-        :options="report?.filter_options"
-        :saved-views="savedViews"
-        :loading="loading"
-        @update:model-value="updateState"
-        @apply-view="applySavedView"
-        @save-view="saveCurrentView"
-        @delete-view="deleteSavedView"
-      />
+      <div ref="filtersAnchor">
+        <CatalogQualityFilters
+          :model-value="state"
+          :options="report?.filter_options"
+          :saved-views="savedViews"
+          :view-counts="report?.builtin_view_counts"
+          :loading="loading"
+          @update:model-value="updateState"
+          @apply-view="applySavedView"
+          @save-view="saveCurrentView"
+          @delete-view="deleteSavedView"
+        />
+      </div>
 
       <CatalogQualitySummary v-if="report" :report="report" :selected-issue-code="state.issueCode" @select-issue="selectIssue" />
 
       <div v-if="error" class="border-b border-red-200 bg-red-50 px-5 py-3 text-sm font-semibold text-red-700">Не удалось загрузить отчет: {{ error }}</div>
 
       <section class="sticky top-0 z-20 flex flex-col gap-2 border-b border-gray-200 bg-gray-50/95 px-4 py-2 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-950/95 lg:flex-row lg:items-center lg:justify-between sm:px-5">
-        <div class="flex flex-wrap items-center gap-2 text-sm">
+        <div class="flex min-w-0 flex-wrap items-center gap-2 text-sm">
           <strong v-if="selectedBrandTitle" class="text-teal-800">{{ selectedBrandTitle }}</strong>
           <span v-if="selectedBrandTitle" class="text-gray-400">·</span>
-          <strong class="text-gray-950 dark:text-slate-100">{{ productCountLabel(meta?.total) }}</strong>
+          <strong class="text-gray-950 dark:text-slate-100">
+            <template v-if="selectedBrandTitle && selectedBrandCatalogCount > Number(meta?.total || 0)">{{ formatNumber(meta?.total) }} в очереди из {{ productCountLabel(selectedBrandCatalogCount) }}</template>
+            <template v-else>{{ productCountLabel(meta?.total) }}</template>
+          </strong>
           <span class="text-gray-400">·</span>
-          <span class="text-gray-500 dark:text-slate-400">страница {{ meta?.page || 1 }} из {{ totalPages }}</span>
+          <span class="text-gray-500 dark:text-slate-400">score {{ report?.average_score ?? '—' }}</span>
+          <span class="hidden text-gray-400 sm:inline">·</span>
+          <span class="hidden text-gray-500 dark:text-slate-400 sm:inline">страница {{ meta?.page || 1 }} из {{ totalPages }}</span>
           <span v-if="loading" class="font-semibold text-teal-700">обновляем...</span>
-          <button v-if="shouldSuggestSeriesGrouping" class="h-8 rounded-lg bg-teal-50 px-2.5 text-xs font-semibold text-teal-800 hover:bg-teal-100" @click="state.groupBy = 'series'">Сгруппировать по сериям</button>
+          <span v-if="shouldSuggestSeriesGrouping" class="inline-flex items-center gap-1.5 rounded-lg bg-teal-50 px-2 py-1 text-xs text-teal-900 dark:bg-teal-950 dark:text-teal-100">У бренда несколько серий. <button class="font-bold underline decoration-teal-400 underline-offset-2" @click="state.groupBy = 'series'">Применить группировку</button></span>
         </div>
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="flex items-center gap-2 overflow-x-auto pb-0.5">
+          <button class="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 text-xs font-semibold text-gray-600 hover:border-teal-300 hover:text-teal-800 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" @click="scrollToFilters"><SlidersHorizontal class="h-4 w-4" />Фильтры</button>
           <label class="flex items-center gap-2 text-xs font-semibold text-gray-500 dark:text-slate-300">Сортировка
             <select v-model="state.sortBy" class="h-9 rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-800 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
               <option value="priority">По рабочему приоритету</option><option value="score_asc">Худший score</option><option value="critical">Критичные сначала</option><option value="stock">С наличием сначала</option><option value="newest">Новые сначала</option><option value="brand">По бренду</option><option value="series">По серии</option><option value="title">По названию</option>
@@ -267,6 +283,7 @@ onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState));
           :hide-series="Boolean(state.seriesId) || state.groupBy === 'series'"
           @open="openProduct"
           @open-media="openProductMedia"
+          @open-series-media="openProductMedia"
         />
         <CatalogQualityTable v-else :items="report.items" @open="openProduct" @select-issue="selectIssue" />
       </template>

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -36,6 +36,7 @@ import {
   parseCatalogQualityState,
   serializeCatalogQualityState,
 } from '../src/components/catalog-quality/catalog-quality-state';
+import { countLabel } from '../src/components/catalog-quality/catalog-quality-copy';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -164,6 +165,9 @@ const savedQualityView = applyCatalogQualityView(
 assert(savedQualityView.availability === 'in_stock' && savedQualityView.category === 'media', 'saved catalog view must apply its filters');
 assert(savedQualityView.view === 'table' && savedQualityView.limit === 100, 'saved catalog view must preserve personal display preferences');
 assert(savedQualityView.page === 1, 'saved catalog view must restart pagination');
+assert(countLabel(1, 'поставщик', 'поставщика', 'поставщиков') === '1 поставщик', 'catalog counts must use singular form');
+assert(countLabel(3, 'поставщик', 'поставщика', 'поставщиков') === '3 поставщика', 'catalog counts must use paucal form');
+assert(countLabel(12, 'поставщик', 'поставщика', 'поставщиков') === '12 поставщиков', 'catalog counts must use plural form');
 
 const workspaceBase = {
   status: 'negotiation',

--- a/openapi.json
+++ b/openapi.json
@@ -27893,6 +27893,13 @@
           "filter_options": {
             "$ref": "#/components/schemas/ManagerCatalogQualityFilterOptionsResponse"
           },
+          "builtin_view_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Builtin View Counts"
+          },
           "severity_issue_counts": {
             "additionalProperties": {
               "type": "integer"

--- a/schemas.py
+++ b/schemas.py
@@ -1769,6 +1769,7 @@ class ManagerCatalogQualityReportResponse(BaseModel):
     categories: List[ManagerCatalogQualityCategoryResponse]
     groups: List[ManagerCatalogQualityGroupResponse] = Field(default_factory=list)
     filter_options: ManagerCatalogQualityFilterOptionsResponse
+    builtin_view_counts: Dict[str, int] = Field(default_factory=dict)
     severity_issue_counts: Dict[str, int] = Field(default_factory=dict)
     severity_product_counts: Dict[str, int] = Field(default_factory=dict)
     meta: Meta

--- a/services/catalog_quality_filters.py
+++ b/services/catalog_quality_filters.py
@@ -39,6 +39,25 @@ MULTI_COMPONENT_LABELS = {
 
 FIXABLE_CATEGORIES = {"media", "identity", "specs"}
 
+BUILTIN_VIEW_FILTERS: dict[str, dict[str, Any]] = {
+    "critical-published": {
+        "dimensions": {"publication": "published"},
+        "issues": {"severity": "critical", "only_problems": True},
+    },
+    "stock-media": {
+        "dimensions": {"availability": "in_stock"},
+        "issues": {"category": "media", "only_problems": True},
+    },
+    "household-no-series": {
+        "dimensions": {"equipment_type": "cat-household", "series_state": "missing"},
+        "issues": {"only_problems": False},
+    },
+    "supplier-unmapped": {
+        "dimensions": {"supplier_state": "unmapped"},
+        "issues": {"category": "supplier", "only_problems": True},
+    },
+}
+
 
 def _clean(value: Any) -> str:
     return str(value or "").strip().lower().replace("ё", "е")
@@ -110,16 +129,16 @@ def enrich_work_priority(row: dict[str, Any]) -> None:
 
     if published and in_stock and critical_fixable:
         priority = "high"
-        reason = "На сайте · в наличии · критичная проблема контента"
+        reason = "Критичная проблема контента"
     elif published and in_stock and fixable:
         priority = "medium"
-        reason = "На сайте · в наличии · есть исправимые замечания"
+        reason = "Есть исправимые замечания"
     else:
         priority = "low"
         if not published:
-            reason = "Товар скрыт с сайта"
+            reason = "Отложено: товар скрыт"
         elif not in_stock:
-            reason = "Нет доступного наличия"
+            reason = "Отложено до появления наличия"
         else:
             reason = "Нет срочных исправимых замечаний"
 
@@ -232,8 +251,30 @@ def sort_rows(rows: list[dict[str, Any]], sort_by: str) -> list[dict[str, Any]]:
     elif sort_by == "title":
         key = lambda row: _clean(row.get("title"))
     else:
-        key = lambda row: (-int(row.get("work_priority_score") or 0), int(row.get("score") or 0), _clean(row.get("title")))
+        priority_rank = {"high": 0, "medium": 1, "low": 2}
+        key = lambda row: (
+            priority_rank.get(row.get("work_priority"), 3),
+            -int(row.get("work_priority_score") or 0),
+            int(row.get("score") or 0),
+            _clean(row.get("title")),
+        )
     return sorted(rows, key=key)
+
+
+def build_builtin_view_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for view_id, filters in BUILTIN_VIEW_FILTERS.items():
+        scoped = filter_dimension_rows(rows, **filters["dimensions"])
+        counts[view_id] = len(
+            filter_issue_rows(
+                scoped,
+                category=filters["issues"].get("category"),
+                severity=filters["issues"].get("severity"),
+                issue_code=None,
+                only_problems=filters["issues"]["only_problems"],
+            )
+        )
+    return counts
 
 
 def row_group(row: dict[str, Any], group_by: str) -> tuple[str, str]:

--- a/services/catalog_quality_service.py
+++ b/services/catalog_quality_service.py
@@ -16,6 +16,7 @@ from models.media import MediaAsset
 from models.product import Product, Tag
 from models.supplier import ProductSupplierMapping, Supplier, SupplierOffer
 from services.catalog_quality_filters import (
+    build_builtin_view_counts,
     build_filter_options,
     build_groups,
     classify_product,
@@ -226,6 +227,7 @@ class CatalogQualityService:
         ]
 
         filter_options = build_filter_options(rows)
+        builtin_view_counts = build_builtin_view_counts(rows)
         scoped_rows = filter_dimension_rows(
             rows,
             equipment_type=equipment_type,
@@ -288,6 +290,7 @@ class CatalogQualityService:
             "categories": categories,
             "groups": groups,
             "filter_options": filter_options,
+            "builtin_view_counts": builtin_view_counts,
             "severity_issue_counts": severity_issue_counts,
             "severity_product_counts": severity_product_counts,
             "meta": {

--- a/tests/integration/test_manager_catalog_quality_api.py
+++ b/tests/integration/test_manager_catalog_quality_api.py
@@ -65,6 +65,12 @@ async def test_catalog_quality_report_supports_normalized_workspace_filters(asyn
     assert payload["meta"]["total"] == 1
     assert payload["total_products"] == 1
     assert payload["fixable_products"] == 1
+    assert set(payload["builtin_view_counts"]) == {
+        "critical-published",
+        "stock-media",
+        "household-no-series",
+        "supplier-unmapped",
+    }
     assert payload["items"][0]["product_id"] == product.id
     assert payload["items"][0]["equipment_type"] == "cat-household"
     assert payload["groups"][0]["key"] == "equipment:cat-household"

--- a/tests/unit/test_catalog_quality_service.py
+++ b/tests/unit/test_catalog_quality_service.py
@@ -1,5 +1,6 @@
 from models.product import Product, ProductImage, Tag, TagGroup
 from services.catalog_quality_filters import (
+    build_builtin_view_counts,
     build_groups,
     classify_product,
     enrich_work_priority,
@@ -180,6 +181,7 @@ def test_priority_sort_and_series_groups_are_transparent():
             "series_id": 100,
             "series_title": "Elite",
             "score": 92,
+            "work_priority": "medium",
             "work_priority_score": 20,
             "critical_issue_count": 0,
             "issues": [],
@@ -190,6 +192,7 @@ def test_priority_sort_and_series_groups_are_transparent():
             "series_id": 100,
             "series_title": "Elite",
             "score": 60,
+            "work_priority": "high",
             "work_priority_score": 180,
             "critical_issue_count": 1,
             "issues": [{"category": "media", "severity": "critical"}],
@@ -208,3 +211,46 @@ def test_priority_sort_and_series_groups_are_transparent():
             "spec_problem_products": 0,
         }
     ]
+
+
+def test_priority_sort_keeps_medium_ahead_of_low_even_with_a_lower_numeric_score():
+    rows = [
+        {"product_id": 1, "title": "Deferred", "score": 30, "work_priority": "low", "work_priority_score": 500},
+        {"product_id": 2, "title": "Current", "score": 70, "work_priority": "medium", "work_priority_score": 80},
+    ]
+
+    assert [row["product_id"] for row in sort_rows(rows, "priority")] == [2, 1]
+
+
+def test_builtin_view_counts_use_the_same_filters_as_workspace_presets():
+    rows = [
+        {
+            "product_id": 1,
+            "equipment_type": "cat-household",
+            "series_id": None,
+            "is_published": True,
+            "available_qty": 4,
+            "score": 40,
+            "issues": [{"category": "media", "severity": "critical"}],
+            "suppliers": [],
+        },
+        {
+            "product_id": 2,
+            "equipment_type": "cat-household",
+            "series_id": None,
+            "is_published": False,
+            "available_qty": 0,
+            "score": 80,
+            "issues": [{"category": "supplier", "severity": "warning"}],
+            "suppliers": [],
+        },
+    ]
+    for row in rows:
+        enrich_work_priority(row)
+
+    assert build_builtin_view_counts(rows) == {
+        "critical-published": 1,
+        "stock-media": 1,
+        "household-no-series": 2,
+        "supplier-unmapped": 1,
+    }


### PR DESCRIPTION
## Что изменено

- рабочий приоритет теперь строго идет: высокий, средний, отложенный
- сохраненные рабочие выборки показывают количество карточек и активное состояние
- причины разделены на контент и коммерческую готовность; убраны дубли статуса и наличия
- sticky-контекст объясняет выборку: сколько товаров в очереди из общего каталога бренда
- группировка по сериям стала рекомендацией, а у проблемной серии появилось действие для исправления медиа
- исправлены русские склонения в счетчиках

## Проверка

- `pytest tests/unit/test_catalog_quality_service.py -q`
- `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/integration/test_manager_catalog_quality_api.py -q`
- `manager_frontend: pnpm run build`
- `manager_frontend: pnpm run test:ui-logic`
- `bash scripts/audit_theme_hardcodes.sh`
- визуальная проверка desktop/mobile/dark theme, KINGHOME и группировка по сериям