### PR TITLE
Add manager product workspace

### DIFF
--- a/manager_frontend/src/App.vue
+++ b/manager_frontend/src/App.vue
@@ -15,6 +15,7 @@ import {
 } from './manager-navigation';
 
 const ProductsView = defineAsyncComponent(() => import('./views/ProductsView.vue'));
+const ProductWorkspaceView = defineAsyncComponent(() => import('./views/ProductWorkspaceView.vue'));
 const MediaLibraryView = defineAsyncComponent(() => import('./views/MediaLibraryView.vue'));
 const CustomersView = defineAsyncComponent(() => import('./views/CustomersView.vue'));
 const CustomerProfileView = defineAsyncComponent(() => import('./views/CustomerProfileView.vue'));
@@ -161,6 +162,7 @@ const currentView = computed(() => {
   if (path.startsWith('/manager/supply')) return 'supply';
   if (path.startsWith('/manager/suppliers')) return 'suppliers';
   if (path.startsWith('/manager/supplier-mapping')) return 'supplier-mapping';
+  if (/^\/manager\/products\/\d+(?:\/|$)/.test(path)) return 'product-workspace';
   return 'products';
 });
 
@@ -658,6 +660,7 @@ watch(currentPath, () => {
       <SupplyRequestsView v-else-if="currentView === 'supply'" :key="currentLocation" />
       <SupplierFeedsView v-else-if="currentView === 'suppliers'" :key="currentLocation" />
       <SupplierMappingView v-else-if="currentView === 'supplier-mapping'" :key="currentLocation" />
+      <ProductWorkspaceView v-else-if="currentView === 'product-workspace'" :key="currentLocation" />
       <ProductsView v-else :key="currentLocation" />
     </main>
 

--- a/manager_frontend/src/api.ts
+++ b/manager_frontend/src/api.ts
@@ -797,6 +797,10 @@ export const api = {
         );
     },
 
+    async getManagerProduct(productId: number): Promise<Product> {
+        return await ManagerService.getManagerProduct(productId);
+    },
+
     async getManagerCustomers(page = 1, limit = 20, search?: string, type?: string, onlyWithOrders = false) {
         return await ManagerService.getManagerCustomers(page, limit, search ?? undefined, type ?? undefined, onlyWithOrders);
     },

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -179,71 +179,6 @@ export class ManagerService {
         });
     }
     /**
-     * Get Product For Manager
-     * @param productId
-     * @returns ManagerCatalogProductItemResponse Successful Response
-     * @throws ApiError
-     */
-    public static getManagerProduct(
-        productId: number,
-    ): CancelablePromise<ManagerCatalogProductItemResponse> {
-        return __request(OpenAPI, {
-            method: 'GET',
-            url: '/api/manager/products/{product_id}',
-            path: {
-                'product_id': productId,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Update Product
-     * Update individual product fields.
-     * @param productId
-     * @param requestBody
-     * @returns ManagerActionMessageResponse Successful Response
-     * @throws ApiError
-     */
-    public static updateProduct(
-        productId: number,
-        requestBody: ProductUpdate,
-    ): CancelablePromise<ManagerActionMessageResponse> {
-        return __request(OpenAPI, {
-            method: 'PATCH',
-            url: '/api/manager/products/{product_id}',
-            path: {
-                'product_id': productId,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Delete Product
-     * @param productId
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static deleteManagerProduct(
-        productId: number,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/manager/products/{product_id}',
-            path: {
-                'product_id': productId,
-            },
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
      * List Customers For Manager
      * Paginated customer list for manager UI.
      * Includes order count per customer.
@@ -594,6 +529,71 @@ export class ManagerService {
             },
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Product
+     * Update individual product fields.
+     * @param productId
+     * @param requestBody
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateProduct(
+        productId: number,
+        requestBody: ProductUpdate,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Product
+     * @param productId
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteManagerProduct(
+        productId: number,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Product For Manager
+     * @param productId
+     * @returns ManagerCatalogProductItemResponse Successful Response
+     * @throws ApiError
+     */
+    public static getManagerProduct(
+        productId: number,
+    ): CancelablePromise<ManagerCatalogProductItemResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/client/services/ManagerService.ts
+++ b/manager_frontend/src/client/services/ManagerService.ts
@@ -26,6 +26,7 @@ import type { ManagerBulkSetRrcPriceResponse } from '../models/ManagerBulkSetRrc
 import type { ManagerBulkSpecsResponse } from '../models/ManagerBulkSpecsResponse';
 import type { ManagerCatalogCustomerItemResponse } from '../models/ManagerCatalogCustomerItemResponse';
 import type { ManagerCatalogCustomerListResponse } from '../models/ManagerCatalogCustomerListResponse';
+import type { ManagerCatalogProductItemResponse } from '../models/ManagerCatalogProductItemResponse';
 import type { ManagerCatalogProductListResponse } from '../models/ManagerCatalogProductListResponse';
 import type { ManagerCustomerBranchCreatePayload } from '../models/ManagerCustomerBranchCreatePayload';
 import type { ManagerCustomerBranchItemResponse } from '../models/ManagerCustomerBranchItemResponse';
@@ -171,6 +172,71 @@ export class ManagerService {
                 'category_slug': categorySlug,
                 'category_status': categoryStatus,
                 'sort': sort,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Product For Manager
+     * @param productId
+     * @returns ManagerCatalogProductItemResponse Successful Response
+     * @throws ApiError
+     */
+    public static getManagerProduct(
+        productId: number,
+    ): CancelablePromise<ManagerCatalogProductItemResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Update Product
+     * Update individual product fields.
+     * @param productId
+     * @param requestBody
+     * @returns ManagerActionMessageResponse Successful Response
+     * @throws ApiError
+     */
+    public static updateProduct(
+        productId: number,
+        requestBody: ProductUpdate,
+    ): CancelablePromise<ManagerActionMessageResponse> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete Product
+     * @param productId
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteManagerProduct(
+        productId: number,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/manager/products/{product_id}',
+            path: {
+                'product_id': productId,
             },
             errors: {
                 422: `Validation Error`,
@@ -528,51 +594,6 @@ export class ManagerService {
             },
             body: requestBody,
             mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Update Product
-     * Update individual product fields.
-     * @param productId
-     * @param requestBody
-     * @returns ManagerActionMessageResponse Successful Response
-     * @throws ApiError
-     */
-    public static updateProduct(
-        productId: number,
-        requestBody: ProductUpdate,
-    ): CancelablePromise<ManagerActionMessageResponse> {
-        return __request(OpenAPI, {
-            method: 'PATCH',
-            url: '/api/manager/products/{product_id}',
-            path: {
-                'product_id': productId,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * Delete Product
-     * @param productId
-     * @returns any Successful Response
-     * @throws ApiError
-     */
-    public static deleteManagerProduct(
-        productId: number,
-    ): CancelablePromise<any> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/manager/products/{product_id}',
-            path: {
-                'product_id': productId,
-            },
             errors: {
                 422: `Validation Error`,
             },

--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -51,13 +51,16 @@ const props = withDefaults(defineProps<{
     modelValue: boolean;
     product: Product | null;
     mode?: ProductEditorMode;
+    presentation?: 'modal' | 'workspace';
 }>(), {
     mode: 'edit',
+    presentation: 'modal',
 });
 
 const emit = defineEmits<{
     (e: 'update:modelValue', value: boolean): void;
     (e: 'success'): void;
+    (e: 'dirty-change', value: boolean): void;
 }>();
 
 const form = ref<any>({
@@ -113,6 +116,8 @@ const logisticsComponents = ref<ProductLogisticsComponent[]>([]);
 const isCreateMode = computed(() => props.mode === 'create');
 const isDuplicateMode = computed(() => props.mode === 'duplicate');
 const isPersistedProduct = computed(() => props.mode === 'edit' && Boolean(props.product?.id));
+const isWorkspace = computed(() => props.presentation === 'workspace');
+const cleanFingerprint = ref('');
 const modalTitle = computed(() => {
     if (isCreateMode.value) return 'Создание товара';
     if (isDuplicateMode.value) return 'Дублирование товара';
@@ -991,7 +996,28 @@ const resetEditorState = () => {
     selectedBrandEntityId.value = null;
     vitebskQty.value = 0;
     supplierOffers.value = [];
+    cleanFingerprint.value = '';
 };
+
+const editorFingerprint = () => JSON.stringify({
+    form: form.value,
+    specs: specs.value,
+    manuals: manuals.value,
+    tagIds: Array.from(selectedTagIds.value).sort((a, b) => a - b),
+    brandId: selectedBrandEntityId.value,
+    vitebskQty: vitebskQty.value,
+    indoorSlugs: compatibilityIndoorSlugs.value,
+    outdoorSlugs: compatibilityOutdoorSlugs.value,
+    logisticsComponents: logisticsComponents.value,
+    comboRules: multiComboRules.value,
+    compatMode: multiCompatMode.value,
+    capacityCombos: capacityCombosInput.value,
+});
+
+const isDirty = computed(() => Boolean(
+    cleanFingerprint.value
+    && cleanFingerprint.value !== editorFingerprint()
+));
 
 const getDuplicateSlug = (product: Product | null): string => {
     const sourceSlug = String(product?.slug || '').trim();
@@ -1057,15 +1083,18 @@ const initializeEditor = async () => {
 
     if (isPersistedProduct.value) {
         vitebskQty.value = Number((source as any)?.vitebsk_qty || 0);
-        loadSupplierOffers();
+        await loadSupplierOffers();
     }
+    cleanFingerprint.value = editorFingerprint();
 };
 
 watch(() => [props.modelValue, props.mode, props.product?.id] as const, async ([val]) => {
     if (val) {
         await initializeEditor();
     }
-});
+}, { immediate: true });
+
+watch(isDirty, (value) => emit('dirty-change', value));
 
 const loadSupplierOffers = async () => {
     if (!props.product) return;
@@ -1099,8 +1128,8 @@ const saveLocalStock = async () => {
     }
 };
 
-const save = async () => {
-    if ((isDuplicateMode.value || props.mode === 'edit') && !props.product) return;
+const save = async (): Promise<boolean> => {
+    if ((isDuplicateMode.value || props.mode === 'edit') && !props.product) return false;
     
     // Process specs back to object
     const validSpecs: Record<string, any> = {};
@@ -1188,8 +1217,10 @@ const save = async () => {
         } else {
             await api.updateProduct(props.product!.id, updateData);
         }
+        cleanFingerprint.value = editorFingerprint();
         emit('success');
-        close();
+        if (!isWorkspace.value) close();
+        return true;
     } catch (e) {
         const parsed = parseApiFieldErrors(e, [
             'title',
@@ -1205,6 +1236,7 @@ const save = async () => {
         formServerErrors.value = parsed.fieldErrors;
         formMessage.value = parsed.message || `Ошибка при сохранении: ${getApiErrorMessage(e)}`;
         console.error(e);
+        return false;
     } finally {
         loading.value = false;
     }
@@ -1226,13 +1258,29 @@ const unlinkSupplierOffer = async (offer: any) => {
         unlinkingMappingId.value = null;
     }
 };
+
+const handleBackdropClick = () => {
+    if (!isWorkspace.value) close();
+};
+
+defineExpose({ save, isDirty, loading });
 </script>
 
 <template>
-    <div v-if="modelValue" class="product-edit-modal fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[60] p-4" @click.self="close">
-        <div class="bg-slate-50 dark:bg-slate-900 rounded-2xl w-full max-w-5xl flex flex-col max-h-[90vh] shadow-2xl border border-gray-100 dark:border-slate-800 overflow-hidden">
+    <div
+        v-if="modelValue"
+        class="product-edit-modal"
+        :class="isWorkspace ? 'w-full' : 'fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm'"
+        @click.self="handleBackdropClick"
+    >
+        <div
+            class="w-full bg-slate-50 dark:bg-slate-900"
+            :class="isWorkspace
+                ? 'min-w-0'
+                : 'flex max-w-5xl flex-col max-h-[90vh] overflow-hidden rounded-2xl border border-gray-100 shadow-2xl dark:border-slate-800'"
+        >
             <!-- Header -->
-            <header class="p-5 border-b dark:border-slate-800 flex justify-between items-center bg-slate-100/50 dark:bg-slate-800/50">
+            <header v-if="!isWorkspace" class="p-5 border-b dark:border-slate-800 flex justify-between items-center bg-slate-100/50 dark:bg-slate-800/50">
                 <div class="flex items-center gap-3">
                     <div class="p-2 bg-teal-100 rounded-lg text-teal-700">
                         <Edit3 class="w-5 h-5" />
@@ -1250,10 +1298,10 @@ const unlinkSupplierOffer = async (offer: any) => {
                 {{ formMessage }}
             </div>
             
-            <div class="flex-1 overflow-y-auto p-6">
+            <div class="flex-1 p-6" :class="isWorkspace ? '' : 'overflow-y-auto'">
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                     <!-- Column 1: Basic Info -->
-                    <section class="space-y-5">
+                    <section id="product-section-main" class="scroll-mt-28 space-y-5">
                         <h3 class="text-xs font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest">Основные данные</h3>
                         
                         <div>
@@ -1293,7 +1341,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                                         class="w-full pl-3 pr-10 py-2 bg-slate-100 dark:bg-slate-800 border rounded-xl focus:bg-white dark:focus:bg-slate-700 focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all font-bold text-teal-700 dark:text-teal-400 text-sm"
                                         :class="formServerErrors.price ? 'border-red-400 dark:border-red-800 focus:border-red-500' : 'border-gray-200 dark:border-slate-700'"
                                     />
-                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 text-xs">руб.</span>
+                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 text-xs">BYN</span>
                                 </div>
                                 <p v-if="formServerErrors.price" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ formServerErrors.price }}</p>
                             </div>
@@ -1306,7 +1354,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                                         class="w-full pl-3 pr-10 py-2 bg-slate-100 dark:bg-slate-800 border rounded-xl focus:bg-white dark:focus:bg-slate-700 focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500 outline-none transition-all text-gray-500 dark:text-slate-400 text-sm"
                                         :class="formServerErrors.old_price ? 'border-red-400 dark:border-red-800 focus:border-red-500' : 'border-gray-200 dark:border-slate-700'"
                                     />
-                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 text-xs">руб.</span>
+                                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 text-xs">BYN</span>
                                 </div>
                                 <p v-if="formServerErrors.old_price" class="mt-1 text-xs text-red-600 dark:text-red-400">{{ formServerErrors.old_price }}</p>
                             </div>
@@ -1320,7 +1368,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                             </label>
                         </div>
 
-                        <div v-if="isPersistedProduct" class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
+                        <div id="product-section-suppliers" v-if="isPersistedProduct" class="scroll-mt-28 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
                             <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Supply</h4>
                             <div class="flex items-end gap-2">
                                 <div class="flex-1">
@@ -1738,8 +1786,8 @@ const unlinkSupplierOffer = async (offer: any) => {
                     </section>
 
                     <!-- Column 2: Specs -->
-                    <section class="space-y-5">
-                        <div class="rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 space-y-2">
+                    <section id="product-section-specifications" class="scroll-mt-28 space-y-5">
+                        <div id="product-section-publication" class="scroll-mt-28 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 space-y-2">
                             <div class="flex justify-between items-center">
                                 <h3 class="text-xs font-bold text-gray-500 dark:text-slate-400 uppercase tracking-widest">
                                     Инструкции и файлы
@@ -1934,7 +1982,7 @@ const unlinkSupplierOffer = async (offer: any) => {
                     </section>
                 </div>
 
-                <details class="mt-6 border border-gray-200 dark:border-slate-700 rounded-xl bg-slate-50 dark:bg-slate-800/50 group">
+                <details id="product-section-links" class="scroll-mt-28 mt-6 border border-gray-200 dark:border-slate-700 rounded-xl bg-slate-50 dark:bg-slate-800/50 group">
                     <summary class="cursor-pointer p-4 font-bold text-gray-700 dark:text-slate-300 flex justify-between items-center outline-none">
                         <span class="flex items-center gap-2"><Tag class="w-4 h-4 text-gray-400 dark:text-slate-500"/> Теги ({{ selectedTagIds.size }} выбрано)</span>
                     </summary>
@@ -1971,7 +2019,7 @@ const unlinkSupplierOffer = async (offer: any) => {
             </div>
             
             <!-- Footer -->
-            <footer class="p-5 border-t dark:border-slate-800 bg-slate-100/50 dark:bg-slate-800/50 flex justify-end gap-3">
+            <footer v-if="!isWorkspace" class="p-5 border-t dark:border-slate-800 bg-slate-100/50 dark:bg-slate-800/50 flex justify-end gap-3">
                 <button @click="close" class="px-5 py-2 text-sm font-bold text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-xl transition-all">
                     Отмена
                 </button>

--- a/manager_frontend/src/components/products/ProductWorkspaceMedia.vue
+++ b/manager_frontend/src/components/products/ProductWorkspaceMedia.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Images, ImagePlus, Star, ExternalLink } from 'lucide-vue-next';
+import type { Product } from '../../api';
+
+const props = defineProps<{
+  product: Product;
+}>();
+
+const emit = defineEmits<{
+  (event: 'open-editor'): void;
+}>();
+
+const getImageUrl = (path: string | null | undefined): string => {
+  if (!path) return '';
+  if (path.startsWith('http') || path.startsWith('/')) return path;
+  return `/${path}`;
+};
+
+const galleryImages = computed(() => (
+  props.product.gallery_images.filter((image) => image.url !== props.product.main_image)
+));
+
+const imageCount = computed(() => galleryImages.value.length + (props.product.main_image ? 1 : 0));
+</script>
+
+<template>
+  <section class="min-h-[520px] bg-white px-4 py-5 dark:bg-slate-900 sm:px-6">
+    <div class="flex flex-col gap-4 border-b border-gray-100 pb-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p class="text-xs font-bold uppercase tracking-[0.16em] text-teal-700 dark:text-teal-300">Медиа товара</p>
+        <h2 class="mt-1 text-xl font-bold text-gray-950 dark:text-white">Галерея и главное изображение</h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">
+          {{ imageCount }} изображений. Редактирование использует общий быстрый медиарежим каталога.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-teal-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-700"
+        @click="emit('open-editor')"
+      >
+        <ImagePlus class="h-4 w-4" />
+        Открыть редактор
+      </button>
+    </div>
+
+    <div v-if="product.main_image" class="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1.5fr)_minmax(240px,0.5fr)]">
+      <button
+        type="button"
+        class="group relative min-h-[280px] overflow-hidden rounded-lg border border-gray-200 bg-gray-100 text-left dark:border-slate-700 dark:bg-slate-800"
+        @click="emit('open-editor')"
+      >
+        <img :src="getImageUrl(product.main_image)" :alt="product.title" class="h-full max-h-[520px] w-full object-contain p-4" />
+        <span class="absolute left-3 top-3 inline-flex items-center gap-1 rounded-md bg-white/95 px-2 py-1 text-xs font-bold text-gray-800 shadow-sm dark:bg-slate-900/95 dark:text-slate-100">
+          <Star class="h-3.5 w-3.5 fill-amber-400 text-amber-500" /> Главное
+        </span>
+        <span class="absolute bottom-3 right-3 inline-flex items-center gap-1 rounded-md bg-gray-950/75 px-2 py-1 text-xs font-semibold text-white opacity-0 transition group-hover:opacity-100">
+          <ExternalLink class="h-3.5 w-3.5" /> Редактировать
+        </span>
+      </button>
+
+      <div class="grid grid-cols-2 gap-3 content-start">
+        <button
+          v-for="image in galleryImages"
+          :key="image.id"
+          type="button"
+          class="aspect-square overflow-hidden rounded-lg border border-gray-200 bg-gray-100 transition hover:border-teal-400 dark:border-slate-700 dark:bg-slate-800"
+          @click="emit('open-editor')"
+        >
+          <img :src="getImageUrl(image.url)" :alt="product.title" class="h-full w-full object-contain p-2" />
+        </button>
+      </div>
+    </div>
+
+    <button
+      v-else
+      type="button"
+      class="mt-6 flex min-h-[360px] w-full flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center transition hover:border-teal-400 hover:bg-teal-50/40 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-teal-700"
+      @click="emit('open-editor')"
+    >
+      <span class="flex h-14 w-14 items-center justify-center rounded-full bg-white text-gray-400 shadow-sm dark:bg-slate-800 dark:text-slate-500">
+        <Images class="h-7 w-7" />
+      </span>
+      <span class="mt-4 text-base font-bold text-gray-900 dark:text-white">Изображения ещё не добавлены</span>
+      <span class="mt-1 max-w-md text-sm text-gray-500 dark:text-slate-400">Загрузите файл, вставьте ссылку или выберите изображение из медиатеки.</span>
+      <span class="mt-4 inline-flex h-10 items-center gap-2 rounded-lg bg-teal-600 px-4 text-sm font-semibold text-white">
+        <ImagePlus class="h-4 w-4" /> Добавить изображения
+      </span>
+    </button>
+  </section>
+</template>

--- a/manager_frontend/src/utils/product-workspace.ts
+++ b/manager_frontend/src/utils/product-workspace.ts
@@ -1,0 +1,77 @@
+export type ProductWorkspaceSection = 'main' | 'media' | 'specifications' | 'suppliers' | 'publication';
+
+export type ProductListWorkspaceContext = {
+  returnTo: string;
+  productIds: number[];
+  currentProductId: number;
+  scrollTop: number;
+  page: number;
+  listState: Record<string, unknown>;
+};
+
+export const PRODUCT_WORKSPACE_CONTEXT_KEY = 'manager:products:workspace-context:v1';
+
+const sectionPath: Record<ProductWorkspaceSection, string> = {
+  main: '',
+  media: '/media',
+  specifications: '/specifications',
+  suppliers: '/suppliers',
+  publication: '/publication',
+};
+
+export const buildProductWorkspacePath = (
+  productId: number,
+  section: ProductWorkspaceSection = 'main',
+): string => `/manager/products/${productId}${sectionPath[section]}`;
+
+export const parseProductWorkspaceLocation = (pathname: string): {
+  productId: number | null;
+  section: ProductWorkspaceSection;
+} => {
+  const match = pathname.match(/^\/manager\/products\/(\d+)(?:\/(media|specifications|suppliers|publication))?\/?$/);
+  if (!match) return { productId: null, section: 'main' };
+  const productId = Number(match[1]);
+  return {
+    productId: Number.isInteger(productId) && productId > 0 ? productId : null,
+    section: (match[2] || 'main') as ProductWorkspaceSection,
+  };
+};
+
+export const getProductWorkspaceNeighbors = (
+  productIds: number[],
+  currentProductId: number,
+): { previousId: number | null; nextId: number | null } => {
+  const index = productIds.indexOf(currentProductId);
+  if (index < 0) return { previousId: null, nextId: null };
+  return {
+    previousId: index > 0 ? productIds[index - 1] : null,
+    nextId: index < productIds.length - 1 ? productIds[index + 1] : null,
+  };
+};
+
+export const saveProductWorkspaceContext = (context: ProductListWorkspaceContext): void => {
+  window.sessionStorage.setItem(PRODUCT_WORKSPACE_CONTEXT_KEY, JSON.stringify(context));
+};
+
+export const loadProductWorkspaceContext = (): ProductListWorkspaceContext | null => {
+  try {
+    const raw = window.sessionStorage.getItem(PRODUCT_WORKSPACE_CONTEXT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ProductListWorkspaceContext>;
+    const productIds = Array.isArray(parsed.productIds)
+      ? parsed.productIds.map(Number).filter((id) => Number.isInteger(id) && id > 0)
+      : [];
+    const currentProductId = Number(parsed.currentProductId);
+    if (!parsed.returnTo || !Number.isInteger(currentProductId) || currentProductId <= 0) return null;
+    return {
+      returnTo: String(parsed.returnTo),
+      productIds,
+      currentProductId,
+      scrollTop: Math.max(0, Number(parsed.scrollTop) || 0),
+      page: Math.max(1, Number(parsed.page) || 1),
+      listState: parsed.listState && typeof parsed.listState === 'object' ? parsed.listState : {},
+    };
+  } catch {
+    return null;
+  }
+};

--- a/manager_frontend/src/utils/product-workspace.ts
+++ b/manager_frontend/src/utils/product-workspace.ts
@@ -44,8 +44,8 @@ export const getProductWorkspaceNeighbors = (
   const index = productIds.indexOf(currentProductId);
   if (index < 0) return { previousId: null, nextId: null };
   return {
-    previousId: index > 0 ? productIds[index - 1] : null,
-    nextId: index < productIds.length - 1 ? productIds[index + 1] : null,
+    previousId: index > 0 ? (productIds[index - 1] ?? null) : null,
+    nextId: index < productIds.length - 1 ? (productIds[index + 1] ?? null) : null,
   };
 };
 

--- a/manager_frontend/src/views/ProductWorkspaceView.vue
+++ b/manager_frontend/src/views/ProductWorkspaceView.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ChevronLeft,
+  CircleAlert,
+  ClipboardCopy,
+  ExternalLink,
+  FileText,
+  Images,
+  Link2,
+  MoreHorizontal,
+  Package,
+  Save,
+  Settings2,
+  Store,
+  Trash2,
+} from 'lucide-vue-next';
+import { api, type Product } from '../api';
+import ProductEditModal from '../components/ProductEditModal.vue';
+import ProductWorkspaceMedia from '../components/products/ProductWorkspaceMedia.vue';
+import { getApiErrorMessage } from '../utils/api-errors';
+import {
+  buildProductWorkspacePath,
+  getProductWorkspaceNeighbors,
+  loadProductWorkspaceContext,
+  parseProductWorkspaceLocation,
+  type ProductWorkspaceSection,
+} from '../utils/product-workspace';
+
+type ProductEditorExpose = {
+  save: () => Promise<boolean>;
+};
+
+const editor = ref<ProductEditorExpose | null>(null);
+const product = ref<Product | null>(null);
+const loading = ref(true);
+const saving = ref(false);
+const deleting = ref(false);
+const dirty = ref(false);
+const errorMessage = ref('');
+const toast = ref('');
+const moreOpen = ref(false);
+const supplierOfferCount = ref(0);
+const location = parseProductWorkspaceLocation(window.location.pathname);
+const productId = location.productId;
+const activeSection = ref<ProductWorkspaceSection>(location.section);
+const context = loadProductWorkspaceContext();
+const neighbors = computed(() => getProductWorkspaceNeighbors(context?.productIds || [], productId || 0));
+
+const sections: Array<{ id: ProductWorkspaceSection; label: string; icon: typeof Package }> = [
+  { id: 'main', label: 'Основное', icon: Package },
+  { id: 'media', label: 'Медиа', icon: Images },
+  { id: 'specifications', label: 'Характеристики', icon: Settings2 },
+  { id: 'suppliers', label: 'Поставщики', icon: Store },
+  { id: 'publication', label: 'Публикация и файлы', icon: FileText },
+];
+
+const publicProductUrl = computed(() => {
+  if (!product.value?.slug) return null;
+  const configured = String(import.meta.env.WEBSITE_URL || '').trim().replace(/\/+$/, '');
+  const base = configured || (window.location.hostname === 'localhost'
+    ? `${window.location.protocol}//${window.location.hostname}:4321`
+    : window.location.origin);
+  return `${base}/product/${product.value.slug}`;
+});
+
+const availabilityLabel = computed(() => {
+  if (!product.value) return 'Нет данных';
+  if (product.value.availability_status === 'in_stock_now') return 'В наличии';
+  if (product.value.availability_status === 'available_2_3_days') return '2–3 дня';
+  if (product.value.availability_status === 'check_availability') return 'Уточнить';
+  return 'Нет в наличии';
+});
+
+const qualityIssues = computed(() => {
+  const current = product.value;
+  if (!current) return [];
+  const issues: Array<{ label: string; section: ProductWorkspaceSection; critical?: boolean }> = [];
+  if (!current.main_image) issues.push({ label: 'Нет главного изображения', section: 'media', critical: true });
+  if (current.gallery_images.length < 2) issues.push({ label: 'Мало изображений в галерее', section: 'media' });
+  if (!current.price || current.price <= 0) issues.push({ label: 'Не указана цена', section: 'main', critical: true });
+  if (!current.brand_id) issues.push({ label: 'Не выбран бренд', section: 'main' });
+  if (!current.series_id) issues.push({ label: 'Не выбрана серия', section: 'main' });
+  if (supplierOfferCount.value === 0) issues.push({ label: 'Нет предложений поставщиков', section: 'suppliers' });
+  return issues;
+});
+
+const setToast = (message: string) => {
+  toast.value = message;
+  window.setTimeout(() => {
+    if (toast.value === message) toast.value = '';
+  }, 3500);
+};
+
+const navigate = (path: string, replace = false) => {
+  if (replace) window.history.replaceState({}, '', path);
+  else window.history.pushState({}, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+};
+
+const loadProduct = async () => {
+  if (!productId) {
+    errorMessage.value = 'Некорректный ID товара';
+    loading.value = false;
+    return;
+  }
+  loading.value = true;
+  errorMessage.value = '';
+  try {
+    const [detail, offers] = await Promise.all([
+      api.getManagerProduct(productId),
+      api.getProductSupplierOffers(productId).catch(() => ({ items: [] } as any)),
+    ]);
+    product.value = detail;
+    supplierOfferCount.value = Number(offers?.items?.length || 0);
+  } catch (error) {
+    errorMessage.value = `Не удалось открыть товар: ${getApiErrorMessage(error)}`;
+  } finally {
+    loading.value = false;
+  }
+};
+
+const confirmLeave = (): boolean => !dirty.value || window.confirm('В товаре есть несохранённые изменения. Выйти без сохранения?');
+
+const goBack = () => {
+  if (!confirmLeave()) return;
+  navigate(context?.returnTo || '/manager/products');
+};
+
+const navigateProduct = (targetId: number | null) => {
+  if (!targetId || !confirmLeave()) return;
+  navigate(buildProductWorkspacePath(targetId, activeSection.value));
+};
+
+const scrollToSection = async (section: ProductWorkspaceSection) => {
+  activeSection.value = section;
+  window.history.replaceState({}, '', buildProductWorkspacePath(productId || 0, section));
+  if (section === 'media') return;
+  await nextTick();
+  const targetId = section === 'main' ? 'product-section-main' : `product-section-${section}`;
+  document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+};
+
+const saveCurrent = async (): Promise<boolean> => {
+  if (!editor.value || saving.value) return false;
+  saving.value = true;
+  try {
+    const saved = await editor.value.save();
+    if (saved) {
+      await loadProduct();
+      dirty.value = false;
+      setToast('Изменения сохранены в CRM');
+    }
+    return saved;
+  } finally {
+    saving.value = false;
+  }
+};
+
+const saveAndNext = async () => {
+  const saved = await saveCurrent();
+  if (saved && neighbors.value.nextId) navigateProduct(neighbors.value.nextId);
+};
+
+const openMediaEditor = () => {
+  if (!product.value || !confirmLeave()) return;
+  const returnTo = buildProductWorkspacePath(product.value.id, 'media');
+  const params = new URLSearchParams({
+    editProductId: String(product.value.id),
+    editProductQuery: product.value.title,
+    productPanel: 'media',
+    returnTo,
+  });
+  navigate(`/manager/products?${params.toString()}`);
+};
+
+const openPublicProduct = () => {
+  if (publicProductUrl.value) window.open(publicProductUrl.value, '_blank', 'noopener,noreferrer');
+};
+
+const copyPublicProductLink = async () => {
+  if (!publicProductUrl.value) return;
+  await navigator.clipboard.writeText(publicProductUrl.value);
+  setToast('Ссылка на товар скопирована');
+  moreOpen.value = false;
+};
+
+const deleteProduct = async () => {
+  if (!product.value || deleting.value) return;
+  if (!window.confirm(`Удалить товар «${product.value.title}»? Товар со связями удалить не получится.`)) return;
+  deleting.value = true;
+  try {
+    await api.deleteProduct(product.value.id);
+    navigate(context?.returnTo || '/manager/products');
+  } catch (error) {
+    setToast(getApiErrorMessage(error));
+  } finally {
+    deleting.value = false;
+    moreOpen.value = false;
+  }
+};
+
+const beforeUnload = (event: BeforeUnloadEvent) => {
+  if (!dirty.value) return;
+  event.preventDefault();
+  event.returnValue = '';
+};
+
+onMounted(() => {
+  window.addEventListener('beforeunload', beforeUnload);
+  void loadProduct();
+});
+
+onBeforeUnmount(() => window.removeEventListener('beforeunload', beforeUnload));
+</script>
+
+<template>
+  <div class="min-h-full bg-gray-50 dark:bg-slate-950">
+    <header class="sticky top-0 z-30 border-b border-gray-200 bg-white/95 px-4 py-3 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-950/95 sm:px-6">
+      <div class="mx-auto flex max-w-[1680px] flex-col gap-3">
+        <div class="flex min-w-0 items-center gap-3 pl-12 md:pl-0">
+          <button type="button" class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-slate-700 dark:text-slate-200" title="К товарам" @click="goBack">
+            <ArrowLeft class="h-4 w-4" />
+          </button>
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-slate-400">
+              <span>Товары</span><span>/</span><span>#{{ productId }}</span>
+              <span v-if="dirty" class="rounded-md bg-amber-100 px-2 py-0.5 font-semibold text-amber-800">Есть изменения</span>
+            </div>
+            <h1 class="mt-0.5 truncate text-lg font-bold text-gray-950 dark:text-white sm:text-xl" :title="product?.title || ''">
+              {{ product?.title || 'Карточка товара' }}
+            </h1>
+          </div>
+          <div class="hidden items-center gap-2 lg:flex">
+            <span v-if="product" class="rounded-md px-2 py-1 text-xs font-semibold" :class="product.is_published ? 'bg-emerald-100 text-emerald-800' : 'bg-gray-100 text-gray-600'">
+              {{ product.is_published ? 'Опубликован' : 'Скрыт' }}
+            </span>
+            <span v-if="product" class="rounded-md bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-700 dark:bg-slate-800 dark:text-slate-200">{{ product.price }} BYN</span>
+            <span v-if="product" class="rounded-md bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-800 dark:bg-blue-950 dark:text-blue-200">{{ availabilityLabel }}</span>
+          </div>
+          <button type="button" class="hidden h-9 items-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-slate-700 dark:text-slate-200 sm:inline-flex" :disabled="!publicProductUrl" @click="openPublicProduct">
+            <ExternalLink class="h-4 w-4" /> На сайте
+          </button>
+          <button type="button" class="inline-flex h-9 items-center gap-2 rounded-lg bg-teal-600 px-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 disabled:opacity-50" :disabled="saving || loading || activeSection === 'media'" @click="saveCurrent">
+            <Save class="h-4 w-4" /> <span class="hidden sm:inline">{{ saving ? 'Сохранение…' : 'Сохранить' }}</span>
+          </button>
+          <div class="relative">
+            <button type="button" class="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-slate-700 dark:text-slate-200" title="Дополнительные действия" @click="moreOpen = !moreOpen">
+              <MoreHorizontal class="h-5 w-5" />
+            </button>
+            <div v-if="moreOpen" class="absolute right-0 top-11 z-40 w-56 rounded-lg border border-gray-200 bg-white p-1.5 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+              <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!publicProductUrl" @click="openPublicProduct"><ExternalLink class="h-4 w-4" />Открыть на сайте</button>
+              <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!publicProductUrl" @click="copyPublicProductLink"><ClipboardCopy class="h-4 w-4" />Копировать ссылку</button>
+              <div class="my-1 border-t border-gray-100 dark:border-slate-800" />
+              <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30" :disabled="deleting" @click="deleteProduct"><Trash2 class="h-4 w-4" />Удалить товар</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-1">
+            <button type="button" class="flex h-8 items-center gap-1 rounded-md px-2 text-xs font-semibold text-gray-600 hover:bg-gray-100 disabled:opacity-35 dark:text-slate-300 dark:hover:bg-slate-800" :disabled="!neighbors.previousId" @click="navigateProduct(neighbors.previousId)"><ChevronLeft class="h-4 w-4" />Предыдущий</button>
+            <button type="button" class="flex h-8 items-center gap-1 rounded-md px-2 text-xs font-semibold text-gray-600 hover:bg-gray-100 disabled:opacity-35 dark:text-slate-300 dark:hover:bg-slate-800" :disabled="!neighbors.nextId" @click="navigateProduct(neighbors.nextId)">Следующий<ArrowRight class="h-4 w-4" /></button>
+          </div>
+          <button v-if="neighbors.nextId && activeSection !== 'media'" type="button" class="hidden h-8 items-center gap-1 rounded-md px-2 text-xs font-semibold text-teal-700 hover:bg-teal-50 sm:flex" :disabled="saving" @click="saveAndNext">Сохранить и дальше<ArrowRight class="h-4 w-4" /></button>
+        </div>
+      </div>
+    </header>
+
+    <div v-if="loading" class="flex min-h-[520px] items-center justify-center gap-3 text-gray-500">
+      <span class="h-6 w-6 animate-spin rounded-full border-2 border-teal-600 border-t-transparent" /> Загрузка товара…
+    </div>
+    <div v-else-if="errorMessage" class="mx-auto max-w-2xl px-4 py-20 text-center">
+      <CircleAlert class="mx-auto h-10 w-10 text-red-500" />
+      <p class="mt-4 font-semibold text-red-700">{{ errorMessage }}</p>
+      <button type="button" class="mt-5 rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold" @click="goBack">Вернуться к товарам</button>
+    </div>
+    <div v-else-if="product" class="mx-auto grid max-w-[1680px] gap-5 px-4 py-5 xl:grid-cols-[190px_minmax(0,1fr)_270px] xl:px-6">
+      <nav class="sticky top-[132px] z-20 -mx-4 flex gap-1 overflow-x-auto border-y border-gray-200 bg-white px-4 py-2 dark:border-slate-800 dark:bg-slate-950 xl:mx-0 xl:block xl:self-start xl:border-0 xl:bg-transparent xl:px-0 xl:py-0">
+        <button v-for="section in sections" :key="section.id" type="button" class="flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-semibold transition xl:mb-1 xl:w-full" :class="activeSection === section.id ? 'bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-200' : 'text-gray-600 hover:bg-white dark:text-slate-300 dark:hover:bg-slate-900'" @click="scrollToSection(section.id)">
+          <component :is="section.icon" class="h-4 w-4" />{{ section.label }}
+          <span v-if="section.id === 'media'" class="ml-auto rounded-full bg-white px-1.5 text-[10px] text-gray-500 dark:bg-slate-800">{{ product.gallery_images.length }}</span>
+          <span v-if="section.id === 'suppliers'" class="ml-auto rounded-full bg-white px-1.5 text-[10px] text-gray-500 dark:bg-slate-800">{{ supplierOfferCount }}</span>
+        </button>
+      </nav>
+
+      <main class="min-w-0 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        <ProductWorkspaceMedia v-show="activeSection === 'media'" :product="product" @open-editor="openMediaEditor" />
+        <ProductEditModal ref="editor" v-show="activeSection !== 'media'" :model-value="true" :product="product" mode="edit" presentation="workspace" @update:model-value="goBack" @dirty-change="dirty = $event" />
+      </main>
+
+      <aside class="space-y-4 xl:sticky xl:top-[132px] xl:self-start">
+        <section class="border-y border-gray-200 bg-white py-4 dark:border-slate-800 dark:bg-slate-950 xl:rounded-lg xl:border xl:p-4">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-xs font-bold uppercase tracking-[0.14em] text-gray-400">Базовая готовность</p>
+              <p class="mt-1 text-lg font-bold text-gray-950 dark:text-white">{{ qualityIssues.length ? `${qualityIssues.length} проблем` : 'Явных проблем нет' }}</p>
+            </div>
+            <CheckCircle2 v-if="qualityIssues.length === 0" class="h-7 w-7 text-emerald-500" />
+            <CircleAlert v-else class="h-7 w-7 text-amber-500" />
+          </div>
+          <div v-if="qualityIssues.length" class="mt-3 space-y-1.5">
+            <button v-for="issue in qualityIssues" :key="issue.label" type="button" class="flex w-full items-start gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-gray-50 dark:hover:bg-slate-900" :class="issue.critical ? 'text-red-700 dark:text-red-300' : 'text-gray-600 dark:text-slate-300'" @click="scrollToSection(issue.section)">
+              <CircleAlert class="mt-0.5 h-3.5 w-3.5 shrink-0" />{{ issue.label }}
+            </button>
+          </div>
+        </section>
+
+        <section class="border-y border-gray-200 bg-white py-4 text-sm dark:border-slate-800 dark:bg-slate-950 xl:rounded-lg xl:border xl:p-4">
+          <p class="text-xs font-bold uppercase tracking-[0.14em] text-gray-400">Коммерция</p>
+          <dl class="mt-3 space-y-2 text-gray-600 dark:text-slate-300">
+            <div class="flex justify-between gap-3"><dt>Цена</dt><dd class="font-semibold text-gray-900 dark:text-white">{{ product.price }} BYN</dd></div>
+            <div class="flex justify-between gap-3"><dt>Себестоимость</dt><dd>{{ product.min_cost_byn != null ? `${product.min_cost_byn.toFixed(2)} BYN` : '—' }}</dd></div>
+            <div class="flex justify-between gap-3"><dt>Маржа</dt><dd>{{ product.margin_pct_preview != null ? `${(product.margin_pct_preview * 100).toFixed(1)}%` : '—' }}</dd></div>
+            <div class="flex justify-between gap-3"><dt>Витебск</dt><dd>{{ product.vitebsk_qty || 0 }}</dd></div>
+            <div class="flex justify-between gap-3"><dt>Минск</dt><dd>{{ product.minsk_qty || 0 }}</dd></div>
+          </dl>
+        </section>
+
+        <section class="border-y border-blue-200 bg-blue-50 py-4 text-sm text-blue-900 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-100 xl:rounded-lg xl:border xl:p-4">
+          <div class="flex items-start gap-2"><Link2 class="mt-0.5 h-4 w-4 shrink-0" /><p>Сохранение меняет данные CRM. Публичный Astro-сайт обновится после отдельной пересборки.</p></div>
+        </section>
+      </aside>
+    </div>
+
+    <Transition name="fade"><div v-if="toast" class="fixed bottom-5 right-5 z-50 rounded-lg bg-gray-950 px-4 py-3 text-sm font-semibold text-white shadow-xl">{{ toast }}</div></Transition>
+  </div>
+</template>

--- a/manager_frontend/src/views/ProductsView.vue
+++ b/manager_frontend/src/views/ProductsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
+import { ref, onMounted, onUnmounted, watch, computed, nextTick } from 'vue';
 import { watchDebounced } from '@vueuse/core';
 import {
     api,
@@ -28,6 +28,13 @@ import {
 } from '../utils/media-processing';
 import { optimizeImageForUpload } from '../utils/image-upload-optimization';
 import { uploadSequentially } from '../utils/sequential-upload';
+import {
+    buildProductWorkspacePath,
+    loadProductWorkspaceContext,
+    saveProductWorkspaceContext,
+    type ProductListWorkspaceContext,
+    type ProductWorkspaceSection,
+} from '../utils/product-workspace';
 
 // Product state
 const products = ref<Product[]>([]);
@@ -234,6 +241,51 @@ const CATEGORY_FILTER_TABS: Array<{ value: CatalogCategoryFilterValue; title: st
     { value: 'cat-industrial', title: 'Полупром' },
     { value: 'missing', title: 'Без категории' },
 ];
+const skipNextSearchReload = ref(false);
+
+const currentRelativeUrl = () => `${window.location.pathname}${window.location.search}`;
+const getProductsScrollContainer = (): HTMLElement | null => document.querySelector('main.flex-1.overflow-auto');
+
+const productListState = (): Record<string, unknown> => ({
+    searchQuery: searchQuery.value,
+    areaMin: areaMin.value ?? null,
+    areaMax: areaMax.value ?? null,
+    isInverter: isInverter.value ?? null,
+    heatingMin: heatingMin.value ?? null,
+    hasWifi: hasWifi.value ?? null,
+    hasFreshAir: hasFreshAir.value ?? null,
+    selectedBrandSlug: selectedBrandSlug.value,
+    selectedSeriesId: selectedSeriesId.value,
+    selectedSeriesTitle: selectedSeriesTitle.value,
+    filtersOpen: filtersOpen.value,
+    viewType: viewType.value,
+    sortMode: sortMode.value,
+    categoryFilter: categoryFilter.value,
+});
+
+const restoreProductListState = (context: ProductListWorkspaceContext): void => {
+    const state = context.listState;
+    const restoredSearch = typeof state.searchQuery === 'string' ? state.searchQuery : '';
+    if (restoredSearch !== searchQuery.value) skipNextSearchReload.value = true;
+    searchQuery.value = restoredSearch;
+    areaMin.value = state.areaMin == null ? undefined : Number(state.areaMin);
+    areaMax.value = state.areaMax == null ? undefined : Number(state.areaMax);
+    isInverter.value = typeof state.isInverter === 'boolean' ? state.isInverter : undefined;
+    heatingMin.value = state.heatingMin == null ? undefined : Number(state.heatingMin);
+    hasWifi.value = typeof state.hasWifi === 'boolean' ? state.hasWifi : undefined;
+    hasFreshAir.value = typeof state.hasFreshAir === 'boolean' ? state.hasFreshAir : undefined;
+    selectedBrandSlug.value = typeof state.selectedBrandSlug === 'string' ? state.selectedBrandSlug : null;
+    selectedSeriesId.value = state.selectedSeriesId == null ? null : Number(state.selectedSeriesId);
+    selectedSeriesTitle.value = typeof state.selectedSeriesTitle === 'string' ? state.selectedSeriesTitle : '';
+    filtersOpen.value = Boolean(state.filtersOpen);
+    viewType.value = state.viewType === 'table' ? 'table' : 'grid';
+    sortMode.value = ['newest', 'price_asc', 'price_desc', 'title'].includes(String(state.sortMode))
+        ? state.sortMode as typeof sortMode.value
+        : 'recommended';
+    categoryFilter.value = CATEGORY_FILTER_TABS.some((item) => item.value === state.categoryFilter)
+        ? state.categoryFilter as CatalogCategoryFilterValue
+        : 'cat-household';
+};
 const isMissingCategoryFilter = computed(() => categoryFilter.value === 'missing');
 const categorySlug = computed<CatalogCategorySlug | undefined>(() => (
     isMissingCategoryFilter.value || categoryFilter.value === 'all' ? undefined : categoryFilter.value as CatalogCategorySlug
@@ -718,15 +770,22 @@ const loadProducts = async () => {
       hasMore.value = products.value.length >= limit;
     }
     if (pendingEditProductId.value && !pendingEditHandled.value) {
-      const target = products.value.find((p) => p.id === pendingEditProductId.value)
+      let target = products.value.find((p) => p.id === pendingEditProductId.value)
         || (pendingEditProductQuery.value
           ? products.value.find((p) => p.title.toLowerCase().includes(pendingEditProductQuery.value.toLowerCase()))
           : null);
+      if (!target) {
+        try {
+          target = await api.getManagerProduct(pendingEditProductId.value);
+        } catch (error) {
+          console.error(error);
+        }
+      }
       if (target) {
         pendingEditHandled.value = true;
         if (pendingProductPanel.value === 'media') openSearchModal(target);
         else openEditModal(target);
-      } else if (searchQuery.value.trim()) {
+      } else {
         pendingEditHandled.value = true;
         setToast(`Товар #${pendingEditProductId.value} не найден`);
       }
@@ -867,6 +926,23 @@ const openEditModal = (product: Product) => {
     editingProduct.value = product;
     productEditorMode.value = 'edit';
     showEditModal.value = true;
+};
+
+const openProductWorkspace = (
+    product: Product,
+    section: ProductWorkspaceSection = 'main',
+) => {
+    const scrollTop = getProductsScrollContainer()?.scrollTop || 0;
+    saveProductWorkspaceContext({
+        returnTo: currentRelativeUrl(),
+        productIds: products.value.map((item) => item.id),
+        currentProductId: product.id,
+        scrollTop,
+        page: page.value,
+        listState: productListState(),
+    });
+    window.history.pushState({}, '', buildProductWorkspacePath(product.id, section));
+    window.dispatchEvent(new PopStateEvent('popstate'));
 };
 
 const openCreateProductModal = () => {
@@ -1405,8 +1481,15 @@ const selectImage = async (url: string) => {
 };
 
 // Intersection Observer for infinite scroll
-onMounted(() => {
+onMounted(async () => {
     const params = new URLSearchParams(window.location.search);
+    const savedContext = loadProductWorkspaceContext();
+    const contextMatchesList = Boolean(
+        savedContext
+        && !params.has('editProductId')
+        && savedContext.returnTo === currentRelativeUrl()
+    );
+    if (savedContext && contextMatchesList) restoreProductListState(savedContext);
     const seriesIdRaw = Number(params.get('seriesId'));
     if (Number.isInteger(seriesIdRaw) && seriesIdRaw > 0) {
         selectedSeriesId.value = seriesIdRaw;
@@ -1421,16 +1504,17 @@ onMounted(() => {
     pendingEditProductQuery.value = params.get('editProductQuery') || '';
     pendingReturnTo.value = params.get('returnTo') || '';
     pendingProductPanel.value = params.get('productPanel') === 'media' ? 'media' : 'edit';
-    if (!searchQuery.value) {
-        if (pendingEditProductQuery.value) {
-            searchQuery.value = pendingEditProductQuery.value;
-        } else if (pendingEditProductId.value) {
-            searchQuery.value = String(pendingEditProductId.value);
-        }
-    }
     document.addEventListener('paste', onProductImagePaste);
-    loadBrands();
-    loadProducts();
+    void loadBrands();
+    await loadProducts();
+    if (savedContext && contextMatchesList) {
+        while (page.value < savedContext.page && hasMore.value) {
+            await loadMore();
+        }
+        await nextTick();
+        const scrollContainer = getProductsScrollContainer();
+        if (scrollContainer) scrollContainer.scrollTop = savedContext.scrollTop;
+    }
 
     const observer = new IntersectionObserver((entries) => {
         if (entries[0]?.isIntersecting && hasMore.value && !loadingMore.value) {
@@ -1473,6 +1557,10 @@ const deleteProduct = async (product: Product) => {
 watchDebounced(
     searchQuery,
     () => {
+        if (skipNextSearchReload.value) {
+            skipNextSearchReload.value = false;
+            return;
+        }
         page.value = 1;
         loadProducts();
     },
@@ -1484,7 +1572,10 @@ watchDebounced(
   <div class="p-6">
     <!-- Header -->
     <header class="mb-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-      <div class="flex flex-wrap items-center gap-3 sm:gap-4">
+      <div
+        class="flex flex-wrap items-center gap-3 sm:gap-4"
+        :class="pendingReturnTo ? 'pl-12 sm:pl-0' : ''"
+      >
           <button
             v-if="pendingReturnTo"
             @click="navigateBackFromProducts"
@@ -1493,7 +1584,7 @@ watchDebounced(
             <ArrowLeft class="w-4 h-4" />
             Назад
           </button>
-          <h1 class="pl-20 text-2xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3 sm:pl-0">
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-white tracking-tight flex items-center gap-3 sm:pl-0" :class="pendingReturnTo ? 'pl-0' : 'pl-20'">
             <span class="material-icons-round text-teal-600 dark:text-teal-400">inventory_2</span>
             Товары
           </h1>
@@ -1849,8 +1940,9 @@ watchDebounced(
       <!-- Grid View -->
       <div v-if="viewType === 'grid'" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-5">
         <div v-for="product in products" :key="product.id" 
-             class="bg-white dark:bg-slate-800 rounded-xl shadow-sm overflow-hidden group border-2 transition-all hover:shadow-md relative"
+             class="relative cursor-pointer overflow-hidden rounded-lg border-2 bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md dark:bg-slate-800"
              :class="selectedProductIds.has(product.id) ? 'border-teal-500 ring-2 ring-teal-100 dark:ring-teal-900/50' : 'border-transparent'"
+             @click="openProductWorkspace(product)"
         >
              <!-- Selection Checkbox Overlay -->
              <div class="absolute top-2.5 left-2.5 z-10">
@@ -1872,35 +1964,14 @@ watchDebounced(
                     />
                  </button>
              </div>
-            <div class="aspect-video bg-gray-100 dark:bg-slate-700 relative">
-                <img v-if="product.main_image" :src="getImageUrl(product.main_image)" class="w-full h-full object-cover" />
+            <div class="aspect-[16/8.5] bg-gray-100 dark:bg-slate-700 relative" title="Открыть быстрый редактор фотографий" @click.stop="openSearchModal(product)">
+                <img v-if="product.main_image" :src="getImageUrl(product.main_image)" class="w-full h-full object-contain p-2" />
                 <div v-else class="w-full h-full flex items-center justify-center text-gray-300">
                     <Package class="w-10 h-10" />
                 </div>
-                
-                <!-- Overlay Actions -->
-                <div class="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex flex-col items-center justify-center gap-2">
-                    <button
-                      @click.stop="deleteProduct(product)"
-                      :disabled="isDeletingProduct === product.id"
-                      class="absolute top-2.5 right-11 flex h-7 w-7 items-center justify-center rounded-full bg-red-600/90 text-white shadow-sm transition-colors hover:bg-red-700 disabled:opacity-50"
-                      title="Удалить"
-                    >
-                      <span class="material-icons-round text-[16px] leading-none">close</span>
-                    </button>
-                    <button @click="openSearchModal(product)" class="bg-teal-600 text-white px-4 py-2 rounded-full flex items-center gap-2 hover:bg-teal-700 text-sm font-medium transition-colors w-36 justify-center">
-                        <Images class="w-4 h-4" /> Фото
-                    </button>
-                    <button @click="openEditModal(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
-                        <Settings class="w-4 h-4 text-teal-600" /> Изменить
-                    </button>
-                    <button @click="openDuplicateProductModal(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
-                        <Copy class="w-4 h-4 text-teal-600" /> Дублировать
-                    </button>
-                    <button @click="copyPublicProductLink(product)" class="bg-white text-gray-900 px-4 py-2 rounded-full flex items-center gap-2 hover:bg-gray-100 text-sm font-medium transition-colors w-36 justify-center">
-                        <Link2 class="w-4 h-4 text-teal-600" /> Ссылка
-                    </button>
-                </div>
+                <span class="absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-md bg-gray-950/70 px-2 py-1 text-[11px] font-semibold text-white">
+                    <Images class="h-3.5 w-3.5" /> {{ product.gallery_images.length }}
+                </span>
             </div>
             <div class="p-3.5">
                 <h3 class="font-medium text-gray-900 dark:text-slate-200 text-sm truncate" :title="product.title">{{ product.title }}</h3>
@@ -1915,7 +1986,7 @@ watchDebounced(
                             class="w-24 px-1 py-0.5 border border-teal-500 dark:border-teal-400 rounded text-sm outline-none bg-teal-50 dark:bg-teal-900/30 text-gray-900 dark:text-slate-200"
                             auto-focus
                         />
-                        <span class="text-xs text-teal-600 dark:text-teal-400 ml-1">руб.</span>
+                        <span class="text-xs text-teal-600 dark:text-teal-400 ml-1">BYN</span>
                     </template>
                     <p 
                         v-else 
@@ -1923,10 +1994,10 @@ watchDebounced(
                         class="text-teal-700 dark:text-teal-400 font-semibold text-sm cursor-pointer hover:bg-teal-50 dark:hover:bg-teal-900/40 rounded px-1 -ml-1 transition-colors"
                         title="Нажмите, чтобы изменить цену"
                     >
-                        {{ product.price }} руб.
+                        {{ product.price }} BYN
                     </p>
                     <button
-                        @click="openPublicProductPage(product)"
+                        @click.stop="openPublicProductPage(product)"
                         class="inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium text-teal-700 dark:text-teal-300 bg-teal-50 dark:bg-teal-900/30 hover:bg-teal-100 dark:hover:bg-teal-900/40 transition-colors disabled:opacity-45 disabled:cursor-not-allowed disabled:hover:bg-teal-50 dark:disabled:hover:bg-teal-900/30"
                         :disabled="!product.slug"
                         :title="product.slug ? 'Открыть карточку товара на сайте' : 'У товара нет публичного slug'"
@@ -1966,6 +2037,26 @@ watchDebounced(
                     <span v-if="product.gallery_images.length > 6" class="w-7 h-7 bg-gray-100 rounded flex items-center justify-center text-[10px] text-gray-500">+{{ product.gallery_images.length - 6 }}</span>
                 </div>
             </div>
+            <div class="grid grid-cols-[1fr_1fr_auto] border-t border-gray-100 dark:border-slate-700">
+                <button type="button" class="inline-flex h-10 items-center justify-center gap-1.5 text-xs font-semibold text-gray-600 transition hover:bg-gray-50 hover:text-teal-700 dark:text-slate-300 dark:hover:bg-slate-700" @click.stop="openSearchModal(product)">
+                    <Images class="h-4 w-4" /> Фото
+                </button>
+                <button type="button" class="inline-flex h-10 items-center justify-center gap-1.5 border-l border-gray-100 text-xs font-semibold text-teal-700 transition hover:bg-teal-50 dark:border-slate-700 dark:text-teal-300 dark:hover:bg-slate-700" @click.stop="openProductWorkspace(product)">
+                    <ExternalLink class="h-4 w-4" /> Открыть
+                </button>
+                <details class="relative border-l border-gray-100 dark:border-slate-700" @click.stop>
+                    <summary class="flex h-10 w-10 cursor-pointer list-none items-center justify-center text-gray-500 hover:bg-gray-50 dark:text-slate-300 dark:hover:bg-slate-700" title="Дополнительные действия">
+                        <MoreHorizontal class="h-4 w-4" />
+                    </summary>
+                    <div class="absolute bottom-11 right-1 z-30 w-52 rounded-lg border border-gray-200 bg-white p-1.5 text-left shadow-xl dark:border-slate-700 dark:bg-slate-900">
+                        <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" @click="openDuplicateProductModal(product)"><Copy class="h-4 w-4" />Дублировать</button>
+                        <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!product.slug" @click="copyPublicProductLink(product)"><Link2 class="h-4 w-4" />Копировать ссылку</button>
+                        <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!product.slug" @click="openPublicProductPage(product)"><ExternalLink class="h-4 w-4" />Открыть на сайте</button>
+                        <div class="my-1 border-t border-gray-100 dark:border-slate-800" />
+                        <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30" :disabled="isDeletingProduct === product.id" @click="deleteProduct(product)"><Trash2 class="h-4 w-4" />Удалить</button>
+                    </div>
+                </details>
+            </div>
         </div>
       </div>
 
@@ -1989,18 +2080,19 @@ watchDebounced(
           </thead>
           <tbody class="divide-y divide-gray-100 dark:divide-slate-700">
             <tr v-for="product in products" :key="product.id" 
-                class="hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors"
+                class="cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors"
                 :class="{ 'bg-teal-50/50 dark:bg-teal-900/20': selectedProductIds.has(product.id) }"
+                @click="openProductWorkspace(product)"
             >
               <td class="p-4">
-                <button @click="toggleSelection(product.id)" class="text-gray-400 hover:text-gray-600 dark:hover:text-slate-300">
+                <button @click.stop="toggleSelection(product.id)" class="text-gray-400 hover:text-gray-600 dark:hover:text-slate-300">
                   <CheckSquare v-if="selectedProductIds.has(product.id)" class="w-5 h-5 text-teal-600" />
                   <Square v-else class="w-5 h-5" />
                 </button>
               </td>
               <td class="p-4">
-                <div class="w-16 h-10 bg-gray-100 dark:bg-slate-700 rounded overflow-hidden shadow-sm relative group/thumb cursor-pointer" @click="openEditModal(product)">
-                    <img v-if="product.main_image" :src="getImageUrl(product.main_image)" class="w-full h-full object-cover" />
+                <div class="w-16 h-10 bg-gray-100 dark:bg-slate-700 rounded overflow-hidden shadow-sm relative cursor-pointer" title="Открыть фотографии" @click.stop="openSearchModal(product)">
+                    <img v-if="product.main_image" :src="getImageUrl(product.main_image)" class="w-full h-full object-contain p-0.5" />
                     <div v-else class="w-full h-full flex items-center justify-center text-gray-300">
                       <Package class="w-5 h-5" />
                     </div>
@@ -2013,7 +2105,7 @@ watchDebounced(
               </td>
               <td class="p-4">
                 <div class="text-sm font-semibold text-teal-700 dark:text-teal-400">
-                   {{ product.price }} руб.
+                   {{ product.price }} BYN
                 </div>
               </td>
               <td class="p-4 text-xs text-gray-600 dark:text-slate-400">
@@ -2024,7 +2116,7 @@ watchDebounced(
               <td class="p-4 text-right">
                 <div class="flex justify-end gap-2 text-gray-400">
                   <button
-                    @click="toggleFavoriteProduct(product)"
+                    @click.stop="toggleFavoriteProduct(product)"
                     :disabled="favoriteUpdatingIds.has(product.id)"
                     class="p-2 transition-colors disabled:opacity-50"
                     :class="isFavoriteProduct(product) ? 'text-amber-500 hover:text-amber-600' : 'hover:text-amber-500'"
@@ -2032,24 +2124,22 @@ watchDebounced(
                   >
                     <Star class="w-4 h-4" :class="{ 'fill-amber-400': isFavoriteProduct(product) }" />
                   </button>
-                  <button @click="copyPublicProductLink(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" :title="product.slug ? 'Скопировать ссылку на сайт' : 'У товара нет публичного slug'" :disabled="!product.slug">
-                    <Link2 class="w-4 h-4" />
-                  </button>
-                  <button @click="openPublicProductPage(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" :title="product.slug ? 'Открыть сайт' : 'У товара нет публичного slug'" :disabled="!product.slug">
-                    <ExternalLink class="w-4 h-4" />
-                  </button>
-                  <button @click="openSearchModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Фото">
+                  <button @click.stop="openSearchModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Фото">
                     <Images class="w-4 h-4" />
                   </button>
-                  <button @click="openEditModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Изменить">
-                    <Settings class="w-4 h-4" />
+                  <button @click.stop="openProductWorkspace(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Открыть товар">
+                    <ExternalLink class="w-4 h-4" />
                   </button>
-                  <button @click="openDuplicateProductModal(product)" class="p-2 hover:text-teal-600 dark:hover:text-teal-400 transition-colors" title="Дублировать">
-                    <Copy class="w-4 h-4" />
-                  </button>
-                  <button @click.stop="deleteProduct(product)" :disabled="isDeletingProduct === product.id" class="p-2 hover:text-red-600 transition-colors" title="Удалить">
-                    <span class="material-icons-round text-[18px]">delete</span>
-                  </button>
+                  <details class="relative" @click.stop>
+                    <summary class="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-slate-700" title="Дополнительные действия"><MoreHorizontal class="h-4 w-4" /></summary>
+                    <div class="absolute right-0 top-9 z-30 w-52 rounded-lg border border-gray-200 bg-white p-1.5 text-left shadow-xl dark:border-slate-700 dark:bg-slate-900">
+                      <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" @click="openDuplicateProductModal(product)"><Copy class="h-4 w-4" />Дублировать</button>
+                      <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!product.slug" @click="copyPublicProductLink(product)"><Link2 class="h-4 w-4" />Копировать ссылку</button>
+                      <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!product.slug" @click="openPublicProductPage(product)"><ExternalLink class="h-4 w-4" />Открыть на сайте</button>
+                      <div class="my-1 border-t border-gray-100 dark:border-slate-800" />
+                      <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30" :disabled="isDeletingProduct === product.id" @click="deleteProduct(product)"><Trash2 class="h-4 w-4" />Удалить</button>
+                    </div>
+                  </details>
                 </div>
               </td>
             </tr>
@@ -2095,28 +2185,35 @@ watchDebounced(
   <div v-if="showModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" @click.self="showModal = false">
       <div class="relative bg-white rounded-xl w-full max-w-6xl h-[90vh] flex flex-col shadow-2xl">
           <!-- Tabs -->
-          <div class="flex border-b bg-gray-50 rounded-t-xl">
+          <div class="flex min-w-0 border-b bg-gray-50 rounded-t-xl">
+            <div class="flex min-w-0 flex-1 overflow-x-auto">
                <button 
                   @click="activeTab = 'upload'" 
-                  class="px-6 py-3 font-medium border-b-2 text-sm transition-colors"
+                  class="shrink-0 px-4 py-3 font-medium border-b-2 text-sm transition-colors sm:px-6"
                   :class="activeTab === 'upload' ? 'border-teal-600 text-teal-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
                >Загрузить</button>
                <button 
                   @click="activeTab = 'search'" 
-                  class="px-6 py-3 font-medium border-b-2 text-sm transition-colors"
+                  class="shrink-0 px-4 py-3 font-medium border-b-2 text-sm transition-colors sm:px-6"
                   :class="activeTab === 'search' ? 'border-teal-600 text-teal-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
                >Поиск изображений</button>
                <button 
                   @click="activeTab = 'reuse'" 
-                  class="px-6 py-3 font-medium border-b-2 text-sm transition-colors"
+                  class="shrink-0 px-4 py-3 font-medium border-b-2 text-sm transition-colors sm:px-6"
                   :class="activeTab === 'reuse' ? 'border-teal-600 text-teal-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
                >Из каталога</button>
-               <div v-if="isBulkMode" class="flex items-center text-sm text-teal-700 font-medium px-3">
+               <div v-if="isBulkMode" class="flex shrink-0 items-center text-sm text-teal-700 font-medium px-3">
                   {{ selectedIdsArray.length }} товаров
                </div>
-               <div class="flex-1 flex justify-end items-center px-4">
-                   <button @click="showModal = false" class="text-gray-400 hover:text-gray-600 text-sm transition-colors">Закрыть</button>
-               </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Закрыть"
+              class="flex h-11 w-11 shrink-0 items-center justify-center border-l border-gray-200 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+              @click="showModal = false"
+            >
+              <X class="h-5 w-5" />
+            </button>
           </div>
 
           <!-- Tab Content -->

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -37,6 +37,11 @@ import {
   serializeCatalogQualityState,
 } from '../src/components/catalog-quality/catalog-quality-state';
 import { countLabel } from '../src/components/catalog-quality/catalog-quality-copy';
+import {
+  buildProductWorkspacePath,
+  getProductWorkspaceNeighbors,
+  parseProductWorkspaceLocation,
+} from '../src/utils/product-workspace';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -168,6 +173,30 @@ assert(savedQualityView.page === 1, 'saved catalog view must restart pagination'
 assert(countLabel(1, 'поставщик', 'поставщика', 'поставщиков') === '1 поставщик', 'catalog counts must use singular form');
 assert(countLabel(3, 'поставщик', 'поставщика', 'поставщиков') === '3 поставщика', 'catalog counts must use paucal form');
 assert(countLabel(12, 'поставщик', 'поставщика', 'поставщиков') === '12 поставщиков', 'catalog counts must use plural form');
+
+assert(
+  buildProductWorkspacePath(143, 'media') === '/manager/products/143/media',
+  'product workspace links must preserve the requested section',
+);
+const parsedProductWorkspace = parseProductWorkspaceLocation('/manager/products/143/specifications');
+assert(
+  parsedProductWorkspace?.productId === 143 && parsedProductWorkspace.section === 'specifications',
+  'product workspace location must restore product and section',
+);
+assert(
+  parseProductWorkspaceLocation('/manager/products/not-a-number').productId === null,
+  'invalid product workspace routes must not resolve',
+);
+const middleProductNeighbors = getProductWorkspaceNeighbors([11, 143, 22], 143);
+assert(
+  middleProductNeighbors.previousId === 11 && middleProductNeighbors.nextId === 22,
+  'product workspace navigation must follow the saved list order',
+);
+const edgeProductNeighbors = getProductWorkspaceNeighbors([11, 143, 22], 11);
+assert(
+  edgeProductNeighbors.previousId === null && edgeProductNeighbors.nextId === 143,
+  'product workspace navigation must stop at list boundaries',
+);
 
 const workspaceBase = {
   status: 'negotiation',

--- a/openapi.json
+++ b/openapi.json
@@ -4108,152 +4108,6 @@
         }
       }
     },
-    "/api/manager/products/{product_id}": {
-      "get": {
-        "tags": [
-          "manager"
-        ],
-        "summary": "Get Product For Manager",
-        "operationId": "get_manager_product",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "product_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Product Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ManagerCatalogProductItemResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "manager"
-        ],
-        "summary": "Update Product",
-        "description": "Update individual product fields.",
-        "operationId": "update_product",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "product_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Product Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProductUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "manager"
-        ],
-        "summary": "Delete Product",
-        "operationId": "delete_manager_product",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "product_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Product Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/manager/customers": {
       "get": {
         "tags": [
@@ -5125,6 +4979,152 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/manager/products/{product_id}": {
+      "patch": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Update Product",
+        "description": "Update individual product fields.",
+        "operationId": "update_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Delete Product",
+        "operationId": "delete_manager_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Get Product For Manager",
+        "operationId": "get_manager_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerCatalogProductItemResponse"
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -4108,6 +4108,152 @@
         }
       }
     },
+    "/api/manager/products/{product_id}": {
+      "get": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Get Product For Manager",
+        "operationId": "get_manager_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerCatalogProductItemResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Update Product",
+        "description": "Update individual product fields.",
+        "operationId": "update_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "manager"
+        ],
+        "summary": "Delete Product",
+        "operationId": "delete_manager_product",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "product_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Product Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/manager/customers": {
       "get": {
         "tags": [
@@ -4980,107 +5126,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/ManagerActionMessageResponse"
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/manager/products/{product_id}": {
-      "patch": {
-        "tags": [
-          "manager"
-        ],
-        "summary": "Update Product",
-        "description": "Update individual product fields.",
-        "operationId": "update_product",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "product_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Product Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProductUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ManagerActionMessageResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "manager"
-        ],
-        "summary": "Delete Product",
-        "operationId": "delete_manager_product",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "product_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Product Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
               }
             }
           },

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -134,29 +134,6 @@ async def list_products_for_manager(
 
 
 @router.get(
-    "/products/{product_id}",
-    response_model=ManagerCatalogProductItemResponse,
-    operation_id=GET_MANAGER_PRODUCT,
-)
-async def get_product_for_manager(
-    product_id: int,
-    session: AsyncSession = Depends(get_session),
-    _user: str = Depends(get_current_username),
-):
-    product = await ManagerCatalogService.get_product(
-        session=session,
-        product_id=product_id,
-    )
-    if not product:
-        raise manager_http_error(
-            status_code=404,
-            endpoint=GET_MANAGER_PRODUCT,
-            error_code=PRODUCT_NOT_FOUND,
-        )
-    return product
-
-
-@router.get(
     "/customers",
     response_model=ManagerCatalogCustomerListResponse,
     operation_id=GET_MANAGER_CUSTOMERS,
@@ -750,6 +727,29 @@ async def smart_search_products(
         brand_slugs=brand_slugs,
         category_slug=category_slug,
     )
+
+
+@router.get(
+    "/products/{product_id}",
+    response_model=ManagerCatalogProductItemResponse,
+    operation_id=GET_MANAGER_PRODUCT,
+)
+async def get_product_for_manager(
+    product_id: int,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    product = await ManagerCatalogService.get_product(
+        session=session,
+        product_id=product_id,
+    )
+    if not product:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=GET_MANAGER_PRODUCT,
+            error_code=PRODUCT_NOT_FOUND,
+        )
+    return product
 
 
 @router.post(

--- a/routers/manager_catalog.py
+++ b/routers/manager_catalog.py
@@ -28,6 +28,7 @@ from routers.manager_operation_ids import (
     PATCH_MANAGER_CUSTOMER_BRANCH,
     DELETE_MANAGER_CUSTOMER_BRANCH,
     GET_MANAGER_PRODUCTS,
+    GET_MANAGER_PRODUCT,
     PATCH_MANAGER_CUSTOMER,
     DELETE_MANAGER_CUSTOMER,
     CREATE_MANAGER_PRODUCT,
@@ -62,6 +63,7 @@ from schemas import (
     ManagerCustomerReconciliationDocumentResponse,
     ManagerCustomerReconciliationResponse,
     ManagerCatalogProductListResponse,
+    ManagerCatalogProductItemResponse,
     ManagerCustomerUpdatePayload,
     ManagerTagGroupResponse,
     OnlinerImportPayload,
@@ -129,6 +131,29 @@ async def list_products_for_manager(
         category_status=category_status,
         sort=sort,
     )
+
+
+@router.get(
+    "/products/{product_id}",
+    response_model=ManagerCatalogProductItemResponse,
+    operation_id=GET_MANAGER_PRODUCT,
+)
+async def get_product_for_manager(
+    product_id: int,
+    session: AsyncSession = Depends(get_session),
+    _user: str = Depends(get_current_username),
+):
+    product = await ManagerCatalogService.get_product(
+        session=session,
+        product_id=product_id,
+    )
+    if not product:
+        raise manager_http_error(
+            status_code=404,
+            endpoint=GET_MANAGER_PRODUCT,
+            error_code=PRODUCT_NOT_FOUND,
+        )
+    return product
 
 
 @router.get(

--- a/routers/manager_operation_ids.py
+++ b/routers/manager_operation_ids.py
@@ -4,6 +4,7 @@ READ_USER_ME = "read_user_me"
 GET_MANAGER_CALENDAR_EVENTS = "get_manager_calendar_events"
 
 GET_MANAGER_PRODUCTS = "get_manager_products"
+GET_MANAGER_PRODUCT = "get_manager_product"
 GET_MANAGER_CATALOG_QUALITY_REPORT = "get_manager_catalog_quality_report"
 GET_MANAGER_CUSTOMERS = "get_manager_customers"
 GET_MANAGER_CUSTOMER_DETAIL = "get_manager_customer_detail"
@@ -279,6 +280,7 @@ ALL_MANAGER_OPERATION_IDS = (
     READ_USER_ME,
     GET_MANAGER_CALENDAR_EVENTS,
     GET_MANAGER_PRODUCTS,
+    GET_MANAGER_PRODUCT,
     GET_MANAGER_CATALOG_QUALITY_REPORT,
     GET_MANAGER_CUSTOMERS,
     GET_MANAGER_CUSTOMER_DETAIL,

--- a/services/manager_catalog_service.py
+++ b/services/manager_catalog_service.py
@@ -18,6 +18,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 class ManagerCatalogService:
     @staticmethod
+    async def get_product(
+        session: AsyncSession,
+        *,
+        product_id: int,
+    ) -> Optional[Dict[str, Any]]:
+        return await ProductService.get_manager_product(session, product_id)
+
+    @staticmethod
     async def list_products(
         session: AsyncSession,
         *,

--- a/services/product_manager_service.py
+++ b/services/product_manager_service.py
@@ -36,6 +36,77 @@ class ProductManagerService:
         ]
 
     @staticmethod
+    def _serialize_manager_product(
+        product: Product,
+        supply_metrics: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "id": product.id,
+            "brand_id": product.brand_id,
+            "series_id": product.series_id,
+            "title": product.title,
+            "slug": product.slug,
+            "price": product.price,
+            "old_price": product.old_price,
+            "area": product.area,
+            "is_inverter": product.is_inverter,
+            "power_cooling": product.power_cooling,
+            "main_image": product.main_image,
+            "is_published": product.is_published,
+            "created_at": product.created_at.isoformat() if product.created_at else None,
+            "specs": sanitize_specs(product.specs),
+            "gallery_images": [
+                {
+                    "id": image.id,
+                    "url": image.url,
+                    "is_installation_photo": image.is_installation_photo,
+                }
+                for image in (product.gallery_images or [])
+            ],
+            "manuals": ProductManagerService._serialize_manuals(product),
+            "tags": [
+                {
+                    "id": tag.id,
+                    "title": tag.title,
+                    "slug": tag.slug,
+                    "group_title": tag.group.title if tag.group else None,
+                    "group_color": tag.group.color if tag.group else "secondary",
+                }
+                for tag in (product.tags or [])
+            ],
+            "min_cost_byn": supply_metrics.get("min_cost_byn"),
+            "recommended_price_byn": supply_metrics.get("recommended_price_byn"),
+            "margin_abs_preview": supply_metrics.get("margin_abs_preview"),
+            "margin_pct_preview": supply_metrics.get("margin_pct_preview"),
+            "vitebsk_qty": supply_metrics.get("vitebsk_qty", 0),
+            "minsk_qty": supply_metrics.get("minsk_qty", 0),
+            "availability_status": supply_metrics.get("availability_status", "out_of_stock"),
+        }
+
+    @staticmethod
+    async def get_manager_product(
+        session: AsyncSession,
+        product_id: int,
+    ) -> Optional[Dict[str, Any]]:
+        result = await session.execute(
+            select(Product)
+            .options(
+                selectinload(Product.tags).selectinload(Tag.group),
+                selectinload(Product.gallery_images),
+                selectinload(Product.attachments),
+            )
+            .where(Product.id == product_id)
+        )
+        product = result.scalars().first()
+        if not product:
+            return None
+        supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, [product])
+        return ProductManagerService._serialize_manager_product(
+            product,
+            supply_metrics.get(product.id, {}),
+        )
+
+    @staticmethod
     async def smart_search(
         session: AsyncSession,
         q: str,
@@ -191,52 +262,13 @@ class ProductManagerService:
         )
         supply_metrics = await ProductSupplyMetricsService.compute_for_products(session, list(items))
 
-        formatted_items = []
-        for p in items:
-            formatted_items.append(
-                {
-                    "id": p.id,
-                    "brand_id": p.brand_id,
-                    "series_id": p.series_id,
-                    "title": p.title,
-                    "slug": p.slug,
-                    "price": p.price,
-                    "old_price": p.old_price,
-                    "area": p.area,
-                    "is_inverter": p.is_inverter,
-                    "power_cooling": p.power_cooling,
-                    "main_image": p.main_image,
-                    "is_published": p.is_published,
-                    "created_at": p.created_at.isoformat() if p.created_at else None,
-                    "specs": sanitize_specs(p.specs),
-                    "gallery_images": [
-                        {
-                            "id": img.id,
-                            "url": img.url,
-                            "is_installation_photo": img.is_installation_photo,
-                        }
-                        for img in (p.gallery_images or [])
-                    ],
-                    "manuals": ProductManagerService._serialize_manuals(p),
-                    "tags": [
-                        {
-                            "id": t.id,
-                            "title": t.title,
-                            "slug": t.slug,
-                            "group_title": t.group.title if t.group else None,
-                            "group_color": t.group.color if t.group else "secondary",
-                        }
-                        for t in (p.tags or [])
-                    ],
-                    "min_cost_byn": supply_metrics.get(p.id, {}).get("min_cost_byn"),
-                    "recommended_price_byn": supply_metrics.get(p.id, {}).get("recommended_price_byn"),
-                    "margin_abs_preview": supply_metrics.get(p.id, {}).get("margin_abs_preview"),
-                    "margin_pct_preview": supply_metrics.get(p.id, {}).get("margin_pct_preview"),
-                    "vitebsk_qty": supply_metrics.get(p.id, {}).get("vitebsk_qty", 0),
-                    "minsk_qty": supply_metrics.get(p.id, {}).get("minsk_qty", 0),
-                    "availability_status": supply_metrics.get(p.id, {}).get("availability_status", "out_of_stock"),
-                }
+        formatted_items = [
+            ProductManagerService._serialize_manager_product(
+                product,
+                supply_metrics.get(product.id, {}),
             )
+            for product in items
+        ]
 
         return {
             "items": formatted_items,

--- a/tests/integration/test_manager_products_visibility_api.py
+++ b/tests/integration/test_manager_products_visibility_api.py
@@ -39,3 +39,41 @@ async def test_manager_products_list_can_show_unpublished_product(async_client, 
     items = response.json()["items"]
     match = next(item for item in items if item["id"] == product.id)
     assert match["is_published"] is False
+
+
+@pytest.mark.asyncio
+async def test_manager_product_detail_can_open_unpublished_product(async_client, db):
+    headers = await _auth_headers(async_client)
+    product = Product(
+        title="Workspace Draft Product",
+        slug="workspace-draft-product",
+        price=1250,
+        area=32,
+        is_published=False,
+    )
+    db.add(product)
+    await db.commit()
+    await db.refresh(product)
+
+    response = await async_client.get(
+        f"/api/manager/products/{product.id}",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["id"] == product.id
+    assert payload["title"] == "Workspace Draft Product"
+    assert payload["is_published"] is False
+
+
+@pytest.mark.asyncio
+async def test_manager_product_detail_returns_not_found(async_client):
+    headers = await _auth_headers(async_client)
+
+    response = await async_client.get(
+        "/api/manager/products/99999999",
+        headers=headers,
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- add a full-page manager workspace for products with readable section URLs
- reuse the existing product editor and quick media workflow instead of creating parallel forms
- preserve product-list filters, page, ordering, scroll position, and previous/next navigation
- add an authenticated product detail endpoint that also supports unpublished products
- keep the shared media editor usable on mobile and return users to the product workspace

## Verification

- `SECRET_KEY=test ADMIN_USERNAME=admin ADMIN_PASSWORD=admin pytest tests/unit/test_manager_operation_ids_contract.py tests/integration/test_manager_products_visibility_api.py -q`
- `node scripts/run-ui-logic-tests.mjs`
- `node node_modules/vue-tsc/index.js -b`
- `node node_modules/vite/bin/vite.js build`
- `bash scripts/audit_theme_hardcodes.sh`
- mobile browser QA at 390 x 844 for workspace, media editor, and return navigation

## Scope

This is the first product-workspace phase. It deliberately reuses current APIs and workflows. Attribute inheritance, image roles, provenance/history, and deeper supplier mapping remain separate data-model phases.
