### PR TITLE
Cut catalog synchronization over to standalone web

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,15 @@ WEBSITE_URL=http://localhost:4321
 # Public storefront base URL used by backend catalog freshness purges.
 PUBLIC_SITE_URL=https://mvn.by
 
+# --- Standalone storefront catalog synchronization ---
+# Use a narrowly scoped token with Actions access to the private mvn-web repo.
+GITHUB_TOKEN=
+WEB_REBUILD_GITHUB_OWNER=mvnby
+WEB_REBUILD_GITHUB_REPO=mvn-web
+WEB_REBUILD_GITHUB_REF=main
+# Must match the WEB_REBUILD_CALLBACK_TOKEN secret in mvnby/mvn-web.
+WEB_REBUILD_CALLBACK_TOKEN=
+
 # --- Cloudflare catalog cache purge ---
 # Safe defaults: disabled + dry-run, even if credentials are present.
 CLOUDFLARE_PURGE_ENABLED=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,6 @@ on:
     types:
       - completed
   workflow_dispatch:
-    inputs:
-      deploy_frontend:
-        description: "Run frontend deployment after backend"
-        type: boolean
-        required: false
-        default: false
 
 concurrency:
   group: production-release
@@ -30,7 +24,7 @@ env:
 
 jobs:
   # ======================================================
-  # 0. RELEASE GATE AND FRONTEND CHANGE DETECTION
+  # 0. RELEASE GATE
   # ======================================================
   release-gate:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
@@ -86,87 +80,6 @@ jobs:
             echo "- event: ${{ github.event_name }}"
             echo "- tested_sha: ${deploy_sha}"
             echo "- result: passed"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  detect-frontend-changes:
-    needs: release-gate
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      web_changed: ${{ steps.detect.outputs.web_changed }}
-      reason: ${{ steps.detect.outputs.reason }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ needs.release-gate.outputs.deploy_sha }}
-          fetch-depth: 0
-
-      - name: Detect storefront-relevant changes
-        id: detect
-        run: |
-          set -euo pipefail
-
-          web_changed=false
-          reason="no storefront-relevant changes detected"
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ github.event.inputs.deploy_frontend }}" = "true" ]; then
-              web_changed=true
-              reason="manual dispatch requested deploy_frontend=true"
-            else
-              reason="manual dispatch did not request frontend deploy"
-            fi
-          else
-            after="${{ needs.release-gate.outputs.deploy_sha }}"
-            deployed_web_sha="$(
-              curl -fsS --retry 3 --retry-delay 2 \
-                -H 'Cache-Control: no-cache' \
-                "https://mvn.by/release.json?ci_run=${GITHUB_RUN_ID}" 2>/dev/null \
-                | jq -r '.sha // empty' 2>/dev/null \
-                || true
-            )"
-            if [[ "${deployed_web_sha}" =~ ^[0-9a-f]{40}$ ]] \
-              && git cat-file -e "${deployed_web_sha}^{commit}" 2>/dev/null \
-              && git merge-base --is-ancestor "${deployed_web_sha}" "${after}"; then
-              if git diff --name-only "${deployed_web_sha}" "${after}" | grep -E '^(web/|\.github/workflows/(deploy|deploy-web|rebuild-web|check-web-ssh)\.yml$|scripts/(check_web_dist\.py|deploy_cloudflare_pages\.sh|deploy_web_atomic\.sh|promote_web_release\.sh)$)' >/dev/null; then
-                web_changed=true
-                reason="storefront-relevant files changed since deployed web SHA"
-              else
-                reason="no storefront-relevant changes since deployed web SHA"
-              fi
-            else
-              web_changed=true
-              reason="deployed web SHA is unavailable or not an ancestor; deploying frontend conservatively"
-            fi
-          fi
-
-          echo "web_changed=${web_changed}" >> "$GITHUB_OUTPUT"
-          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
-
-          {
-            echo "## Frontend Deploy Decision"
-            echo "- web_changed: ${web_changed}"
-            echo "- reason: ${reason}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  frontend-deploy-decision:
-    runs-on: ubuntu-latest
-    needs: detect-frontend-changes
-    steps:
-      - name: Report frontend deploy decision
-        run: |
-          {
-            echo "## Frontend Deploy Decision"
-            echo "- web_changed: ${{ needs.detect-frontend-changes.outputs.web_changed }}"
-            echo "- reason: ${{ needs.detect-frontend-changes.outputs.reason }}"
-            if [ "${{ needs.detect-frontend-changes.outputs.web_changed }}" != "true" ]; then
-              echo "- result: deploy-frontend will be skipped; backend deploy can still make this workflow green"
-            else
-              echo "- result: deploy-frontend is eligible to run after backend deploy"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ======================================================
@@ -620,20 +533,4 @@ jobs:
     with:
       deploy_sha: ${{ needs.release-gate.outputs.deploy_sha }}
       backend_image: ${{ needs.backend-release.outputs.backend_image }}
-    secrets: inherit
-
-  # Web release is isolated in one reusable workflow so automatic releases and
-  # manual catalog rebuilds use the same immutable artifact and promotion path.
-  deploy-frontend:
-    if: ${{ always() && needs.backend-release.result == 'success' && needs.detect-frontend-changes.result == 'success' && needs.release-gate.result == 'success' && needs.detect-frontend-changes.outputs.web_changed == 'true' }}
-    needs:
-      - backend-release
-      - detect-frontend-changes
-      - release-gate
-    permissions:
-      contents: read
-      deployments: write
-    uses: ./.github/workflows/deploy-web.yml
-    with:
-      deploy_sha: ${{ needs.release-gate.outputs.deploy_sha }}
     secrets: inherit

--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -1,112 +1,13 @@
-name: Turbo Rebuild Web
+name: Legacy Web Publisher Disabled
 
 on:
   workflow_dispatch:
-    inputs:
-      catalog_revision:
-        description: Catalog revision that should be marked published after deploy
-        required: false
-        type: string
-
-concurrency:
-  group: production-release
-  cancel-in-progress: false
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  main-branch-guard:
+  retired:
     runs-on: ubuntu-latest
     steps:
-      - name: Require main branch
+      - name: Refuse legacy storefront publication
         run: |
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "::error::Production web rebuilds are allowed only from main"
-            exit 1
-          fi
-
-  rebuild:
-    needs: main-branch-guard
-    permissions:
-      contents: read
-      deployments: write
-    uses: ./.github/workflows/deploy-web.yml
-    with:
-      deploy_sha: ${{ github.sha }}
-    secrets: inherit
-
-  callback:
-    if: ${{ always() }}
-    needs:
-      - main-branch-guard
-      - rebuild
-    runs-on: ubuntu-latest
-    steps:
-      - name: Report catalog rebuild result
-        env:
-          CATALOG_REVISION: ${{ inputs.catalog_revision }}
-          REBUILD_RESULT: ${{ needs.rebuild.result }}
-          GUARD_RESULT: ${{ needs.main-branch-guard.result }}
-          WEB_REBUILD_CALLBACK_TOKEN: ${{ secrets.WEB_REBUILD_CALLBACK_TOKEN }}
-          WEB_REBUILD_CALLBACK_URL: ${{ vars.WEB_REBUILD_CALLBACK_URL }}
-          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
-          SSH_USER_API: ${{ secrets.SSH_USER_API }}
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${WEB_REBUILD_CALLBACK_TOKEN:-}" ]; then
-            echo "No callback token configured; skipping API callback."
-            exit 0
-          fi
-
-          catalog_revision="${CATALOG_REVISION:-0}"
-          if [[ ! "${catalog_revision}" =~ ^[0-9]+$ ]]; then
-            echo "::warning::Invalid catalog_revision; reporting revision 0"
-            catalog_revision=0
-          fi
-          callback_url="${WEB_REBUILD_CALLBACK_URL:-https://api.mvn.by/api/system/rebuild-web/complete}"
-          if [ "${GUARD_RESULT}" = "success" ] && [ "${REBUILD_RESULT}" = "success" ]; then
-            payload="{\"catalog_revision\":${catalog_revision},\"status\":\"success\"}"
-          else
-            payload="{\"catalog_revision\":${catalog_revision},\"status\":\"failed\",\"error\":\"GitHub Actions rebuild-web failed\"}"
-          fi
-
-          mkdir -p ~/.ssh
-          printf '%s\n' "${SSH_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          : > ~/.ssh/known_hosts
-          scanned=false
-          for attempt in 1 2 3 4 5; do
-            if ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts 2>/dev/null; then
-              scanned=true
-              break
-            fi
-            sleep $((attempt * 3))
-          done
-          if [ "${scanned}" != "true" ]; then
-            echo "::warning::Could not obtain API SSH host key for web rebuild callback."
-            exit 0
-          fi
-
-          callback_sent=false
-          for attempt in 1 2 3 4 5; do
-            if printf '%s\n%s\n%s\n' \
-              "${WEB_REBUILD_CALLBACK_TOKEN}" "${payload}" "${callback_url}" \
-              | ssh \
-                -i ~/.ssh/deploy_key \
-                -o BatchMode=yes \
-                -o StrictHostKeyChecking=yes \
-                -o ConnectTimeout=20 \
-                -o ServerAliveInterval=15 \
-                -o ServerAliveCountMax=3 \
-                "${SSH_USER_API}@${SSH_HOST_API}" \
-                'IFS= read -r callback_token; IFS= read -r payload; IFS= read -r callback_url; curl -fsS -X POST "${callback_url}" -H "Content-Type: application/json" -H "X-Web-Rebuild-Token: ${callback_token}" --data "${payload}"'; then
-              callback_sent=true
-              break
-            fi
-            sleep $((attempt * 5))
-          done
-          if [ "${callback_sent}" != "true" ]; then
-            echo "::warning::Web rebuild callback failed."
-          fi
+          echo "::error::The monolith storefront publisher is retired. Catalog sync belongs to mvnby/mvn-web."
+          exit 1

--- a/core/config.py
+++ b/core/config.py
@@ -350,6 +350,9 @@ class Settings(BaseSettings):
     GITHUB_TOKEN: str = ""
     GITHUB_OWNER: str = "mvnby"
     GITHUB_REPO: str = "air-api"
+    WEB_REBUILD_GITHUB_OWNER: str = "mvnby"
+    WEB_REBUILD_GITHUB_REPO: str = "mvn-web"
+    WEB_REBUILD_GITHUB_REF: str = "main"
     WEB_REBUILD_CALLBACK_TOKEN: str = ""
 
     # Destructive restore is intentionally disabled by default. Enabling this

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -582,7 +582,7 @@ Switch back to the repo-tracked files after the emergency is resolved.
 Manual deploy verification:
 
 ```bash
-gh workflow run deploy.yml --repo mvnby/air-api --ref main -f deploy_frontend=false
+gh workflow run deploy.yml --repo mvnby/air-api --ref main
 ```
 
 The command is accepted only for `main` commits that already have a successful

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -345,11 +345,10 @@ The workflow requires these env vars in the build step:
    guarded Patroni cutover, role-aware mode probes both nodes, migrates only on
    the current primary, updates the fenced replica, then blue-greens the primary.
 3. **backend-release:** Requires exactly one physical or Patroni deployment path
-   to succeed before the web release may continue.
-4. **deploy-frontend:** When web files changed (or manual rebuild was requested),
-   builds Astro once, validates the static artifact and release marker, deploys
-   a Cloudflare Pages canary, atomically promotes the same artifact on the VPS,
-   and finally promotes it to the Pages production branch.
+   to succeed. It never publishes storefront files.
+4. **standalone storefront:** `mvnby/mvn-web` owns its immutable SSR image,
+   shadow deployment, catalog synchronization, and public cutover. The last
+   atomic static release remains available as an nginx rollback target.
 
 The three GitHub environments are deployment audit boundaries. They contain no
 new secrets by default; existing repository secrets remain the credential source.
@@ -415,11 +414,17 @@ image automatically if the post-activation Google durability probe fails.
 The old `deploy_api.sh` source-bind path is intentionally retired. Production
 changes must use the CI-tested immutable-image workflow.
 
-### Web Release Safety
+### Legacy Web Release Safety
 
-Both automatic releases and `rebuild-web.yml` call
-`.github/workflows/deploy-web.yml`. They share the `production-release`
-concurrency group, so a catalog rebuild cannot race a normal production release.
+The monolith publisher is retired: `.github/workflows/deploy.yml` has no
+storefront job and `.github/workflows/rebuild-web.yml` fails closed. The old
+`.github/workflows/deploy-web.yml` and atomic release scripts are retained only
+for audited rollback history while the standalone SSR cutover is observed.
+
+Active storefront deployment and catalog revision verification live in the
+private `mvnby/mvn-web` repository. The API dispatch target is controlled by
+`WEB_REBUILD_GITHUB_OWNER`, `WEB_REBUILD_GITHUB_REPO`, and
+`WEB_REBUILD_GITHUB_REF`.
 
 Required GitHub secrets:
 

--- a/docs/web-service-extraction.md
+++ b/docs/web-service-extraction.md
@@ -28,13 +28,16 @@ The only runtime connection is HTTP through `INTERNAL_API_URL` and
 web commit SHA and a catalog revision, but it must not receive database or bot
 credentials.
 
-## Current coupling to remove
+## Current production contract
 
-1. Web deployment workflows and release scripts live in the API repository.
-2. `SystemService` dispatches `rebuild-web.yml` in the API repository.
-3. The web rebuild callback and deployment secrets are configured for that
-   workflow location.
-4. Root Docker Compose files still describe the storefront runtime.
+1. `SystemService` dispatches `rebuild-web.yml` in the private
+   `mvnby/mvn-web` repository with the requested catalog revision.
+2. The standalone workflow verifies that the SSR runtime has reached that
+   revision and reports the existing signed callback.
+3. The API production workflow cannot call the legacy static storefront
+   publisher, and the monolith `rebuild-web.yml` fails closed.
+4. The last atomic static release remains on the web VPS only as the immediate
+   nginx rollback target until the public SSR cutover is proven.
 
 The local `web` scripts are now self-contained and `npm run audit:boundary`
 prevents source imports, package scripts, and sensitive runtime configuration
@@ -60,7 +63,7 @@ No traffic or production configuration changes in this phase.
 
 The monolith remains the production source during comparison.
 
-### 3. Decouple catalog rebuild dispatch
+### 3. Decouple catalog rebuild dispatch (complete)
 
 - Configure the API with explicit web repository owner, name, workflow, and
   branch settings.
@@ -69,7 +72,7 @@ The monolith remains the production source during comparison.
 - Preserve the signed callback to `/api/system/rebuild-web/complete`.
 - Prove success, failure, retry, and duplicate-dispatch behavior.
 
-### 4. Shadow deployment
+### 4. Shadow deployment (complete)
 
 - Deploy `mvn-web` to a separate Cloudflare preview and SSR shadow runtime.
 - Compare catalog totals, canonical URLs, sitemaps, key product pages, asset

--- a/manager_frontend/src/client/services/SystemService.ts
+++ b/manager_frontend/src/client/services/SystemService.ts
@@ -11,7 +11,7 @@ import { request as __request } from '../core/request';
 export class SystemService {
     /**
      * Get Rebuild Web Status
-     * Return whether the static Astro storefront is behind catalog data.
+     * Return whether the storefront has acknowledged the latest catalog revision.
      * @returns WebRebuildStatusResponse Successful Response
      * @throws ApiError
      */
@@ -23,7 +23,7 @@ export class SystemService {
     }
     /**
      * Trigger Rebuild Web
-     * Trigger a turbo-rebuild of the frontend Astro site.
+     * Trigger catalog revision verification in the standalone storefront runtime.
      * Accessible only by authenticated managers/admins.
      * @returns WebRebuildTriggerResponse Successful Response
      * @throws ApiError
@@ -36,7 +36,7 @@ export class SystemService {
     }
     /**
      * Complete Rebuild Web
-     * Callback for GitHub Actions after the static storefront deploy completes.
+     * Signed callback after the standalone storefront verifies catalog freshness.
      * @param requestBody
      * @param xWebRebuildToken
      * @returns WebRebuildStatusResponse Successful Response

--- a/openapi.json
+++ b/openapi.json
@@ -19405,7 +19405,7 @@
           "system"
         ],
         "summary": "Get Rebuild Web Status",
-        "description": "Return whether the static Astro storefront is behind catalog data.",
+        "description": "Return whether the storefront has acknowledged the latest catalog revision.",
         "operationId": "get_rebuild_web_status_api_system_rebuild_web_status_get",
         "responses": {
           "200": {
@@ -19432,7 +19432,7 @@
           "system"
         ],
         "summary": "Trigger Rebuild Web",
-        "description": "Trigger a turbo-rebuild of the frontend Astro site.\nAccessible only by authenticated managers/admins.",
+        "description": "Trigger catalog revision verification in the standalone storefront runtime.\nAccessible only by authenticated managers/admins.",
         "operationId": "trigger_rebuild_web_api_system_rebuild_web_post",
         "responses": {
           "200": {
@@ -19459,7 +19459,7 @@
           "system"
         ],
         "summary": "Complete Rebuild Web",
-        "description": "Callback for GitHub Actions after the static storefront deploy completes.",
+        "description": "Signed callback after the standalone storefront verifies catalog freshness.",
         "operationId": "complete_rebuild_web_api_system_rebuild_web_complete_post",
         "parameters": [
           {

--- a/routers/system.py
+++ b/routers/system.py
@@ -22,7 +22,7 @@ async def get_rebuild_web_status(
     session: AsyncSession = Depends(get_session),
 ):
     """
-    Return whether the static Astro storefront is behind catalog data.
+    Return whether the storefront has acknowledged the latest catalog revision.
     """
     logger.debug("User %s checked web rebuild status.", username)
     return await CatalogRevisionService.get_static_rebuild_status(session)
@@ -34,7 +34,7 @@ async def trigger_rebuild_web(
     session: AsyncSession = Depends(get_session),
 ):
     """
-    Trigger a turbo-rebuild of the frontend Astro site.
+    Trigger catalog revision verification in the standalone storefront runtime.
     Accessible only by authenticated managers/admins.
     """
     status = await CatalogRevisionService.get_static_rebuild_status(session)
@@ -70,7 +70,7 @@ async def trigger_rebuild_web(
 
     return {
         **status,
-        "message": "Rebuild triggered successfully. The site will be updated in ~2 minutes.",
+        "message": "Storefront catalog synchronization started.",
     }
 
 
@@ -81,7 +81,7 @@ async def complete_rebuild_web(
     session: AsyncSession = Depends(get_session),
 ):
     """
-    Callback for GitHub Actions after the static storefront deploy completes.
+    Signed callback after the standalone storefront verifies catalog freshness.
     """
     if not settings.WEB_REBUILD_CALLBACK_TOKEN:
         raise HTTPException(status_code=503, detail="Web rebuild callback token is not configured")

--- a/services/system_service.py
+++ b/services/system_service.py
@@ -6,15 +6,16 @@ class SystemService:
     @staticmethod
     async def trigger_web_rebuild(catalog_revision: int | None = None) -> dict:
         """
-        Triggers the 'rebuild-web.yml' workflow in GitHub Actions.
-        Requires GITHUB_TOKEN to be set in .env.
+        Ask the standalone storefront to verify the requested catalog revision.
+        Requires GITHUB_TOKEN with Actions access to the private web repository.
         """
         if not settings.GITHUB_TOKEN:
             logger.error("GITHUB_TOKEN is not set. Cannot trigger rebuild.")
             return {"success": False, "error": "GITHUB_TOKEN_MISSING"}
 
-        owner = settings.GITHUB_OWNER
-        repo = settings.GITHUB_REPO
+        owner = settings.WEB_REBUILD_GITHUB_OWNER
+        repo = settings.WEB_REBUILD_GITHUB_REPO
+        ref = settings.WEB_REBUILD_GITHUB_REF
         workflow_id = "rebuild-web.yml"
         
         url = f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"
@@ -26,18 +27,18 @@ class SystemService:
         }
         
         payload: dict[str, object] = {
-            "ref": "main"  # Build from main branch
+            "ref": ref,
         }
         if catalog_revision is not None:
             payload["inputs"] = {"catalog_revision": str(max(0, int(catalog_revision)))}
         
         async with httpx.AsyncClient() as client:
             try:
-                logger.info(f"Triggering GitHub rebuild for {owner}/{repo}...")
+                logger.info("Triggering storefront catalog sync for %s/%s at %s.", owner, repo, ref)
                 response = await client.post(url, headers=headers, json=payload, timeout=10.0)
                 
                 if response.status_code == 204:
-                    logger.info("Successfully triggered rebuild-web workflow.")
+                    logger.info("Successfully triggered storefront catalog sync workflow.")
                     return {"success": True}
                 else:
                     try:

--- a/tests/unit/test_deploy_web_workflow.py
+++ b/tests/unit/test_deploy_web_workflow.py
@@ -47,27 +47,19 @@ def test_reusable_web_release_promotes_one_immutable_artifact_in_safe_order():
     assert "CLOUDFLARE_PAGES_PROJECT='${CLOUDFLARE_PAGES_PROJECT}' bash -s" in stable_smoke
 
 
-def test_release_and_manual_rebuild_call_the_same_web_workflow():
+def test_legacy_web_publishers_are_disconnected_from_active_workflows():
     deploy = _workflow(".github/workflows/deploy.yml")
     rebuild = _workflow(".github/workflows/rebuild-web.yml")
-    automatic = deploy["jobs"]["deploy-frontend"]
-    manual = rebuild["jobs"]["rebuild"]
+    retired = _step(rebuild["jobs"]["retired"], "Refuse legacy storefront publication")["run"]
 
-    assert automatic["uses"] == "./.github/workflows/deploy-web.yml"
-    assert automatic["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
-    assert manual["uses"] == "./.github/workflows/deploy-web.yml"
-    assert manual["with"]["deploy_sha"] == "${{ github.sha }}"
-    assert manual["needs"] == "main-branch-guard"
-    assert rebuild["jobs"]["callback"]["if"] == "${{ always() }}"
-    callback = _step(rebuild["jobs"]["callback"], "Report catalog rebuild result")["run"]
-    assert "for attempt in 1 2 3 4 5" in callback
-    assert 'printf \'%s\\n%s\\n%s\\n\'' in callback
-    assert "| ssh \\" in callback
-    assert '"${SSH_USER_API}@${SSH_HOST_API}"' in callback
-    assert "X-Web-Rebuild-Token: ${callback_token}" in callback
+    assert "deploy-frontend" not in deploy["jobs"]
+    assert "detect-frontend-changes" not in deploy["jobs"]
+    assert "mvnby/mvn-web" in retired
+    assert "exit 1" in retired
 
     workflow_text = "\n".join(
         (REPO_ROOT / path).read_text(encoding="utf-8")
         for path in (".github/workflows/deploy.yml", ".github/workflows/rebuild-web.yml")
     )
+    assert "uses: ./.github/workflows/deploy-web.yml" not in workflow_text
     assert "rsync -avz --delete" not in workflow_text

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -94,23 +94,8 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert standby_call["with"]["backend_image"] == "${{ needs.backend-release.outputs.backend_image }}"
     assert standby_call["secrets"] == "inherit"
 
-    web_workflow = _workflow(".github/workflows/deploy-web.yml")
-    web_job = web_workflow["jobs"]["production-web"]
-    assert web_job["environment"] == "production-web"
-    web_checkout = next(
-        step
-        for step in web_job["steps"]
-        if step.get("uses")
-        == "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
-    )
-    assert web_checkout["with"]["ref"] == "${{ inputs.deploy_sha }}"
-    web_call = jobs["deploy-frontend"]
-    assert web_call["uses"] == "./.github/workflows/deploy-web.yml"
-    assert "always()" in web_call["if"]
-    assert "needs.backend-release.result == 'success'" in web_call["if"]
-    assert web_call["with"]["deploy_sha"] == "${{ needs.release-gate.outputs.deploy_sha }}"
-    assert web_call["secrets"] == "inherit"
-    assert "backend-release" in web_call["needs"]
+    assert "deploy-frontend" not in jobs
+    assert "detect-frontend-changes" not in jobs
 
     workflow_text = (REPO_ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
     assert "backend:latest" not in workflow_text
@@ -121,16 +106,14 @@ def test_release_jobs_use_immutable_tested_sha_and_protected_environments():
     assert 'reference="ghcr.io/${{ steps.prep.outputs.repo }}/backend@${digest}"' in workflow_text
 
 
-def test_frontend_detection_compares_against_the_deployed_release_sha():
+def test_backend_release_cannot_publish_the_legacy_storefront():
     workflow = _workflow(".github/workflows/deploy.yml")
-    detect = _step(workflow["jobs"]["detect-frontend-changes"], "Detect storefront-relevant changes")[
-        "run"
-    ]
+    workflow_text = (REPO_ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
 
-    assert "https://mvn.by/release.json?ci_run=${GITHUB_RUN_ID}" in detect
-    assert 'git merge-base --is-ancestor "${deployed_web_sha}" "${after}"' in detect
-    assert 'git diff --name-only "${deployed_web_sha}" "${after}"' in detect
-    assert "deploying frontend conservatively" in detect
+    assert "deploy-frontend" not in workflow["jobs"]
+    assert "detect-frontend-changes" not in workflow["jobs"]
+    assert "deploy_frontend" not in workflow_text
+    assert "./.github/workflows/deploy-web.yml" not in workflow_text
 
 
 def test_backend_release_is_scoped_and_has_guarded_rollback():

--- a/tests/unit/test_system_service.py
+++ b/tests/unit/test_system_service.py
@@ -27,8 +27,9 @@ async def test_trigger_web_rebuild_sends_catalog_revision_input(monkeypatch):
             return DummyResponse()
 
     monkeypatch.setattr(system_service_module.settings, "GITHUB_TOKEN", "token")
-    monkeypatch.setattr(system_service_module.settings, "GITHUB_OWNER", "owner")
-    monkeypatch.setattr(system_service_module.settings, "GITHUB_REPO", "repo")
+    monkeypatch.setattr(system_service_module.settings, "WEB_REBUILD_GITHUB_OWNER", "owner")
+    monkeypatch.setattr(system_service_module.settings, "WEB_REBUILD_GITHUB_REPO", "repo")
+    monkeypatch.setattr(system_service_module.settings, "WEB_REBUILD_GITHUB_REF", "stable")
     monkeypatch.setattr(system_service_module.httpx, "AsyncClient", lambda: DummyAsyncClient())
 
     result = await SystemService.trigger_web_rebuild(catalog_revision=17)
@@ -38,7 +39,7 @@ async def test_trigger_web_rebuild_sends_catalog_revision_input(monkeypatch):
         "https://api.github.com/repos/owner/repo/actions/workflows/rebuild-web.yml/dispatches"
     )
     assert captured["json"] == {
-        "ref": "main",
+        "ref": "stable",
         "inputs": {"catalog_revision": "17"},
     }
     assert captured["timeout"] == 10.0


### PR DESCRIPTION
## Summary
- dispatch catalog synchronization to the private standalone mvn-web repository
- retain the signed status callback contract and update manager-facing wording
- remove the frontend publish job from the API production release
- make the legacy monolith rebuild workflow fail closed
- document the standalone ownership and static rollback boundary

## Verification
- full unit suite: 2201 passed, 4 skipped
- focused catalog revision and workflow tests: 18 passed
- production GitHub token can read the private mvn-web workflow: HTTP 200
- standalone failure callback drill: expected verification failure plus successful signed callback
- standalone success callback drill: runtime revision 323 verified, signed callback succeeded, state fresh and last_error cleared
- protected canary and rollback rehearsal already green
