### PR TITLE
ops: add reversible Cloudflare web cutover

### DIFF
--- a/.github/workflows/cutover-web-origin.yml
+++ b/.github/workflows/cutover-web-origin.yml
@@ -1,0 +1,104 @@
+name: Cut Over Web Origin
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Audit only, cut over Pages to SSR, or roll back to Pages"
+        required: true
+        type: choice
+        options:
+          - audit
+          - cutover
+          - rollback
+        default: audit
+      confirmation:
+        description: "For cutover enter 153.80.244.78; for rollback enter mvn-by"
+        required: false
+        type: string
+        default: ""
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+  CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'mvn-by' }}
+  WEB_ORIGIN_IP: "153.80.244.78"
+
+jobs:
+  web-origin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production-web
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Verify SSR origin before cutover
+        if: ${{ inputs.operation == 'cutover' }}
+        run: |
+          set -euo pipefail
+          headers="$(mktemp)"
+          trap 'rm -f "${headers}"' EXIT
+          curl --fail --silent --show-error --max-time 30 \
+            --resolve "mvn.by:443:${WEB_ORIGIN_IP}" \
+            --dump-header "${headers}" --output /dev/null \
+            https://mvn.by/catalog/
+          grep -Eiq '^x-catalog-revision: [0-9]+' "${headers}"
+          grep -Eiq '^x-web-data-cache: (hit|miss|shared)$' "${headers}"
+
+      - name: Audit or switch Cloudflare web routing
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_PAGES }}
+        run: |
+          set -euo pipefail
+          python3 scripts/cutover_cloudflare_web_origin.py \
+            "${{ inputs.operation }}" \
+            --confirm "${{ inputs.confirmation }}" \
+            | tee cloudflare-web-origin.log
+
+      - name: Verify public SSR after cutover
+        if: ${{ inputs.operation == 'cutover' }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            headers="$(mktemp)"
+            if curl --fail --silent --show-error --max-time 30 \
+              --dump-header "${headers}" --output /dev/null \
+              https://mvn.by/catalog/ \
+              && grep -Eiq '^x-catalog-revision: [0-9]+' "${headers}" \
+              && grep -Eiq '^x-web-data-cache: (hit|miss|shared)$' "${headers}"; then
+              rm -f "${headers}"
+              exit 0
+            fi
+            rm -f "${headers}"
+            sleep 5
+          done
+          echo "::error::Public mvn.by did not converge to the SSR origin"
+          exit 1
+
+      - name: Verify public Pages after rollback
+        if: ${{ inputs.operation == 'rollback' }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error --max-time 30 \
+              https://mvn.by/release.json | grep -Eq '"sha":"[0-9a-f]{40}"'; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Public mvn.by did not converge to Cloudflare Pages"
+          exit 1
+
+      - name: Upload routing audit
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6f58ed0dc250532a479d7789f # v6
+        with:
+          name: cloudflare-web-origin-${{ github.run_id }}
+          path: cloudflare-web-origin.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -426,6 +426,15 @@ private `mvnby/mvn-web` repository. The API dispatch target is controlled by
 `WEB_REBUILD_GITHUB_OWNER`, `WEB_REBUILD_GITHUB_REPO`, and
 `WEB_REBUILD_GITHUB_REF`.
 
+The final Cloudflare routing change is owned by
+`.github/workflows/cutover-web-origin.yml`. Its default `audit` mode is
+read-only. `cutover` first proves DNS write permission with a temporary TXT
+record, verifies the direct SSR origin, detaches only `mvn.by` and `www.mvn.by`
+from the `mvn-by` Pages project, and creates proxied A records for
+`153.80.244.78`. `rollback` removes only those exact origin records and restores
+the Pages custom domains. Both mutating modes require the explicit target value
+shown by the workflow input.
+
 Required GitHub secrets:
 
 ```text

--- a/scripts/cutover_cloudflare_web_origin.py
+++ b/scripts/cutover_cloudflare_web_origin.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Move mvn.by between Cloudflare Pages and the audited SSR origin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+API_BASE = "https://api.cloudflare.com/client/v4"
+DEFAULT_DOMAINS = ("mvn.by", "www.mvn.by")
+
+
+class CloudflareError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Config:
+    token: str
+    account_id: str
+    zone_id: str
+    project: str
+    origin_ip: str
+    domains: tuple[str, ...] = DEFAULT_DOMAINS
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        values = {
+            "token": os.getenv("CLOUDFLARE_API_TOKEN", "").strip(),
+            "account_id": os.getenv("CLOUDFLARE_ACCOUNT_ID", "").strip(),
+            "zone_id": os.getenv("CLOUDFLARE_ZONE_ID", "").strip(),
+            "project": os.getenv("CLOUDFLARE_PAGES_PROJECT", "mvn-by").strip(),
+            "origin_ip": os.getenv("WEB_ORIGIN_IP", "153.80.244.78").strip(),
+        }
+        missing = [name for name, value in values.items() if not value]
+        if missing:
+            raise CloudflareError(f"missing configuration: {', '.join(missing)}")
+        return cls(**values)
+
+
+class CloudflareClient:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        body = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"{API_BASE}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.config.token}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                envelope = json.load(response)
+        except urllib.error.HTTPError as exc:
+            try:
+                envelope = json.load(exc)
+            except (ValueError, TypeError):
+                envelope = {"errors": [{"message": str(exc)}]}
+            raise CloudflareError(
+                f"Cloudflare {method} {path} failed ({exc.code}): "
+                f"{_error_messages(envelope)}"
+            ) from exc
+        if not envelope.get("success"):
+            raise CloudflareError(
+                f"Cloudflare {method} {path} failed: {_error_messages(envelope)}"
+            )
+        return envelope.get("result")
+
+    def pages_domains(self) -> set[str]:
+        path = (
+            f"/accounts/{self.config.account_id}/pages/projects/"
+            f"{urllib.parse.quote(self.config.project, safe='')}/domains"
+        )
+        return {item["name"] for item in self.request("GET", path)}
+
+    def delete_pages_domain(self, domain: str) -> None:
+        path = (
+            f"/accounts/{self.config.account_id}/pages/projects/"
+            f"{urllib.parse.quote(self.config.project, safe='')}/domains/"
+            f"{urllib.parse.quote(domain, safe='')}"
+        )
+        self.request("DELETE", path)
+
+    def add_pages_domain(self, domain: str) -> None:
+        path = (
+            f"/accounts/{self.config.account_id}/pages/projects/"
+            f"{urllib.parse.quote(self.config.project, safe='')}/domains"
+        )
+        self.request("POST", path, {"name": domain})
+
+    def dns_records(self, domain: str) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode({"name": domain, "per_page": 100})
+        return list(
+            self.request(
+                "GET",
+                f"/zones/{self.config.zone_id}/dns_records?{query}",
+            )
+        )
+
+    def create_dns_record(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self.request(
+            "POST", f"/zones/{self.config.zone_id}/dns_records", payload
+        )
+
+    def update_dns_record(
+        self, record_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return self.request(
+            "PATCH",
+            f"/zones/{self.config.zone_id}/dns_records/{record_id}",
+            payload,
+        )
+
+    def delete_dns_record(self, record_id: str) -> None:
+        self.request(
+            "DELETE", f"/zones/{self.config.zone_id}/dns_records/{record_id}"
+        )
+
+
+def _error_messages(envelope: dict[str, Any]) -> str:
+    errors = envelope.get("errors") or []
+    return "; ".join(str(item.get("message") or item) for item in errors) or "unknown error"
+
+
+def _safe_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": record.get("id"),
+        "type": record.get("type"),
+        "name": record.get("name"),
+        "content": record.get("content"),
+        "proxied": record.get("proxied"),
+        "managed": bool((record.get("meta") or {}).get("managed_by_apps")),
+    }
+
+
+def audit(client: CloudflareClient) -> dict[str, Any]:
+    pages = client.pages_domains()
+    return {
+        "pages_project": client.config.project,
+        "pages_domains": sorted(pages),
+        "origin_ip": client.config.origin_ip,
+        "dns": {
+            domain: [_safe_record(record) for record in client.dns_records(domain)]
+            for domain in client.config.domains
+        },
+    }
+
+
+def probe_dns_write(client: CloudflareClient) -> None:
+    name = f"_mvn-web-cutover-probe.{client.config.domains[0]}"
+    record = client.create_dns_record(
+        {
+            "type": "TXT",
+            "name": name,
+            "content": f"cutover-probe-{uuid.uuid4().hex}",
+            "ttl": 60,
+            "proxied": False,
+            "comment": "Temporary write-permission probe; safe to delete",
+        }
+    )
+    try:
+        if not record.get("id"):
+            raise CloudflareError("DNS write probe returned no record id")
+    finally:
+        if record.get("id"):
+            client.delete_dns_record(record["id"])
+
+
+def _is_origin_record(record: dict[str, Any], config: Config) -> bool:
+    return (
+        record.get("type") == "A"
+        and record.get("content") == config.origin_ip
+        and record.get("proxied") is True
+    )
+
+
+def _single_record(client: CloudflareClient, domain: str) -> dict[str, Any] | None:
+    records = client.dns_records(domain)
+    if len(records) > 1:
+        raise CloudflareError(f"refusing multiple DNS records for {domain}")
+    return records[0] if records else None
+
+
+def _wait_for(
+    predicate: Any, description: str, *, attempts: int = 20, interval: float = 1.0
+) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        time.sleep(interval)
+    raise CloudflareError(f"timed out waiting for {description}")
+
+
+def _restore_pages_domain(client: CloudflareClient, domain: str) -> None:
+    record = _single_record(client, domain)
+    if record and _is_origin_record(record, client.config):
+        client.delete_dns_record(record["id"])
+        _wait_for(lambda: not client.dns_records(domain), f"DNS removal for {domain}")
+    elif record:
+        raise CloudflareError(f"refusing to delete unexpected DNS record for {domain}")
+    if domain not in client.pages_domains():
+        client.add_pages_domain(domain)
+    _wait_for(
+        lambda: domain in client.pages_domains(), f"Pages domain restoration for {domain}"
+    )
+
+
+def cutover(client: CloudflareClient) -> None:
+    probe_dns_write(client)
+    changed: list[str] = []
+    active_domain: str | None = None
+    try:
+        for domain in client.config.domains:
+            active_domain = domain
+            current = _single_record(client, domain)
+            if current and _is_origin_record(current, client.config):
+                active_domain = None
+                continue
+            if domain not in client.pages_domains():
+                raise CloudflareError(
+                    f"{domain} is neither on Pages nor the expected SSR origin"
+                )
+            client.delete_pages_domain(domain)
+            _wait_for(
+                lambda: domain not in client.pages_domains(),
+                f"Pages detachment for {domain}",
+            )
+            _wait_for(
+                lambda: not client.dns_records(domain), f"managed DNS removal for {domain}"
+            )
+            client.create_dns_record(
+                {
+                    "type": "A",
+                    "name": domain,
+                    "content": client.config.origin_ip,
+                    "ttl": 1,
+                    "proxied": True,
+                    "comment": "Standalone mvn-web SSR origin",
+                }
+            )
+            _wait_for(
+                lambda: bool(
+                    (record := _single_record(client, domain))
+                    and _is_origin_record(record, client.config)
+                ),
+                f"SSR origin record for {domain}",
+            )
+            changed.append(domain)
+            active_domain = None
+    except Exception:
+        recovery = list(reversed(changed))
+        if active_domain and active_domain not in recovery:
+            recovery.insert(0, active_domain)
+        for domain in recovery:
+            try:
+                _restore_pages_domain(client, domain)
+            except Exception as recovery_error:  # noqa: BLE001
+                print(f"recovery_failed domain={domain} error={recovery_error}")
+        raise
+
+
+def rollback(client: CloudflareClient) -> None:
+    probe_dns_write(client)
+    for domain in client.config.domains:
+        _restore_pages_domain(client, domain)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("operation", choices=("audit", "cutover", "rollback"))
+    parser.add_argument(
+        "--confirm",
+        default="",
+        help="Required confirmation: origin IP for cutover, Pages project for rollback",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = Config.from_env()
+    client = CloudflareClient(config)
+    print(json.dumps(audit(client), ensure_ascii=False, indent=2, sort_keys=True))
+    if args.operation == "audit":
+        return 0
+    expected = config.origin_ip if args.operation == "cutover" else config.project
+    if args.confirm != expected:
+        raise CloudflareError(f"confirmation must equal {expected!r}")
+    if args.operation == "cutover":
+        cutover(client)
+    else:
+        rollback(client)
+    print(json.dumps(audit(client), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_cutover_cloudflare_web_origin.py
+++ b/tests/unit/test_cutover_cloudflare_web_origin.py
@@ -1,0 +1,137 @@
+import pytest
+
+from scripts.cutover_cloudflare_web_origin import (
+    CloudflareError,
+    Config,
+    audit,
+    cutover,
+    probe_dns_write,
+    rollback,
+)
+
+
+class FakeClient:
+    def __init__(self, *, dns_write: bool = True) -> None:
+        self.config = Config(
+            token="secret",
+            account_id="account",
+            zone_id="zone",
+            project="mvn-by",
+            origin_ip="153.80.244.78",
+        )
+        self.pages = set(self.config.domains)
+        self.records = {
+            domain: [
+                {
+                    "id": f"pages-{domain}",
+                    "type": "CNAME",
+                    "name": domain,
+                    "content": "mvn-by.pages.dev",
+                    "proxied": True,
+                    "meta": {"managed_by_apps": True},
+                }
+            ]
+            for domain in self.config.domains
+        }
+        self.dns_write = dns_write
+        self.counter = 0
+
+    def pages_domains(self):
+        return set(self.pages)
+
+    def dns_records(self, domain):
+        return list(self.records.get(domain, []))
+
+    def delete_pages_domain(self, domain):
+        self.pages.remove(domain)
+        self.records[domain] = []
+
+    def add_pages_domain(self, domain):
+        self.pages.add(domain)
+        self.records[domain] = [
+            {
+                "id": f"pages-{domain}",
+                "type": "CNAME",
+                "name": domain,
+                "content": "mvn-by.pages.dev",
+                "proxied": True,
+                "meta": {"managed_by_apps": True},
+            }
+        ]
+
+    def create_dns_record(self, payload):
+        if not self.dns_write:
+            raise CloudflareError("DNS write forbidden")
+        self.counter += 1
+        record = {"id": f"record-{self.counter}", **payload}
+        self.records[payload["name"]] = [record]
+        return record
+
+    def delete_dns_record(self, record_id):
+        for name, records in self.records.items():
+            if records and records[0]["id"] == record_id:
+                self.records[name] = []
+                return
+        raise AssertionError(f"unknown record {record_id}")
+
+
+def test_audit_reports_pages_and_managed_dns_without_token():
+    state = audit(FakeClient())
+
+    assert state["pages_domains"] == ["mvn.by", "www.mvn.by"]
+    assert state["dns"]["mvn.by"][0]["managed"] is True
+    assert "secret" not in str(state)
+
+
+def test_cutover_replaces_pages_domains_with_proxied_origin_records(monkeypatch):
+    monkeypatch.setattr("scripts.cutover_cloudflare_web_origin.time.sleep", lambda _: None)
+    client = FakeClient()
+
+    cutover(client)
+
+    assert client.pages == set()
+    for domain in client.config.domains:
+        assert client.records[domain][0]["type"] == "A"
+        assert client.records[domain][0]["content"] == client.config.origin_ip
+        assert client.records[domain][0]["proxied"] is True
+
+
+def test_cutover_stops_before_pages_mutation_without_dns_write():
+    client = FakeClient(dns_write=False)
+
+    with pytest.raises(CloudflareError, match="DNS write forbidden"):
+        probe_dns_write(client)
+
+    assert client.pages == set(client.config.domains)
+
+
+def test_rollback_restores_pages_domains(monkeypatch):
+    monkeypatch.setattr("scripts.cutover_cloudflare_web_origin.time.sleep", lambda _: None)
+    client = FakeClient()
+    cutover(client)
+
+    rollback(client)
+
+    assert client.pages == set(client.config.domains)
+    for domain in client.config.domains:
+        assert client.records[domain][0]["content"] == "mvn-by.pages.dev"
+
+
+def test_cutover_refuses_an_unknown_existing_record(monkeypatch):
+    monkeypatch.setattr("scripts.cutover_cloudflare_web_origin.time.sleep", lambda _: None)
+    client = FakeClient()
+    client.pages.remove("mvn.by")
+    client.records["mvn.by"] = [
+        {
+            "id": "unexpected",
+            "type": "A",
+            "name": "mvn.by",
+            "content": "192.0.2.1",
+            "proxied": True,
+        }
+    ]
+
+    with pytest.raises(CloudflareError, match="neither on Pages"):
+        cutover(client)
+
+    assert client.records["mvn.by"][0]["content"] == "192.0.2.1"


### PR DESCRIPTION
## Summary
- add an explicit audit/cutover/rollback workflow for moving mvn.by from Cloudflare Pages to the standalone SSR origin
- fail closed on unexpected DNS state and prove DNS write access before detaching Pages
- automatically attempt Pages recovery if a cutover step fails
- document the final routing boundary

## Verification
- python3 -m pytest tests/unit/test_cutover_cloudflare_web_origin.py -q (5 passed)
- python3 -m py_compile scripts/cutover_cloudflare_web_origin.py
- git diff --check

## Operational sequence
1. merge and run audit
2. inspect Pages/DNS state
3. run cutover with confirmation 153.80.244.78
4. verify public SSR headers and retain rollback with confirmation mvn-by