### PR TITLE
fix: use available artifact action

### DIFF
--- a/.github/workflows/cutover-web-origin.yml
+++ b/.github/workflows/cutover-web-origin.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload routing audit
         if: ${{ always() }}
-        uses: actions/upload-artifact@b7c566a772e6b6f58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@v7
         with:
           name: cloudflare-web-origin-${{ github.run_id }}
           path: cloudflare-web-origin.log


### PR DESCRIPTION
## Summary
- use the upload-artifact v7 release already used by repository workflows
- unblock the Cloudflare web-origin audit job

## Verification
- git diff --check
- failure occurred before any Cloudflare call, so no external state changed