### PR TITLE
fix: preserve non-web DNS during cutover

### DIFF
--- a/scripts/cutover_cloudflare_web_origin.py
+++ b/scripts/cutover_cloudflare_web_origin.py
@@ -17,6 +17,7 @@ from typing import Any
 
 API_BASE = "https://api.cloudflare.com/client/v4"
 DEFAULT_DOMAINS = ("mvn.by", "www.mvn.by")
+WEB_RECORD_TYPES = frozenset({"A", "AAAA", "CNAME"})
 
 
 class CloudflareError(RuntimeError):
@@ -159,7 +160,11 @@ def audit(client: CloudflareClient) -> dict[str, Any]:
         "pages_domains": sorted(pages),
         "origin_ip": client.config.origin_ip,
         "dns": {
-            domain: [_safe_record(record) for record in client.dns_records(domain)]
+            domain: [
+                _safe_record(record)
+                for record in client.dns_records(domain)
+                if record.get("type") in WEB_RECORD_TYPES
+            ]
             for domain in client.config.domains
         },
     }
@@ -194,7 +199,11 @@ def _is_origin_record(record: dict[str, Any], config: Config) -> bool:
 
 
 def _single_record(client: CloudflareClient, domain: str) -> dict[str, Any] | None:
-    records = client.dns_records(domain)
+    records = [
+        record
+        for record in client.dns_records(domain)
+        if record.get("type") in WEB_RECORD_TYPES
+    ]
     if len(records) > 1:
         raise CloudflareError(f"refusing multiple DNS records for {domain}")
     return records[0] if records else None
@@ -213,10 +222,25 @@ def _wait_for(
 def _restore_pages_domain(client: CloudflareClient, domain: str) -> None:
     record = _single_record(client, domain)
     if record and _is_origin_record(record, client.config):
-        client.delete_dns_record(record["id"])
-        _wait_for(lambda: not client.dns_records(domain), f"DNS removal for {domain}")
+        client.update_dns_record(
+            record["id"],
+            {
+                "type": "CNAME",
+                "name": domain,
+                "content": f"{client.config.project}.pages.dev",
+                "ttl": 1,
+                "proxied": True,
+                "comment": "Cloudflare Pages storefront rollback",
+            },
+        )
     elif record:
-        raise CloudflareError(f"refusing to delete unexpected DNS record for {domain}")
+        expected_pages = (
+            record.get("type") == "CNAME"
+            and record.get("content") == f"{client.config.project}.pages.dev"
+            and record.get("proxied") is True
+        )
+        if not expected_pages:
+            raise CloudflareError(f"refusing to replace unexpected DNS record for {domain}")
     if domain not in client.pages_domains():
         client.add_pages_domain(domain)
     _wait_for(
@@ -244,19 +268,28 @@ def cutover(client: CloudflareClient) -> None:
                 lambda: domain not in client.pages_domains(),
                 f"Pages detachment for {domain}",
             )
-            _wait_for(
-                lambda: not client.dns_records(domain), f"managed DNS removal for {domain}"
-            )
-            client.create_dns_record(
-                {
-                    "type": "A",
-                    "name": domain,
-                    "content": client.config.origin_ip,
-                    "ttl": 1,
-                    "proxied": True,
-                    "comment": "Standalone mvn-web SSR origin",
-                }
-            )
+            origin_payload = {
+                "type": "A",
+                "name": domain,
+                "content": client.config.origin_ip,
+                "ttl": 1,
+                "proxied": True,
+                "comment": "Standalone mvn-web SSR origin",
+            }
+            current = _single_record(client, domain)
+            if current:
+                expected_pages = (
+                    current.get("type") == "CNAME"
+                    and current.get("content") == f"{client.config.project}.pages.dev"
+                    and current.get("proxied") is True
+                )
+                if not expected_pages:
+                    raise CloudflareError(
+                        f"refusing to replace unexpected DNS record for {domain}"
+                    )
+                client.update_dns_record(current["id"], origin_payload)
+            else:
+                client.create_dns_record(origin_payload)
             _wait_for(
                 lambda: bool(
                     (record := _single_record(client, domain))

--- a/tests/unit/test_cutover_cloudflare_web_origin.py
+++ b/tests/unit/test_cutover_cloudflare_web_origin.py
@@ -33,6 +33,24 @@ class FakeClient:
             ]
             for domain in self.config.domains
         }
+        self.records["mvn.by"].extend(
+            [
+                {
+                    "id": "mail-mx",
+                    "type": "MX",
+                    "name": "mvn.by",
+                    "content": "mx.example.test",
+                    "proxied": False,
+                },
+                {
+                    "id": "mail-spf",
+                    "type": "TXT",
+                    "name": "mvn.by",
+                    "content": "v=spf1 -all",
+                    "proxied": False,
+                },
+            ]
+        )
         self.dns_write = dns_write
         self.counter = 0
 
@@ -44,34 +62,35 @@ class FakeClient:
 
     def delete_pages_domain(self, domain):
         self.pages.remove(domain)
-        self.records[domain] = []
 
     def add_pages_domain(self, domain):
         self.pages.add(domain)
-        self.records[domain] = [
-            {
-                "id": f"pages-{domain}",
-                "type": "CNAME",
-                "name": domain,
-                "content": "mvn-by.pages.dev",
-                "proxied": True,
-                "meta": {"managed_by_apps": True},
-            }
-        ]
 
     def create_dns_record(self, payload):
         if not self.dns_write:
             raise CloudflareError("DNS write forbidden")
         self.counter += 1
         record = {"id": f"record-{self.counter}", **payload}
-        self.records[payload["name"]] = [record]
+        self.records.setdefault(payload["name"], []).append(record)
         return record
+
+    def update_dns_record(self, record_id, payload):
+        if not self.dns_write:
+            raise CloudflareError("DNS write forbidden")
+        for name, records in self.records.items():
+            for index, record in enumerate(records):
+                if record["id"] == record_id:
+                    updated = {"id": record_id, **payload}
+                    records[index] = updated
+                    return updated
+        raise AssertionError(f"unknown record {record_id}")
 
     def delete_dns_record(self, record_id):
         for name, records in self.records.items():
-            if records and records[0]["id"] == record_id:
-                self.records[name] = []
-                return
+            for index, record in enumerate(records):
+                if record["id"] == record_id:
+                    del records[index]
+                    return
         raise AssertionError(f"unknown record {record_id}")
 
 
@@ -80,6 +99,8 @@ def test_audit_reports_pages_and_managed_dns_without_token():
 
     assert state["pages_domains"] == ["mvn.by", "www.mvn.by"]
     assert state["dns"]["mvn.by"][0]["managed"] is True
+    assert len(state["dns"]["mvn.by"]) == 1
+    assert "mx.example.test" not in str(state)
     assert "secret" not in str(state)
 
 
@@ -91,9 +112,16 @@ def test_cutover_replaces_pages_domains_with_proxied_origin_records(monkeypatch)
 
     assert client.pages == set()
     for domain in client.config.domains:
-        assert client.records[domain][0]["type"] == "A"
-        assert client.records[domain][0]["content"] == client.config.origin_ip
-        assert client.records[domain][0]["proxied"] is True
+        web_record = next(
+            record for record in client.records[domain] if record["type"] == "A"
+        )
+        assert web_record["content"] == client.config.origin_ip
+        assert web_record["proxied"] is True
+    assert {record["type"] for record in client.records["mvn.by"]} == {
+        "A",
+        "MX",
+        "TXT",
+    }
 
 
 def test_cutover_stops_before_pages_mutation_without_dns_write():
@@ -114,7 +142,15 @@ def test_rollback_restores_pages_domains(monkeypatch):
 
     assert client.pages == set(client.config.domains)
     for domain in client.config.domains:
-        assert client.records[domain][0]["content"] == "mvn-by.pages.dev"
+        web_record = next(
+            record for record in client.records[domain] if record["type"] == "CNAME"
+        )
+        assert web_record["content"] == "mvn-by.pages.dev"
+    assert {record["type"] for record in client.records["mvn.by"]} == {
+        "CNAME",
+        "MX",
+        "TXT",
+    }
 
 
 def test_cutover_refuses_an_unknown_existing_record(monkeypatch):


### PR DESCRIPTION
## Summary
- scope web routing changes to A, AAAA, and CNAME records only
- preserve root MX and TXT records exactly as they are
- replace the Pages CNAME with the SSR A record in place and reverse it for rollback
- omit unrelated DNS values from workflow audit logs

## Verification
- python3 -m pytest tests/unit/test_cutover_cloudflare_web_origin.py -q (5 passed)
- python3 -m py_compile scripts/cutover_cloudflare_web_origin.py
- git diff --check

The read-only audit proved both custom domains currently point at mvn-by.pages.dev and exposed the legitimate root mail and verification records that this change now protects.