### PR TITLE
fix: accept CRLF in origin header checks

### DIFF
--- a/.github/workflows/cutover-web-origin.yml
+++ b/.github/workflows/cutover-web-origin.yml
@@ -48,7 +48,7 @@ jobs:
             --dump-header "${headers}" --output /dev/null \
             https://mvn.by/catalog/
           grep -Eiq '^x-catalog-revision: [0-9]+' "${headers}"
-          grep -Eiq '^x-web-data-cache: (hit|miss|shared)$' "${headers}"
+          grep -Eiq '^x-web-data-cache: (hit|miss|shared)[[:space:]]*$' "${headers}"
 
       - name: Audit or switch Cloudflare web routing
         env:
@@ -70,7 +70,7 @@ jobs:
               --dump-header "${headers}" --output /dev/null \
               https://mvn.by/catalog/ \
               && grep -Eiq '^x-catalog-revision: [0-9]+' "${headers}" \
-              && grep -Eiq '^x-web-data-cache: (hit|miss|shared)$' "${headers}"; then
+              && grep -Eiq '^x-web-data-cache: (hit|miss|shared)[[:space:]]*$' "${headers}"; then
               rm -f "${headers}"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- accept the standard HTTP CRLF terminator in x-web-data-cache checks
- apply the same correction to pre-cutover and post-cutover verification

## Verification
- CRLF sample header matches the corrected expression
- exact workflow checks pass against the direct 153.80.244.78 SSR origin
- git diff --check

The failed cutover run stopped before the Cloudflare mutation step.