### PR TITLE
Polish product workspace safety and navigation

### DIFF
--- a/manager_frontend/src/components/ProductEditModal.vue
+++ b/manager_frontend/src/components/ProductEditModal.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
 import { api, type Product, type ManagerBrand, type ProductCreate, type ProductDuplicatePayload, type ProductUpdate } from '../api';
-import { X, Save, Plus, Trash2, Edit3, Globe, Hash, Tag, CircleHelp } from 'lucide-vue-next';
+import { X, Save, Plus, Trash2, Edit3, Globe, Tag } from 'lucide-vue-next';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
-import SpecKeyCombobox from './SpecKeyCombobox.vue';
-import SpecValueInput from './SpecValueInput.vue';
+import ProductSpecificationsEditor from './products/ProductSpecificationsEditor.vue';
+import ProductSuppliersEditor from './products/ProductSuppliersEditor.vue';
 import { useSpecRegistry } from '../composables/useSpecRegistry';
+import { collapseWifiSpecs } from '../utils/product-spec-safety';
+import type { ProductWorkspaceSection } from '../utils/product-workspace';
+import type { SupplierOfferResponse } from '../client/models/SupplierOfferResponse';
 
 interface TagItem {
     id: number;
@@ -52,9 +55,13 @@ const props = withDefaults(defineProps<{
     product: Product | null;
     mode?: ProductEditorMode;
     presentation?: 'modal' | 'workspace';
+    workspaceSection?: ProductWorkspaceSection;
+    expertMode?: boolean;
 }>(), {
     mode: 'edit',
     presentation: 'modal',
+    workspaceSection: 'main',
+    expertMode: false,
 });
 
 const emit = defineEmits<{
@@ -84,7 +91,7 @@ const tagSearchQuery = ref('');
 const managerBrands = ref<ManagerBrand[]>([]);
 const selectedBrandEntityId = ref<number | null>(null);
 const vitebskQty = ref(0);
-const supplierOffers = ref<any[]>([]);
+const supplierOffers = ref<SupplierOfferResponse[]>([]);
 const localStockSaving = ref(false);
 const unlinkingMappingId = ref<number | null>(null);
 const COMPATIBLE_INDOOR_KEY = 'compatible_indoor_slugs';
@@ -117,6 +124,12 @@ const isCreateMode = computed(() => props.mode === 'create');
 const isDuplicateMode = computed(() => props.mode === 'duplicate');
 const isPersistedProduct = computed(() => props.mode === 'edit' && Boolean(props.product?.id));
 const isWorkspace = computed(() => props.presentation === 'workspace');
+const showMainSection = computed(() => !isWorkspace.value || props.workspaceSection === 'main');
+const showSpecificationsSection = computed(() => !isWorkspace.value || props.workspaceSection === 'specifications');
+const showSuppliersSection = computed(() => !isWorkspace.value || props.workspaceSection === 'suppliers');
+const showPublicationSection = computed(() => !isWorkspace.value || props.workspaceSection === 'publication');
+const showRelationsSection = computed(() => !isWorkspace.value || props.workspaceSection === 'relations');
+const effectiveExpertMode = computed(() => !isWorkspace.value || props.expertMode);
 const cleanFingerprint = ref('');
 const modalTitle = computed(() => {
     if (isCreateMode.value) return 'Создание товара';
@@ -138,32 +151,11 @@ const saveButtonText = computed(() => {
 const normalizeText = (value: unknown): string => String(value ?? '').toLowerCase().replace(/ё/g, 'е').trim();
 const normalizeBrandToken = (value: unknown): string => normalizeText(value).replace(/[^a-z0-9а-я]/g, '');
 const {
-    getSpecConfig,
-    getSpecGroup,
-    getSpecGroupLabel,
-    getSpecHelpText,
     isHiddenSpecKey,
-    knownSpecKeys,
     loadSpecRegistry,
     normalizeValueForEdit,
     serializeSpecValue,
-    specGroupOrder,
 } = useSpecRegistry();
-const showSpecHelp = (key: string) => {
-    const text = getSpecHelpText(key);
-    if (text) window.alert(text);
-};
-const getSpecLabel = (key: string): string => getSpecConfig(key)?.label || key || 'Новая характеристика';
-const getSpecTypeHint = (key: string): string => {
-    const config = getSpecConfig(key);
-    if (!config) return '';
-    if (config.type === 'range') return 'диапазон';
-    if (config.type === 'number_list') return 'список';
-    if (config.type === 'number') return config.unit ? `число, ${config.unit}` : 'число';
-    if (config.type === 'select') return 'выбор';
-    if (config.type === 'boolean') return 'да / нет';
-    return '';
-};
 const INVALID_BRAND_TOKENS = new Set([
     'мультисплитсистема',
     'сплитсистема',
@@ -868,9 +860,12 @@ const fetchBrands = async (force = false) => {
 };
 
 const filteredTagGroups = computed(() => {
-    if (!tagSearchQuery.value.trim()) return tagGroups.value;
+    const visibleGroups = effectiveExpertMode.value
+        ? tagGroups.value
+        : tagGroups.value.filter((group) => normalizeText(group.slug) !== 'brand');
+    if (!tagSearchQuery.value.trim()) return visibleGroups;
     const q = tagSearchQuery.value.toLowerCase().trim();
-    return tagGroups.value
+    return visibleGroups
         .map(g => ({
             ...g,
             tags: g.tags.filter(t => t.title.toLowerCase().includes(q)),
@@ -878,33 +873,10 @@ const filteredTagGroups = computed(() => {
         .filter(g => g.tags.length > 0);
 });
 
-const groupedSpecRows = computed(() => {
-    const groups = new Map<string, {
-        group: string;
-        label: string;
-        entries: Array<{ row: { key: string; value: string }; index: number }>;
-    }>();
-
-    specs.value.forEach((row, index) => {
-        const group = row.key.trim() ? getSpecGroup(row.key) : 'other';
-        if (!groups.has(group)) {
-            groups.set(group, {
-                group,
-                label: getSpecGroupLabel(group),
-                entries: [],
-            });
-        }
-        groups.get(group)?.entries.push({ row, index });
-    });
-
-    return Array.from(groups.values()).sort((a, b) => {
-        const aIndex = specGroupOrder.indexOf(a.group as any);
-        const bIndex = specGroupOrder.indexOf(b.group as any);
-        const safeA = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex;
-        const safeB = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex;
-        return safeA - safeB || a.label.localeCompare(b.label, 'ru');
-    });
-});
+const selectedTags = computed(() => tagGroups.value
+    .flatMap((group) => group.tags.map((tag) => ({ ...tag, groupSlug: group.slug })))
+    .filter((tag) => selectedTagIds.value.has(tag.id))
+    .filter((tag) => effectiveExpertMode.value || normalizeText(tag.groupSlug) !== 'brand'));
 
 const isTagSelected = (id: number) => selectedTagIds.value.has(id);
 
@@ -1005,7 +977,6 @@ const editorFingerprint = () => JSON.stringify({
     manuals: manuals.value,
     tagIds: Array.from(selectedTagIds.value).sort((a, b) => a - b),
     brandId: selectedBrandEntityId.value,
-    vitebskQty: vitebskQty.value,
     indoorSlugs: compatibilityIndoorSlugs.value,
     outdoorSlugs: compatibilityOutdoorSlugs.value,
     logisticsComponents: logisticsComponents.value,
@@ -1046,9 +1017,9 @@ const initializeEditor = async () => {
         ? 'strict'
         : 'free_match';
     capacityCombosInput.value = parseCapacityCombos((s as any)[MULTI_CAPACITY_COMBOS_KEY]).join(', ');
-    specs.value = Object.entries(s)
+    specs.value = collapseWifiSpecs(Object.entries(s)
         .filter(([key]) => !COMPATIBILITY_KEYS.has(key) && !isHiddenSpecKey(key))
-        .map(([key, value]) => ({ key, value: normalizeValueForEdit(key, value) }));
+        .map(([key, value]) => ({ key, value: normalizeValueForEdit(key, value) })));
     manuals.value = (((source as any)?.manuals || []) as Array<any>)
         .map((item) => ({
             title: String(item?.title || 'Инструкция').trim() || 'Инструкция',
@@ -1107,8 +1078,6 @@ const loadSupplierOffers = async () => {
     }
 };
 
-const addRow = () => specs.value.push({ key: '', value: '' });
-const removeRow = (index: number) => specs.value.splice(index, 1);
 const addManualRow = () => manuals.value.push({ title: 'Инструкция', url: '' });
 const removeManualRow = (index: number) => manuals.value.splice(index, 1);
 
@@ -1299,10 +1268,14 @@ defineExpose({ save, isDirty, loading });
             </div>
             
             <div class="flex-1 p-6" :class="isWorkspace ? '' : 'overflow-y-auto'">
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div class="grid grid-cols-1 gap-6" :class="isWorkspace ? '' : 'lg:grid-cols-2'">
                     <!-- Column 1: Basic Info -->
-                    <section id="product-section-main" class="scroll-mt-28 space-y-5">
-                        <h3 class="text-xs font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest">Основные данные</h3>
+                    <section v-if="showMainSection || showSuppliersSection || showRelationsSection" id="product-section-main" class="scroll-mt-28 space-y-5">
+                        <template v-if="showMainSection">
+                        <div class="border-b border-gray-100 pb-4 dark:border-slate-800">
+                            <p class="text-xs font-bold uppercase tracking-[0.16em] text-teal-700 dark:text-teal-300">Основное</p>
+                            <h2 class="mt-1 text-xl font-bold text-gray-950 dark:text-white">Название, цена и публикация</h2>
+                        </div>
                         
                         <div>
                             <label class="block text-sm font-semibold text-gray-700 dark:text-slate-300 mb-1">Название модели</label>
@@ -1367,45 +1340,22 @@ defineExpose({ save, isDirty, loading });
                                 <span class="ms-3 text-sm font-semibold text-gray-700 dark:text-slate-300">Опубликовано</span>
                             </label>
                         </div>
+                        </template>
 
-                        <div id="product-section-suppliers" v-if="isPersistedProduct" class="scroll-mt-28 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
-                            <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Supply</h4>
-                            <div class="flex items-end gap-2">
-                                <div class="flex-1">
-                                    <label class="block text-sm font-semibold text-gray-700 dark:text-slate-300 mb-1">Склад Витебск (шт)</label>
-                                    <input v-model.number="vitebskQty" type="number" min="0" class="w-full px-3 py-2 bg-slate-100 dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl text-sm" />
-                                </div>
-                                <button
-                                    @click="saveLocalStock"
-                                    :disabled="localStockSaving"
-                                    class="px-3 py-2 rounded-xl bg-teal-600 text-white text-sm font-semibold disabled:opacity-50"
-                                >
-                                    {{ localStockSaving ? 'Сохранение...' : 'Сохранить' }}
-                                </button>
-                            </div>
-                            <div class="max-h-40 overflow-y-auto space-y-2">
-                                <div v-if="supplierOffers.length === 0" class="text-xs text-gray-500 dark:text-slate-400">Нет привязанных офферов</div>
-                                <div v-for="offer in supplierOffers" :key="`${offer.supplier_id}-${offer.external_id}`" class="text-xs border border-gray-100 dark:border-slate-700 rounded-lg p-2 bg-slate-50 dark:bg-slate-900/40">
-                                    <div class="flex items-start justify-between gap-2">
-                                        <div class="font-semibold text-gray-700 dark:text-slate-200">{{ offer.supplier_name || offer.supplier_id }} / {{ offer.external_id }}</div>
-                                        <button
-                                            v-if="offer.mapping_id"
-                                            @click="unlinkSupplierOffer(offer)"
-                                            :disabled="unlinkingMappingId === offer.mapping_id"
-                                            class="px-2 py-1 rounded border border-red-300 text-red-600 text-[11px] font-semibold disabled:opacity-50"
-                                        >
-                                            {{ unlinkingMappingId === offer.mapping_id ? '...' : 'Отвязать' }}
-                                        </button>
-                                    </div>
-                                    <div class="text-gray-500 dark:text-slate-400">
-                                        qty: {{ offer.qty }} | wholesale: {{ offer.wholesale_value ?? '—' }} {{ offer.wholesale_currency || '' }} | rrc: {{ offer.rrc_byn ?? '—' }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        <ProductSuppliersEditor
+                            v-if="showSuppliersSection && isPersistedProduct"
+                            id="product-section-suppliers"
+                            :offers="supplierOffers"
+                            :vitebsk-qty="vitebskQty"
+                            :stock-saving="localStockSaving"
+                            :unlinking-mapping-id="unlinkingMappingId"
+                            @update:vitebsk-qty="vitebskQty = $event"
+                            @save-stock="saveLocalStock"
+                            @unlink="unlinkSupplierOffer"
+                        />
 
                         <div
-                            v-if="isCurrentProductMulti"
+                            v-if="showRelationsSection && effectiveExpertMode && isCurrentProductMulti"
                             class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3"
                         >
                             <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Быстрые пресеты</h4>
@@ -1455,7 +1405,7 @@ defineExpose({ save, isDirty, loading });
                             </div>
                         </div>
 
-                        <div class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
+                        <div v-if="showMainSection" class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
                             <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Бренд</h4>
                             <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-2 items-start">
                                 <select
@@ -1477,9 +1427,8 @@ defineExpose({ save, isDirty, loading });
                                     Очистить
                                 </button>
                             </div>
-                            <p class="text-[11px] text-gray-500 dark:text-slate-400">
-                                Канонический источник бренда: <code>product.brand_id</code>.
-                            </p>
+                            <p class="text-[11px] text-emerald-700 dark:text-emerald-300">Связанные данные бренда синхронизируются при сохранении.</p>
+                            <template v-if="effectiveExpertMode">
                             <div class="h-px bg-gray-100 dark:bg-slate-700"></div>
                             <p class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-slate-500">
                                 Совместимость (brand tag)
@@ -1523,9 +1472,10 @@ defineExpose({ save, isDirty, loading });
                             <p class="text-[11px] text-gray-500 dark:text-slate-400">
                                 При выборе бренда мы синхронизируем <code>brand_id</code>, тег группы <code>brand</code> и <code>specs.brand</code>.
                             </p>
+                            </template>
                         </div>
 
-                        <div class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
+                        <div v-if="showRelationsSection && isCurrentProductMulti" class="rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-3 space-y-3">
                             <div class="flex items-start justify-between gap-2">
                                 <h4 class="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500">Совместимость мульти</h4>
                                 <div class="text-[11px] text-gray-500 dark:text-slate-400 text-right">
@@ -1786,8 +1736,8 @@ defineExpose({ save, isDirty, loading });
                     </section>
 
                     <!-- Column 2: Specs -->
-                    <section id="product-section-specifications" class="scroll-mt-28 space-y-5">
-                        <div id="product-section-publication" class="scroll-mt-28 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 space-y-2">
+                    <section v-if="showPublicationSection || showSpecificationsSection" id="product-section-specifications" class="scroll-mt-28 space-y-5">
+                        <div v-if="showPublicationSection" id="product-section-publication" class="scroll-mt-28 rounded-2xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 space-y-2">
                             <div class="flex justify-between items-center">
                                 <h3 class="text-xs font-bold text-gray-500 dark:text-slate-400 uppercase tracking-widest">
                                     Инструкции и файлы
@@ -1820,7 +1770,7 @@ defineExpose({ save, isDirty, loading });
                             </div>
                         </div>
 
-                        <div class="rounded-2xl border border-teal-100 dark:border-teal-900 bg-teal-50/40 dark:bg-teal-950/20 p-3 space-y-3">
+                        <div v-if="showPublicationSection" class="rounded-2xl border border-teal-100 dark:border-teal-900 bg-teal-50/40 dark:bg-teal-950/20 p-3 space-y-3">
                             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
                                     <h3 class="text-xs font-bold text-teal-700 dark:text-teal-300 uppercase tracking-widest">
@@ -1909,82 +1859,17 @@ defineExpose({ save, isDirty, loading });
                             </div>
                         </div>
 
-                        <div class="flex justify-between items-center">
-                            <h3 class="text-xs font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest flex items-center gap-1.5">
-                                 Характеристики
-                            </h3>
-                            <button @click="addRow" class="text-xs bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 px-2.5 py-1 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 text-teal-600 dark:text-teal-400 font-bold flex items-center gap-1 transition-colors shadow-sm">
-                                <Plus class="w-3 h-3" /> Добавить
-                            </button>
-                        </div>
-
-                        <div class="space-y-4 bg-slate-100/50 dark:bg-slate-800/50 p-3 rounded-2xl border border-gray-100 dark:border-slate-800 max-h-[460px] overflow-y-auto">
-                            <div v-for="group in groupedSpecRows" :key="group.group" class="space-y-2">
-                                <div class="flex items-center gap-2 px-1">
-                                    <p class="text-[11px] font-black uppercase tracking-widest text-slate-400 dark:text-slate-500">
-                                        {{ group.label }}
-                                    </p>
-                                    <span class="rounded-full bg-white px-2 py-0.5 text-[10px] font-bold text-slate-400 shadow-sm dark:bg-slate-800 dark:text-slate-500">
-                                        {{ group.entries.length }}
-                                    </span>
-                                </div>
-
-                                <div
-                                    v-for="{ row, index } in group.entries"
-                                    :key="index"
-                                    class="rounded-xl border border-white/80 bg-white/70 p-2 shadow-sm transition-colors hover:border-teal-100 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:border-teal-900"
-                                >
-                                    <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)_auto] sm:items-start">
-                                        <div class="min-w-0">
-                                            <SpecKeyCombobox
-                                                v-model="row.key"
-                                                :known-keys="knownSpecKeys"
-                                            />
-                                            <div v-if="row.key" class="mt-1 flex min-w-0 items-center gap-1.5">
-                                                <span class="truncate text-[11px] font-semibold text-slate-500 dark:text-slate-400" :title="getSpecLabel(row.key)">
-                                                    {{ getSpecLabel(row.key) }}
-                                                </span>
-                                                <span v-if="getSpecTypeHint(row.key)" class="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-bold text-slate-400 dark:bg-slate-800 dark:text-slate-500">
-                                                    {{ getSpecTypeHint(row.key) }}
-                                                </span>
-                                            </div>
-                                        </div>
-
-                                        <SpecValueInput
-                                            v-model="row.value"
-                                            :spec-key="row.key"
-                                            compact
-                                        />
-
-                                        <div class="flex items-center justify-end gap-1 sm:pt-1">
-                                            <button
-                                                v-if="getSpecHelpText(row.key)"
-                                                type="button"
-                                                class="rounded-full p-1.5 text-slate-400 transition hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-700 dark:hover:text-teal-300"
-                                                :title="getSpecHelpText(row.key)"
-                                                @click="showSpecHelp(row.key)"
-                                            >
-                                                <CircleHelp class="h-4 w-4" />
-                                            </button>
-                                            <button @click="removeRow(index)" class="rounded-lg p-1.5 text-gray-300 transition-all hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30">
-                                                <Trash2 class="w-3.5 h-3.5" />
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div v-if="specs.length === 0" class="text-center py-6 text-gray-400 dark:text-slate-500">
-                                 <Hash class="w-6 h-6 mx-auto mb-1.5 opacity-20" />
-                                 <p class="text-xs">Нет характеристик</p>
-                            </div>
-                        </div>
+                        <ProductSpecificationsEditor v-if="showSpecificationsSection" v-model="specs" :expert-mode="effectiveExpertMode" />
                     </section>
                 </div>
 
-                <details id="product-section-links" class="scroll-mt-28 mt-6 border border-gray-200 dark:border-slate-700 rounded-xl bg-slate-50 dark:bg-slate-800/50 group">
+                <details v-if="showRelationsSection" id="product-section-relations" class="scroll-mt-28 mt-6 border border-gray-200 dark:border-slate-700 rounded-xl bg-slate-50 dark:bg-slate-800/50 group">
                     <summary class="cursor-pointer p-4 font-bold text-gray-700 dark:text-slate-300 flex justify-between items-center outline-none">
-                        <span class="flex items-center gap-2"><Tag class="w-4 h-4 text-gray-400 dark:text-slate-500"/> Теги ({{ selectedTagIds.size }} выбрано)</span>
+                        <span class="flex flex-wrap items-center gap-2">
+                            <Tag class="w-4 h-4 text-gray-400 dark:text-slate-500"/> Теги ({{ selectedTags.length }} выбрано)
+                            <span v-for="tag in selectedTags.slice(0, 4)" :key="tag.id" class="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-gray-600 shadow-sm dark:bg-slate-900 dark:text-slate-300">{{ tag.title }}</span>
+                            <span v-if="selectedTags.length > 4" class="text-xs text-gray-400">+{{ selectedTags.length - 4 }}</span>
+                        </span>
                     </summary>
                     <div class="p-4 border-t border-gray-200 dark:border-slate-700">
                         <input 

--- a/manager_frontend/src/components/products/ProductSpecificationsEditor.vue
+++ b/manager_frontend/src/components/products/ProductSpecificationsEditor.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { CircleAlert, CircleHelp, Hash, Plus, Trash2, Wrench } from 'lucide-vue-next';
+import SpecKeyCombobox from '../SpecKeyCombobox.vue';
+import SpecValueInput from '../SpecValueInput.vue';
+import { useSpecRegistry } from '../../composables/useSpecRegistry';
+import { getLegacySpecSuggestion, isTechnicalSpecKey, type EditableSpec } from '../../utils/product-spec-safety';
+
+type FilterMode = 'filled' | 'problems' | 'all';
+
+const props = defineProps<{
+  modelValue: EditableSpec[];
+  expertMode: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: EditableSpec[]): void;
+}>();
+
+const filterMode = ref<FilterMode>('filled');
+const {
+  getSpecConfig,
+  getSpecGroup,
+  getSpecGroupLabel,
+  getSpecHelpText,
+  knownSpecKeys,
+  loadSpecRegistry,
+  specGroupOrder,
+} = useSpecRegistry();
+
+onMounted(() => void loadSpecRegistry());
+
+const isFilled = (row: EditableSpec): boolean => String(row.value || '').trim().length > 0;
+const hasProblem = (row: EditableSpec): boolean => Boolean(getLegacySpecSuggestion(row.key, row.value));
+
+const visibleEntries = computed(() => props.modelValue
+  .map((row, index) => ({ row, index }))
+  .filter(({ row }) => props.expertMode || !isTechnicalSpecKey(row.key))
+  .filter(({ row }) => {
+    if (filterMode.value === 'problems') return hasProblem(row);
+    if (filterMode.value === 'filled') return isFilled(row);
+    return true;
+  }));
+
+const groupedRows = computed(() => {
+  const groups = new Map<string, {
+    group: string;
+    label: string;
+    total: number;
+    filled: number;
+    entries: Array<{ row: EditableSpec; index: number }>;
+  }>();
+  const source = props.modelValue.filter((row) => props.expertMode || !isTechnicalSpecKey(row.key));
+  for (const row of source) {
+    const group = row.key.trim() ? getSpecGroup(row.key) : 'other';
+    if (!groups.has(group)) {
+      groups.set(group, { group, label: getSpecGroupLabel(group), total: 0, filled: 0, entries: [] });
+    }
+    const target = groups.get(group)!;
+    target.total += 1;
+    if (isFilled(row)) target.filled += 1;
+  }
+  for (const entry of visibleEntries.value) {
+    const group = entry.row.key.trim() ? getSpecGroup(entry.row.key) : 'other';
+    groups.get(group)?.entries.push(entry);
+  }
+  return Array.from(groups.values())
+    .filter((group) => group.entries.length > 0)
+    .sort((a, b) => {
+      const aIndex = specGroupOrder.indexOf(a.group as never);
+      const bIndex = specGroupOrder.indexOf(b.group as never);
+      return (aIndex < 0 ? 999 : aIndex) - (bIndex < 0 ? 999 : bIndex)
+        || a.label.localeCompare(b.label, 'ru');
+    });
+});
+
+const problemCount = computed(() => props.modelValue.filter(hasProblem).length);
+
+const replaceRow = (index: number, patch: Partial<EditableSpec>) => {
+  const next = props.modelValue.map((row, rowIndex) => rowIndex === index ? { ...row, ...patch } : row);
+  emit('update:modelValue', next);
+};
+
+const addRow = () => emit('update:modelValue', [...props.modelValue, { key: '', value: '' }]);
+const removeRow = (index: number) => emit('update:modelValue', props.modelValue.filter((_, rowIndex) => rowIndex !== index));
+
+const showHelp = (key: string) => {
+  const text = getSpecHelpText(key);
+  if (text) window.alert(text);
+};
+</script>
+
+<template>
+  <section class="space-y-4">
+    <header class="flex flex-col gap-3 border-b border-gray-100 pb-4 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p class="text-xs font-bold uppercase tracking-[0.16em] text-teal-700 dark:text-teal-300">Характеристики</p>
+        <h2 class="mt-1 text-xl font-bold text-gray-950 dark:text-white">Технические данные товара</h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">
+          {{ expertMode ? 'Экспертный режим: доступны ключи схемы и удаление полей.' : 'Безопасный режим: редактируются только значения.' }}
+        </p>
+      </div>
+      <button v-if="expertMode" type="button" class="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-slate-700 dark:text-slate-200" @click="addRow">
+        <Plus class="h-4 w-4" /> Добавить поле
+      </button>
+    </header>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <button v-for="option in ([['filled', 'Заполненные'], ['problems', `Проблемные${problemCount ? ` · ${problemCount}` : ''}`], ['all', 'Все поля']] as const)" :key="option[0]" type="button" class="h-9 rounded-lg border px-3 text-sm font-semibold transition" :class="filterMode === option[0] ? 'border-teal-300 bg-teal-50 text-teal-800 dark:border-teal-800 dark:bg-teal-950 dark:text-teal-200' : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-slate-700 dark:text-slate-300'" @click="filterMode = option[0]">
+        {{ option[1] }}
+      </button>
+    </div>
+
+    <div v-if="groupedRows.length" class="space-y-3">
+      <details v-for="group in groupedRows" :key="group.group" open class="rounded-lg border border-gray-200 bg-gray-50/60 dark:border-slate-700 dark:bg-slate-950/30">
+        <summary class="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3">
+          <span class="font-bold text-gray-800 dark:text-slate-100">{{ group.label }}</span>
+          <span class="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-gray-500 shadow-sm dark:bg-slate-800 dark:text-slate-300">{{ group.filled }} / {{ group.total }}</span>
+        </summary>
+        <div class="space-y-2 border-t border-gray-200 p-3 dark:border-slate-700">
+          <div v-for="{ row, index } in group.entries" :key="`${row.key}-${index}`" class="rounded-lg border border-gray-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+            <div class="grid gap-3" :class="expertMode ? 'lg:grid-cols-[minmax(200px,.8fr)_minmax(260px,1.2fr)_auto]' : 'lg:grid-cols-[minmax(220px,.8fr)_minmax(260px,1.2fr)_auto]'">
+              <div class="min-w-0">
+                <SpecKeyCombobox v-if="expertMode" :model-value="row.key" :known-keys="knownSpecKeys" @update:model-value="replaceRow(index, { key: $event })" />
+                <template v-else>
+                  <p class="text-sm font-semibold text-gray-800 dark:text-slate-100">{{ getSpecConfig(row.key)?.label || row.key }}</p>
+                  <p v-if="getSpecConfig(row.key)?.unit" class="mt-0.5 text-xs text-gray-400">Единица: {{ getSpecConfig(row.key)?.unit }}</p>
+                </template>
+              </div>
+              <SpecValueInput :model-value="row.value" :spec-key="row.key" compact @update:model-value="replaceRow(index, { value: $event })" />
+              <div class="flex items-start justify-end gap-1">
+                <button v-if="getSpecHelpText(row.key)" type="button" class="rounded-full p-2 text-slate-400 hover:bg-teal-50 hover:text-teal-700 dark:hover:bg-slate-800" title="Пояснение" @click="showHelp(row.key)"><CircleHelp class="h-4 w-4" /></button>
+                <button v-if="expertMode" type="button" class="rounded-lg p-2 text-gray-300 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30" title="Удалить поле" @click="removeRow(index)"><Trash2 class="h-4 w-4" /></button>
+              </div>
+            </div>
+            <div v-if="getLegacySpecSuggestion(row.key, row.value)" class="mt-3 flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100 sm:flex-row sm:items-center sm:justify-between">
+              <span class="flex items-start gap-2"><CircleAlert class="mt-0.5 h-4 w-4 shrink-0" />{{ getLegacySpecSuggestion(row.key, row.value)?.message }}</span>
+              <button type="button" class="shrink-0 rounded-md border border-amber-300 bg-white px-2.5 py-1 font-bold dark:border-amber-800 dark:bg-slate-900" @click="replaceRow(index, { value: getLegacySpecSuggestion(row.key, row.value)?.value || row.value })">Преобразовать</button>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <div v-else class="flex min-h-48 flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-5 text-center dark:border-slate-700 dark:bg-slate-950/30">
+      <Hash v-if="filterMode !== 'problems'" class="h-7 w-7 text-gray-300" />
+      <Wrench v-else class="h-7 w-7 text-emerald-500" />
+      <p class="mt-2 font-semibold text-gray-700 dark:text-slate-200">{{ filterMode === 'problems' ? 'Подозрительных legacy-значений не найдено' : 'Нет характеристик для выбранного фильтра' }}</p>
+    </div>
+  </section>
+</template>

--- a/manager_frontend/src/components/products/ProductSuppliersEditor.vue
+++ b/manager_frontend/src/components/products/ProductSuppliersEditor.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ExternalLink, MoreHorizontal, Store } from 'lucide-vue-next';
+import type { SupplierOfferResponse } from '../../client/models/SupplierOfferResponse';
+
+defineProps<{
+  offers: SupplierOfferResponse[];
+  vitebskQty: number;
+  stockSaving: boolean;
+  unlinkingMappingId: number | null;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:vitebskQty', value: number): void;
+  (event: 'save-stock'): void;
+  (event: 'unlink', offer: SupplierOfferResponse): void;
+}>();
+
+const money = (value: number | null | undefined, currency = '') => (
+  value == null ? '—' : `${new Intl.NumberFormat('ru-BY', { maximumFractionDigits: 2 }).format(value)}${currency ? ` ${currency}` : ''}`
+);
+
+const updatedLabel = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('ru-BY', { day: '2-digit', month: '2-digit', year: '2-digit' }).format(date);
+};
+</script>
+
+<template>
+  <section class="space-y-5">
+    <header class="border-b border-gray-100 pb-4 dark:border-slate-800">
+      <p class="text-xs font-bold uppercase tracking-[0.16em] text-teal-700 dark:text-teal-300">Поставщики</p>
+      <h2 class="mt-1 text-xl font-bold text-gray-950 dark:text-white">Остатки и коммерческие связи</h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-slate-400">Проверяйте источник цены и наличие, не раскрывая технические детали маппинга.</p>
+    </header>
+
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-slate-700 dark:bg-slate-950/30">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <label class="flex-1 text-sm font-semibold text-gray-700 dark:text-slate-200">
+          Остаток на складе в Витебске
+          <input :value="vitebskQty" type="number" min="0" class="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900" @input="emit('update:vitebskQty', Number(($event.target as HTMLInputElement).value || 0))" />
+        </label>
+        <button type="button" class="h-10 rounded-lg bg-teal-600 px-4 text-sm font-semibold text-white hover:bg-teal-700 disabled:opacity-50" :disabled="stockSaving" @click="emit('save-stock')">{{ stockSaving ? 'Применяем…' : 'Применить остаток' }}</button>
+      </div>
+      <p class="mt-2 text-xs text-gray-500 dark:text-slate-400">Это отдельная складская операция. Остальные данные сохраняются общей кнопкой страницы.</p>
+    </div>
+
+    <div v-if="offers.length" class="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-700">
+      <table class="min-w-[760px] w-full text-left text-sm">
+        <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 dark:bg-slate-950/50 dark:text-slate-400">
+          <tr><th class="px-4 py-3">Поставщик</th><th class="px-4 py-3">Позиция</th><th class="px-4 py-3 text-right">Остаток</th><th class="px-4 py-3 text-right">Закупка</th><th class="px-4 py-3 text-right">РРЦ</th><th class="px-4 py-3">Обновлено</th><th class="w-12 px-2 py-3" /></tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-slate-800">
+          <tr v-for="offer in offers" :key="`${offer.supplier_id}-${offer.external_id}`" class="bg-white dark:bg-slate-900">
+            <td class="px-4 py-3 font-semibold text-gray-900 dark:text-white">
+              {{ offer.supplier_name || `#${offer.supplier_id}` }}
+              <span class="mt-1 block w-fit rounded-full px-2 py-0.5 text-[10px]" :class="offer.is_active ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300' : 'bg-gray-100 text-gray-500 dark:bg-slate-800 dark:text-slate-400'">{{ offer.is_active ? 'Активно' : 'Неактивно' }}</span>
+            </td>
+            <td class="max-w-[280px] px-4 py-3">
+              <p class="truncate font-medium text-gray-700 dark:text-slate-200" :title="offer.title_raw || offer.external_id">{{ offer.title_raw || offer.external_id }}</p>
+              <a v-if="offer.source_url" :href="offer.source_url" target="_blank" rel="noopener noreferrer" class="mt-0.5 inline-flex items-center gap-1 text-xs text-teal-700 hover:underline dark:text-teal-300"><ExternalLink class="h-3 w-3" />Открыть позицию</a>
+            </td>
+            <td class="px-4 py-3 text-right font-semibold">{{ offer.qty }}</td>
+            <td class="px-4 py-3 text-right">{{ money(offer.wholesale_value, offer.wholesale_currency || '') }}</td>
+            <td class="px-4 py-3 text-right">{{ money(offer.rrc_byn, 'BYN') }}</td>
+            <td class="px-4 py-3 text-gray-500 dark:text-slate-400">{{ updatedLabel(offer.updated_at) }}</td>
+            <td class="relative px-2 py-3 text-right">
+              <details class="relative">
+                <summary class="flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 dark:hover:bg-slate-800" title="Действия"><MoreHorizontal class="h-4 w-4" /></summary>
+                <div class="absolute right-0 top-9 z-20 w-44 rounded-lg border border-gray-200 bg-white p-1 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+                  <button v-if="offer.mapping_id" type="button" class="w-full rounded-md px-3 py-2 text-left text-sm font-semibold text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30" :disabled="unlinkingMappingId === offer.mapping_id" @click="emit('unlink', offer)">{{ unlinkingMappingId === offer.mapping_id ? 'Отвязываем…' : 'Отвязать от товара' }}</button>
+                </div>
+              </details>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-else class="flex min-h-56 flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 text-center dark:border-slate-700 dark:bg-slate-950/30">
+      <Store class="h-8 w-8 text-gray-300" />
+      <p class="mt-3 font-semibold text-gray-800 dark:text-slate-100">Нет предложений поставщиков</p>
+      <p class="mt-1 max-w-md text-sm text-gray-500 dark:text-slate-400">Свяжите товар с позицией прайса через раздел «Маппинг прайсов».</p>
+    </div>
+  </section>
+</template>

--- a/manager_frontend/src/components/products/ProductWorkspaceMedia.vue
+++ b/manager_frontend/src/components/products/ProductWorkspaceMedia.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { Images, ImagePlus, Star, ExternalLink } from 'lucide-vue-next';
 import type { Product } from '../../api';
+import { getProductImageCount } from '../../utils/product-workspace';
 
 const props = defineProps<{
   product: Product;
@@ -21,7 +22,7 @@ const galleryImages = computed(() => (
   props.product.gallery_images.filter((image) => image.url !== props.product.main_image)
 ));
 
-const imageCount = computed(() => galleryImages.value.length + (props.product.main_image ? 1 : 0));
+const imageCount = computed(() => getProductImageCount(props.product));
 </script>
 
 <template>

--- a/manager_frontend/src/utils/product-spec-safety.ts
+++ b/manager_frontend/src/utils/product-spec-safety.ts
@@ -1,0 +1,57 @@
+export type EditableSpec = { key: string; value: string };
+
+const WIFI_KEYS = new Set(['wifi_state', 'wifi_ready', 'wifi_builtin']);
+const ENERGY_CLASS_KEYS = new Set(['energy_class_cooling', 'energy_class_heating']);
+
+const normalizeBoolean = (value: unknown): boolean | null => {
+  const token = String(value ?? '').trim().toLowerCase();
+  if (['1', 'true', 'yes', 'да', 'есть', 'встроен', 'встроенный'].includes(token)) return true;
+  if (['0', 'false', 'no', 'нет', 'отсутствует'].includes(token)) return false;
+  return null;
+};
+
+export const canonicalEnergyClass = (value: string): string => (
+  value.trim().replace(/[Аа]/g, 'A').replace(/\s+/g, '')
+);
+
+export const collapseWifiSpecs = (entries: EditableSpec[]): EditableSpec[] => {
+  const values = new Map(entries.map((entry) => [entry.key, entry.value]));
+  const explicitState = String(values.get('wifi_state') || '').trim().toLowerCase();
+  const builtin = normalizeBoolean(values.get('wifi_builtin'));
+  const ready = normalizeBoolean(values.get('wifi_ready'));
+  const state = ['builtin', 'ready', 'none'].includes(explicitState)
+    ? explicitState
+    : builtin === true
+      ? 'builtin'
+      : ready === true
+        ? 'ready'
+        : builtin === false || ready === false
+          ? 'none'
+          : '';
+
+  const normalized = entries
+    .filter((entry) => !WIFI_KEYS.has(entry.key))
+    .map((entry) => (
+      ENERGY_CLASS_KEYS.has(entry.key)
+        ? { ...entry, value: canonicalEnergyClass(entry.value) }
+        : entry
+    ));
+  if (state) normalized.push({ key: 'wifi_state', value: state });
+  return normalized;
+};
+
+export const isTechnicalSpecKey = (key: string): boolean => key === 'brand';
+
+export const getLegacySpecSuggestion = (
+  key: string,
+  value: string,
+): { value: string; message: string } | null => {
+  if (!['pipe_liquid', 'pipe_gas'].includes(key)) return null;
+  const token = value.trim().replace(',', '.');
+  const suggestion = token === '3' ? '3/8"' : token === '5' ? '5/8"' : '';
+  if (!suggestion) return null;
+  return {
+    value: suggestion,
+    message: `Значение «${value}» не соответствует формату диаметра. Проверьте преобразование в ${suggestion}.`,
+  };
+};

--- a/manager_frontend/src/utils/product-workspace.ts
+++ b/manager_frontend/src/utils/product-workspace.ts
@@ -1,4 +1,6 @@
-export type ProductWorkspaceSection = 'main' | 'media' | 'specifications' | 'suppliers' | 'publication';
+import type { Product } from '../api';
+
+export type ProductWorkspaceSection = 'main' | 'media' | 'specifications' | 'suppliers' | 'publication' | 'relations';
 
 export type ProductListWorkspaceContext = {
   returnTo: string;
@@ -17,6 +19,7 @@ const sectionPath: Record<ProductWorkspaceSection, string> = {
   specifications: '/specifications',
   suppliers: '/suppliers',
   publication: '/publication',
+  relations: '/relations',
 };
 
 export const buildProductWorkspacePath = (
@@ -28,7 +31,7 @@ export const parseProductWorkspaceLocation = (pathname: string): {
   productId: number | null;
   section: ProductWorkspaceSection;
 } => {
-  const match = pathname.match(/^\/manager\/products\/(\d+)(?:\/(media|specifications|suppliers|publication))?\/?$/);
+  const match = pathname.match(/^\/manager\/products\/(\d+)(?:\/(media|specifications|suppliers|publication|relations))?\/?$/);
   if (!match) return { productId: null, section: 'main' };
   const productId = Number(match[1]);
   return {
@@ -36,6 +39,20 @@ export const parseProductWorkspaceLocation = (pathname: string): {
     section: (match[2] || 'main') as ProductWorkspaceSection,
   };
 };
+
+export const getProductImageUrls = (product: Pick<Product, 'main_image' | 'gallery_images'>): string[] => {
+  const urls = [
+    product.main_image,
+    ...product.gallery_images.map((image) => image.url),
+  ]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  return Array.from(new Set(urls));
+};
+
+export const getProductImageCount = (product: Pick<Product, 'main_image' | 'gallery_images'>): number => (
+  getProductImageUrls(product).length
+);
 
 export const getProductWorkspaceNeighbors = (
   productIds: number[],

--- a/manager_frontend/src/views/ProductWorkspaceView.vue
+++ b/manager_frontend/src/views/ProductWorkspaceView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import {
   ArrowLeft,
   ArrowRight,
@@ -17,8 +17,10 @@ import {
   Settings2,
   Store,
   Trash2,
+  Wrench,
 } from 'lucide-vue-next';
-import { api, type Product } from '../api';
+import { api, type ManagerCatalogQualityReportResponse, type Product } from '../api';
+import type { WebRebuildStatusResponse } from '../client/models/WebRebuildStatusResponse';
 import ProductEditModal from '../components/ProductEditModal.vue';
 import ProductWorkspaceMedia from '../components/products/ProductWorkspaceMedia.vue';
 import { getApiErrorMessage } from '../utils/api-errors';
@@ -27,8 +29,11 @@ import {
   getProductWorkspaceNeighbors,
   loadProductWorkspaceContext,
   parseProductWorkspaceLocation,
+  getProductImageCount,
   type ProductWorkspaceSection,
 } from '../utils/product-workspace';
+
+type QualityProduct = ManagerCatalogQualityReportResponse['items'][number];
 
 type ProductEditorExpose = {
   save: () => Promise<boolean>;
@@ -44,6 +49,11 @@ const errorMessage = ref('');
 const toast = ref('');
 const moreOpen = ref(false);
 const supplierOfferCount = ref(0);
+const qualityProduct = ref<QualityProduct | null>(null);
+const qualityLoaded = ref(false);
+const rebuildStatus = ref<WebRebuildStatusResponse | null>(null);
+const rebuildLoading = ref(false);
+const expertMode = ref(window.localStorage.getItem('manager:product-workspace:expert') === '1');
 const location = parseProductWorkspaceLocation(window.location.pathname);
 const productId = location.productId;
 const activeSection = ref<ProductWorkspaceSection>(location.section);
@@ -56,7 +66,10 @@ const sections: Array<{ id: ProductWorkspaceSection; label: string; icon: typeof
   { id: 'specifications', label: 'Характеристики', icon: Settings2 },
   { id: 'suppliers', label: 'Поставщики', icon: Store },
   { id: 'publication', label: 'Публикация и файлы', icon: FileText },
+  { id: 'relations', label: 'Связи и теги', icon: Link2 },
 ];
+
+const mediaCount = computed(() => product.value ? getProductImageCount(product.value) : 0);
 
 const publicProductUrl = computed(() => {
   if (!product.value?.slug) return null;
@@ -76,17 +89,23 @@ const availabilityLabel = computed(() => {
 });
 
 const qualityIssues = computed(() => {
-  const current = product.value;
-  if (!current) return [];
-  const issues: Array<{ label: string; section: ProductWorkspaceSection; critical?: boolean }> = [];
-  if (!current.main_image) issues.push({ label: 'Нет главного изображения', section: 'media', critical: true });
-  if (current.gallery_images.length < 2) issues.push({ label: 'Мало изображений в галерее', section: 'media' });
-  if (!current.price || current.price <= 0) issues.push({ label: 'Не указана цена', section: 'main', critical: true });
-  if (!current.brand_id) issues.push({ label: 'Не выбран бренд', section: 'main' });
-  if (!current.series_id) issues.push({ label: 'Не выбрана серия', section: 'main' });
-  if (supplierOfferCount.value === 0) issues.push({ label: 'Нет предложений поставщиков', section: 'suppliers' });
-  return issues;
+  const sectionByCategory: Record<string, ProductWorkspaceSection> = {
+    media: 'media', specs: 'specifications', supplier: 'suppliers', commerce: 'main', identity: 'main',
+  };
+  return (qualityProduct.value?.issues || []).map((issue) => ({
+    label: issue.message || issue.label,
+    section: sectionByCategory[issue.category] || 'main',
+    critical: issue.severity === 'critical',
+  }));
 });
+
+const saveStateLabel = computed(() => saving.value ? 'Сохранение…' : dirty.value ? 'Есть несохранённые изменения' : 'Сохранено');
+
+const setExpertMode = (value: boolean) => {
+  expertMode.value = value;
+  window.localStorage.setItem('manager:product-workspace:expert', value ? '1' : '0');
+  moreOpen.value = false;
+};
 
 const setToast = (message: string) => {
   toast.value = message;
@@ -101,6 +120,19 @@ const navigate = (path: string, replace = false) => {
   window.dispatchEvent(new PopStateEvent('popstate'));
 };
 
+const loadProductQuality = async (detail: Product) => {
+  qualityLoaded.value = false;
+  qualityProduct.value = null;
+  const quality = await api.getCatalogQualityReport({
+    q: detail.slug || detail.title,
+    onlyProblems: false,
+    limit: 20,
+  }).catch(() => null);
+  if (product.value?.id !== detail.id) return;
+  qualityProduct.value = quality?.items.find((item) => item.product_id === detail.id) || null;
+  qualityLoaded.value = true;
+};
+
 const loadProduct = async () => {
   if (!productId) {
     errorMessage.value = 'Некорректный ID товара';
@@ -110,16 +142,33 @@ const loadProduct = async () => {
   loading.value = true;
   errorMessage.value = '';
   try {
-    const [detail, offers] = await Promise.all([
+    const [detail, offers, rebuild] = await Promise.all([
       api.getManagerProduct(productId),
       api.getProductSupplierOffers(productId).catch(() => ({ items: [] } as any)),
+      api.getWebRebuildStatus().catch(() => null),
     ]);
     product.value = detail;
     supplierOfferCount.value = Number(offers?.items?.length || 0);
+    rebuildStatus.value = rebuild;
+    loading.value = false;
+    void loadProductQuality(detail);
   } catch (error) {
     errorMessage.value = `Не удалось открыть товар: ${getApiErrorMessage(error)}`;
   } finally {
     loading.value = false;
+  }
+};
+
+const rebuildSite = async () => {
+  if (rebuildLoading.value) return;
+  rebuildLoading.value = true;
+  try {
+    rebuildStatus.value = await api.rebuildWeb();
+    setToast('Пересборка сайта запущена');
+  } catch (error) {
+    setToast(`Не удалось запустить сборку: ${getApiErrorMessage(error)}`);
+  } finally {
+    rebuildLoading.value = false;
   }
 };
 
@@ -135,13 +184,9 @@ const navigateProduct = (targetId: number | null) => {
   navigate(buildProductWorkspacePath(targetId, activeSection.value));
 };
 
-const scrollToSection = async (section: ProductWorkspaceSection) => {
+const scrollToSection = (section: ProductWorkspaceSection) => {
   activeSection.value = section;
   window.history.replaceState({}, '', buildProductWorkspacePath(productId || 0, section));
-  if (section === 'media') return;
-  await nextTick();
-  const targetId = section === 'main' ? 'product-section-main' : `product-section-${section}`;
-  document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 };
 
 const saveCurrent = async (): Promise<boolean> => {
@@ -228,7 +273,7 @@ onBeforeUnmount(() => window.removeEventListener('beforeunload', beforeUnload));
           <div class="min-w-0 flex-1">
             <div class="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-slate-400">
               <span>Товары</span><span>/</span><span>#{{ productId }}</span>
-              <span v-if="dirty" class="rounded-md bg-amber-100 px-2 py-0.5 font-semibold text-amber-800">Есть изменения</span>
+              <span class="rounded-md px-2 py-0.5 font-semibold" :class="dirty ? 'bg-amber-100 text-amber-800' : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300'">{{ saveStateLabel }}</span>
             </div>
             <h1 class="mt-0.5 truncate text-lg font-bold text-gray-950 dark:text-white sm:text-xl" :title="product?.title || ''">
               {{ product?.title || 'Карточка товара' }}
@@ -254,6 +299,7 @@ onBeforeUnmount(() => window.removeEventListener('beforeunload', beforeUnload));
             <div v-if="moreOpen" class="absolute right-0 top-11 z-40 w-56 rounded-lg border border-gray-200 bg-white p-1.5 shadow-xl dark:border-slate-700 dark:bg-slate-900">
               <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!publicProductUrl" @click="openPublicProduct"><ExternalLink class="h-4 w-4" />Открыть на сайте</button>
               <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-slate-800" :disabled="!publicProductUrl" @click="copyPublicProductLink"><ClipboardCopy class="h-4 w-4" />Копировать ссылку</button>
+              <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-slate-800" @click="setExpertMode(!expertMode)"><Wrench class="h-4 w-4" />{{ expertMode ? 'Выключить экспертный режим' : 'Экспертный режим' }}</button>
               <div class="my-1 border-t border-gray-100 dark:border-slate-800" />
               <button type="button" class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30" :disabled="deleting" @click="deleteProduct"><Trash2 class="h-4 w-4" />Удалить товар</button>
             </div>
@@ -282,25 +328,27 @@ onBeforeUnmount(() => window.removeEventListener('beforeunload', beforeUnload));
       <nav class="sticky top-[132px] z-20 -mx-4 flex gap-1 overflow-x-auto border-y border-gray-200 bg-white px-4 py-2 dark:border-slate-800 dark:bg-slate-950 xl:mx-0 xl:block xl:self-start xl:border-0 xl:bg-transparent xl:px-0 xl:py-0">
         <button v-for="section in sections" :key="section.id" type="button" class="flex h-10 shrink-0 items-center gap-2 rounded-lg px-3 text-sm font-semibold transition xl:mb-1 xl:w-full" :class="activeSection === section.id ? 'bg-teal-100 text-teal-800 dark:bg-teal-950 dark:text-teal-200' : 'text-gray-600 hover:bg-white dark:text-slate-300 dark:hover:bg-slate-900'" @click="scrollToSection(section.id)">
           <component :is="section.icon" class="h-4 w-4" />{{ section.label }}
-          <span v-if="section.id === 'media'" class="ml-auto rounded-full bg-white px-1.5 text-[10px] text-gray-500 dark:bg-slate-800">{{ product.gallery_images.length }}</span>
+          <span v-if="section.id === 'media'" class="ml-auto rounded-full bg-white px-1.5 text-[10px] text-gray-500 dark:bg-slate-800">{{ mediaCount }}</span>
           <span v-if="section.id === 'suppliers'" class="ml-auto rounded-full bg-white px-1.5 text-[10px] text-gray-500 dark:bg-slate-800">{{ supplierOfferCount }}</span>
+          <span v-if="section.id === 'publication' && rebuildStatus?.needs_rebuild" class="ml-auto h-2 w-2 rounded-full bg-amber-500" title="Сайт требует пересборки" />
         </button>
       </nav>
 
       <main class="min-w-0 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-slate-800 dark:bg-slate-900">
         <ProductWorkspaceMedia v-show="activeSection === 'media'" :product="product" @open-editor="openMediaEditor" />
-        <ProductEditModal ref="editor" v-show="activeSection !== 'media'" :model-value="true" :product="product" mode="edit" presentation="workspace" @update:model-value="goBack" @dirty-change="dirty = $event" />
+        <ProductEditModal ref="editor" v-show="activeSection !== 'media'" :model-value="true" :product="product" mode="edit" presentation="workspace" :workspace-section="activeSection" :expert-mode="expertMode" @update:model-value="goBack" @dirty-change="dirty = $event" />
       </main>
 
       <aside class="space-y-4 xl:sticky xl:top-[132px] xl:self-start">
         <section class="border-y border-gray-200 bg-white py-4 dark:border-slate-800 dark:bg-slate-950 xl:rounded-lg xl:border xl:p-4">
           <div class="flex items-center justify-between gap-3">
             <div>
-              <p class="text-xs font-bold uppercase tracking-[0.14em] text-gray-400">Базовая готовность</p>
-              <p class="mt-1 text-lg font-bold text-gray-950 dark:text-white">{{ qualityIssues.length ? `${qualityIssues.length} проблем` : 'Явных проблем нет' }}</p>
+              <p class="text-xs font-bold uppercase tracking-[0.14em] text-gray-400">Качество карточки</p>
+              <p v-if="qualityProduct" class="mt-1 text-lg font-bold text-gray-950 dark:text-white">{{ qualityProduct.score }} / 100</p>
+              <p v-else class="mt-1 text-sm font-bold text-gray-700 dark:text-slate-200">{{ qualityLoaded ? 'Нет данных отчёта' : 'Проверяем…' }}</p>
             </div>
-            <CheckCircle2 v-if="qualityIssues.length === 0" class="h-7 w-7 text-emerald-500" />
-            <CircleAlert v-else class="h-7 w-7 text-amber-500" />
+            <CheckCircle2 v-if="qualityProduct && qualityIssues.length === 0" class="h-7 w-7 text-emerald-500" />
+            <CircleAlert v-else-if="qualityProduct" class="h-7 w-7 text-amber-500" />
           </div>
           <div v-if="qualityIssues.length" class="mt-3 space-y-1.5">
             <button v-for="issue in qualityIssues" :key="issue.label" type="button" class="flex w-full items-start gap-2 rounded-md px-2 py-2 text-left text-xs hover:bg-gray-50 dark:hover:bg-slate-900" :class="issue.critical ? 'text-red-700 dark:text-red-300' : 'text-gray-600 dark:text-slate-300'" @click="scrollToSection(issue.section)">
@@ -320,8 +368,10 @@ onBeforeUnmount(() => window.removeEventListener('beforeunload', beforeUnload));
           </dl>
         </section>
 
-        <section class="border-y border-blue-200 bg-blue-50 py-4 text-sm text-blue-900 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-100 xl:rounded-lg xl:border xl:p-4">
-          <div class="flex items-start gap-2"><Link2 class="mt-0.5 h-4 w-4 shrink-0" /><p>Сохранение меняет данные CRM. Публичный Astro-сайт обновится после отдельной пересборки.</p></div>
+        <section class="border-y py-4 text-sm xl:rounded-lg xl:border xl:p-4" :class="!rebuildStatus ? 'border-gray-200 bg-gray-50 text-gray-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300' : rebuildStatus.needs_rebuild ? 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100' : 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100'">
+          <div class="flex items-start gap-2"><Link2 class="mt-0.5 h-4 w-4 shrink-0" /><p>{{ !rebuildStatus ? 'Статус публикации сайта сейчас недоступен.' : rebuildStatus.needs_rebuild ? 'В CRM есть изменения, которые ещё не опубликованы на сайте.' : 'Публичный сайт синхронизирован с каталогом.' }}</p></div>
+          <p v-if="rebuildStatus?.last_error" class="mt-2 text-xs font-semibold text-red-700 dark:text-red-300">{{ rebuildStatus.last_error }}</p>
+          <button v-if="rebuildStatus?.needs_rebuild" type="button" class="mt-3 inline-flex h-9 w-full items-center justify-center rounded-lg bg-amber-600 px-3 text-sm font-bold text-white hover:bg-amber-700 disabled:opacity-50" :disabled="rebuildLoading" @click="rebuildSite">{{ rebuildLoading ? 'Запускаем…' : 'Пересобрать сайт' }}</button>
         </section>
       </aside>
     </div>

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -42,9 +42,15 @@ import { countLabel } from '../src/components/catalog-quality/catalog-quality-co
 import { navSections } from '../src/manager-navigation';
 import {
   buildProductWorkspacePath,
+  getProductImageCount,
   getProductWorkspaceNeighbors,
   parseProductWorkspaceLocation,
 } from '../src/utils/product-workspace';
+import {
+  canonicalEnergyClass,
+  collapseWifiSpecs,
+  getLegacySpecSuggestion,
+} from '../src/utils/product-spec-safety';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -195,6 +201,10 @@ assert(
   buildProductWorkspacePath(143, 'media') === '/manager/products/143/media',
   'product workspace links must preserve the requested section',
 );
+assert(
+  buildProductWorkspacePath(143, 'relations') === '/manager/products/143/relations',
+  'product workspace must expose relations as a real section',
+);
 const parsedProductWorkspace = parseProductWorkspaceLocation('/manager/products/143/specifications');
 assert(
   parsedProductWorkspace?.productId === 143 && parsedProductWorkspace.section === 'specifications',
@@ -213,6 +223,25 @@ const edgeProductNeighbors = getProductWorkspaceNeighbors([11, 143, 22], 11);
 assert(
   edgeProductNeighbors.previousId === null && edgeProductNeighbors.nextId === 143,
   'product workspace navigation must stop at list boundaries',
+);
+assert(
+  getProductImageCount({
+    main_image: '/media/main.webp',
+    gallery_images: [{ id: 1, url: '/media/main.webp' }, { id: 2, url: '/media/side.webp' }],
+  } as any) === 2,
+  'product media count must deduplicate the main image from the gallery',
+);
+const wifiSpecs = collapseWifiSpecs([
+  { key: 'wifi_ready', value: 'true' },
+  { key: 'wifi_builtin', value: 'true' },
+  { key: 'energy_class_cooling', value: 'А++' },
+]);
+assert(wifiSpecs.filter((row) => row.key.startsWith('wifi_')).length === 1, 'Wi-Fi aliases must collapse to one editor field');
+assert(wifiSpecs.find((row) => row.key === 'wifi_state')?.value === 'builtin', 'built-in Wi-Fi must take priority over ready');
+assert(canonicalEnergyClass(' А++ ') === 'A++', 'energy class must use canonical Latin A');
+assert(
+  getLegacySpecSuggestion('pipe_gas', '5')?.value === '5/8"',
+  'ambiguous legacy pipe values must offer an explicit conversion',
 );
 
 const workspaceBase = {


### PR DESCRIPTION
## Summary
- turn product workspace navigation into real isolated sections
- add safe and expert specification modes, canonical Wi-Fi and energy values, and explicit legacy pipe warnings
- compact tags, conditionally show multi-split tools, and present supplier mappings as a readable table
- use shared media counts, real catalog quality data, save state, and website rebuild status

## Verification
- `./node_modules/.bin/vue-tsc -b`
- `./node_modules/.bin/vite build`
- `node scripts/run-ui-logic-tests.mjs`
- `bash scripts/audit_theme_hardcodes.sh`
- desktop and 390px mobile browser checks; no console errors or horizontal overflow