### PR TITLE
add tenant storefront foundation

### DIFF
--- a/alembic/versions/a13c5e7f9b24_add_tenant_storefront_foundation.py
+++ b/alembic/versions/a13c5e7f9b24_add_tenant_storefront_foundation.py
@@ -1,0 +1,255 @@
+"""Add tenant and storefront foundation.
+
+Revision ID: a13c5e7f9b24
+Revises: 9b4d6f8a1c30
+"""
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a13c5e7f9b24"
+down_revision: Union[str, Sequence[str], None] = "9b4d6f8a1c30"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenant",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=160), nullable=False),
+        sa.Column("kind", sa.String(length=40), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("is_system", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("status IN ('active', 'disabled')", name="ck_tenant_status_valid"),
+        sa.UniqueConstraint("slug", name="uq_tenant_slug"),
+    )
+    op.create_index("ix_tenant_kind", "tenant", ["kind"], unique=False)
+    op.create_index("ix_tenant_status", "tenant", ["status"], unique=False)
+
+    op.create_table(
+        "tenant_membership",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("staff_user_id", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(length=40), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('active', 'suspended', 'disabled')",
+            name="ck_tenant_membership_status_valid",
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenant.id"]),
+        sa.ForeignKeyConstraint(["staff_user_id"], ["staff_users.id"]),
+        sa.UniqueConstraint(
+            "tenant_id",
+            "staff_user_id",
+            name="uq_tenant_membership_tenant_staff_user",
+        ),
+    )
+    op.create_index("ix_tenant_membership_tenant_id", "tenant_membership", ["tenant_id"], unique=False)
+    op.create_index("ix_tenant_membership_staff_user_id", "tenant_membership", ["staff_user_id"], unique=False)
+    op.create_index("ix_tenant_membership_role", "tenant_membership", ["role"], unique=False)
+    op.create_index("ix_tenant_membership_status", "tenant_membership", ["status"], unique=False)
+
+    op.create_table(
+        "storefront",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=160), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("city", sa.String(length=120), nullable=True),
+        sa.Column("default_locale", sa.String(length=16), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("is_default", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('draft', 'active', 'disabled')",
+            name="ck_storefront_status_valid",
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenant.id"]),
+        sa.UniqueConstraint("tenant_id", "slug", name="uq_storefront_tenant_slug"),
+    )
+    op.create_index("ix_storefront_tenant_id", "storefront", ["tenant_id"], unique=False)
+    op.create_index("ix_storefront_slug", "storefront", ["slug"], unique=False)
+    op.create_index("ix_storefront_status", "storefront", ["status"], unique=False)
+    op.create_index("ix_storefront_city", "storefront", ["city"], unique=False)
+    op.create_index(
+        "uq_storefront_default_per_tenant",
+        "storefront",
+        ["tenant_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+        sqlite_where=sa.text("is_default = 1"),
+    )
+
+    op.create_table(
+        "storefront_domain",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("storefront_id", sa.Integer(), nullable=False),
+        sa.Column("hostname", sa.String(length=253), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('pending', 'active', 'disabled')",
+            name="ck_storefront_domain_status_valid",
+        ),
+        sa.ForeignKeyConstraint(["storefront_id"], ["storefront.id"]),
+        sa.UniqueConstraint("hostname", name="uq_storefront_domain_hostname"),
+    )
+    op.create_index("ix_storefront_domain_storefront_id", "storefront_domain", ["storefront_id"], unique=False)
+    op.create_index("ix_storefront_domain_status", "storefront_domain", ["status"], unique=False)
+    op.create_index(
+        "uq_storefront_primary_domain",
+        "storefront_domain",
+        ["storefront_id"],
+        unique=True,
+        postgresql_where=sa.text("is_primary"),
+        sqlite_where=sa.text("is_primary = 1"),
+    )
+
+    now = datetime.now(timezone.utc)
+    tenant_table = sa.table(
+        "tenant",
+        sa.column("slug", sa.String),
+        sa.column("display_name", sa.String),
+        sa.column("kind", sa.String),
+        sa.column("status", sa.String),
+        sa.column("is_system", sa.Boolean),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    op.bulk_insert(
+        tenant_table,
+        [
+            {
+                "slug": "mvn",
+                "display_name": "Мастер Воздуха",
+                "kind": "operator",
+                "status": "active",
+                "is_system": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+
+    connection = op.get_bind()
+    tenant_id = connection.execute(sa.text("SELECT id FROM tenant WHERE slug = 'mvn'")).scalar_one()
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO tenant_membership (
+                tenant_id, staff_user_id, role, status, created_at, updated_at
+            )
+            SELECT
+                :tenant_id,
+                staff.id,
+                COALESCE(NULLIF(TRIM(staff.primary_role), ''), 'installer'),
+                CASE WHEN staff.status = 'active' THEN 'active' ELSE 'disabled' END,
+                :created_at,
+                :updated_at
+            FROM staff_users AS staff
+            """
+        ),
+        {
+            "tenant_id": tenant_id,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO storefront (
+                tenant_id, slug, display_name, status, city, default_locale,
+                currency, is_default, created_at, updated_at
+            ) VALUES (
+                :tenant_id, 'main', 'MVN', 'active', 'Витебск', 'ru-BY',
+                'BYN', :is_default, :created_at, :updated_at
+            )
+            """
+        ),
+        {
+            "tenant_id": tenant_id,
+            "is_default": True,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    storefront_id = connection.execute(
+        sa.text("SELECT id FROM storefront WHERE tenant_id = :tenant_id AND slug = 'main'"),
+        {"tenant_id": tenant_id},
+    ).scalar_one()
+
+    domain_table = sa.table(
+        "storefront_domain",
+        sa.column("storefront_id", sa.Integer),
+        sa.column("hostname", sa.String),
+        sa.column("status", sa.String),
+        sa.column("is_primary", sa.Boolean),
+        sa.column("verified_at", sa.DateTime(timezone=True)),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    op.bulk_insert(
+        domain_table,
+        [
+            {
+                "storefront_id": storefront_id,
+                "hostname": "mvn.by",
+                "status": "active",
+                "is_primary": True,
+                "verified_at": now,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "storefront_id": storefront_id,
+                "hostname": "www.mvn.by",
+                "status": "active",
+                "is_primary": False,
+                "verified_at": now,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_storefront_primary_domain", table_name="storefront_domain")
+    op.drop_index("ix_storefront_domain_status", table_name="storefront_domain")
+    op.drop_index("ix_storefront_domain_storefront_id", table_name="storefront_domain")
+    op.drop_table("storefront_domain")
+
+    op.drop_index("uq_storefront_default_per_tenant", table_name="storefront")
+    op.drop_index("ix_storefront_city", table_name="storefront")
+    op.drop_index("ix_storefront_status", table_name="storefront")
+    op.drop_index("ix_storefront_slug", table_name="storefront")
+    op.drop_index("ix_storefront_tenant_id", table_name="storefront")
+    op.drop_table("storefront")
+
+    op.drop_index("ix_tenant_membership_status", table_name="tenant_membership")
+    op.drop_index("ix_tenant_membership_role", table_name="tenant_membership")
+    op.drop_index("ix_tenant_membership_staff_user_id", table_name="tenant_membership")
+    op.drop_index("ix_tenant_membership_tenant_id", table_name="tenant_membership")
+    op.drop_table("tenant_membership")
+
+    op.drop_index("ix_tenant_status", table_name="tenant")
+    op.drop_index("ix_tenant_kind", table_name="tenant")
+    op.drop_table("tenant")

--- a/crud/tenancy.py
+++ b/crud/tenancy.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.tenancy import Storefront, StorefrontDomain, Tenant
+
+
+@dataclass(frozen=True)
+class StorefrontContextRow:
+    tenant_id: int
+    tenant_slug: str
+    tenant_kind: str
+    storefront_id: int
+    storefront_slug: str
+    storefront_name: str
+    hostname: str
+    city: str | None
+    default_locale: str
+    currency: str
+
+
+class TenancyDAO:
+    @staticmethod
+    async def get_active_storefront_by_hostname(
+        session: AsyncSession,
+        hostname: str,
+    ) -> StorefrontContextRow | None:
+        statement = (
+            select(Tenant, Storefront, StorefrontDomain)
+            .join(Storefront, Storefront.tenant_id == Tenant.id)
+            .join(StorefrontDomain, StorefrontDomain.storefront_id == Storefront.id)
+            .where(
+                Tenant.status == "active",
+                Storefront.status == "active",
+                StorefrontDomain.status == "active",
+                StorefrontDomain.hostname == hostname,
+            )
+        )
+        row = (await session.execute(statement)).first()
+        if row is None:
+            return None
+
+        tenant, storefront, domain = row
+        return StorefrontContextRow(
+            tenant_id=int(tenant.id),
+            tenant_slug=tenant.slug,
+            tenant_kind=tenant.kind,
+            storefront_id=int(storefront.id),
+            storefront_slug=storefront.slug,
+            storefront_name=storefront.display_name,
+            hostname=domain.hostname,
+            city=storefront.city,
+            default_locale=storefront.default_locale,
+            currency=storefront.currency,
+        )

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -36,6 +36,7 @@ from .service_asset import (
     WarrantyPolicy,
 )
 from .staff import StaffUser
+from .tenancy import Storefront, StorefrontDomain, Tenant, TenantMembership
 from .order import (
     BankReceipt,
     Installer,
@@ -164,6 +165,10 @@ __all__ = [
     "StaffUser",
     "Tag",
     "TagGroup",
+    "Tenant",
+    "TenantMembership",
+    "Storefront",
+    "StorefrontDomain",
     "Payment",
     "PaymentType",
     "Supplier",

--- a/models/tenancy.py
+++ b/models/tenancy.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, Index, String, UniqueConstraint, text
+from sqlmodel import Field, SQLModel
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Tenant(SQLModel, table=True):
+    __tablename__ = "tenant"
+    __table_args__ = (
+        UniqueConstraint("slug", name="uq_tenant_slug"),
+        CheckConstraint(
+            "status IN ('active', 'disabled')",
+            name="ck_tenant_status_valid",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    slug: str = Field(sa_column=Column(String(64), nullable=False))
+    display_name: str = Field(sa_column=Column(String(160), nullable=False))
+    kind: str = Field(default="independent_seller", sa_column=Column(String(40), nullable=False, index=True))
+    status: str = Field(default="active", sa_column=Column(String(24), nullable=False, index=True))
+    is_system: bool = Field(default=False, sa_column=Column(Boolean, nullable=False))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class TenantMembership(SQLModel, table=True):
+    __tablename__ = "tenant_membership"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "staff_user_id",
+            name="uq_tenant_membership_tenant_staff_user",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'suspended', 'disabled')",
+            name="ck_tenant_membership_status_valid",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    tenant_id: int = Field(foreign_key="tenant.id", index=True)
+    staff_user_id: int = Field(foreign_key="staff_users.id", index=True)
+    role: str = Field(sa_column=Column(String(40), nullable=False, index=True))
+    status: str = Field(default="active", sa_column=Column(String(24), nullable=False, index=True))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class Storefront(SQLModel, table=True):
+    __tablename__ = "storefront"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "slug", name="uq_storefront_tenant_slug"),
+        Index(
+            "uq_storefront_default_per_tenant",
+            "tenant_id",
+            unique=True,
+            postgresql_where=text("is_default"),
+            sqlite_where=text("is_default = 1"),
+        ),
+        CheckConstraint(
+            "status IN ('draft', 'active', 'disabled')",
+            name="ck_storefront_status_valid",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    tenant_id: int = Field(foreign_key="tenant.id", index=True)
+    slug: str = Field(sa_column=Column(String(64), nullable=False, index=True))
+    display_name: str = Field(sa_column=Column(String(160), nullable=False))
+    status: str = Field(default="draft", sa_column=Column(String(24), nullable=False, index=True))
+    city: Optional[str] = Field(default=None, sa_column=Column(String(120), nullable=True, index=True))
+    default_locale: str = Field(default="ru-BY", sa_column=Column(String(16), nullable=False))
+    currency: str = Field(default="BYN", sa_column=Column(String(3), nullable=False))
+    is_default: bool = Field(default=False, sa_column=Column(Boolean, nullable=False))
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+
+
+class StorefrontDomain(SQLModel, table=True):
+    __tablename__ = "storefront_domain"
+    __table_args__ = (
+        UniqueConstraint("hostname", name="uq_storefront_domain_hostname"),
+        Index(
+            "uq_storefront_primary_domain",
+            "storefront_id",
+            unique=True,
+            postgresql_where=text("is_primary"),
+            sqlite_where=text("is_primary = 1"),
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'active', 'disabled')",
+            name="ck_storefront_domain_status_valid",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    storefront_id: int = Field(foreign_key="storefront.id", index=True)
+    hostname: str = Field(sa_column=Column(String(253), nullable=False))
+    status: str = Field(default="pending", sa_column=Column(String(24), nullable=False, index=True))
+    is_primary: bool = Field(default=False, sa_column=Column(Boolean, nullable=False))
+    verified_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    created_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=utc_now,
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/services/storefront_context_service.py
+++ b/services/storefront_context_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from urllib.parse import urlsplit
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from crud.tenancy import TenancyDAO
+
+
+_HOST_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+class InvalidStorefrontHostError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class StorefrontContext:
+    tenant_id: int
+    tenant_slug: str
+    tenant_kind: str
+    storefront_id: int
+    storefront_slug: str
+    storefront_name: str
+    hostname: str
+    city: str | None
+    default_locale: str
+    currency: str
+
+
+class StorefrontContextService:
+    @staticmethod
+    def normalize_hostname(raw_host: str) -> str:
+        value = str(raw_host or "").strip()
+        if not value or len(value) > 320:
+            raise InvalidStorefrontHostError("Storefront host is missing or too long")
+        if "://" in value or any(char in value for char in "/?#@,\\"):
+            raise InvalidStorefrontHostError("Storefront host must contain only a hostname and optional port")
+        if any(ord(char) < 33 or ord(char) == 127 for char in value):
+            raise InvalidStorefrontHostError("Storefront host contains invalid characters")
+
+        try:
+            parsed = urlsplit(f"//{value}")
+            hostname = (parsed.hostname or "").rstrip(".").lower()
+            parsed.port
+        except ValueError as exc:
+            raise InvalidStorefrontHostError("Storefront host contains an invalid port") from exc
+        if value.endswith(":"):
+            raise InvalidStorefrontHostError("Storefront host contains an invalid port")
+
+        if not hostname:
+            raise InvalidStorefrontHostError("Storefront hostname is missing")
+
+        try:
+            ascii_hostname = hostname.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise InvalidStorefrontHostError("Storefront hostname is not a valid IDNA domain") from exc
+
+        if len(ascii_hostname) > 253:
+            raise InvalidStorefrontHostError("Storefront hostname is too long")
+        labels = ascii_hostname.split(".")
+        if any(not _HOST_LABEL_PATTERN.fullmatch(label) for label in labels):
+            raise InvalidStorefrontHostError("Storefront hostname contains an invalid label")
+        return ascii_hostname
+
+    @classmethod
+    async def resolve_by_host(
+        cls,
+        session: AsyncSession,
+        raw_host: str,
+    ) -> StorefrontContext | None:
+        hostname = cls.normalize_hostname(raw_host)
+        row = await TenancyDAO.get_active_storefront_by_hostname(session, hostname)
+        if row is None:
+            return None
+        return StorefrontContext(**asdict(row))

--- a/tests/unit/test_bot_voice_audit_migration.py
+++ b/tests/unit/test_bot_voice_audit_migration.py
@@ -26,9 +26,14 @@ def test_bot_voice_audit_is_in_single_alembic_head_chain():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == [REVISION]
+    heads = script.get_heads()
+
+    assert len(heads) == 1
     assert revision is not None
     assert revision.down_revision == "8a3c5e7f9b21"
+    assert REVISION in {
+        item.revision for item in script.iterate_revisions(heads[0], "base")
+    }
 
 
 def test_bot_voice_audit_migration_upgrades_and_downgrades_sqlite():

--- a/tests/unit/test_storefront_context_service.py
+++ b/tests/unit/test_storefront_context_service.py
@@ -1,0 +1,84 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from crud.tenancy import StorefrontContextRow
+from services.storefront_context_service import (
+    InvalidStorefrontHostError,
+    StorefrontContextService,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_host", "expected"),
+    [
+        ("mvn.by", "mvn.by"),
+        ("MVN.BY:443", "mvn.by"),
+        ("www.mvn.by.", "www.mvn.by"),
+        ("пример.бел", "xn--e1afmkfd.xn--90ais"),
+        ("localhost:8000", "localhost"),
+    ],
+)
+def test_normalize_hostname_accepts_domain_and_optional_port(raw_host, expected):
+    assert StorefrontContextService.normalize_hostname(raw_host) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_host",
+    [
+        "",
+        "https://mvn.by",
+        "mvn.by/path",
+        "user@mvn.by",
+        "mvn.by,evil.example",
+        "bad_label.mvn.by",
+        "-bad.mvn.by",
+        "mvn.by:",
+        "mvn.by:99999",
+    ],
+)
+def test_normalize_hostname_rejects_untrusted_host_syntax(raw_host):
+    with pytest.raises(InvalidStorefrontHostError):
+        StorefrontContextService.normalize_hostname(raw_host)
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_host_returns_typed_context(monkeypatch):
+    session = object()
+    dao = AsyncMock(
+        return_value=StorefrontContextRow(
+            tenant_id=1,
+            tenant_slug="mvn",
+            tenant_kind="operator",
+            storefront_id=2,
+            storefront_slug="main",
+            storefront_name="MVN",
+            hostname="mvn.by",
+            city="Витебск",
+            default_locale="ru-BY",
+            currency="BYN",
+        )
+    )
+    monkeypatch.setattr(
+        "services.storefront_context_service.TenancyDAO.get_active_storefront_by_hostname",
+        dao,
+    )
+
+    context = await StorefrontContextService.resolve_by_host(session, "MVN.BY:443")
+
+    assert context is not None
+    assert context.tenant_slug == "mvn"
+    assert context.storefront_slug == "main"
+    assert context.hostname == "mvn.by"
+    dao.assert_awaited_once_with(session, "mvn.by")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_host_returns_none_for_unknown_domain(monkeypatch):
+    dao = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "services.storefront_context_service.TenancyDAO.get_active_storefront_by_hostname",
+        dao,
+    )
+
+    assert await StorefrontContextService.resolve_by_host(object(), "unknown.example") is None

--- a/tests/unit/test_tenant_storefront_foundation_migration.py
+++ b/tests/unit/test_tenant_storefront_foundation_migration.py
@@ -1,0 +1,99 @@
+import importlib.util
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+
+
+REVISION = "a13c5e7f9b24"
+MIGRATION_PATH = Path("alembic/versions/a13c5e7f9b24_add_tenant_storefront_foundation.py")
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location("tenant_storefront_foundation_migration", MIGRATION_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tenant_storefront_foundation_is_in_the_single_alembic_head_chain():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(REVISION)
+    heads = script.get_heads()
+
+    assert heads == [REVISION]
+    assert revision is not None
+    assert revision.down_revision == "9b4d6f8a1c30"
+
+
+def test_tenant_storefront_foundation_migration_seeds_mvn_and_downgrades_sqlite():
+    migration = _load_migration_module()
+    engine = create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE staff_users (
+                    id INTEGER PRIMARY KEY,
+                    display_name VARCHAR(160) NOT NULL,
+                    status VARCHAR(24) NOT NULL,
+                    primary_role VARCHAR(40) NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO staff_users (id, display_name, status, primary_role)
+                VALUES (7, 'Owner', 'active', 'owner')
+                """
+            )
+        )
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+        inspector = inspect(connection)
+
+        assert {"tenant", "tenant_membership", "storefront", "storefront_domain"}.issubset(
+            inspector.get_table_names()
+        )
+        tenant = connection.execute(
+            text("SELECT slug, kind, status, is_system FROM tenant")
+        ).mappings().one()
+        assert dict(tenant) == {
+            "slug": "mvn",
+            "kind": "operator",
+            "status": "active",
+            "is_system": 1,
+        }
+        domains = connection.execute(
+            text("SELECT hostname, status, is_primary FROM storefront_domain ORDER BY hostname")
+        ).mappings().all()
+        assert [dict(item) for item in domains] == [
+            {"hostname": "mvn.by", "status": "active", "is_primary": 1},
+            {"hostname": "www.mvn.by", "status": "active", "is_primary": 0},
+        ]
+        membership = connection.execute(
+            text("SELECT tenant_id, staff_user_id, role, status FROM tenant_membership")
+        ).mappings().one()
+        assert membership["tenant_id"] > 0
+        assert dict(membership) | {"tenant_id": "present"} == {
+            "tenant_id": "present",
+            "staff_user_id": 7,
+            "role": "owner",
+            "status": "active",
+        }
+        storefront_indexes = {item["name"] for item in inspector.get_indexes("storefront")}
+        domain_indexes = {item["name"] for item in inspector.get_indexes("storefront_domain")}
+        assert "uq_storefront_default_per_tenant" in storefront_indexes
+        assert "uq_storefront_primary_domain" in domain_indexes
+
+        migration.downgrade()
+        assert not {"tenant", "tenant_membership", "storefront", "storefront_domain"}.intersection(
+            inspect(connection).get_table_names()
+        )


### PR DESCRIPTION
## What changed

- add `Tenant`, `TenantMembership`, `Storefront`, and `StorefrontDomain` models
- seed the existing MVN business, public domains, and staff memberships through an expand-only migration
- add safe hostname normalization and active storefront resolution behind a service/CRUD boundary
- protect one default storefront per tenant and one primary domain per storefront
- update the previous Alembic-head test so future linear migrations remain valid

## Why

This is the first isolated foundation block for the documented white-label platform. It establishes ownership and storefront identity without changing existing public API behavior, pricing, leads, or orders.

## Validation

- 2,223 unit tests passed; 4 skipped; the only initial failure was the intentionally superseded Alembic-head assertion, which was corrected and rerun
- focused tenancy/migration tests: 20 passed
- PostgreSQL 15 migration from the previous head with existing staff membership backfill
- PostgreSQL 15 downgrade to the previous head
- `alembic check`: no new upgrade operations detected
- `git diff --check`

No OpenAPI or manager-client contract changed.