### PR TITLE
Drop legacy product area column

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -29,13 +29,12 @@ target_metadata = SQLModel.metadata
 
 
 def include_object(object_, name, type_, reflected, compare_to):
-    """Allow only the temporary product.area expand-contract drift."""
-    if not reflected or compare_to is not None:
-        return True
+    """Skip PostgreSQL's unstable rendering of the area expression index."""
     table_name = getattr(getattr(object_, "table", None), "name", None)
-    if table_name == "product" and (
-        (type_ == "column" and name == "area")
-        or (type_ == "index" and name == "ix_product_area")
+    if (
+        type_ == "index"
+        and table_name == "product"
+        and name == "ix_product_specs_area_m2"
     ):
         return False
     return True

--- a/alembic/versions/c35e9a2b7d41_drop_legacy_product_area.py
+++ b/alembic/versions/c35e9a2b7d41_drop_legacy_product_area.py
@@ -1,0 +1,108 @@
+"""Drop the legacy product.area mirror.
+
+Revision ID: c35e9a2b7d41
+Revises: b24d8f1a6c30
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c35e9a2b7d41"
+down_revision: Union[str, Sequence[str], None] = "b24d8f1a6c30"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+AREA_VALUE_SQL = "jsonb_extract_path_text(CAST(specs AS jsonb), 'area_m2')"
+
+
+def upgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_sync_product_area_transition ON product")
+    op.execute("DROP FUNCTION IF EXISTS sync_product_area_transition()")
+    op.drop_index("ix_product_area", table_name="product")
+    op.drop_column("product", "area")
+    op.create_check_constraint(
+        "ck_product_specs_area_m2_positive_number",
+        "product",
+        """
+        CASE
+            WHEN CAST(specs AS jsonb) ? 'area_m2' THEN
+                CASE
+                    WHEN specs ->> 'area_m2' ~ '^[0-9]+([.][0-9]+)?$'
+                        THEN CAST(specs ->> 'area_m2' AS numeric) > 0
+                    ELSE false
+                END
+            ELSE true
+        END
+        """,
+    )
+    op.execute(
+        f"""
+        CREATE INDEX ix_product_specs_area_m2
+        ON product ((CAST({AREA_VALUE_SQL} AS double precision)))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_product_specs_area_m2", table_name="product")
+    op.drop_constraint(
+        "ck_product_specs_area_m2_positive_number",
+        "product",
+        type_="check",
+    )
+    op.add_column("product", sa.Column("area", sa.Integer(), nullable=True))
+    op.execute(
+        """
+        UPDATE product
+        SET area = CASE
+            WHEN specs ->> 'area_m2' ~ '^[0-9]+([.][0-9]+)?$'
+                THEN CEIL(CAST(specs ->> 'area_m2' AS numeric))::integer
+            ELSE 0
+        END
+        """
+    )
+    op.alter_column(
+        "product",
+        "area",
+        nullable=False,
+        server_default=sa.text("0"),
+    )
+    op.create_index("ix_product_area", "product", ["area"], unique=False)
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION sync_product_area_transition()
+        RETURNS trigger AS $$
+        DECLARE
+            canonical_text text;
+        BEGIN
+            NEW.specs := (
+                COALESCE(NEW.specs, '{}'::json) :: jsonb - 'recommended_area_m2'
+            ) :: json;
+            canonical_text := NEW.specs ->> 'area_m2';
+
+            IF canonical_text ~ '^[0-9]+([.,][0-9]+)?$'
+               AND (TG_OP = 'INSERT' OR NEW.specs::jsonb IS DISTINCT FROM OLD.specs::jsonb) THEN
+                NEW.area := CEIL(REPLACE(canonical_text, ',', '.')::numeric)::integer;
+            ELSIF NEW.area > 0 AND (TG_OP = 'INSERT' OR NEW.area IS DISTINCT FROM OLD.area) THEN
+                NEW.specs := (
+                    COALESCE(NEW.specs, '{}'::json) :: jsonb
+                    || jsonb_build_object('area_m2', NEW.area)
+                ) :: json;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_sync_product_area_transition
+        BEFORE INSERT OR UPDATE OF area, specs ON product
+        FOR EACH ROW EXECUTE FUNCTION sync_product_area_transition()
+        """
+    )

--- a/models/product.py
+++ b/models/product.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Column, String, UniqueConstraint
+from sqlalchemy import Column, Float, Index, String, UniqueConstraint, cast, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, JSON, Relationship, SQLModel
 
 
@@ -106,6 +107,18 @@ class Product(SQLModel, table=True):
 
     def __str__(self):
         return f"{self.title} ({self.price} р)"
+
+
+Index(
+    "ix_product_specs_area_m2",
+    cast(
+        func.jsonb_extract_path_text(
+            cast(Product.__table__.c.specs, JSONB),
+            "area_m2",
+        ),
+        Float,
+    ),
+).ddl_if(dialect="postgresql")
 
 
 class ProductImage(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- drop the transition trigger, `ix_product_area`, and the legacy `product.area` column
- enforce positive numeric `specs.area_m2` values when the key is present
- add a PostgreSQL expression index for canonical area filtering
- replace the temporary expand-contract Alembic allowlist with a narrow expression-index normalization exception

## Rollout safety
PR #808 is already deployed and verified on both primary and standby with the same immutable image. Neither application container maps, reads, nor writes the legacy column, so this migration can run before blue-green replacement without breaking the active container.

## Verification
- PostgreSQL 15 upgrade/check/downgrade drill passed
- query planner uses `ix_product_specs_area_m2`
- invalid area values are rejected; decimal `20.5` is preserved
- SQLite metadata creation passed with the PostgreSQL-only index condition
- focused backend suite: `40 passed`
- production preflight: 1082 canonical values, 0 invalid values