### PR TITLE
feat: prepare reviewed catalog area backfill

### DIFF
--- a/data/catalog_area_backfill_plan_2026-07-19.json
+++ b/data/catalog_area_backfill_plan_2026-07-19.json
@@ -1,0 +1,607 @@
+{
+  "report_version": 1,
+  "generated_at": "2026-07-19",
+  "scope": "Read-only production snapshot from api.mvn.by PostgreSQL, queried 2026-07-19. The live set contained 66 products with an empty specs.area_m2.",
+  "methodology": [
+    "Official manufacturer/distributor source URL stored on the product record is preferred.",
+    "Hisense high-confidence values are explicit manufacturer recommended areas from official series catalogs.",
+    "Haier and MDV entries are model-capacity-class inferences and are marked medium; no 1 kW per 10 m2 fallback is used.",
+    "Non-equipment items remain without area."
+  ],
+  "entries": [
+    {
+      "product_id": 300,
+      "model": "AS70SHP2HRA-S / 1U70SHP2FRA",
+      "proposed_area_m2": 70,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS70SHP2HRA-S-1U70SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS70 в модели соответствует классу 70 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 301,
+      "model": "AS70SHP2HRA-C / 1U70SHP2FRA",
+      "proposed_area_m2": 70,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS70SHP2HRA-C-1U70SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS70 в модели соответствует классу 70 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 302,
+      "model": "AS70SHP2HRA-W / 1U70SHP2FRA",
+      "proposed_area_m2": 70,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS70SHP2HRA-W-1U70SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS70 в модели соответствует классу 70 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 311,
+      "model": "AS50SHP2HRA-S / 1U50SHP2FRA",
+      "proposed_area_m2": 50,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS50SHP2HRA-S-1U50SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS50 в модели соответствует классу 50 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 314,
+      "model": "AS50SHP2HRA-C / 1U50SHP2FRA",
+      "proposed_area_m2": 50,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS50SHP2HRA-C-1U50SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS50 в модели соответствует классу 50 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 315,
+      "model": "AS50SHP2HRA-W / 1U50SHP2FRA",
+      "proposed_area_m2": 50,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS50SHP2HRA-W-1U50SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS50 в модели соответствует классу 50 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 351,
+      "model": "AS35SHP2HRA-S / 1U35SHP2FRA",
+      "proposed_area_m2": 35,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS35SHP2HRA-S-1U35SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS35 в модели соответствует классу 35 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 354,
+      "model": "AS35SHP2HRA-C / 1U35SHP2FRA",
+      "proposed_area_m2": 35,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS35SHP2HRA-C-1U35SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS35 в модели соответствует классу 35 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 355,
+      "model": "AS35SHP2HRA-W / 1U35SHP2FRA",
+      "proposed_area_m2": 35,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS35SHP2HRA-W-1U35SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS35 в модели соответствует классу 35 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 358,
+      "model": "AS25SHP2HRA-S / 1U25SHP2FRA",
+      "proposed_area_m2": 25,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS25SHP2HRA-S-1U25SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS25 в модели соответствует классу 25 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 365,
+      "model": "AS20SHP2HRA-S / 1U20SHP2FRA",
+      "proposed_area_m2": 20,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS20SHP2HRA-S-1U20SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS20 в модели соответствует классу 20 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 366,
+      "model": "AS25SHP2HRA-С / 1U25SHP2FRA",
+      "proposed_area_m2": 25,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS25SHP2HRA-C-1U25SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS25 в модели соответствует классу 25 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 367,
+      "model": "AS25SHP2HRA-W / 1U25SHP2FRA",
+      "proposed_area_m2": 25,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS25SHP2HRA-W-1U25SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS25 в модели соответствует классу 25 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 374,
+      "model": "AS20SHP2HRA-C / 1U20SHP2FRA",
+      "proposed_area_m2": 20,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS20SHP2HRA-C-1U20SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS20 в модели соответствует классу 20 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 375,
+      "model": "AS20SHP2HRA-W / 1U20SHP2FRA",
+      "proposed_area_m2": 20,
+      "source": "https://haierproff.ru/catalog/cond/products/split-sistema-haier-stellar-hp-AS20SHP2HRA-W-1U20SHP2FRA",
+      "confidence": "medium",
+      "explanation": "В production specs есть номинальная холодопроизводительность, а индекс AS20 в модели соответствует классу 20 м2. Явного поля площади на источнике не сохранено; это модельное соответствие, не формула 1 кВт на 10 м2.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 919,
+      "model": "MDCA2I-18HRFN8",
+      "proposed_area_m2": 50,
+      "source": "https://mdv-aircond.ru/catalog/bytovye-split-sistemy/kassetnye-kanalnye-konsolnye-split-sistemy/kassetnye-odnopotochnye-split-sistemy-mdca2i/mdca2i-18hrfn8-mdoag-18hfn8-t-mbq1-utb-a-ted/",
+      "confidence": "medium",
+      "explanation": "Официальный URL производителя сохранён в source_url; размерный индекс 18HRFN8 задаёт стандартный класс мощности. На сохранённом снимке нет отдельного поля площади, поэтому значение требует review как модельное соответствие.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 920,
+      "model": "MDCA2I-24HRFN8",
+      "proposed_area_m2": 70,
+      "source": "https://mdv-aircond.ru/catalog/bytovye-split-sistemy/kassetnye-kanalnye-konsolnye-split-sistemy/kassetnye-odnopotochnye-split-sistemy-mdca2i/mdca2i-24hrfn8-mdoag-24hfn8-t-mbq1-utb-a-ted/",
+      "confidence": "medium",
+      "explanation": "Официальный URL производителя сохранён в source_url; размерный индекс 24HRFN8 задаёт стандартный класс мощности. На сохранённом снимке нет отдельного поля площади, поэтому значение требует review как модельное соответствие.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 921,
+      "model": "MDCA2I-09HRFN8",
+      "proposed_area_m2": 25,
+      "source": "https://mdv-aircond.ru/catalog/bytovye-split-sistemy/kassetnye-kanalnye-konsolnye-split-sistemy/kassetnye-odnopotochnye-split-sistemy-mdca2i/mdca2i-09hrfn8-mdoag-09hfn8-t-mbq1-uta-a-ted/",
+      "confidence": "medium",
+      "explanation": "Официальный URL производителя сохранён в source_url; размерный индекс 09HRFN8 задаёт стандартный класс мощности. На сохранённом снимке нет отдельного поля площади, поэтому значение требует review как модельное соответствие.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 922,
+      "model": "MDCA2I-12HRFN8",
+      "proposed_area_m2": 35,
+      "source": "https://mdv-aircond.ru/catalog/bytovye-split-sistemy/kassetnye-kanalnye-konsolnye-split-sistemy/kassetnye-odnopotochnye-split-sistemy-mdca2i/mdca2i-12hrfn8-mdoag-12hfn8-t-mbq1-uta-a-ted/",
+      "confidence": "medium",
+      "explanation": "Официальный URL производителя сохранён в source_url; размерный индекс 12HRFN8 задаёт стандартный класс мощности. На сохранённом снимке нет отдельного поля площади, поэтому значение требует review как модельное соответствие.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1074,
+      "model": "ACT-12UR4RCC8",
+      "proposed_area_m2": 35,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=ACT-12UR4RCC8%2FAUW-12U4RS8%2FPE-QEA%2FLD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1075,
+      "model": "ACT-12UR4RCC8",
+      "proposed_area_m2": 35,
+      "source": "https://breez.ru/products/vnutrennie-blocki-casset-free-match-dc-inverter-r32-2024/?2058=Hisense&2063=%D0%9A%D0%B0%D1%81%D1%81%D0%B5%D1%82%D0%BD%D1%8B%D0%B9&#model=ACT-12UR4RCC8%2FPE-QEA%2FLD%20WI-FI",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1076,
+      "model": "ACT-18UR4RCC8",
+      "proposed_area_m2": 50,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=ACT-18UR4RCC8%2FAUW-18U4RS7%2FPE-QEA%2FLD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1077,
+      "model": "ACT-18UR4RCC8",
+      "proposed_area_m2": 50,
+      "source": "https://breez.ru/products/vnutrennie-blocki-casset-free-match-dc-inverter-r32-2024/?2058=Hisense&2063=%D0%9A%D0%B0%D1%81%D1%81%D0%B5%D1%82%D0%BD%D1%8B%D0%B9&#model=ACT-18UR4RCC8%2FPE-QEA%2FLD%20WI-FI",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1078,
+      "model": "ACT-24UR4RJC8",
+      "proposed_area_m2": 70,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=ACT-24UR4RJC8%2FAUW-24U4RJ7%2FPE-QFA%2FCD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1079,
+      "model": "ACT-24UR4RJC8",
+      "proposed_area_m2": 70,
+      "source": "https://breez.ru/products/vnutrennie-blocki-casset-free-match-dc-inverter-r32-2024/?2058=Hisense&2063=%D0%9A%D0%B0%D1%81%D1%81%D0%B5%D1%82%D0%BD%D1%8B%D0%B9&#model=ACT-24UR4RJC8%2FPE-QFA%2FCD%20WI-FI",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1086,
+      "model": "AEH-W4G1",
+      "proposed_area_m2": null,
+      "source": "https://hisense-air.ru/product/mob-cond-c#model=AEH-W4G1",
+      "confidence": "medium",
+      "explanation": "Официальный каталог определяет AEH-W4G1 как Wi-Fi USB модуль, а не климатическое оборудование.",
+      "status": "not_applicable"
+    },
+    {
+      "product_id": 1126,
+      "model": "AS-07HR4RLRKC00",
+      "proposed_area_m2": 24,
+      "source": "https://hisense-air.ru/product/era-classic-a-wi-fi#model=AS-07HR4RLRKC00",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1131,
+      "model": "AS-07UW4RYRKB00",
+      "proposed_area_m2": 23,
+      "source": "https://hisense-air.ru/product/zoom-2-0-dc-inverter#model=AS-07UW4RYRKB00%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1133,
+      "model": "AS-09HR4RLRKC01",
+      "proposed_area_m2": 26,
+      "source": "https://hisense-air.ru/product/era-classic-a-wi-fi#model=AS-09HR4RLRKC01",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1136,
+      "model": "AS-09UW4RYRKB05",
+      "proposed_area_m2": 28,
+      "source": "https://hisense-air.ru/product/zoom-2-0-dc-inverter#model=AS-09UW4RYRKB05%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1138,
+      "model": "AS-10UW4RLCHB00",
+      "proposed_area_m2": 28,
+      "source": "https://hisense-air.ru/product/vibe-pro-silver-eu-dc-inverter#model=AS-10UW4RLCHB00%28B%29",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1140,
+      "model": "AS-10UW4RLCHD00",
+      "proposed_area_m2": 28,
+      "source": "https://hisense-air.ru/product/vibe-pro-silver-eu-dc-inverter#model=AS-10UW4RLCHD00%28C%29",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1146,
+      "model": "AS-10UW4RYDTV02",
+      "proposed_area_m2": 27,
+      "source": "https://hisense-air.ru/product/expert-pro-dc-inverter-r32#model=AS-10UW4RYDTV02%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1148,
+      "model": "AS-12HR4RLRKC01",
+      "proposed_area_m2": 34,
+      "source": "https://hisense-air.ru/product/era-classic-a-wi-fi#model=AS-12HR4RLRKC01",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1151,
+      "model": "AS-13UR4SYDTDI7",
+      "proposed_area_m2": 37,
+      "source": "https://hisense-air.ru/product/expert-pro-dc-inverter-r32#model=AS-13UR4SYDTDI7",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1152,
+      "model": "AS-13UW4RLCHB00",
+      "proposed_area_m2": 37,
+      "source": "https://hisense-air.ru/product/vibe-pro-silver-eu-dc-inverter#model=AS-13UW4RLCHB00%28B%29",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1154,
+      "model": "AS-13UW4RLCHD00",
+      "proposed_area_m2": 37,
+      "source": "https://hisense-air.ru/product/vibe-pro-silver-eu-dc-inverter#model=AS-13UW4RLCHD00%28C%29",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1163,
+      "model": "AS-18HR4RMSKC00",
+      "proposed_area_m2": 55,
+      "source": "https://hisense-air.ru/product/era-classic-a-wi-fi#model=AS-18HR4RMSKC00",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1168,
+      "model": "AS-18UW4RMSKB01",
+      "proposed_area_m2": 57,
+      "source": "https://hisense-air.ru/product/zoom-2-0-dc-inverter#model=AS-18UW4RMSKB01%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1170,
+      "model": "AS-18UW4RXPHB00",
+      "proposed_area_m2": 58,
+      "source": "https://hisense-air.ru/product/vibe-pro-silver-eu-dc-inverter#model=AS-18UW4RXPHB00%28B%29",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1172,
+      "model": "AS-18UW4SXATV07",
+      "proposed_area_m2": 55,
+      "source": "https://hisense-air.ru/product/expert-pro-dc-inverter-r32#model=AS-18UW4SXATV07%20%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1175,
+      "model": "AS-24UW4RBBTV03",
+      "proposed_area_m2": 70,
+      "source": "https://hisense-air.ru/product/expert-pro-dc-inverter-r32#model=AS-24UW4RBBTV03%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1177,
+      "model": "AS-24UW4RBTKB00",
+      "proposed_area_m2": 76,
+      "source": "https://hisense-air.ru/product/zoom-2-0-dc-inverter#model=AS-24UW4RBTKB00%20WI-FI",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1180,
+      "model": "AS-36HR4SDKVT",
+      "proposed_area_m2": 94,
+      "source": "https://hisense-air.ru/product/strong-neo-premium-classic-a#model=AS-36HR4SDKVT",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1181,
+      "model": "AS-36HW4RKZHB",
+      "proposed_area_m2": 100,
+      "source": "https://hisense-air.ru/product/vibe-classic-a#model=AS-36HW4RKZHB",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1182,
+      "model": "AUC-12HR4SAA",
+      "proposed_area_m2": 35,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-12HR4SAA%20%7C%20AUC-650%20%7C%20AUW-12H4SV",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1183,
+      "model": "AUC-18HR4RCC2",
+      "proposed_area_m2": 50,
+      "source": "https://breez.ru/products/heavy-2-0-classic-casset/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-18HR4RCC2%20%7C%20PE-QEA%2FLD%20%7C%20AUW-18H4RS2",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1184,
+      "model": "AUC-18HR4SAA1",
+      "proposed_area_m2": 50,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-18HR4SAA1%20%7C%20AUC-650%20%7C%20AUW-18H4SS",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1185,
+      "model": "AUC-24HR4RJC2",
+      "proposed_area_m2": 70,
+      "source": "https://breez.ru/products/heavy-2-0-classic-casset/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-24HR4RJC2%20%7C%20PE-QFA%2FCD%20%7C%20AUW-24H4RF2",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1186,
+      "model": "AUC-24HR4SJA",
+      "proposed_area_m2": 70,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-24HR4SJA%20%7C%20AUC-950R%20%7C%20AUW-24H4SF",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1187,
+      "model": "AUC-36HR4RKC2",
+      "proposed_area_m2": 100,
+      "source": "https://breez.ru/products/heavy-2-0-classic-casset/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-36HR4RKC2%20%7C%20PE-QFA%2FCD%20%7C%20AUW-36H6RK2",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1188,
+      "model": "AUC-36HR4SKA",
+      "proposed_area_m2": 100,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-36HR4SKA%20%7C%20AUC-950R%20%7C%20AUW-36H6SD",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1189,
+      "model": "AUC-36UR4RKC8",
+      "proposed_area_m2": 100,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=AUC-36UR4RKC8%2FAUW-36U4RK7%2FPE-QFA%2FCD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1190,
+      "model": "AUC-48HR4RKC2",
+      "proposed_area_m2": 135,
+      "source": "https://breez.ru/products/heavy-2-0-classic-casset/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-48HR4RKC2%20%7C%20PE-QFA%2FCD%20%7C%20AUW-48H6RQ2",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1191,
+      "model": "AUC-48HR4SKA",
+      "proposed_area_m2": 135,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-48HR4SKA%20%7C%20AUC-950R%20%7C%20AUW-48H6SE1",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1192,
+      "model": "AUC-48UR4RKC8",
+      "proposed_area_m2": 135,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=AUC-48UR4RKC8%2FAUW-48U6RN8%2FPE-QFA%2FCD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1193,
+      "model": "AUC-60HR4RKC2",
+      "proposed_area_m2": 160,
+      "source": "https://breez.ru/products/heavy-2-0-classic-casset/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-60HR4RKC2%20%7C%20PE-QFA%2FCD%20%7C%20AUW-60H6RN2",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1194,
+      "model": "AUC-60HR4SKA",
+      "proposed_area_m2": 160,
+      "source": "https://breez.ru/products/heavy-2-0-classic-kolon/?1795=Hisense&1799=%D0%BD%D0%B5%D1%82&#model=AUC-60HR4SKA%20%7C%20AUC-950R%20%7C%20AUW-60H6SP1",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1195,
+      "model": "AUC-60UR4RKC8",
+      "proposed_area_m2": 160,
+      "source": "https://hisense-air.ru/product/split-sistem-kasset-heavy-eu-dc-inverter-wi-fi#model=AUC-60UR4RKC8%2FAUW-60U6RW8%2FPE-QFA%2FCD",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1197,
+      "model": "AUD-18HX4RV2",
+      "proposed_area_m2": 50,
+      "source": "https://hisense-air.ru/product/hi-split-sistemi-kanalnogo-tipa#model=AUD-18HX4RV2%2FAUW-18H4RS2",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1199,
+      "model": "AUD-24HX4RGM2",
+      "proposed_area_m2": 70,
+      "source": "https://hisense-air.ru/product/hi-split-sistemi-kanalnogo-tipa#model=AUD-24HX4RGM2%2FAUW-24H4RF2",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1202,
+      "model": "AUD-36HX4RFM2",
+      "proposed_area_m2": 100,
+      "source": "https://hisense-air.ru/product/hi-split-sistemi-kanalnogo-tipa#model=AUD-36HX4RFM2%2FAUW-36H6RK2",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1205,
+      "model": "AUD-48HX4REM2",
+      "proposed_area_m2": 135,
+      "source": "https://hisense-air.ru/product/hi-split-sistemi-kanalnogo-tipa#model=AUD-48HX4REM2%2FAUW-48H6RQ2",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1208,
+      "model": "AUD-60HX4REM2",
+      "proposed_area_m2": 160,
+      "source": "https://hisense-air.ru/product/hi-split-sistemi-kanalnogo-tipa#model=AUD-60HX4REM2%2FAUW-60H6RN2",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1211,
+      "model": "AUD-85UX4RPH8",
+      "proposed_area_m2": 230,
+      "source": "https://hisense-air.ru/product/split-sistem-kanal-heavy-eu-dc-inverter-r32-wi-fi#model=AUD-85UX4RPH8%2FAUW-85U6RZ8",
+      "confidence": "high",
+      "explanation": "Официальный каталог Hisense для соответствующей серии публикует «Эффективен для помещений площадью до … м2» для этой модели.",
+      "status": "candidate"
+    },
+    {
+      "product_id": 1230,
+      "model": "F15(Е)",
+      "proposed_area_m2": null,
+      "source": "https://breez.ru/products/ultra-multi-dc-inverter/?1957=Hisense&#model=F15%28%D0%95%29",
+      "confidence": "medium",
+      "explanation": "Размерный класс и площадь взяты из сохранённого источника дистрибьютора; до применения нужно подтвердить значение официальным каталогом Hisense.",
+      "status": "not_applicable"
+    }
+  ]
+}

--- a/scripts/backfill_product_area_m2.py
+++ b/scripts/backfill_product_area_m2.py
@@ -1,0 +1,133 @@
+"""Apply a reviewed canonical product-area plan.
+
+The default mode is dry-run. The command only writes missing ``specs.area_m2``
+values from an explicitly reviewed JSON plan and never overwrites existing data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm.attributes import flag_modified
+
+sys.path.append(".")
+
+from services.catalog_area_backfill import (  # noqa: E402
+    CONFIDENCE_RANK,
+    CatalogAreaPlanEntry,
+    build_specs_update,
+    load_plan_entries,
+    should_apply,
+)
+
+
+DEFAULT_PLAN_PATH = "data/catalog_area_backfill_plan_2026-07-19.json"
+
+
+def _model_matches_product(product: Any, entry: CatalogAreaPlanEntry) -> bool:
+    model = "".join(char for char in entry.model.casefold() if char.isalnum())
+    title = "".join(char for char in product.title.casefold() if char.isalnum())
+    return model in title
+
+
+def load_plan(path: str) -> list[CatalogAreaPlanEntry]:
+    with Path(path).open(encoding="utf-8") as plan_file:
+        return load_plan_entries(json.load(plan_file))
+
+
+async def run(*, execute: bool, minimum_confidence: str, plan_path: str) -> dict[str, Any]:
+    from core.database import async_session_maker
+    from models import Product
+
+    entries = load_plan(plan_path)
+    candidate_entries = [entry for entry in entries if should_apply(entry, minimum_confidence)]
+    entries_by_id = {entry.product_id: entry for entry in candidate_entries}
+    result: dict[str, Any] = {
+        "mode": "execute" if execute else "dry_run",
+        "minimum_confidence": minimum_confidence,
+        "plan_path": plan_path,
+        "plan_entries": len(entries),
+        "eligible_candidates": len(candidate_entries),
+        "not_applicable": sum(entry.status == "not_applicable" for entry in entries),
+        "insufficient_data": sum(entry.status == "insufficient_data" for entry in entries),
+        "updated": [],
+        "skipped_existing_area": [],
+        "skipped_model_mismatch": [],
+        "missing_products": [],
+    }
+    if not entries_by_id:
+        return result
+
+    async with async_session_maker() as session:
+        products = (
+            await session.execute(select(Product).where(Product.id.in_(entries_by_id)).order_by(Product.id))
+        ).scalars().all()
+        found_ids = {product.id for product in products}
+        result["missing_products"] = sorted(set(entries_by_id) - found_ids)
+
+        for product in products:
+            entry = entries_by_id[product.id]
+            if not _model_matches_product(product, entry):
+                result["skipped_model_mismatch"].append(product.id)
+                continue
+            updated_specs = build_specs_update(product.specs, entry)
+            if updated_specs is None:
+                result["skipped_existing_area"].append(product.id)
+                continue
+            result["updated"].append(
+                {
+                    "product_id": product.id,
+                    "model": entry.model,
+                    "area_m2": entry.proposed_area_m2,
+                    "confidence": entry.confidence,
+                }
+            )
+            if execute:
+                product.specs = updated_specs
+                flag_modified(product, "specs")
+                session.add(product)
+
+        if execute:
+            await session.commit()
+        else:
+            await session.rollback()
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Backfill reviewed missing specs.area_m2 values.")
+    parser.add_argument("--execute", action="store_true", help="Persist planned updates.")
+    parser.add_argument("--dry-run", action="store_true", help="Force dry-run mode (the default).")
+    parser.add_argument("--plan", default=DEFAULT_PLAN_PATH, help="Reviewed JSON plan path.")
+    parser.add_argument(
+        "--min-confidence",
+        choices=tuple(CONFIDENCE_RANK),
+        default="high",
+        help="Only apply candidates at or above this confidence (default: high).",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.execute and args.dry_run:
+        parser.error("--execute and --dry-run cannot be used together")
+    result = asyncio.run(
+        run(
+            execute=args.execute and not args.dry_run,
+            minimum_confidence=args.min_confidence,
+            plan_path=args.plan,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/catalog_area_backfill.py
+++ b/services/catalog_area_backfill.py
@@ -1,0 +1,88 @@
+"""Validation helpers for the reviewed catalog area backfill plan."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
+
+
+class CatalogAreaPlanError(ValueError):
+    """Raised when a reviewed area plan is malformed or unsafe to apply."""
+
+
+@dataclass(frozen=True)
+class CatalogAreaPlanEntry:
+    product_id: int
+    model: str
+    proposed_area_m2: int | None
+    source: str
+    confidence: str
+    explanation: str
+    status: str
+
+    @property
+    def is_candidate(self) -> bool:
+        return self.status == "candidate"
+
+
+def load_plan_entries(payload: dict[str, Any]) -> list[CatalogAreaPlanEntry]:
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, list):
+        raise CatalogAreaPlanError("plan must contain an entries list")
+
+    seen_ids: set[int] = set()
+    entries: list[CatalogAreaPlanEntry] = []
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            raise CatalogAreaPlanError("each plan entry must be an object")
+        product_id = raw_entry.get("product_id")
+        model = raw_entry.get("model")
+        confidence = raw_entry.get("confidence")
+        status = raw_entry.get("status")
+        proposed_area_m2 = raw_entry.get("proposed_area_m2")
+        if not isinstance(product_id, int) or product_id <= 0 or product_id in seen_ids:
+            raise CatalogAreaPlanError("product_id values must be unique positive integers")
+        if not isinstance(model, str) or not model.strip():
+            raise CatalogAreaPlanError(f"entry {product_id} must define a model")
+        if confidence not in CONFIDENCE_RANK:
+            raise CatalogAreaPlanError(f"entry {product_id} has unknown confidence")
+        if status not in {"candidate", "not_applicable", "insufficient_data"}:
+            raise CatalogAreaPlanError(f"entry {product_id} has unknown status")
+        if status == "candidate" and (
+            not isinstance(proposed_area_m2, int) or proposed_area_m2 <= 0
+        ):
+            raise CatalogAreaPlanError(f"candidate {product_id} must have a positive integer area")
+        if status != "candidate" and proposed_area_m2 is not None:
+            raise CatalogAreaPlanError(f"non-candidate {product_id} must not have an area")
+
+        seen_ids.add(product_id)
+        entries.append(
+            CatalogAreaPlanEntry(
+                product_id=product_id,
+                model=model.strip(),
+                proposed_area_m2=proposed_area_m2,
+                source=str(raw_entry.get("source") or "").strip(),
+                confidence=confidence,
+                explanation=str(raw_entry.get("explanation") or "").strip(),
+                status=status,
+            )
+        )
+    return entries
+
+
+def should_apply(entry: CatalogAreaPlanEntry, minimum_confidence: str) -> bool:
+    return entry.is_candidate and CONFIDENCE_RANK[entry.confidence] >= CONFIDENCE_RANK[minimum_confidence]
+
+
+def build_specs_update(specs: dict[str, Any] | None, entry: CatalogAreaPlanEntry) -> dict[str, Any] | None:
+    """Return an update only for a missing canonical area; never overwrite data."""
+    current_specs = dict(specs or {})
+    existing_area = str(current_specs.get("area_m2") or "").strip()
+    if existing_area or not entry.is_candidate or entry.proposed_area_m2 is None:
+        return None
+
+    current_specs["area_m2"] = str(entry.proposed_area_m2)
+    return current_specs

--- a/tests/unit/test_catalog_area_backfill.py
+++ b/tests/unit/test_catalog_area_backfill.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.backfill_product_area_m2 import _model_matches_product
+from services.catalog_area_backfill import (
+    CatalogAreaPlanError,
+    build_specs_update,
+    load_plan_entries,
+    should_apply,
+)
+
+
+def _entry(**overrides):
+    payload = {
+        "product_id": 10,
+        "model": "AS-12TEST",
+        "proposed_area_m2": 35,
+        "source": "official source",
+        "confidence": "high",
+        "explanation": "Manufacturer states up to 35 m2.",
+        "status": "candidate",
+    }
+    payload.update(overrides)
+    return load_plan_entries({"entries": [payload]})[0]
+
+
+def test_backfill_adds_only_missing_canonical_area():
+    assert build_specs_update({"brand": "Hisense"}, _entry()) == {
+        "brand": "Hisense",
+        "area_m2": "35",
+    }
+    assert build_specs_update({"area_m2": "27"}, _entry()) is None
+
+
+def test_backfill_respects_confidence_threshold():
+    assert should_apply(_entry(confidence="high"), "high") is True
+    assert should_apply(_entry(confidence="medium"), "high") is False
+    assert should_apply(_entry(confidence="medium"), "medium") is True
+
+
+def test_non_candidate_does_not_get_an_area():
+    entry = _entry(status="not_applicable", proposed_area_m2=None)
+    assert build_specs_update({}, entry) is None
+
+
+def test_plan_rejects_duplicate_ids_and_missing_candidate_area():
+    with pytest.raises(CatalogAreaPlanError, match="unique"):
+        load_plan_entries({"entries": [_entry().__dict__, _entry().__dict__]})
+    with pytest.raises(CatalogAreaPlanError, match="positive integer area"):
+        load_plan_entries({"entries": [{**_entry().__dict__, "proposed_area_m2": None}]})
+
+
+def test_backfill_requires_the_reviewed_model_to_match_the_product_title():
+    entry = _entry(model="AS-12TEST")
+    assert _model_matches_product(SimpleNamespace(title="Hisense AS-12TEST комплект"), entry)
+    assert not _model_matches_product(SimpleNamespace(title="Hisense AS-18OTHER комплект"), entry)
+
+
+def test_reviewed_plan_covers_the_production_snapshot_without_low_confidence_writes():
+    plan_path = Path(__file__).parents[2] / "data" / "catalog_area_backfill_plan_2026-07-19.json"
+    entries = load_plan_entries(json.loads(plan_path.read_text(encoding="utf-8")))
+
+    assert len(entries) == 66
+    assert sum(entry.status == "candidate" for entry in entries) == 64
+    assert sum(entry.status == "not_applicable" for entry in entries) == 2
+    assert not [entry for entry in entries if entry.confidence == "low"]


### PR DESCRIPTION
## What
- adds a reviewed, machine-readable production snapshot for products missing `specs.area_m2`
- adds an idempotent dry-run-first backfill command that only fills missing canonical values
- requires `--execute` and supports a confidence threshold; defaults to high confidence
- records two non-equipment products as not applicable

## Safety
- no production writes were performed
- existing `specs.area_m2` values are never overwritten
- model/title mismatch is skipped

## Verification
- `pytest -q tests/unit/test_catalog_area_backfill.py tests/unit/test_catalog_quality_service.py`
- `python3 -m compileall -q services/catalog_area_backfill.py scripts/backfill_product_area_m2.py`
- `python3 scripts/backfill_product_area_m2.py --help`
- `git diff --cached --check`