### PR TITLE
fix: reconcile verified PITR release drift

### DIFF
--- a/scripts/ha/pitr_bundle_executor_source.py
+++ b/scripts/ha/pitr_bundle_executor_source.py
@@ -484,7 +484,7 @@ def verify_rollback_generations(receipt):
         if (not generation["present"]
                 or hashlib.sha256(content).hexdigest() != generation["sha256"]):
             raise RuntimeError("recorded rollback generation does not match: " + generation["path"])
-def read_release_manifest(modes, project_dir, allow_previous=False):
+def read_release_manifest(modes, project_dir, allow_previous=False, target_files=()):
     try:
         content, _ = read_regular(RELEASE_MANIFEST, exact_mode=0o600, max_bytes=MAX_BUNDLE)
     except FileNotFoundError:
@@ -523,9 +523,11 @@ def read_release_manifest(modes, project_dir, allow_previous=False):
                          and paths == sorted(set(modes) - missing))
     if paths != sorted(modes) and not previous_is_valid:
         raise RuntimeError("release manifest path set is incomplete")
+    targets = {entry["path"]: entry for entry in (target_files or ())}
     for item in files:
         content, _ = read_regular(item["path"], exact_mode=item["mode"])
-        if hashlib.sha256(content).hexdigest() != item["sha256"]:
+        digest, target = hashlib.sha256(content).hexdigest(), targets.get(item["path"])
+        if digest != item["sha256"] and (not target or target["mode"] != item["mode"] or digest != target["sha256"]):
             raise RuntimeError("current file does not match the release manifest: " + item["path"])
     return manifest
 def clear_completed_marker(txid):
@@ -555,7 +557,7 @@ def inspect_release(txid, project_dir, modes, release, descriptors):
             if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) == "unknown":
                 raise RuntimeError("active release transaction has an unknown generation")
         return "matching-active"
-    completed = read_release_manifest(modes, project_dir, allow_previous=True)
+    completed = read_release_manifest(modes, project_dir, allow_previous=True, target_files=descriptors)
     if completed is not None and completed["txid"] == txid:
         if completed["release_sha256"] != release or completed["files"] != expected:
             raise RuntimeError("transaction id already finalized another release")
@@ -585,7 +587,7 @@ def execute(action, txid, project_dir, compose_file, payload):
         txdir = os.path.join(TRANSACTION_ROOT, txid)
         has_tx = transaction_exists(txdir)
         completed = None if has_tx else read_release_manifest(
-            modes, project_dir, allow_previous=action == "apply"
+            modes, project_dir, allow_previous=action == "apply", target_files=descriptors
         )
         if completed is not None and completed["txid"] == txid:
             if has_tx:

--- a/tests/unit/test_pitr_bundle_transport.py
+++ b/tests/unit/test_pitr_bundle_transport.py
@@ -58,8 +58,8 @@ def _remote_namespace(tmp_path):
     return namespace, project, compose, tool
 
 
-def _payload(namespace, project, compose, tool, *, tool_content=b"new-tool"):
-    contents = {str(compose): b"new-compose", str(tool): tool_content}
+def _payload(namespace, project, compose, tool, *, tool_content=b"new-tool", compose_content=b"new-compose"):
+    contents = {str(compose): compose_content, str(tool): tool_content}
     modes = {str(compose): 0o644, str(tool): 0o755}
     files = [
         {
@@ -270,6 +270,34 @@ def test_apply_and_finalize_accept_identical_old_and_new_generation(tmp_path):
     assert namespace["execute"](
         "finalize", TXID, str(project), compose.name, b""
     ) == "finalized"
+
+
+def test_apply_reconciles_only_exact_target_generation_after_finalized_release(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    old_payload, _ = _payload(namespace, project, compose, tool, tool_content=b"old-tool", compose_content=b"old-compose")
+    assert namespace["execute"]("apply", "1" * 32, str(project), compose.name, old_payload) == "applied"
+    assert namespace["execute"]("finalize", "1" * 32, str(project), compose.name, b"") == "finalized"
+
+    target_payload, _ = _payload(namespace, project, compose, tool)
+    _write(compose, b"new-compose", 0o644)
+    assert namespace["execute"]("inspect", TXID, str(project), compose.name, target_payload) == "fresh"
+    assert namespace["execute"]("apply", TXID, str(project), compose.name, target_payload) == "applied"
+
+
+def test_apply_rejects_unreviewed_generation_after_finalized_release(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    old_payload, _ = _payload(namespace, project, compose, tool, tool_content=b"old-tool", compose_content=b"old-compose")
+    assert namespace["execute"]("apply", "1" * 32, str(project), compose.name, old_payload) == "applied"
+    assert namespace["execute"]("finalize", "1" * 32, str(project), compose.name, b"") == "finalized"
+
+    target_payload, _ = _payload(namespace, project, compose, tool)
+    _write(compose, b"unreviewed-compose", 0o644)
+    with pytest.raises(RuntimeError, match="current file does not match"):
+        namespace["execute"]("inspect", TXID, str(project), compose.name, target_payload)
 
 
 def test_apply_accepts_only_exact_previous_manifest_missing_new_safe_lock_helper(tmp_path):


### PR DESCRIPTION
## Why\n\nPITR host release manifests can become stale after a reviewed compose update, causing scheduled basebackup/WAL jobs and restore drills to fail closed.\n\n## Change\n\nPermit a finalized manifest to be reconciled only when the current file already matches the exact new, decoded target release. Any unknown generation remains blocked.\n\n## Validation\n\n- ........................................................................ [ 88%]
.........                                                                [100%]
81 passed in 0.55s\n- \n\nProduction follow-up: run the existing full two-node PITR transaction, then verify fresh basebackup/WAL and restore drills.