### PR TITLE
fix: prefetch pinned PITR basebackup image

### DIFF
--- a/scripts/ha/bootstrap_postgres_pitr.sh
+++ b/scripts/ha/bootstrap_postgres_pitr.sh
@@ -16,6 +16,7 @@ STATUS_HELPER="${STATUS_HELPER:-/usr/local/sbin/mvn-postgres-pitr-status}"
 RESTORE_DRILL_HELPER="${RESTORE_DRILL_HELPER:-/usr/local/sbin/mvn-postgres-pitr-restore-drill}"
 RUNTIME_CHECK_HELPER="${RUNTIME_CHECK_HELPER:-/usr/local/sbin/mvn-postgres-pitr-runtime-check}"
 TOOL_RUNNER_HELPER="${TOOL_RUNNER_HELPER:-/usr/local/sbin/mvn-postgres-pitr-tool-runner}"
+PITR_BASEBACKUP_IMAGE="postgres:15.18-alpine@sha256:3d0f7584ed7d04e27fa050d6683a74746608faf21f202be78460d679cc56461f"
 BLUE_GREEN_HELPER="${BLUE_GREEN_HELPER:-/usr/local/libexec/mvn-pitr/deploy_backend_blue_green.sh}"
 BLUE_GREEN_SAFETY_HELPER="${API_BLUE_GREEN_SAFETY_HELPER:-/usr/local/libexec/mvn-pitr/deploy_backend_blue_green_safety.sh}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-/usr/local/libexec/mvn-pitr/safe_deploy_lock.py}"
@@ -76,6 +77,14 @@ require_command() {
 }
 require_executable() {
   [[ -x "$1" ]] || die "required helper is not executable: $1"
+}
+ensure_basebackup_image() {
+  require_command docker
+  log "prefetching pinned pg_basebackup image before maintenance"
+  docker pull --platform linux/amd64 "${PITR_BASEBACKUP_IMAGE}" >/dev/null ||
+    die "could not prefetch the pinned pg_basebackup image"
+  docker image inspect "${PITR_BASEBACKUP_IMAGE}" >/dev/null ||
+    die "pinned pg_basebackup image is unavailable after prefetch"
 }
 require_active_patroni_compose() {
   local db_container managed_configs runtime_policy target_config
@@ -289,6 +298,7 @@ preflight() {
   require_executable "${RESTORE_DRILL_HELPER}"
   require_executable "${RUNTIME_CHECK_HELPER}"
   require_executable "${TOOL_RUNNER_HELPER}"
+  ensure_basebackup_image
   print_archive_settings
   require_env_input_file
   log "validating PITR input env with dry-run configure helper"

--- a/tests/unit/test_postgres_pitr_runtime_contract.py
+++ b/tests/unit/test_postgres_pitr_runtime_contract.py
@@ -466,6 +466,19 @@ def test_timer_units_and_wrappers_use_clean_pinned_execution():
     assert ":ro" in restore_source
 
 
+def test_pitr_preflight_prefetches_the_pinned_basebackup_image():
+    source = (REPO_ROOT / "scripts/ha/bootstrap_postgres_pitr.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'PITR_BASEBACKUP_IMAGE="postgres:15.18-alpine@sha256:' in source
+    assert 'docker pull --platform linux/amd64 "${PITR_BASEBACKUP_IMAGE}"' in source
+    assert 'docker image inspect "${PITR_BASEBACKUP_IMAGE}"' in source
+    assert source.index("ensure_basebackup_image") < source.index("preflight()")
+    preflight = source[source.index("preflight()") : source.index("provision_node()")]
+    assert '  ensure_basebackup_image\n' in preflight
+
+
 def test_explicit_upload_helper_precedes_image_package_import():
     for name in (
         "check_postgres_pitr_remote.py",


### PR DESCRIPTION
## Why

The cluster PITR migration reached the initial basebackup stage with the pinned PostgreSQL image absent. The helper deliberately uses `--pull never`, so Docker returned status 125 after maintenance had started.

## Change

Prefetch and inspect the exact immutable `pg_basebackup` image during the existing preflight phase, before timers or runtime are quiesced. A registry/cache failure now stops safely before mutation.

## Validation

- `python3 -m pytest tests/unit/test_postgres_pitr_runtime_contract.py -q` (22 passed)
- `bash -n scripts/ha/bootstrap_postgres_pitr.sh`
- `git diff --check`

Note: the broader local bundle-transport selection is sensitive to macOS temporary-directory modes and fails before the changed code; GitHub CI runs the authoritative Linux suite.