### PR TITLE
fix: distinguish historical PITR verification failures

### DIFF
--- a/scripts/ha/check_postgres_pitr_remote.py
+++ b/scripts/ha/check_postgres_pitr_remote.py
@@ -74,6 +74,7 @@ SOURCE_NODES = {"mvn-api", "zakup"}
 EXPECTED_UPLOADER = "mvn-postgres-pitr"
 WAL_SEGMENT_BYTES = 16 * 1024 * 1024
 MAX_MANIFEST_BYTES = 256 * 1024
+MAX_MANIFEST_CLOCK_SKEW = timedelta(minutes=5)
 MAX_MANIFEST_FILES = 128
 MAX_LIST_PAGES = 256
 MAX_LIST_OBJECTS = 100_000
@@ -393,9 +394,9 @@ def _load_manifest_proof(
         expected_system_identifier=expected_system_identifier,
     )
     publish_delay = last_modified - proof.completed_at
-    if publish_delay < timedelta(0):
+    if publish_delay < -MAX_MANIFEST_CLOCK_SKEW:
         raise StatusProofError(
-            "basebackup manifest LastModified does not match its completion time"
+            "basebackup manifest LastModified predates its completion time beyond clock skew"
         )
     return proof, expected_size
 

--- a/scripts/ha/check_postgres_pitr_status.sh
+++ b/scripts/ha/check_postgres_pitr_status.sh
@@ -311,22 +311,32 @@ SELECT
   coalesce(last_archived_time::text, '<none>'),
   failed_count,
   coalesce(last_failed_wal, '<none>'),
-  coalesce(last_failed_time::text, '<none>')
+  coalesce(last_failed_time::text, '<none>'),
+  CASE
+    WHEN last_failed_time IS NULL THEN 'false'
+    WHEN last_archived_time IS NULL THEN 'true'
+    WHEN last_failed_time > last_archived_time THEN 'true'
+    ELSE 'false'
+  END
 FROM pg_stat_archiver;
 SQL
 )"
-IFS='|' read -r archived_count last_archived_wal last_archived_time failed_count last_failed_wal last_failed_time <<< "${archiver_output}"
+IFS='|' read -r archived_count last_archived_wal last_archived_time failed_count last_failed_wal last_failed_time unresolved_archive_failure <<< "${archiver_output}"
 archived_count="${archived_count:-0}"
 failed_count="${failed_count:-0}"
 
 log info "archived_count=${archived_count} last_archived_wal=${last_archived_wal:-<none>} last_archived_time=${last_archived_time:-<none>}"
-log info "failed_count=${failed_count} last_failed_wal=${last_failed_wal:-<none>} last_failed_time=${last_failed_time:-<none>}"
+log info "failed_count=${failed_count} last_failed_wal=${last_failed_wal:-<none>} last_failed_time=${last_failed_time:-<none>} unresolved_archive_failure=${unresolved_archive_failure:-<none>}"
 
 if [[ "${PITR_REQUIRED}" == "true" ]]; then
   if ! is_unsigned_int "${failed_count}"; then
     fail "pg_stat_archiver failed_count is not numeric: ${failed_count}"
-  elif (( failed_count > PITR_MAX_ARCHIVER_FAILURES )); then
+  elif [[ "${unresolved_archive_failure}" != "true" && "${unresolved_archive_failure}" != "false" ]]; then
+    fail "pg_stat_archiver unresolved failure state is invalid: ${unresolved_archive_failure:-<empty>}"
+  elif (( failed_count > PITR_MAX_ARCHIVER_FAILURES )) && [[ "${unresolved_archive_failure}" == "true" ]]; then
     fail "pg_stat_archiver failed_count=${failed_count} exceeds ${PITR_MAX_ARCHIVER_FAILURES}"
+  elif (( failed_count > PITR_MAX_ARCHIVER_FAILURES )); then
+    log warn "pg_stat_archiver failed_count=${failed_count} is historical; a newer WAL archive succeeded"
   else
     ok "pg_stat_archiver failed_count=${failed_count}"
   fi

--- a/tests/unit/test_postgres_pitr_remote_check.py
+++ b/tests/unit/test_postgres_pitr_remote_check.py
@@ -436,14 +436,33 @@ def test_manifest_proof_rejects_oversized_head_before_get():
     assert client.get_calls == []
 
 
-def test_manifest_proof_rejects_last_modified_before_completion():
+def test_manifest_proof_accepts_small_object_storage_clock_skew():
     payload = _manifest_payload()
     client, key, _raw = _manifest_client(payload)
     client.heads[key]["LastModified"] = datetime(
-        2026, 7, 14, 1, 4, tzinfo=timezone.utc
+        2026, 7, 14, 1, 4, 59, tzinfo=timezone.utc
     )
 
-    with pytest.raises(pitr_remote.StatusProofError, match="LastModified"):
+    proof, _size = pitr_remote._load_manifest_proof(
+        client,
+        bucket="private",
+        key=key,
+        key_prefix="postgres/pitr",
+        cluster="mvn-api",
+        expected_system_identifier=SYSTEM_IDENTIFIER,
+    )
+
+    assert proof.backup_id == "backup-1"
+
+
+def test_manifest_proof_rejects_last_modified_before_completion_beyond_clock_skew():
+    payload = _manifest_payload()
+    client, key, _raw = _manifest_client(payload)
+    client.heads[key]["LastModified"] = datetime(
+        2026, 7, 14, 0, 59, 59, tzinfo=timezone.utc
+    )
+
+    with pytest.raises(pitr_remote.StatusProofError, match="clock skew"):
         pitr_remote._load_manifest_proof(
             client,
             bucket="private",

--- a/tests/unit/test_postgres_pitr_runtime_contract.py
+++ b/tests/unit/test_postgres_pitr_runtime_contract.py
@@ -479,6 +479,16 @@ def test_pitr_preflight_prefetches_the_pinned_basebackup_image():
     assert '  ensure_basebackup_image\n' in preflight
 
 
+def test_pitr_status_distinguishes_historical_archiver_failures_from_live_ones():
+    source = (REPO_ROOT / "scripts/ha/check_postgres_pitr_status.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "WHEN last_failed_time > last_archived_time THEN 'true'" in source
+    assert '[[ "${unresolved_archive_failure}" == "true" ]]' in source
+    assert "is historical; a newer WAL archive succeeded" in source
+
+
 def test_explicit_upload_helper_precedes_image_package_import():
     for name in (
         "check_postgres_pitr_remote.py",


### PR DESCRIPTION
## Why

PITR recovery successfully created and restored a fresh basebackup, but strict status validation still rejected two historical/clock-domain artifacts: PostgreSQL keeps cumulative archiver failure counters, and R2 object timestamps can lag the primary clock by a few seconds.

## Change

- Treat `failed_count` above the threshold as an error only when its last failure is newer than the last successful archive.
- Permit up to five minutes of object-storage clock skew for a signed basebackup manifest; reject larger inversions.

The strict forced-WAL proof, fresh remote object proof, archive settings, and active timers remain mandatory.

## Validation

- `python3 -m pytest tests/unit/test_postgres_pitr_remote_check.py tests/unit/test_postgres_pitr_runtime_contract.py -q` (48 passed)
- `bash -n scripts/ha/check_postgres_pitr_status.sh`
- `git diff --check`