### PR TITLE
fix: allow Patroni local timeline checks

### DIFF
--- a/deploy/ha/patroni/render_patroni_config.py
+++ b/deploy/ha/patroni/render_patroni_config.py
@@ -119,6 +119,9 @@ def render_config() -> dict[str, Any]:
     reviewed_pg_hba = [
         "local all all trust",
         "host all all 127.0.0.1/32 scram-sha-256",
+        # Patroni checks a demoted node's timeline through its local TCP
+        # replication connection before allowing it to rejoin or fail over.
+        f"host replication {replication_user} 127.0.0.1/32 scram-sha-256",
         "host all all 172.16.0.0/12 scram-sha-256",
         f"host replication {replication_user} 172.16.0.0/12 scram-sha-256",
         f"host replication {replication_user} 10.77.0.0/24 scram-sha-256",

--- a/tests/unit/test_patroni_quorum_assets.py
+++ b/tests/unit/test_patroni_quorum_assets.py
@@ -52,6 +52,7 @@ def test_renderer_builds_synchronous_tls_patroni_config(patroni_env):
     expected_pg_hba = [
         "local all all trust",
         "host all all 127.0.0.1/32 scram-sha-256",
+        "host replication mvn_replicator 127.0.0.1/32 scram-sha-256",
         "host all all 172.16.0.0/12 scram-sha-256",
         "host replication mvn_replicator 172.16.0.0/12 scram-sha-256",
         "host replication mvn_replicator 10.77.0.0/24 scram-sha-256",


### PR DESCRIPTION
## What changed

- allow the Patroni replication user to connect over local TCP (`127.0.0.1/32`)
- assert the rule is present in both bootstrap and existing-cluster `pg_hba` rendering

## Root cause

During the 2026-07-21 inter-site HA network interruption, the former primary safely demoted itself. After connectivity returned, Patroni attempted to inspect its local replica timeline over a TCP replication connection to localhost. The rendered `pg_hba` rules allowed ordinary localhost connections but not replication connections, so the node could not determine its timeline and the cluster remained without a writable leader.

## Impact

Future demotion/rejoin and failover recovery can complete without the `no pg_hba.conf entry for replication connection from host "127.0.0.1"` deadlock.

## Validation

- `pytest tests/unit/test_patroni_quorum_assets.py -q` — 9 passed
- `python3 -m py_compile deploy/ha/patroni/render_patroni_config.py`
- `git diff --check`
- production dynamic Patroni config reconciled; primary restored to `mvn-api`; `zakup` is streaming sync standby; API and bot are healthy