### PR TITLE
Fix Patroni rollout from promoted archive baseline

### DIFF
--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -355,10 +355,13 @@ variable while Patroni is still managing either database node.
 
 Use `.github/workflows/rollout-patroni-image.yml` only for the reviewed
 two-node transition from the exact current Patroni digest to one exact
-published target digest. The supported starting DCS generation is deliberately
-narrow: `archive_mode=on`, `archive_timeout=300`, and the compiled legacy local
-copy `archive_command`. This controller does not authorize an `off -> on` PITR
-migration or any other DCS edit.
+published target digest. The supported starting DCS generations are deliberately
+narrow: `archive_mode=on`, `archive_timeout=300`, and either the compiled legacy
+local-copy `archive_command` or the already-promoted immutable helper command.
+The controller journals the complete starting DCS document on both nodes,
+rejects every other command, and allows no drift outside the reviewed
+archive-command transition. It does not authorize an `off -> on` PITR migration
+or any other DCS edit.
 
 The approved workflow requires the tested `deploy_sha`, both immutable image
 digests, the exact successful `Publish Patroni Image` `publish_run_id` and

--- a/scripts/ha/patroni_rollout_remote.py
+++ b/scripts/ha/patroni_rollout_remote.py
@@ -49,6 +49,7 @@ ACTIONS = {
     "attest-archive-runtime",
     "attest-current-runtime",
     "attest-runtime-ownership",
+    "check-baseline-dcs",
     "check-legacy-dcs",
     "check-target-dcs",
     "finalize",

--- a/scripts/ha/patroni_rollout_remote_contract.py
+++ b/scripts/ha/patroni_rollout_remote_contract.py
@@ -141,15 +141,17 @@ def load_journal(path, node, txid, payload):
     }
     if (not isinstance(data, dict) or data.get("version") != 1
             or any(data.get(key) != value for key, value in expected.items())
+            or not {"baseline_archive_command", "dcs_baseline",
+                    "dcs_baseline_sha256"}.issubset(data)
             or not isinstance(data.get("completed"), list)
             or not isinstance(data.get("operation"), str)
             or len(data["completed"]) != len(set(data["completed"]))
             or any(item not in COMPLETED for item in data["completed"])
             or data["operation"] not in ({"idle"} | COMPLETED)):
         die("rollout journal contract mismatch")
-    allowed = set(expected) | {"baseline_primary", "baseline_system_identifier",
-        "baseline_timeline", "completed", "dcs_baseline", "dcs_baseline_sha256",
-        "last_error", "legacy_archive_command", "operation", "version"}
+    allowed = set(expected) | {"baseline_archive_command", "baseline_primary",
+        "baseline_system_identifier", "baseline_timeline", "completed", "dcs_baseline",
+        "dcs_baseline_sha256", "last_error", "legacy_archive_command", "operation", "version"}
     if set(data) - allowed or raw != canonical(data):
         die("rollout journal is not canonical or has extra fields")
     return data

--- a/scripts/ha/patroni_rollout_remote_executor.py
+++ b/scripts/ha/patroni_rollout_remote_executor.py
@@ -13,21 +13,6 @@ except ModuleNotFoundError:
 
 REMOTE_EXECUTOR = REMOTE_PRELUDE + REMOTE_CONTRACT + REMOTE_RUNTIME_PROOF + r'''
 
-def compose_args(project, compose):
-    return ["docker", "compose", "-f", compose]
-
-def unit_state(unit):
-    return run(["systemctl", "show", "--property=ActiveState", "--value", unit])
-
-def validate_units():
-    if unit_state("mvn-patroni-role-agent.service") != "active":
-        die("Patroni role agent must be active")
-    if run(["systemctl", "is-enabled", "mvn-patroni-role-agent.service"]) != "enabled":
-        die("Patroni role agent must be enabled")
-    for unit in UNITS_INACTIVE:
-        if unit_state(unit) != "inactive":
-            die("PITR unit must remain inactive: " + unit)
-
 def validate_role_assets(payload):
     assets = (("/usr/local/sbin/mvn-patroni-role-agent", 0o755, payload["role_agent_sha256"]),
         ("/usr/local/sbin/patroni_local_identity.py", 0o644, payload["role_identity_sha256"]),
@@ -238,13 +223,17 @@ def check_legacy_dcs(project, compose, legacy_digest):
     if values["archive_command"] != LEGACY_COMMAND or sha(values["archive_command"]) != legacy_digest:
         die("legacy DCS archive command digest drifted")
 
-def check_supported_dcs(project, compose, legacy_digest):
-    values = archive_values(yaml_config(project, compose))
+def supported_archive_command(config, legacy_digest):
+    values = archive_values(config)
     if values["archive_mode"] != "on" or values["archive_timeout"] != "300":
         die("DCS archive mode/timeout drifted")
     command = values["archive_command"]
     if command != EXPECTED_COMMAND and sha(command) != legacy_digest:
         die("DCS archive command is outside the approved generations")
+    return command
+
+def check_supported_dcs(project, compose, legacy_digest):
+    return supported_archive_command(yaml_config(project, compose), legacy_digest)
 
 def diff_paths(before, after, prefix=()):
     if isinstance(before, dict) and isinstance(after, dict):
@@ -260,11 +249,18 @@ def journal_dcs_baseline(journal):
     if (not isinstance(baseline, dict) or not isinstance(digest, str)
             or not DIGEST_RE.fullmatch(digest) or sha(canonical(baseline)) != digest):
         die("journal has no canonical DCS baseline")
+    command = journal.get("baseline_archive_command")
+    if command not in {LEGACY_COMMAND, EXPECTED_COMMAND}:
+        die("journal DCS baseline command is outside the approved generations")
     if archive_values(baseline) != {
             "archive_mode": "on", "archive_timeout": "300",
-            "archive_command": LEGACY_COMMAND}:
-        die("journal DCS baseline is not the reviewed legacy generation")
+            "archive_command": command}:
+        die("journal DCS baseline differs from the reviewed generation")
     return baseline
+
+def check_baseline_dcs(project, compose, journal):
+    if yaml_config(project, compose) != journal_dcs_baseline(journal):
+        die("DCS generation drifted from the journaled baseline")
 
 def check_target_dcs(project, compose, journal=None):
     current = yaml_config(project, compose)
@@ -272,30 +268,29 @@ def check_target_dcs(project, compose, journal=None):
     if values != {"archive_mode": "on", "archive_timeout": "300",
                   "archive_command": EXPECTED_COMMAND}:
         die("DCS archive settings do not match the reviewed target")
-    if journal is not None and diff_paths(journal_dcs_baseline(journal), current) != [
-            ("postgresql", "parameters", "archive_command")]:
-        die("target DCS generation drifted from the journaled baseline")
+    if journal is not None:
+        baseline = journal_dcs_baseline(journal)
+        expected_diff = ([] if journal["baseline_archive_command"] == EXPECTED_COMMAND
+                         else [("postgresql", "parameters", "archive_command")])
+        if diff_paths(baseline, current) != expected_diff:
+            die("target DCS generation drifted from the journaled baseline")
 
 def apply_archive_command(project, compose, legacy_digest, journal_path, journal):
     identifier = container_id(project, compose)
     before = yaml_config(project, compose)
     values = archive_values(before)
-    if "dcs_baseline" not in journal:
-        if values != {"archive_mode": "on", "archive_timeout": "300",
-                      "archive_command": LEGACY_COMMAND}:
-            die("cannot establish the exact legacy DCS baseline")
-        journal["legacy_archive_command"] = values["archive_command"]
-        journal["dcs_baseline"] = before
-        journal["dcs_baseline_sha256"] = sha(canonical(before))
-        save_journal(journal_path, journal)
     baseline = journal_dcs_baseline(journal)
+    baseline_command = journal["baseline_archive_command"]
     if values["archive_command"] == EXPECTED_COMMAND:
+        expected_diff = ([] if baseline_command == EXPECTED_COMMAND
+                         else [("postgresql", "parameters", "archive_command")])
         if (values != {"archive_mode": "on", "archive_timeout": "300",
                        "archive_command": EXPECTED_COMMAND}
-                or diff_paths(baseline, before) != [
-                    ("postgresql", "parameters", "archive_command")]):
+                or diff_paths(baseline, before) != expected_diff):
             die("target DCS generation drifted from the journaled baseline")
         return
+    if baseline_command != LEGACY_COMMAND:
+        die("target DCS baseline cannot transition through the legacy generation")
     if before != baseline:
         die("legacy DCS generation drifted from the journaled baseline")
     check_legacy_dcs(project, compose, legacy_digest)
@@ -310,17 +305,22 @@ def apply_archive_command(project, compose, legacy_digest, journal_path, journal
         die("DCS archive settings do not match the reviewed target")
 
 def revert_archive_command(project, compose, legacy_digest, journal):
-    legacy = journal.get("legacy_archive_command")
-    if legacy != LEGACY_COMMAND or sha(legacy) != legacy_digest:
-        die("journal has no attested legacy archive command")
+    original = journal.get("baseline_archive_command")
+    if original not in {LEGACY_COMMAND, EXPECTED_COMMAND}:
+        die("journal has no attested baseline archive command")
+    if original == LEGACY_COMMAND and sha(original) != legacy_digest:
+        die("journal legacy archive command digest drifted")
     identifier = container_id(project, compose)
     baseline = journal_dcs_baseline(journal)
     before = yaml_config(project, compose)
     values = archive_values(before)
-    if values["archive_command"] == legacy:
+    if values["archive_command"] == original:
         if before != baseline:
             die("compensated DCS generation drifted from the journaled baseline")
-        check_legacy_dcs(project, compose, legacy_digest)
+        if original == LEGACY_COMMAND:
+            check_legacy_dcs(project, compose, legacy_digest)
+        else:
+            check_target_dcs(project, compose, journal)
         return
     if (values != {"archive_mode": "on", "archive_timeout": "300",
                    "archive_command": EXPECTED_COMMAND}
@@ -328,11 +328,14 @@ def revert_archive_command(project, compose, legacy_digest, journal):
                 ("postgresql", "parameters", "archive_command")]):
         die("cannot compensate an unreviewed DCS generation")
     run(["docker", "exec", identifier, "patronictl", "-c", "/etc/patroni/patroni.yml",
-         "edit-config", "mvn-postgres", "--pg", "archive_command=" + legacy, "--force"])
+         "edit-config", "mvn-postgres", "--pg", "archive_command=" + original, "--force"])
     after = yaml_config(project, compose)
     if after != baseline:
         die("compensating DCS mutation did not restore the exact baseline")
-    check_legacy_dcs(project, compose, legacy_digest)
+    if original == LEGACY_COMMAND:
+        check_legacy_dcs(project, compose, legacy_digest)
+    else:
+        check_target_dcs(project, compose, journal)
 
 def sql(project, compose, statement):
     command = compose_args(project, compose) + ["exec", "-T", "db", "sh", "-lc",
@@ -480,7 +483,11 @@ def main():
                 if not payload["resume"]:
                     die("existing transaction requires resume=true")
             except FileNotFoundError:
+                baseline_dcs = yaml_config(project, compose)
+                baseline_archive_command = supported_archive_command(
+                    baseline_dcs, payload["legacy_command_sha256"])
                 journal = {"completed": [], "current_image": payload["current_image"],
+                    "baseline_archive_command": baseline_archive_command,
                     "baseline_primary": baseline_primary,
                     "baseline_system_identifier": baseline_system,
                     "baseline_timeline": int(baseline_timeline),
@@ -498,7 +505,9 @@ def main():
                     "role_identity_sha256": payload["role_identity_sha256"],
                     "role_unit_sha256": payload["role_unit_sha256"],
                     "node": node, "operation": "idle", "target_image": payload["target_image"],
-                    "transaction_id": txid, "version": 1}
+                    "transaction_id": txid, "version": 1,
+                    "dcs_baseline": baseline_dcs,
+                    "dcs_baseline_sha256": sha(canonical(baseline_dcs))}
                 save_journal(journal_path, journal)
             marker(marker_path, txid, create=True)
             print("prepared")
@@ -515,7 +524,8 @@ def main():
                     prove_final_generation(project, compose, compose_project, volume,
                                            payload, journal, node)
                 else:
-                    prove_aborted_generation(project, compose, compose_project, volume, payload)
+                    prove_aborted_generation(
+                        project, compose, compose_project, volume, payload, journal)
                 remove_marker_if_owned(marker_path, txid)
                 print(action + "=already-passed")
                 return
@@ -613,6 +623,8 @@ def main():
             attest_archive_runtime(project, compose, payload["target_image"], payload["helper_sha256"])
         elif action == "prove-etcd":
             prove_etcd(payload)
+        elif action == "check-baseline-dcs":
+            check_baseline_dcs(project, compose, journal)
         elif action == "check-legacy-dcs":
             check_legacy_dcs(project, compose, payload["legacy_command_sha256"])
         elif action == "check-target-dcs":
@@ -635,7 +647,7 @@ def main():
             require_completed(journal, "record:standby-updated")
             if local_patroni_role() != "primary": die("switchover source is not primary")
             prove_etcd(payload)
-            check_legacy_dcs(project, compose, payload["legacy_command_sha256"])
+            check_baseline_dcs(project, compose, journal)
             identifier = container_id(project, compose)
             run(["docker", "exec", identifier, "patronictl", "-c", "/etc/patroni/patroni.yml",
                  "switchover", "mvn-postgres", "--primary", expected_primary,
@@ -659,7 +671,8 @@ def main():
             print(action + "=passed")
             return
         elif action == "abort":
-            prove_aborted_generation(project, compose, compose_project, volume, payload)
+            prove_aborted_generation(
+                project, compose, compose_project, volume, payload, journal)
             complete(journal_path, journal, action)
             remove_marker_if_owned(marker_path, txid)
             print(action + "=passed")

--- a/scripts/ha/patroni_rollout_remote_prelude.py
+++ b/scripts/ha/patroni_rollout_remote_prelude.py
@@ -49,7 +49,7 @@ JOURNAL_ACTIONS = {
     "abort", "apply-archive-command", "finalize", "prove-archive",
     "revert-archive-command", "rollback-node", "switchover", "update-node",
 }
-READ_ACTIONS = {"attest-archive-runtime", "attest-current-runtime", "attest-runtime-ownership", "attest-target-runtime", "check-legacy-dcs", "check-target-dcs", "preflight", "prove-etcd", "stage"}
+READ_ACTIONS = {"attest-archive-runtime", "attest-current-runtime", "attest-runtime-ownership", "attest-target-runtime", "check-baseline-dcs", "check-legacy-dcs", "check-target-dcs", "preflight", "prove-etcd", "stage"}
 COMPLETED = JOURNAL_ACTIONS | {"record:" + name for name in RECORDS}
 CLEAN_ENV = {
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/scripts/ha/patroni_rollout_remote_runtime.py
+++ b/scripts/ha/patroni_rollout_remote_runtime.py
@@ -1,6 +1,21 @@
 """Runtime-ownership proof embedded into the Patroni rollout executor."""
 
 REMOTE_RUNTIME_PROOF = r'''
+def compose_args(project, compose):
+    return ["docker", "compose", "-f", compose]
+
+def unit_state(unit):
+    return run(["systemctl", "show", "--property=ActiveState", "--value", unit])
+
+def validate_units():
+    if unit_state("mvn-patroni-role-agent.service") != "active":
+        die("Patroni role agent must be active")
+    if run(["systemctl", "is-enabled", "mvn-patroni-role-agent.service"]) != "enabled":
+        die("Patroni role agent must be enabled")
+    for unit in UNITS_INACTIVE:
+        if unit_state(unit) != "inactive":
+            die("PITR unit must remain inactive: " + unit)
+
 def read_proc_file(path, maximum=131072):
     fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     try:
@@ -189,9 +204,9 @@ def prove_final_generation(project, compose, compose_project, volume, payload, j
     attest_archive_runtime(project, compose, payload["target_image"], payload["helper_sha256"])
     attest_runtime_ownership(project, compose, final_role)
 
-def prove_aborted_generation(project, compose, compose_project, volume, payload):
+def prove_aborted_generation(project, compose, compose_project, volume, payload, journal):
     validate_compose(project, compose, compose_project, volume,
                      payload["current_image"], payload["compose_contract_sha256"], payload)
     runtime_attestation(project, compose, payload["current_image"])
-    check_legacy_dcs(project, compose, payload["legacy_command_sha256"])
+    check_baseline_dcs(project, compose, journal)
 '''

--- a/scripts/ha/rollout_patroni_image.py
+++ b/scripts/ha/rollout_patroni_image.py
@@ -465,7 +465,7 @@ class _Orchestrator:
                         try:
                             for node in PATRONI_NODES:
                                 self._remote("attest-current-runtime", node)
-                            self._remote("check-legacy-dcs", current.primary)
+                            self._remote("check-baseline-dcs", current.primary)
                             for node in PATRONI_NODES:
                                 self._remote("abort", node)
                         except BaseException as mixed_error:
@@ -491,7 +491,7 @@ class _Orchestrator:
                     system_identifier=original.system_identifier,
                     timeline=original.timeline,
                 )
-                self._remote("check-legacy-dcs", current.primary)
+                self._remote("check-baseline-dcs", current.primary)
                 if not self._has_record(statuses, "standby-updated"):
                     self.db_mutation_attempted = True
                 self._remote(
@@ -590,8 +590,8 @@ class _Orchestrator:
                             f"reversion could not be proved: {proof_error}; {compensation_error}"
                         ) from proof_error
                     raise RuntimeError(
-                        "archive helper proof failed; exact legacy archive_command was "
-                        f"restored and the transaction remains fenced: {proof_error}"
+                        "archive helper proof failed; exact journaled archive_command "
+                        f"generation was restored and the transaction remains fenced: {proof_error}"
                     ) from proof_error
                 statuses = self._ensure_record(self._statuses(), "archive-proved")
             final = self._wait_topology(

--- a/tests/unit/test_patroni_rollout_controller.py
+++ b/tests/unit/test_patroni_rollout_controller.py
@@ -63,7 +63,10 @@ class FakeOperations:
         "revert-archive-command", "rollback-node", "switchover", "update-node",
     }
 
-    def __init__(self, *, switched=False, existing=False, baseline_primary="mvn-api"):
+    def __init__(
+        self, *, switched=False, existing=False, baseline_primary="mvn-api",
+        archive_command=LEGACY_ARCHIVE_COMMAND,
+    ):
         self.switched = switched
         self.baseline_primary = baseline_primary
         self.events = []
@@ -82,7 +85,8 @@ class FakeOperations:
         self.ambiguous_switch = False
         self.fail_discover = False
         self.lose_after_completion = []
-        self.archive_command = LEGACY_ARCHIVE_COMMAND
+        self.archive_command = archive_command
+        self.baseline_archive_command = archive_command
         self.prepared = {node.alias for node in PATRONI_NODES} if existing else set()
         standby = "zakup" if baseline_primary == "mvn-api" else "mvn-api"
         self.images = {node.alias: CURRENT for node in PATRONI_NODES}
@@ -111,10 +115,10 @@ class FakeOperations:
     def remote(self, *, action, node, extra=None, **_kwargs):
         self.events.append((action, node.alias, dict(extra or {})))
         if (
-            action == "check-legacy-dcs"
-            and self.archive_command != LEGACY_ARCHIVE_COMMAND
+            action == "check-baseline-dcs"
+            and self.archive_command != self.baseline_archive_command
         ):
-            raise RuntimeError("legacy DCS archive command drifted")
+            raise RuntimeError("baseline DCS archive command drifted")
         if (
             action == "check-target-dcs"
             and self.archive_command != EXPECTED_ARCHIVE_COMMAND
@@ -155,7 +159,7 @@ class FakeOperations:
         if action == "apply-archive-command":
             self.archive_command = EXPECTED_ARCHIVE_COMMAND
         if action == "revert-archive-command":
-            self.archive_command = LEGACY_ARCHIVE_COMMAND
+            self.archive_command = self.baseline_archive_command
         if action in self.JOURNAL_ACTIONS:
             self.statuses[node.alias]["operation"] = "idle"
             if action not in self.statuses[node.alias]["completed"]:
@@ -303,6 +307,28 @@ def test_rollout_orders_both_images_before_archive_command(tmp_path):
     assert result.timeline == 10
 
 
+def test_rollout_accepts_already_promoted_archive_command_baseline(tmp_path):
+    operations = FakeOperations(archive_command=EXPECTED_ARCHIVE_COMMAND)
+
+    result = _orchestrator(tmp_path, operations).run()
+
+    assert result.final_primary == "zakup"
+    assert operations.archive_command == EXPECTED_ARCHIVE_COMMAND
+    assert "check-baseline-dcs" in _mutation_names(operations.events)
+
+
+def test_target_archive_baseline_is_preserved_when_archive_proof_fails(tmp_path):
+    operations = FakeOperations(archive_command=EXPECTED_ARCHIVE_COMMAND)
+    operations.fail_action = "prove-archive"
+
+    with pytest.raises(
+        RuntimeError, match="journaled archive_command generation was restored"
+    ):
+        _orchestrator(tmp_path, operations).run()
+
+    assert operations.archive_command == EXPECTED_ARCHIVE_COMMAND
+
+
 def test_lost_switchover_response_is_discovered_and_rolls_forward(tmp_path):
     operations = FakeOperations()
     operations.ambiguous_switch = True
@@ -401,7 +427,7 @@ def test_archive_proof_failure_compensates_exact_legacy_command(tmp_path):
     operations = FakeOperations()
     operations.fail_action = "prove-archive"
 
-    with pytest.raises(RuntimeError, match="legacy archive_command was restored"):
+    with pytest.raises(RuntimeError, match="journaled archive_command generation was restored"):
         _orchestrator(tmp_path, operations).run()
 
     names = _mutation_names(operations.events)
@@ -412,7 +438,7 @@ def test_archive_proof_failure_compensates_exact_legacy_command(tmp_path):
 def test_compensated_archive_proof_converges_on_one_resume(tmp_path):
     operations = FakeOperations()
     operations.fail_action = "prove-archive"
-    with pytest.raises(RuntimeError, match="legacy archive_command was restored"):
+    with pytest.raises(RuntimeError, match="journaled archive_command generation was restored"):
         _orchestrator(tmp_path, operations).run()
 
     operations.fail_action = None

--- a/tests/unit/test_patroni_rollout_remote.py
+++ b/tests/unit/test_patroni_rollout_remote.py
@@ -353,12 +353,32 @@ def test_target_dcs_rejects_any_extra_drift_from_journaled_baseline():
     target["postgresql"]["parameters"]["archive_command"] = namespace["EXPECTED_COMMAND"]
     target["loop_wait"] = 11
     journal = {
+        "baseline_archive_command": namespace["LEGACY_COMMAND"],
         "dcs_baseline": baseline,
         "dcs_baseline_sha256": namespace["sha"](namespace["canonical"](baseline)),
     }
     namespace["yaml_config"] = lambda *_args: target
     with pytest.raises(RuntimeError, match="drifted from the journaled baseline"):
         namespace["check_target_dcs"]("/opt/air-api", "compose.yml", journal)
+
+
+def test_target_dcs_accepts_unchanged_target_baseline():
+    namespace = _remote_namespace()
+    baseline = {
+        "loop_wait": 10,
+        "postgresql": {"parameters": {
+            "archive_mode": "on", "archive_timeout": "300",
+            "archive_command": namespace["EXPECTED_COMMAND"],
+        }},
+    }
+    journal = {
+        "baseline_archive_command": namespace["EXPECTED_COMMAND"],
+        "dcs_baseline": baseline,
+        "dcs_baseline_sha256": namespace["sha"](namespace["canonical"](baseline)),
+    }
+    namespace["yaml_config"] = lambda *_args: copy.deepcopy(baseline)
+
+    namespace["check_target_dcs"]("/opt/air-api", "compose.yml", journal)
 
 
 @pytest.mark.parametrize("operation", ["apply", "revert"])
@@ -372,7 +392,7 @@ def test_dcs_retry_rejects_extra_drift_after_a_committed_edit(operation):
     live["postgresql"]["parameters"]["archive_command"] = namespace["EXPECTED_COMMAND"]
     live["loop_wait"] = 11
     journal = {
-        "legacy_archive_command": namespace["LEGACY_COMMAND"],
+        "baseline_archive_command": namespace["LEGACY_COMMAND"],
         "dcs_baseline": baseline,
         "dcs_baseline_sha256": namespace["sha"](namespace["canonical"](baseline)),
     }


### PR DESCRIPTION
## What changed
- journal the complete starting Patroni DCS document before rollout mutations
- accept only the reviewed legacy or already-promoted archive command generation
- prove the journaled baseline before switchover and restore that exact generation on compensation/abort
- document the two supported starting generations and add target-baseline regression coverage

## Why
Production rollout preflight correctly rejected the live already-promoted archive command because the controller still required the legacy generation. The failed transaction stopped before any database/image mutation. This change preserves fail-closed behavior while making subsequent immutable Patroni image upgrades idempotent.

## Validation
- `pytest -q tests/unit/test_patroni_rollout_controller.py tests/unit/test_patroni_rollout_remote.py tests/unit/test_patroni_rollout_workflow.py tests/unit/test_patroni_quorum_assets.py` (68 passed)
- HA/Patroni/PITR unit selection (556 passed, 1 skipped)
- full unit run: 2227 passed, 4 skipped; 13 failures + 2 setup errors were unrelated concurrent local PostgreSQL DDL deadlocks in shared DB fixtures
- `python3 -m py_compile ...`
- `git diff --check`