### PR TITLE
fix: make HA monitoring maintenance-aware

### DIFF
--- a/.github/workflows/api-restore-drill.yml
+++ b/.github/workflows/api-restore-drill.yml
@@ -47,9 +47,12 @@ jobs:
           ssh_identity="${SSH_KEY}"
           unset SSH_KEY
           trap 'ssh_identity=' EXIT
+          args=(--phase logical-restore-drill)
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            args+=(--allow-maintenance-skip)
+          fi
           printf '%s\n' "${ssh_identity}" \
-            | python3 -I scripts/ha/run_postgres_pitr_workflow.py \
-                --phase logical-restore-drill 2>&1 \
+            | python3 -I scripts/ha/run_postgres_pitr_workflow.py "${args[@]}" 2>&1 \
             | tee api-restore-drill.log
 
       - name: Upload restore drill log

--- a/.github/workflows/check-api-ha-invariants.yml
+++ b/.github/workflows/check-api-ha-invariants.yml
@@ -30,7 +30,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup API SSH Key
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/api_ha_invariant_key
+          chmod 600 ~/.ssh/api_ha_invariant_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Detect official Patroni maintenance
+        id: maintenance
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ~/.ssh/api_ha_invariant_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+          export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+          export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export API_NODE_PROJECT_DIR="${API_PROJECT_DIR}"
+          export RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          python3 scripts/ha/check_patroni_maintenance.py \
+            --github-output "${GITHUB_OUTPUT}" 2>&1 | tee api-ha-invariant.log
+
       - name: Run active-passive invariant check
+        if: steps.maintenance.outputs.active != 'true'
         env:
           API_HOST: api.mvn.by
           PUBLIC_BASE_URL: https://api.mvn.by
@@ -40,7 +80,7 @@ jobs:
           STANDBY_ROLE: standby
           DISCOVER_PRIMARY_FROM_READY: ${{ vars.API_DB_HA_MODE == 'patroni' && 'true' || 'false' }}
           CHECK_PUBLIC_READY: "false"
-        run: bash scripts/ha/check_active_passive.sh | tee api-ha-invariant.log
+        run: bash scripts/ha/check_active_passive.sh | tee -a api-ha-invariant.log
 
       - name: Upload HA invariant log
         if: always()

--- a/.github/workflows/check-api-ha-readiness.yml
+++ b/.github/workflows/check-api-ha-readiness.yml
@@ -45,7 +45,28 @@ jobs:
           ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
           ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
 
+      - name: Detect official Patroni maintenance
+        id: maintenance
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ~/.ssh/ha_readiness_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+          export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export API_NODE_PROJECT_DIR="${API_PROJECT_DIR}"
+          export RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          python3 scripts/ha/check_patroni_maintenance.py \
+            --github-output "${GITHUB_OUTPUT}" 2>&1 | tee api-ha-readiness.log
+
       - name: Run API HA readiness audit
+        if: steps.maintenance.outputs.active != 'true'
         env:
           API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
@@ -77,7 +98,7 @@ jobs:
           export STANDBY_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
           export STANDBY_COMPOSE_FILE="${API_STANDBY_COMPOSE_FILE}"
           export PITR_WORKFLOW_IDENTITY_FILE="${HOME}/.ssh/ha_readiness_key"
-          bash scripts/ha/check_api_ha_readiness.sh | tee api-ha-readiness.log
+          bash scripts/ha/check_api_ha_readiness.sh | tee -a api-ha-readiness.log
 
       - name: Write Summary
         if: always()
@@ -89,6 +110,7 @@ jobs:
             echo "- standby_origin: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
             echo "- api_project_dir: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}"
             echo "- standby_project_dir: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}"
+            echo "- official_maintenance: ${{ steps.maintenance.outputs.active || 'false' }}"
             echo "- log_artifact: api-ha-readiness-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/check-api-vps-health.yml
+++ b/.github/workflows/check-api-vps-health.yml
@@ -59,7 +59,28 @@ jobs:
             ssh-keyscan -T 10 -H "${host}" >> ~/.ssh/known_hosts
           done
 
+      - name: Detect official Patroni maintenance
+        id: maintenance
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh') && (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          API_SSH_HOST: ${{ secrets.SSH_HOST_API }}
+          API_SSH_USER: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ${HOME}/.ssh/api_vps_health_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+          export API_NODE_SSH="${API_SSH_USER}@${API_SSH_HOST}"
+          export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export API_NODE_PROJECT_DIR="${API_PROJECT_DIR}"
+          export RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          python3 scripts/ha/check_patroni_maintenance.py \
+            --github-output "${GITHUB_OUTPUT}" 2>&1 | tee api-vps-health.log
+
       - name: Run API VPS Health Check
+        if: steps.maintenance.outputs.active != 'true'
         env:
           BASE_URL: https://api.mvn.by
           API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
@@ -81,7 +102,7 @@ jobs:
 
           mode="${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'ssh' }}"
           if [ "${mode}" = "public-only" ]; then
-            bash scripts/check_api_vps_health.sh --public-only | tee api-vps-health.log
+            bash scripts/check_api_vps_health.sh --public-only | tee -a api-vps-health.log
           else
             target_host="${API_SSH_HOST}"
             target_user="${API_SSH_USER}"
@@ -117,7 +138,7 @@ jobs:
               API_PROJECT_DIR="${target_project_dir}" \
               API_COMPOSE_FILE="${target_compose_file}" \
               API_SSH_KEY_PATH="${HOME}/.ssh/api_vps_health_key" \
-              bash scripts/check_api_vps_health.sh | tee api-vps-health.log
+              bash scripts/check_api_vps_health.sh | tee -a api-vps-health.log
           fi
 
       - name: Write Summary
@@ -135,6 +156,7 @@ jobs:
             echo "- backup_max_age_hours: ${{ github.event_name == 'workflow_dispatch' && inputs.backup_max_age_hours || '36' }}"
             echo "- check_backups: ${{ github.event_name != 'workflow_dispatch' || inputs.check_backups }}"
             echo "- skip_public_checks: ${{ github.event_name != 'workflow_dispatch' || inputs.mode == 'ssh' }}"
+            echo "- official_maintenance: ${{ steps.maintenance.outputs.active || 'false' }}"
             echo "- log_artifact: api-vps-health-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/check-postgres-replication.yml
+++ b/.github/workflows/check-postgres-replication.yml
@@ -44,7 +44,28 @@ jobs:
           ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
           ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
 
+      - name: Detect official Patroni maintenance
+        id: maintenance
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_NODE_PROJECT_DIR: ${{ vars.API_NODE_PROJECT_DIR || '/opt/air-api' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ~/.ssh/postgres_replication_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+          export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+          export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export API_NODE_PROJECT_DIR="${API_NODE_PROJECT_DIR}"
+          export RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          python3 scripts/ha/check_patroni_maintenance.py \
+            --github-output "${GITHUB_OUTPUT}" 2>&1 | tee postgres-replication-check.log
+
       - name: Run PostgreSQL replication check
+        if: steps.maintenance.outputs.active != 'true'
         env:
           API_DB_HA_MODE: ${{ vars.API_DB_HA_MODE || 'physical' }}
           SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
@@ -74,12 +95,12 @@ jobs:
               export RESERVE_NODE_COMPOSE_FILE=docker-compose.patroni.yml
               export API_NODE_WG_IP="${EXPECTED_PRIMARY_WG_IP}"
               export RESERVE_NODE_WG_IP="${EXPECTED_STANDBY_WG_IP}"
-              python3 scripts/ha/check_patroni_production.py | tee postgres-replication-check.log
+              python3 scripts/ha/check_patroni_production.py | tee -a postgres-replication-check.log
               ;;
             physical)
               export PRIMARY_SSH="${SSH_USER_API}@${SSH_HOST_API}"
               export STANDBY_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
-              bash scripts/ha/check_postgres_replication.sh | tee postgres-replication-check.log
+              bash scripts/ha/check_postgres_replication.sh | tee -a postgres-replication-check.log
               ;;
             *)
               echo "::error::API_DB_HA_MODE must be physical or patroni"
@@ -99,6 +120,7 @@ jobs:
             echo "- standby_project_dir: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}"
             echo "- expected_slot: ${{ vars.POSTGRES_STANDBY_SLOT || 'zakup_standby' }}"
             echo "- max_replay_lag_bytes: ${{ github.event_name == 'workflow_dispatch' && inputs.max_replay_lag_bytes || vars.POSTGRES_REPLICATION_MAX_LAG_BYTES || '1048576' }}"
+            echo "- official_maintenance: ${{ steps.maintenance.outputs.active || 'false' }}"
             echo "- log_artifact: postgres-replication-check-log-${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/postgres-pitr-restore-drill.yml
+++ b/.github/workflows/postgres-pitr-restore-drill.yml
@@ -93,6 +93,9 @@ jobs:
           unset SSH_KEY
           trap 'ssh_identity=' EXIT
           args=(--phase restore-drill)
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            args+=(--allow-maintenance-skip)
+          fi
           if [ -n "${PITR_RESTORE_BACKUP_ID}" ]; then
             args+=(--backup-id "${PITR_RESTORE_BACKUP_ID}")
           fi

--- a/.github/workflows/report-ha-status.yml
+++ b/.github/workflows/report-ha-status.yml
@@ -33,7 +33,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup API SSH Key
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_HOST_API}" ] || [ -z "${SSH_USER_API}" ] || [ -z "${SSH_KEY}" ]; then
+            echo "::error::Missing one of required secrets: SSH_HOST_API, SSH_USER_API, SSH_KEY"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/ha_status_key
+          chmod 600 ~/.ssh/ha_status_key
+          ssh-keyscan -T 10 -H "${SSH_HOST_API}" >> ~/.ssh/known_hosts
+          ssh-keyscan -T 10 -H "${API_STANDBY_HOST}" >> ~/.ssh/known_hosts
+
+      - name: Detect official Patroni maintenance
+        id: maintenance
+        if: ${{ (vars.API_DB_HA_MODE || 'physical') == 'patroni' }}
+        env:
+          SSH_HOST_API: ${{ secrets.SSH_HOST_API }}
+          SSH_USER_API: ${{ secrets.SSH_USER_API }}
+          API_STANDBY_HOST: ${{ vars.API_STANDBY_HOST || '193.47.42.213' }}
+          API_STANDBY_USER: ${{ vars.API_STANDBY_USER || secrets.SSH_USER_API }}
+          API_PROJECT_DIR: ${{ vars.API_PROJECT_DIR || '/opt/air-api' }}
+          API_STANDBY_PROJECT_DIR: ${{ vars.API_STANDBY_PROJECT_DIR || '/opt/mvn-reserve' }}
+        run: |
+          set -euo pipefail
+          export SSH_OPTS="-i ~/.ssh/ha_status_key -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+          export API_NODE_SSH="${SSH_USER_API}@${SSH_HOST_API}"
+          export RESERVE_NODE_SSH="${API_STANDBY_USER}@${API_STANDBY_HOST}"
+          export API_NODE_PROJECT_DIR="${API_PROJECT_DIR}"
+          export RESERVE_NODE_PROJECT_DIR="${API_STANDBY_PROJECT_DIR}"
+          python3 scripts/ha/check_patroni_maintenance.py \
+            --github-output "${GITHUB_OUTPUT}" 2>&1 | tee ha-status-report.log
+
       - name: Run HA status report
+        if: steps.maintenance.outputs.active != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           HA_EXTERNAL_METADATA_SOURCE: env
@@ -65,7 +105,7 @@ jobs:
           if [ "${HA_STATUS_SKIP_LIVE}" = "true" ]; then
             args+=(--skip-live)
           fi
-          python3 scripts/ha/report_ha_status.py "${args[@]}" 2>&1 | tee ha-status-report.log
+          python3 scripts/ha/report_ha_status.py "${args[@]}" 2>&1 | tee -a ha-status-report.log
 
       - name: Write Summary
         if: always()
@@ -74,6 +114,7 @@ jobs:
             echo "## API HA Status Report"
             echo "- require_strict: ${HA_STATUS_REQUIRE_STRICT}"
             echo "- skip_live: ${HA_STATUS_SKIP_LIVE}"
+            echo "- official_maintenance: ${{ steps.maintenance.outputs.active || 'false' }}"
             echo "- primary_origin: ${{ vars.API_PRIMARY_ORIGIN || '185.250.45.54' }}"
             echo "- standby_origin: ${{ vars.API_STANDBY_ORIGIN || '193.47.42.213' }}"
             echo "- log_artifact: ha-status-report-log-${{ github.run_id }}"

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -445,6 +445,23 @@ role-aware instead of treating the API VPS as a permanent primary:
 - both workflows retain the existing Telegram failure action and diagnostic
   artifacts.
 
+Scheduled HA checks recognize an official maintenance window only after
+`scripts/ha/check_patroni_maintenance.py` proves the marker independently on
+both hosts. Both markers must be root-owned regular `0600` files with one link,
+contain the same 32-character transaction id, be no older than two hours, and
+remain stable while read. Both role agents must still be active and every PITR
+timer must be inactive. A valid window is logged and reported as maintenance,
+not as a passing infrastructure check; the disruptive check itself is skipped.
+Missing markers on both nodes mean normal operation. A partial, mismatched,
+unsafe, future-dated, or stale marker fails closed and still sends the normal
+alert.
+
+This gate is applied to replication, active/passive invariants, HA readiness,
+VPS health, HA status rollups, and the strict PITR check. Scheduled restore
+drills may also skip a proven maintenance window. Manually dispatched restore
+drills never skip it silently: they fail with an explicit maintenance error so
+an operator cannot mistake a non-run drill for a recovery proof.
+
 The production checker requires all of these invariants at the same time:
 
 1. exactly one Patroni primary and one running replica;

--- a/scripts/ha/check_patroni_maintenance.py
+++ b/scripts/ha/check_patroni_maintenance.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Report a valid official Patroni maintenance window through both SSH nodes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from scripts.ha.check_patroni_production import SshRunner, load_config
+    from scripts.ha.patroni_maintenance_window import (
+        DEFAULT_MAX_AGE_SECONDS,
+        REMOTE_PROBE,
+        detect_window,
+    )
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from check_patroni_production import SshRunner, load_config  # type: ignore[no-redef]
+    from patroni_maintenance_window import (  # type: ignore[no-redef]
+        DEFAULT_MAX_AGE_SECONDS,
+        REMOTE_PROBE,
+        detect_window,
+    )
+
+
+def _max_age_seconds() -> int:
+    raw = os.getenv(
+        "PATRONI_MAINTENANCE_MAX_AGE_SECONDS", str(DEFAULT_MAX_AGE_SECONDS)
+    ).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "PATRONI_MAINTENANCE_MAX_AGE_SECONDS must be an integer"
+        ) from exc
+    if value < 60:
+        raise ValueError(
+            "PATRONI_MAINTENANCE_MAX_AGE_SECONDS must be at least 60"
+        )
+    return value
+
+
+def _write_github_output(path: str, *, active: bool, transaction_id: str) -> None:
+    if not path:
+        return
+    output = Path(path)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(f"active={'true' if active else 'false'}\n")
+        handle.write(f"transaction_id={transaction_id}\n")
+
+
+def run(*, github_output: str = "") -> int:
+    config = load_config()
+    ssh = SshRunner(config.ssh_options)
+    node_by_label = {node.label: node for node in config.nodes}
+
+    def remote(target: str, source: str):
+        if source != REMOTE_PROBE:
+            raise RuntimeError("unreviewed maintenance probe source")
+        return ssh.run(
+            node_by_label[target],
+            "exec /usr/bin/python3 -I -",
+            stdin=source,
+            check=False,
+        )
+
+    window = detect_window(
+        tuple((node.label, node.label) for node in config.nodes),
+        runner=remote,
+        max_age_seconds=_max_age_seconds(),
+    )
+    _write_github_output(
+        github_output,
+        active=window.active,
+        transaction_id=window.transaction_id,
+    )
+    if window.active:
+        print(
+            "[patroni-maintenance][status] active=true "
+            f"transaction={window.transaction_id} age_seconds={window.age_seconds} "
+            "nodes=2 pitr_timers=fenced"
+        )
+    else:
+        print("[patroni-maintenance][status] active=false nodes=2")
+    return 0
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--github-output",
+        default="",
+        help="Append active and transaction_id outputs to this GitHub output file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        return run(github_output=args.github_output)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"[patroni-maintenance][error] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/patroni_maintenance_window.py
+++ b/scripts/ha/patroni_maintenance_window.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Fail-closed detection of the official two-node Patroni maintenance window."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+
+MAINTENANCE_TRANSACTION_RE = re.compile(r"[0-9a-f]{32}")
+DEFAULT_MAX_AGE_SECONDS = 2 * 60 * 60
+MAX_FUTURE_SKEW_SECONDS = 60
+PITR_TIMERS = (
+    "mvn-postgres-wal-upload.timer",
+    "mvn-postgres-basebackup.timer",
+)
+
+
+REMOTE_PROBE = r'''import json
+import os
+import re
+import stat
+import subprocess
+
+MARKER = "/run/mvn-postgres-pitr-maintenance"
+TRANSACTION_RE = re.compile(rb"[0-9a-f]{32}\n")
+ROLE_AGENT = "mvn-patroni-role-agent.service"
+PITR_TIMERS = (
+    "mvn-postgres-wal-upload.timer",
+    "mvn-postgres-basebackup.timer",
+)
+
+
+def generation(metadata):
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def emit(payload):
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def invalid(message):
+    emit({"status": "invalid", "error": message})
+    raise SystemExit(0)
+
+
+try:
+    before = os.lstat(MARKER)
+except FileNotFoundError:
+    emit({"status": "absent"})
+    raise SystemExit(0)
+except OSError:
+    invalid("maintenance marker metadata cannot be read")
+
+if (
+    not stat.S_ISREG(before.st_mode)
+    or stat.S_ISLNK(before.st_mode)
+    or stat.S_IMODE(before.st_mode) != 0o600
+    or before.st_uid != 0
+    or before.st_gid != 0
+    or before.st_nlink != 1
+    or before.st_size != 33
+):
+    invalid("maintenance marker metadata is unsafe")
+
+flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+try:
+    descriptor = os.open(MARKER, flags)
+except OSError:
+    invalid("maintenance marker cannot be opened safely")
+try:
+    opened = os.fstat(descriptor)
+    if generation(opened) != generation(before):
+        invalid("maintenance marker changed before open")
+    content = os.read(descriptor, 34)
+    after = os.fstat(descriptor)
+    if generation(after) != generation(opened):
+        invalid("maintenance marker changed while being read")
+finally:
+    os.close(descriptor)
+
+try:
+    final = os.lstat(MARKER)
+except OSError:
+    invalid("maintenance marker path changed while being read")
+if generation(final) != generation(after):
+    invalid("maintenance marker path changed while being read")
+if TRANSACTION_RE.fullmatch(content) is None:
+    invalid("maintenance marker content is invalid")
+
+
+def active_state(unit):
+    result = subprocess.run(
+        ["/usr/bin/systemctl", "is-active", unit],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout.strip() or "unknown"
+
+
+role_agent_state = active_state(ROLE_AGENT)
+timer_states = {timer: active_state(timer) for timer in PITR_TIMERS}
+if role_agent_state != "active":
+    invalid("Patroni role agent is not active during maintenance")
+if any(state != "inactive" for state in timer_states.values()):
+    invalid("PITR timers are not fenced during maintenance")
+
+emit(
+    {
+        "status": "active",
+        "transaction_id": content[:-1].decode("ascii"),
+        "mtime_ns": final.st_mtime_ns,
+        "role_agent_state": role_agent_state,
+        "timer_states": timer_states,
+    }
+)
+'''
+
+
+@dataclass(frozen=True)
+class NodeObservation:
+    label: str
+    status: str
+    transaction_id: str = ""
+    mtime_ns: int = 0
+
+
+@dataclass(frozen=True)
+class MaintenanceWindow:
+    active: bool
+    transaction_id: str = ""
+    age_seconds: int = 0
+
+
+RemoteRunner = Callable[[str, str], subprocess.CompletedProcess[str]]
+
+
+def parse_observation(label: str, result: subprocess.CompletedProcess[str]) -> NodeObservation:
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "remote marker probe failed").strip()
+        raise RuntimeError(f"{label}: {detail}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{label}: invalid maintenance probe response") from exc
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f"{label}: invalid maintenance probe response")
+    status = payload.get("status")
+    if status == "absent":
+        if set(payload) != {"status"}:
+            raise RuntimeError(f"{label}: unexpected absent marker response")
+        return NodeObservation(label=label, status="absent")
+    if status == "invalid":
+        error = payload.get("error")
+        if not isinstance(error, str) or not error:
+            error = "official maintenance marker is invalid"
+        raise RuntimeError(f"{label}: {error}")
+    if status != "active":
+        raise RuntimeError(f"{label}: unsupported maintenance marker status")
+
+    expected_keys = {
+        "status",
+        "transaction_id",
+        "mtime_ns",
+        "role_agent_state",
+        "timer_states",
+    }
+    if set(payload) != expected_keys:
+        raise RuntimeError(f"{label}: unexpected active maintenance probe response")
+
+    transaction_id = payload.get("transaction_id")
+    mtime_ns = payload.get("mtime_ns")
+    role_agent_state = payload.get("role_agent_state")
+    timer_states = payload.get("timer_states")
+    if (
+        not isinstance(transaction_id, str)
+        or MAINTENANCE_TRANSACTION_RE.fullmatch(transaction_id) is None
+        or not isinstance(mtime_ns, int)
+        or isinstance(mtime_ns, bool)
+        or mtime_ns <= 0
+        or role_agent_state != "active"
+        or not isinstance(timer_states, Mapping)
+        or set(timer_states) != set(PITR_TIMERS)
+        or any(timer_states[timer] != "inactive" for timer in PITR_TIMERS)
+    ):
+        raise RuntimeError(f"{label}: invalid active maintenance probe response")
+    return NodeObservation(
+        label=label,
+        status="active",
+        transaction_id=transaction_id,
+        mtime_ns=mtime_ns,
+    )
+
+
+def evaluate_window(
+    observations: Sequence[NodeObservation],
+    *,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    now_ns: int | None = None,
+) -> MaintenanceWindow:
+    if len(observations) != 2 or len({item.label for item in observations}) != 2:
+        raise RuntimeError("maintenance proof requires exactly two distinct nodes")
+    if max_age_seconds < 60:
+        raise RuntimeError("maintenance maximum age must be at least 60 seconds")
+    statuses = {item.status for item in observations}
+    if statuses == {"absent"}:
+        return MaintenanceWindow(active=False)
+    if statuses != {"active"}:
+        rendered = ", ".join(f"{item.label}={item.status}" for item in observations)
+        raise RuntimeError(f"partial Patroni maintenance window: {rendered}")
+
+    transaction_ids = {item.transaction_id for item in observations}
+    if len(transaction_ids) != 1:
+        raise RuntimeError("Patroni nodes have different maintenance transactions")
+    current_ns = time.time_ns() if now_ns is None else now_ns
+    ages = [(current_ns - item.mtime_ns) / 1_000_000_000 for item in observations]
+    if any(age < -MAX_FUTURE_SKEW_SECONDS for age in ages):
+        raise RuntimeError("Patroni maintenance marker timestamp is in the future")
+    oldest_age = max(0, int(max(ages)))
+    if oldest_age > max_age_seconds:
+        raise RuntimeError(
+            f"Patroni maintenance window is stale: age={oldest_age}s "
+            f"limit={max_age_seconds}s"
+        )
+    return MaintenanceWindow(
+        active=True,
+        transaction_id=next(iter(transaction_ids)),
+        age_seconds=oldest_age,
+    )
+
+
+def detect_window(
+    nodes: Sequence[tuple[str, str]],
+    *,
+    runner: RemoteRunner,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    now_ns: int | None = None,
+) -> MaintenanceWindow:
+    observations = []
+    for label, target in nodes:
+        result = runner(target, REMOTE_PROBE)
+        observations.append(parse_observation(label, result))
+    return evaluate_window(
+        observations,
+        max_age_seconds=max_age_seconds,
+        now_ns=now_ns,
+    )

--- a/scripts/ha/run_postgres_pitr_workflow.py
+++ b/scripts/ha/run_postgres_pitr_workflow.py
@@ -39,6 +39,7 @@ try:
         validate_effective_config,
     )
     from scripts.ha.pitr_remote_execution import build_host_release_bundle
+    from scripts.ha.patroni_maintenance_window import REMOTE_PROBE, detect_window
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
     from pitr_cluster_topology import (  # type: ignore[no-redef]
         ClusterTopology,
@@ -53,6 +54,10 @@ except ModuleNotFoundError:  # Direct execution from scripts/ha.
         validate_effective_config,
     )
     from pitr_remote_execution import build_host_release_bundle  # type: ignore[no-redef]
+    from patroni_maintenance_window import (  # type: ignore[no-redef]
+        REMOTE_PROBE,
+        detect_window,
+    )
 
 
 Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
@@ -225,11 +230,31 @@ def _same_topology(before: ClusterTopology, after: ClusterTopology) -> bool:
     )
 
 
+def _detect_pinned_maintenance(
+    *,
+    context: PinnedSshContext,
+    runner: Runner,
+):
+    nodes_by_alias = {node.alias: node for node in PATRONI_NODES}
+
+    def remote(target: str, source: str) -> subprocess.CompletedProcess[str]:
+        if source != REMOTE_PROBE:
+            raise WorkflowError("unreviewed maintenance probe source")
+        node = nodes_by_alias[target]
+        return runner([*ssh_args(node, context), "exec /usr/bin/python3 -I -"], source)
+
+    return detect_window(
+        tuple((node.alias, node.alias) for node in PATRONI_NODES),
+        runner=remote,
+    )
+
+
 def execute(
     *,
     phase: str,
     backup_id: str,
     target_time: str,
+    allow_maintenance_skip: bool = False,
     identity_stream: BinaryIO,
     runner: Runner | None = None,
 ) -> None:
@@ -247,6 +272,21 @@ def execute(
         context: PinnedSshContext = create_context(temporary, identity)
         for node in PATRONI_NODES:
             validate_effective_config(node, context)
+        maintenance = _detect_pinned_maintenance(
+            context=context,
+            runner=actual_runner,
+        )
+        if maintenance.active:
+            if phase == "verify" or allow_maintenance_skip:
+                print(
+                    "[pitr-workflow][maintenance] status=skipped "
+                    f"transaction={maintenance.transaction_id} "
+                    f"age_seconds={maintenance.age_seconds} nodes=2"
+                )
+                return
+            raise WorkflowError(
+                "official Patroni maintenance is active; this manual drill was not skipped"
+            )
         before = discover_cluster_topology(context=context, runner=actual_runner)
         operation_id = secrets.token_hex(16)
         expected_release_sha256 = _expected_release_sha256(before)
@@ -306,6 +346,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--backup-id", default="")
     parser.add_argument("--target-time", default="")
+    parser.add_argument(
+        "--allow-maintenance-skip",
+        action="store_true",
+        help="Skip a scheduled drill only while both nodes prove official maintenance",
+    )
     args = parser.parse_args(argv)
     if args.phase != "restore-drill" and (args.backup_id or args.target_time):
         parser.error("backup/target overrides are valid only for restore-drill")
@@ -328,6 +373,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             phase=args.phase,
             backup_id=args.backup_id,
             target_time=args.target_time,
+            allow_maintenance_skip=args.allow_maintenance_skip,
             identity_stream=sys.stdin.buffer,
         )
         return 0

--- a/tests/unit/test_ha_status_report_workflow.py
+++ b/tests/unit/test_ha_status_report_workflow.py
@@ -38,7 +38,7 @@ def test_ha_status_report_workflow_runs_scheduled_operator_rollup():
     assert "scripts/ha/report_ha_status.py" in run
     assert "--require-strict" in run
     assert "--skip-live" in run
-    assert "tee ha-status-report.log" in run
+    assert "tee -a ha-status-report.log" in run
 
     artifact_step = _step(workflow, "Upload HA status report log")
     assert artifact_step["uses"] == "actions/upload-artifact@v7"

--- a/tests/unit/test_patroni_maintenance_window.py
+++ b/tests/unit/test_patroni_maintenance_window.py
@@ -1,0 +1,146 @@
+import json
+import subprocess
+
+import pytest
+
+from scripts.ha import patroni_maintenance_window as maintenance
+
+
+def _result(payload: dict, *, returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(
+        ["ssh"],
+        returncode,
+        json.dumps(payload),
+        stderr,
+    )
+
+
+def _active(label: str, *, transaction_id: str = "a" * 32, mtime_ns: int = 10**12):
+    return maintenance.NodeObservation(
+        label=label,
+        status="active",
+        transaction_id=transaction_id,
+        mtime_ns=mtime_ns,
+    )
+
+
+def test_parse_observation_accepts_only_attested_active_payload():
+    payload = {
+        "status": "active",
+        "transaction_id": "b" * 32,
+        "mtime_ns": 123,
+        "role_agent_state": "active",
+        "timer_states": {
+            "mvn-postgres-wal-upload.timer": "inactive",
+            "mvn-postgres-basebackup.timer": "inactive",
+        },
+    }
+
+    observation = maintenance.parse_observation("api", _result(payload))
+
+    assert observation == maintenance.NodeObservation(
+        label="api",
+        status="active",
+        transaction_id="b" * 32,
+        mtime_ns=123,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload, match",
+    [
+        ({"status": "invalid", "error": "marker unsafe"}, "marker unsafe"),
+        (
+            {
+                "status": "active",
+                "transaction_id": "c" * 32,
+                "mtime_ns": 123,
+                "role_agent_state": "inactive",
+                "timer_states": {
+                    "mvn-postgres-wal-upload.timer": "inactive",
+                    "mvn-postgres-basebackup.timer": "inactive",
+                },
+            },
+            "invalid active",
+        ),
+    ],
+)
+def test_parse_observation_fails_closed(payload, match):
+    with pytest.raises(RuntimeError, match=match):
+        maintenance.parse_observation("api", _result(payload))
+
+
+def test_evaluate_window_distinguishes_inactive_and_valid_active():
+    inactive = maintenance.evaluate_window(
+        [
+            maintenance.NodeObservation("api", "absent"),
+            maintenance.NodeObservation("reserve", "absent"),
+        ]
+    )
+    active = maintenance.evaluate_window(
+        [_active("api"), _active("reserve")],
+        now_ns=1_030_000_000_000,
+        max_age_seconds=60,
+    )
+
+    assert inactive == maintenance.MaintenanceWindow(active=False)
+    assert active == maintenance.MaintenanceWindow(
+        active=True,
+        transaction_id="a" * 32,
+        age_seconds=30,
+    )
+
+
+def test_evaluate_window_rejects_partial_mismatched_stale_and_future_markers():
+    with pytest.raises(RuntimeError, match="partial"):
+        maintenance.evaluate_window(
+            [_active("api"), maintenance.NodeObservation("reserve", "absent")]
+        )
+    with pytest.raises(RuntimeError, match="different"):
+        maintenance.evaluate_window(
+            [_active("api"), _active("reserve", transaction_id="b" * 32)]
+        )
+    with pytest.raises(RuntimeError, match="stale"):
+        maintenance.evaluate_window(
+            [_active("api"), _active("reserve")],
+            now_ns=1_061_000_000_000,
+            max_age_seconds=60,
+        )
+    with pytest.raises(RuntimeError, match="future"):
+        maintenance.evaluate_window(
+            [_active("api", mtime_ns=1_061_000_000_000),
+             _active("reserve", mtime_ns=1_061_000_000_000)],
+            now_ns=10**12,
+            max_age_seconds=60,
+        )
+
+
+def test_detect_window_probes_both_nodes_with_reviewed_source():
+    calls = []
+
+    def runner(target, source):
+        calls.append((target, source))
+        return _result({"status": "absent"})
+
+    window = maintenance.detect_window(
+        (("api", "api-target"), ("reserve", "reserve-target")),
+        runner=runner,
+    )
+
+    assert window.active is False
+    assert [target for target, _ in calls] == ["api-target", "reserve-target"]
+    assert all(source == maintenance.REMOTE_PROBE for _, source in calls)
+
+
+def test_remote_probe_contract_checks_marker_generation_and_runtime_fencing():
+    source = maintenance.REMOTE_PROBE
+
+    assert 'getattr(os, "O_NOFOLLOW", 0)' in source
+    assert '["/usr/bin/systemctl", "is-active", unit]' in source
+    assert "before.st_uid != 0" in source
+    assert "before.st_gid != 0" in source
+    assert "before.st_nlink != 1" in source
+    assert "before.st_size != 33" in source
+    assert "generation(after) != generation(opened)" in source
+    assert 'role_agent_state != "active"' in source
+    assert 'state != "inactive"' in source

--- a/tests/unit/test_patroni_maintenance_workflows.py
+++ b/tests/unit/test_patroni_maintenance_workflows.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAINTENANCE_AWARE_WORKFLOWS = (
+    (".github/workflows/check-postgres-replication.yml", "check"),
+    (".github/workflows/check-api-ha-readiness.yml", "audit"),
+    (".github/workflows/check-api-vps-health.yml", "check"),
+    (".github/workflows/check-api-ha-invariants.yml", "check"),
+    (".github/workflows/report-ha-status.yml", "report"),
+)
+
+
+def _workflow(path: str) -> dict:
+    return yaml.load(
+        (REPO_ROOT / path).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+
+def test_frequent_ha_workflows_skip_only_after_official_maintenance_proof():
+    for path, job_name in MAINTENANCE_AWARE_WORKFLOWS:
+        workflow = _workflow(path)
+        steps = workflow["jobs"][job_name]["steps"]
+        detector = next(
+            step for step in steps if step.get("name") == "Detect official Patroni maintenance"
+        )
+        detector_index = steps.index(detector)
+        normal_step = steps[detector_index + 1]
+
+        assert detector["id"] == "maintenance"
+        assert "API_DB_HA_MODE" in detector["if"]
+        assert "check_patroni_maintenance.py" in detector["run"]
+        assert '--github-output "${GITHUB_OUTPUT}"' in detector["run"]
+        assert "2>&1 | tee" in detector["run"]
+        assert normal_step["if"] == "steps.maintenance.outputs.active != 'true'"
+        summaries = [
+            step["run"] for step in steps if step.get("name") == "Write Summary"
+        ]
+        if summaries:
+            assert "official_maintenance:" in summaries[0]
+
+
+def test_scheduled_restore_drills_allow_bounded_maintenance_skip_only_on_schedule():
+    for path, job_name, step_name in (
+        (
+            ".github/workflows/api-restore-drill.yml",
+            "restore-drill",
+            "Run logical restore drill on the proven Patroni primary",
+        ),
+        (
+            ".github/workflows/postgres-pitr-restore-drill.yml",
+            "pitr-restore-drill",
+            "Run PostgreSQL PITR Restore Drill",
+        ),
+    ):
+        workflow = _workflow(path)
+        step = next(
+            item
+            for item in workflow["jobs"][job_name]["steps"]
+            if item.get("name") == step_name
+        )
+
+        assert 'if [ "${GITHUB_EVENT_NAME}" = "schedule" ]' in step["run"]
+        assert "args+=(--allow-maintenance-skip)" in step["run"]

--- a/tests/unit/test_postgres_pitr_workflow_runner.py
+++ b/tests/unit/test_postgres_pitr_workflow_runner.py
@@ -1,5 +1,6 @@
 import io
 import subprocess
+import time
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -13,6 +14,21 @@ IDENTITY = b"""-----BEGIN OPENSSH PRIVATE KEY-----
 dGVzdC1vbmx5
 -----END OPENSSH PRIVATE KEY-----
 """
+ABSENT_MARKER = '{"status":"absent"}\n'
+
+
+def _is_maintenance_probe(args) -> bool:
+    return bool(args) and args[-1] == "exec /usr/bin/python3 -I -"
+
+
+def _active_marker_payload(transaction_id: str = "a" * 32) -> str:
+    return (
+        f'{{"mtime_ns":{time.time_ns()},"role_agent_state":"active",'
+        '"status":"active","timer_states":{'
+        '"mvn-postgres-basebackup.timer":"inactive",'
+        '"mvn-postgres-wal-upload.timer":"inactive"},'
+        f'"transaction_id":"{transaction_id}"}}\n'
+    )
 
 
 def _topology(*, primary_index: int = 0, timeline: int = 9) -> ClusterTopology:
@@ -91,6 +107,9 @@ def test_execute_uses_pinned_alias_proves_topology_twice_and_cleans_context(
 
     def runner(args, stdin=None):
         commands.append((list(args), stdin))
+        if _is_maintenance_probe(args):
+            assert stdin == workflow_runner.REMOTE_PROBE
+            return subprocess.CompletedProcess(list(args), 0, ABSENT_MARKER, "")
         return subprocess.CompletedProcess(list(args), 0, "guarded proof passed\n", "")
 
     monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
@@ -108,8 +127,8 @@ def test_execute_uses_pinned_alias_proves_topology_twice_and_cleans_context(
     )
 
     assert len(proofs) == 2
-    assert len(commands) == 1
-    args, stdin = commands[0]
+    assert len(commands) == 3
+    args, stdin = commands[-1]
     assert stdin is None
     assert args[-2] == "mvn-api"
     assert "/usr/local/sbin/mvn-postgres-pitr-manual-runner" in args[-1]
@@ -134,13 +153,18 @@ def test_execute_fails_if_topology_changes_and_still_cleans_context(
     monkeypatch.setattr(workflow_runner.secrets, "token_hex", lambda _: "d" * 32)
     monkeypatch.setattr(workflow_runner, "_expected_release_sha256", lambda _: "f" * 64)
 
+    def runner(args, stdin=None):
+        if _is_maintenance_probe(args):
+            return subprocess.CompletedProcess(args, 0, ABSENT_MARKER, "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
     with pytest.raises(workflow_runner.WorkflowError, match="topology changed"):
         workflow_runner.execute(
             phase="logical-restore-drill",
             backup_id="",
             target_time="",
             identity_stream=io.BytesIO(IDENTITY),
-            runner=lambda args, stdin=None: subprocess.CompletedProcess(args, 0, "", ""),
+            runner=runner,
         )
 
     assert not list(tmp_path.iterdir())
@@ -161,18 +185,78 @@ def test_execute_reproves_topology_after_a_remote_failure(tmp_path, monkeypatch)
     monkeypatch.setattr(workflow_runner.secrets, "token_hex", lambda _: "e" * 32)
     monkeypatch.setattr(workflow_runner, "_expected_release_sha256", lambda _: "f" * 64)
 
+    def runner(args, stdin=None):
+        if _is_maintenance_probe(args):
+            return subprocess.CompletedProcess(args, 0, ABSENT_MARKER, "")
+        return subprocess.CompletedProcess(args, 75, "", "operation lock busy\n")
+
     with pytest.raises(workflow_runner.WorkflowError, match="status 75"):
         workflow_runner.execute(
             phase="verify",
             backup_id="",
             target_time="",
             identity_stream=io.BytesIO(IDENTITY),
-            runner=lambda args, stdin=None: subprocess.CompletedProcess(
-                args, 75, "", "operation lock busy\n"
-            ),
+            runner=runner,
         )
 
     assert proof_count == 2
+    assert not list(tmp_path.iterdir())
+
+
+def test_execute_skips_verify_during_proven_two_node_maintenance(tmp_path, monkeypatch):
+    transaction_id = "a" * 32
+    active = _active_marker_payload(transaction_id)
+    commands = []
+
+    def runner(args, stdin=None):
+        commands.append(list(args))
+        return subprocess.CompletedProcess(args, 0, active, "")
+
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    monkeypatch.setattr(workflow_runner, "validate_effective_config", lambda *_: None)
+
+    workflow_runner.execute(
+        phase="verify",
+        backup_id="",
+        target_time="",
+        identity_stream=io.BytesIO(IDENTITY),
+        runner=runner,
+    )
+
+    assert len(commands) == 2
+    assert all(_is_maintenance_probe(command) for command in commands)
+    assert not list(tmp_path.iterdir())
+
+
+def test_manual_restore_drill_fails_but_scheduled_drill_skips_during_maintenance(
+    tmp_path, monkeypatch
+):
+    active = _active_marker_payload()
+
+    def runner(args, stdin=None):
+        return subprocess.CompletedProcess(args, 0, active, "")
+
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+    monkeypatch.setattr(workflow_runner, "validate_effective_config", lambda *_: None)
+
+    with pytest.raises(workflow_runner.WorkflowError, match="manual drill"):
+        workflow_runner.execute(
+            phase="restore-drill",
+            backup_id="",
+            target_time="",
+            identity_stream=io.BytesIO(IDENTITY),
+            runner=runner,
+        )
+    assert not list(tmp_path.iterdir())
+
+    workflow_runner.execute(
+        phase="restore-drill",
+        backup_id="",
+        target_time="",
+        allow_maintenance_skip=True,
+        identity_stream=io.BytesIO(IDENTITY),
+        runner=runner,
+    )
     assert not list(tmp_path.iterdir())
 
 


### PR DESCRIPTION
## Что изменено

- добавлен fail-closed детектор официального Patroni maintenance window на обоих узлах;
- marker принимается только при root:root, regular file, mode 0600, nlink=1, одинаковом transaction id, возрасте до 2 часов и стабильном чтении;
- дополнительно доказываются активные role agents и остановленные PITR timers;
- replication, invariant, readiness, VPS health и HA status workflows теперь явно завершаются как maintenance вместо ложной аварии;
- строгий PITR verify пропускается только при том же двухузловом доказательстве;
- scheduled restore drills могут пропустить доказанное обслуживание, а ручные drills по-прежнему fail closed;
- partial, mismatched, unsafe, future-dated и stale markers остаются авариями;
- runbook дополнен точным контрактом.

## Проверки

- `python3 -m py_compile scripts/ha/patroni_maintenance_window.py scripts/ha/check_patroni_maintenance.py scripts/ha/run_postgres_pitr_workflow.py`
- `git diff --check origin/main...HEAD`
- `pytest -q tests/unit -k 'patroni or pitr or ha_'`
  - 777 passed, 4 skipped, 1476 deselected
- read-only live probe после завершённой ротации: `active=false nodes=2`

## Почему это не скрывает реальные сбои

Оба marker должны независимо пройти строгую проверку и совпасть. Отсутствие marker на обоих узлах запускает обычный мониторинг. Любое промежуточное или небезопасное состояние валит workflow и сохраняет Telegram alert + artifact.
