### PR TITLE
fix: harden Feature scope isolation

### DIFF
--- a/manager_frontend/src/client/services/ManagerFeaturesService.ts
+++ b/manager_frontend/src/client/services/ManagerFeaturesService.ts
@@ -31,6 +31,7 @@ export class ManagerFeaturesService {
      * @param search
      * @param categoryId
      * @param brandId
+     * @param productId
      * @param scopeType
      * @param isActive
      * @returns ManagerFeatureListResponse Successful Response
@@ -40,6 +41,7 @@ export class ManagerFeaturesService {
         search?: (string | null),
         categoryId?: (number | null),
         brandId?: (number | null),
+        productId?: (number | null),
         scopeType?: ('universal' | 'brand' | 'series' | 'product' | 'derived' | null),
         isActive?: (boolean | null),
     ): CancelablePromise<ManagerFeatureListResponse> {
@@ -50,6 +52,7 @@ export class ManagerFeaturesService {
                 'search': search,
                 'category_id': categoryId,
                 'brand_id': brandId,
+                'product_id': productId,
                 'scope_type': scopeType,
                 'is_active': isActive,
             },

--- a/manager_frontend/src/components/products/ProductWorkspaceFeatures.vue
+++ b/manager_frontend/src/components/products/ProductWorkspaceFeatures.vue
@@ -66,7 +66,7 @@ const load = async () => {
   try {
     const [featureData, libraryData] = await Promise.all([
       ManagerFeaturesService.getManagerProductFeatures(props.product.id),
-      ManagerFeaturesService.listManagerFeatures(undefined, undefined, undefined, undefined, true),
+      ManagerFeaturesService.listManagerFeatures(undefined, undefined, undefined, props.product.id, undefined, true),
     ]);
     workspace.value = normalizeWorkspace(featureData);
     library.value = libraryData.items;

--- a/manager_frontend/src/views/FeaturesView.vue
+++ b/manager_frontend/src/views/FeaturesView.vue
@@ -81,6 +81,7 @@ const load = async () => {
         search.value.trim() || undefined,
         categoryId.value || undefined,
         brandId.value || undefined,
+        undefined,
         scope.value || undefined,
         !showArchived.value,
       ),

--- a/openapi.json
+++ b/openapi.json
@@ -3920,6 +3920,22 @@
             }
           },
           {
+            "name": "product_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Product Id"
+            }
+          },
+          {
             "name": "scope_type",
             "in": "query",
             "required": false,

--- a/routers/manager_features.py
+++ b/routers/manager_features.py
@@ -58,6 +58,7 @@ async def list_features(
     search: str | None = Query(None),
     category_id: int | None = Query(None),
     brand_id: int | None = Query(None),
+    product_id: int | None = Query(None),
     scope_type: Literal["universal", "brand", "series", "product", "derived"] | None = Query(None),
     is_active: bool | None = Query(True),
     session: AsyncSession = Depends(get_session),
@@ -68,6 +69,7 @@ async def list_features(
         search=search,
         category_id=category_id,
         brand_id=brand_id,
+        product_id=product_id,
         scope_type=scope_type,
         is_active=is_active,
     )

--- a/services/content_api_service.py
+++ b/services/content_api_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from models import Brand, Feature, FeatureBrandLink, GlobalConfig, Product, Service
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 class ContentApiService:
@@ -201,6 +202,15 @@ class ContentApiService:
                 )
             ).scalars().all()
         )
+        features = [
+            feature
+            for feature in features
+            if FeatureScopePolicy.allows_target(
+                feature,
+                target_type="brand",
+                brand_id=int(brand.id),
+            )
+        ]
         brand.__dict__["_resolved_brand_features"] = features
         return ContentApiService._serialize_brand(brand, products_count=products_count, include_features=True)
 

--- a/services/feature_assignment_service.py
+++ b/services/feature_assignment_service.py
@@ -23,6 +23,7 @@ from schemas_features import (
 )
 from services.catalog_revision_service import CatalogRevisionService
 from services.feature_resolver_service import FeatureResolverService
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 class FeatureAssignmentService:
@@ -51,7 +52,7 @@ class FeatureAssignmentService:
         feature_ids = [item.feature_id for item in assignments]
         if len(feature_ids) != len(set(feature_ids)):
             raise HTTPException(status_code=400, detail="Фича не может быть назначена товару дважды")
-        await FeatureAssignmentService._validate_features(session, feature_ids)
+        features = await FeatureAssignmentService._get_active_features(session, feature_ids)
         await FeatureAssignmentService._validate_override_media(
             session, [item.override_media_id for item in assignments]
         )
@@ -61,22 +62,64 @@ class FeatureAssignmentService:
                 detail="Derived-фичи применяются только через endpoint предложений",
             )
 
-        await session.execute(
-            delete(FeatureProductLink).where(
-                FeatureProductLink.product_id == product_id,
-                FeatureProductLink.source == "manual",
-            )
+        existing_links = list(
+            (
+                await session.execute(
+                    select(FeatureProductLink).where(
+                        FeatureProductLink.product_id == product_id
+                    )
+                )
+            ).scalars().all()
         )
+        existing_by_feature_id = {
+            int(link.feature_id): link for link in existing_links
+        }
+        series_feature_ids: set[int] = set()
+        if product.series_id is not None:
+            series_feature_ids = set(
+                (
+                    await session.execute(
+                        select(FeatureSeriesLink.feature_id).where(
+                            FeatureSeriesLink.series_id == product.series_id
+                        )
+                    )
+                ).scalars().all()
+            )
+        for feature_id, feature in features.items():
+            if not FeatureScopePolicy.allows_product(
+                feature,
+                product,
+                has_series_link=feature_id in series_feature_ids,
+                has_product_link=feature_id in existing_by_feature_id,
+                mode="manual",
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "message": "Фича неприменима к этому товару",
+                        "feature_ids": [feature_id],
+                    },
+                )
+
+        requested_ids = set(feature_ids)
+        for link in existing_links:
+            if link.source == "manual" and int(link.feature_id) not in requested_ids:
+                await session.delete(link)
+
         now = datetime.now()
         for item in assignments:
-            session.add(
-                FeatureProductLink(
+            link = existing_by_feature_id.get(item.feature_id)
+            if link is None:
+                link = FeatureProductLink(
                     product_id=product_id,
+                    feature_id=item.feature_id,
                     created_at=now,
-                    updated_at=now,
-                    **item.model_dump(),
                 )
-            )
+            for key, value in item.model_dump(exclude={"feature_id"}).items():
+                setattr(link, key, value)
+            link.source = "manual"
+            link.updated_at = now
+            session.add(link)
         await CatalogRevisionService.bump_commit_and_purge(
             session,
             scope="product_features_update",
@@ -173,7 +216,9 @@ class FeatureAssignmentService:
         target_id: int,
         payload: FeatureTargetLinkPayload,
     ) -> None:
-        await FeatureAssignmentService._validate_features(session, [feature_id])
+        feature = (await FeatureAssignmentService._get_active_features(session, [feature_id]))[
+            feature_id
+        ]
         await FeatureAssignmentService._validate_override_media(session, [payload.override_media_id])
         config = {
             "brand": (Brand, FeatureBrandLink, FeatureBrandLink.brand_id, "brand_id"),
@@ -182,8 +227,19 @@ class FeatureAssignmentService:
         if config is None:
             raise ValueError("Unsupported feature target")
         target_model, link_model, target_column, target_field = config
-        if await session.get(target_model, target_id) is None:
+        target = await session.get(target_model, target_id)
+        if target is None:
             raise HTTPException(status_code=404, detail="Цель назначения не найдена")
+        target_brand_id = int(target.id) if target_type == "brand" else target.brand_id
+        if not FeatureScopePolicy.allows_target(
+            feature,
+            target_type=target_type,
+            brand_id=target_brand_id,
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Фича неприменима к выбранному бренду или серии",
+            )
         link = (
             await session.execute(
                 select(link_model).where(
@@ -231,22 +287,28 @@ class FeatureAssignmentService:
         )
 
     @staticmethod
-    async def _validate_features(session: AsyncSession, feature_ids: list[int]) -> None:
+    async def _get_active_features(
+        session: AsyncSession,
+        feature_ids: list[int],
+    ) -> dict[int, Feature]:
         if not feature_ids:
-            return
-        found = set(
+            return {}
+        rows = list(
             (
                 await session.execute(
-                    select(Feature.id).where(
+                    select(Feature).where(
                         Feature.id.in_(set(feature_ids)),
                         Feature.is_active.is_(True),
+                        Feature.archived_at.is_(None),
                     )
                 )
             ).scalars().all()
         )
-        missing = sorted(set(feature_ids) - found)
+        found = {int(feature.id): feature for feature in rows}
+        missing = sorted(set(feature_ids) - set(found))
         if missing:
             raise HTTPException(status_code=400, detail={"message": "Фичи не найдены", "feature_ids": missing})
+        return found
 
     @staticmethod
     async def _validate_override_media(session: AsyncSession, media_ids) -> None:

--- a/services/feature_library_service.py
+++ b/services/feature_library_service.py
@@ -29,6 +29,7 @@ from schemas_features import (
     ManagerFeatureResponse,
 )
 from services.catalog_revision_service import CatalogRevisionService
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 class FeatureLibraryService:
@@ -50,6 +51,7 @@ class FeatureLibraryService:
         search: str | None = None,
         category_id: int | None = None,
         brand_id: int | None = None,
+        product_id: int | None = None,
         scope_type: str | None = None,
         is_active: bool | None = True,
     ) -> list[ManagerFeatureResponse]:
@@ -68,6 +70,41 @@ class FeatureLibraryService:
             stmt = stmt.where(Feature.is_active == is_active)
         stmt = stmt.order_by(Feature.sort_order, Feature.name, Feature.id)
         features = list((await session.execute(stmt)).scalars().all())
+        if product_id is not None:
+            product = await session.get(Product, product_id)
+            if product is None:
+                raise HTTPException(status_code=404, detail="Товар не найден")
+            product_feature_ids = set(
+                (
+                    await session.execute(
+                        select(FeatureProductLink.feature_id).where(
+                            FeatureProductLink.product_id == product_id
+                        )
+                    )
+                ).scalars().all()
+            )
+            series_feature_ids: set[int] = set()
+            if product.series_id is not None:
+                series_feature_ids = set(
+                    (
+                        await session.execute(
+                            select(FeatureSeriesLink.feature_id).where(
+                                FeatureSeriesLink.series_id == product.series_id
+                            )
+                        )
+                    ).scalars().all()
+                )
+            features = [
+                feature
+                for feature in features
+                if FeatureScopePolicy.allows_product(
+                    feature,
+                    product,
+                    has_series_link=int(feature.id) in series_feature_ids,
+                    has_product_link=int(feature.id) in product_feature_ids,
+                    mode="manual",
+                )
+            ]
         return await FeatureLibraryService._serialize_many(session, features)
 
     @staticmethod

--- a/services/feature_resolver_service.py
+++ b/services/feature_resolver_service.py
@@ -17,6 +17,7 @@ from models import (
 )
 from schemas_features import FeatureCategoryResponse, FeatureLinkPayload, PublicFeatureResponse
 from services.feature_rule_engine import describe_rules, matches_all_rules
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 class FeatureResolverService:
@@ -78,12 +79,21 @@ class FeatureResolverService:
             inherited: list[PublicFeatureResponse] = []
             manual: list[PublicFeatureResponse] = []
             disabled_ids: list[int] = []
+            applicable_feature_ids: set[int] = set()
 
             for feature_id, feature in features.items():
                 p_link = product_link_map.get(pid, {}).get(feature_id)
                 s_link = series_link_map.get(int(product.series_id or 0), {}).get(feature_id)
                 b_link = brand_link_map.get(int(product.brand_id or 0), {}).get(feature_id)
                 matched = matches_all_rules(specs, list(feature.rules or []))
+                if not FeatureScopePolicy.allows_product(
+                    feature,
+                    product,
+                    has_series_link=s_link is not None,
+                    has_product_link=p_link is not None,
+                ):
+                    continue
+                applicable_feature_ids.add(feature_id)
                 chosen = None
                 source = None
 
@@ -126,7 +136,18 @@ class FeatureResolverService:
                         manual.append(item)
                     continue
 
-                if include_suggestions and matched and feature.rules:
+                if (
+                    include_suggestions
+                    and matched
+                    and feature.rules
+                    and FeatureScopePolicy.allows_product(
+                        feature,
+                        product,
+                        has_series_link=s_link is not None,
+                        has_product_link=p_link is not None,
+                        mode="suggestion",
+                    )
+                ):
                     suggestions.append(
                         FeatureResolverService._serialize_resolved(
                             feature,
@@ -144,7 +165,9 @@ class FeatureResolverService:
                 "inherited": sorted(inherited, key=sort_key),
                 "manual": sorted(manual, key=sort_key),
                 "manual_assignments": FeatureResolverService._manual_assignments(
-                    product_link_map.get(pid, {}).values()
+                    link
+                    for feature_id, link in product_link_map.get(pid, {}).items()
+                    if feature_id in applicable_feature_ids
                 ),
                 "disabled_feature_ids": sorted(set(disabled_ids)),
             }
@@ -157,6 +180,13 @@ class FeatureResolverService:
                 for feature_id, feature in features.items():
                     s_link = series_link_map.get(int(product.series_id or 0), {}).get(feature_id)
                     b_link = brand_link_map.get(int(product.brand_id or 0), {}).get(feature_id)
+                    if not FeatureScopePolicy.allows_product(
+                        feature,
+                        product,
+                        has_series_link=s_link is not None,
+                        has_product_link=False,
+                    ):
+                        continue
                     chosen, source = (s_link, "series") if s_link is not None else (b_link, "brand")
                     if chosen is None or not chosen.is_enabled:
                         continue

--- a/services/feature_scope_policy.py
+++ b/services/feature_scope_policy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from models import Feature, Product
+
+
+class FeatureScopePolicy:
+    """Pure applicability rules shared by resolvers and assignment commands."""
+
+    @staticmethod
+    def allows_brand(feature: Feature, brand_id: int | None) -> bool:
+        if feature.scope_type == "brand":
+            return feature.brand_id is not None and feature.brand_id == brand_id
+        if feature.scope_type == "derived" and feature.brand_id is not None:
+            return feature.brand_id == brand_id
+        return True
+
+    @staticmethod
+    def allows_product(
+        feature: Feature,
+        product: Product,
+        *,
+        has_series_link: bool,
+        has_product_link: bool,
+        mode: str = "resolve",
+    ) -> bool:
+        if not FeatureScopePolicy.allows_brand(feature, product.brand_id):
+            return False
+        if mode == "suggestion":
+            return feature.scope_type in {"universal", "derived"}
+        if feature.scope_type == "series":
+            return has_series_link
+        if feature.scope_type == "product":
+            return has_product_link or mode == "manual"
+        if feature.scope_type == "derived" and mode == "manual":
+            return has_product_link
+        return True
+
+    @staticmethod
+    def allows_target(feature: Feature, *, target_type: str, brand_id: int | None) -> bool:
+        if not FeatureScopePolicy.allows_brand(feature, brand_id):
+            return False
+        if target_type == "brand":
+            return feature.scope_type in {"universal", "brand", "derived"}
+        if target_type == "series":
+            return feature.scope_type in {"universal", "brand", "series", "derived"}
+        return False

--- a/services/manager_brand_service.py
+++ b/services/manager_brand_service.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException
 from slugify import slugify
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import (
@@ -20,6 +20,7 @@ from models import (
 )
 from services.brand_series_service import extract_series_name, sync_product_brand_series
 from services.catalog_revision_service import CatalogRevisionService
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 class ManagerBrandService:
@@ -793,8 +794,9 @@ class ManagerBrandService:
 
         rows = (
             await session.execute(
-                select(FeatureSeriesLink, Feature)
+                select(FeatureSeriesLink, Feature, ProductSeries.brand_id)
                 .join(Feature, Feature.id == FeatureSeriesLink.feature_id)
+                .join(ProductSeries, ProductSeries.id == FeatureSeriesLink.series_id)
                 .where(FeatureSeriesLink.series_id.in_(normalized_ids))
                 .order_by(
                     FeatureSeriesLink.series_id.asc(),
@@ -805,7 +807,13 @@ class ManagerBrandService:
             )
         ).all()
         out: Dict[int, List[Dict[str, Any]]] = {series_id: [] for series_id in normalized_ids}
-        for link, feature in rows:
+        for link, feature, brand_id in rows:
+            if not FeatureScopePolicy.allows_target(
+                feature,
+                target_type="series",
+                brand_id=brand_id,
+            ):
+                continue
             out.setdefault(int(link.series_id), []).append(
                 ManagerBrandService._serialize_series_feature_link(link, feature)
             )
@@ -832,26 +840,26 @@ class ManagerBrandService:
                 normalized_ids.append(feature_id)
 
         if normalized_ids:
-            found_ids = set(
+            candidates = list(
                 (
                     await session.execute(
-                        select(Feature.id)
-                        .outerjoin(
-                            FeatureBrandLink,
-                            FeatureBrandLink.feature_id == Feature.id,
-                        )
-                        .where(
+                        select(Feature).where(
                             Feature.id.in_(normalized_ids),
                             Feature.is_active.is_(True),
-                            or_(
-                                Feature.brand_id == brand_id,
-                                Feature.scope_type.in_(("universal", "derived")),
-                                FeatureBrandLink.brand_id == brand_id,
-                            ),
+                            Feature.archived_at.is_(None),
                         )
                     )
                 ).scalars().all()
             )
+            found_ids = {
+                int(feature.id)
+                for feature in candidates
+                if FeatureScopePolicy.allows_target(
+                    feature,
+                    target_type="series",
+                    brand_id=brand_id,
+                )
+            }
             missing_ids = [feature_id for feature_id in normalized_ids if feature_id not in found_ids]
             if missing_ids:
                 raise HTTPException(

--- a/services/product_series_payloads.py
+++ b/services/product_series_payloads.py
@@ -4,6 +4,7 @@ from typing import Any, List
 
 from models import ProductSeries
 from schemas import ProductSeriesBrandFeatureResponse, ProductSeriesResponse
+from services.feature_scope_policy import FeatureScopePolicy
 
 
 def serialize_series_brand_features(series: ProductSeries) -> List[ProductSeriesBrandFeatureResponse]:
@@ -17,6 +18,12 @@ def serialize_series_brand_features(series: ProductSeries) -> List[ProductSeries
     for link in links:
         feature = getattr(link, "__dict__", {}).get("feature")
         if not feature or not getattr(feature, "is_active", False):
+            continue
+        if not FeatureScopePolicy.allows_target(
+            feature,
+            target_type="series",
+            brand_id=series.brand_id,
+        ):
             continue
         payload.append(
             ProductSeriesBrandFeatureResponse(

--- a/tests/integration/test_manager_features_api.py
+++ b/tests/integration/test_manager_features_api.py
@@ -167,6 +167,12 @@ async def test_feature_resolution_precedence_derived_apply_and_public_dto(async_
         override_title="Персональный поток",
     ))
     db.add(FeatureBrandLink(brand_id=brand.id, feature_id=suppressed.id))
+    db.add(FeatureRule(
+        feature_id=suppressed.id,
+        spec_key="wifi",
+        operator="eq",
+        target_value=True,
+    ))
     db.add(FeatureProductLink(
         product_id=product.id,
         feature_id=suppressed.id,
@@ -262,13 +268,48 @@ async def test_feature_resolution_precedence_derived_apply_and_public_dto(async_
     )
     assert repeated.status_code == 200, repeated.text
 
+    converted = await async_client.put(
+        f"/api/manager/products/{product.id}/features",
+        headers=headers,
+        json={
+            "assignments": [
+                *body["manual_assignments"],
+                {
+                    "feature_id": derived.id,
+                    "source": "manual",
+                    "is_enabled": True,
+                    "sort_order": 50,
+                    "override_title": "Большая площадь с override",
+                },
+            ]
+        },
+    )
+    assert converted.status_code == 200, converted.text
+    converted_item = next(
+        item for item in converted.json()["effective"] if item["id"] == derived.id
+    )
+    assert converted_item["source"] == "product_override"
+    assert converted_item["name"] == "Большая площадь с override"
+    product_links = list(
+        (
+            await db.execute(
+                FeatureProductLink.__table__.select().where(
+                    FeatureProductLink.product_id == product.id,
+                    FeatureProductLink.feature_id == derived.id,
+                )
+            )
+        ).all()
+    )
+    assert len(product_links) == 1
+    assert product_links[0].source == "manual"
+
     public = await async_client.get(f"/api/v1/products/{product.slug}")
     assert public.status_code == 200, public.text
     public_features = public.json()["features"]
     assert [(item["slug"], item["source"]) for item in public_features] == [
         ("air-flow-test", "product_override"),
-        ("large-room-test", "derived"),
         ("inherited-over-derived-test", "brand"),
+        ("large-room-test", "product_override"),
     ]
     assert all("category" in item and "feature_sort_order" in item for item in public_features)
 
@@ -279,3 +320,136 @@ async def test_feature_resolution_precedence_derived_apply_and_public_dto(async_
     assert [item["slug"] for item in removed.json()["automatic_suggestions"]] == [
         "large-room-test"
     ]
+
+
+@pytest.mark.asyncio
+async def test_feature_scope_isolation_and_universal_assignments(async_client, db):
+    category = FeatureCategory(slug="scope-test", name="Scope", sort_order=10)
+    tcl = Brand(title="Scope TCL", slug="scope-tcl", is_published=True)
+    mdv = Brand(title="Scope MDV", slug="scope-mdv", is_published=True)
+    db.add_all([category, tcl, mdv])
+    await db.flush()
+    tcl_series = ProductSeries(
+        brand_id=tcl.id,
+        title="Scope TCL Series",
+        slug="scope-tcl-series",
+        is_published=True,
+    )
+    mdv_series = ProductSeries(
+        brand_id=mdv.id,
+        title="Scope MDV Series",
+        slug="scope-mdv-series",
+        is_published=True,
+    )
+    db.add_all([tcl_series, mdv_series])
+    await db.flush()
+    tcl_product = Product(
+        title="Scope TCL Product",
+        slug="scope-tcl-product",
+        price=1000,
+        specs={"wifi_state": "builtin"},
+        brand_id=tcl.id,
+        series_id=tcl_series.id,
+        is_published=True,
+    )
+    mdv_product = Product(
+        title="Scope MDV Product",
+        slug="scope-mdv-product",
+        price=1000,
+        specs={"wifi_state": "builtin"},
+        brand_id=mdv.id,
+        series_id=mdv_series.id,
+        is_published=True,
+    )
+    db.add_all([tcl_product, mdv_product])
+    await db.flush()
+    tcl_feature = Feature(
+        slug="scope-tcl-freshin",
+        name="TCL FreshIN",
+        category_id=category.id,
+        scope_type="brand",
+        brand_id=tcl.id,
+    )
+    tcl_derived = Feature(
+        slug="scope-tcl-derived",
+        name="TCL Derived",
+        category_id=category.id,
+        scope_type="derived",
+        brand_id=tcl.id,
+    )
+    universal = Feature(
+        slug="scope-universal-wifi",
+        name="Universal Wi-Fi",
+        category_id=category.id,
+        scope_type="universal",
+    )
+    db.add_all([tcl_feature, tcl_derived, universal])
+    await db.flush()
+    for feature in (tcl_derived, universal):
+        db.add(
+            FeatureRule(
+                feature_id=feature.id,
+                spec_key="wifi_state",
+                operator="eq",
+                target_value="builtin",
+            )
+        )
+
+    # Simulate legacy/corrupted cross-brand rows: reads must still remain isolated.
+    db.add_all(
+        [
+            FeatureBrandLink(brand_id=mdv.id, feature_id=tcl_feature.id),
+            FeatureSeriesLink(series_id=mdv_series.id, feature_id=tcl_feature.id),
+            FeatureProductLink(product_id=mdv_product.id, feature_id=tcl_feature.id),
+        ]
+    )
+    await db.commit()
+    headers = await _auth_headers(async_client)
+
+    mdv_workspace = await async_client.get(
+        f"/api/manager/products/{mdv_product.id}/features",
+        headers=headers,
+    )
+    assert mdv_workspace.status_code == 200, mdv_workspace.text
+    assert [item["slug"] for item in mdv_workspace.json()["effective"]] == []
+    assert [item["slug"] for item in mdv_workspace.json()["automatic_suggestions"]] == [
+        "scope-universal-wifi"
+    ]
+
+    mdv_library = await async_client.get(
+        "/api/manager/features",
+        headers=headers,
+        params={"product_id": mdv_product.id},
+    )
+    assert mdv_library.status_code == 200, mdv_library.text
+    library_slugs = {item["slug"] for item in mdv_library.json()["items"]}
+    assert "scope-tcl-freshin" not in library_slugs
+    assert "scope-tcl-derived" not in library_slugs
+    assert "scope-universal-wifi" in library_slugs
+
+    invalid_manual = await async_client.put(
+        f"/api/manager/products/{mdv_product.id}/features",
+        headers=headers,
+        json={
+            "assignments": [
+                {"feature_id": tcl_feature.id, "source": "manual"}
+            ]
+        },
+    )
+    assert invalid_manual.status_code == 400
+
+    invalid_series = await async_client.put(
+        f"/api/manager/features/{tcl_feature.id}/series/{mdv_series.id}",
+        headers=headers,
+        json={},
+    )
+    assert invalid_series.status_code == 400
+
+    for product in (tcl_product, mdv_product):
+        applied = await async_client.post(
+            f"/api/manager/products/{product.id}/features/suggestions/apply",
+            headers=headers,
+            json={"feature_ids": [universal.id]},
+        )
+        assert applied.status_code == 200, applied.text
+        assert any(item["id"] == universal.id for item in applied.json()["effective"])

--- a/tests/integration/test_public_brands_api.py
+++ b/tests/integration/test_public_brands_api.py
@@ -53,6 +53,7 @@ async def test_public_brands_include_only_published_brands_with_published_produc
     db.add_all([
         FeatureBrandLink(brand_id=tcl.id, feature_id=active_feature.id, sort_order=20),
         FeatureBrandLink(brand_id=tcl.id, feature_id=draft_feature.id, sort_order=10),
+        FeatureBrandLink(brand_id=mdv.id, feature_id=active_feature.id, sort_order=5),
     ])
 
     db.add_all(
@@ -128,6 +129,10 @@ async def test_public_brands_include_only_published_brands_with_published_produc
             "sort_order": 20,
         }
     ]
+
+    mdv_detail_response = await async_client.get("/api/v1/content/brands/mdv")
+    assert mdv_detail_response.status_code == 200, mdv_detail_response.text
+    assert mdv_detail_response.json()["features"] == []
 
     for slug in ("hidden", "empty", "missing"):
         missing_response = await async_client.get(f"/api/v1/content/brands/{slug}")


### PR DESCRIPTION
## Контекст
Post-merge hardening для Feature-системы из #819 перед массовым наполнением каталога. Архитектура и модель данных не меняются.

## Что исправлено
- единая scope policy для resolver, Manager assignments и compatibility payloads
- brand-scoped и brand-restricted derived Feature не могут попасть к чужому бренду
- derived suggestions допускают только universal/derived Feature с подходящими scope/rules
- Product Workspace получает отфильтрованную сервером библиотеку через optional `product_id`
- cross-brand product/brand/series назначения отклоняются сервером
- applied derived link преобразуется в manual override в той же строке без unique-конфликта
- manual suppression продолжает перекрывать brand, series и derived
- повреждённые legacy cross-brand links фильтруются в public product, brand и series payloads

## Проверки
- `pytest -q`: 2467 passed, 4 skipped
- scoped Feature/Brand/Series regression: 36 passed
- final focused regression: 4 passed
- `vue-tsc -b --force`
- `vite build`
- theme hardcode audit passed
- OpenAPI/client regenerated; публичные DTO и таблицы не изменены

Follow-up to #814 and #819.