### PR TITLE
Add TCL 2026 Feature canary migration

### DIFF
--- a/data/feature_canary/tcl_2026.json
+++ b/data/feature_canary/tcl_2026.json
@@ -1,0 +1,203 @@
+{
+  "catalog": {
+    "name": "TCL 2026",
+    "source_url": "https://tcl-shop.by/doc/catalog-compress.pdf",
+    "brand_slug": "tcl"
+  },
+  "series_allowlist": {
+    "freshin3-0": "FreshIN 3.0 / FCI",
+    "breeze-in-2-0-a": "BreezeIN 2.0 / UG11V3AH",
+    "elite-inverter-c-paneliu-xa71n": "Elite Inverter / XA71IF, XA71IN",
+    "elite-on": "Elite On/Off / XAB1"
+  },
+  "legacy_brand_links_to_remove": [
+    "vstroennyi-wi-fi",
+    "bipoliarnyi-ionizator",
+    "uf-sterilizatsiia"
+  ],
+  "features": [
+    {
+      "slug": "inverter-control",
+      "name": "Инверторное управление",
+      "category_slug": "efficiency",
+      "scope_type": "derived",
+      "short_description": "Компрессор плавно регулирует производительность вместо постоянных включений и остановок.",
+      "full_description": "Инверторное управление помогает точнее поддерживать заданную температуру и снижает лишние пусковые нагрузки при длительной работе.",
+      "aliases": ["Inverter", "Инвертор", "Инверторное управление компрессором"],
+      "source_notes": "TCL 2026: технические таблицы FreshIN 3.0 (PDF p.7), BreezeIN 2.0 (PDF p.15), Elite Inverter (PDF p.26).",
+      "sort_order": 10,
+      "rules": [{"spec_key": "compressor_type_norm", "operator": "in", "target_value": ["inverter", "full_dc"]}]
+    },
+    {
+      "slug": "vstroennyi-wi-fi",
+      "reuse_required": true,
+      "name": "Встроенный Wi-Fi",
+      "category_slug": "control",
+      "scope_type": "derived",
+      "brand_slug": "tcl",
+      "short_description": "Встроенный модуль позволяет управлять кондиционером через совместимое приложение.",
+      "full_description": "Встроенный Wi-Fi даёт доступ к удалённому управлению режимами и настройками кондиционера без покупки отдельного модуля.",
+      "aliases": ["Built-in Wi-Fi", "IoT Wi-Fi-управление", "Встроенный Wi-Fi-модуль"],
+      "source_notes": "TCL 2026: FreshIN 3.0 (PDF p.6-7), BreezeIN 2.0 (PDF p.13-15), Elite Inverter XA71IN (PDF p.24, p.26).",
+      "sort_order": 20,
+      "rules": [{"spec_key": "wifi_state", "operator": "eq", "target_value": "builtin"}]
+    },
+    {
+      "slug": "wifi-ready",
+      "name": "Wi-Fi Ready",
+      "category_slug": "control",
+      "scope_type": "derived",
+      "brand_slug": "tcl",
+      "short_description": "Удалённое управление доступно после установки совместимого Wi-Fi-модуля.",
+      "full_description": "Кондиционер подготовлен для подключения Wi-Fi, но модуль приобретается или устанавливается отдельно.",
+      "aliases": ["Optional Wi-Fi", "Опциональный Wi-Fi", "Wi-Fi-модуль (опция)"],
+      "source_notes": "TCL 2026: Elite Inverter XA71IF, модуль устанавливается по желанию заказчика (PDF p.24, p.26).",
+      "sort_order": 30,
+      "rules": [{"spec_key": "wifi_state", "operator": "eq", "target_value": "ready"}]
+    },
+    {
+      "slug": "heating-minus-20",
+      "name": "Обогрев до −20 °C",
+      "category_slug": "performance",
+      "scope_type": "derived",
+      "short_description": "Режим обогрева рассчитан на работу при наружной температуре до −20 °C.",
+      "full_description": "Модель может использоваться для обогрева в пределах указанного производителем диапазона наружных температур, включая температуру до −20 °C.",
+      "aliases": ["Heating to -20 C", "Обогрев при −20 °C"],
+      "source_notes": "TCL 2026: FreshIN 3.0, рабочий диапазон обогрева до −20 °C (PDF p.7, p.32).",
+      "sort_order": 40,
+      "rules": [{"spec_key": "__filter_min_heat", "operator": "eq", "target_value": -20}]
+    },
+    {
+      "slug": "heating-minus-25",
+      "name": "Обогрев до −25 °C",
+      "category_slug": "performance",
+      "scope_type": "derived",
+      "short_description": "Режим обогрева рассчитан на работу при наружной температуре до −25 °C.",
+      "full_description": "Модель может использоваться для обогрева в пределах указанного производителем диапазона наружных температур, включая температуру до −25 °C.",
+      "aliases": ["Heating to -25 C", "Обогрев при −25 °C"],
+      "source_notes": "TCL 2026: BreezeIN 2.0, рабочий диапазон обогрева до −25 °C (PDF p.15, p.32).",
+      "sort_order": 50,
+      "rules": [{"spec_key": "__filter_min_heat", "operator": "eq", "target_value": -25}]
+    },
+    {
+      "slug": "freshin-plus",
+      "name": "FreshIN+",
+      "category_slug": "air-quality",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Система подаёт в помещение наружный воздух через отдельный канал.",
+      "full_description": "FreshIN+ организует контролируемую подачу наружного воздуха и предварительно обрабатывает его перед поступлением в помещение.",
+      "aliases": ["FreshIN+", "Подача свежего воздуха", "Режим подачи свежего воздуха FreshIN+"],
+      "source_notes": "TCL 2026: FreshIN 3.0 / FCI, описание технологии и таблица модели (PDF p.5, p.7).",
+      "sort_order": 100
+    },
+    {
+      "slug": "quadripuri",
+      "name": "QuadriPuri",
+      "category_slug": "air-quality",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Четырёхступенчатая система фильтрации дополняет обработку проходящего воздуха.",
+      "full_description": "QuadriPuri объединяет предварительный фильтр, слой с ионами серебра, HEPA-фильтр и фильтр высокой плотности для последовательной фильтрации воздуха.",
+      "aliases": ["QuadriPuri", "Фильтры QuadriPuri", "Четырёхступенчатая фильтрация"],
+      "source_notes": "TCL 2026: FreshIN 3.0 / FCI, состав фильтров QuadriPuri (PDF p.5, p.7).",
+      "legal_notes": "Не использовать формулировки о гарантированной защите от вирусов или стерилизации помещения.",
+      "sort_order": 110
+    },
+    {
+      "slug": "air-quality-indicator",
+      "name": "Индикатор качества воздуха",
+      "category_slug": "air-quality",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Цветовой индикатор показывает текущее состояние воздуха в помещении.",
+      "full_description": "Индикатор в реальном времени помогает оценивать состояние воздуха и выбирать подходящий режим работы кондиционера.",
+      "aliases": ["Air Quality Indicator", "Цветовой индикатор качества воздуха"],
+      "source_notes": "TCL 2026: FreshIN 3.0 / FCI, индикатор качества воздуха (PDF p.5).",
+      "sort_order": 120
+    },
+    {
+      "slug": "gentle-breeze",
+      "name": "Gentle Breeze",
+      "category_slug": "comfort",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Перфорированные жалюзи рассеивают поток и уменьшают ощущение прямого холодного обдува.",
+      "full_description": "В режиме Gentle Breeze вертикальные жалюзи дробят прямой поток на множество небольших струй, делая охлаждение мягче и комфортнее.",
+      "aliases": ["Gentle Breeze", "Мягкий поток", "Охлаждение без ветра"],
+      "source_notes": "TCL 2026: BreezeIN 2.0 / UG11V3AH, описание Gentle Breeze и таблица модели (PDF p.13, p.15).",
+      "sort_order": 130
+    },
+    {
+      "slug": "bipoliarnyi-ionizator",
+      "reuse_required": true,
+      "name": "Биполярный ионизатор",
+      "category_slug": "air-quality",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Ионизатор дополняет систему обработки воздуха во время работы кондиционера.",
+      "full_description": "Биполярный ионизатор создаёт положительно и отрицательно заряженные ионы и используется как дополнительная ступень обработки проходящего воздуха.",
+      "aliases": ["Bipolar Ionizer", "Биполярный ионизатор"],
+      "source_notes": "TCL 2026: BreezeIN 2.0 / UG11V3AH, описание и таблица модели (PDF p.15).",
+      "legal_notes": "Не заявлять стерилизацию помещения, защиту от вирусов или гарантированное уничтожение микроорганизмов.",
+      "sort_order": 135
+    },
+    {
+      "slug": "uf-sterilizatsiia",
+      "reuse_required": true,
+      "name": "УФ-лампа (UVC)",
+      "category_slug": "air-quality",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Встроенная UVC-лампа дополняет обработку внутренних поверхностей блока.",
+      "full_description": "UVC-лампа используется внутри кондиционера как дополнительный элемент обработки внутренних поверхностей воздушного тракта.",
+      "aliases": ["UVC", "УФ-лампа", "BIG CARE"],
+      "source_notes": "TCL 2026: BreezeIN 2.0 / UG11V3AH, описание и таблица модели (PDF p.15).",
+      "legal_notes": "Не использовать медицинские обещания и не описывать функцию как стерилизацию воздуха во всём помещении.",
+      "sort_order": 136
+    },
+    {
+      "slug": "smart-inverter-tcl",
+      "name": "Smart Inverter",
+      "category_slug": "efficiency",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Инверторная система регулирует производительность для более стабильного поддержания температуры.",
+      "full_description": "TCL Smart Inverter плавно изменяет производительность компрессора, помогая быстрее выходить на заданный режим и избегать лишних пусков.",
+      "aliases": ["Smart Inverter", "TCL Smart Inverter"],
+      "source_notes": "TCL 2026: FreshIN 3.0 (PDF p.7), BreezeIN 2.0 (PDF p.15), Elite Inverter (PDF p.25-26).",
+      "sort_order": 140
+    },
+    {
+      "slug": "eight-airflow-modes",
+      "name": "8 режимов подачи воздуха",
+      "category_slug": "comfort",
+      "scope_type": "brand",
+      "brand_slug": "tcl",
+      "short_description": "Восемь положений жалюзи помогают точнее направить поток вверх или вниз.",
+      "full_description": "Набор из восьми положений подачи воздуха позволяет подобрать направление потока под расположение людей и сценарий использования помещения.",
+      "aliases": ["8 airflow modes", "8 режимов подачи воздуха вверх-вниз"],
+      "source_notes": "TCL 2026: Elite On/Off / XAB1, таблица модели (PDF p.31).",
+      "sort_order": 150
+    }
+  ],
+  "series_links": {
+    "freshin3-0": ["freshin-plus", "quadripuri", "air-quality-indicator", "smart-inverter-tcl"],
+    "breeze-in-2-0-a": ["gentle-breeze", "smart-inverter-tcl", "bipoliarnyi-ionizator", "uf-sterilizatsiia", "vstroennyi-wi-fi"],
+    "elite-inverter-c-paneliu-xa71n": ["smart-inverter-tcl"],
+    "elite-on": ["eight-airflow-modes"]
+  },
+  "product_states": [
+    {"series_slug": "freshin3-0", "model_marker": "/FCI", "wifi_state": "builtin"},
+    {"series_slug": "breeze-in-2-0-a", "model_marker": "/UG11V3AH", "wifi_state": "builtin"},
+    {"series_slug": "elite-inverter-c-paneliu-xa71n", "model_marker": "/XA71IN", "wifi_state": "builtin", "min_heat": -15},
+    {"series_slug": "elite-inverter-c-paneliu-xa71n", "model_marker": "/XA71IF", "wifi_state": "ready", "min_heat": -15}
+  ],
+  "derived_apply": [
+    {"feature_slug": "inverter-control", "series_slugs": ["freshin3-0", "breeze-in-2-0-a", "elite-inverter-c-paneliu-xa71n"]},
+    {"feature_slug": "vstroennyi-wi-fi", "series_slugs": ["freshin3-0", "elite-inverter-c-paneliu-xa71n"], "wifi_state": "builtin"},
+    {"feature_slug": "wifi-ready", "series_slugs": ["elite-inverter-c-paneliu-xa71n"], "wifi_state": "ready"},
+    {"feature_slug": "heating-minus-20", "series_slugs": ["freshin3-0"]},
+    {"feature_slug": "heating-minus-25", "series_slugs": ["breeze-in-2-0-a"]}
+  ]
+}

--- a/scripts/migrate_tcl_feature_canary.py
+++ b/scripts/migrate_tcl_feature_canary.py
@@ -1,0 +1,52 @@
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(".")
+
+from core.config import settings
+from services.tcl_feature_canary_service import (
+    TclFeatureCanaryService,
+    load_tcl_feature_canary_manifest,
+)
+
+
+DEFAULT_MANIFEST = Path("data/feature_canary/tcl_2026.json")
+
+
+async def run(*, manifest_path: Path, execute: bool, output: Path | None) -> dict:
+    manifest = load_tcl_feature_canary_manifest(manifest_path)
+    engine = create_async_engine(settings.DATABASE_URL)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            report = await TclFeatureCanaryService(session, manifest).run(execute=execute)
+            if execute:
+                await session.commit()
+            else:
+                await session.rollback()
+    finally:
+        await engine.dispose()
+    rendered = json.dumps(report, ensure_ascii=False, indent=2, default=str)
+    if output:
+        output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Canary migration of TCL 2026 catalog Features")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--execute", action="store_true", help="Commit reviewed changes")
+    parser.add_argument("--output", type=Path, help="Write the JSON report to this path")
+    args = parser.parse_args()
+    asyncio.run(run(manifest_path=args.manifest, execute=args.execute, output=args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tcl_feature_canary_service.py
+++ b/services/tcl_feature_canary_service.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import delete, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from models import (
+    Brand,
+    Feature,
+    FeatureBrandLink,
+    FeatureCategory,
+    FeatureProductLink,
+    FeatureRule,
+    FeatureSeriesLink,
+    Product,
+    ProductSeries,
+)
+from services.catalog_revision_service import CatalogRevisionService
+from services.feature_resolver_service import FeatureResolverService
+from services.feature_rule_engine import get_spec_value, matches_all_rules
+from services.spec_normalizer import normalize_specs
+
+
+WIFI_SPEC_KEYS = (
+    "wifi_ready",
+    "wifi_builtin",
+    "wifi_state",
+    "__filter_wifi",
+    "__filter_wifi_builtin",
+)
+
+
+def load_tcl_feature_canary_manifest(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+class TclFeatureCanaryError(RuntimeError):
+    pass
+
+
+class TclFeatureCanaryService:
+    def __init__(self, session: AsyncSession, manifest: dict[str, Any]):
+        self.session = session
+        self.manifest = manifest
+        self.actions: list[dict[str, Any]] = []
+        self.source_reconciliations: list[dict[str, Any]] = []
+        self.brand: Brand | None = None
+        self.series: dict[str, ProductSeries] = {}
+        self.products: list[Product] = []
+        self.skipped_products: list[Product] = []
+        self.features: dict[str, Feature] = {}
+        self.initial_feature_slugs: set[str] = set()
+
+    async def run(self, *, execute: bool) -> dict[str, Any]:
+        await self._load_inventory()
+        await self._upsert_features()
+        await self._remove_legacy_brand_links()
+        await self._normalize_product_states()
+        await self._upsert_series_links()
+        await self._upsert_derived_links()
+        await self.session.flush()
+
+        report = await self._build_report(execute=execute)
+        violations = (
+            report["cross_brand_violations"]
+            + report["duplicate_feature_ids"]
+            + report["unexpected_inheritance"]
+            + report["missing_expected_features"]
+            + report["unexpected_features"]
+            + report["unresolved_source_conflicts"]
+        )
+        if violations:
+            raise TclFeatureCanaryError(
+                "Canary verification failed: " + json.dumps(violations, ensure_ascii=False)
+            )
+
+        if execute and self.actions:
+            await CatalogRevisionService.bump_commit_and_purge(
+                self.session,
+                scope="tcl_2026_feature_canary",
+                brand_slugs=[self.manifest["catalog"]["brand_slug"]],
+            )
+        return report
+
+    async def _load_inventory(self) -> None:
+        brand_slug = self.manifest["catalog"]["brand_slug"]
+        self.brand = (
+            await self.session.execute(select(Brand).where(Brand.slug == brand_slug))
+        ).scalar_one_or_none()
+        if self.brand is None:
+            raise TclFeatureCanaryError(f"Brand {brand_slug!r} not found")
+
+        allowlist = set(self.manifest["series_allowlist"])
+        rows = list(
+            (
+                await self.session.execute(
+                    select(ProductSeries).where(
+                        ProductSeries.brand_id == self.brand.id,
+                        ProductSeries.slug.in_(allowlist),
+                    )
+                )
+            ).scalars().all()
+        )
+        self.series = {item.slug: item for item in rows}
+        missing = sorted(allowlist - set(self.series))
+        if missing:
+            raise TclFeatureCanaryError(f"Pilot series not found: {missing}")
+
+        series_ids = [int(item.id) for item in rows]
+        self.products = list(
+            (
+                await self.session.execute(
+                    select(Product)
+                    .where(Product.brand_id == self.brand.id, Product.series_id.in_(series_ids))
+                    .options(selectinload(Product.series))
+                    .order_by(Product.series_id, Product.id)
+                )
+            ).scalars().all()
+        )
+        if not self.products:
+            raise TclFeatureCanaryError("Pilot contains no products")
+        self.skipped_products = list(
+            (
+                await self.session.execute(
+                    select(Product)
+                    .where(
+                        Product.brand_id == self.brand.id,
+                        or_(Product.series_id.is_(None), Product.series_id.not_in(series_ids)),
+                    )
+                    .order_by(Product.id)
+                )
+            ).scalars().all()
+        )
+
+        feature_slugs = {item["slug"] for item in self.manifest["features"]}
+        feature_slugs.update(self.manifest["legacy_brand_links_to_remove"])
+        feature_rows = list(
+            (
+                await self.session.execute(
+                    select(Feature)
+                    .where(Feature.slug.in_(feature_slugs))
+                    .options(selectinload(Feature.rules), selectinload(Feature.category))
+                )
+            ).scalars().all()
+        )
+        self.features = {item.slug: item for item in feature_rows}
+        self.initial_feature_slugs = set(self.features)
+
+    async def _upsert_features(self) -> None:
+        categories = {
+            item.slug: item
+            for item in (
+                await self.session.execute(select(FeatureCategory))
+            ).scalars().all()
+        }
+        for spec in self.manifest["features"]:
+            category = categories.get(spec["category_slug"])
+            if category is None:
+                raise TclFeatureCanaryError(
+                    f"Feature category {spec['category_slug']!r} not found"
+                )
+            feature = self.features.get(spec["slug"])
+            if feature is None and spec.get("reuse_required"):
+                raise TclFeatureCanaryError(
+                    f"Required legacy Feature {spec['slug']!r} not found"
+                )
+            if feature is None:
+                feature = Feature(slug=spec["slug"], name=spec["name"], category_id=int(category.id))
+                self.session.add(feature)
+                await self.session.flush()
+                self.features[feature.slug] = feature
+                self._action("create_feature", feature=feature.slug)
+            set_committed_value(feature, "category", category)
+
+            desired = {
+                "name": spec["name"],
+                "short_description": spec.get("short_description"),
+                "full_description": spec.get("full_description"),
+                "category_id": int(category.id),
+                "scope_type": spec["scope_type"],
+                "brand_id": int(self.brand.id) if spec.get("brand_slug") else None,
+                "aliases": self._strings(spec.get("aliases", [])),
+                "source_url": self.manifest["catalog"]["source_url"],
+                "source_notes": spec.get("source_notes"),
+                "legal_notes": spec.get("legal_notes"),
+                "sort_order": int(spec.get("sort_order", 0)),
+                "is_active": True,
+                "archived_at": None,
+            }
+            changes = {}
+            for field, value in desired.items():
+                if getattr(feature, field) != value:
+                    changes[field] = {"from": getattr(feature, field), "to": value}
+                    setattr(feature, field, value)
+            if changes:
+                feature.updated_at = datetime.now()
+                self.session.add(feature)
+                self._action("update_feature", feature=feature.slug, changes=changes)
+            await self._sync_rules(feature, spec.get("rules", []))
+
+    async def _sync_rules(self, feature: Feature, desired: list[dict[str, Any]]) -> None:
+        current_models = list(
+            (
+                await self.session.execute(
+                    select(FeatureRule).where(FeatureRule.feature_id == feature.id)
+                )
+            ).scalars().all()
+        )
+        current = sorted(
+            (
+                {
+                    "spec_key": rule.spec_key,
+                    "operator": rule.operator,
+                    "target_value": rule.target_value,
+                    "is_active": bool(rule.is_active),
+                    "sort_order": int(rule.sort_order),
+                }
+                for rule in current_models
+            ),
+            key=lambda item: (item["sort_order"], item["spec_key"], item["operator"]),
+        )
+        normalized = []
+        for index, rule in enumerate(desired):
+            normalized.append(
+                {
+                    "spec_key": rule["spec_key"],
+                    "operator": rule["operator"],
+                    "target_value": rule.get("target_value"),
+                    "is_active": bool(rule.get("is_active", True)),
+                    "sort_order": int(rule.get("sort_order", index * 10)),
+                }
+            )
+        normalized.sort(key=lambda item: (item["sort_order"], item["spec_key"], item["operator"]))
+        if current == normalized:
+            set_committed_value(feature, "rules", current_models)
+            return
+        await self.session.execute(delete(FeatureRule).where(FeatureRule.feature_id == feature.id))
+        for rule in normalized:
+            self.session.add(FeatureRule(feature_id=int(feature.id), **rule))
+        await self.session.flush()
+        current_models = list(
+            (
+                await self.session.execute(
+                    select(FeatureRule).where(FeatureRule.feature_id == feature.id)
+                )
+            ).scalars().all()
+        )
+        set_committed_value(feature, "rules", current_models)
+        self._action("replace_rules", feature=feature.slug, rules=normalized)
+
+    async def _remove_legacy_brand_links(self) -> None:
+        slugs = self.manifest["legacy_brand_links_to_remove"]
+        ids = [int(self.features[slug].id) for slug in slugs]
+        links = list(
+            (
+                await self.session.execute(
+                    select(FeatureBrandLink).where(
+                        FeatureBrandLink.brand_id == self.brand.id,
+                        FeatureBrandLink.feature_id.in_(ids),
+                    )
+                )
+            ).scalars().all()
+        )
+        for link in links:
+            feature = next(item for item in self.features.values() if item.id == link.feature_id)
+            await self.session.delete(link)
+            self._action("remove_legacy_brand_link", feature=feature.slug)
+
+    async def _normalize_product_states(self) -> None:
+        matched_ids: set[int] = set()
+        for state in self.manifest["product_states"]:
+            matches = [
+                product
+                for product in self.products
+                if product.series.slug == state["series_slug"]
+                and state["model_marker"].casefold() in product.title.casefold()
+            ]
+            if not matches:
+                raise TclFeatureCanaryError(f"Product selector matched nothing: {state}")
+            for product in matches:
+                if int(product.id) in matched_ids:
+                    raise TclFeatureCanaryError(f"Product #{product.id} matched multiple state rules")
+                matched_ids.add(int(product.id))
+                before = dict(product.specs or {})
+                after = self._normalized_specs(before, state)
+                if before != after:
+                    product.specs = after
+                    self.session.add(product)
+                    changed = sorted(key for key in set(before) | set(after) if before.get(key) != after.get(key))
+                    self._action("update_product_specs", product_id=int(product.id), slug=product.slug, keys=changed)
+                    self.source_reconciliations.append(
+                        {
+                            "product_id": int(product.id),
+                            "product": product.title,
+                            "catalog_source": state,
+                            "changed_keys": changed,
+                            "before": {key: self._report_spec_value(key, before.get(key)) for key in changed},
+                            "after": {key: self._report_spec_value(key, after.get(key)) for key in changed},
+                        }
+                    )
+
+    @staticmethod
+    def _normalized_specs(specs: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+        probe = dict(specs)
+        if "wifi_state" in state:
+            probe["wifi_state"] = state["wifi_state"]
+            probe.pop("wifi_ready", None)
+            probe.pop("wifi_builtin", None)
+        if "min_heat" in state:
+            probe["temp_range_heat"] = f"от {state['min_heat']} до +30 °C"
+        normalized = normalize_specs(probe, keep_units=True)
+        updated = dict(specs)
+        for key in WIFI_SPEC_KEYS:
+            if key in normalized:
+                updated[key] = normalized[key]
+        if "min_heat" in state:
+            updated["temp_range_heat"] = normalized["temp_range_heat"]
+            updated["__filter_min_heat"] = normalized["__filter_min_heat"]
+        typed = dict(updated.get("__typed_specs") or {})
+        normalized_typed = normalized.get("__typed_specs") or {}
+        typed_keys = ["wifi_state", "wifi_ready", "wifi_builtin"]
+        if "min_heat" in state:
+            typed_keys.append("temp_range_heat")
+        for key in typed_keys:
+            if key in normalized_typed:
+                typed[key] = normalized_typed[key]
+        if typed:
+            updated["__typed_specs"] = typed
+        return updated
+
+    async def _upsert_series_links(self) -> None:
+        for series_slug, feature_slugs in self.manifest["series_links"].items():
+            series = self.series[series_slug]
+            for index, feature_slug in enumerate(feature_slugs):
+                feature = self.features[feature_slug]
+                link = (
+                    await self.session.execute(
+                        select(FeatureSeriesLink).where(
+                            FeatureSeriesLink.series_id == series.id,
+                            FeatureSeriesLink.feature_id == feature.id,
+                        )
+                    )
+                ).scalar_one_or_none()
+                if link is None:
+                    link = FeatureSeriesLink(series_id=int(series.id), feature_id=int(feature.id))
+                    self.session.add(link)
+                desired_order = int(feature.sort_order or 0) + index
+                changed = link.id is None or link.source != "manual" or not link.is_enabled or link.sort_order != desired_order
+                link.source = "manual"
+                link.is_enabled = True
+                link.sort_order = desired_order
+                link.updated_at = datetime.now()
+                if changed:
+                    self._action("upsert_series_link", series=series_slug, feature=feature_slug)
+
+    async def _upsert_derived_links(self) -> None:
+        for apply in self.manifest["derived_apply"]:
+            feature = self.features[apply["feature_slug"]]
+            rules = list(feature.rules or [])
+            for product in self.products:
+                if product.series.slug not in apply["series_slugs"]:
+                    continue
+                if apply.get("wifi_state") and product.specs.get("wifi_state") != apply["wifi_state"]:
+                    continue
+                if not matches_all_rules(product.specs or {}, rules):
+                    continue
+                link = (
+                    await self.session.execute(
+                        select(FeatureProductLink).where(
+                            FeatureProductLink.product_id == product.id,
+                            FeatureProductLink.feature_id == feature.id,
+                        )
+                    )
+                ).scalar_one_or_none()
+                if link is not None and link.source == "manual":
+                    continue
+                if link is None:
+                    link = FeatureProductLink(product_id=int(product.id), feature_id=int(feature.id))
+                    self.session.add(link)
+                changed = link.id is None or link.source != "derived" or not link.is_enabled
+                link.source = "derived"
+                link.is_enabled = True
+                link.sort_order = int(feature.sort_order or 0)
+                link.updated_at = datetime.now()
+                if changed:
+                    self._action("upsert_derived_link", product_id=int(product.id), feature=feature.slug)
+
+    async def _build_report(self, *, execute: bool) -> dict[str, Any]:
+        resolved = await FeatureResolverService.resolve_for_products(
+            self.session, self.products, include_suggestions=True
+        )
+        managed_slugs = {item["slug"] for item in self.manifest["features"]}
+        expected = self._expected_by_product()
+        matrix = []
+        missing = []
+        unexpected = []
+        duplicates = []
+        unexpected_inheritance = []
+
+        for product in self.products:
+            actual_items = [item for item in resolved[int(product.id)]["effective"] if item.slug in managed_slugs]
+            counts = Counter(item.id for item in actual_items)
+            duplicates.extend(
+                {"product_id": int(product.id), "feature_id": feature_id, "count": count}
+                for feature_id, count in counts.items()
+                if count > 1
+            )
+            actual = {item.slug: item for item in actual_items}
+            expected_slugs = expected[int(product.id)]
+            for slug in sorted(expected_slugs | set(actual)):
+                item = actual.get(slug)
+                should_exist = slug in expected_slugs
+                matrix.append(
+                    {
+                        "brand": self.brand.slug,
+                        "series": product.series.slug,
+                        "product": product.slug,
+                        "feature": slug,
+                        "source": item.source if item else None,
+                        "is_enabled": item is not None,
+                        "is_overridden": item.is_overridden if item else False,
+                        "applied_rule": item.applied_rule if item else None,
+                        "expected": should_exist,
+                        "actual": item is not None,
+                    }
+                )
+                if should_exist and item is None:
+                    missing.append({"product_id": int(product.id), "feature": slug})
+                if not should_exist and item is not None:
+                    unexpected.append({"product_id": int(product.id), "feature": slug})
+                if item is not None and item.source in {"brand", "series"}:
+                    allowed_series = {
+                        series_slug
+                        for series_slug, slugs in self.manifest["series_links"].items()
+                        if slug in slugs
+                    }
+                    if product.series.slug not in allowed_series:
+                        unexpected_inheritance.append(
+                            {"product_id": int(product.id), "feature": slug, "source": item.source}
+                        )
+
+        return {
+            "mode": "execute" if execute else "dry-run",
+            "catalog": self.manifest["catalog"],
+            "brand": {"id": int(self.brand.id), "slug": self.brand.slug},
+            "series": [
+                {"id": int(item.id), "slug": item.slug, "title": item.title}
+                for item in self.series.values()
+            ],
+            "actions": self.actions,
+            "feature_plan": [
+                {
+                    "slug": item["slug"],
+                    "result": "reuse" if item["slug"] in self.initial_feature_slugs else "create",
+                }
+                for item in self.manifest["features"]
+            ],
+            "rule_audit": self._rule_audit(),
+            "source_reconciliations": self.source_reconciliations,
+            "ambiguities": [],
+            "skipped_products": [
+                {"id": int(item.id), "slug": item.slug, "reason": "outside_pilot_allowlist"}
+                for item in self.skipped_products
+            ],
+            "result_matrix": matrix,
+            "cross_brand_violations": await self._cross_brand_violations(),
+            "duplicate_feature_ids": duplicates,
+            "unexpected_inheritance": unexpected_inheritance,
+            "missing_expected_features": missing,
+            "unexpected_features": unexpected,
+            "unresolved_source_conflicts": [],
+        }
+
+    def _expected_by_product(self) -> dict[int, set[str]]:
+        expected: dict[int, set[str]] = {}
+        for product in self.products:
+            slugs = set(self.manifest["series_links"].get(product.series.slug, []))
+            for apply in self.manifest["derived_apply"]:
+                if product.series.slug not in apply["series_slugs"]:
+                    continue
+                if apply.get("wifi_state") and product.specs.get("wifi_state") != apply["wifi_state"]:
+                    continue
+                feature = self.features[apply["feature_slug"]]
+                if matches_all_rules(product.specs or {}, list(feature.rules or [])):
+                    slugs.add(feature.slug)
+            expected[int(product.id)] = slugs
+        return expected
+
+    def _rule_audit(self) -> list[dict[str, Any]]:
+        rows = []
+        for feature_spec in self.manifest["features"]:
+            feature = self.features[feature_spec["slug"]]
+            rules = list(feature.rules or [])
+            if not rules:
+                continue
+            values = Counter()
+            matched = []
+            unmatched = []
+            for product in self.products:
+                for rule in rules:
+                    value = get_spec_value(product.specs or {}, rule.spec_key)
+                    values[repr(value)] += 1
+                target = matched if matches_all_rules(product.specs or {}, rules) else unmatched
+                if len(target) < 5:
+                    target.append({"id": int(product.id), "model": product.title})
+            rows.append(
+                {
+                    "feature": feature.slug,
+                    "rules": [
+                        {
+                            "spec_key": rule.spec_key,
+                            "operator": rule.operator,
+                            "target_value": rule.target_value,
+                        }
+                        for rule in rules
+                    ],
+                    "real_values": dict(values),
+                    "match_count": sum(
+                        matches_all_rules(product.specs or {}, rules) for product in self.products
+                    ),
+                    "matching_examples": matched,
+                    "nonmatching_examples": unmatched,
+                }
+            )
+        return rows
+
+    async def _cross_brand_violations(self) -> list[dict[str, Any]]:
+        feature_ids = [int(item.id) for item in self.features.values()]
+        violations = []
+        series_links = list(
+            (
+                await self.session.execute(
+                    select(FeatureSeriesLink, ProductSeries)
+                    .join(ProductSeries, ProductSeries.id == FeatureSeriesLink.series_id)
+                    .where(FeatureSeriesLink.feature_id.in_(feature_ids))
+                )
+            ).all()
+        )
+        product_links = list(
+            (
+                await self.session.execute(
+                    select(FeatureProductLink, Product)
+                    .join(Product, Product.id == FeatureProductLink.product_id)
+                    .where(FeatureProductLink.feature_id.in_(feature_ids))
+                )
+            ).all()
+        )
+        by_id = {int(item.id): item for item in self.features.values()}
+        for link, target in [*series_links, *product_links]:
+            feature = by_id[int(link.feature_id)]
+            if feature.brand_id is not None and target.brand_id != feature.brand_id:
+                violations.append(
+                    {"feature": feature.slug, "target_id": int(target.id), "target_brand_id": target.brand_id}
+                )
+        return violations
+
+    def _action(self, action: str, **payload: Any) -> None:
+        self.actions.append({"action": action, **payload})
+
+    @staticmethod
+    def _report_spec_value(key: str, value: Any) -> Any:
+        if key != "__typed_specs" or not isinstance(value, dict):
+            return value
+        return {
+            typed_key: value.get(typed_key)
+            for typed_key in ("wifi_state", "wifi_ready", "wifi_builtin", "temp_range_heat")
+            if typed_key in value
+        }
+
+    @staticmethod
+    def _strings(values: list[str]) -> list[str]:
+        return list(dict.fromkeys(item.strip() for item in values if item and item.strip()))

--- a/tests/integration/test_tcl_feature_canary.py
+++ b/tests/integration/test_tcl_feature_canary.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+
+import pytest
+from sqlmodel import select
+
+from models import (
+    Brand,
+    Feature,
+    FeatureBrandLink,
+    FeatureCategory,
+    FeatureProductLink,
+    Product,
+    ProductSeries,
+)
+from services.feature_resolver_service import FeatureResolverService
+from services.tcl_feature_canary_service import (
+    TclFeatureCanaryService,
+    load_tcl_feature_canary_manifest,
+)
+
+
+MANIFEST = Path(__file__).parents[2] / "data/feature_canary/tcl_2026.json"
+
+
+async def _seed(db):
+    categories = [
+        FeatureCategory(slug="comfort", name="Комфорт", sort_order=10),
+        FeatureCategory(slug="control", name="Управление", sort_order=20),
+        FeatureCategory(slug="air-quality", name="Очистка воздуха", sort_order=30),
+        FeatureCategory(slug="efficiency", name="Энергоэффективность", sort_order=40),
+        FeatureCategory(slug="performance", name="Производительность", sort_order=50),
+    ]
+    brand = Brand(title="TCL", slug="tcl", is_published=True)
+    db.add_all([*categories, brand])
+    await db.flush()
+    by_category = {item.slug: item for item in categories}
+
+    legacy = [
+        Feature(
+            slug="vstroennyi-wi-fi",
+            name="Встроенный Wi-Fi",
+            category_id=by_category["comfort"].id,
+            scope_type="brand",
+            brand_id=brand.id,
+        ),
+        Feature(
+            slug="bipoliarnyi-ionizator",
+            name="Биполярный ионизатор",
+            category_id=by_category["comfort"].id,
+            scope_type="brand",
+            brand_id=brand.id,
+        ),
+        Feature(
+            slug="uf-sterilizatsiia",
+            name="УФ-стерилизация",
+            category_id=by_category["comfort"].id,
+            scope_type="brand",
+            brand_id=brand.id,
+        ),
+    ]
+    db.add_all(legacy)
+    await db.flush()
+    db.add_all(
+        FeatureBrandLink(brand_id=brand.id, feature_id=feature.id)
+        for feature in legacy
+    )
+
+    series = {
+        slug: ProductSeries(brand_id=brand.id, slug=slug, title=title, is_published=True)
+        for slug, title in {
+            "freshin3-0": "FreshIN 3.0",
+            "breeze-in-2-0-a": "BreezeIN 2.0",
+            "elite-inverter-c-paneliu-xa71n": "Elite Inverter",
+            "elite-on": "Elite On/Off",
+        }.items()
+    }
+    db.add_all(series.values())
+    await db.flush()
+    products = [
+        Product(
+            title="TCL Fresh In 3.0 TAC-09CHSD/FCI",
+            slug="freshin-fci",
+            price=1,
+            brand_id=brand.id,
+            series_id=series["freshin3-0"].id,
+            is_inverter=True,
+            specs={"compressor_type_norm": "inverter", "wifi_ready": True, "__filter_min_heat": -20},
+        ),
+        Product(
+            title="TCL BreezeIN 2.0 TAC-09CHSD/UG11V3AH",
+            slug="breeze-ug11",
+            price=1,
+            brand_id=brand.id,
+            series_id=series["breeze-in-2-0-a"].id,
+            is_inverter=True,
+            specs={"compressor_type_norm": "inverter", "wifi_ready": False, "__filter_min_heat": -25},
+        ),
+        Product(
+            title="TCL Elite TAC-09CHSD/XA71IN",
+            slug="elite-xa71in",
+            price=1,
+            brand_id=brand.id,
+            series_id=series["elite-inverter-c-paneliu-xa71n"].id,
+            is_inverter=True,
+            specs={"compressor_type_norm": "inverter", "wifi_ready": True, "__filter_min_heat": -20},
+        ),
+        Product(
+            title="TCL Elite TAC-09CHSD/XA71IF",
+            slug="elite-xa71if",
+            price=1,
+            brand_id=brand.id,
+            series_id=series["elite-inverter-c-paneliu-xa71n"].id,
+            is_inverter=True,
+            specs={"compressor_type_norm": "inverter", "wifi_ready": False, "__filter_min_heat": -10},
+        ),
+        Product(
+            title="TCL Elite TAC-09CHSA/XAB1N",
+            slug="elite-xab1",
+            price=1,
+            brand_id=brand.id,
+            series_id=series["elite-on"].id,
+            is_inverter=False,
+            specs={"compressor_type_norm": "on_off", "wifi_ready": False, "__filter_min_heat": -7},
+        ),
+    ]
+    db.add_all(products)
+    await db.commit()
+    return brand, products
+
+
+@pytest.mark.asyncio
+async def test_tcl_feature_canary_is_scoped_verified_and_idempotent(db):
+    brand, products = await _seed(db)
+    manifest = load_tcl_feature_canary_manifest(MANIFEST)
+
+    first = await TclFeatureCanaryService(db, manifest).run(execute=True)
+    await db.commit()
+
+    assert first["actions"]
+    assert first["cross_brand_violations"] == []
+    assert first["duplicate_feature_ids"] == []
+    assert first["unexpected_inheritance"] == []
+    assert first["missing_expected_features"] == []
+    assert first["unexpected_features"] == []
+    assert first["unresolved_source_conflicts"] == []
+
+    remaining_brand_links = list(
+        (
+            await db.execute(
+                select(FeatureBrandLink).where(FeatureBrandLink.brand_id == brand.id)
+            )
+        ).scalars().all()
+    )
+    assert remaining_brand_links == []
+
+    by_slug = {product.slug: product for product in products}
+    await db.refresh(by_slug["elite-xa71in"])
+    await db.refresh(by_slug["elite-xa71if"])
+    assert by_slug["elite-xa71in"].specs["wifi_state"] == "builtin"
+    assert by_slug["elite-xa71if"].specs["wifi_state"] == "ready"
+    assert by_slug["elite-xa71in"].specs["__filter_min_heat"] == -15
+    assert by_slug["elite-xa71if"].specs["__filter_min_heat"] == -15
+
+    resolved = await FeatureResolverService.resolve_for_products(db, products)
+    in_features = {item.slug for item in resolved[int(by_slug["elite-xa71in"].id)]["effective"]}
+    if_features = {item.slug for item in resolved[int(by_slug["elite-xa71if"].id)]["effective"]}
+    assert "vstroennyi-wi-fi" in in_features
+    assert "wifi-ready" not in in_features
+    assert "wifi-ready" in if_features
+    assert "vstroennyi-wi-fi" not in if_features
+
+    uvc = (await db.execute(select(Feature).where(Feature.slug == "uf-sterilizatsiia"))).scalar_one()
+    breeze = by_slug["breeze-ug11"]
+    freshin = by_slug["freshin-fci"]
+    breeze_links = set(
+        (
+            await db.execute(
+                select(FeatureProductLink.feature_id).where(FeatureProductLink.product_id == breeze.id)
+            )
+        ).scalars().all()
+    )
+    assert uvc.id not in breeze_links  # Series inheritance, not a duplicated product link.
+    freshin_features = {item.slug for item in resolved[int(freshin.id)]["effective"]}
+    assert "uf-sterilizatsiia" not in freshin_features
+    assert "gentle-breeze" not in freshin_features
+
+    second = await TclFeatureCanaryService(db, manifest).run(execute=True)
+    await db.commit()
+    assert second["actions"] == []
+
+
+@pytest.mark.asyncio
+async def test_tcl_feature_canary_dry_run_can_be_rolled_back(db):
+    await _seed(db)
+    manifest = load_tcl_feature_canary_manifest(MANIFEST)
+    transaction = await db.begin_nested()
+    report = await TclFeatureCanaryService(db, manifest).run(execute=False)
+    assert report["mode"] == "dry-run"
+    assert report["actions"]
+    await transaction.rollback()
+
+    created = (
+        await db.execute(select(Feature).where(Feature.slug == "freshin-plus"))
+    ).scalar_one_or_none()
+    assert created is None


### PR DESCRIPTION
## Summary
- add reviewed TCL 2026 Feature manifest limited to FreshIN 3.0, BreezeIN 2.0, Elite Inverter and Elite On/Off
- add an idempotent dry-run-first migration runner with exact series/product allowlists
- reconcile confirmed Wi-Fi states and Elite heating ranges from the approved supplier catalog
- replace broad legacy TCL Wi-Fi/UVC/ionizer brand inheritance with targeted series/product/derived assignments
- add result matrix, rule evidence, skipped-product reporting and hard verification gates

## Approved source
- https://tcl-shop.by/doc/catalog-compress.pdf
- FreshIN 3.0: PDF pages 4-7
- BreezeIN 2.0: PDF pages 12-15
- Elite Inverter: PDF pages 24-26
- Elite On/Off: PDF pages 30-31
- Cross-check table: PDF page 32

## Production dry-run
- brand: `tcl` (`id=3`)
- pilot products: 17
- products skipped outside allowlist: 51
- Feature plan: 10 create, 3 reuse
- confirmed spec reconciliations: 12 products
- result matrix: 65 rows
- `cross_brand_violations`: empty
- `duplicate_feature_ids`: empty
- `unexpected_inheritance`: empty
- `missing_expected_features`: empty
- `unexpected_features`: empty
- `unresolved_source_conflicts`: empty
- dry-run transaction rolled back; no production data changed

## Rule evidence
- inverter: `compressor_type_norm in [inverter, full_dc]`, 12/17 pilot matches
- built-in Wi-Fi: `wifi_state == builtin`, 10/17 matches
- Wi-Fi Ready: `wifi_state == ready`, 2/17 matches (XA71IF only)
- heating to -20 C: `__filter_min_heat == -20`, 2/17 matches (FreshIN 3.0)
- heating to -25 C: `__filter_min_heat == -25`, 4/17 matches (BreezeIN 2.0)

## Verification
- `pytest -q`: 2469 passed, 4 skipped
- Feature regression: 5 passed
- OpenAPI extraction: no diff
- Manager API client generation: no diff
- Manager typecheck/build: passed
