### PR TITLE
Fix TCL Feature canary idempotency

### DIFF
--- a/services/tcl_feature_canary_service.py
+++ b/services/tcl_feature_canary_service.py
@@ -311,9 +311,10 @@ class TclFeatureCanaryService:
     def _normalized_specs(specs: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
         probe = dict(specs)
         if "wifi_state" in state:
-            probe["wifi_state"] = state["wifi_state"]
-            probe.pop("wifi_ready", None)
-            probe.pop("wifi_builtin", None)
+            wifi_state = state["wifi_state"]
+            probe["wifi_state"] = wifi_state
+            probe["wifi_ready"] = wifi_state in {"builtin", "ready"}
+            probe["wifi_builtin"] = wifi_state == "builtin"
         if "min_heat" in state:
             probe["temp_range_heat"] = f"от {state['min_heat']} до +30 °C"
         normalized = normalize_specs(probe, keep_units=True)

--- a/tests/integration/test_tcl_feature_canary.py
+++ b/tests/integration/test_tcl_feature_canary.py
@@ -111,7 +111,12 @@ async def _seed(db):
             brand_id=brand.id,
             series_id=series["elite-inverter-c-paneliu-xa71n"].id,
             is_inverter=True,
-            specs={"compressor_type_norm": "inverter", "wifi_ready": False, "__filter_min_heat": -10},
+            specs={
+                "compressor_type_norm": "inverter",
+                "wifi_ready": False,
+                "wifi_module": True,
+                "__filter_min_heat": -10,
+            },
         ),
         Product(
             title="TCL Elite TAC-09CHSA/XAB1N",


### PR DESCRIPTION
## Summary
- make approved Wi-Fi state override legacy ambiguous Wi-Fi markers during TCL canary normalization
- reproduce the production XA71IF conflict in the integration fixture
- keep the second migration run strictly action-free

## Verification
- `pytest -q tests/integration/test_tcl_feature_canary.py`