### PR TITLE
Исправить IntegrityError при обновлении клиента

### DIFF
--- a/manager_frontend/src/components/customers/customer-profile-form.ts
+++ b/manager_frontend/src/components/customers/customer-profile-form.ts
@@ -1,0 +1,45 @@
+import { normalizeIban, normalizeUnp } from '../../utils/legal-requisites';
+import { normalizePhoneForApi } from '../../utils/phone';
+import { normalizeEmail } from '../../utils/validation';
+
+export type CustomerForm = {
+  name: string;
+  phone: string;
+  email: string;
+  type: 'individual' | 'company';
+  inn: string;
+  kpp: string;
+  full_legal_name: string;
+  legal_address: string;
+  actual_address: string;
+  bank_name: string;
+  bic: string;
+  iban: string;
+  signer_position: string;
+  signer_name: string;
+  acting_basis: string;
+};
+
+type CustomerFormDiff = Partial<Record<keyof CustomerForm, boolean>>;
+
+const normalizers: Partial<Record<keyof CustomerForm, (value: string) => string>> = {
+  phone: normalizePhoneForApi,
+  email: normalizeEmail,
+  inn: normalizeUnp,
+  iban: normalizeIban,
+};
+
+export const buildCustomerPatchPayload = (
+  form: CustomerForm,
+  diff: CustomerFormDiff,
+): Record<string, string> => {
+  const payload: Record<string, string> = {};
+
+  (Object.keys(diff) as (keyof CustomerForm)[]).forEach((key) => {
+    if (!diff[key]) return;
+    const trimmed = String(form[key] ?? '').trim();
+    payload[key] = normalizers[key]?.(trimmed) ?? trimmed;
+  });
+
+  return payload;
+};

--- a/manager_frontend/src/views/CustomerProfileView.vue
+++ b/manager_frontend/src/views/CustomerProfileView.vue
@@ -7,6 +7,10 @@ import EquipmentAttachmentsPanel from '../components/equipment/EquipmentAttachme
 import EquipmentWarrantyPanel from '../components/equipment/EquipmentWarrantyPanel.vue';
 import { equipmentWarrantySummary } from '../components/equipment/equipmentWarrantySummary';
 import { listAllCustomerEquipment } from '../components/equipment/loadAllCustomerEquipment';
+import {
+  buildCustomerPatchPayload,
+  type CustomerForm,
+} from '../components/customers/customer-profile-form';
 import { api } from '../api';
 import { confirmDialog } from '../services/ui-feedback';
 import {
@@ -38,7 +42,6 @@ import { useB2BLookup } from '../composables/useB2BLookup';
 import { dispatchCustomerUpdated } from '../utils/customer-events';
 import { getApiErrorMessage, parseApiFieldErrors } from '../utils/api-errors';
 import { normalizeIban, normalizeUnp } from '../utils/legal-requisites';
-import { normalizePhoneForApi } from '../utils/phone';
 import {
   normalizeEmail,
   validateOptionalBelarusPhone,
@@ -46,24 +49,6 @@ import {
   validateOptionalByUnp,
   validateOptionalEmail,
 } from '../utils/validation';
-
-type CustomerForm = {
-  name: string;
-  phone: string;
-  email: string;
-  type: 'individual' | 'company';
-  inn: string;
-  kpp: string;
-  full_legal_name: string;
-  legal_address: string;
-  actual_address: string;
-  bank_name: string;
-  bic: string;
-  iban: string;
-  signer_position: string;
-  signer_name: string;
-  acting_basis: string;
-};
 
 type EquipmentForm = {
   customer_branch_id: number | null;
@@ -1202,35 +1187,7 @@ const validateForm = (): boolean => {
 const saveCustomer = async () => {
   if (!customer.value || !hasChanges.value || !validateForm()) return;
 
-  const payload: Record<string, string> = {};
-  (Object.keys(formDiff.value) as (keyof CustomerForm)[]).forEach((key) => {
-    if (!formDiff.value[key]) return;
-    payload[key] = currentForm.value[key]?.trim?.() ?? currentForm.value[key];
-  });
-
-  payload.phone = normalizePhoneForApi(form.value.phone || '');
-  payload.email = normalizeEmail(form.value.email || '');
-  payload.inn = normalizeUnp(form.value.inn || '');
-  payload.iban = normalizeIban(form.value.iban || '');
-
-  const optionalKeys: (keyof CustomerForm)[] = [
-    'email',
-    'inn',
-    'kpp',
-    'full_legal_name',
-    'legal_address',
-    'actual_address',
-    'bank_name',
-    'bic',
-    'iban',
-    'signer_position',
-    'signer_name',
-    'acting_basis',
-  ];
-  optionalKeys.forEach((key) => {
-    if (!(key in payload)) return;
-    if (!payload[key]) payload[key] = '';
-  });
+  const payload = buildCustomerPatchPayload(currentForm.value, formDiff.value);
 
   saving.value = true;
   success.value = '';

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -65,10 +65,49 @@ import {
   needsExecutionWithoutPaymentConfirmation,
   runOptimisticOrderTransition,
 } from '../src/components/orders/order-transition';
+import {
+  buildCustomerPatchPayload,
+  type CustomerForm,
+} from '../src/components/customers/customer-profile-form';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
 };
+
+const customerForm: CustomerForm = {
+  name: 'ООО Клиент',
+  phone: '+375 (29) 591-26-81',
+  email: 'CLIENT@EXAMPLE.COM ',
+  type: 'company',
+  inn: '123 456 789',
+  kpp: '',
+  full_legal_name: 'ООО Клиент',
+  legal_address: '',
+  actual_address: '',
+  bank_name: '',
+  bic: '',
+  iban: 'BY12 AKBB 3012 0000 0000 0000 0000',
+  signer_position: '',
+  signer_name: '',
+  acting_basis: '',
+};
+const phoneOnlyPatch = buildCustomerPatchPayload(customerForm, { phone: true });
+assert(
+  Object.keys(phoneOnlyPatch).join(',') === 'phone',
+  'customer PATCH must contain only fields changed by the user',
+);
+assert(
+  phoneOnlyPatch.phone === '+375 (29) 591-26-81',
+  'changed customer phone must be normalized before PATCH',
+);
+const blankSignerPatch = buildCustomerPatchPayload(customerForm, {
+  signer_position: true,
+  acting_basis: true,
+});
+assert(
+  blankSignerPatch.signer_position === '' && blankSignerPatch.acting_basis === '',
+  'explicitly cleared signer requisites must reach the API for safe defaulting',
+);
 
 assert(
   navSections.find((section) => section.id === 'catalog')?.items.map((item) => item.label).join('|')

--- a/services/customer_service.py
+++ b/services/customer_service.py
@@ -236,6 +236,10 @@ class CustomerService:
         if not customer:
             return None
 
+        defaulted_text_fields = {
+            "signer_position": "директора",
+            "acting_basis": "Устава",
+        }
         optional_text_fields = (
             "email",
             "inn",
@@ -246,9 +250,7 @@ class CustomerService:
             "bank_name",
             "bic",
             "iban",
-            "signer_position",
             "signer_name",
-            "acting_basis",
         )
 
         if "name" in payload and payload["name"] is not None:
@@ -262,6 +264,13 @@ class CustomerService:
 
         if "is_favorite" in payload and payload["is_favorite"] is not None:
             customer.is_favorite = bool(payload["is_favorite"])
+
+        for field, default_value in defaulted_text_fields.items():
+            if field not in payload:
+                continue
+            value = payload[field]
+            trimmed = str(value).strip() if value is not None else ""
+            setattr(customer, field, trimmed or default_value)
 
         for field in optional_text_fields:
             if field not in payload:

--- a/tests/integration/test_manager_customers_api.py
+++ b/tests/integration/test_manager_customers_api.py
@@ -124,6 +124,38 @@ async def test_manager_customer_patch_updates_requisites(async_client, db):
 
 
 @pytest.mark.asyncio
+async def test_manager_customer_patch_defaults_blank_required_requisites(async_client, db):
+    headers = await _auth_headers(async_client)
+
+    customer = Customer(
+        name="ООО Клиент",
+        phone="+375291112233",
+        type=CustomerType.company,
+        signer_position="Директор",
+        acting_basis="Доверенности",
+    )
+    db.add(customer)
+    await db.commit()
+    await db.refresh(customer)
+
+    patch_resp = await async_client.patch(
+        f"/api/manager/customers/{customer.id}",
+        headers=headers,
+        json={
+            "phone": "+375 (29) 591-26-81",
+            "signer_position": "",
+            "acting_basis": None,
+        },
+    )
+
+    assert patch_resp.status_code == 200
+    patched = patch_resp.json()
+    assert patched["phone"] == "+375 (29) 591-26-81"
+    assert patched["signer_position"] == "директора"
+    assert patched["acting_basis"] == "Устава"
+
+
+@pytest.mark.asyncio
 async def test_manager_customer_favorite_patch_and_sort(async_client, db):
     headers = await _auth_headers(async_client)
 


### PR DESCRIPTION
## Что исправлено
- обязательные реквизиты подписанта больше не превращаются в NULL при пустом значении
- менеджер отправляет только реально изменённые поля клиента
- добавлен регрессионный тест по точному production-сценарию

## Проверки
- `pytest tests/integration/test_manager_customers_api.py -q`
- `pytest tests/unit/test_customer_service.py -q`
- manager UI logic tests
- `vue-tsc -b`
- `vite build`