### PR TITLE
Добавить публичный API страницы серии

### DIFF
--- a/crud/product.py
+++ b/crud/product.py
@@ -116,6 +116,32 @@ class ProductDAO:
         return list(result.scalars().all())
 
     @staticmethod
+    async def get_published_by_series_id(
+        session: AsyncSession,
+        series_id: int,
+        *,
+        load_image_variants: bool = False,
+    ) -> List[Product]:
+        stmt = (
+            select(Product)
+            .where(
+                Product.series_id == series_id,
+                Product.is_published.is_(True),
+            )
+            .options(
+                selectinload(Product.brand),
+                ProductDAO._series_option(),
+                selectinload(Product.tags).selectinload(Tag.group),
+                ProductDAO._gallery_images_option(
+                    load_image_variants=load_image_variants
+                ),
+                selectinload(Product.attachments),
+            )
+            .order_by(Product.title.asc(), Product.id.asc())
+        )
+        return list((await session.execute(stmt)).scalars().all())
+
+    @staticmethod
     async def get_by_ids(
         session: AsyncSession,
         product_ids: List[int],

--- a/manager_frontend/src/client/index.ts
+++ b/manager_frontend/src/client/index.ts
@@ -441,6 +441,8 @@ export type { PublicContactLeadResponse } from './models/PublicContactLeadRespon
 export type { PublicFeatureResponse } from './models/PublicFeatureResponse';
 export type { PublicOrderPricingErrorDetail } from './models/PublicOrderPricingErrorDetail';
 export type { PublicOrderPricingErrorResponse } from './models/PublicOrderPricingErrorResponse';
+export type { PublicRelatedSeriesResponse } from './models/PublicRelatedSeriesResponse';
+export type { PublicSeriesPageResponse } from './models/PublicSeriesPageResponse';
 export type { RepairDiagnosticLeadResponse } from './models/RepairDiagnosticLeadResponse';
 export type { ServiceResponse } from './models/ServiceResponse';
 export type { SpecRegistryItemResponse } from './models/SpecRegistryItemResponse';

--- a/manager_frontend/src/client/models/PublicRelatedSeriesResponse.ts
+++ b/manager_frontend/src/client/models/PublicRelatedSeriesResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type PublicRelatedSeriesResponse = {
+    title: string;
+    slug: string;
+    short_description?: (string | null);
+    hero_image?: (string | null);
+    products_count?: number;
+};
+

--- a/manager_frontend/src/client/models/PublicSeriesPageResponse.ts
+++ b/manager_frontend/src/client/models/PublicSeriesPageResponse.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProductBrandResponse } from './ProductBrandResponse';
+import type { ProductResponse } from './ProductResponse';
+import type { ProductSeriesResponse } from './ProductSeriesResponse';
+import type { PublicRelatedSeriesResponse } from './PublicRelatedSeriesResponse';
+export type PublicSeriesPageResponse = {
+    brand: ProductBrandResponse;
+    series: ProductSeriesResponse;
+    products?: Array<ProductResponse>;
+    related_series?: Array<PublicRelatedSeriesResponse>;
+};
+

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -18,6 +18,7 @@ import type { PublicBrandDetailResponse } from '../models/PublicBrandDetailRespo
 import type { PublicBrandResponse } from '../models/PublicBrandResponse';
 import type { PublicContactLeadPayload } from '../models/PublicContactLeadPayload';
 import type { PublicContactLeadResponse } from '../models/PublicContactLeadResponse';
+import type { PublicSeriesPageResponse } from '../models/PublicSeriesPageResponse';
 import type { RepairDiagnosticLeadResponse } from '../models/RepairDiagnosticLeadResponse';
 import type { ServiceResponse } from '../models/ServiceResponse';
 import type { SpecRegistryResponse } from '../models/SpecRegistryResponse';
@@ -211,6 +212,30 @@ export class ApiService {
             url: '/api/v1/content/brands/{slug}',
             path: {
                 'slug': slug,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get Public Brand Series
+     * Get one published series and its public product cards.
+     * @param brandSlug
+     * @param seriesSlug
+     * @returns PublicSeriesPageResponse Successful Response
+     * @throws ApiError
+     */
+    public static getPublicBrandSeries(
+        brandSlug: string,
+        seriesSlug: string,
+    ): CancelablePromise<PublicSeriesPageResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/content/brands/{brand_slug}/series/{series_slug}',
+            path: {
+                'brand_slug': brandSlug,
+                'series_slug': seriesSlug,
             },
             errors: {
                 422: `Validation Error`,

--- a/openapi.json
+++ b/openapi.json
@@ -2304,6 +2304,59 @@
         }
       }
     },
+    "/api/v1/content/brands/{brand_slug}/series/{series_slug}": {
+      "get": {
+        "tags": [
+          "api",
+          "api"
+        ],
+        "summary": "Get Public Brand Series",
+        "description": "Get one published series and its public product cards.",
+        "operationId": "get_public_brand_series",
+        "parameters": [
+          {
+            "name": "brand_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Brand Slug"
+            }
+          },
+          {
+            "name": "series_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Series Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicSeriesPageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/services/options": {
       "get": {
         "tags": [
@@ -48636,6 +48689,81 @@
           "detail"
         ],
         "title": "PublicOrderPricingErrorResponse"
+      },
+      "PublicRelatedSeriesResponse": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "short_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Description"
+          },
+          "hero_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hero Image"
+          },
+          "products_count": {
+            "type": "integer",
+            "title": "Products Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "slug"
+        ],
+        "title": "PublicRelatedSeriesResponse"
+      },
+      "PublicSeriesPageResponse": {
+        "properties": {
+          "brand": {
+            "$ref": "#/components/schemas/ProductBrandResponse"
+          },
+          "series": {
+            "$ref": "#/components/schemas/ProductSeriesResponse"
+          },
+          "products": {
+            "items": {
+              "$ref": "#/components/schemas/ProductResponse"
+            },
+            "type": "array",
+            "title": "Products"
+          },
+          "related_series": {
+            "items": {
+              "$ref": "#/components/schemas/PublicRelatedSeriesResponse"
+            },
+            "type": "array",
+            "title": "Related Series"
+          }
+        },
+        "type": "object",
+        "required": [
+          "brand",
+          "series"
+        ],
+        "title": "PublicSeriesPageResponse"
       },
       "RepairDiagnosticLeadResponse": {
         "properties": {

--- a/routers/api_content.py
+++ b/routers/api_content.py
@@ -5,10 +5,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
 
 from core.database import get_session
-from schemas import ArticleResponse, PublicBrandDetailResponse, PublicBrandResponse, ServiceResponse
+from schemas import (
+    ArticleResponse,
+    PublicBrandDetailResponse,
+    PublicBrandResponse,
+    PublicSeriesPageResponse,
+    ServiceResponse,
+)
 from services.article_service import ArticleService
 from services.content_api_service import ContentApiService
 from services.installation_service import InstallationService
+from services.public_series_page_service import PublicSeriesPageService
 
 router = APIRouter(tags=["api"])
 
@@ -51,6 +58,30 @@ async def get_public_brand(slug: str, session: AsyncSession = Depends(get_sessio
     if not brand:
         raise HTTPException(status_code=404, detail=f"Brand with slug '{slug}' not found")
     return brand
+
+
+@router.get(
+    "/v1/content/brands/{brand_slug}/series/{series_slug}",
+    response_model=PublicSeriesPageResponse,
+    operation_id="get_public_brand_series",
+)
+async def get_public_brand_series(
+    brand_slug: str,
+    series_slug: str,
+    session: AsyncSession = Depends(get_session),
+):
+    """Get one published series and its public product cards."""
+    payload = await PublicSeriesPageService.get_by_slugs(
+        session,
+        brand_slug=brand_slug,
+        series_slug=series_slug,
+    )
+    if payload is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Published series '{brand_slug}/{series_slug}' not found",
+        )
+    return payload
 
 
 @router.get("/v1/services/options", response_model=List[ServiceResponse])

--- a/schemas.py
+++ b/schemas.py
@@ -502,6 +502,21 @@ class PublicBrandResponse(BaseModel):
 class PublicBrandDetailResponse(PublicBrandResponse):
     features: List[ProductSeriesBrandFeatureResponse] = Field(default_factory=list)
 
+
+class PublicRelatedSeriesResponse(BaseModel):
+    title: str
+    slug: str
+    short_description: Optional[str] = None
+    hero_image: Optional[str] = None
+    products_count: int = 0
+
+
+class PublicSeriesPageResponse(BaseModel):
+    brand: ProductBrandResponse
+    series: ProductSeriesResponse
+    products: List[ProductResponse] = Field(default_factory=list)
+    related_series: List[PublicRelatedSeriesResponse] = Field(default_factory=list)
+
 # --- ORDERS ---
 
 class CalendarEventType(str, Enum):

--- a/services/public_series_page_service.py
+++ b/services/public_series_page_service.py
@@ -1,0 +1,131 @@
+"""Public read model for one published brand series page."""
+
+from sqlalchemy import and_, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from crud.product import ProductDAO
+from models import Brand, FeatureSeriesLink, Product, ProductSeries
+from schemas import (
+    ProductBrandResponse,
+    PublicRelatedSeriesResponse,
+    PublicSeriesPageResponse,
+)
+from services.feature_resolver_service import FeatureResolverService
+from services.product_read_service import ProductReadService
+from services.product_response_mapper import map_product_to_response
+from services.product_series_payloads import build_product_series_response
+
+
+class PublicSeriesPageService:
+    RELATED_LIMIT = 4
+
+    @staticmethod
+    async def get_by_slugs(
+        session: AsyncSession,
+        *,
+        brand_slug: str,
+        series_slug: str,
+    ) -> PublicSeriesPageResponse | None:
+        row = (
+            await session.execute(
+                select(ProductSeries, Brand)
+                .join(Brand, Brand.id == ProductSeries.brand_id)
+                .where(
+                    Brand.slug == brand_slug,
+                    Brand.is_published.is_(True),
+                    ProductSeries.slug == series_slug,
+                    ProductSeries.is_published.is_(True),
+                )
+                .options(
+                    selectinload(ProductSeries.feature_links).selectinload(
+                        FeatureSeriesLink.feature
+                    )
+                )
+            )
+        ).one_or_none()
+        if row is None:
+            return None
+
+        series, brand = row
+        products = await ProductDAO.get_published_by_series_id(
+            session,
+            int(series.id),
+            load_image_variants=True,
+        )
+        supply_metrics = await ProductReadService.get_supply_metrics_map(session, products)
+        await FeatureResolverService.resolve_for_products(session, products)
+
+        series_payload = build_product_series_response(series)
+        if series_payload is None:
+            return None
+
+        return PublicSeriesPageResponse(
+            brand=ProductBrandResponse(
+                id=int(brand.id),
+                title=brand.title,
+                slug=brand.slug,
+                logo_url=brand.logo_url,
+            ),
+            series=series_payload,
+            products=[
+                map_product_to_response(
+                    product,
+                    supply_metrics=supply_metrics.get(int(product.id)),
+                )
+                for product in products
+            ],
+            related_series=await PublicSeriesPageService._get_related_series(
+                session,
+                brand_id=int(brand.id),
+                current_series_id=int(series.id),
+            ),
+        )
+
+    @staticmethod
+    async def _get_related_series(
+        session: AsyncSession,
+        *,
+        brand_id: int,
+        current_series_id: int,
+    ) -> list[PublicRelatedSeriesResponse]:
+        rows = list(
+            (
+                await session.execute(
+                    select(
+                        ProductSeries,
+                        func.count(Product.id).label("products_count"),
+                    )
+                    .outerjoin(
+                        Product,
+                        and_(
+                            Product.series_id == ProductSeries.id,
+                            Product.is_published.is_(True),
+                        ),
+                    )
+                    .where(
+                        ProductSeries.brand_id == brand_id,
+                        ProductSeries.id != current_series_id,
+                        ProductSeries.is_published.is_(True),
+                    )
+                    .group_by(ProductSeries.id)
+                    .order_by(
+                        ProductSeries.sort_order.asc(),
+                        ProductSeries.title.asc(),
+                        ProductSeries.id.asc(),
+                    )
+                    .limit(PublicSeriesPageService.RELATED_LIMIT)
+                )
+            ).all()
+        )
+        return [
+            PublicRelatedSeriesResponse(
+                title=related.title,
+                slug=related.slug,
+                short_description=related.short_description,
+                hero_image=related.hero_image,
+                products_count=int(products_count or 0),
+            )
+            for related, products_count in rows
+        ]

--- a/tests/integration/test_public_series_api.py
+++ b/tests/integration/test_public_series_api.py
@@ -1,0 +1,206 @@
+import pytest
+from httpx import AsyncClient
+
+from models import Brand, Feature, FeatureCategory, FeatureSeriesLink, Product, ProductSeries
+
+
+@pytest.mark.asyncio
+async def test_public_series_page_uses_public_product_contract(
+    async_client: AsyncClient,
+    db,
+):
+    brand = Brand(
+        title="TCL",
+        slug="tcl",
+        logo_url="/media/brands/tcl.svg",
+        is_published=True,
+    )
+    db.add(brand)
+    await db.flush()
+
+    series = ProductSeries(
+        brand_id=brand.id,
+        title="FreshIN 3.0",
+        slug="freshin-3",
+        tagline="Приток свежего воздуха",
+        short_description="Флагманская серия TCL.",
+        description="Полное описание серии.",
+        hero_image="/media/series/freshin.webp",
+        gallery_images=["/media/series/freshin-1.webp"],
+        features=["FreshIN+"],
+        feature_blocks=[{"title": "FreshIN+", "text": "Приток воздуха"}],
+        content_blocks=[{"kind": "text", "title": "Комфорт", "text": "Описание"}],
+        footnotes=["Характеристики зависят от модели."],
+        seo_title="TCL FreshIN 3.0",
+        seo_description="Серия TCL FreshIN 3.0.",
+        source_url="https://example.com/tcl.pdf",
+        is_published=True,
+    )
+    related_empty = ProductSeries(
+        brand_id=brand.id,
+        title="BreezeIN",
+        slug="breezein",
+        short_description="Комфортная подача воздуха.",
+        hero_image="/media/series/breezein.webp",
+        is_published=True,
+        sort_order=10,
+    )
+    related_with_product = ProductSeries(
+        brand_id=brand.id,
+        title="Elite",
+        slug="elite",
+        is_published=True,
+        sort_order=20,
+    )
+    hidden_series = ProductSeries(
+        brand_id=brand.id,
+        title="Hidden",
+        slug="hidden",
+        is_published=False,
+    )
+    db.add_all([series, related_empty, related_with_product, hidden_series])
+    await db.flush()
+
+    category = FeatureCategory(slug="air", name="Воздух")
+    db.add(category)
+    await db.flush()
+    feature = Feature(
+        brand_id=brand.id,
+        category_id=category.id,
+        scope_type="series",
+        name="FreshIN+",
+        slug="freshin-plus",
+        full_description="Приток наружного воздуха.",
+        is_active=True,
+    )
+    db.add(feature)
+    await db.flush()
+    db.add(
+        FeatureSeriesLink(
+            series_id=series.id,
+            feature_id=feature.id,
+            is_enabled=True,
+            sort_order=10,
+        )
+    )
+
+    published = Product(
+        title="TCL FreshIN TAC-09CHSD/FCI",
+        slug="tcl-freshin-09",
+        price=3200,
+        specs={"area_m2": 25, "__filter_min_heat": -20},
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=True,
+    )
+    hidden = Product(
+        title="TCL FreshIN hidden",
+        slug="tcl-freshin-hidden",
+        price=3300,
+        brand_id=brand.id,
+        series_id=series.id,
+        is_published=False,
+    )
+    related_product = Product(
+        title="TCL Elite",
+        slug="tcl-elite",
+        price=1800,
+        brand_id=brand.id,
+        series_id=related_with_product.id,
+        is_published=True,
+    )
+    hidden_related_product = Product(
+        title="TCL Elite hidden",
+        slug="tcl-elite-hidden",
+        price=1700,
+        brand_id=brand.id,
+        series_id=related_with_product.id,
+        is_published=False,
+    )
+    db.add_all([published, hidden, related_product, hidden_related_product])
+    await db.commit()
+
+    response = await async_client.get(
+        "/api/v1/content/brands/tcl/series/freshin-3"
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["brand"] == {
+        "id": brand.id,
+        "title": "TCL",
+        "slug": "tcl",
+        "logo_url": "/media/brands/tcl.svg",
+    }
+    assert payload["series"]["slug"] == "freshin-3"
+    assert payload["series"]["brand_features"][0]["slug"] == "freshin-plus"
+    assert [item["slug"] for item in payload["products"]] == ["tcl-freshin-09"]
+    assert "__filter_min_heat" not in payload["products"][0]["specs"]
+    assert payload["related_series"] == [
+        {
+            "title": "BreezeIN",
+            "slug": "breezein",
+            "short_description": "Комфортная подача воздуха.",
+            "hero_image": "/media/series/breezein.webp",
+            "products_count": 0,
+        },
+        {
+            "title": "Elite",
+            "slug": "elite",
+            "short_description": None,
+            "hero_image": None,
+            "products_count": 1,
+        },
+    ]
+
+    catalog_response = await async_client.get(
+        "/api/v1/products",
+        params={"q": "TCL FreshIN TAC-09CHSD/FCI", "limit": 5},
+    )
+    assert catalog_response.status_code == 200, catalog_response.text
+    assert payload["products"][0] == catalog_response.json()["items"][0]
+
+
+@pytest.mark.asyncio
+async def test_public_series_page_allows_empty_series_and_hides_unpublished_data(
+    async_client: AsyncClient,
+    db,
+):
+    brand = Brand(title="TCL", slug="tcl", is_published=True)
+    hidden_brand = Brand(title="Hidden", slug="hidden", is_published=False)
+    db.add_all([brand, hidden_brand])
+    await db.flush()
+
+    empty_series = ProductSeries(
+        brand_id=brand.id,
+        title="Empty",
+        slug="empty",
+        is_published=True,
+    )
+    hidden_series = ProductSeries(
+        brand_id=brand.id,
+        title="Draft",
+        slug="draft",
+        is_published=False,
+    )
+    hidden_brand_series = ProductSeries(
+        brand_id=hidden_brand.id,
+        title="Visible series",
+        slug="visible-series",
+        is_published=True,
+    )
+    db.add_all([empty_series, hidden_series, hidden_brand_series])
+    await db.commit()
+
+    response = await async_client.get("/api/v1/content/brands/tcl/series/empty")
+    assert response.status_code == 200, response.text
+    assert response.json()["products"] == []
+
+    for path in (
+        "/api/v1/content/brands/tcl/series/draft",
+        "/api/v1/content/brands/hidden/series/visible-series",
+        "/api/v1/content/brands/tcl/series/missing",
+        "/api/v1/content/brands/missing/series/empty",
+    ):
+        missing_response = await async_client.get(path)
+        assert missing_response.status_code == 404


### PR DESCRIPTION
## Что сделано
- добавлен `GET /api/v1/content/brands/{brand_slug}/series/{series_slug}`
- серия доступна даже при пустом списке опубликованных моделей
- товары используют тот же публичный DTO, supply metrics и Feature resolver, что каталог
- related series содержат только опубликованные серии и считают только опубликованные товары
- скрытые бренд, серия и товары не попадают в ответ
- обновлены OpenAPI и типизированный manager client

## Проверки
- `pytest -q tests/integration/test_public_series_api.py tests/integration/test_public_brands_api.py tests/integration/test_product_series_siblings.py tests/unit/test_public_product_series_payloads.py tests/unit/test_brand_series_service.py` — 20 passed
- manager TypeScript typecheck — passed
- manager Vite build — passed
- локальный дублирующий full suite остановлен после 154 passed из-за скорости; полный suite обязателен в CI
- `git diff --check` — passed

Closes #816