### PR TITLE
Восстановить канонические типы товаров для подборок

### DIFF
--- a/scripts/backfill_product_kinds.py
+++ b/scripts/backfill_product_kinds.py
@@ -1,0 +1,159 @@
+import argparse
+import asyncio
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+sys.path.append(".")
+
+from models import Product
+from services.product_kind_service import ProductKindService
+
+
+@dataclass(frozen=True)
+class ProductKindBackfillPlanItem:
+    product_id: int
+    title: str
+    previous_kind: str
+    next_kind: str
+
+
+def build_backfill_plan(
+    products: Iterable[Product],
+    *,
+    repair_conflicts: bool,
+) -> list[ProductKindBackfillPlanItem]:
+    plan: list[ProductKindBackfillPlanItem] = []
+    for product in products:
+        next_kind = ProductKindService.derive_from_specs(product.specs)
+        previous_kind = str(product.product_kind or "unknown")
+        if next_kind == "unknown" or next_kind == previous_kind:
+            continue
+        if previous_kind != "unknown" and not repair_conflicts:
+            continue
+        plan.append(
+            ProductKindBackfillPlanItem(
+                product_id=int(product.id),
+                title=product.title,
+                previous_kind=previous_kind,
+                next_kind=next_kind,
+            )
+        )
+    return plan
+
+
+def _print_plan(
+    plan: Sequence[ProductKindBackfillPlanItem],
+    *,
+    sample_limit: int,
+) -> None:
+    transitions = Counter(
+        (item.previous_kind, item.next_kind)
+        for item in plan
+    )
+    print("Product Kind Backfill")
+    print(f"  planned_changes={len(plan)}")
+    for (previous_kind, next_kind), count in sorted(transitions.items()):
+        print(f"  {previous_kind} -> {next_kind}: {count}")
+
+    if not plan or sample_limit <= 0:
+        return
+    print(f"\nSample (up to {sample_limit}):")
+    for item in plan[:sample_limit]:
+        print(
+            f"  [{item.product_id}] {item.previous_kind} -> {item.next_kind}: "
+            f"{item.title}"
+        )
+
+
+async def run(
+    *,
+    execute: bool,
+    product_ids: set[int] | None,
+    repair_conflicts: bool,
+    sample_limit: int,
+) -> None:
+    from core.config import settings
+
+    db_url = settings.DATABASE_URL.replace("+asyncpg", "+psycopg")
+    engine = create_async_engine(db_url)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    try:
+        async with async_session() as session:
+            statement = select(Product).order_by(Product.id.asc())
+            if product_ids:
+                statement = statement.where(Product.id.in_(product_ids))
+            products = list((await session.execute(statement)).scalars().all())
+            plan = build_backfill_plan(
+                products,
+                repair_conflicts=repair_conflicts,
+            )
+            _print_plan(plan, sample_limit=sample_limit)
+
+            if not plan:
+                print("Nothing to backfill.")
+                return
+            if not execute:
+                print("\nDry run only. Use --execute to persist product kinds.")
+                return
+
+            products_by_id = {int(product.id): product for product in products}
+            for item in plan:
+                product = products_by_id[item.product_id]
+                product.product_kind = item.next_kind
+                session.add(product)
+            await session.commit()
+            print(f"\nApplied. Updated {len(plan)} products.")
+    finally:
+        await engine.dispose()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill product_kind from canonical specs. "
+            "Default mode is dry-run and only fills unknown kinds."
+        )
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist changes. Without this flag the script only reports the plan.",
+    )
+    parser.add_argument(
+        "--product-id",
+        action="append",
+        type=int,
+        default=None,
+        help="Limit the operation to a product id. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--repair-conflicts",
+        action="store_true",
+        help="Also repair known kinds that conflict with canonical specs.type.",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=30,
+        help="Maximum number of planned products to print (default: 30).",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run(
+            execute=args.execute,
+            product_ids=set(args.product_id) if args.product_id else None,
+            repair_conflicts=args.repair_conflicts,
+            sample_limit=max(0, args.sample_limit),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/product_kind_service.py
+++ b/services/product_kind_service.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 
@@ -12,6 +13,15 @@ KNOWN_PRODUCT_KINDS = {
     "other",
 }
 
+PRODUCT_KIND_BY_SYSTEM_TYPE = {
+    "сплит-система": "complete_split_system",
+    "внутренний блок": "indoor_unit",
+    "наружный блок": "outdoor_unit",
+    "мобильный": "other",
+    "мульти-сплит-система": "other",
+    "полупромышленный кондиционер": "other",
+}
+
 
 def _as_bool(value: Any) -> bool | None:
     if isinstance(value, bool):
@@ -24,12 +34,37 @@ def _as_bool(value: Any) -> bool | None:
     return None
 
 
+def _spec_value(values: dict[str, Any], key: str) -> Any:
+    if values.get(key) is not None:
+        return values[key]
+    typed = values.get("__typed_specs")
+    if not isinstance(typed, dict):
+        return None
+    entry = typed.get(key)
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("value") is not None:
+        return entry["value"]
+    return entry.get("raw")
+
+
+def _kind_from_system_type(value: Any) -> str | None:
+    normalized = str(value or "").strip().lower().replace("ё", "е")
+    normalized = normalized.replace("—", "-")
+    normalized = re.sub(r"\s+", " ", normalized)
+    return PRODUCT_KIND_BY_SYSTEM_TYPE.get(normalized)
+
+
 class ProductKindService:
     @staticmethod
     def derive_from_specs(specs: dict[str, Any] | None) -> str:
         values = specs or {}
-        includes_indoor = _as_bool(values.get("includes_indoor_unit"))
-        includes_outdoor = _as_bool(values.get("includes_outdoor_unit"))
+        system_type_kind = _kind_from_system_type(_spec_value(values, "type"))
+        if system_type_kind is not None:
+            return system_type_kind
+
+        includes_indoor = _as_bool(_spec_value(values, "includes_indoor_unit"))
+        includes_outdoor = _as_bool(_spec_value(values, "includes_outdoor_unit"))
         if includes_indoor is True and includes_outdoor is True:
             return "complete_split_system"
         if includes_indoor is True and includes_outdoor is False:

--- a/tests/unit/test_product_kind_backfill.py
+++ b/tests/unit/test_product_kind_backfill.py
@@ -1,0 +1,61 @@
+from models import Product
+from scripts.backfill_product_kinds import build_backfill_plan
+
+
+def _product(
+    *,
+    product_id: int,
+    product_kind: str,
+    system_type: str,
+) -> Product:
+    return Product(
+        id=product_id,
+        title=f"Product {product_id}",
+        slug=f"product-{product_id}",
+        product_kind=product_kind,
+        specs={"type": system_type},
+    )
+
+
+def test_backfill_plan_fills_unknown_kinds_and_is_idempotent():
+    products = [
+        _product(
+            product_id=1,
+            product_kind="unknown",
+            system_type="сплит-система",
+        ),
+        _product(
+            product_id=2,
+            product_kind="unknown",
+            system_type="внутренний блок",
+        ),
+    ]
+
+    plan = build_backfill_plan(products, repair_conflicts=False)
+
+    assert [
+        (item.product_id, item.previous_kind, item.next_kind)
+        for item in plan
+    ] == [
+        (1, "unknown", "complete_split_system"),
+        (2, "unknown", "indoor_unit"),
+    ]
+
+    for item in plan:
+        products[item.product_id - 1].product_kind = item.next_kind
+    assert build_backfill_plan(products, repair_conflicts=False) == []
+
+
+def test_backfill_plan_requires_explicit_flag_to_repair_known_conflicts():
+    mobile = _product(
+        product_id=3,
+        product_kind="indoor_unit",
+        system_type="мобильный",
+    )
+
+    assert build_backfill_plan([mobile], repair_conflicts=False) == []
+
+    plan = build_backfill_plan([mobile], repair_conflicts=True)
+    assert len(plan) == 1
+    assert plan[0].previous_kind == "indoor_unit"
+    assert plan[0].next_kind == "other"

--- a/tests/unit/test_product_kind_service.py
+++ b/tests/unit/test_product_kind_service.py
@@ -22,6 +22,46 @@ def test_product_kind_derives_only_from_explicit_component_flags():
     ) == "outdoor_unit"
 
 
+def test_product_kind_derives_from_canonical_system_type():
+    assert ProductKindService.derive_from_specs(
+        {"type": "сплит-система"},
+    ) == "complete_split_system"
+    assert ProductKindService.derive_from_specs(
+        {"type": "внутренний блок"},
+    ) == "indoor_unit"
+    assert ProductKindService.derive_from_specs(
+        {"type": "наружный блок"},
+    ) == "outdoor_unit"
+
+
+def test_product_kind_keeps_non_household_systems_out_of_complete_split_kind():
+    assert ProductKindService.derive_from_specs(
+        {
+            "type": "мобильный",
+            "includes_indoor_unit": True,
+            "includes_outdoor_unit": False,
+        },
+    ) == "other"
+    assert ProductKindService.derive_from_specs(
+        {
+            "type": "полупромышленный кондиционер",
+            "includes_indoor_unit": True,
+            "includes_outdoor_unit": True,
+        },
+    ) == "other"
+
+
+def test_product_kind_reads_confirmed_typed_component_flags():
+    assert ProductKindService.derive_from_specs(
+        {
+            "__typed_specs": {
+                "includes_indoor_unit": {"type": "boolean", "value": True},
+                "includes_outdoor_unit": {"type": "boolean", "raw": "да"},
+            }
+        },
+    ) == "complete_split_system"
+
+
 def test_product_kind_does_not_guess_from_title_or_partial_data():
     assert ProductKindService.derive_from_specs(
         {


### PR DESCRIPTION
## Причина
Production preview исключает выбранные бытовые сплит-системы как `unsupported_product_kind`: у всех товаров подборок `product_kind=unknown`, хотя канонический `specs.type` равен `сплит-система`. Первичная миграция читала только top-level component flags и пропустила старый каталог с `__typed_specs`/нормализованным `type`.

## Что изменено
- `ProductKindService` использует канонический `specs.type` и подтверждённые значения из `__typed_specs`
- бытовые сплит-системы, внутренние и наружные блоки классифицируются явно
- мобильные и полупромышленные модели получают безопасный `other` и не просачиваются в домашний slot
- добавлен `scripts/backfill_product_kinds.py`: dry-run по умолчанию, `--execute`, scope по product id, отдельный `--repair-conflicts`
- backfill план идемпотентен

## Проверки
- 14 профильных unit-тестов — passed
- `tests/integration/test_product_collections_api.py` — 6 passed
- CLI `--help` — passed
- `git diff --check` — passed

После деплоя: production dry-run, execute, повторный dry-run с нулём изменений и проверка preview/public resolver.