### PR TITLE
Harden Patroni proxy slot reconciliation

### DIFF
--- a/scripts/ha/check_patroni_production.py
+++ b/scripts/ha/check_patroni_production.py
@@ -492,6 +492,30 @@ def _running_services(runner: SshRunner, node: NodeConfig) -> set[str]:
     return set(runner.run(node, command).stdout.split())
 
 
+def _optional_runtime_file(
+    runner: SshRunner,
+    node: NodeConfig,
+    relative_path: str,
+) -> str:
+    path = f"{node.project_dir}/{relative_path}"
+    command = (
+        f"if [ -f {shlex.quote(path)} ]; then cat {shlex.quote(path)}; fi"
+    )
+    return runner.run(node, command).stdout.strip()
+
+
+def _active_api_slot(runner: SshRunner, node: NodeConfig) -> str:
+    return _optional_runtime_file(runner, node, ".active-api-slot").lower()
+
+
+def _proxy_upstream(runner: SshRunner, node: NodeConfig) -> str:
+    return _optional_runtime_file(
+        runner,
+        node,
+        "api-proxy/upstream.conf",
+    )
+
+
 def _role_env(runner: SshRunner, node: NodeConfig, filename: str) -> dict[str, str]:
     path = f"{node.project_dir}/{filename}"
     content = runner.run(node, f"cat {shlex.quote(path)}").stdout
@@ -569,6 +593,34 @@ def _check_runtime(
         app_services = services.intersection({"app", "app-blue", "app-green"})
         if not app_services:
             report.fail(f"{node.label}: no API app service is running")
+        active_slot = _active_api_slot(runner, node)
+        if active_slot:
+            if active_slot not in {"blue", "green"}:
+                report.fail(
+                    f"{node.label}: active API slot is invalid: {active_slot!r}"
+                )
+            else:
+                expected_service = f"app-{active_slot}"
+                if app_services != {expected_service}:
+                    report.fail(
+                        f"{node.label}: active slot={active_slot} requires only "
+                        f"{expected_service}, running={sorted(app_services)}"
+                    )
+                if "api-proxy" in services:
+                    expected_upstream = (
+                        f"proxy_pass http://{expected_service}:8000;"
+                    )
+                    actual_upstream = _proxy_upstream(runner, node)
+                    if actual_upstream != expected_upstream:
+                        report.fail(
+                            f"{node.label}: active slot={active_slot} but proxy "
+                            f"upstream={actual_upstream!r}, expected={expected_upstream!r}"
+                        )
+        elif len(app_services) > 1:
+            report.fail(
+                f"{node.label}: multiple API app services are running without "
+                f"an active slot: {sorted(app_services)}"
+            )
         bot_running = "bot" in services
         if bot_running:
             report.fail(

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import argparse
 import fcntl
 import importlib.util
+import json
 import os
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -187,6 +190,74 @@ def _refresh_container_proxy_dns(
         return False
     _run_compose(config, "restart", CONTAINER_PROXY_SERVICE)
     return True
+
+
+def _proxy_upstream_path(config: AgentConfig) -> Path:
+    return config.project_dir / "api-proxy" / "upstream.conf"
+
+
+def _expected_proxy_upstream(service: str) -> str:
+    if service not in APP_SERVICE_NAMES:
+        raise ValueError(f"unsupported API app service: {service}")
+    return f"proxy_pass http://{service}:8000;\n"
+
+
+def _container_proxy_upstream_matches(
+    config: AgentConfig,
+    service: str,
+    *,
+    running_services: set[str],
+) -> bool:
+    if CONTAINER_PROXY_SERVICE not in running_services:
+        return True
+    try:
+        current = _proxy_upstream_path(config).read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return False
+    return current == _expected_proxy_upstream(service)
+
+
+def _reconcile_container_proxy_upstream(
+    config: AgentConfig,
+    service: str,
+    *,
+    running_services: set[str],
+) -> bool:
+    if _container_proxy_upstream_matches(
+        config,
+        service,
+        running_services=running_services,
+    ):
+        return False
+    _atomic_write(
+        _proxy_upstream_path(config),
+        _expected_proxy_upstream(service),
+        mode=0o644,
+    )
+    return True
+
+
+def _wait_scheduler_running(config: AgentConfig) -> None:
+    for _ in range(config.ready_attempts):
+        try:
+            with urllib.request.urlopen(config.ready_url, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            runtime = payload.get("scheduler_runtime")
+            if (
+                response.status == 200
+                and payload.get("api") == "ready"
+                and payload.get("database_writable") is True
+                and isinstance(runtime, dict)
+                and runtime.get("expected") is True
+                and runtime.get("status") == "running"
+            ):
+                return
+        except (OSError, ValueError, urllib.error.URLError):
+            pass
+        time.sleep(2)
+    raise RuntimeError(
+        f"primary scheduler did not acquire runtime ownership: {config.ready_url}"
+    )
 
 
 def _stop_service_verified(config: AgentConfig, service: str) -> None:
@@ -397,6 +468,14 @@ def reconcile(config: AgentConfig, role: str) -> bool:
     service = app_service(config)
     running = _running_services(config)
     app_running = service in running
+    extra_running_apps = sorted(
+        name for name in APP_SERVICE_NAMES if name != service and name in running
+    )
+    proxy_upstream_drift = not _container_proxy_upstream_matches(
+        config,
+        service,
+        running_services=running,
+    )
     bot_running = "bot" in running
     bot_expected = False
     # On demotion, Docker singleton fencing must happen before any fallible or
@@ -417,6 +496,10 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         reasons.append("bot_env")
     if not app_running:
         reasons.append("app_not_running")
+    if role == "primary" and extra_running_apps:
+        reasons.append("extra_app_running")
+    if role == "primary" and proxy_upstream_drift:
+        reasons.append("proxy_upstream_drift")
     if bot_running:
         reasons.append("legacy_bot_running")
     if not systemd_matches:
@@ -479,6 +562,8 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         or bot_env_changed
         or not app_running
         or bot_running != bot_expected
+        or (role == "primary" and bool(extra_running_apps))
+        or (role == "primary" and proxy_upstream_drift)
     )
     if not needs_runtime_reconcile and systemd_matches:
         if actions:
@@ -515,8 +600,12 @@ def reconcile(config: AgentConfig, role: str) -> bool:
 
         # Re-read after acquiring the lock: a concurrent deploy may have changed
         # the concrete containers while fail-safe pre-lock fencing was running.
+        service = app_service(config)
         running = _running_services(config)
         app_running = service in running
+        extra_running_apps = sorted(
+            name for name in APP_SERVICE_NAMES if name != service and name in running
+        )
         bot_running = "bot" in running
 
         if bot_running:
@@ -558,14 +647,40 @@ def reconcile(config: AgentConfig, role: str) -> bool:
                 _require_fresh_primary_or_fence(config, "app_activation")
                 _start_service(config, service, recreate=app_env_changed)
                 actions.append("recreate_app" if app_env_changed else "start_app")
+                running = _running_services(config)
+            proxy_upstream_changed = not _container_proxy_upstream_matches(
+                config,
+                service,
+                running_services=running,
+            )
+            if proxy_upstream_changed:
+                _require_fresh_primary_or_fence(config, "proxy_convergence")
+                _reconcile_container_proxy_upstream(
+                    config,
+                    service,
+                    running_services=running,
+                )
+                actions.append("write_proxy_upstream")
+            if app_needs_start or proxy_upstream_changed:
                 if _refresh_container_proxy_dns(
                     config,
                     running_services=running,
                 ):
                     actions.append("refresh_container_proxy_dns")
-            if app_needs_start:
+            if app_needs_start or proxy_upstream_changed:
                 _wait_ready(config)
                 actions.append("wait_ready")
+            if extra_running_apps:
+                _require_fresh_primary_or_fence(config, "extra_app_fence")
+                for running_app in extra_running_apps:
+                    _stop_service_verified(config, running_app)
+                    actions.append("stop_extra_app")
+            if (
+                service in {"app-blue", "app-green"}
+                and (app_needs_start or proxy_upstream_changed or extra_running_apps)
+            ):
+                _wait_scheduler_running(config)
+                actions.append("wait_scheduler_running")
             if not systemd_matches:
                 if maintenance_transaction is not None:
                     _reconcile_primary_systemd_units(config, "standby")
@@ -591,7 +706,18 @@ def reconcile(config: AgentConfig, role: str) -> bool:
                 _reconcile_primary_systemd_units(config, "standby")
                 actions.append("stop_pitr_units_for_final_maintenance")
             final_running = _running_services(config)
-            if service not in final_running or "bot" in final_running:
+            if (
+                service not in final_running
+                or "bot" in final_running
+                or any(
+                    name in final_running for name in APP_SERVICE_NAMES if name != service
+                )
+                or not _container_proxy_upstream_matches(
+                    config,
+                    service,
+                    running_services=final_running,
+                )
+            ):
                 raise RuntimeError("primary runtime activation postcondition failed")
             expected_pitr_role = (
                 "standby"

--- a/tests/unit/test_patroni_production_check.py
+++ b/tests/unit/test_patroni_production_check.py
@@ -294,6 +294,16 @@ def test_runtime_check_requires_role_aware_scheduler_state(monkeypatch):
     )
     monkeypatch.setattr(
         patroni_check,
+        "_active_api_slot",
+        lambda _runner, _node: "blue",
+    )
+    monkeypatch.setattr(
+        patroni_check,
+        "_proxy_upstream",
+        lambda _runner, _node: "proxy_pass http://app-blue:8000;",
+    )
+    monkeypatch.setattr(
+        patroni_check,
         "_ready_response",
         lambda _runner, node, _url: readiness[node.label],
     )
@@ -309,6 +319,118 @@ def test_runtime_check_requires_role_aware_scheduler_state(monkeypatch):
     report = Report()
     _check_runtime(config, FakeRunner(), api, reserve, report)
     assert any("primary scheduler runtime" in failure for failure in report.failures)
+
+
+def test_runtime_check_reports_active_slot_proxy_drift(monkeypatch):
+    api, reserve = _nodes()
+    config = CheckerConfig(
+        api=api,
+        reserve=reserve,
+        ssh_options=(),
+        max_replay_lag_bytes=1_048_576,
+        role_agent_unit="mvn-patroni-role-agent.service",
+        etcd_check_command="check-etcd",
+        ready_url="http://127.0.0.1:18080/api/ready",
+    )
+
+    class FakeRunner:
+        def run(self, node, command, *, stdin=None, check=True):
+            del stdin, check
+            if command.endswith("/.ha-runtime-role"):
+                role = "primary" if node == api else "standby"
+                return subprocess.CompletedProcess([], 0, f"{role}\n", "")
+            raise AssertionError(command)
+
+    def role_env(_runner, node, filename):
+        primary = node == api
+        role = "primary" if primary else "standby"
+        values = {
+            "APP_ROLE": role,
+            "API_READY_ENABLED": (
+                str(primary).lower() if filename == ".ha-app-role.env" else "false"
+            ),
+            "DB_BOOTSTRAP_ENABLED": "false",
+            "SCHEDULER_ENABLED": (
+                str(primary).lower() if filename == ".ha-app-role.env" else "false"
+            ),
+        }
+        if filename == ".ha-bot-role.env":
+            values["BOT_ENABLED"] = "false"
+        if not primary and filename == ".ha-app-role.env":
+            values.update(
+                {
+                    "MAIL_IMAP_AUTO_IMPORT_ENABLED": "false",
+                    "MAIL_IMAP_LEAD_AUTO_IMPORT_ENABLED": "false",
+                    "CLOUDFLARE_PURGE_ENABLED": "false",
+                }
+            )
+        return values
+
+    monkeypatch.setattr(patroni_check, "_unit_enabled", lambda *_args: True)
+    monkeypatch.setattr(
+        patroni_check,
+        "_unit_active",
+        lambda _runner, node, unit: (
+            True if unit == config.role_agent_unit else node == api
+        ),
+    )
+    monkeypatch.setattr(patroni_check, "_role_env", role_env)
+    monkeypatch.setattr(
+        patroni_check,
+        "_running_services",
+        lambda _runner, _node: {"api-proxy", "app-blue", "app-green"},
+    )
+    monkeypatch.setattr(
+        patroni_check,
+        "_active_api_slot",
+        lambda _runner, _node: "green",
+    )
+    monkeypatch.setattr(
+        patroni_check,
+        "_proxy_upstream",
+        lambda _runner, _node: "proxy_pass http://app-blue:8000;",
+    )
+    monkeypatch.setattr(
+        patroni_check,
+        "_ready_response",
+        lambda _runner, node, _url: (
+            (
+                200,
+                {
+                    "api": "ready",
+                    "traffic": "enabled",
+                    "scheduler_runtime": {
+                        "expected": True,
+                        "status": "waiting_lock",
+                    },
+                },
+            )
+            if node == api
+            else (
+                503,
+                {
+                    "api": "not_ready",
+                    "traffic": "disabled",
+                    "scheduler_runtime": {
+                        "expected": False,
+                        "status": "disabled",
+                    },
+                },
+            )
+        ),
+    )
+
+    report = Report()
+    _check_runtime(config, FakeRunner(), api, reserve, report)
+
+    assert any(
+        "active slot=green requires only app-green" in failure
+        for failure in report.failures
+    )
+    assert any(
+        "active slot=green but proxy upstream=" in failure
+        for failure in report.failures
+    )
 
 
 def test_replication_workflow_switches_to_role_aware_patroni_monitoring():

--- a/tests/unit/test_patroni_role_agent_proxy_recovery.py
+++ b/tests/unit/test_patroni_role_agent_proxy_recovery.py
@@ -22,6 +22,9 @@ def _safe_host_contracts(monkeypatch):
     monkeypatch.setattr(
         patroni_role_agent, "_cancel_pitr_operations", lambda _config: []
     )
+    monkeypatch.setattr(
+        patroni_role_agent, "_wait_scheduler_running", lambda _config: None
+    )
 
 
 def _config(tmp_path: Path) -> AgentConfig:
@@ -174,3 +177,89 @@ def test_standby_recreate_refreshes_proxy_before_committing_fenced_state(
     )
     assert runtime.services == {"app-blue", "api-proxy"}
     assert config.state_file.read_text(encoding="utf-8") == "standby\n"
+
+
+def test_primary_repairs_proxy_slot_drift_and_fences_extra_app(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.active_slot_file.write_text("green\n", encoding="utf-8")
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    upstream = tmp_path / "api-proxy" / "upstream.conf"
+    upstream.parent.mkdir()
+    upstream.write_text("proxy_pass http://app-blue:8000;\n", encoding="utf-8")
+    runtime = _Runtime("app-blue", "app-green", "api-proxy")
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda _config, _boundary: None,
+    )
+
+    def wait_scheduler(_config):
+        assert "app-blue" not in runtime.services
+        assert upstream.read_text(encoding="utf-8") == (
+            "proxy_pass http://app-green:8000;\n"
+        )
+
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_wait_scheduler_running",
+        wait_scheduler,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_wait_ready",
+        lambda _config: None,
+    )
+
+    assert reconcile(config, "primary") is True
+    assert ("restart", "api-proxy") in runtime.calls
+    assert ("rm", "--stop", "--force", "app-blue") in runtime.calls
+    assert runtime.services == {"app-green", "api-proxy"}
+
+
+def test_primary_defers_proxy_drift_repair_while_deploy_lock_is_busy(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.active_slot_file.write_text("green\n", encoding="utf-8")
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    upstream = tmp_path / "api-proxy" / "upstream.conf"
+    upstream.parent.mkdir()
+    upstream.write_text("proxy_pass http://app-blue:8000;\n", encoding="utf-8")
+    runtime = _Runtime("app-blue", "app-green", "api-proxy")
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+
+    with config.deploy_lock.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        assert reconcile(config, "primary") is False
+
+    assert upstream.read_text(encoding="utf-8") == (
+        "proxy_pass http://app-blue:8000;\n"
+    )
+    assert runtime.services == {"app-blue", "app-green", "api-proxy"}


### PR DESCRIPTION
## Что изменено

- Role-agent теперь сопоставляет `.active-api-slot`, реально запущенные API-контейнеры и upstream контейнерного nginx.
- При рассинхронизации на primary агент под deploy-lock восстанавливает правильный upstream, обновляет proxy, останавливает лишний цвет и ждёт фактического захвата scheduler runtime активным контейнером.
- Перед изменением маршрутизации повторно доказывается актуальная роль Patroni primary.
- Финальная проверка агента требует ровно один активный API-контейнер и совпадающий proxy upstream.
- Production replication check теперь отдельно сообщает неверный slot, два одновременно работающих цвета и drift upstream, вместо косвенной ошибки `scheduler_runtime=waiting_lock`.

## Причина

После blue/green-операции `/opt/mvn-reserve/.active-api-slot` указывал на `green`, nginx продолжал направлять readiness в `blue`, а оба контейнера оставались запущены. Scheduler корректно принадлежал `green`, но HA-проверка видела `blue` со статусом `waiting_lock`.

## Эффект

Повтор такой рассинхронизации будет не только диагностирован точным сообщением, но и автоматически исправлен role-agent без вмешательства в PostgreSQL, Patroni или belzakupki.

## Проверки

- `pytest tests/unit -q`: 2284 passed, 4 skipped
- HA/Patroni subset: 335 passed
- `py_compile` изменённых HA-скриптов
- `git diff --check`
- После оперативного исправления production workflow `PostgreSQL Replication Check` успешно прошёл: run 30068761981
