### PR TITLE
Allow isolated logical restore drill on standby

### DIFF
--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -49,6 +49,7 @@ except ModuleNotFoundError:
 
 
 OPERATION_GUARD_PATH = Path("/usr/local/sbin/mvn_postgres_pitr_operation_guard.py")
+PITR_OPERATION_RECORD_ROOT = Path("/run/mvn-postgres-pitr-operations")
 COMMAND_TIMEOUT_SECONDS = 60
 EXPECTED_LOCAL_PATRONI_URL = "http://127.0.0.1:8008/patroni"
 EXPECTED_PATRONI_SCOPE = "mvn-postgres"
@@ -300,7 +301,7 @@ def _stop_service_verified(config: AgentConfig, service: str) -> None:
 
 
 def _cancel_pitr_operations(config: AgentConfig) -> list[str]:
-    if not Path("/run/mvn-postgres-pitr-operations").exists():
+    if not PITR_OPERATION_RECORD_ROOT.exists():
         return []
     try:
         from scripts.ha.pitr_operation_guard import cancel_project_operations
@@ -317,7 +318,13 @@ def _cancel_pitr_operations(config: AgentConfig) -> list[str]:
         sys.modules[specification.name] = module
         specification.loader.exec_module(module)
         cancel_project_operations = module.cancel_project_operations
-    return cancel_project_operations(str(config.project_dir))
+    # A logical restore drill only reads the managed database identity and
+    # restores into an isolated temporary PostgreSQL container. It is safe to
+    # keep running on a standby. Every mutating PITR phase remains fenced.
+    return cancel_project_operations(
+        str(config.project_dir),
+        preserve_standby_safe=True,
+    )
 
 
 def _systemd_units_match(config: AgentConfig, role: str) -> bool:

--- a/scripts/ha/pitr_operation_guard.py
+++ b/scripts/ha/pitr_operation_guard.py
@@ -44,6 +44,7 @@ SCHEDULED_UNITS = {
     "mvn-postgres-wal-upload.service",
     "mvn-postgres-basebackup.service",
 }
+STANDBY_SAFE_PHASES = frozenset({"logical-restore-drill"})
 CLEAN_ENV = {
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "HOME": "/root",
@@ -458,11 +459,17 @@ def finalize_record(record: OperationRecord, *, timeout: float = 5) -> None:
     raise RuntimeError("completed PITR operation left a live process group or unit")
 
 
-def cancel_project_operations(project_dir: str) -> list[str]:
+def cancel_project_operations(
+    project_dir: str,
+    *,
+    preserve_standby_safe: bool = False,
+) -> list[str]:
     if project_dir not in ALLOWED_PROJECT_DIRS:
         raise RuntimeError("unreviewed project directory for PITR cancellation")
     cancelled: list[str] = []
     for record in list_records(project_dir=project_dir):
+        if preserve_standby_safe and record.phase in STANDBY_SAFE_PHASES:
+            continue
         terminate_record(record)
         cancelled.append(record.operation_id)
     return cancelled

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ha import patroni_role_agent
+from scripts.ha import pitr_operation_guard
 from scripts.ha.patroni_role_agent import (
     AgentConfig,
     app_service,
@@ -123,6 +124,27 @@ def test_app_service_follows_blue_green_slot(tmp_path):
 
 def test_app_service_override_supports_in_place_standby(tmp_path):
     assert app_service(_config(tmp_path, app_service_override="app")) == "app"
+
+
+def test_role_agent_preserves_standby_safe_pitr_operations(tmp_path, monkeypatch):
+    record_root = tmp_path / "operations"
+    record_root.mkdir()
+    calls = []
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "PITR_OPERATION_RECORD_ROOT",
+        record_root,
+    )
+
+    def cancel(project_dir, *, preserve_standby_safe=False):
+        calls.append((project_dir, preserve_standby_safe))
+        return []
+
+    monkeypatch.setattr(pitr_operation_guard, "cancel_project_operations", cancel)
+
+    config = _config(tmp_path)
+    assert patroni_role_agent._cancel_pitr_operations(config) == []
+    assert calls == [(str(tmp_path), True)]
 
 
 class _ComposeRuntime:

--- a/tests/unit/test_pitr_operation_guard.py
+++ b/tests/unit/test_pitr_operation_guard.py
@@ -3,6 +3,7 @@ import shlex
 import subprocess
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -201,6 +202,56 @@ def test_reconcile_project_refuses_active_or_ambiguous_record(monkeypatch):
 
     with pytest.raises(RuntimeError, match="active PITR operation"):
         guard.reconcile_project_operations("/opt/air-api")
+
+
+def test_cancel_project_operations_preserves_only_standby_safe_drill(monkeypatch):
+    mutating = _record()
+    logical = replace(
+        _record(),
+        operation_id="b" * 32,
+        phase="logical-restore-drill",
+        command="/usr/local/sbin/mvn-restore-drill-latest-db",
+        unit="mvn-postgres-pitr-manual-" + "b" * 32 + ".service",
+    )
+    terminated = []
+    monkeypatch.setattr(
+        guard,
+        "list_records",
+        lambda **_kwargs: [mutating, logical],
+    )
+    monkeypatch.setattr(
+        guard,
+        "terminate_record",
+        lambda record: terminated.append(record.operation_id),
+    )
+
+    cancelled = guard.cancel_project_operations(
+        "/opt/air-api",
+        preserve_standby_safe=True,
+    )
+
+    assert cancelled == [mutating.operation_id]
+    assert terminated == [mutating.operation_id]
+
+
+def test_cancel_project_operations_defaults_to_fencing_all_phases(monkeypatch):
+    logical = replace(
+        _record(),
+        phase="logical-restore-drill",
+        command="/usr/local/sbin/mvn-restore-drill-latest-db",
+    )
+    terminated = []
+    monkeypatch.setattr(guard, "list_records", lambda **_kwargs: [logical])
+    monkeypatch.setattr(
+        guard,
+        "terminate_record",
+        lambda record: terminated.append(record.operation_id),
+    )
+
+    cancelled = guard.cancel_project_operations("/opt/air-api")
+
+    assert cancelled == [logical.operation_id]
+    assert terminated == [logical.operation_id]
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="PDEATHSIG is Linux-specific")


### PR DESCRIPTION
## Что исправлено

- защитный Patroni-агент теперь сохраняет только безопасную операцию logical-restore-drill на резервном узле
- все изменяющие PostgreSQL PITR-операции по-прежнему немедленно останавливаются при standby/demotion
- обычные административные процедуры сохраняют прежнее поведение и отменяют все операции
- добавлены тесты обоих fail-closed сценариев

## Проверки

- pytest tests/unit -q: 2294 passed, 4 skipped
- целевой PITR/Patroni набор: 111 passed, 3 skipped
- git diff --check

Причина сбоя подтверждена журналом standby: роль-агент вызывал cancel_pitr_prelock через несколько секунд после запуска изолированной logical restore drill. Изменение не ослабляет fencing для операций, способных менять production PostgreSQL.