### PR TITLE
Keep standby restore drill compatible with current agent

### DIFF
--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -49,7 +49,6 @@ except ModuleNotFoundError:
 
 
 OPERATION_GUARD_PATH = Path("/usr/local/sbin/mvn_postgres_pitr_operation_guard.py")
-PITR_OPERATION_RECORD_ROOT = Path("/run/mvn-postgres-pitr-operations")
 COMMAND_TIMEOUT_SECONDS = 60
 EXPECTED_LOCAL_PATRONI_URL = "http://127.0.0.1:8008/patroni"
 EXPECTED_PATRONI_SCOPE = "mvn-postgres"
@@ -301,7 +300,7 @@ def _stop_service_verified(config: AgentConfig, service: str) -> None:
 
 
 def _cancel_pitr_operations(config: AgentConfig) -> list[str]:
-    if not PITR_OPERATION_RECORD_ROOT.exists():
+    if not Path("/run/mvn-postgres-pitr-operations").exists():
         return []
     try:
         from scripts.ha.pitr_operation_guard import cancel_project_operations
@@ -318,13 +317,7 @@ def _cancel_pitr_operations(config: AgentConfig) -> list[str]:
         sys.modules[specification.name] = module
         specification.loader.exec_module(module)
         cancel_project_operations = module.cancel_project_operations
-    # A logical restore drill only reads the managed database identity and
-    # restores into an isolated temporary PostgreSQL container. It is safe to
-    # keep running on a standby. Every mutating PITR phase remains fenced.
-    return cancel_project_operations(
-        str(config.project_dir),
-        preserve_standby_safe=True,
-    )
+    return cancel_project_operations(str(config.project_dir))
 
 
 def _systemd_units_match(config: AgentConfig, role: str) -> bool:

--- a/scripts/ha/pitr_operation_guard.py
+++ b/scripts/ha/pitr_operation_guard.py
@@ -459,10 +459,10 @@ def finalize_record(record: OperationRecord, *, timeout: float = 5) -> None:
     raise RuntimeError("completed PITR operation left a live process group or unit")
 
 
-def cancel_project_operations(
+def _cancel_project_operations(
     project_dir: str,
     *,
-    preserve_standby_safe: bool = False,
+    preserve_standby_safe: bool,
 ) -> list[str]:
     if project_dir not in ALLOWED_PROJECT_DIRS:
         raise RuntimeError("unreviewed project directory for PITR cancellation")
@@ -473,6 +473,24 @@ def cancel_project_operations(
         terminate_record(record)
         cancelled.append(record.operation_id)
     return cancelled
+
+
+def cancel_project_operations(project_dir: str) -> list[str]:
+    """Fence mutating work while preserving a standby-safe logical drill."""
+
+    return _cancel_project_operations(
+        project_dir,
+        preserve_standby_safe=True,
+    )
+
+
+def cancel_all_project_operations(project_dir: str) -> list[str]:
+    """Cancel every operation for exclusive administrative maintenance."""
+
+    return _cancel_project_operations(
+        project_dir,
+        preserve_standby_safe=False,
+    )
 
 
 def reconcile_project_operations(project_dir: str) -> list[str]:

--- a/scripts/ha/pitr_role_agent_remote_executor.py
+++ b/scripts/ha/pitr_role_agent_remote_executor.py
@@ -338,7 +338,7 @@ def drain_operations(project_dir, transaction_id, guard, *, wait_seconds=10):
     try:
         guard.reconcile_project_operations(project_dir)
     except RuntimeError:
-        guard.cancel_project_operations(project_dir)
+        guard.cancel_all_project_operations(project_dir)
         guard.reconcile_project_operations(project_dir)
     if guard.list_records(project_dir=project_dir):
         raise RuntimeError("PITR operation records remained after bounded cleanup")

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ha import patroni_role_agent
-from scripts.ha import pitr_operation_guard
 from scripts.ha.patroni_role_agent import (
     AgentConfig,
     app_service,
@@ -124,27 +123,6 @@ def test_app_service_follows_blue_green_slot(tmp_path):
 
 def test_app_service_override_supports_in_place_standby(tmp_path):
     assert app_service(_config(tmp_path, app_service_override="app")) == "app"
-
-
-def test_role_agent_preserves_standby_safe_pitr_operations(tmp_path, monkeypatch):
-    record_root = tmp_path / "operations"
-    record_root.mkdir()
-    calls = []
-    monkeypatch.setattr(
-        patroni_role_agent,
-        "PITR_OPERATION_RECORD_ROOT",
-        record_root,
-    )
-
-    def cancel(project_dir, *, preserve_standby_safe=False):
-        calls.append((project_dir, preserve_standby_safe))
-        return []
-
-    monkeypatch.setattr(pitr_operation_guard, "cancel_project_operations", cancel)
-
-    config = _config(tmp_path)
-    assert patroni_role_agent._cancel_pitr_operations(config) == []
-    assert calls == [(str(tmp_path), True)]
 
 
 class _ComposeRuntime:

--- a/tests/unit/test_pitr_operation_guard.py
+++ b/tests/unit/test_pitr_operation_guard.py
@@ -225,16 +225,13 @@ def test_cancel_project_operations_preserves_only_standby_safe_drill(monkeypatch
         lambda record: terminated.append(record.operation_id),
     )
 
-    cancelled = guard.cancel_project_operations(
-        "/opt/air-api",
-        preserve_standby_safe=True,
-    )
+    cancelled = guard.cancel_project_operations("/opt/air-api")
 
     assert cancelled == [mutating.operation_id]
     assert terminated == [mutating.operation_id]
 
 
-def test_cancel_project_operations_defaults_to_fencing_all_phases(monkeypatch):
+def test_cancel_all_project_operations_fences_every_phase(monkeypatch):
     logical = replace(
         _record(),
         phase="logical-restore-drill",
@@ -248,7 +245,7 @@ def test_cancel_project_operations_defaults_to_fencing_all_phases(monkeypatch):
         lambda record: terminated.append(record.operation_id),
     )
 
-    cancelled = guard.cancel_project_operations("/opt/air-api")
+    cancelled = guard.cancel_all_project_operations("/opt/air-api")
 
     assert cancelled == [logical.operation_id]
     assert terminated == [logical.operation_id]

--- a/tests/unit/test_pitr_role_agent_state_machine.py
+++ b/tests/unit/test_pitr_role_agent_state_machine.py
@@ -24,7 +24,7 @@ def test_role_agent_executor_keeps_quiesce_fenced_and_resume_fail_closed():
     assert 'unit_state("is-active") != "inactive"' in source
     assert 'unit_state("is-enabled") != "disabled"' in source
     assert "role_agent._fence_lost_primary(config)" in source
-    assert "guard.cancel_project_operations(project_dir)" in source
+    assert "guard.cancel_all_project_operations(project_dir)" in source
     assert "execute_attested_module" in source
     assert "sources[OPERATION_GUARD_PATH]" in source
     assert '["/usr/bin/systemctl", "restart", ROLE_AGENT_UNIT]' in source
@@ -93,7 +93,7 @@ def test_record_drain_waits_then_reaps_and_cancels_via_attested_guard():
             if self.records:
                 raise RuntimeError("active")
 
-        def cancel_project_operations(self, _project):
+        def cancel_all_project_operations(self, _project):
             events.append("cancel")
             self.records.clear()
 
@@ -119,7 +119,7 @@ def test_record_drain_never_reaps_or_cancels_a_foreign_transaction():
         def reconcile_project_operations(self, _project):
             events.append("reconcile")
 
-        def cancel_project_operations(self, _project):
+        def cancel_all_project_operations(self, _project):
             events.append("cancel")
 
     with pytest.raises(RuntimeError, match="foreign PITR operation"):


### PR DESCRIPTION
## Итог

- безопасная logical restore drill теперь сохраняется самим root-owned operation guard по умолчанию
- установленное поколение Patroni role agent получает исправление без отдельного рискованного rollout
- эксклюзивное административное обслуживание использует отдельный cancel_all_project_operations и по-прежнему останавливает вообще все PITR-операции
- откатывается переходная зависимость от одновременного обновления role-agent файла

## Почему

PR #842 исправил поведение нового исходника агента, но host-side role agent обновляется отдельным протоколом и на серверах оставалось предыдущее поколение. Общий guard уже входит в атомарный PITR release bundle, поэтому совместимый контракт должен находиться именно там.

## Проверки

- 151 passed, 3 skipped в расширенном PITR/Patroni наборе
- compileall для изменённых Python-модулей
- git diff --check
- официальная двухузловая PITR-транзакция 1c62e23a3059363f1c7b254e1ec752af завершена успешно после совместимого resume; физическое восстановление подтвердило 92 таблицы и критические данные.