### PR TITLE
Preserve PITR guard rolling compatibility

### DIFF
--- a/scripts/ha/pitr_operation_guard.py
+++ b/scripts/ha/pitr_operation_guard.py
@@ -475,12 +475,16 @@ def _cancel_project_operations(
     return cancelled
 
 
-def cancel_project_operations(project_dir: str) -> list[str]:
+def cancel_project_operations(
+    project_dir: str,
+    *,
+    preserve_standby_safe: bool = True,
+) -> list[str]:
     """Fence mutating work while preserving a standby-safe logical drill."""
 
     return _cancel_project_operations(
         project_dir,
-        preserve_standby_safe=True,
+        preserve_standby_safe=preserve_standby_safe,
     )
 
 

--- a/tests/unit/test_pitr_operation_guard.py
+++ b/tests/unit/test_pitr_operation_guard.py
@@ -251,6 +251,31 @@ def test_cancel_all_project_operations_fences_every_phase(monkeypatch):
     assert terminated == [logical.operation_id]
 
 
+def test_cancel_project_operations_accepts_explicit_safe_rolling_contract(
+    monkeypatch,
+):
+    logical = replace(
+        _record(),
+        phase="logical-restore-drill",
+        command="/usr/local/sbin/mvn-restore-drill-latest-db",
+    )
+    terminated = []
+    monkeypatch.setattr(guard, "list_records", lambda **_kwargs: [logical])
+    monkeypatch.setattr(
+        guard,
+        "terminate_record",
+        lambda record: terminated.append(record.operation_id),
+    )
+
+    cancelled = guard.cancel_project_operations(
+        "/opt/air-api",
+        preserve_standby_safe=True,
+    )
+
+    assert cancelled == []
+    assert terminated == []
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="PDEATHSIG is Linux-specific")
 @pytest.mark.parametrize("release_barrier", [False, True])
 def test_parent_death_never_leaves_the_guarded_payload_running(


### PR DESCRIPTION
## Итог

- standby-safe cancellation keeps the keyword contract used by the #842 role-agent generation
- default remains safe for the older generation and preserves only logical-restore-drill
- exclusive administrative cancellation remains cancel_all_project_operations and still fences every phase
- добавлен отдельный regression test переходного контракта

## Проверки

- 152 passed, 3 skipped в расширенном PITR/Patroni наборе
- Python compileall
- git diff --check

Это закрывает rolling window, когда root-owned guard уже обновлён, а systemd role-agent ещё работает на предыдущем протестированном поколении.