### PR TITLE
feat: add dormant communications worker HA contract

### DIFF
--- a/.github/workflows/deploy-api-patroni.yml
+++ b/.github/workflows/deploy-api-patroni.yml
@@ -252,7 +252,7 @@ jobs:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
-        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
 
   deploy-replica-api:
     if: ${{ needs.validate-topology.outputs.primary_node == 'reserve' }}
@@ -283,7 +283,7 @@ jobs:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
-        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
 
   deploy-primary-api:
     if: ${{ needs.validate-topology.outputs.primary_node == 'api' }}
@@ -315,7 +315,7 @@ jobs:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
-        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
 
   deploy-primary-reserve:
     if: ${{ needs.validate-topology.outputs.primary_node == 'reserve' }}
@@ -347,7 +347,7 @@ jobs:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
           BOT_VOICE_TRANSCRIPTION_API_KEY: ${{ secrets.BOT_VOICE_TRANSCRIPTION_API_KEY }}
           BACKEND_IMAGE: ${{ needs.build-backend.outputs.backend_image }}
-        run: bash scripts/ha/run_patroni_node_remote.sh deploy
+        run: bash scripts/ha/run_patroni_node_remote.sh deploy && bash scripts/ha/run_patroni_node_remote.sh verify
 
   deployment-complete:
     if: ${{ always() }}
@@ -372,4 +372,4 @@ jobs:
             echo "::error::No validated Patroni primary branch completed"
             exit 1
           fi
-          echo "Patroni-aware API release completed through ${PRIMARY_NODE}"
+          echo "Patroni-aware API and dormant worker release verified on both nodes through ${PRIMARY_NODE}"

--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -86,6 +86,23 @@ services:
     ports:
       - "127.0.0.1:18002:8000"
 
+  communications-worker:
+    image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+      - .ha-app-role.env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
+      ENVIRONMENT: production
+      COMMUNICATIONS_WORKER_ENABLED: "false"
+      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
+    command: python -m services.communications.runtime
+    mem_limit: ${MVN_PATRONI_COMMUNICATIONS_WORKER_MEMORY:-256m}
+
   bot:
     profiles: [legacy-bot]
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}

--- a/deploy/ha/patroni/mvn-patroni-role-agent.service
+++ b/deploy/ha/patroni/mvn-patroni-role-agent.service
@@ -4,6 +4,8 @@ Wants=network-online.target mvn-etcd-quorum.service
 After=network-online.target docker.service mvn-etcd-quorum.service
 Requires=docker.service
 ConditionPathExists=/usr/local/sbin/mvn-patroni-role-agent
+ConditionPathExists=/usr/local/sbin/patroni_compose_runtime.py
+ConditionPathExists=/usr/local/sbin/patroni_role_agent_config.py
 ConditionPathExists=/usr/local/sbin/patroni_local_identity.py
 ConditionPathExists=/etc/default/mvn-patroni-role-agent
 

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -93,6 +93,24 @@ services:
     ports:
       - "127.0.0.1:18002:8000"
 
+  communications-worker:
+    image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ${MVN_RESERVE_ENV_FILE:-.env}
+      - .ha-app-role.env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
+      ENVIRONMENT: production
+      COMMUNICATIONS_WORKER_ENABLED: "false"
+      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
+    command: python -m services.communications.runtime
+    mem_limit: ${MVN_RESERVE_COMMUNICATIONS_WORKER_MEMORY:-256m}
+    networks: [reserve]
+
   bot:
     profiles: [legacy-bot]
     image: ${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -39,8 +39,10 @@ networking so it can bind directly to each node's WireGuard address.
 - `scripts/ha/rehearse_patroni_failover.sh`: disposable failover/rejoin drill
   that can either build source locally or fail closed around one exact published
   `linux/amd64` digest and prove both running image IDs plus archive behavior;
-- `scripts/ha/patroni_role_agent.py` + `scripts/ha/patroni_local_identity.py`:
-  local API/scheduler/bot role reconciler with strict local DCS leader-lock proof.
+- `scripts/ha/patroni_role_agent.py` with its
+  `patroni_local_identity.py`, `patroni_role_agent_config.py`, and
+  `patroni_compose_runtime.py` siblings: local API/scheduler/bot role reconciler
+  with strict local DCS leader-lock proof.
 - `.github/workflows/patroni-failover-rehearsal.yml`: weekly source-only drill
   (`release_evidence=false`) plus manual exact-digest rehearsal and retained log.
 - `.github/workflows/publish-patroni-image.yml`: manual, CI-gated publication of
@@ -265,10 +267,14 @@ on the former primary.
 Install the agent only during the Patroni migration window:
 
 ```bash
-install -m 0755 scripts/ha/patroni_role_agent.py \
-  /usr/local/sbin/mvn-patroni-role-agent
 install -m 0644 scripts/ha/patroni_local_identity.py \
   /usr/local/sbin/patroni_local_identity.py
+install -m 0644 scripts/ha/patroni_role_agent_config.py \
+  /usr/local/sbin/patroni_role_agent_config.py
+install -m 0644 scripts/ha/patroni_compose_runtime.py \
+  /usr/local/sbin/patroni_compose_runtime.py
+install -m 0755 scripts/ha/patroni_role_agent.py \
+  /usr/local/sbin/mvn-patroni-role-agent
 install -m 0644 deploy/ha/patroni/mvn-patroni-role-agent.service \
   /etc/systemd/system/mvn-patroni-role-agent.service
 install -m 0600 deploy/ha/patroni/role-agent.env.example \
@@ -283,6 +289,38 @@ During a PITR host transaction, the installer owns the root-only regular file
 agent continues reconciling primary app/bot traffic while this marker is valid,
 but keeps all PITR timers and their services fenced. Unsafe marker metadata or
 content causes a full standby fence.
+
+### Communications Worker Phase 2A
+
+Both Patroni API nodes define `communications-worker` from the exact immutable
+`BACKEND_IMAGE` used by the API. It uses that node's local PostgreSQL service
+and the same role-resolved `.ha-app-role.env`; deploy and verification reject
+any image or `APP_ROLE` mismatch. During Phase 2A both delivery gates,
+`COMMUNICATIONS_WORKER_ENABLED` and `COMMUNICATIONS_WORKER_ALLOW_ALL_MODE`,
+must remain exactly `false`.
+
+The root-owned project marker
+`.ha-communications-worker-release-fenced` is a durable fail-closed latch.
+While it exists, including as a broken symlink, the role agent keeps the worker
+stopped. A release sets the latch before stopping or replacing the worker,
+clears it only under the deployment lock immediately before a controlled
+start, and latches it again on any failed start or verification. Rollback
+restores both the previous marker state and the previous worker running state;
+it never starts a worker that was already fenced.
+
+After each node deploy, the verifier proves the canonical Compose file is a
+regular non-symlink, API/worker image parity, false delivery gates, the expected
+runtime role, a stable active role-agent unit, and an absent release latch. It
+then runs `/usr/local/sbin/mvn-patroni-role-agent --once`. A successful no-op
+or reconciliation must end with exactly:
+
+```text
+patroni_role_agent_once_status=verified role=<primary|standby>
+```
+
+Do not enable either delivery gate manually during Phase 2A. Delivery
+activation, token ownership, retry/ack canaries, and accumulated-event policy
+belong to the separately approved Phase 2B transaction.
 
 ## Production Cutover
 

--- a/scripts/ha/communications_worker_release_contract.sh
+++ b/scripts/ha/communications_worker_release_contract.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# Shell library. The caller owns COMPOSE, BACKEND_IMAGE and
+# COMMUNICATIONS_WORKER_SERVICE.
+
+COMMUNICATIONS_WORKER_FENCE_MARKER="${COMMUNICATIONS_WORKER_FENCE_MARKER:-${PROJECT_DIR}/.ha-communications-worker-release-fenced}"
+
+communications_worker_require_safe_fence_marker() {
+  [[ ! -e "${COMMUNICATIONS_WORKER_FENCE_MARKER}" \
+    && ! -L "${COMMUNICATIONS_WORKER_FENCE_MARKER}" ]] && return 0
+  python3 - "${COMMUNICATIONS_WORKER_FENCE_MARKER}" <<'PY'
+import os
+import stat
+import sys
+
+metadata = os.lstat(sys.argv[1])
+if (
+    not stat.S_ISREG(metadata.st_mode)
+    or stat.S_ISLNK(metadata.st_mode)
+    or metadata.st_uid != os.geteuid()
+    or metadata.st_nlink != 1
+    or metadata.st_mode & 0o077
+):
+    raise SystemExit("communications worker release fence metadata is unsafe")
+PY
+}
+
+communications_worker_set_release_fence() {
+  local temporary=""
+  communications_worker_require_safe_fence_marker
+  temporary="$(mktemp "${COMMUNICATIONS_WORKER_FENCE_MARKER}.tmp.XXXXXX")"
+  if ! printf 'fenced\n' >"${temporary}" || ! chmod 0600 "${temporary}" \
+    || ! mv -f -- "${temporary}" "${COMMUNICATIONS_WORKER_FENCE_MARKER}"; then
+    rm -f -- "${temporary}"
+    return 1
+  fi
+}
+
+communications_worker_clear_release_fence() {
+  local lock_fd="${DEPLOY_LOCK_FD:-${API_DEPLOY_LOCK_FD:-}}"
+  [[ "${lock_fd}" == "9" ]] || {
+    echo "communications worker release fence requires deploy lock fd 9" >&2
+    return 1
+  }
+  communications_worker_require_safe_fence_marker
+  rm -f -- "${COMMUNICATIONS_WORKER_FENCE_MARKER}"
+}
+
+communications_worker_require_release_unfenced() {
+  if [[ -e "${COMMUNICATIONS_WORKER_FENCE_MARKER}" \
+    || -L "${COMMUNICATIONS_WORKER_FENCE_MARKER}" ]]; then
+    echo "communications worker release fence remains latched" >&2
+    return 1
+  fi
+}
+
+communications_worker_has_service() {
+  local services=""
+  services="$("${COMPOSE[@]}" config --services)" || {
+    echo "could not render compose services for communications worker" >&2
+    return 2
+  }
+  grep -Fxq "${COMMUNICATIONS_WORKER_SERVICE}" <<<"${services}" && return 0
+  return 3
+}
+
+communications_worker_require_contract() {
+  local service_status=0
+  communications_worker_has_service || service_status=$?
+  [[ "${service_status}" -eq 0 ]] || {
+    if [[ "${service_status}" -eq 3 ]]; then
+      echo "compose is missing ${COMMUNICATIONS_WORKER_SERVICE}" >&2
+    fi
+    return "${service_status}"
+  }
+  "${COMPOSE[@]}" config --format json \
+    | python3 -c '
+import json
+import sys
+
+service_name, expected_image = sys.argv[1:]
+payload = json.load(sys.stdin)
+service = (payload.get("services") or {}).get(service_name)
+if not isinstance(service, dict):
+    raise SystemExit("communications worker is absent from rendered compose")
+if service.get("image") != expected_image:
+    raise SystemExit("communications worker effective image differs from BACKEND_IMAGE")
+environment = service.get("environment") or {}
+if not isinstance(environment, dict):
+    raise SystemExit("communications worker environment is not a mapping")
+for key in (
+    "COMMUNICATIONS_WORKER_ENABLED",
+    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE",
+):
+    if str(environment.get(key, "")).lower() != "false":
+        raise SystemExit(f"{key} must remain false during Phase 2A")
+' "${COMMUNICATIONS_WORKER_SERVICE}" "${BACKEND_IMAGE}"
+}
+
+communications_worker_require_runtime() {
+  local expected_role="${1:-${EXPECTED_ROLE:-}}"
+  local container_ids=""
+  local runtime=""
+  communications_worker_require_release_unfenced
+  [[ "${expected_role}" == "primary" || "${expected_role}" == "standby" ]] || {
+    echo "communications worker runtime role expectation is invalid" >&2
+    return 1
+  }
+  container_ids="$("${COMPOSE[@]}" ps -q "${COMMUNICATIONS_WORKER_SERVICE}")"
+  [[ -n "${container_ids}" && "${container_ids}" != *$'\n'* ]] || {
+    echo "expected exactly one running communications worker container" >&2
+    return 1
+  }
+  runtime="$(docker inspect --format '{{.Config.Image}}|{{.State.Running}}' \
+    "${container_ids}")"
+  [[ "${runtime}" == "${BACKEND_IMAGE}|true" ]] || {
+    echo "communications worker runtime does not match BACKEND_IMAGE" >&2
+    return 1
+  }
+  if ! "${COMPOSE[@]}" exec -T "${COMMUNICATIONS_WORKER_SERVICE}" \
+    python3 -c '
+import os
+import sys
+
+expected_role = sys.argv[1]
+valid = (
+    os.environ.get("APP_ROLE") == expected_role
+    and os.environ.get("COMMUNICATIONS_WORKER_ENABLED", "").lower() == "false"
+    and os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE", "").lower() == "false"
+)
+raise SystemExit(0 if valid else 1)
+' "${expected_role}" >/dev/null; then
+    echo "communications worker runtime role or Phase 2A gates drifted" >&2
+    return 1
+  fi
+}
+
+communications_worker_start_controlled() {
+  local expected_role="$1"
+  communications_worker_clear_release_fence
+  if ! "${COMPOSE[@]}" up -d --no-deps --force-recreate \
+    "${COMMUNICATIONS_WORKER_SERVICE}" \
+    || ! communications_worker_require_runtime "${expected_role}"; then
+    communications_worker_set_release_fence || true
+    "${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null 2>&1 || true
+    return 1
+  fi
+}

--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -24,15 +24,26 @@ PREVIOUS_IMAGE_FILE="${PROJECT_DIR}/.previous-backend-image"
 ENV_FILE="${PROJECT_DIR}/.env"
 HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
 GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/../prepare_google_oauth_token_dir.sh}"
+COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
+COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/communications_worker_release_contract.sh}"
 
 previous_image=""
 active_service="app"
 env_updated=false
 TMP_DIR=""
+worker_supported=false
 
 log() {
   printf '[patroni-node-deploy][%s] %s\n' "$1" "$2"
 }
+
+[[ -f "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" \
+  && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" ]] || {
+  log error "communications worker release helper is missing or unsafe"
+  exit 1
+}
+# shellcheck disable=SC1090
+source "${COMMUNICATIONS_WORKER_RELEASE_HELPER}"
 
 if [[ "${API_DEPLOY_LOCK_ALREADY_HELD:-false}" == "true" && -z "${DEPLOY_LOCK_FD}" ]]; then
   log error "legacy deploy-lock boolean cannot replace an inherited descriptor"
@@ -93,6 +104,20 @@ write_backend_image() {
   mv "${temporary}" "${ENV_FILE}"
 }
 
+fence_communications_worker() {
+  [[ "${worker_supported}" == "true" ]] || return 0
+  communications_worker_set_release_fence
+  "${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null
+}
+
+deploy_communications_worker() {
+  communications_worker_require_contract
+  fence_communications_worker
+  "${COMPOSE[@]}" pull "${COMMUNICATIONS_WORKER_SERVICE}"
+  require_deploy_capacity
+  communications_worker_start_controlled "${EXPECTED_ROLE}"
+}
+
 wait_fenced_standby() {
   local health_file="${TMP_DIR}/health.json"
   local ready_file="${TMP_DIR}/ready.json"
@@ -142,11 +167,19 @@ rollback_standby() {
   local exit_code=$?
   trap - ERR
   set +e
-  if [[ "${env_updated}" == "true" && "${previous_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
-    log rollback "restoring ${previous_image} on ${active_service}"
+  if [[ "${previous_image}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]]; then
+    fence_communications_worker
     export BACKEND_IMAGE="${previous_image}"
-    write_backend_image "${previous_image}"
-    "${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
+    if [[ "${env_updated}" == "true" ]]; then
+      log rollback "restoring previous release on ${active_service}"
+      write_backend_image "${previous_image}"
+      "${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
+    fi
+    if [[ "${worker_supported}" == "true" ]]; then
+      if require_expected_role; then
+        communications_worker_start_controlled "${EXPECTED_ROLE}" || true
+      fi
+    fi
   fi
   "${COMPOSE[@]}" stop bot >/dev/null 2>&1 || true
   exit "${exit_code}"
@@ -243,7 +276,13 @@ if [[ "${EXPECTED_ROLE}" == "primary" ]]; then
     API_RUN_DEFAULTS=false \
     bash "${BLUE_GREEN_SCRIPT}"
   require_expected_role
-  log "done" "primary blue-green deployment completed"
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+  COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
+  worker_supported=true
+  deploy_communications_worker
+  require_expected_role
+  log "done" "primary API and dormant communications worker deployment completed"
   exit 0
 fi
 
@@ -258,22 +297,28 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
 export BACKEND_IMAGE
+worker_supported=true
 if [[ -n "${GHCR_PAT:-}" ]]; then
   printf '%s' "${GHCR_PAT}" | docker login ghcr.io -u "${GITHUB_ACTOR:-github-actions}" --password-stdin
 fi
 
 trap rollback_standby ERR
 reconcile_standby_proxy
+communications_worker_require_contract
 log standby "updating fenced service ${active_service}"
 "${COMPOSE[@]}" pull "${active_service}"
+"${COMPOSE[@]}" pull "${COMMUNICATIONS_WORKER_SERVICE}"
 require_deploy_capacity
+fence_communications_worker
 write_backend_image "${BACKEND_IMAGE}"
 env_updated=true
 "${COMPOSE[@]}" stop bot >/dev/null 2>&1 || true
 "${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
 require_expected_role
 wait_fenced_standby
+communications_worker_start_controlled "${EXPECTED_ROLE}"
+require_expected_role
 printf '%s\n' "${previous_image}" > "${PREVIOUS_IMAGE_FILE}"
 chmod 600 "${PREVIOUS_IMAGE_FILE}"
 trap - ERR
-log "done" "standby image updated without enabling traffic or singleton processes"
+log "done" "standby image updated without enabling traffic; dormant communications worker aligned"

--- a/scripts/ha/patroni_communications_candidate_lifecycle.sh
+++ b/scripts/ha/patroni_communications_candidate_lifecycle.sh
@@ -193,17 +193,18 @@ patroni_communications_fence_candidate() {
   communications_worker_set_release_fence
   if ! docker compose -f "${CANDIDATE_FILE}" --profile bluegreen \
     stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null; then
-    patroni_communications_force_fence_candidate_runtime
-    return
+    patroni_communications_force_fence_candidate_runtime || return 1
+    return 0
   fi
   if [[ "${PREVIOUS_WORKER_SUPPORTED}" != "true" ]]; then
     if ! docker compose -f "${CANDIDATE_FILE}" --profile bluegreen \
       rm -s -f "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null; then
-      patroni_communications_force_fence_candidate_runtime
-      return
+      patroni_communications_force_fence_candidate_runtime || return 1
+      return 0
     fi
-    patroni_communications_force_fence_candidate_runtime
+    patroni_communications_force_fence_candidate_runtime || return 1
   fi
+  return 0
 }
 
 patroni_communications_fence_canonical() {

--- a/scripts/ha/patroni_communications_candidate_lifecycle.sh
+++ b/scripts/ha/patroni_communications_candidate_lifecycle.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # lifecycle state is consumed by the sourcing caller
+
+# Shell library for the communications-worker portion of a Patroni candidate
+# transaction. The caller supplies the canonical/candidate paths and release
+# image globals.
+
+COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
+PREVIOUS_WORKER_SUPPORTED=false
+PREVIOUS_WORKER_RUNNING=false
+CANDIDATE_WORKER_SUPPORTED=false
+CANONICAL_WORKER_PROJECT=""
+CANDIDATE_WORKER_PROJECT=""
+PREVIOUS_WORKER_FENCE_MARKER_PRESENT=false
+
+patroni_communications_capture_release_fence() {
+  if [[ -e "${COMMUNICATIONS_WORKER_FENCE_MARKER}" \
+    || -L "${COMMUNICATIONS_WORKER_FENCE_MARKER}" ]]; then
+    PREVIOUS_WORKER_FENCE_MARKER_PRESENT=true
+  fi
+  communications_worker_require_safe_fence_marker
+}
+
+patroni_communications_restore_release_fence() {
+  if [[ "${PREVIOUS_WORKER_FENCE_MARKER_PRESENT}" == "true" ]]; then
+    communications_worker_set_release_fence
+  else
+    communications_worker_clear_release_fence
+  fi
+}
+
+patroni_communications_require_previous_fence_restored() {
+  [[ "${PREVIOUS_WORKER_FENCE_MARKER_PRESENT}" == "true" ]] || return 0
+  local running=""
+  if [[ "${PREVIOUS_WORKER_SUPPORTED}" == "true" ]]; then
+    running="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+      ps --status running -q "${COMMUNICATIONS_WORKER_SERVICE}")" || return 1
+  else
+    [[ -n "${CANONICAL_WORKER_PROJECT}" ]] || {
+      echo "canonical Compose project identity is unavailable" >&2
+      return 1
+    }
+    running="$(docker ps -a -q \
+      --filter "label=com.docker.compose.project=${CANONICAL_WORKER_PROJECT}" \
+      --filter "label=com.docker.compose.service=${COMMUNICATIONS_WORKER_SERVICE}")" \
+      || return 1
+  fi
+  [[ -z "${running}" ]] || {
+    echo "communications worker restarted under the restored release fence" >&2
+    return 1
+  }
+}
+
+patroni_communications_compose_project() {
+  local compose_file="$1"
+
+  docker compose -f "${compose_file}" --profile bluegreen \
+    config --format json \
+    | python3 -c '
+import json
+import re
+import sys
+
+name = (json.load(sys.stdin) or {}).get("name")
+if not isinstance(name, str) or re.fullmatch(r"[a-z0-9][a-z0-9_.-]{0,126}", name) is None:
+    raise SystemExit(1)
+print(name)
+'
+}
+
+patroni_communications_compose_has_worker() {
+  local compose_file="$1"
+  local service_status=0
+  # shellcheck disable=SC2034  # consumed by the release-contract helper
+  local -a COMPOSE=(docker compose -f "${compose_file}" --profile bluegreen)
+
+  communications_worker_has_service || service_status=$?
+  [[ "${service_status}" -ne 2 ]] || {
+    echo "could not establish communications worker service support" >&2
+    exit 86
+  }
+  [[ "${service_status}" -eq 0 ]]
+}
+
+patroni_communications_require_runtime() {
+  local compose_file="$1"
+  local expected_image="$2"
+
+  API_RECONCILE_OPERATION=verify \
+    API_DEPLOY_SERVICES="${COMMUNICATIONS_WORKER_SERVICE}" \
+    API_COMPOSE_FILE="$(basename "${compose_file}")" \
+    API_RECONCILE_BACKEND_IMAGE="${expected_image}" \
+    API_EXPECTED_PATRONI_ROLE="${EXPECTED_ROLE}" \
+    bash "${RECONCILE_SCRIPT}"
+}
+
+patroni_communications_capture_previous() {
+  local container_ids=""
+  local runtime=""
+
+  CANONICAL_WORKER_PROJECT="$(
+    patroni_communications_compose_project "${CANONICAL_FILE}"
+  )" || {
+    echo "canonical Compose project identity is invalid" >&2
+    return 1
+  }
+  patroni_communications_compose_has_worker "${CANONICAL_FILE}" || return 0
+  PREVIOUS_WORKER_SUPPORTED=true
+  local BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}"
+  # shellcheck disable=SC2034  # consumed by the release-contract helper
+  local -a COMPOSE=(
+    docker compose -f "${CANONICAL_FILE}" --profile bluegreen
+  )
+  export BACKEND_IMAGE
+  communications_worker_require_contract
+
+  if [[ "${PREVIOUS_WORKER_FENCE_MARKER_PRESENT}" == "true" ]]; then
+    container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+      ps --status running -q "${COMMUNICATIONS_WORKER_SERVICE}")"
+    [[ -z "${container_ids}" ]] || {
+      echo "latched communications worker release fence has a running worker" >&2
+      return 1
+    }
+    return 0
+  fi
+
+  container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+    ps -q "${COMMUNICATIONS_WORKER_SERVICE}")"
+  [[ -n "${container_ids}" && "${container_ids}" != *$'\n'* ]] || {
+    echo "previous communications worker runtime is ambiguous" >&2
+    return 1
+  }
+  runtime="$(docker inspect --format '{{.Config.Image}}|{{.State.Running}}' \
+    "${container_ids}")"
+  [[ "${runtime}" == "${PREVIOUS_BACKEND_IMAGE}|true" ]] || {
+    echo "previous communications worker is not aligned with the active API image" >&2
+    return 1
+  }
+  PREVIOUS_WORKER_RUNNING=true
+}
+
+patroni_communications_detect_candidate_support() {
+  CANDIDATE_WORKER_PROJECT="$(
+    patroni_communications_compose_project "${CANDIDATE_FILE}"
+  )" || {
+    echo "candidate communications worker Compose project is invalid" >&2
+    return 1
+  }
+  if patroni_communications_compose_has_worker "${CANDIDATE_FILE}"; then
+    CANDIDATE_WORKER_SUPPORTED=true
+  fi
+}
+
+patroni_communications_force_fence_candidate_runtime() {
+  [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]] || return 0
+  communications_worker_set_release_fence
+  [[ -n "${CANDIDATE_WORKER_PROJECT}" ]] || {
+    echo "candidate communications worker project identity is unavailable" >&2
+    return 1
+  }
+  local container_ids=""
+  local remaining=""
+  local container_id=""
+  local -a exact_ids=()
+
+  container_ids="$(docker ps -a -q \
+    --filter "label=com.docker.compose.project=${CANDIDATE_WORKER_PROJECT}" \
+    --filter "label=com.docker.compose.service=${COMMUNICATIONS_WORKER_SERVICE}")" \
+    || return 1
+  while IFS= read -r container_id; do
+    [[ -z "${container_id}" ]] && continue
+    [[ "${container_id}" =~ ^[0-9a-f]{12,64}$ ]] || {
+      echo "candidate communications worker container identity is invalid" >&2
+      return 1
+    }
+    exact_ids+=("${container_id}")
+  done <<<"${container_ids}"
+  if [[ "${#exact_ids[@]}" -gt 0 ]]; then
+    docker rm -f -- "${exact_ids[@]}" >/dev/null || return 1
+  fi
+  remaining="$(docker ps -a -q \
+    --filter "label=com.docker.compose.project=${CANDIDATE_WORKER_PROJECT}" \
+    --filter "label=com.docker.compose.service=${COMMUNICATIONS_WORKER_SERVICE}")" \
+    || return 1
+  [[ -z "${remaining}" ]] || {
+    echo "candidate communications worker remained after forced fence" >&2
+    return 1
+  }
+}
+
+patroni_communications_fence_candidate() {
+  [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]] || return 0
+  communications_worker_set_release_fence
+  if ! docker compose -f "${CANDIDATE_FILE}" --profile bluegreen \
+    stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null; then
+    patroni_communications_force_fence_candidate_runtime
+    return
+  fi
+  if [[ "${PREVIOUS_WORKER_SUPPORTED}" != "true" ]]; then
+    if ! docker compose -f "${CANDIDATE_FILE}" --profile bluegreen \
+      rm -s -f "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null; then
+      patroni_communications_force_fence_candidate_runtime
+      return
+    fi
+    patroni_communications_force_fence_candidate_runtime
+  fi
+}
+
+patroni_communications_fence_canonical() {
+  [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]] || return 0
+  communications_worker_set_release_fence
+  docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
+    stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null
+}

--- a/scripts/ha/patroni_compose_runtime.py
+++ b/scripts/ha/patroni_compose_runtime.py
@@ -1,0 +1,486 @@
+"""Docker Compose runtime operations used by the Patroni role agent."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Protocol
+
+try:
+    from scripts.ha.patroni_role_agent_config import (
+        APP_SERVICE_NAMES,
+        COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME,
+        CONTAINER_PROXY_SERVICE,
+        PRODUCTION_COMPOSE_PROJECT_NAMES,
+    )
+except ModuleNotFoundError:
+    from patroni_role_agent_config import (
+        APP_SERVICE_NAMES,
+        COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME,
+        CONTAINER_PROXY_SERVICE,
+        PRODUCTION_COMPOSE_PROJECT_NAMES,
+    )
+
+
+COMMAND_TIMEOUT_SECONDS = 60
+OPERATION_GUARD_PATH = Path("/usr/local/sbin/mvn_postgres_pitr_operation_guard.py")
+ComposeRunner = Callable[..., subprocess.CompletedProcess[str]]
+DockerRunner = Callable[..., subprocess.CompletedProcess[str]]
+AtomicWriter = Callable[..., None]
+CONTAINER_ID_PATTERN = re.compile(r"^[0-9a-f]{12,64}$")
+ServiceDefinitionProbe = Callable[..., bool]
+WorkerRoleProbe = Callable[..., bool]
+
+
+class RuntimeConfig(Protocol):
+    project_dir: Path
+    compose_file: str
+    ready_url: str
+    ready_attempts: int
+
+
+@dataclass(frozen=True)
+class WorkerRuntimeState:
+    defined: bool
+    running: bool
+    role_matches: bool
+    unsafe_mismatch: bool
+
+
+def run_compose(
+    config: RuntimeConfig,
+    *args: str,
+    check: bool = True,
+    timeout: int = COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        "docker",
+        "compose",
+        "--profile",
+        "bluegreen",
+        "-f",
+        config.compose_file,
+        *args,
+    ]
+    return subprocess.run(
+        command,
+        cwd=config.project_dir,
+        check=check,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def run_docker(
+    *args: str,
+    check: bool = True,
+    timeout: int = COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        check=check,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+class ComposeRuntime:
+    """Bound Compose operations with injectable command and file-write seams."""
+
+    def __init__(
+        self,
+        config: RuntimeConfig,
+        *,
+        compose_runner: ComposeRunner = run_compose,
+        docker_runner: DockerRunner = run_docker,
+        atomic_writer: AtomicWriter,
+    ) -> None:
+        self.config = config
+        self.compose_runner = compose_runner
+        self.docker_runner = docker_runner
+        self.atomic_writer = atomic_writer
+
+    def compose_project_name(self) -> str:
+        reviewed_name = PRODUCTION_COMPOSE_PROJECT_NAMES.get(
+            self.config.project_dir.resolve()
+        )
+        return reviewed_name or self.config.project_dir.name
+
+    def worker_release_fence_active(self) -> bool:
+        marker = (
+            self.config.project_dir
+            / COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME
+        )
+        return marker.exists() or marker.is_symlink()
+
+    def enforce_worker_release_fence(
+        self,
+        service: str,
+        *,
+        latched: bool = False,
+    ) -> bool:
+        active = latched or self.worker_release_fence_active()
+        if active:
+            self.fence_labeled_service_containers(service)
+        return active
+
+    def labeled_service_container_ids(self, service: str) -> tuple[str, ...]:
+        result = self.docker_runner(
+            "ps",
+            "--all",
+            "--quiet",
+            "--filter",
+            f"label=com.docker.compose.project={self.compose_project_name()}",
+            "--filter",
+            f"label=com.docker.compose.service={service}",
+            check=False,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout or "docker ps failed").strip()
+            raise RuntimeError(error)
+        container_ids = tuple(
+            value.strip() for value in result.stdout.splitlines() if value.strip()
+        )
+        if any(not CONTAINER_ID_PATTERN.fullmatch(value) for value in container_ids):
+            raise RuntimeError("docker ps returned an invalid container identity")
+        return container_ids
+
+    def fence_labeled_service_containers(self, service: str) -> bool:
+        """Remove only containers with this project's exact Compose service label."""
+
+        fenced = False
+        for _ in range(2):
+            container_ids = self.labeled_service_container_ids(service)
+            if not container_ids:
+                return fenced
+            fenced = True
+            for container_id in container_ids:
+                try:
+                    stopped = self.docker_runner(
+                        "stop",
+                        "--timeout",
+                        "10",
+                        container_id,
+                        check=False,
+                        timeout=20,
+                    )
+                except subprocess.TimeoutExpired:
+                    stopped = subprocess.CompletedProcess([], 1, "", "stop timed out")
+                if stopped.returncode != 0:
+                    try:
+                        self.docker_runner(
+                            "kill",
+                            "--signal",
+                            "SIGKILL",
+                            container_id,
+                            check=False,
+                            timeout=10,
+                        )
+                    except subprocess.TimeoutExpired:
+                        pass
+                try:
+                    self.docker_runner(
+                        "rm",
+                        "--force",
+                        container_id,
+                        check=False,
+                        timeout=20,
+                    )
+                except subprocess.TimeoutExpired:
+                    pass
+        remaining = self.labeled_service_container_ids(service)
+        if remaining:
+            raise RuntimeError(
+                f"could not fence labeled Compose service {service}: "
+                f"{len(remaining)} container(s) remain"
+            )
+        return fenced
+
+    def worker_runtime_state(
+        self,
+        *,
+        service: str,
+        role: str,
+        running_services: set[str],
+        definition_probe: ServiceDefinitionProbe,
+        role_probe: WorkerRoleProbe,
+        release_fenced: bool = False,
+    ) -> WorkerRuntimeState:
+        if release_fenced:
+            return WorkerRuntimeState(False, False, True, False)
+        try:
+            defined = definition_probe(
+                self.config,
+                service,
+                compose_runner=self.compose_runner,
+            )
+        except Exception:
+            self.fence_labeled_service_containers(service)
+            raise
+        running = service in running_services
+        if not defined:
+            # The candidate transaction starts the new service before atomically
+            # promoting its Compose file. The old canonical agent must ignore
+            # that same-project orphan during this bounded rollout window.
+            return WorkerRuntimeState(False, False, False, False)
+        if not running:
+            return WorkerRuntimeState(True, False, True, False)
+        try:
+            role_matches = role_probe(
+                self.config,
+                role,
+                compose_runner=self.compose_runner,
+            )
+        except Exception:
+            self.fence_labeled_service_containers(service)
+            return WorkerRuntimeState(True, False, False, True)
+        if not role_matches:
+            self.fence_labeled_service_containers(service)
+            return WorkerRuntimeState(True, False, False, True)
+        return WorkerRuntimeState(
+            True,
+            True,
+            True,
+            False,
+        )
+
+    def running_services(self) -> set[str]:
+        result = self.compose_runner(
+            self.config,
+            "ps",
+            "--status",
+            "running",
+            "--format",
+            "json",
+            check=False,
+        )
+        if result.returncode != 0:
+            error = (
+                result.stderr or result.stdout or "docker compose ps failed"
+            ).strip()
+            raise RuntimeError(error)
+        payload = result.stdout.strip()
+        if not payload:
+            return set()
+        try:
+            parsed = json.loads(payload)
+            records = parsed if isinstance(parsed, list) else [parsed]
+        except json.JSONDecodeError:
+            try:
+                records = [
+                    json.loads(line) for line in payload.splitlines() if line.strip()
+                ]
+            except json.JSONDecodeError as exc:
+                raise RuntimeError("docker compose ps returned invalid JSON") from exc
+
+        services: set[str] = set()
+        for record in records:
+            if not isinstance(record, dict):
+                raise RuntimeError("docker compose ps returned an invalid record")
+            service = record.get("Service")
+            labels = record.get("Labels", "")
+            if not isinstance(service, str) or not service:
+                raise RuntimeError("docker compose ps record is missing its service")
+            if isinstance(labels, dict):
+                oneoff = str(labels.get("com.docker.compose.oneoff", "")).lower()
+            elif isinstance(labels, str):
+                oneoff = next(
+                    (
+                        value.lower()
+                        for label in labels.split(",")
+                        if "=" in label
+                        for key, value in [label.split("=", 1)]
+                        if key == "com.docker.compose.oneoff"
+                    ),
+                    "",
+                )
+            else:
+                raise RuntimeError("docker compose ps record has invalid labels")
+            if oneoff not in {"true", "false"}:
+                raise RuntimeError(
+                    "docker compose ps record is missing its one-off identity"
+                )
+            if oneoff == "false":
+                services.add(service)
+        return services
+
+    def start_service(self, service: str, *, recreate: bool) -> None:
+        args = ["up", "-d", "--no-deps"]
+        if recreate:
+            args.append("--force-recreate")
+        args.append(service)
+        self.compose_runner(self.config, *args)
+
+    def refresh_container_proxy_dns(self, *, running_services: set[str]) -> bool:
+        """Refresh nginx's startup-time Docker DNS after an app changes."""
+
+        if CONTAINER_PROXY_SERVICE not in running_services:
+            return False
+        self.compose_runner(self.config, "restart", CONTAINER_PROXY_SERVICE)
+        return True
+
+    def proxy_upstream_path(self) -> Path:
+        return self.config.project_dir / "api-proxy" / "upstream.conf"
+
+    @staticmethod
+    def expected_proxy_upstream(service: str) -> str:
+        if service not in APP_SERVICE_NAMES:
+            raise ValueError(f"unsupported API app service: {service}")
+        return f"proxy_pass http://{service}:8000;\n"
+
+    def container_proxy_upstream_matches(
+        self,
+        service: str,
+        *,
+        running_services: set[str],
+    ) -> bool:
+        if CONTAINER_PROXY_SERVICE not in running_services:
+            return True
+        try:
+            current = self.proxy_upstream_path().read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            return False
+        return current == self.expected_proxy_upstream(service)
+
+    def reconcile_container_proxy_upstream(
+        self,
+        service: str,
+        *,
+        running_services: set[str],
+    ) -> bool:
+        if self.container_proxy_upstream_matches(
+            service,
+            running_services=running_services,
+        ):
+            return False
+        self.atomic_writer(
+            self.proxy_upstream_path(),
+            self.expected_proxy_upstream(service),
+            mode=0o644,
+        )
+        return True
+
+    def stop_service_verified(self, service: str) -> None:
+        error = ""
+        try:
+            removed = self.compose_runner(
+                self.config,
+                "rm",
+                "--stop",
+                "--force",
+                service,
+                check=False,
+                timeout=20,
+            )
+            error = (removed.stderr or removed.stdout).strip()
+        except subprocess.TimeoutExpired:
+            error = "container removal timed out"
+        try:
+            remaining = self.compose_runner(
+                self.config,
+                "ps",
+                "--all",
+                "--quiet",
+                service,
+                check=False,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            remaining = subprocess.CompletedProcess(
+                [], 1, "", "container inventory timed out"
+            )
+        if remaining.returncode == 0 and not remaining.stdout.strip():
+            return
+        try:
+            self.compose_runner(
+                self.config,
+                "kill",
+                "--signal",
+                "SIGKILL",
+                service,
+                check=False,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            forced = self.compose_runner(
+                self.config,
+                "rm",
+                "--force",
+                service,
+                check=False,
+                timeout=20,
+            )
+            error = (forced.stderr or forced.stdout or error).strip()
+        except subprocess.TimeoutExpired:
+            error = "forced container removal timed out"
+        final = self.compose_runner(
+            self.config,
+            "ps",
+            "--all",
+            "--quiet",
+            service,
+            check=False,
+            timeout=10,
+        )
+        if final.returncode != 0 or final.stdout.strip():
+            raise RuntimeError(
+                f"could not fence Compose service {service}: "
+                f"{error or 'container remains'}"
+            )
+
+
+def wait_scheduler_running(config: RuntimeConfig) -> None:
+    for _ in range(config.ready_attempts):
+        try:
+            with urllib.request.urlopen(config.ready_url, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            runtime = payload.get("scheduler_runtime")
+            if (
+                response.status == 200
+                and payload.get("api") == "ready"
+                and payload.get("database_writable") is True
+                and isinstance(runtime, dict)
+                and runtime.get("expected") is True
+                and runtime.get("status") == "running"
+            ):
+                return
+        except (OSError, ValueError, urllib.error.URLError):
+            pass
+        time.sleep(2)
+    raise RuntimeError(
+        f"primary scheduler did not acquire runtime ownership: {config.ready_url}"
+    )
+
+
+def cancel_pitr_operations(config: RuntimeConfig) -> list[str]:
+    if not Path("/run/mvn-postgres-pitr-operations").exists():
+        return []
+    try:
+        from scripts.ha.pitr_operation_guard import cancel_project_operations
+    except ModuleNotFoundError:
+        specification = importlib.util.spec_from_file_location(
+            "mvn_postgres_pitr_operation_guard",
+            OPERATION_GUARD_PATH,
+        )
+        if specification is None or specification.loader is None:
+            if Path("/run/mvn-postgres-pitr-operations").exists():
+                raise RuntimeError("PITR operation guard is unavailable")
+            return []
+        module = importlib.util.module_from_spec(specification)
+        sys.modules[specification.name] = module
+        specification.loader.exec_module(module)
+        cancel_project_operations = module.cancel_project_operations
+    return cancel_project_operations(str(config.project_dir))

--- a/scripts/ha/patroni_local_identity.py
+++ b/scripts/ha/patroni_local_identity.py
@@ -20,6 +20,7 @@ from typing import Any, Callable
 
 PRIMARY_ROLES = {"leader", "master", "primary"}
 REPLICA_ROLES = {"replica", "standby"}
+COMMUNICATIONS_WORKER_SERVICE = "communications-worker"
 EXPECTED_CLUSTER_NAMES = frozenset({"mvn-api", "zakup"})
 MAINTENANCE_MARKER_PATH = Path("/run/mvn-postgres-pitr-maintenance")
 MAINTENANCE_TRANSACTION_RE = re.compile(rb"[0-9a-f]{32}\n\Z")
@@ -90,6 +91,70 @@ def resolve_app_service(config: Any) -> str:
     except FileNotFoundError:
         slot = ""
     return f"app-{slot}" if slot in {"blue", "green"} else "app"
+
+
+def compose_service_is_defined(
+    config: Any,
+    service: str,
+    *,
+    compose_runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> bool:
+    """Probe the rendered Compose model for one exact service name.
+
+    This deliberately uses ``config --services`` instead of runtime inventory:
+    a stopped service is still part of the deployed topology. An absent service
+    is valid during a rolling role-agent-before-Compose upgrade.
+    """
+
+    result = compose_runner(config, "config", "--services", check=False, timeout=20)
+    if result.returncode != 0:
+        detail = (
+            result.stderr or result.stdout or "docker compose config failed"
+        ).strip()
+        raise RuntimeError(detail)
+    services = {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip()
+    }
+    if any(
+        "\x00" in name or any(character.isspace() for character in name)
+        for name in services
+    ):
+        raise RuntimeError("docker compose config returned an invalid service name")
+    return service in services
+
+
+def communications_worker_role_matches(
+    config: Any,
+    role: str,
+    *,
+    compose_runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> bool:
+    """Check the worker's effective APP_ROLE without reading or logging its env."""
+
+    if role not in {"primary", "standby"}:
+        raise ValueError(f"unsupported communications worker role: {role}")
+    probe = (
+        "import os,sys;"
+        "ok=os.environ.get('APP_ROLE')==sys.argv[1]"
+        " and os.environ.get('COMMUNICATIONS_WORKER_ENABLED')=='false'"
+        " and os.environ.get('COMMUNICATIONS_WORKER_ALLOW_ALL_MODE')=='false';"
+        "raise SystemExit(0 if ok else 1)"
+    )
+    result = compose_runner(
+        config,
+        "exec",
+        "-T",
+        COMMUNICATIONS_WORKER_SERVICE,
+        "python3",
+        "-c",
+        probe,
+        role,
+        check=False,
+        timeout=10,
+    )
+    return result.returncode == 0
 
 
 def wait_primary_ready(config: Any) -> None:

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -10,35 +10,48 @@ from __future__ import annotations
 
 import argparse
 import fcntl
-import importlib.util
-import json
-import os
-import subprocess
-import sys
 import time
-import urllib.error
-import urllib.request
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Callable
 
 try:
+    from scripts.ha.patroni_compose_runtime import (
+        ComposeRuntime,
+        cancel_pitr_operations,
+        run_compose,
+        run_docker,
+        wait_scheduler_running,
+    )
     from scripts.ha.patroni_local_identity import (
+        COMMUNICATIONS_WORKER_SERVICE,
         atomic_write as _atomic_write,
-        fetch_patroni_role,
-        integer_env as _integer,
+        compose_service_is_defined as _compose_service_is_defined,
+        communications_worker_role_matches as _communications_worker_role_matches,
         read_maintenance_transaction_id,
         reconcile_primary_systemd_units as _reconcile_systemd_units,
         render_role_env as role_env,
         resolve_app_service as app_service,
         systemd_units_match as _identity_systemd_units_match,
         wait_primary_ready as _wait_ready,
+    )
+    from scripts.ha.patroni_role_agent_config import (
+        APP_SERVICE_NAMES,
+        AgentConfig,
+        fetch_configured_patroni_role as _fetch_configured_patroni_role,
+        load_config,
     )
 except ModuleNotFoundError:
+    from patroni_compose_runtime import (
+        ComposeRuntime,
+        cancel_pitr_operations,
+        run_compose,
+        run_docker,
+        wait_scheduler_running,
+    )
     from patroni_local_identity import (
+        COMMUNICATIONS_WORKER_SERVICE,
         atomic_write as _atomic_write,
-        fetch_patroni_role,
-        integer_env as _integer,
+        compose_service_is_defined as _compose_service_is_defined,
+        communications_worker_role_matches as _communications_worker_role_matches,
         read_maintenance_transaction_id,
         reconcile_primary_systemd_units as _reconcile_systemd_units,
         render_role_env as role_env,
@@ -46,326 +59,31 @@ except ModuleNotFoundError:
         systemd_units_match as _identity_systemd_units_match,
         wait_primary_ready as _wait_ready,
     )
-
-
-OPERATION_GUARD_PATH = Path("/usr/local/sbin/mvn_postgres_pitr_operation_guard.py")
-COMMAND_TIMEOUT_SECONDS = 60
-EXPECTED_LOCAL_PATRONI_URL = "http://127.0.0.1:8008/patroni"
-EXPECTED_PATRONI_SCOPE = "mvn-postgres"
-DEFAULT_MAX_DCS_AGE_SECONDS = 20
-MAX_CONFIGURED_DCS_AGE_SECONDS = 20
-PRODUCTION_NODE_NAMES = {Path("/opt/air-api"): "mvn-api", Path("/opt/mvn-reserve"): "zakup"}
-REVIEWED_PRIMARY_SYSTEMD_UNITS = (
-    "mvn-postgres-wal-upload.timer",
-    "mvn-postgres-basebackup.timer",
-)
-APP_SERVICE_NAMES = ("app", "app-blue", "app-green")
-CONTAINER_PROXY_SERVICE = "api-proxy"
-
-
-@dataclass(frozen=True)
-class AgentConfig:
-    project_dir: Path
-    compose_file: str
-    patroni_url: str
-    patroni_scope: str
-    patroni_name: str
-    max_dcs_age_seconds: int
-    ready_url: str
-    app_role_env: Path
-    bot_role_env: Path
-    state_file: Path
-    deploy_lock: Path
-    active_slot_file: Path
-    app_service: str
-    primary_systemd_units: tuple[str, ...]
-    poll_seconds: int
-    promotion_delay_seconds: int
-    ready_attempts: int
-
-
-def load_config() -> AgentConfig:
-    project_dir = Path(os.getenv("HA_PROJECT_DIR", "/opt/air-api")).resolve()
-    compose_file = os.getenv("HA_COMPOSE_FILE", "docker-compose.prod.yml").strip()
-    patroni_url = os.getenv("HA_PATRONI_URL", EXPECTED_LOCAL_PATRONI_URL).rstrip("/")
-    if patroni_url != EXPECTED_LOCAL_PATRONI_URL:
-        raise ValueError(f"HA_PATRONI_URL must be {EXPECTED_LOCAL_PATRONI_URL}")
-    patroni_scope = os.getenv("HA_PATRONI_SCOPE", EXPECTED_PATRONI_SCOPE).strip()
-    if patroni_scope != EXPECTED_PATRONI_SCOPE:
-        raise ValueError(f"HA_PATRONI_SCOPE must be {EXPECTED_PATRONI_SCOPE}")
-    inferred_patroni_name = PRODUCTION_NODE_NAMES.get(project_dir, "")
-    patroni_name = os.getenv("HA_PATRONI_NAME", inferred_patroni_name).strip()
-    if not inferred_patroni_name:
-        raise ValueError(f"HA_PROJECT_DIR is not a reviewed Patroni node path: {project_dir}")
-    if patroni_name != inferred_patroni_name:
-        raise ValueError(
-            f"HA_PATRONI_NAME must be {inferred_patroni_name} for {project_dir}"
-        )
-    max_dcs_age_seconds = _integer(
-        "HA_PATRONI_MAX_DCS_AGE_SECONDS", DEFAULT_MAX_DCS_AGE_SECONDS
-    )
-    if max_dcs_age_seconds > MAX_CONFIGURED_DCS_AGE_SECONDS:
-        raise ValueError(
-            "HA_PATRONI_MAX_DCS_AGE_SECONDS must not exceed the reviewed 20s bound"
-        )
-    raw_units = os.getenv(
-        "HA_PRIMARY_SYSTEMD_UNITS", " ".join(REVIEWED_PRIMARY_SYSTEMD_UNITS)
-    )
-    primary_systemd_units = tuple(raw_units.split())
-    if primary_systemd_units != REVIEWED_PRIMARY_SYSTEMD_UNITS:
-        raise ValueError(
-            "HA_PRIMARY_SYSTEMD_UNITS must contain the exact reviewed PITR timers"
-        )
-    return AgentConfig(
-        project_dir=project_dir,
-        compose_file=compose_file,
-        patroni_url=patroni_url,
-        patroni_scope=patroni_scope,
-        patroni_name=patroni_name,
-        max_dcs_age_seconds=max_dcs_age_seconds,
-        ready_url=os.getenv("HA_READY_URL", "http://127.0.0.1:18080/api/ready"),
-        app_role_env=project_dir / ".ha-app-role.env",
-        bot_role_env=project_dir / ".ha-bot-role.env",
-        state_file=project_dir / ".ha-runtime-role",
-        deploy_lock=project_dir / ".deploy.lock",
-        active_slot_file=project_dir / ".active-api-slot",
-        app_service=os.getenv("HA_APP_SERVICE", "").strip(),
-        primary_systemd_units=primary_systemd_units,
-        poll_seconds=_integer("HA_ROLE_POLL_SECONDS", 3),
-        promotion_delay_seconds=_integer("HA_PROMOTION_DELAY_SECONDS", 8, minimum=0),
-        ready_attempts=_integer("HA_READY_ATTEMPTS", 30),
+    from patroni_role_agent_config import (
+        APP_SERVICE_NAMES,
+        AgentConfig,
+        fetch_configured_patroni_role as _fetch_configured_patroni_role,
+        load_config,
     )
 
 
-def _fetch_configured_patroni_role(config: AgentConfig) -> str:
-    return fetch_patroni_role(
-        config.patroni_url,
-        expected_name=config.patroni_name,
-        expected_scope=config.patroni_scope,
-        max_dcs_age_seconds=config.max_dcs_age_seconds,
-    )
+_run_compose = run_compose
+_run_docker = run_docker
+_wait_scheduler_running = wait_scheduler_running
+_cancel_pitr_operations = cancel_pitr_operations
 
 
-def _run_compose(
-    config: AgentConfig,
-    *args: str,
-    check: bool = True,
-    timeout: int = COMMAND_TIMEOUT_SECONDS,
-) -> subprocess.CompletedProcess[str]:
-    command = ["docker", "compose", "--profile", "bluegreen", "-f", config.compose_file, *args]
-    return subprocess.run(
-        command,
-        cwd=config.project_dir,
-        check=check,
-        text=True,
-        capture_output=True,
-        timeout=timeout,
+def _compose_runtime(config: AgentConfig) -> ComposeRuntime:
+    return ComposeRuntime(
+        config,
+        compose_runner=_run_compose,
+        docker_runner=_run_docker,
+        atomic_writer=_atomic_write,
     )
 
 
 def _running_services(config: AgentConfig) -> set[str]:
-    result = _run_compose(
-        config,
-        "ps",
-        "--status",
-        "running",
-        "--format",
-        "json",
-        check=False,
-    )
-    if result.returncode != 0:
-        error = (result.stderr or result.stdout or "docker compose ps failed").strip()
-        raise RuntimeError(error)
-    payload = result.stdout.strip()
-    if not payload:
-        return set()
-    try:
-        parsed = json.loads(payload)
-        records = parsed if isinstance(parsed, list) else [parsed]
-    except json.JSONDecodeError:
-        try:
-            records = [json.loads(line) for line in payload.splitlines() if line.strip()]
-        except json.JSONDecodeError as exc:
-            raise RuntimeError("docker compose ps returned invalid JSON") from exc
-
-    services: set[str] = set()
-    for record in records:
-        if not isinstance(record, dict):
-            raise RuntimeError("docker compose ps returned an invalid record")
-        service = record.get("Service")
-        labels = record.get("Labels", "")
-        if not isinstance(service, str) or not service:
-            raise RuntimeError("docker compose ps record is missing its service")
-        if isinstance(labels, dict):
-            oneoff = str(labels.get("com.docker.compose.oneoff", "")).lower()
-        elif isinstance(labels, str):
-            oneoff = next(
-                (
-                    value.lower()
-                    for label in labels.split(",")
-                    if "=" in label
-                    for key, value in [label.split("=", 1)]
-                    if key == "com.docker.compose.oneoff"
-                ),
-                "",
-            )
-        else:
-            raise RuntimeError("docker compose ps record has invalid labels")
-        if oneoff not in {"true", "false"}:
-            raise RuntimeError("docker compose ps record is missing its one-off identity")
-        if oneoff == "true":
-            continue
-        services.add(service)
-    return services
-
-
-def _start_service(config: AgentConfig, service: str, *, recreate: bool) -> None:
-    args = ["up", "-d", "--no-deps"]
-    if recreate:
-        args.append("--force-recreate")
-    args.append(service)
-    _run_compose(config, *args)
-
-
-def _refresh_container_proxy_dns(
-    config: AgentConfig,
-    *,
-    running_services: set[str],
-) -> bool:
-    """Refresh nginx's startup-time Docker DNS after an app container changes."""
-
-    if CONTAINER_PROXY_SERVICE not in running_services:
-        return False
-    _run_compose(config, "restart", CONTAINER_PROXY_SERVICE)
-    return True
-
-
-def _proxy_upstream_path(config: AgentConfig) -> Path:
-    return config.project_dir / "api-proxy" / "upstream.conf"
-
-
-def _expected_proxy_upstream(service: str) -> str:
-    if service not in APP_SERVICE_NAMES:
-        raise ValueError(f"unsupported API app service: {service}")
-    return f"proxy_pass http://{service}:8000;\n"
-
-
-def _container_proxy_upstream_matches(
-    config: AgentConfig,
-    service: str,
-    *,
-    running_services: set[str],
-) -> bool:
-    if CONTAINER_PROXY_SERVICE not in running_services:
-        return True
-    try:
-        current = _proxy_upstream_path(config).read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
-        return False
-    return current == _expected_proxy_upstream(service)
-
-
-def _reconcile_container_proxy_upstream(
-    config: AgentConfig,
-    service: str,
-    *,
-    running_services: set[str],
-) -> bool:
-    if _container_proxy_upstream_matches(
-        config,
-        service,
-        running_services=running_services,
-    ):
-        return False
-    _atomic_write(
-        _proxy_upstream_path(config),
-        _expected_proxy_upstream(service),
-        mode=0o644,
-    )
-    return True
-
-
-def _wait_scheduler_running(config: AgentConfig) -> None:
-    for _ in range(config.ready_attempts):
-        try:
-            with urllib.request.urlopen(config.ready_url, timeout=5) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-            runtime = payload.get("scheduler_runtime")
-            if (
-                response.status == 200
-                and payload.get("api") == "ready"
-                and payload.get("database_writable") is True
-                and isinstance(runtime, dict)
-                and runtime.get("expected") is True
-                and runtime.get("status") == "running"
-            ):
-                return
-        except (OSError, ValueError, urllib.error.URLError):
-            pass
-        time.sleep(2)
-    raise RuntimeError(
-        f"primary scheduler did not acquire runtime ownership: {config.ready_url}"
-    )
-
-
-def _stop_service_verified(config: AgentConfig, service: str) -> None:
-    error = ""
-    try:
-        removed = _run_compose(
-            config, "rm", "--stop", "--force", service, check=False, timeout=20
-        )
-        error = (removed.stderr or removed.stdout).strip()
-    except subprocess.TimeoutExpired:
-        error = "container removal timed out"
-    try:
-        remaining = _run_compose(
-            config, "ps", "--all", "--quiet", service, check=False, timeout=10
-        )
-    except subprocess.TimeoutExpired:
-        remaining = subprocess.CompletedProcess([], 1, "", "container inventory timed out")
-    if remaining.returncode == 0 and not remaining.stdout.strip():
-        return
-    try:
-        _run_compose(
-            config, "kill", "--signal", "SIGKILL", service, check=False, timeout=10
-        )
-    except subprocess.TimeoutExpired:
-        pass
-    try:
-        forced = _run_compose(
-            config, "rm", "--force", service, check=False, timeout=20
-        )
-        error = (forced.stderr or forced.stdout or error).strip()
-    except subprocess.TimeoutExpired:
-        error = "forced container removal timed out"
-    final = _run_compose(
-        config, "ps", "--all", "--quiet", service, check=False, timeout=10
-    )
-    if final.returncode != 0 or final.stdout.strip():
-        raise RuntimeError(
-            f"could not fence Compose service {service}: {error or 'container remains'}"
-        )
-
-
-def _cancel_pitr_operations(config: AgentConfig) -> list[str]:
-    if not Path("/run/mvn-postgres-pitr-operations").exists():
-        return []
-    try:
-        from scripts.ha.pitr_operation_guard import cancel_project_operations
-    except ModuleNotFoundError:
-        specification = importlib.util.spec_from_file_location(
-            "mvn_postgres_pitr_operation_guard",
-            OPERATION_GUARD_PATH,
-        )
-        if specification is None or specification.loader is None:
-            if Path("/run/mvn-postgres-pitr-operations").exists():
-                raise RuntimeError("PITR operation guard is unavailable")
-            return []
-        module = importlib.util.module_from_spec(specification)
-        sys.modules[specification.name] = module
-        specification.loader.exec_module(module)
-        cancel_project_operations = module.cancel_project_operations
-    return cancel_project_operations(str(config.project_dir))
+    return _compose_runtime(config).running_services()
 
 
 def _systemd_units_match(config: AgentConfig, role: str) -> bool:
@@ -389,6 +107,7 @@ def _reconcile_primary_systemd_units(
 def _fence_lost_primary(config: AgentConfig) -> None:
     """Best-effort immediate fence that does not wait for the deploy lock."""
 
+    compose = _compose_runtime(config)
     failures: list[str] = []
     fencing_state_persisted = False
     try:
@@ -399,6 +118,15 @@ def _fence_lost_primary(config: AgentConfig) -> None:
         fencing_state_persisted = True
     except Exception as exc:
         failures.append(f"state_fencing:{exc}")
+
+    try:
+        # This inventory bypasses rendered Compose entirely. During the first
+        # modular rollout the new service may be absent from the installed
+        # Compose file while an old-primary container still exists.
+        compose.fence_labeled_service_containers(COMMUNICATIONS_WORKER_SERVICE)
+    except Exception as exc:
+        failures.append(f"{COMMUNICATIONS_WORKER_SERVICE}:{exc}")
+
     standby_app = role_env("standby", bot_process=False)
     standby_bot = role_env("standby", bot_process=True)
     if fencing_state_persisted:
@@ -415,7 +143,7 @@ def _fence_lost_primary(config: AgentConfig) -> None:
     # started a side-effect owner between the failed identity check and fence.
     for service in ("bot", *APP_SERVICE_NAMES):
         try:
-            _stop_service_verified(config, service)
+            compose.stop_service_verified(service)
         except Exception as exc:
             failures.append(f"{service}:{exc}")
 
@@ -423,6 +151,12 @@ def _fence_lost_primary(config: AgentConfig) -> None:
         _cancel_pitr_operations(config)
     except Exception as exc:
         failures.append(f"pitr:{exc}")
+    try:
+        # Close the race with a concurrent candidate deployment immediately
+        # before touching primary-only systemd ownership.
+        compose.fence_labeled_service_containers(COMMUNICATIONS_WORKER_SERVICE)
+    except Exception as exc:
+        failures.append(f"{COMMUNICATIONS_WORKER_SERVICE}_postcondition:{exc}")
     try:
         _reconcile_primary_systemd_units(config, "standby")
     except Exception as exc:
@@ -486,7 +220,9 @@ def _guard_pitr_activation(config: AgentConfig, unit: str) -> None:
         )
 
 
-def reconcile(config: AgentConfig, role: str) -> bool:
+def reconcile(config: AgentConfig, role: str) -> bool | None:
+    compose = _compose_runtime(config)
+    release_fenced = compose.enforce_worker_release_fence(COMMUNICATIONS_WORKER_SERVICE)
     maintenance_transaction = _maintenance_transaction_or_fence(config)
     pitr_role = "standby" if maintenance_transaction is not None else role
     desired_app = role_env(role, bot_process=False)
@@ -514,13 +250,39 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         _fence_lost_primary(config)
         fast_fenced = True
     service = app_service(config)
-    running = _running_services(config)
+    running = compose.running_services()
+    release_fenced = compose.enforce_worker_release_fence(
+        COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
+    )
+    worker_state = compose.worker_runtime_state(
+        service=COMMUNICATIONS_WORKER_SERVICE,
+        role=role,
+        running_services=running,
+        definition_probe=_compose_service_is_defined,
+        role_probe=_communications_worker_role_matches,
+        release_fenced=release_fenced,
+    )
+    worker_defined = worker_state.defined
+    worker_running = worker_state.running
+    worker_role_matches = worker_state.role_matches
+    worker_role_drift = worker_state.unsafe_mismatch
+    if not worker_running:
+        running.discard(COMMUNICATIONS_WORKER_SERVICE)
+    if role == "standby" and worker_role_drift:
+        # A living worker with the old primary role is equivalent to a lost
+        # primary identity. Fence every local side-effect owner before the
+        # later systemd probes or deploy-lock acquisition.
+        _fence_lost_primary(config)
+        fast_fenced = True
+        running.difference_update(
+            {"bot", COMMUNICATIONS_WORKER_SERVICE, *APP_SERVICE_NAMES}
+        )
+        worker_running = False
     app_running = service in running
     extra_running_apps = sorted(
         name for name in APP_SERVICE_NAMES if name != service and name in running
     )
-    proxy_upstream_drift = not _container_proxy_upstream_matches(
-        config,
+    proxy_upstream_drift = not compose.container_proxy_upstream_matches(
         service,
         running_services=running,
     )
@@ -550,19 +312,27 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         reasons.append("proxy_upstream_drift")
     if bot_running:
         reasons.append("legacy_bot_running")
+    if worker_defined and not worker_running:
+        reasons.append("communications_worker_not_running")
+    if worker_role_drift:
+        reasons.append("communications_worker_role_drift")
     if not systemd_matches:
         reasons.append("systemd_units")
     if maintenance_transaction is not None:
         reasons.append("pitr_maintenance")
+    if release_fenced:
+        reasons.append("communications_worker_release_fenced")
 
     actions: list[str] = []
+    if release_fenced:
+        actions.append("fence_communications_worker_release")
     if fast_fenced:
         actions.append("demotion_fast_fence")
     if bot_running:
         # The polling process is owned by mvn-telegram-bot now. Fence the old
         # Compose service before the deployment lock so a concurrent API
         # release cannot prolong duplicate Telegram polling.
-        _stop_service_verified(config, "bot")
+        compose.stop_service_verified("bot")
         bot_running = False
         actions.append("stop_legacy_bot_prelock")
     if role == "standby":
@@ -583,7 +353,7 @@ def reconcile(config: AgentConfig, role: str) -> bool:
             or any(name != service for name in running_apps)
         ):
             for running_app in running_apps:
-                _stop_service_verified(config, running_app)
+                compose.stop_service_verified(running_app)
             app_running = False
             if running_apps:
                 actions.append("stop_apps_prelock")
@@ -610,6 +380,7 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         or bot_env_changed
         or not app_running
         or bot_running != bot_expected
+        or (worker_defined and (not worker_running or worker_role_drift))
         or (role == "primary" and bool(extra_running_apps))
         or (role == "primary" and proxy_upstream_drift)
     )
@@ -630,7 +401,7 @@ def reconcile(config: AgentConfig, role: str) -> bool:
             fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
             print("patroni_role_agent_status=deferred reason=deployment_lock_busy", flush=True)
-            return False
+            return None
 
         if role == "primary" and role_changed and config.promotion_delay_seconds:
             time.sleep(config.promotion_delay_seconds)
@@ -649,7 +420,23 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         # Re-read after acquiring the lock: a concurrent deploy may have changed
         # the concrete containers while fail-safe pre-lock fencing was running.
         service = app_service(config)
-        running = _running_services(config)
+        running = compose.running_services()
+        release_fenced = compose.enforce_worker_release_fence(
+            COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
+        )
+        worker_state = compose.worker_runtime_state(
+            service=COMMUNICATIONS_WORKER_SERVICE,
+            role=role,
+            running_services=running,
+            definition_probe=_compose_service_is_defined,
+            role_probe=_communications_worker_role_matches,
+            release_fenced=release_fenced,
+        )
+        worker_defined = worker_state.defined
+        worker_running = worker_state.running
+        worker_role_matches = worker_state.role_matches
+        if not worker_running:
+            running.discard(COMMUNICATIONS_WORKER_SERVICE)
         app_running = service in running
         extra_running_apps = sorted(
             name for name in APP_SERVICE_NAMES if name != service and name in running
@@ -657,7 +444,7 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         bot_running = "bot" in running
 
         if bot_running:
-            _stop_service_verified(config, "bot")
+            compose.stop_service_verified("bot")
             bot_running = False
             actions.append("stop_legacy_bot")
 
@@ -668,20 +455,57 @@ def reconcile(config: AgentConfig, role: str) -> bool:
                 actions.append("stop_primary_units")
             for running_app in APP_SERVICE_NAMES:
                 if running_app != service and running_app in running:
-                    _stop_service_verified(config, running_app)
+                    compose.stop_service_verified(running_app)
                     actions.append("stop_extra_app")
             if app_needs_start:
                 recreate_app = fast_fenced or app_env_changed or role_changed
-                _start_service(config, service, recreate=recreate_app)
+                compose.start_service(service, recreate=recreate_app)
                 actions.append(
                     "recreate_app" if recreate_app else "start_app"
                 )
-                if _refresh_container_proxy_dns(
-                    config,
-                    running_services=running,
-                ):
+                if compose.refresh_container_proxy_dns(running_services=running):
                     actions.append("refresh_container_proxy_dns")
-            final_running = _running_services(config)
+            if worker_defined and (
+                fast_fenced
+                or app_env_changed
+                or role_changed
+                or not worker_running
+                or not worker_role_matches
+            ):
+                recreate_worker = (
+                    fast_fenced
+                    or app_env_changed
+                    or role_changed
+                    or not worker_role_matches
+                )
+                compose.start_service(
+                    COMMUNICATIONS_WORKER_SERVICE,
+                    recreate=recreate_worker,
+                )
+                actions.append(
+                    "recreate_communications_worker"
+                    if recreate_worker
+                    else "start_communications_worker"
+                )
+            final_running = compose.running_services()
+            release_fenced = compose.enforce_worker_release_fence(
+                COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
+            )
+            final_worker_state = compose.worker_runtime_state(
+                service=COMMUNICATIONS_WORKER_SERVICE,
+                role=role,
+                running_services=final_running,
+                definition_probe=_compose_service_is_defined,
+                role_probe=_communications_worker_role_matches,
+                release_fenced=release_fenced,
+            )
+            if final_worker_state.unsafe_mismatch or (
+                worker_defined and not final_worker_state.running
+            ):
+                _fence_lost_primary(config)
+                raise RuntimeError(
+                    "standby communications worker role postcondition failed"
+                )
             if (
                 service not in final_running
                 or "bot" in final_running
@@ -693,35 +517,58 @@ def reconcile(config: AgentConfig, role: str) -> bool:
         else:
             if app_needs_start:
                 _require_fresh_primary_or_fence(config, "app_activation")
-                _start_service(config, service, recreate=app_env_changed)
+                compose.start_service(service, recreate=app_env_changed)
                 actions.append("recreate_app" if app_env_changed else "start_app")
-                running = _running_services(config)
-            proxy_upstream_changed = not _container_proxy_upstream_matches(
-                config,
+                running = compose.running_services()
+            proxy_upstream_changed = not compose.container_proxy_upstream_matches(
                 service,
                 running_services=running,
             )
             if proxy_upstream_changed:
                 _require_fresh_primary_or_fence(config, "proxy_convergence")
-                _reconcile_container_proxy_upstream(
-                    config,
+                compose.reconcile_container_proxy_upstream(
                     service,
                     running_services=running,
                 )
                 actions.append("write_proxy_upstream")
             if app_needs_start or proxy_upstream_changed:
-                if _refresh_container_proxy_dns(
-                    config,
-                    running_services=running,
-                ):
+                if compose.refresh_container_proxy_dns(running_services=running):
                     actions.append("refresh_container_proxy_dns")
             if app_needs_start or proxy_upstream_changed:
                 _wait_ready(config)
                 actions.append("wait_ready")
+            worker_needs_start = worker_defined and (
+                app_env_changed
+                or role_changed
+                or not worker_running
+                or not worker_role_matches
+                or worker_role_drift
+            )
+            if worker_needs_start:
+                # Delivery activation is downstream of both the fresh
+                # Patroni/DCS proof and the writable/ready API proof.
+                if not (app_needs_start or proxy_upstream_changed):
+                    _wait_ready(config)
+                    actions.append("wait_ready_for_communications_worker")
+                _require_fresh_primary_or_fence(
+                    config,
+                    "communications_worker_activation",
+                )
+                recreate_worker = worker_role_drift or not worker_role_matches
+                recreate_worker = recreate_worker or role_changed or app_env_changed
+                compose.start_service(
+                    COMMUNICATIONS_WORKER_SERVICE,
+                    recreate=recreate_worker,
+                )
+                actions.append(
+                    "recreate_communications_worker"
+                    if recreate_worker
+                    else "start_communications_worker"
+                )
             if extra_running_apps:
                 _require_fresh_primary_or_fence(config, "extra_app_fence")
                 for running_app in extra_running_apps:
-                    _stop_service_verified(config, running_app)
+                    compose.stop_service_verified(running_app)
                     actions.append("stop_extra_app")
             if (
                 service in {"app-blue", "app-green"}
@@ -753,15 +600,33 @@ def reconcile(config: AgentConfig, role: str) -> bool:
             ):
                 _reconcile_primary_systemd_units(config, "standby")
                 actions.append("stop_pitr_units_for_final_maintenance")
-            final_running = _running_services(config)
+            final_running = compose.running_services()
+            release_fenced = compose.enforce_worker_release_fence(
+                COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
+            )
+            final_worker_state = compose.worker_runtime_state(
+                service=COMMUNICATIONS_WORKER_SERVICE,
+                role=role,
+                running_services=final_running,
+                definition_probe=_compose_service_is_defined,
+                role_probe=_communications_worker_role_matches,
+                release_fenced=release_fenced,
+            )
+            if final_worker_state.unsafe_mismatch or (
+                worker_defined and not final_worker_state.running
+            ):
+                if COMMUNICATIONS_WORKER_SERVICE in final_running:
+                    compose.stop_service_verified(COMMUNICATIONS_WORKER_SERVICE)
+                raise RuntimeError(
+                    "primary communications worker role postcondition failed"
+                )
             if (
                 service not in final_running
                 or "bot" in final_running
                 or any(
                     name in final_running for name in APP_SERVICE_NAMES if name != service
                 )
-                or not _container_proxy_upstream_matches(
-                    config,
+                or not compose.container_proxy_upstream_matches(
                     service,
                     running_services=final_running,
                 )
@@ -803,12 +668,15 @@ def run(config: AgentConfig, *, once: bool) -> int:
             role = "standby"
             print(f"patroni_role_agent_status=warning patroni_unavailable={exc}", flush=True)
         try:
-            reconcile(config, role)
+            changed = reconcile(config, role)
         except Exception as exc:
             print(f"patroni_role_agent_status=failed role={role} error={exc}", flush=True)
             if once:
                 return 1
         if once:
+            if changed is None:
+                return 75
+            print(f"patroni_role_agent_once_status=verified role={role}", flush=True)
             return 0
         time.sleep(config.poll_seconds)
 

--- a/scripts/ha/patroni_role_agent_candidate_assets.sh
+++ b/scripts/ha/patroni_role_agent_candidate_assets.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Shell library for transactional installation of the Patroni role-agent
+# runtime. The caller supplies source/target paths, PROJECT_DIR,
+# ROLE_AGENT_UNIT and atomic file helpers.
+
+PATRONI_ROLE_ASSET_SOURCES=(
+  "${ROLE_IDENTITY_SOURCE}"
+  "${ROLE_AGENT_CONFIG_SOURCE}"
+  "${ROLE_COMPOSE_RUNTIME_SOURCE}"
+  "${ROLE_UNIT_SOURCE}"
+  "${ROLE_AGENT_SOURCE}"
+)
+PATRONI_ROLE_ASSET_TARGETS=(
+  "${ROLE_IDENTITY_TARGET}"
+  "${ROLE_AGENT_CONFIG_TARGET}"
+  "${ROLE_COMPOSE_RUNTIME_TARGET}"
+  "${ROLE_UNIT_TARGET}"
+  "${ROLE_AGENT_TARGET}"
+)
+PATRONI_ROLE_ASSET_MODES=(0644 0644 0644 0644 0755)
+PATRONI_ROLE_ASSET_LABELS=(
+  role-identity
+  role-agent-config
+  compose-runtime
+  role-agent-unit
+  role-agent
+)
+PATRONI_ROLE_ASSET_NAMES=(
+  "identity helper"
+  "role agent config"
+  "compose runtime"
+  "role agent unit"
+  "role agent"
+)
+PATRONI_ROLE_ASSET_BACKUPS=("" "" "" "" "")
+PATRONI_ROLE_ASSET_PREEXISTED=(false false false false false)
+PATRONI_ROLE_ASSETS_CHANGED=false
+
+patroni_role_assets_cleanup_backups() {
+  local failed=false
+  local index=""
+
+  for index in "${!PATRONI_ROLE_ASSET_TARGETS[@]}"; do
+    if [[ -n "${PATRONI_ROLE_ASSET_BACKUPS[${index}]}" ]]; then
+      rm -f -- "${PATRONI_ROLE_ASSET_BACKUPS[${index}]}" || failed=true
+      PATRONI_ROLE_ASSET_BACKUPS[index]=""
+    fi
+  done
+  [[ "${failed}" == "false" ]]
+}
+
+patroni_role_assets_backups_present() {
+  local backup=""
+  for backup in "${PATRONI_ROLE_ASSET_BACKUPS[@]}"; do
+    [[ -z "${backup}" ]] || return 0
+  done
+  return 1
+}
+
+patroni_role_assets_backup() {
+  local index=""
+  local target=""
+  local backup=""
+
+  for index in "${!PATRONI_ROLE_ASSET_TARGETS[@]}"; do
+    target="${PATRONI_ROLE_ASSET_TARGETS[${index}]}"
+    if [[ -e "${target}" || -L "${target}" ]]; then
+      [[ -f "${target}" && ! -L "${target}" ]] || {
+        echo "existing Patroni ${PATRONI_ROLE_ASSET_NAMES[${index}]} target is unsafe: ${target}" >&2
+        return 1
+      }
+    fi
+  done
+  if { [[ -f "${ROLE_AGENT_TARGET}" ]] && [[ ! -f "${ROLE_UNIT_TARGET}" ]]; } \
+    || { [[ ! -f "${ROLE_AGENT_TARGET}" ]] && [[ -f "${ROLE_UNIT_TARGET}" ]]; }; then
+    echo "existing Patroni role agent executable/unit bundle is incomplete" >&2
+    return 1
+  fi
+  if [[ -f "${ROLE_AGENT_TARGET}" ]]; then
+    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || {
+      echo "existing Patroni role agent unit is not active" >&2
+      return 1
+    }
+  fi
+
+  for index in "${!PATRONI_ROLE_ASSET_TARGETS[@]}"; do
+    target="${PATRONI_ROLE_ASSET_TARGETS[${index}]}"
+    [[ -f "${target}" ]] || continue
+    backup="$(mktemp "${PROJECT_DIR}/.patroni-${PATRONI_ROLE_ASSET_LABELS[${index}]}.backup.XXXXXX")"
+    if ! cp -p -- "${target}" "${backup}"; then
+      rm -f -- "${backup}"
+      patroni_role_assets_cleanup_backups || true
+      return 1
+    fi
+    PATRONI_ROLE_ASSET_BACKUPS[index]="${backup}"
+    PATRONI_ROLE_ASSET_PREEXISTED[index]=true
+  done
+}
+
+patroni_role_assets_install() {
+  local index=""
+  local source=""
+
+  for source in "${PATRONI_ROLE_ASSET_SOURCES[@]}"; do
+    [[ -f "${source}" && ! -L "${source}" ]] || {
+      echo "Patroni role agent source bundle is incomplete" >&2
+      return 1
+    }
+  done
+
+  PATRONI_ROLE_ASSETS_CHANGED=true
+  for index in "${!PATRONI_ROLE_ASSET_TARGETS[@]}"; do
+    atomic_install_file \
+      "${PATRONI_ROLE_ASSET_SOURCES[${index}]}" \
+      "${PATRONI_ROLE_ASSET_TARGETS[${index}]}" \
+      "${PATRONI_ROLE_ASSET_MODES[${index}]}"
+  done
+  patroni_role_assets_cleanup_sources
+  systemctl daemon-reload
+  systemctl restart "${ROLE_AGENT_UNIT}"
+  systemctl is-active --quiet "${ROLE_AGENT_UNIT}"
+}
+
+patroni_role_assets_cleanup_sources() {
+  local source=""
+  local failed=false
+
+  for source in "${PATRONI_ROLE_ASSET_SOURCES[@]}"; do
+    [[ -z "${source}" ]] || rm -f -- "${source}" || failed=true
+  done
+  [[ "${failed}" == "false" ]]
+}
+
+patroni_role_assets_restore() {
+  [[ "${PATRONI_ROLE_ASSETS_CHANGED}" == "true" ]] || return 0
+  local failed=false
+  local index=""
+
+  systemctl stop "${ROLE_AGENT_UNIT}" >/dev/null 2>&1 || failed=true
+
+  # Restore dependencies first while the service is stopped. The executable is
+  # restored last so no automatic restart can observe a partially old bundle.
+  for index in 0 1 2; do
+    if [[ "${PATRONI_ROLE_ASSET_PREEXISTED[${index}]}" == "true" ]]; then
+      atomic_restore_file \
+        "${PATRONI_ROLE_ASSET_BACKUPS[${index}]}" \
+        "${PATRONI_ROLE_ASSET_TARGETS[${index}]}" || failed=true
+    fi
+  done
+  if [[ "${PATRONI_ROLE_ASSET_PREEXISTED[3]}" == "true" ]]; then
+    atomic_restore_file \
+      "${PATRONI_ROLE_ASSET_BACKUPS[3]}" \
+      "${PATRONI_ROLE_ASSET_TARGETS[3]}" || failed=true
+  else
+    rm -f -- "${PATRONI_ROLE_ASSET_TARGETS[3]}" || failed=true
+  fi
+  if [[ "${PATRONI_ROLE_ASSET_PREEXISTED[4]}" == "true" ]]; then
+    atomic_restore_file \
+      "${PATRONI_ROLE_ASSET_BACKUPS[4]}" \
+      "${PATRONI_ROLE_ASSET_TARGETS[4]}" || failed=true
+  else
+    rm -f -- "${PATRONI_ROLE_ASSET_TARGETS[4]}" || failed=true
+  fi
+
+  # New-only dependency modules are removed only after the prior executable is
+  # back in place (or the new-only executable has been removed).
+  for index in 0 1 2; do
+    if [[ "${PATRONI_ROLE_ASSET_PREEXISTED[${index}]}" != "true" ]]; then
+      rm -f -- "${PATRONI_ROLE_ASSET_TARGETS[${index}]}" || failed=true
+    fi
+  done
+  systemctl daemon-reload || failed=true
+
+  if [[ "${PATRONI_ROLE_ASSET_PREEXISTED[4]}" == "true" ]]; then
+    systemctl restart "${ROLE_AGENT_UNIT}" || failed=true
+    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || failed=true
+  else
+    if systemctl is-active --quiet "${ROLE_AGENT_UNIT}"; then
+      echo "new Patroni role agent unit remained active after stop" >&2
+      failed=true
+    fi
+  fi
+  [[ "${failed}" == "false" ]]
+}

--- a/scripts/ha/patroni_role_agent_config.py
+++ b/scripts/ha/patroni_role_agent_config.py
@@ -1,0 +1,122 @@
+"""Reviewed configuration contract for the Patroni API role agent."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from scripts.ha.patroni_local_identity import fetch_patroni_role, integer_env
+except ModuleNotFoundError:
+    from patroni_local_identity import fetch_patroni_role, integer_env
+
+
+EXPECTED_LOCAL_PATRONI_URL = "http://127.0.0.1:8008/patroni"
+EXPECTED_PATRONI_SCOPE = "mvn-postgres"
+DEFAULT_MAX_DCS_AGE_SECONDS = 20
+MAX_CONFIGURED_DCS_AGE_SECONDS = 20
+PRODUCTION_NODE_NAMES = {
+    Path("/opt/air-api"): "mvn-api",
+    Path("/opt/mvn-reserve"): "zakup",
+}
+PRODUCTION_COMPOSE_PROJECT_NAMES = {
+    Path("/opt/air-api"): "air-api",
+    Path("/opt/mvn-reserve"): "mvn_reserve",
+}
+REVIEWED_PRIMARY_SYSTEMD_UNITS = (
+    "mvn-postgres-wal-upload.timer",
+    "mvn-postgres-basebackup.timer",
+)
+APP_SERVICE_NAMES = ("app", "app-blue", "app-green")
+CONTAINER_PROXY_SERVICE = "api-proxy"
+COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME = (
+    ".ha-communications-worker-release-fenced"
+)
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    project_dir: Path
+    compose_file: str
+    patroni_url: str
+    patroni_scope: str
+    patroni_name: str
+    max_dcs_age_seconds: int
+    ready_url: str
+    app_role_env: Path
+    bot_role_env: Path
+    state_file: Path
+    deploy_lock: Path
+    active_slot_file: Path
+    app_service: str
+    primary_systemd_units: tuple[str, ...]
+    poll_seconds: int
+    promotion_delay_seconds: int
+    ready_attempts: int
+
+
+def fetch_configured_patroni_role(config: AgentConfig) -> str:
+    return fetch_patroni_role(
+        config.patroni_url,
+        expected_name=config.patroni_name,
+        expected_scope=config.patroni_scope,
+        max_dcs_age_seconds=config.max_dcs_age_seconds,
+    )
+
+
+def load_config() -> AgentConfig:
+    project_dir = Path(os.getenv("HA_PROJECT_DIR", "/opt/air-api")).resolve()
+    compose_file = os.getenv("HA_COMPOSE_FILE", "docker-compose.prod.yml").strip()
+    patroni_url = os.getenv("HA_PATRONI_URL", EXPECTED_LOCAL_PATRONI_URL).rstrip("/")
+    if patroni_url != EXPECTED_LOCAL_PATRONI_URL:
+        raise ValueError(f"HA_PATRONI_URL must be {EXPECTED_LOCAL_PATRONI_URL}")
+    patroni_scope = os.getenv("HA_PATRONI_SCOPE", EXPECTED_PATRONI_SCOPE).strip()
+    if patroni_scope != EXPECTED_PATRONI_SCOPE:
+        raise ValueError(f"HA_PATRONI_SCOPE must be {EXPECTED_PATRONI_SCOPE}")
+    inferred_patroni_name = PRODUCTION_NODE_NAMES.get(project_dir, "")
+    patroni_name = os.getenv("HA_PATRONI_NAME", inferred_patroni_name).strip()
+    if not inferred_patroni_name:
+        raise ValueError(
+            f"HA_PROJECT_DIR is not a reviewed Patroni node path: {project_dir}"
+        )
+    if patroni_name != inferred_patroni_name:
+        raise ValueError(
+            f"HA_PATRONI_NAME must be {inferred_patroni_name} for {project_dir}"
+        )
+    max_dcs_age_seconds = integer_env(
+        "HA_PATRONI_MAX_DCS_AGE_SECONDS", DEFAULT_MAX_DCS_AGE_SECONDS
+    )
+    if max_dcs_age_seconds > MAX_CONFIGURED_DCS_AGE_SECONDS:
+        raise ValueError(
+            "HA_PATRONI_MAX_DCS_AGE_SECONDS must not exceed the reviewed 20s bound"
+        )
+    raw_units = os.getenv(
+        "HA_PRIMARY_SYSTEMD_UNITS", " ".join(REVIEWED_PRIMARY_SYSTEMD_UNITS)
+    )
+    primary_systemd_units = tuple(raw_units.split())
+    if primary_systemd_units != REVIEWED_PRIMARY_SYSTEMD_UNITS:
+        raise ValueError(
+            "HA_PRIMARY_SYSTEMD_UNITS must contain the exact reviewed PITR timers"
+        )
+    return AgentConfig(
+        project_dir=project_dir,
+        compose_file=compose_file,
+        patroni_url=patroni_url,
+        patroni_scope=patroni_scope,
+        patroni_name=patroni_name,
+        max_dcs_age_seconds=max_dcs_age_seconds,
+        ready_url=os.getenv("HA_READY_URL", "http://127.0.0.1:18080/api/ready"),
+        app_role_env=project_dir / ".ha-app-role.env",
+        bot_role_env=project_dir / ".ha-bot-role.env",
+        state_file=project_dir / ".ha-runtime-role",
+        deploy_lock=project_dir / ".deploy.lock",
+        active_slot_file=project_dir / ".active-api-slot",
+        app_service=os.getenv("HA_APP_SERVICE", "").strip(),
+        primary_systemd_units=primary_systemd_units,
+        poll_seconds=integer_env("HA_ROLE_POLL_SECONDS", 3),
+        promotion_delay_seconds=integer_env(
+            "HA_PROMOTION_DELAY_SECONDS", 8, minimum=0
+        ),
+        ready_attempts=integer_env("HA_READY_ATTEMPTS", 30),
+    )

--- a/scripts/ha/patroni_rollout_local.py
+++ b/scripts/ha/patroni_rollout_local.py
@@ -40,6 +40,8 @@ REVIEWED_ASSETS = (
     "scripts/ha/pitr_cluster_topology.py",
     "scripts/ha/pitr_pinned_ssh.py",
     "scripts/ha/patroni_role_agent.py",
+    "scripts/ha/patroni_compose_runtime.py",
+    "scripts/ha/patroni_role_agent_config.py",
     "scripts/ha/patroni_local_identity.py",
     "deploy/ha/patroni/mvn-patroni-role-agent.service",
     "deploy/ha/security/mvn-api-ssh-host-key.pub",

--- a/scripts/ha/patroni_rollout_remote.py
+++ b/scripts/ha/patroni_rollout_remote.py
@@ -40,6 +40,8 @@ HELPER_SOURCE = REPO_ROOT / "deploy/ha/patroni/archive_wal.py"
 CONTRACT_SOURCE = REPO_ROOT / "scripts/ha/patroni_compose_db_contract.py"
 ETCD_CHECK_SOURCE = REPO_ROOT / "scripts/ha/check_etcd_quorum.sh"
 ROLE_AGENT_SOURCE = REPO_ROOT / "scripts/ha/patroni_role_agent.py"
+ROLE_COMPOSE_RUNTIME_SOURCE = REPO_ROOT / "scripts/ha/patroni_compose_runtime.py"
+ROLE_AGENT_CONFIG_SOURCE = REPO_ROOT / "scripts/ha/patroni_role_agent_config.py"
 ROLE_IDENTITY_SOURCE = REPO_ROOT / "scripts/ha/patroni_local_identity.py"
 ROLE_UNIT_SOURCE = REPO_ROOT / "deploy/ha/patroni/mvn-patroni-role-agent.service"
 ACTIONS = {
@@ -134,6 +136,8 @@ def build_payload(
     contract_source = _read_local_asset(CONTRACT_SOURCE)
     etcd_source = _read_local_asset(ETCD_CHECK_SOURCE)
     role_agent_source = _read_local_asset(ROLE_AGENT_SOURCE)
+    role_compose_runtime_source = _read_local_asset(ROLE_COMPOSE_RUNTIME_SOURCE)
+    role_agent_config_source = _read_local_asset(ROLE_AGENT_CONFIG_SOURCE)
     role_identity_source = _read_local_asset(ROLE_IDENTITY_SOURCE)
     role_unit_source = _read_local_asset(ROLE_UNIT_SOURCE)
     payload: dict[str, object] = {
@@ -152,6 +156,12 @@ def build_payload(
         "maintenance_transaction_id": inputs.maintenance_transaction_id,
         "resume": inputs.resume,
         "role_agent_sha256": hashlib.sha256(role_agent_source).hexdigest(),
+        "role_compose_runtime_sha256": hashlib.sha256(
+            role_compose_runtime_source
+        ).hexdigest(),
+        "role_agent_config_sha256": hashlib.sha256(
+            role_agent_config_source
+        ).hexdigest(),
         "role_identity_sha256": hashlib.sha256(role_identity_source).hexdigest(),
         "role_unit_sha256": hashlib.sha256(role_unit_source).hexdigest(),
         "target_image": inputs.target_image,

--- a/scripts/ha/patroni_rollout_remote_contract.py
+++ b/scripts/ha/patroni_rollout_remote_contract.py
@@ -6,7 +6,8 @@ def validate_payload(payload):
                 "controller_sha256", "current_image", "deploy_sha", "helper_sha256",
                 "etcd_check_b64", "etcd_check_sha256", "legacy_command_sha256",
                 "maintenance_transaction_id", "publish_run_attempt", "publish_run_id",
-                "resume", "role_agent_sha256",
+                "resume", "role_agent_sha256", "role_agent_config_sha256",
+                "role_compose_runtime_sha256",
                 "role_identity_sha256", "role_unit_sha256", "target_image"}
     if not isinstance(payload, dict) or not required.issubset(payload):
         die("invalid rollout payload")
@@ -20,7 +21,9 @@ def validate_payload(payload):
         die("legacy archive command is not the compiled reviewed generation")
     for key in ("compose_contract_sha256", "contract_helper_sha256", "controller_sha256",
                 "etcd_check_sha256", "helper_sha256", "legacy_command_sha256",
-                "role_agent_sha256", "role_identity_sha256", "role_unit_sha256"):
+                "role_agent_sha256", "role_agent_config_sha256",
+                "role_compose_runtime_sha256", "role_identity_sha256",
+                "role_unit_sha256"):
         if not isinstance(payload[key], str) or not DIGEST_RE.fullmatch(payload[key]):
             die("invalid rollout digest: " + key)
     if not isinstance(payload["deploy_sha"], str) or not re.fullmatch(r"[0-9a-f]{40}", payload["deploy_sha"]):
@@ -52,7 +55,8 @@ def validate_action(action, payload):
         "controller_sha256", "current_image", "deploy_sha", "etcd_check_b64",
         "etcd_check_sha256", "helper_sha256", "legacy_command_sha256", "resume",
         "maintenance_transaction_id", "publish_run_attempt", "publish_run_id",
-        "role_agent_sha256", "role_identity_sha256",
+        "role_agent_sha256", "role_agent_config_sha256",
+        "role_compose_runtime_sha256", "role_identity_sha256",
         "role_unit_sha256", "target_image"}
     extras = {
         "prepare": {"baseline_primary", "baseline_system_identifier", "baseline_timeline"},
@@ -136,6 +140,8 @@ def load_journal(path, node, txid, payload):
         "publish_run_attempt": payload["publish_run_attempt"],
         "publish_run_id": payload["publish_run_id"],
         "role_agent_sha256": payload["role_agent_sha256"],
+        "role_agent_config_sha256": payload["role_agent_config_sha256"],
+        "role_compose_runtime_sha256": payload["role_compose_runtime_sha256"],
         "role_identity_sha256": payload["role_identity_sha256"],
         "role_unit_sha256": payload["role_unit_sha256"],
     }

--- a/scripts/ha/patroni_rollout_remote_executor.py
+++ b/scripts/ha/patroni_rollout_remote_executor.py
@@ -15,6 +15,8 @@ REMOTE_EXECUTOR = REMOTE_PRELUDE + REMOTE_CONTRACT + REMOTE_RUNTIME_PROOF + r'''
 
 def validate_role_assets(payload):
     assets = (("/usr/local/sbin/mvn-patroni-role-agent", 0o755, payload["role_agent_sha256"]),
+        ("/usr/local/sbin/patroni_compose_runtime.py", 0o644, payload["role_compose_runtime_sha256"]),
+        ("/usr/local/sbin/patroni_role_agent_config.py", 0o644, payload["role_agent_config_sha256"]),
         ("/usr/local/sbin/patroni_local_identity.py", 0o644, payload["role_identity_sha256"]),
         ("/etc/systemd/system/mvn-patroni-role-agent.service", 0o644,
          payload["role_unit_sha256"]))
@@ -502,6 +504,8 @@ def main():
                     "publish_run_attempt": payload["publish_run_attempt"],
                     "publish_run_id": payload["publish_run_id"],
                     "role_agent_sha256": payload["role_agent_sha256"],
+                    "role_agent_config_sha256": payload["role_agent_config_sha256"],
+                    "role_compose_runtime_sha256": payload["role_compose_runtime_sha256"],
                     "role_identity_sha256": payload["role_identity_sha256"],
                     "role_unit_sha256": payload["role_unit_sha256"],
                     "node": node, "operation": "idle", "target_image": payload["target_image"],

--- a/scripts/ha/patroni_rollout_remote_runtime.py
+++ b/scripts/ha/patroni_rollout_remote_runtime.py
@@ -49,6 +49,8 @@ def process_start_ns(pid):
 def validate_role_process_generation(pid, expected):
     assets = (
         "/usr/local/sbin/mvn-patroni-role-agent",
+        "/usr/local/sbin/patroni_compose_runtime.py",
+        "/usr/local/sbin/patroni_role_agent_config.py",
         "/usr/local/sbin/patroni_local_identity.py",
         "/etc/systemd/system/mvn-patroni-role-agent.service",
         "/etc/default/mvn-patroni-role-agent",

--- a/scripts/ha/pitr_remote_execution.py
+++ b/scripts/ha/pitr_remote_execution.py
@@ -259,6 +259,16 @@ ROLE_AGENT_ASSETS = (
         0o755,
     ),
     PitrHostAsset(
+        REPO_ROOT / "scripts/ha/patroni_compose_runtime.py",
+        "/usr/local/sbin/patroni_compose_runtime.py",
+        0o644,
+    ),
+    PitrHostAsset(
+        REPO_ROOT / "scripts/ha/patroni_role_agent_config.py",
+        "/usr/local/sbin/patroni_role_agent_config.py",
+        0o644,
+    ),
+    PitrHostAsset(
         REPO_ROOT / "scripts/ha/patroni_local_identity.py",
         "/usr/local/sbin/patroni_local_identity.py",
         0o644,

--- a/scripts/ha/pitr_role_agent_remote_executor.py
+++ b/scripts/ha/pitr_role_agent_remote_executor.py
@@ -10,6 +10,8 @@ import types
 
 ROLE_AGENT_UNIT = "mvn-patroni-role-agent.service"
 ROLE_AGENT_PATH = "/usr/local/sbin/mvn-patroni-role-agent"
+ROLE_COMPOSE_RUNTIME_PATH = "/usr/local/sbin/patroni_compose_runtime.py"
+ROLE_AGENT_CONFIG_PATH = "/usr/local/sbin/patroni_role_agent_config.py"
 ROLE_IDENTITY_PATH = "/usr/local/sbin/patroni_local_identity.py"
 ROLE_UNIT_PATH = "/etc/systemd/system/mvn-patroni-role-agent.service"
 ROLE_ENV_PATH = "/etc/default/mvn-patroni-role-agent"
@@ -20,6 +22,8 @@ RELEASE_MANIFEST = "/var/lib/mvn-postgres-pitr/release-manifest.json"
 GLOBAL_LOCK = "/run/lock/mvn-postgres-pitr-prerequisites.lock"
 ROLE_ASSET_MODES = {
     ROLE_AGENT_PATH: 0o755,
+    ROLE_COMPOSE_RUNTIME_PATH: 0o644,
+    ROLE_AGENT_CONFIG_PATH: 0o644,
     ROLE_IDENTITY_PATH: 0o644,
     ROLE_UNIT_PATH: 0o644,
     OPERATION_GUARD_PATH: 0o755,
@@ -296,6 +300,18 @@ def load_attested_modules(sources, expected_environment):
         sources[ROLE_IDENTITY_PATH],
     )
     sys.modules["patroni_local_identity"] = identity
+    role_config = execute_attested_module(
+        "scripts.ha.patroni_role_agent_config",
+        ROLE_AGENT_CONFIG_PATH,
+        sources[ROLE_AGENT_CONFIG_PATH],
+    )
+    sys.modules["patroni_role_agent_config"] = role_config
+    compose_runtime = execute_attested_module(
+        "scripts.ha.patroni_compose_runtime",
+        ROLE_COMPOSE_RUNTIME_PATH,
+        sources[ROLE_COMPOSE_RUNTIME_PATH],
+    )
+    sys.modules["patroni_compose_runtime"] = compose_runtime
     role_agent = execute_attested_module(
         "mvn_pinned_patroni_role_agent",
         ROLE_AGENT_PATH,

--- a/scripts/ha/run_patroni_candidate_transaction.sh
+++ b/scripts/ha/run_patroni_candidate_transaction.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034  # globals are consumed by sourced lifecycle modules
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,11 +13,20 @@ MIGRATION_SCRIPT="${PATRONI_MIGRATION_SCRIPT:-/tmp/run_patroni_migrations.sh}"
 DEPLOY_SCRIPT="${PATRONI_DEPLOY_SCRIPT:-/tmp/deploy_patroni_api_node.sh}"
 ROLE_AGENT_SOURCE="${PATRONI_ROLE_AGENT_SOURCE:-}"
 ROLE_AGENT_TARGET="${PATRONI_ROLE_AGENT_TARGET:-/usr/local/sbin/mvn-patroni-role-agent}"
+ROLE_COMPOSE_RUNTIME_SOURCE="${PATRONI_ROLE_COMPOSE_RUNTIME_SOURCE:-}"
+ROLE_COMPOSE_RUNTIME_TARGET="${PATRONI_ROLE_COMPOSE_RUNTIME_TARGET:-/usr/local/sbin/patroni_compose_runtime.py}"
+ROLE_AGENT_CONFIG_SOURCE="${PATRONI_ROLE_AGENT_CONFIG_SOURCE:-}"
+ROLE_AGENT_CONFIG_TARGET="${PATRONI_ROLE_AGENT_CONFIG_TARGET:-/usr/local/sbin/patroni_role_agent_config.py}"
 ROLE_IDENTITY_SOURCE="${PATRONI_ROLE_IDENTITY_SOURCE:-}"
 ROLE_IDENTITY_TARGET="${PATRONI_ROLE_IDENTITY_TARGET:-/usr/local/sbin/patroni_local_identity.py}"
+ROLE_UNIT_SOURCE="${PATRONI_ROLE_UNIT_SOURCE:-}"
+ROLE_UNIT_TARGET="${PATRONI_ROLE_UNIT_TARGET:-/etc/systemd/system/mvn-patroni-role-agent.service}"
 DB_CONTRACT_HELPER="${PATRONI_DB_CONTRACT_HELPER:-/tmp/patroni_compose_db_contract.py}"
 ROLE_AGENT_UNIT="${PATRONI_ROLE_AGENT_UNIT:-mvn-patroni-role-agent.service}"
 RECONCILE_SCRIPT="${API_RECONCILE_SCRIPT:-/tmp/reconcile_backend_compose_runtime.sh}"
+COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/communications_worker_release_contract.sh}"
+PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE="${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE:-${SCRIPT_DIR}/patroni_communications_candidate_lifecycle.sh}"
+PATRONI_ROLE_AGENT_CANDIDATE_ASSETS="${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS:-${SCRIPT_DIR}/patroni_role_agent_candidate_assets.sh}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/safe_deploy_lock.py}"
@@ -25,11 +35,7 @@ PATRONI_CUTOVER_MARKER="${PATRONI_CUTOVER_MARKER:-${PROJECT_DIR}/.patroni-cutove
 PITR_MAINTENANCE_MARKER="${API_PITR_MAINTENANCE_MARKER:-/run/mvn-postgres-pitr-maintenance}"
 ACTIVE_SLOT_FILE="${API_ACTIVE_SLOT_FILE:-${PROJECT_DIR}/.active-api-slot}"
 PREVIOUS_BACKEND_IMAGE="${API_PREVIOUS_BACKEND_IMAGE:-}"
-ROLE_AGENT_BACKUP=""
-ROLE_AGENT_PREEXISTED=false
-ROLE_IDENTITY_BACKUP=""
-ROLE_IDENTITY_PREEXISTED=false
-ROLE_AGENT_CHANGED=false
+BACKEND_IMAGE="${BACKEND_IMAGE:-}"
 CANDIDATE_CHECKSUM=""
 CANDIDATE_OWNED=false
 PATRONI_URL="${API_PATRONI_URL:-http://127.0.0.1:8008/patroni}"
@@ -47,6 +53,22 @@ PROXY_UPSTREAM_CREATED=false
 PROXY_FILES_CHANGED=false
 PROXY_DIR_CREATED=false
 PROXY_RUNTIME_STATE=not-applicable
+
+[[ -f "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" \
+  && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" ]] \
+  || { echo "communications worker release helper is missing or unsafe" >&2; exit 1; }
+[[ -f "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE}" \
+  && ! -L "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE}" ]] \
+  || { echo "Patroni communications candidate lifecycle is missing or unsafe" >&2; exit 1; }
+[[ -f "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}" \
+  && ! -L "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}" ]] \
+  || { echo "Patroni role-agent candidate assets helper is missing or unsafe" >&2; exit 1; }
+# shellcheck disable=SC1090
+source "${COMMUNICATIONS_WORKER_RELEASE_HELPER}"
+# shellcheck disable=SC1090
+source "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE}"
+# shellcheck disable=SC1090
+source "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}"
 
 [[ "${DEPLOY_LOCK_HELPER_SHA256}" =~ ^[0-9a-f]{64}$ ]] || {
   echo "safe deployment lock helper digest is missing" >&2; exit 1;
@@ -135,7 +157,6 @@ stage_candidate_compose() {
     return 1
   fi
 }
-
 cleanup_migration_candidate() {
   local status=$?
   trap - EXIT
@@ -143,7 +164,6 @@ cleanup_migration_candidate() {
   [[ "${CANDIDATE_OWNED}" == "true" ]] && transaction cleanup
   exit "${status}"
 }
-
 cleanup_candidate_only() {
   local status=$?
   trap - EXIT
@@ -151,13 +171,11 @@ cleanup_candidate_only() {
   [[ "${CANDIDATE_OWNED}" == "true" ]] && transaction cleanup
   exit "${status}"
 }
-
 resolve_previous_backend_image() {
   local active_service="app"
   local active_slot=""
   local container_ids=""
   local runtime_image=""
-
   if [[ -n "${PREVIOUS_BACKEND_IMAGE}" ]]; then
     [[ "${PREVIOUS_BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
       echo "API_PREVIOUS_BACKEND_IMAGE must be immutable" >&2
@@ -185,80 +203,18 @@ resolve_previous_backend_image() {
   PREVIOUS_BACKEND_IMAGE="${runtime_image}"
 }
 
-backup_role_agent() {
-  if [[ -e "${ROLE_AGENT_TARGET}" || -L "${ROLE_AGENT_TARGET}" ]]; then
-    [[ -f "${ROLE_AGENT_TARGET}" && ! -L "${ROLE_AGENT_TARGET}" ]] || {
-      echo "existing Patroni role agent target is unsafe" >&2
-      return 1
-    }
-  fi
-  if [[ -e "${ROLE_IDENTITY_TARGET}" || -L "${ROLE_IDENTITY_TARGET}" ]]; then
-    [[ -f "${ROLE_IDENTITY_TARGET}" && ! -L "${ROLE_IDENTITY_TARGET}" ]] || {
-      echo "existing Patroni identity helper target is unsafe" >&2
-      return 1
-    }
-  fi
-  if [[ -f "${ROLE_AGENT_TARGET}" ]]; then
-    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || {
-      echo "existing Patroni role agent unit is not active" >&2
-      return 1
-    }
-    ROLE_AGENT_BACKUP="$(mktemp "${PROJECT_DIR}/.patroni-role-agent.backup.XXXXXX")"
-    if ! cp -p -- "${ROLE_AGENT_TARGET}" "${ROLE_AGENT_BACKUP}"; then
-      rm -f -- "${ROLE_AGENT_BACKUP}"
-      ROLE_AGENT_BACKUP=""
-      return 1
-    fi
-    ROLE_AGENT_PREEXISTED=true
-  fi
-  if [[ -f "${ROLE_IDENTITY_TARGET}" ]]; then
-    ROLE_IDENTITY_BACKUP="$(mktemp "${PROJECT_DIR}/.patroni-role-identity.backup.XXXXXX")"
-    if ! cp -p -- "${ROLE_IDENTITY_TARGET}" "${ROLE_IDENTITY_BACKUP}"; then
-      rm -f -- "${ROLE_AGENT_BACKUP}" "${ROLE_IDENTITY_BACKUP}"
-      ROLE_AGENT_BACKUP=""
-      ROLE_AGENT_PREEXISTED=false
-      ROLE_IDENTITY_BACKUP=""
-      return 1
-    fi
-    ROLE_IDENTITY_PREEXISTED=true
-  fi
-}
-
-restore_role_agent() {
-  [[ "${ROLE_AGENT_CHANGED}" == "true" ]] || return 0
-  local failed=false
-  if [[ "${ROLE_IDENTITY_PREEXISTED}" == "true" ]]; then
-    cp -p -- "${ROLE_IDENTITY_BACKUP}" "${ROLE_IDENTITY_TARGET}" || failed=true
-  else
-    rm -f -- "${ROLE_IDENTITY_TARGET}" || failed=true
-  fi
-  if [[ "${ROLE_AGENT_PREEXISTED}" == "true" ]]; then
-    cp -p -- "${ROLE_AGENT_BACKUP}" "${ROLE_AGENT_TARGET}" || failed=true
-    systemctl restart "${ROLE_AGENT_UNIT}" || failed=true
-    systemctl is-active --quiet "${ROLE_AGENT_UNIT}" || failed=true
-  else
-    systemctl stop "${ROLE_AGENT_UNIT}" >/dev/null 2>&1 || failed=true
-    if systemctl is-active --quiet "${ROLE_AGENT_UNIT}"; then
-      echo "new Patroni role agent unit remained active after stop" >&2
-      failed=true
-    fi
-    rm -f -- "${ROLE_AGENT_TARGET}" || failed=true
-  fi
-  [[ "${failed}" == "false" ]]
-}
-
 atomic_install_file() {
   local source="$1"
   local target="$2"
+  local mode="${3:-0644}"
   local temporary=""
   temporary="$(mktemp "${target}.tmp.XXXXXX")"
-  if ! install -m 0644 -- "${source}" "${temporary}"; then
+  if ! install -m "${mode}" -- "${source}" "${temporary}"; then
     rm -f -- "${temporary}"
     return 1
   fi
   mv -f -- "${temporary}" "${target}"
 }
-
 atomic_restore_file() {
   local source="$1"
   local target="$2"
@@ -270,7 +226,6 @@ atomic_restore_file() {
   fi
   mv -f -- "${temporary}" "${target}"
 }
-
 require_safe_proxy_target() {
   python3 - "$1" <<'PY'
 import os, stat, sys
@@ -281,7 +236,6 @@ if (not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode)
     raise SystemExit("container proxy target metadata is unsafe: " + sys.argv[1])
 PY
 }
-
 capture_proxy_runtime_state() {
   local container_ids=""
   local running=""
@@ -303,7 +257,6 @@ capture_proxy_runtime_state() {
     *) echo "container proxy runtime state is invalid" >&2; return 1 ;;
   esac
 }
-
 stage_proxy_files() {
   local proxy_dir=""
   [[ "${PROXY_MODE}" == "container_nginx" ]] || return 0
@@ -468,8 +421,13 @@ require_unchanged_db_contract() {
 }
 
 fence_runtime_for_role_drift() {
+  local services=(app app-blue app-green bot)
+  local failed=false
+  communications_worker_set_release_fence || failed=true
   docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
-    stop app app-blue app-green bot >/dev/null 2>&1
+    stop "${services[@]}" >/dev/null 2>&1 || failed=true
+  patroni_communications_force_fence_candidate_runtime || failed=true
+  [[ "${failed}" == "false" ]]
 }
 
 reconcile_failed_deploy() {
@@ -477,21 +435,30 @@ reconcile_failed_deploy() {
   local restoration_failed=false
   local role_agent_restore_failed=false
   local recovery_role=""
+  local recovery_services="app"
   trap - EXIT
   set +e
   if promotion_committed; then
-    echo "Patroni candidate compose promotion committed; preserving the consistent new runtime" >&2
-    [[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}"
-    [[ -z "${ROLE_IDENTITY_BACKUP}" ]] || rm -f -- "${ROLE_IDENTITY_BACKUP}"
+    if ! patroni_communications_fence_canonical; then
+      echo "CRITICAL: promoted communications worker could not be fenced" >&2
+      exit 90
+    fi
+    echo "Patroni candidate compose promotion committed; fenced the dormant worker for inspection" >&2
+    patroni_role_assets_cleanup_backups \
+      || echo "warning: stale Patroni role asset backup remains" >&2
     [[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}"
     exit "${status}"
+  fi
+  if ! patroni_communications_fence_candidate; then
+    echo "failed to fence candidate communications worker before rollback" >&2
+    restoration_failed=true
   fi
   transaction cleanup || restoration_failed=true
   if ! restore_proxy_state; then
     echo "failed to restore the previous container proxy files and runtime state" >&2
     restoration_failed=true
   fi
-  if ! restore_role_agent; then
+  if ! patroni_role_assets_restore; then
     echo "failed to restore the previous Patroni role agent" >&2
     role_agent_restore_failed=true
     restoration_failed=true
@@ -505,7 +472,10 @@ reconcile_failed_deploy() {
     fence_runtime_for_role_drift || restoration_failed=true
     restoration_failed=true
   elif [[ "${recovery_role}" == "primary" ]]; then
-    if ! API_DEPLOY_SERVICES="app" \
+    if [[ "${PREVIOUS_WORKER_RUNNING}" == "true" ]]; then
+      recovery_services+=" ${COMMUNICATIONS_WORKER_SERVICE}"
+    fi
+    if ! API_DEPLOY_SERVICES="${recovery_services}" \
       API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
       API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
       API_READY_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}" \
@@ -513,7 +483,11 @@ reconcile_failed_deploy() {
       restoration_failed=true
     fi
   else
-    if ! API_DEPLOY_SERVICES="app" \
+    recovery_services="app"
+    if [[ "${PREVIOUS_WORKER_RUNNING}" == "true" ]]; then
+      recovery_services+=" ${COMMUNICATIONS_WORKER_SERVICE}"
+    fi
+    if ! API_DEPLOY_SERVICES="${recovery_services}" \
       API_STOP_SERVICES_AFTER_DEPLOY="bot" \
       API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
       API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
@@ -522,16 +496,24 @@ reconcile_failed_deploy() {
       restoration_failed=true
     fi
   fi
-  [[ -z "${ROLE_AGENT_SOURCE}" ]] || rm -f -- "${ROLE_AGENT_SOURCE}"
-  [[ -z "${ROLE_IDENTITY_SOURCE}" ]] || rm -f -- "${ROLE_IDENTITY_SOURCE}"
-  if [[ -n "${ROLE_AGENT_BACKUP}" || -n "${ROLE_IDENTITY_BACKUP}" ]]; then
+  patroni_role_assets_cleanup_sources || restoration_failed=true
+  if [[ "${restoration_failed}" == "true" ]]; then
+    communications_worker_set_release_fence || true
+  elif ! patroni_communications_restore_release_fence; then
+    echo "failed to restore the previous communications worker release fence" >&2
+    communications_worker_set_release_fence || true
+    restoration_failed=true
+  fi
+  if ! patroni_communications_require_previous_fence_restored; then
+    echo "failed to prove the previous communications worker fence" >&2
+    communications_worker_set_release_fence || true
+    restoration_failed=true
+  fi
+  if patroni_role_assets_backups_present; then
     if [[ "${role_agent_restore_failed}" == "true" ]]; then
       echo "CRITICAL: previous Patroni role asset backups retained" >&2
     else
-      [[ -z "${ROLE_AGENT_BACKUP}" ]] \
-        || rm -f -- "${ROLE_AGENT_BACKUP}" || restoration_failed=true
-      [[ -z "${ROLE_IDENTITY_BACKUP}" ]] \
-        || rm -f -- "${ROLE_IDENTITY_BACKUP}" || restoration_failed=true
+      patroni_role_assets_cleanup_backups || restoration_failed=true
     fi
   fi
   if [[ "${restoration_failed}" == "true" ]]; then
@@ -556,6 +538,10 @@ promotion_committed() {
 if [[ "${OPERATION}" == "deploy" ]]; then
   [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
     echo "API_EXPECTED_PATRONI_ROLE must be primary or standby" >&2
+    exit 2
+  }
+  [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    echo "BACKEND_IMAGE must identify an immutable candidate release" >&2
     exit 2
   }
 fi
@@ -587,21 +573,14 @@ fi
 }
 require_unchanged_db_contract
 resolve_previous_backend_image
-backup_role_agent
+patroni_communications_capture_release_fence
+patroni_communications_capture_previous
+patroni_role_assets_backup
 trap reconcile_failed_deploy EXIT
 transaction stage
+patroni_communications_detect_candidate_support
 
-[[ -f "${ROLE_AGENT_SOURCE}" && ! -L "${ROLE_AGENT_SOURCE}" \
-  && -f "${ROLE_IDENTITY_SOURCE}" && ! -L "${ROLE_IDENTITY_SOURCE}" ]] || {
-  echo "Patroni role agent source bundle is incomplete" >&2
-  exit 1
-}
-ROLE_AGENT_CHANGED=true
-install -m 0644 "${ROLE_IDENTITY_SOURCE}" "${ROLE_IDENTITY_TARGET}"
-install -m 0755 "${ROLE_AGENT_SOURCE}" "${ROLE_AGENT_TARGET}"
-rm -f -- "${ROLE_AGENT_SOURCE}" "${ROLE_IDENTITY_SOURCE}"
-systemctl restart "${ROLE_AGENT_UNIT}"
-systemctl is-active --quiet "${ROLE_AGENT_UNIT}"
+patroni_role_assets_install
 capture_proxy_runtime_state
 stage_proxy_files
 
@@ -610,11 +589,15 @@ API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" \
 bash "${DEPLOY_SCRIPT}"
 require_no_patroni_cutover
 require_unchanged_db_contract
+if [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]]; then
+  patroni_communications_require_runtime "${CANDIDATE_FILE}" "${BACKEND_IMAGE}"
+fi
 transaction promote
+if [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]]; then
+  patroni_communications_require_runtime "${CANONICAL_FILE}" "${BACKEND_IMAGE}"
+fi
 trap - EXIT
-[[ -z "${ROLE_AGENT_BACKUP}" ]] || rm -f -- "${ROLE_AGENT_BACKUP}" \
-  || echo "warning: stale Patroni role agent backup remains at ${ROLE_AGENT_BACKUP}" >&2
-[[ -z "${ROLE_IDENTITY_BACKUP}" ]] || rm -f -- "${ROLE_IDENTITY_BACKUP}" \
-  || echo "warning: stale Patroni identity backup remains at ${ROLE_IDENTITY_BACKUP}" >&2
+patroni_role_assets_cleanup_backups \
+  || echo "warning: stale Patroni role asset backup remains" >&2
 [[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}" \
   || echo "warning: stale Patroni proxy config backup remains at ${PROXY_CONFIG_BACKUP}" >&2

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -19,12 +19,21 @@ KEY_PATH="${RUNNER_TEMP:-/tmp}/mvn-patroni-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:
 KNOWN_HOSTS_PATH="${KEY_PATH}.known_hosts"
 ROLE_AGENT_SOURCE="scripts/ha/patroni_role_agent.py"
 ROLE_AGENT_TARGET="/usr/local/sbin/mvn-patroni-role-agent"
+ROLE_COMPOSE_RUNTIME_SOURCE="scripts/ha/patroni_compose_runtime.py"
+ROLE_COMPOSE_RUNTIME_TARGET="/usr/local/sbin/patroni_compose_runtime.py"
+ROLE_AGENT_CONFIG_SOURCE="scripts/ha/patroni_role_agent_config.py"
+ROLE_AGENT_CONFIG_TARGET="/usr/local/sbin/patroni_role_agent_config.py"
 ROLE_IDENTITY_SOURCE="scripts/ha/patroni_local_identity.py"
 ROLE_IDENTITY_TARGET="/usr/local/sbin/patroni_local_identity.py"
+ROLE_UNIT_SOURCE="deploy/ha/patroni/mvn-patroni-role-agent.service"
+ROLE_UNIT_TARGET="/etc/systemd/system/mvn-patroni-role-agent.service"
 ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
 CANDIDATE_RUNNER_SOURCE="scripts/ha/run_patroni_candidate_transaction.sh"
 DEPLOY_LOCK_HELPER_SOURCE="scripts/ha/safe_deploy_lock.py"
 DEPLOY_CAPACITY_HELPER_SOURCE="scripts/ha/require_deploy_capacity.sh"
+COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE="scripts/ha/communications_worker_release_contract.sh"
+PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE="scripts/ha/patroni_communications_candidate_lifecycle.sh"
+PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE="scripts/ha/patroni_role_agent_candidate_assets.sh"
 DEPLOY_LOCK_HELPER_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${DEPLOY_LOCK_HELPER_SOURCE}")"
 DB_CONTRACT_HELPER_SOURCE="scripts/ha/patroni_compose_db_contract.py"
 TRANSACTION_SOURCE="scripts/compose_candidate_transaction.sh"
@@ -33,13 +42,14 @@ VOICE_ENV_SYNC_SOURCE="scripts/ha/sync_bot_voice_env.py"
 BOT_VOICE_TRANSCRIPTION_API_KEY="${BOT_VOICE_TRANSCRIPTION_API_KEY:-}"
 REMOTE_BUNDLE_DIR=""
 DEPLOY_CAPACITY_PROFILE=primary
+CANONICAL_REMOTE_COMPOSE_FILE="docker-compose.patroni.yml"
 
 log() {
   printf '[patroni-remote][%s] %s\n' "$1" "$2"
 }
 
 usage() {
-  echo "usage: run_patroni_node_remote.sh probe|migrate|deploy" >&2
+  echo "usage: run_patroni_node_remote.sh probe|migrate|deploy|verify" >&2
 }
 
 quote() {
@@ -55,7 +65,8 @@ cleanup() {
   rm -f "${KEY_PATH}" "${KNOWN_HOSTS_PATH}"
 }
 
-[[ "${OPERATION}" == "probe" || "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]] || {
+[[ "${OPERATION}" == "probe" || "${OPERATION}" == "migrate" \
+  || "${OPERATION}" == "deploy" || "${OPERATION}" == "verify" ]] || {
   usage
   exit 2
 }
@@ -79,7 +90,7 @@ cleanup() {
   log error "API_NODE_USER contains unsupported characters"
   exit 1
 }
-if [[ "${OPERATION}" != "probe" ]]; then
+if [[ "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]]; then
   [[ -n "${PROJECT_DIR}" && -f "${COMPOSE_SOURCE}" ]] || {
     log error "project directory and tracked compose source are required"
     exit 1
@@ -96,24 +107,45 @@ fi
 if [[ "${PROJECT_DIR}" == "/opt/mvn-reserve" ]]; then
   DEPLOY_CAPACITY_PROFILE=reserve
 fi
-if [[ "${OPERATION}" == "deploy" ]]; then
+if [[ "${OPERATION}" == "deploy" || "${OPERATION}" == "verify" ]]; then
   [[ "${EXPECTED_ROLE}" == "primary" || "${EXPECTED_ROLE}" == "standby" ]] || {
     log error "API_EXPECTED_PATRONI_ROLE must be primary or standby"
     exit 1
   }
+fi
+if [[ "${OPERATION}" == "verify" ]]; then
+  [[ -n "${PROJECT_DIR}" ]] || {
+    log error "API_NODE_PROJECT_DIR is required for runtime verification"
+    exit 1
+  }
+  [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
+    log error "BACKEND_IMAGE must be immutable"
+    exit 1
+  }
+fi
+if [[ "${OPERATION}" == "deploy" ]]; then
   [[ "${PROXY_MODE}" == "host_nginx" || "${PROXY_MODE}" == "container_nginx" ]] || {
     log error "API_NODE_PROXY_MODE must be host_nginx or container_nginx"
     exit 1
   }
   [[ -f "${ROLE_AGENT_SOURCE}" && ! -L "${ROLE_AGENT_SOURCE}" \
-    && -f "${ROLE_IDENTITY_SOURCE}" && ! -L "${ROLE_IDENTITY_SOURCE}" ]] || {
+    && -f "${ROLE_COMPOSE_RUNTIME_SOURCE}" && ! -L "${ROLE_COMPOSE_RUNTIME_SOURCE}" \
+    && -f "${ROLE_AGENT_CONFIG_SOURCE}" && ! -L "${ROLE_AGENT_CONFIG_SOURCE}" \
+    && -f "${ROLE_IDENTITY_SOURCE}" && ! -L "${ROLE_IDENTITY_SOURCE}" \
+    && -f "${ROLE_UNIT_SOURCE}" && ! -L "${ROLE_UNIT_SOURCE}" ]] || {
     log error "role agent source bundle is incomplete"
     exit 1
   }
 fi
-if [[ "${OPERATION}" != "probe" ]]; then
+if [[ "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]]; then
   [[ -f "${CANDIDATE_RUNNER_SOURCE}" && -f "${TRANSACTION_SOURCE}" \
     && -f "${DEPLOY_CAPACITY_HELPER_SOURCE}" \
+    && -f "${COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE}" \
+    && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE}" \
+    && -f "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}" \
+    && ! -L "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}" \
+    && -f "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}" \
+    && ! -L "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}" \
     && -f "${DEPLOY_LOCK_HELPER_SOURCE}" && -f "${BUNDLE_VERIFIER_SOURCE}" \
     && -f "${VOICE_ENV_SYNC_SOURCE}" && ! -L "${VOICE_ENV_SYNC_SOURCE}" ]] || {
     log error "compose candidate transaction scripts are missing"
@@ -129,7 +161,7 @@ if [[ "${OPERATION}" == "deploy" ]]; then
 fi
 
 required_commands=(ssh ssh-keygen)
-if [[ "${OPERATION}" != "probe" ]]; then
+if [[ "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]]; then
   required_commands+=(scp)
 fi
 for command in "${required_commands[@]}"; do
@@ -197,9 +229,221 @@ if [[ "${OPERATION}" == "probe" ]]; then
   exit 0
 fi
 
+if [[ "${OPERATION}" == "verify" ]]; then
+  verify_config_code='
+import json
+import sys
+
+service_name, app_name, expected_image = sys.argv[1:]
+payload = json.load(sys.stdin)
+services = payload.get("services") or {}
+worker = services.get(service_name)
+app = services.get(app_name)
+if not isinstance(worker, dict) or not isinstance(app, dict):
+    raise SystemExit(1)
+if worker.get("image") != expected_image or app.get("image") != expected_image:
+    raise SystemExit(1)
+environment = worker.get("environment") or {}
+if not isinstance(environment, dict):
+    raise SystemExit(1)
+for key in (
+    "COMMUNICATIONS_WORKER_ENABLED",
+    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE",
+):
+    if str(environment.get(key, "")).lower() != "false":
+        raise SystemExit(1)
+'
+  verify_worker_runtime_code='
+import os
+import sys
+
+expected_role = sys.argv[1]
+valid = (
+    os.environ.get("APP_ROLE") == expected_role
+    and os.environ.get("COMMUNICATIONS_WORKER_ENABLED", "").lower() == "false"
+    and os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE", "").lower() == "false"
+)
+raise SystemExit(0 if valid else 1)
+'
+  verify_canary_code='
+import re
+import sys
+
+expected_role = sys.argv[1]
+lines = sys.stdin.read().splitlines()
+receipt = f"patroni_role_agent_once_status=verified role={expected_role}"
+valid = lines == [receipt]
+if len(lines) == 2 and lines[1] == receipt:
+    reconciled = re.fullmatch(
+        r"patroni_role_agent_status=reconciled "
+        r"role=(primary|standby) "
+        r"app_service=[A-Za-z0-9_.-]+ "
+        r"reasons=(?:[a-z0-9_]+(?:,[a-z0-9_]+)*)? "
+        r"actions=(?:[a-z0-9_]+(?:,[a-z0-9_]+)*)?",
+        lines[0],
+    )
+    valid = reconciled is not None and reconciled.group(1) == expected_role
+raise SystemExit(0 if valid else 1)
+'
+  verify_role_code='
+import json
+import sys
+
+payload = json.load(sys.stdin)
+if payload.get("state") != "running":
+    raise SystemExit(1)
+role = str(payload.get("role") or "").lower()
+mapping = {
+    "leader": "primary",
+    "master": "primary",
+    "primary": "primary",
+    "replica": "standby",
+    "standby": "standby",
+}
+normalized = mapping.get(role)
+if normalized is None:
+    raise SystemExit(1)
+print(normalized)
+'
+  verified="$(
+    ssh "${SSH_OPTS[@]}" "${REMOTE}" "
+      set -euo pipefail
+      if test -e $(quote "${PITR_MAINTENANCE_MARKER}") \
+        || test -L $(quote "${PITR_MAINTENANCE_MARKER}"); then
+        echo 'PITR release maintenance is active; refusing runtime verification' >&2
+        exit 75
+      fi
+      role=\$(curl -fsS --max-time 5 http://127.0.0.1:8008/patroni \
+        | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get(\"state\")==\"running\"; r=str(p.get(\"role\") or \"\").lower(); m={\"leader\":\"primary\",\"master\":\"primary\",\"primary\":\"primary\",\"replica\":\"standby\",\"standby\":\"standby\"}; n=m.get(r); n or sys.exit(1); print(n)')
+      test \"\${role}\" = $(quote "${EXPECTED_ROLE}")
+      cd $(quote "${PROJECT_DIR}")
+      test -f ${CANONICAL_REMOTE_COMPOSE_FILE}
+      test ! -L ${CANONICAL_REMOTE_COMPOSE_FILE}
+      active_service=app
+      if test -f .active-api-slot; then
+        slot=\$(tr -d '\\r\\n' < .active-api-slot)
+        case \"\${slot}\" in
+          blue|green) active_service=\"app-\${slot}\" ;;
+          *) exit 1 ;;
+        esac
+      fi
+      export BACKEND_IMAGE=$(quote "${BACKEND_IMAGE}")
+      docker_command=docker
+      \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} --profile bluegreen \
+        config --format json \
+        | python3 -c $(quote "${verify_config_code}") \
+          communications-worker \"\${active_service}\" $(quote "${BACKEND_IMAGE}")
+      set -- \$(\"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
+        --profile bluegreen ps -q \"\${active_service}\")
+      test \"\$#\" -eq 1
+      app_id=\"\$1\"
+      set -- \$(\"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
+        --profile bluegreen ps -q communications-worker)
+      test \"\$#\" -eq 1
+      worker_id=\"\$1\"
+      test \"\$(\"\${docker_command}\" inspect --format '{{.Config.Image}}|{{.State.Running}}' \"\${app_id}\")\" \
+        = $(quote "${BACKEND_IMAGE}|true")
+      test \"\$(\"\${docker_command}\" inspect --format '{{.Config.Image}}|{{.State.Running}}' \"\${worker_id}\")\" \
+        = $(quote "${BACKEND_IMAGE}|true")
+      if test -e .ha-communications-worker-release-fenced \
+        || test -L .ha-communications-worker-release-fenced; then
+        exit 1
+      fi
+      if ! \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
+        --profile bluegreen exec -T communications-worker \
+        python3 -c $(quote "${verify_worker_runtime_code}") \"\${role}\" >/dev/null; then
+        exit 1
+      fi
+      if ! systemctl is-active --quiet mvn-patroni-role-agent.service; then
+        exit 1
+      fi
+      role_agent_pid_before=\$(systemctl show --property=MainPID --value \
+        mvn-patroni-role-agent.service)
+      role_agent_restarts_before=\$(systemctl show --property=NRestarts --value \
+        mvn-patroni-role-agent.service)
+      case \"\${role_agent_pid_before}\" in
+        ''|*[!0-9]*|0) exit 1 ;;
+      esac
+      case \"\${role_agent_restarts_before}\" in
+        ''|*[!0-9]*) exit 1 ;;
+      esac
+      sleep 2
+      if ! systemctl is-active --quiet mvn-patroni-role-agent.service; then
+        exit 1
+      fi
+      role_agent_pid_after=\$(systemctl show --property=MainPID --value \
+        mvn-patroni-role-agent.service)
+      role_agent_restarts_after=\$(systemctl show --property=NRestarts --value \
+        mvn-patroni-role-agent.service)
+      if test \"\${role_agent_pid_after}\" != \"\${role_agent_pid_before}\" \
+        || test \"\${role_agent_restarts_after}\" != \"\${role_agent_restarts_before}\"; then
+        exit 1
+      fi
+      role_agent_canary_passed=false
+      for canary_attempt in 1 2 3; do
+        role_agent_canary_rc=0
+        role_agent_canary_output=\$(
+          timeout 120 $(quote "${ROLE_AGENT_TARGET}") --once 2>/dev/null
+        ) || role_agent_canary_rc=\$?
+        if test \"\${role_agent_canary_rc}\" -eq 0 \
+          && printf '%s' \"\${role_agent_canary_output}\" \
+            | python3 -c $(quote "${verify_canary_code}") \"\${role}\"; then
+          role_agent_canary_passed=true
+          break
+        fi
+        if test \"\${role_agent_canary_rc}\" -eq 75 \
+          && test \"\${role_agent_canary_output}\" \
+            = 'patroni_role_agent_status=deferred reason=deployment_lock_busy' \
+          && test \"\${canary_attempt}\" -lt 3; then
+          sleep 1
+          continue
+        fi
+        exit 1
+      done
+      test \"\${role_agent_canary_passed}\" = true
+      final_role=\$(curl -fsS --max-time 5 http://127.0.0.1:8008/patroni \
+        | python3 -c $(quote "${verify_role_code}"))
+      if test \"\${final_role}\" != \"\${role}\" \
+        || test \"\${final_role}\" != $(quote "${EXPECTED_ROLE}"); then
+        exit 1
+      fi
+      if test -e .ha-communications-worker-release-fenced \
+        || test -L .ha-communications-worker-release-fenced; then
+        exit 1
+      fi
+      set -- \$(\"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
+        --profile bluegreen ps -q communications-worker)
+      test \"\$#\" -eq 1
+      worker_id=\"\$1\"
+      test \"\$(\"\${docker_command}\" inspect --format '{{.Config.Image}}|{{.State.Running}}' \"\${worker_id}\")\" \
+        = $(quote "${BACKEND_IMAGE}|true")
+      if ! \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
+        --profile bluegreen exec -T communications-worker \
+        python3 -c $(quote "${verify_worker_runtime_code}") \"\${final_role}\" >/dev/null; then
+        exit 1
+      fi
+      if ! systemctl is-active --quiet mvn-patroni-role-agent.service; then
+        exit 1
+      fi
+      if test \"\$(systemctl show --property=MainPID --value \
+          mvn-patroni-role-agent.service)\" != \"\${role_agent_pid_before}\" \
+        || test \"\$(systemctl show --property=NRestarts --value \
+          mvn-patroni-role-agent.service)\" != \"\${role_agent_restarts_before}\"; then
+        exit 1
+      fi
+      printf 'verified:%s\\n' \"\${role}\"
+    "
+  )"
+  [[ "${verified}" == "verified:${EXPECTED_ROLE}" ]] || {
+    log error "runtime postcondition verification failed on ${NODE_HOST}"
+    exit 1
+  }
+  log verify "${NODE_HOST} role=${EXPECTED_ROLE} API/worker parity confirmed"
+  exit 0
+fi
+
 ssh "${SSH_OPTS[@]}" "${REMOTE}" \
   "test -d $(quote "${PROJECT_DIR}"); if test -e $(quote "${PITR_MAINTENANCE_MARKER}") || test -L $(quote "${PITR_MAINTENANCE_MARKER}"); then echo 'PITR release maintenance is active; refusing remote release staging' >&2; exit 75; fi"
-CANONICAL_REMOTE_COMPOSE_FILE="docker-compose.patroni.yml"
 candidate_id="$(printf '%s' "${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}-${OPERATION}-$$" | tr -c 'A-Za-z0-9_.-' '-')"
 REMOTE_COMPOSE_FILE="docker-compose.patroni.candidate.${candidate_id}.yml"
 REMOTE_BUNDLE_DIR="$(
@@ -221,6 +465,9 @@ BUNDLE_SOURCES=(
   "${CANDIDATE_RUNNER_SOURCE}"
   "${DEPLOY_LOCK_HELPER_SOURCE}"
   "${DEPLOY_CAPACITY_HELPER_SOURCE}"
+  "${COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE}"
+  "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}"
+  "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}"
   "${TRANSACTION_SOURCE}"
   "${VOICE_ENV_SYNC_SOURCE}"
 )
@@ -228,7 +475,10 @@ if [[ "${OPERATION}" == "deploy" ]]; then
   BUNDLE_SOURCES+=(
     "${DB_CONTRACT_HELPER_SOURCE}"
     "${ROLE_AGENT_SOURCE}"
+    "${ROLE_COMPOSE_RUNTIME_SOURCE}"
+    "${ROLE_AGENT_CONFIG_SOURCE}"
     "${ROLE_IDENTITY_SOURCE}"
+    "${ROLE_UNIT_SOURCE}"
   )
   if [[ "${PROXY_MODE}" == "container_nginx" ]]; then
     BUNDLE_SOURCES+=(
@@ -240,9 +490,15 @@ fi
 BUNDLE_MANIFEST_B64="$(python3 "${BUNDLE_VERIFIER_SOURCE}" manifest "${BUNDLE_SOURCES[@]}")"
 BUNDLE_VERIFIER_CODE="$(<"${BUNDLE_VERIFIER_SOURCE}")"
 ROLE_AGENT_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_role_agent.py"
+ROLE_COMPOSE_RUNTIME_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_compose_runtime.py"
+ROLE_AGENT_CONFIG_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_role_agent_config.py"
 ROLE_IDENTITY_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_local_identity.py"
+ROLE_UNIT_REMOTE="${REMOTE_BUNDLE_DIR}/mvn-patroni-role-agent.service"
 DB_CONTRACT_HELPER_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_compose_db_contract.py"
 VOICE_ENV_SYNC_REMOTE="${REMOTE_BUNDLE_DIR}/sync_bot_voice_env.py"
+COMMUNICATIONS_WORKER_RELEASE_HELPER_REMOTE="${REMOTE_BUNDLE_DIR}/communications_worker_release_contract.sh"
+PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_communications_candidate_lifecycle.sh"
+PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_role_agent_candidate_assets.sh"
 REMOTE_COMPOSE_SOURCE="${REMOTE_BUNDLE_DIR}/$(basename "${COMPOSE_SOURCE}")"
 scp "${SSH_OPTS[@]}" "${BUNDLE_SOURCES[@]}" "${REMOTE}:${REMOTE_BUNDLE_DIR}/"
 
@@ -291,13 +547,22 @@ printf '%s\n%s\n' "${GHCR_PAT:-}" "${BOT_VOICE_TRANSCRIPTION_API_KEY}" | ssh "${
   COMPOSE_CANDIDATE_TRANSACTION_SCRIPT=$(quote "${REMOTE_BUNDLE_DIR}/compose_candidate_transaction.sh") \
   PATRONI_ROLE_AGENT_SOURCE=$(quote "${ROLE_AGENT_REMOTE}") \
   PATRONI_ROLE_AGENT_TARGET=$(quote "${ROLE_AGENT_TARGET}") \
+  PATRONI_ROLE_COMPOSE_RUNTIME_SOURCE=$(quote "${ROLE_COMPOSE_RUNTIME_REMOTE}") \
+  PATRONI_ROLE_COMPOSE_RUNTIME_TARGET=$(quote "${ROLE_COMPOSE_RUNTIME_TARGET}") \
+  PATRONI_ROLE_AGENT_CONFIG_SOURCE=$(quote "${ROLE_AGENT_CONFIG_REMOTE}") \
+  PATRONI_ROLE_AGENT_CONFIG_TARGET=$(quote "${ROLE_AGENT_CONFIG_TARGET}") \
   PATRONI_ROLE_IDENTITY_SOURCE=$(quote "${ROLE_IDENTITY_REMOTE}") \
   PATRONI_ROLE_IDENTITY_TARGET=$(quote "${ROLE_IDENTITY_TARGET}") \
+  PATRONI_ROLE_UNIT_SOURCE=$(quote "${ROLE_UNIT_REMOTE}") \
+  PATRONI_ROLE_UNIT_TARGET=$(quote "${ROLE_UNIT_TARGET}") \
   PATRONI_DB_CONTRACT_HELPER=$(quote "${DB_CONTRACT_HELPER_REMOTE}") \
   PATRONI_ROLE_AGENT_UNIT=$(quote "${ROLE_AGENT_UNIT}") \
   API_DEPLOY_LOCK_HELPER=$(quote "${REMOTE_BUNDLE_DIR}/safe_deploy_lock.py") \
   API_DEPLOY_CAPACITY_HELPER=$(quote "${REMOTE_BUNDLE_DIR}/require_deploy_capacity.sh") \
   API_DEPLOY_CAPACITY_PROFILE=$(quote "${DEPLOY_CAPACITY_PROFILE}") \
+  COMMUNICATIONS_WORKER_RELEASE_HELPER=$(quote "${COMMUNICATIONS_WORKER_RELEASE_HELPER_REMOTE}") \
+  PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE=$(quote "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_REMOTE}") \
+  PATRONI_ROLE_AGENT_CANDIDATE_ASSETS=$(quote "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_REMOTE}") \
   API_DEPLOY_LOCK_HELPER_SHA256=$(quote "${DEPLOY_LOCK_HELPER_SHA256}") \
   ${proxy_env} \
   bash $(quote "${REMOTE_BUNDLE_DIR}/run_patroni_candidate_transaction.sh")

--- a/scripts/ha/verify_postgres_pitr_runtime.py
+++ b/scripts/ha/verify_postgres_pitr_runtime.py
@@ -27,10 +27,10 @@ PITR_ENV_POLICIES = (*PUBLIC_PITR_ENV_POLICIES, *MIGRATION_PITR_ENV_POLICIES)
 SECRETS_FILE = Path("/etc/mvn-postgres-pitr.secrets.env")
 EXPECTED_COMPOSE_DIGESTS = {
     "/opt/air-api/docker-compose.patroni.yml": (
-        "58f34fde8ba5fb31f74b213063d1a19acf9663ad5e06cee7676d6ed744e49325"
+        "5a63addfd1b00a0bf30346b11625beedb19204563e6f02fa63c6af35667da477"
     ),
     "/opt/mvn-reserve/docker-compose.patroni.yml": (
-        "ec75fd5943898b5e4a295d348b033dc1a6455f04ae5192a6a2f292214336c5a9"
+        "b0662d4736d78442fcf68073249643c58b1452c5c6059055ca7de3fc227d83a2"
     ),
 }
 EXPECTED_PITR_CLUSTERS = {

--- a/scripts/reconcile_backend_compose_runtime.sh
+++ b/scripts/reconcile_backend_compose_runtime.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
 COMPOSE_FILE="${API_COMPOSE_FILE:-docker-compose.prod.yml}"
 DEPLOY_SERVICES="${API_DEPLOY_SERVICES:-app}"
@@ -10,6 +11,10 @@ HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
 STOP_SERVICES="${API_STOP_SERVICES_AFTER_DEPLOY:-}"
 ENV_FILE="${API_ENV_FILE:-${PROJECT_DIR}/.env}"
 RECONCILE_BACKEND_IMAGE="${API_RECONCILE_BACKEND_IMAGE:-}"
+COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
+RECONCILE_OPERATION="${API_RECONCILE_OPERATION:-reconcile}"
+EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/ha/communications_worker_release_contract.sh}"
 
 write_backend_image() {
   local image="$1"
@@ -23,6 +28,27 @@ write_backend_image() {
   chown --reference="${ENV_FILE}" "${temporary}" 2>/dev/null || true
   mv "${temporary}" "${ENV_FILE}"
 }
+
+[[ "${RECONCILE_OPERATION}" == "reconcile" || "${RECONCILE_OPERATION}" == "verify" ]] || {
+  echo "API_RECONCILE_OPERATION must be reconcile or verify" >&2
+  exit 2
+}
+requested_communications_worker=false
+read -r -a requested_services <<<"${DEPLOY_SERVICES}"
+for requested_service in "${requested_services[@]}"; do
+  if [[ "${requested_service}" == "${COMMUNICATIONS_WORKER_SERVICE}" ]]; then
+    requested_communications_worker=true
+  fi
+done
+if [[ "${requested_communications_worker}" == "true" ]]; then
+  [[ -f "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" \
+    && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" ]] || {
+    echo "communications worker release helper is missing or unsafe" >&2
+    exit 1
+  }
+  # shellcheck disable=SC1090
+  source "${COMMUNICATIONS_WORKER_RELEASE_HELPER}"
+fi
 
 cd "${PROJECT_DIR}"
 [[ -f "${COMPOSE_FILE}" ]] || {
@@ -38,12 +64,8 @@ fi
   echo "canonical reconcile requires an immutable BACKEND_IMAGE" >&2
   exit 1
 }
-if [[ -n "${RECONCILE_BACKEND_IMAGE}" ]]; then
-  write_backend_image "${BACKEND_IMAGE}"
-fi
 export BACKEND_IMAGE
 
-read -r -a requested_services <<<"${DEPLOY_SERVICES}"
 resolved_services=()
 for service in "${requested_services[@]}"; do
   if [[ "${service}" == "app" && -f "${ACTIVE_SLOT_FILE}" ]]; then
@@ -56,18 +78,61 @@ for service in "${requested_services[@]}"; do
   resolved_services+=("${service}")
 done
 
-docker compose -f "${COMPOSE_FILE}" --profile bluegreen \
-  up -d --no-deps --force-recreate "${resolved_services[@]}"
-if [[ -n "${STOP_SERVICES}" ]]; then
-  read -r -a stop_services <<<"${STOP_SERVICES}"
-  docker compose -f "${COMPOSE_FILE}" --profile bluegreen stop "${stop_services[@]}"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}" --profile bluegreen)
+# shellcheck disable=SC2329  # invoked by the ERR trap
+reconcile_failure() {
+  local status=$?
+  trap - ERR
+  set +e
+  if [[ "${requested_communications_worker}" == "true" ]]; then
+    communications_worker_set_release_fence
+    "${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null 2>&1
+  fi
+  exit "${status}"
+}
+trap reconcile_failure ERR
+if [[ "${requested_communications_worker}" == "true" ]]; then
+  communications_worker_require_contract
+fi
+if [[ "${RECONCILE_OPERATION}" == "verify" ]]; then
+  [[ "${requested_communications_worker}" == "true" ]] || {
+    echo "verify operation requires ${COMMUNICATIONS_WORKER_SERVICE}" >&2
+    exit 2
+  }
+  communications_worker_require_runtime "${EXPECTED_ROLE}"
+  echo "canonical communications worker runtime verified"
+  exit 0
+fi
+if [[ "${requested_communications_worker}" == "true" ]]; then
+  communications_worker_set_release_fence
+  "${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null
+fi
+if [[ -n "${RECONCILE_BACKEND_IMAGE}" ]]; then
+  write_backend_image "${BACKEND_IMAGE}"
 fi
 
+app_services=()
+for service in "${resolved_services[@]}"; do
+  if [[ "${service}" != "${COMMUNICATIONS_WORKER_SERVICE}" ]]; then
+    app_services+=("${service}")
+  fi
+done
+if [[ "${#app_services[@]}" -gt 0 ]]; then
+  "${COMPOSE[@]}" up -d --no-deps --force-recreate "${app_services[@]}"
+fi
+if [[ "${requested_communications_worker}" == "true" ]]; then
+  communications_worker_start_controlled "${EXPECTED_ROLE}"
+fi
+if [[ -n "${STOP_SERVICES}" ]]; then
+  read -r -a stop_services <<<"${STOP_SERVICES}"
+  "${COMPOSE[@]}" stop "${stop_services[@]}"
+fi
 for _ in $(seq 1 "${HEALTH_ATTEMPTS}"); do
   if curl -fsS "${HEALTH_URL}" >/tmp/mvn-canonical-compose-health.out; then
     cat /tmp/mvn-canonical-compose-health.out
     printf '\n'
     echo "canonical compose runtime reconciled"
+    trap - ERR
     exit 0
   fi
   sleep 2

--- a/tests/unit/test_compose_candidate_transactions.py
+++ b/tests/unit/test_compose_candidate_transactions.py
@@ -9,6 +9,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TRANSACTION = REPO_ROOT / "scripts/compose_candidate_transaction.sh"
 BACKEND_RUNNER = REPO_ROOT / "scripts/deploy_backend_candidate_transaction.sh"
+RECONCILE_RUNTIME = REPO_ROOT / "scripts/reconcile_backend_compose_runtime.sh"
 LOCK_HELPER = REPO_ROOT / "scripts/ha/safe_deploy_lock.py"
 LOCK_HELPER_SHA256 = hashlib.sha256(LOCK_HELPER.read_bytes()).hexdigest()
 PREVIOUS_IMAGE = "ghcr.io/mvnby/air-api/backend:" + "1" * 40
@@ -92,6 +93,7 @@ def _backend_runner(
     promote_after_move_exit: int = 0,
     reconcile_exit: int = 0,
     discover_previous: bool = False,
+    use_real_reconcile: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
     project = _compose_pair(tmp_path)
     if discover_previous:
@@ -108,10 +110,16 @@ if [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
   printf 'active-green-container\n'
 elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
   printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
+elif [[ "$1" == "compose" && "$*" == *" up -d --no-deps --force-recreate app" ]]; then
+  exit 0
 else
   exit 91
 fi
 """,
+    )
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\nprintf '{\"status\":\"ok\"}\\n'\n",
     )
     child = tmp_path / "deploy-child.sh"
     _executable(
@@ -135,17 +143,18 @@ printf 'smoke:%s\n' "$COMPOSE_FILE" >> "$ORDER_LOG"
 exit {smoke_exit}
 """,
     )
-    reconcile = tmp_path / "reconcile.sh"
-    _executable(
-        reconcile,
-        f"""#!/usr/bin/env bash
+    reconcile = RECONCILE_RUNTIME if use_real_reconcile else tmp_path / "reconcile.sh"
+    if not use_real_reconcile:
+        _executable(
+            reconcile,
+            f"""#!/usr/bin/env bash
 set -euo pipefail
 grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
 printf 'reconcile:%s\n' "$API_COMPOSE_FILE" >> "$ORDER_LOG"
 test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_PREVIOUS_IMAGE"
 exit {reconcile_exit}
 """,
-    )
+        )
     transaction_driver = tmp_path / "transaction.sh"
     _executable(
         transaction_driver,
@@ -179,6 +188,9 @@ exec bash "$REAL_TRANSACTION" "$@"
             "EXPECTED_PREVIOUS_IMAGE": PREVIOUS_IMAGE,
             "API_DEPLOY_LOCK_HELPER": str(LOCK_HELPER),
             "API_DEPLOY_LOCK_HELPER_SHA256": LOCK_HELPER_SHA256,
+            "COMMUNICATIONS_WORKER_RELEASE_HELPER": str(
+                tmp_path / "intentionally-absent-worker-helper.sh"
+            ),
         },
         text=True,
         capture_output=True,
@@ -205,6 +217,22 @@ def test_backend_failure_cleans_candidate_and_force_reconciles_canonical(
         "child:compose.yml.candidate:fd=9",
         "reconcile:compose.yml",
     ]
+
+
+def test_legacy_app_only_failure_rollback_does_not_require_worker_helper(tmp_path):
+    result, project, order_log = _backend_runner(
+        tmp_path,
+        child_exit=42,
+        use_real_reconcile=True,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    commands = order_log.read_text(encoding="utf-8")
+    assert "child:compose.yml.candidate:fd=9" in commands
+    assert "up -d --no-deps --force-recreate app" in commands
+    assert "communications-worker" not in commands
 
 
 @pytest.mark.parametrize("strategy", ["in_place", "blue_green"])

--- a/tests/unit/test_patroni_candidate_runtime_assets.py
+++ b/tests/unit/test_patroni_candidate_runtime_assets.py
@@ -1,0 +1,515 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_patroni_candidate_transactions import (
+    PATRONI_RUNNER,
+    TRANSACTION,
+    _patroni_runner_env,
+)
+
+
+ROLE_UNIT = (
+    Path(__file__).resolve().parents[2]
+    / "deploy/ha/patroni/mvn-patroni-role-agent.service"
+)
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _role_asset_pairs(env: dict[str, str]) -> list[tuple[Path, Path, str]]:
+    return [
+        (
+            Path(env["PATRONI_ROLE_IDENTITY_SOURCE"]),
+            Path(env["PATRONI_ROLE_IDENTITY_TARGET"]),
+            "old identity\n",
+        ),
+        (
+            Path(env["PATRONI_ROLE_AGENT_CONFIG_SOURCE"]),
+            Path(env["PATRONI_ROLE_AGENT_CONFIG_TARGET"]),
+            "old config\n",
+        ),
+        (
+            Path(env["PATRONI_ROLE_COMPOSE_RUNTIME_SOURCE"]),
+            Path(env["PATRONI_ROLE_COMPOSE_RUNTIME_TARGET"]),
+            "old compose runtime\n",
+        ),
+        (
+            Path(env["PATRONI_ROLE_UNIT_SOURCE"]),
+            Path(env["PATRONI_ROLE_UNIT_TARGET"]),
+            "[Service]\nExecStart=/old-role-agent\n",
+        ),
+        (
+            Path(env["PATRONI_ROLE_AGENT_SOURCE"]),
+            Path(env["PATRONI_ROLE_AGENT_TARGET"]),
+            "#!/usr/bin/env python3\n# old role agent\n",
+        ),
+    ]
+
+
+def _seed_previous_role_assets(env: dict[str, str]) -> None:
+    for _source, target, content in _role_asset_pairs(env):
+        target.write_text(content, encoding="utf-8")
+        mode = 0o755 if target == Path(env["PATRONI_ROLE_AGENT_TARGET"]) else 0o644
+        target.chmod(mode)
+
+
+def _installed_target_order(env: dict[str, str]) -> list[str]:
+    lines = Path(env["INSTALL_LOG"]).read_text(encoding="utf-8").splitlines()
+    expected_targets = [str(target) for _source, target, _content in _role_asset_pairs(env)]
+    assert len(lines) == len(expected_targets)
+    for temporary, target in zip(lines, expected_targets, strict=True):
+        assert temporary.startswith(target + ".tmp.")
+    return expected_targets
+
+
+def test_candidate_requires_immutable_candidate_image_before_mutation(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    env.pop("BACKEND_IMAGE")
+    canonical = (project / "compose.yml").read_text(encoding="utf-8")
+    candidate = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "BACKEND_IMAGE must identify an immutable candidate release" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == canonical
+    assert (project / "compose.yml.candidate").read_text(encoding="utf-8") == candidate
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+
+
+def test_role_asset_install_orders_dependencies_and_unit_before_executable(tmp_path):
+    env, _project = _patroni_runner_env(tmp_path, child_exit=0)
+    _seed_previous_role_assets(env)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert _installed_target_order(env)[-1] == env["PATRONI_ROLE_AGENT_TARGET"]
+    systemctl = Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8").splitlines()
+    assert systemctl.index("daemon-reload") < systemctl.index("restart test.service")
+
+
+def test_role_asset_install_failure_restores_every_asset_in_safe_order(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    _seed_previous_role_assets(env)
+    env["FAIL_INSTALL_NUMBER"] = "4"
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stderr
+    install_lines = Path(env["INSTALL_LOG"]).read_text(encoding="utf-8").splitlines()
+    assert len(install_lines) == 4
+    assert all(
+        not line.startswith(env["PATRONI_ROLE_AGENT_TARGET"] + ".tmp.")
+        for line in install_lines
+    )
+    restore_lines = [
+        line
+        for line in Path(env["CP_LOG"]).read_text(encoding="utf-8").splitlines()
+        if ".patroni-" in line.split("|", 1)[0]
+    ]
+    labels = (
+        "role-identity",
+        "role-agent-config",
+        "compose-runtime",
+        "role-agent-unit",
+        "role-agent",
+    )
+    assert [
+        next(label for label in labels if f".patroni-{label}.backup." in line)
+        for line in restore_lines
+    ] == list(labels)
+    for _source, target, old_content in _role_asset_pairs(env):
+        assert target.read_text(encoding="utf-8") == old_content
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_partial_role_asset_restore_is_best_effort_and_retains_backups(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    _seed_previous_role_assets(env)
+    env["FAIL_RESTORE_LABEL"] = "compose-runtime"
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "role asset backups retained" in result.stderr
+    for _source, target, old_content in _role_asset_pairs(env):
+        if target == Path(env["PATRONI_ROLE_COMPOSE_RUNTIME_TARGET"]):
+            assert target.read_text(encoding="utf-8") != old_content
+        else:
+            assert target.read_text(encoding="utf-8") == old_content
+    assert len(list(project.glob(".patroni-*.backup.*"))) == 5
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_candidate_rejects_symlinked_role_agent_executable_target(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    victim = tmp_path / "victim-role-agent"
+    victim.write_text("do-not-overwrite\n", encoding="utf-8")
+    Path(env["PATRONI_ROLE_AGENT_TARGET"]).symlink_to(victim)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "role agent target is unsafe" in result.stderr
+    assert victim.read_text(encoding="utf-8") == "do-not-overwrite\n"
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_candidate_rejects_symlinked_identity_helper_target(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    victim = tmp_path / "victim-identity-helper"
+    victim.write_text("do-not-overwrite\n", encoding="utf-8")
+    Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).symlink_to(victim)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "identity helper target is unsafe" in result.stderr
+    assert victim.read_text(encoding="utf-8") == "do-not-overwrite\n"
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("failure_source", "child_exit", "restart_failure", "expected_exit"),
+    [
+        ("child", 42, "0", 42),
+        ("systemctl", 0, "1", 47),
+    ],
+)
+def test_failure_restores_preexisting_role_agent_bundle(
+    tmp_path,
+    failure_source,
+    child_exit,
+    restart_failure,
+    expected_exit,
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=child_exit)
+    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
+    identity_target = Path(env["PATRONI_ROLE_IDENTITY_TARGET"])
+    unit_target = Path(env["PATRONI_ROLE_UNIT_TARGET"])
+    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
+    old_identity = "# previous identity helper\n"
+    old_unit = "[Service]\nExecStart=/previous-role-agent\n"
+    target.write_text(old_content, encoding="utf-8")
+    target.chmod(0o755)
+    identity_target.write_text(old_identity, encoding="utf-8")
+    unit_target.write_text(old_unit, encoding="utf-8")
+    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = restart_failure
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == expected_exit, (
+        failure_source,
+        result.stdout,
+        result.stderr,
+    )
+    assert target.read_text(encoding="utf-8") == old_content
+    assert identity_target.read_text(encoding="utf-8") == old_identity
+    assert unit_target.read_text(encoding="utf-8") == old_unit
+    assert not Path(env["PATRONI_ROLE_AGENT_SOURCE"]).exists()
+    assert not Path(env["PATRONI_ROLE_IDENTITY_SOURCE"]).exists()
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert not (project / "compose.yml.candidate").exists()
+    restarts = [
+        line
+        for line in Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8").splitlines()
+        if line.startswith("restart ")
+    ]
+    assert len(restarts) == 2
+    assert Path(env["RECONCILE_LOG"]).exists()
+
+
+def test_restore_restart_failure_retains_role_agent_backups(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
+    identity_target = Path(env["PATRONI_ROLE_IDENTITY_TARGET"])
+    unit_target = Path(env["PATRONI_ROLE_UNIT_TARGET"])
+    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
+    old_identity = "# previous identity helper\n"
+    old_unit = "[Service]\nExecStart=/previous-role-agent\n"
+    target.write_text(old_content, encoding="utf-8")
+    target.chmod(0o755)
+    identity_target.write_text(old_identity, encoding="utf-8")
+    unit_target.write_text(old_unit, encoding="utf-8")
+    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = "2"
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "role asset backups retained" in result.stderr
+    backup_expectations = (
+        (".patroni-role-agent.backup.*", old_content),
+        (".patroni-role-identity.backup.*", old_identity),
+        (".patroni-role-agent-unit.backup.*", old_unit),
+    )
+    for pattern, content in backup_expectations:
+        backups = list(project.glob(pattern))
+        assert len(backups) == 1
+        assert backups[0].read_text(encoding="utf-8") == content
+    assert target.read_text(encoding="utf-8") == old_content
+    assert identity_target.read_text(encoding="utf-8") == old_identity
+    assert unit_target.read_text(encoding="utf-8") == old_unit
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_first_rollout_role_drift_force_removes_candidate_worker_after_stop_failure(
+    tmp_path,
+):
+    env, project = _patroni_runner_env(
+        tmp_path,
+        child_exit=42,
+        expected_role="primary",
+        current_role="standby",
+    )
+    Path(env["WORKER_RUNTIME_STATE"]).touch()
+    env["FAKE_CANDIDATE_WORKER_SUPPORTED"] = "true"
+    env["FAKE_CANONICAL_WORKER_SUPPORTED"] = "false"
+    env["FAIL_CANDIDATE_WORKER_STOP"] = "true"
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "Patroni role changed during deployment" in result.stderr
+    assert not Path(env["WORKER_RUNTIME_STATE"]).exists()
+    assert not (project / "compose.yml.candidate").exists()
+    assert (project / ".ha-communications-worker-release-fenced").exists()
+    commands = Path(env["PATRONI_COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert " stop communications-worker" in commands
+    assert "ps -a -q --filter label=com.docker.compose.project=air-api" in commands
+    assert "rm -f -- " + "0" * 64 in commands
+
+
+def test_preexisting_release_fence_rolls_back_to_stopped_worker(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    marker = project / ".ha-communications-worker-release-fenced"
+    marker.write_text("fenced\n", encoding="utf-8")
+    marker.chmod(0o600)
+    env.update(
+        {
+            "BACKEND_IMAGE": "ghcr.io/mvnby/air-api/backend@" + "sha256:" + "2" * 64,
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert marker.read_text(encoding="utf-8") == "fenced\n"
+    assert marker.stat().st_mode & 0o777 == 0o600
+    assert not Path(env["WORKER_RUNTIME_STATE"]).exists()
+    assert Path(env["RECONCILE_LOG"]).read_text(encoding="utf-8").strip() == (
+        "compose.yml|app"
+    )
+
+
+def test_first_rollout_preexisting_fence_proves_no_labeled_worker(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    marker = project / ".ha-communications-worker-release-fenced"
+    marker.write_text("fenced\n", encoding="utf-8")
+    marker.chmod(0o600)
+    env.update(
+        {
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "false",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert marker.read_text(encoding="utf-8") == "fenced\n"
+    assert not Path(env["WORKER_RUNTIME_STATE"]).exists()
+    commands = Path(env["PATRONI_COMMAND_LOG"]).read_text(encoding="utf-8")
+    canonical_unknown_service_probe = (
+        f"compose -f {project / 'compose.yml'} --profile bluegreen "
+        "ps --status running -q communications-worker"
+    )
+    assert canonical_unknown_service_probe not in commands
+    assert (
+        "ps -a -q --filter label=com.docker.compose.project=air-api "
+        "--filter label=com.docker.compose.service=communications-worker"
+    ) in commands
+    assert Path(env["RECONCILE_LOG"]).read_text(encoding="utf-8").strip() == (
+        "compose.yml|app"
+    )
+
+
+def test_unfenced_running_worker_is_restored_after_candidate_failure(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    worker_state = Path(env["WORKER_RUNTIME_STATE"])
+    worker_state.touch()
+    env.update(
+        {
+            "BACKEND_IMAGE": "ghcr.io/mvnby/air-api/backend@" + "sha256:" + "2" * 64,
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert worker_state.exists()
+    assert not (project / ".ha-communications-worker-release-fenced").exists()
+    assert Path(env["RECONCILE_LOG"]).read_text(encoding="utf-8").strip() == (
+        "compose.yml|app communications-worker"
+    )
+
+
+def test_broken_symlink_release_fence_is_preserved_and_rejected(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    marker = project / ".ha-communications-worker-release-fenced"
+    missing_target = tmp_path / "missing-marker-target"
+    marker.symlink_to(missing_target)
+    env.update(
+        {
+            "BACKEND_IMAGE": "ghcr.io/mvnby/air-api/backend@" + "sha256:" + "2" * 64,
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "communications worker release fence metadata is unsafe" in result.stderr
+    assert marker.is_symlink()
+    assert not missing_target.exists()
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_post_promotion_failure_latches_durable_worker_fence(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    transaction_driver = tmp_path / "promotion-failure.sh"
+    _executable(
+        transaction_driver,
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "promote" ]]; then
+  bash "$REAL_TRANSACTION" "$1"
+  exit 46
+fi
+exec bash "$REAL_TRANSACTION" "$@"
+""",
+    )
+    env.update(
+        {
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
+            "REAL_TRANSACTION": str(TRANSACTION),
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 46, result.stderr
+    assert not (project / "compose.yml.candidate").exists()
+    assert "/app/google-oauth" in (project / "compose.yml").read_text(encoding="utf-8")
+    marker = project / ".ha-communications-worker-release-fenced"
+    assert marker.read_text(encoding="utf-8") == "fenced\n"
+    assert marker.stat().st_mode & 0o777 == 0o600
+
+
+def test_role_agent_unit_requires_complete_modular_runtime():
+    unit = ROLE_UNIT.read_text(encoding="utf-8")
+
+    for path in (
+        "/usr/local/sbin/mvn-patroni-role-agent",
+        "/usr/local/sbin/patroni_local_identity.py",
+        "/usr/local/sbin/patroni_role_agent_config.py",
+        "/usr/local/sbin/patroni_compose_runtime.py",
+    ):
+        assert f"ConditionPathExists={path}" in unit

--- a/tests/unit/test_patroni_candidate_transactions.py
+++ b/tests/unit/test_patroni_candidate_transactions.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TRANSACTION = REPO_ROOT / "scripts/compose_candidate_transaction.sh"
 PATRONI_RUNNER = REPO_ROOT / "scripts/ha/run_patroni_candidate_transaction.sh"
 PREVIOUS_IMAGE = "ghcr.io/mvnby/air-api/backend:" + "1" * 40
+CANDIDATE_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "2" * 64
 DB_CONTRACT_HELPER = REPO_ROOT / "scripts/ha/patroni_compose_db_contract.py"
 DEPLOY_LOCK_HELPER = REPO_ROOT / "scripts/ha/safe_deploy_lock.py"
 
@@ -94,7 +95,19 @@ def _patroni_runner_env(
         """#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$PATRONI_COMMAND_LOG"
-if [[ "$1" == "compose" && "$*" == *" config --no-env-resolution --no-interpolate --format json" ]]; then
+if [[ "$1" == "compose" && "$*" == *" config --services" ]]; then
+  printf 'app\n'
+  if [[ "$*" == *"compose.yml.candidate"* \
+    && "${FAKE_CANDIDATE_WORKER_SUPPORTED:-false}" == "true" ]]; then
+    printf 'communications-worker\n'
+  elif [[ "$*" != *"compose.yml.candidate"* \
+    && "${FAKE_CANONICAL_WORKER_SUPPORTED:-false}" == "true" ]]; then
+    printf 'communications-worker\n'
+  fi
+elif [[ "$1" == "compose" && "$*" == *" config --format json" ]]; then
+  printf '{"name":"air-api","services":{"communications-worker":{"image":"%s","environment":{"COMMUNICATIONS_WORKER_ENABLED":"false","COMMUNICATIONS_WORKER_ALLOW_ALL_MODE":"false"}}}}\n' \
+    "${BACKEND_IMAGE:-$EXPECTED_PREVIOUS_IMAGE}"
+elif [[ "$1" == "compose" && "$*" == *" config --no-env-resolution --no-interpolate --format json" ]]; then
   if [[ "$*" == *"compose.yml.candidate"* ]]; then
     config_path="$CANDIDATE_DB_CONTRACT"
     if [[ -e "$DEPLOY_CHILD_RAN" && -n "${CANDIDATE_DB_CONTRACT_AFTER_DEPLOY:-}" ]]; then
@@ -108,6 +121,12 @@ elif [[ "$1" == "compose" && "$*" == *" ps -q app-green" ]]; then
   printf 'active-green-container\n'
 elif [[ "$1" == "inspect" && "$*" == *" active-green-container" ]]; then
   printf '%s\n' "$EXPECTED_PREVIOUS_IMAGE"
+elif [[ "$1" == "compose" && "$*" == *" ps --status running -q communications-worker" ]]; then
+  [[ ! -f "${WORKER_RUNTIME_STATE:-}" ]] || printf '%064d\n' 0
+elif [[ "$1" == "compose" && "$*" == *" ps -q communications-worker" ]]; then
+  [[ ! -f "${WORKER_RUNTIME_STATE:-}" ]] || printf '%064d\n' 0
+elif [[ "$1" == "inspect" && "$*" == *"$(printf '%064d' 0)"* ]]; then
+  printf '%s|true\n' "$EXPECTED_PREVIOUS_IMAGE"
 elif [[ "$1" == "compose" && "$*" == *" stop app app-blue app-green bot" ]]; then
   exit 0
 elif [[ "$1" == "compose" && "$*" == *" ps -a -q api-proxy" ]]; then
@@ -116,6 +135,19 @@ elif [[ "$1" == "compose" && "$*" == *" ps -a -q api-proxy" ]]; then
   fi
 elif [[ "$1" == "inspect" && "$*" == *"proxy-container"* && "$*" == *"State.Running"* ]]; then
   [[ "${PROXY_PREVIOUS_RUNTIME_STATE:-absent}" == "running" ]] && printf 'true\n' || printf 'false\n'
+elif [[ "$1" == "compose" && "$*" == *"compose.yml.candidate"* \
+  && "$*" == *" stop communications-worker" ]]; then
+  if [[ "${FAIL_CANDIDATE_WORKER_STOP:-false}" == "true" ]]; then exit 1; fi
+  rm -f -- "${WORKER_RUNTIME_STATE:-}"
+elif [[ "$1" == "compose" && "$*" == *" stop communications-worker" ]]; then
+  rm -f -- "${WORKER_RUNTIME_STATE:-}"
+elif [[ "$1" == "docker-never" ]]; then
+  exit 91
+elif [[ "$1" == "ps" && "$*" == *"label=com.docker.compose.project=air-api"* \
+  && "$*" == *"label=com.docker.compose.service=communications-worker"* ]]; then
+  [[ ! -f "${WORKER_RUNTIME_STATE:-}" ]] || printf '%064d\n' 0
+elif [[ "$1" == "rm" && "$*" == *"$(printf '%064d' 0)"* ]]; then
+  rm -f -- "$WORKER_RUNTIME_STATE"
 elif [[ "$1" == "compose" && "$*" == *" up -d --no-deps --force-recreate --wait --wait-timeout 60 api-proxy" ]]; then
   if [[ -n "${PROXY_RUNTIME_CONFIG:-}" ]]; then
     cp "$API_PROXY_CONFIG_FILE" "$PROXY_RUNTIME_CONFIG"
@@ -134,6 +166,31 @@ elif [[ "$1" == "compose" && "$*" == *" ps --status running -q api-proxy" ]]; th
 else
   exit 91
 fi
+""",
+    )
+    _executable(
+        fake_bin / "install",
+        """#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [[ -f "$INSTALL_COUNT" ]]; then count="$(cat "$INSTALL_COUNT")"; fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$INSTALL_COUNT"
+printf '%s\n' "${!#}" >> "$INSTALL_LOG"
+if [[ "$count" -eq "${FAIL_INSTALL_NUMBER:-0}" ]]; then exit 48; fi
+exec /usr/bin/install "$@"
+""",
+    )
+    _executable(
+        fake_bin / "cp",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s\n' "${@: -2:1}" "${@: -1}" >> "$CP_LOG"
+if [[ -n "${FAIL_RESTORE_LABEL:-}" \
+  && "${@: -2:1}" == *".patroni-${FAIL_RESTORE_LABEL}.backup."* ]]; then
+  exit 49
+fi
+exec /bin/cp "$@"
 """,
     )
     _executable(
@@ -183,17 +240,33 @@ exit {child_exit}
     )
     role_agent = tmp_path / "role-agent.py"
     role_agent.write_text("#!/usr/bin/env python3\n# new role agent\n", encoding="utf-8")
+    role_compose_runtime = tmp_path / "patroni-compose-runtime.py"
+    role_compose_runtime.write_text("# new compose runtime\n", encoding="utf-8")
+    role_agent_config = tmp_path / "patroni-role-agent-config.py"
+    role_agent_config.write_text("# new role agent config\n", encoding="utf-8")
     role_identity = tmp_path / "patroni-local-identity.py"
     role_identity.write_text("# new identity helper\n", encoding="utf-8")
+    role_unit = tmp_path / "mvn-patroni-role-agent.service"
+    role_unit.write_text("[Service]\nExecStart=/new-role-agent\n", encoding="utf-8")
     reconcile = tmp_path / "reconcile.sh"
     _executable(
         reconcile,
         """#!/usr/bin/env bash
 set -euo pipefail
-grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
+if [[ "${API_RECONCILE_OPERATION:-reconcile}" != "verify" ]]; then
+  grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
+fi
 printf '%s|%s\n' "$API_COMPOSE_FILE" "$API_DEPLOY_SERVICES" > "$RECONCILE_LOG"
 printf 'reconcile:%s\n' "$API_COMPOSE_FILE" >> "$PATRONI_COMMAND_LOG"
-test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_PREVIOUS_IMAGE"
+if [[ "${API_RECONCILE_OPERATION:-reconcile}" == "verify" ]]; then
+  test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_CANDIDATE_IMAGE"
+else
+  test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_PREVIOUS_IMAGE"
+fi
+if [[ "${API_RECONCILE_OPERATION:-reconcile}" != "verify" \
+  && " $API_DEPLOY_SERVICES " == *" communications-worker "* ]]; then
+  : > "$WORKER_RUNTIME_STATE"
+fi
 exit 0
 """,
     )
@@ -211,8 +284,18 @@ exit 0
         "API_CURRENT_PATRONI_ROLE": current_role,
         "PATRONI_ROLE_AGENT_SOURCE": str(role_agent),
         "PATRONI_ROLE_AGENT_TARGET": str(tmp_path / "installed-role-agent"),
+        "PATRONI_ROLE_COMPOSE_RUNTIME_SOURCE": str(role_compose_runtime),
+        "PATRONI_ROLE_COMPOSE_RUNTIME_TARGET": str(
+            tmp_path / "installed-patroni-compose-runtime.py"
+        ),
+        "PATRONI_ROLE_AGENT_CONFIG_SOURCE": str(role_agent_config),
+        "PATRONI_ROLE_AGENT_CONFIG_TARGET": str(
+            tmp_path / "installed-patroni-role-agent-config.py"
+        ),
         "PATRONI_ROLE_IDENTITY_SOURCE": str(role_identity),
         "PATRONI_ROLE_IDENTITY_TARGET": str(tmp_path / "installed-role-identity.py"),
+        "PATRONI_ROLE_UNIT_SOURCE": str(role_unit),
+        "PATRONI_ROLE_UNIT_TARGET": str(tmp_path / "installed-role-agent.service"),
         "PATRONI_DB_CONTRACT_HELPER": str(DB_CONTRACT_HELPER),
         "PATRONI_ROLE_AGENT_UNIT": "test.service",
         "CHILD_LOG": str(tmp_path / "child.log"),
@@ -221,11 +304,17 @@ exit 0
         "SYSTEMCTL_LOG": str(systemctl_log),
         "SYSTEMCTL_STATE": str(systemctl_state),
         "SYSTEMCTL_RESTART_COUNT": str(tmp_path / "systemctl-restart-count"),
+        "INSTALL_COUNT": str(tmp_path / "install-count"),
+        "INSTALL_LOG": str(tmp_path / "install.log"),
+        "CP_LOG": str(tmp_path / "cp.log"),
+        "WORKER_RUNTIME_STATE": str(tmp_path / "worker-runtime-state"),
         "CANONICAL_DB_CONTRACT": str(canonical_contract),
         "CANDIDATE_DB_CONTRACT": str(candidate_contract),
         "DEPLOY_CHILD_RAN": str(tmp_path / "deploy-child-ran"),
         "API_PREVIOUS_BACKEND_IMAGE": "" if discover_previous else PREVIOUS_IMAGE,
         "EXPECTED_PREVIOUS_IMAGE": PREVIOUS_IMAGE,
+        "BACKEND_IMAGE": CANDIDATE_IMAGE,
+        "EXPECTED_CANDIDATE_IMAGE": CANDIDATE_IMAGE,
         "API_DEPLOY_LOCK_HELPER": str(DEPLOY_LOCK_HELPER),
         "API_DEPLOY_LOCK_HELPER_SHA256": __import__("hashlib").sha256(
             DEPLOY_LOCK_HELPER.read_bytes()
@@ -386,26 +475,6 @@ def test_patroni_candidate_rechecks_db_contract_immediately_before_promotion(tmp
     )
 
 
-def test_patroni_candidate_rejects_symlinked_identity_helper_target(tmp_path):
-    env, project = _patroni_runner_env(tmp_path, child_exit=0)
-    victim = tmp_path / "victim"
-    victim.write_text("do-not-overwrite\n", encoding="utf-8")
-    Path(env["PATRONI_ROLE_IDENTITY_TARGET"]).symlink_to(victim)
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert "identity helper target is unsafe" in result.stderr
-    assert victim.read_text(encoding="utf-8") == "do-not-overwrite\n"
-    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
-
-
 def test_patroni_discovers_previous_runtime_image_from_active_slot_before_reconcile(
     tmp_path,
 ):
@@ -488,90 +557,6 @@ def test_patroni_unknown_live_role_fences_runtime_instead_of_assuming_standby(tm
     assert not (tmp_path / "reconcile.log").exists()
     commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
     assert " stop app app-blue app-green bot" in commands
-
-
-@pytest.mark.parametrize(
-    ("failure_source", "child_exit", "restart_failure", "expected_exit"),
-    [
-        ("child", 42, "0", 42),
-        ("systemctl", 0, "1", 47),
-    ],
-)
-def test_patroni_failure_restores_preexisting_role_agent(
-    tmp_path,
-    failure_source,
-    child_exit,
-    restart_failure,
-    expected_exit,
-):
-    env, project = _patroni_runner_env(tmp_path, child_exit=child_exit)
-    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
-    identity_target = Path(env["PATRONI_ROLE_IDENTITY_TARGET"])
-    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
-    old_identity = "# previous identity helper\n"
-    target.write_text(old_content, encoding="utf-8")
-    target.chmod(0o755)
-    identity_target.write_text(old_identity, encoding="utf-8")
-    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = restart_failure
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == expected_exit, (
-        failure_source,
-        result.stdout,
-        result.stderr,
-    )
-    assert target.read_text(encoding="utf-8") == old_content
-    assert identity_target.read_text(encoding="utf-8") == old_identity
-    assert not Path(env["PATRONI_ROLE_AGENT_SOURCE"]).exists()
-    assert not Path(env["PATRONI_ROLE_IDENTITY_SOURCE"]).exists()
-    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
-    assert not (project / "compose.yml.candidate").exists()
-    restarts = [
-        line
-        for line in (tmp_path / "systemctl.log").read_text(encoding="utf-8").splitlines()
-        if line.startswith("restart ")
-    ]
-    assert len(restarts) == 2
-    assert (tmp_path / "reconcile.log").exists()
-
-
-def test_patroni_retains_role_agent_backup_when_restore_restart_fails(tmp_path):
-    env, project = _patroni_runner_env(tmp_path, child_exit=42)
-    target = Path(env["PATRONI_ROLE_AGENT_TARGET"])
-    identity_target = Path(env["PATRONI_ROLE_IDENTITY_TARGET"])
-    old_content = "#!/usr/bin/env python3\n# previous role agent\n"
-    old_identity = "# previous identity helper\n"
-    target.write_text(old_content, encoding="utf-8")
-    target.chmod(0o755)
-    identity_target.write_text(old_identity, encoding="utf-8")
-    env["SYSTEMCTL_FAIL_RESTART_NUMBER"] = "2"
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 90
-    assert "role asset backups retained" in result.stderr
-    backups = list(project.glob(".patroni-role-agent.backup.*"))
-    identity_backups = list(project.glob(".patroni-role-identity.backup.*"))
-    assert len(backups) == 1
-    assert len(identity_backups) == 1
-    assert backups[0].read_text(encoding="utf-8") == old_content
-    assert identity_backups[0].read_text(encoding="utf-8") == old_identity
-    assert target.read_text(encoding="utf-8") == old_content
-    assert identity_target.read_text(encoding="utf-8") == old_identity
-    assert not (project / "compose.yml.candidate").exists()
 
 
 @pytest.mark.parametrize("migration_exit", [0, 48])

--- a/tests/unit/test_patroni_communications_compose.py
+++ b/tests/unit/test_patroni_communications_compose.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRIMARY_COMPOSE = REPO_ROOT / "deploy/ha/mvn-api/docker-compose.patroni.yml"
+RESERVE_COMPOSE = REPO_ROOT / "deploy/ha/zakup/docker-compose.patroni.yml"
+IMMUTABLE_BACKEND_IMAGE = "${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}"
+WORKER_COMMAND = "python -m services.communications.runtime"
+
+
+@pytest.mark.parametrize(
+    ("compose_path", "expected_env_file", "expected_database_url", "expected_memory"),
+    [
+        (
+            PRIMARY_COMPOSE,
+            [".env", ".ha-app-role.env"],
+            (
+                "postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}"
+                "@db/${POSTGRES_DB}"
+            ),
+            "${MVN_PATRONI_COMMUNICATIONS_WORKER_MEMORY:-256m}",
+        ),
+        (
+            RESERVE_COMPOSE,
+            ["${MVN_RESERVE_ENV_FILE:-.env}", ".ha-app-role.env"],
+            (
+                "postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}"
+                "@db/${POSTGRES_DB:-air_conditioners}"
+            ),
+            "${MVN_RESERVE_COMMUNICATIONS_WORKER_MEMORY:-256m}",
+        ),
+    ],
+)
+def test_patroni_communications_worker_is_dormant_and_role_driven(
+    compose_path: Path,
+    expected_env_file: list[str],
+    expected_database_url: str,
+    expected_memory: str,
+) -> None:
+    compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    services = compose["services"]
+    worker = services["communications-worker"]
+
+    assert worker["image"] == services["app"]["image"] == IMMUTABLE_BACKEND_IMAGE
+    assert worker["command"] == WORKER_COMMAND
+    assert worker["restart"] == "unless-stopped"
+    assert worker["depends_on"] == {"db": {"condition": "service_healthy"}}
+    assert worker["env_file"] == services["app"]["env_file"] == expected_env_file
+    assert worker["environment"] == {
+        "DATABASE_URL": expected_database_url,
+        "ENVIRONMENT": "production",
+        "COMMUNICATIONS_WORKER_ENABLED": "false",
+        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+    }
+    assert (
+        worker["environment"]["DATABASE_URL"]
+        == services["app"]["environment"]["DATABASE_URL"]
+    )
+    assert "APP_ROLE" not in worker["environment"]
+    assert worker["mem_limit"] == expected_memory
+
+
+@pytest.mark.parametrize("compose_path", [PRIMARY_COMPOSE, RESERVE_COMPOSE])
+def test_patroni_communications_worker_has_no_public_or_host_storage_surface(
+    compose_path: Path,
+) -> None:
+    compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    worker = compose["services"]["communications-worker"]
+
+    assert "ports" not in worker
+    assert "volumes" not in worker
+    assert "privileged" not in worker
+    assert "devices" not in worker
+    assert "network_mode" not in worker
+    assert "profiles" not in worker
+    assert "cap_add" not in worker
+    assert "pid" not in worker
+    assert "ipc" not in worker
+
+
+def test_reserve_communications_worker_stays_on_the_private_reserve_network() -> None:
+    compose = yaml.safe_load(RESERVE_COMPOSE.read_text(encoding="utf-8"))
+
+    assert compose["services"]["communications-worker"]["networks"] == ["reserve"]

--- a/tests/unit/test_patroni_communications_deploy.py
+++ b/tests/unit/test_patroni_communications_deploy.py
@@ -1,0 +1,541 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NODE_DEPLOY = REPO_ROOT / "scripts/ha/deploy_patroni_api_node.sh"
+CANDIDATE = REPO_ROOT / "scripts/ha/run_patroni_candidate_transaction.sh"
+RECONCILE = REPO_ROOT / "scripts/reconcile_backend_compose_runtime.sh"
+REMOTE = REPO_ROOT / "scripts/ha/run_patroni_node_remote.sh"
+RELEASE_CONTRACT = (
+    REPO_ROOT / "scripts/ha/communications_worker_release_contract.sh"
+)
+CANDIDATE_LIFECYCLE = (
+    REPO_ROOT / "scripts/ha/patroni_communications_candidate_lifecycle.sh"
+)
+WORKFLOW = REPO_ROOT / ".github/workflows/deploy-api-patroni.yml"
+OLD_IMAGE = "ghcr.io/mvnby/air-api/backend:" + "1" * 40
+NEW_IMAGE = "ghcr.io/mvnby/air-api/backend@sha256:" + "2" * 64
+
+
+def _executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_node_deploy_keeps_api_cutover_separate_and_worker_dormant():
+    text = NODE_DEPLOY.read_text(encoding="utf-8")
+    contract = RELEASE_CONTRACT.read_text(encoding="utf-8")
+    primary = text.index('bash "${BLUE_GREEN_SCRIPT}"')
+    worker = text.index("deploy_communications_worker", primary)
+
+    assert primary < worker
+    assert '"${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}"' in text
+    assert '"${COMPOSE[@]}" pull "${COMMUNICATIONS_WORKER_SERVICE}"' in text
+    assert 'communications_worker_start_controlled "${EXPECTED_ROLE}"' in text
+    assert "communications_worker_clear_release_fence" in contract
+    assert "communications_worker_set_release_fence" in contract
+    assert '"${runtime}" == "${BACKEND_IMAGE}|true"' in contract
+    assert "COMMUNICATIONS_WORKER_ENABLED" in contract
+    assert "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE" in contract
+    assert "must remain false during Phase 2A" in contract
+
+
+def test_candidate_rollback_fences_worker_before_old_compose_and_image_restore():
+    text = CANDIDATE.read_text(encoding="utf-8")
+    lifecycle = CANDIDATE_LIFECYCLE.read_text(encoding="utf-8")
+    recovery = text[text.index("reconcile_failed_deploy()") :]
+
+    assert recovery.index("patroni_communications_fence_candidate") < recovery.index(
+        "transaction cleanup"
+    )
+    assert "PREVIOUS_WORKER_RUNNING" in recovery
+    assert 'recovery_services+=" ${COMMUNICATIONS_WORKER_SERVICE}"' in recovery
+    assert 'API_DEPLOY_SERVICES="${recovery_services}"' in recovery
+    assert 'patroni_communications_require_runtime "${CANDIDATE_FILE}"' in text
+    assert 'transaction promote' in text
+    assert 'patroni_communications_require_runtime "${CANONICAL_FILE}"' in text
+    assert text.index('transaction promote') < text.index(
+        'patroni_communications_require_runtime "${CANONICAL_FILE}"'
+    )
+    assert "patroni_communications_capture_previous()" in lifecycle
+    assert "patroni_communications_fence_candidate()" in lifecycle
+    assert "patroni_communications_fence_canonical()" in lifecycle
+    assert "patroni_communications_capture_previous()" not in text
+
+
+def test_reconcile_fences_worker_before_image_transition_and_restores_parity(
+    tmp_path,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    env_file = project / ".env"
+    env_file.write_text(f"BACKEND_IMAGE={OLD_IMAGE}\n", encoding="utf-8")
+    fence_marker = project / ".ha-communications-worker-release-fenced"
+    fence_marker.write_text(
+        "fenced\n", encoding="utf-8"
+    )
+    fence_marker.chmod(0o600)
+    (project / ".active-api-slot").write_text("blue\n", encoding="utf-8")
+    (project / "compose.yml").write_text(
+        "services:\n"
+        "  app-blue:\n"
+        "    image: ${BACKEND_IMAGE}\n"
+        "  communications-worker:\n"
+        "    image: ${BACKEND_IMAGE}\n"
+        "    environment:\n"
+        '      COMMUNICATIONS_WORKER_ENABLED: "false"\n'
+        '      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"\n',
+        encoding="utf-8",
+    )
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    rendered = {
+        "services": {
+            "app-blue": {"image": NEW_IMAGE},
+            "communications-worker": {
+                "image": NEW_IMAGE,
+                "environment": {
+                    "COMMUNICATIONS_WORKER_ENABLED": "false",
+                    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+                },
+            },
+        }
+    }
+    rendered_path = tmp_path / "rendered.json"
+    rendered_path.write_text(json.dumps(rendered), encoding="utf-8")
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -euo pipefail
+current="$(sed -n 's/^BACKEND_IMAGE=//p' "$ENV_PATH" | tail -n 1)"
+printf '%s|env=%s\n' "$*" "$current" >> "$COMMAND_LOG"
+if [[ "$1" == "compose" && "$*" == *"config --format json"* ]]; then
+  exec /bin/cat "$RENDERED_PATH"
+fi
+if [[ "$1" == "compose" && "$*" == *"config --services"* ]]; then
+  printf 'app-blue\ncommunications-worker\n'
+  exit 0
+fi
+if [[ "$1" == "compose" && "$*" == *"ps -q communications-worker"* ]]; then
+  printf 'worker-container\n'
+  exit 0
+fi
+if [[ "$1" == "inspect" ]]; then
+  printf '%s|true\n' "$EXPECTED_IMAGE"
+  exit 0
+fi
+if [[ "$1" == "compose" && "$*" == *"exec -T communications-worker"* ]]; then
+  expected_role="${!#}"
+  [[ "${RUNTIME_APP_ROLE:-primary}" == "$expected_role" ]]
+  [[ "${RUNTIME_WORKER_ENABLED:-false}" == "false" ]]
+  [[ "${RUNTIME_ALLOW_ALL_MODE:-false}" == "false" ]]
+  exit 0
+fi
+exit 0
+""",
+    )
+    _executable(fake_bin / "curl", "#!/usr/bin/env bash\nprintf '{\"status\":\"ok\"}\\n'\n")
+
+    result = subprocess.run(
+        ["bash", str(RECONCILE)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "compose.yml",
+            "API_DEPLOY_SERVICES": "app communications-worker",
+            "API_RECONCILE_BACKEND_IMAGE": NEW_IMAGE,
+            "API_READY_URL": "http://127.0.0.1/health",
+            "API_HEALTH_ATTEMPTS": "1",
+            "ENV_PATH": str(env_file),
+            "COMMAND_LOG": str(command_log),
+            "RENDERED_PATH": str(rendered_path),
+            "EXPECTED_IMAGE": NEW_IMAGE,
+            "API_EXPECTED_PATRONI_ROLE": "primary",
+            "API_DEPLOY_LOCK_FD": "9",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert env_file.read_text(encoding="utf-8") == f"BACKEND_IMAGE={NEW_IMAGE}\n"
+    commands = command_log.read_text(encoding="utf-8").splitlines()
+    stop_index = next(
+        index
+        for index, line in enumerate(commands)
+        if "stop communications-worker" in line
+    )
+    up_index = next(
+        index
+        for index, line in enumerate(commands)
+        if "up -d --no-deps --force-recreate app-blue" in line
+    )
+    assert commands[stop_index].endswith(f"env={OLD_IMAGE}")
+    assert commands[up_index].endswith(f"env={NEW_IMAGE}")
+    assert stop_index < up_index
+    assert any("ps -q communications-worker" in line for line in commands)
+    assert any(line.startswith("inspect ") for line in commands)
+    assert any("exec -T communications-worker" in line for line in commands)
+    assert not (project / ".ha-communications-worker-release-fenced").exists()
+
+
+def test_reconcile_verify_rejects_and_stops_stale_fenced_worker(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".env").write_text(f"BACKEND_IMAGE={NEW_IMAGE}\n", encoding="utf-8")
+    (project / "compose.yml").write_text(
+        "services:\n"
+        "  communications-worker:\n"
+        "    image: ${BACKEND_IMAGE}\n"
+        "    environment:\n"
+        '      COMMUNICATIONS_WORKER_ENABLED: "false"\n'
+        '      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"\n',
+        encoding="utf-8",
+    )
+    marker = project / ".ha-communications-worker-release-fenced"
+    marker.write_text("fenced\n", encoding="utf-8")
+    marker.chmod(0o600)
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+if [[ "$1" == "compose" && "$*" == *"config --services"* ]]; then
+  printf 'communications-worker\n'
+elif [[ "$1" == "compose" && "$*" == *"config --format json"* ]]; then
+  printf '%s\n' "$RENDERED_CONFIG"
+elif [[ "$1" == "compose" && "$*" == *"stop communications-worker"* ]]; then
+  exit 0
+else
+  exit 91
+fi
+""",
+    )
+    rendered = json.dumps(
+        {
+            "services": {
+                "communications-worker": {
+                    "image": NEW_IMAGE,
+                    "environment": {
+                        "COMMUNICATIONS_WORKER_ENABLED": "false",
+                        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+                    },
+                }
+            }
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(RECONCILE)],
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "API_PROJECT_DIR": str(project),
+            "API_COMPOSE_FILE": "compose.yml",
+            "API_DEPLOY_SERVICES": "communications-worker",
+            "API_RECONCILE_OPERATION": "verify",
+            "API_RECONCILE_BACKEND_IMAGE": NEW_IMAGE,
+            "API_EXPECTED_PATRONI_ROLE": "primary",
+            "COMMAND_LOG": str(command_log),
+            "RENDERED_CONFIG": rendered,
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "communications worker release fence remains latched" in result.stderr
+    assert marker.read_text(encoding="utf-8") == "fenced\n"
+    assert "stop communications-worker" in command_log.read_text(encoding="utf-8")
+
+
+def test_workflow_verifies_release_parity_on_every_deployed_node():
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    jobs = workflow["jobs"]
+
+    for job_name in (
+        "deploy-replica-reserve",
+        "deploy-replica-api",
+        "deploy-primary-api",
+        "deploy-primary-reserve",
+    ):
+        run = jobs[job_name]["steps"][-1]["run"]
+        assert run == (
+            "bash scripts/ha/run_patroni_node_remote.sh deploy "
+            "&& bash scripts/ha/run_patroni_node_remote.sh verify"
+        )
+    final = jobs["deployment-complete"]["steps"][-1]["run"]
+    assert "dormant worker release verified on both nodes" in final
+
+
+def test_remote_verify_requires_exact_images_running_and_false_phase2a_gates():
+    text = REMOTE.read_text(encoding="utf-8")
+    verify = text[text.index('if [[ "${OPERATION}" == "verify" ]]') :]
+
+    assert "COMMUNICATIONS_WORKER_ENABLED" in verify
+    assert "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE" in verify
+    assert "worker.get(\"image\") != expected_image" in verify
+    assert "app.get(\"image\") != expected_image" in verify
+    assert "communications-worker" in verify
+    assert "{{.Config.Image}}|{{.State.Running}}" in verify
+    assert "exec -T communications-worker" in verify
+    assert "APP_ROLE" in verify
+    assert "NRestarts" in verify
+    assert ".ha-communications-worker-release-fenced" in verify
+    assert "test ! -L ${CANONICAL_REMOTE_COMPOSE_FILE}" in verify
+    assert "API/worker parity confirmed" in verify
+    assert "GHCR_PAT" not in verify.split(
+        'ssh "${SSH_OPTS[@]}" "${REMOTE}" \\\n'
+        '  "test -d', 1
+    )[0]
+
+
+@pytest.mark.parametrize(
+    (
+        "runtime_role",
+        "runtime_enabled",
+        "restart_drift",
+        "stale_marker",
+        "canary_result",
+        "final_role_flip",
+        "expected_code",
+    ),
+    [
+        ("primary", "false", "false", False, "verified", "false", 0),
+        ("primary", "false", "false", False, "changed", "false", 0),
+        ("primary", "false", "false", False, "deferred_once", "false", 0),
+        ("standby", "false", "false", False, "verified", "false", 1),
+        ("primary", "true", "false", False, "verified", "false", 1),
+        ("primary", "false", "true", False, "verified", "false", 1),
+        ("primary", "false", "false", True, "verified", "false", 1),
+        ("primary", "false", "false", False, "failed", "false", 1),
+        ("primary", "false", "false", False, "empty", "false", 1),
+        ("primary", "false", "false", False, "duplicate", "false", 1),
+        ("primary", "false", "false", False, "warning", "false", 1),
+        ("primary", "false", "false", False, "wrong_changed_role", "false", 1),
+        ("primary", "false", "false", False, "always_deferred", "false", 1),
+        ("primary", "false", "false", False, "verified", "true", 1),
+    ],
+)
+def test_remote_verify_path_executes_against_canonical_compose(
+    tmp_path,
+    runtime_role,
+    runtime_enabled,
+    restart_drift,
+    stale_marker,
+    canary_result,
+    final_role_flip,
+    expected_code,
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "docker-compose.patroni.yml").write_text(
+        "services:\n"
+        "  app:\n"
+        "    image: ${BACKEND_IMAGE}\n"
+        "  communications-worker:\n"
+        "    image: ${BACKEND_IMAGE}\n",
+        encoding="utf-8",
+    )
+    if stale_marker:
+        (project / ".ha-communications-worker-release-fenced").write_text(
+            "fenced\n", encoding="utf-8"
+        )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(
+        fake_bin / "ssh",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'remote_command="${!#}"\n'
+        'bash -c "${remote_command}"\n',
+    )
+    curl_count = tmp_path / "curl-count"
+    _executable(
+        fake_bin / "curl",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'count=0; [[ ! -f "$CURL_COUNT" ]] || count="$(cat "$CURL_COUNT")"\n'
+        'count=$((count + 1)); printf "%s\\n" "$count" > "$CURL_COUNT"\n'
+        'role=primary\n'
+        'if [[ "$FINAL_ROLE_FLIP" == "true" && "$count" -gt 1 ]]; then role=standby; fi\n'
+        'printf \'{"state":"running","role":"%s"}\\n\' "$role"\n',
+    )
+    rendered = json.dumps(
+        {
+            "services": {
+                "app": {"image": NEW_IMAGE},
+                "communications-worker": {
+                    "image": NEW_IMAGE,
+                    "environment": {
+                        "COMMUNICATIONS_WORKER_ENABLED": "false",
+                        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+                    },
+                },
+            }
+        }
+    )
+    _executable(
+        fake_bin / "docker",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$REMOTE_DOCKER_LOG"\n'
+        'if [[ "$1" == "compose" && "$*" == *"config --format json"* ]]; then\n'
+        f"  printf '%s\\n' {repr(rendered)}\n"
+        'elif [[ "$1" == "compose" && "$*" == *"ps -q app"* ]]; then\n'
+        "  printf 'app-container\\n'\n"
+        'elif [[ "$1" == "compose" && "$*" == *"ps -q communications-worker"* ]]; then\n'
+        "  printf 'worker-container\\n'\n"
+            'elif [[ "$1" == "inspect" ]]; then\n'
+            f"  printf '%s|true\\n' {repr(NEW_IMAGE)}\n"
+        'elif [[ "$1" == "compose" && "$*" == *"exec -T communications-worker"* ]]; then\n'
+        '  expected_role="${!#}"\n'
+        '  if [[ "$RUNTIME_APP_ROLE" != "$expected_role" '
+        '|| "$RUNTIME_WORKER_ENABLED" != "false" '
+        '|| "$RUNTIME_ALLOW_ALL_MODE" != "false" ]]; then exit 1; fi\n'
+            "else\n"
+            "  exit 91\n"
+            "fi\n",
+        )
+    systemctl_count = tmp_path / "systemctl-count"
+    remote_docker_log = tmp_path / "remote-docker.log"
+    _executable(
+        fake_bin / "systemctl",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'if [[ "$1" == "is-active" ]]; then exit 0; fi\n'
+        'if [[ "$*" == *"--property=MainPID"* ]]; then printf "123\\n"; exit 0; fi\n'
+        'if [[ "$*" == *"--property=NRestarts"* ]]; then\n'
+        '  count=0; [[ ! -f "$SYSTEMCTL_COUNT" ]] || count="$(cat "$SYSTEMCTL_COUNT")"\n'
+        '  count=$((count + 1)); printf "%s\\n" "$count" > "$SYSTEMCTL_COUNT"\n'
+        '  if [[ "$SYSTEMCTL_RESTART_DRIFT" == "true" && "$count" -gt 1 ]]; then\n'
+        '    printf "1\\n"\n'
+        '  else\n'
+        '    printf "0\\n"\n'
+        '  fi\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 91\n",
+    )
+    _executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+    canary_count = tmp_path / "canary-count"
+    _executable(
+        fake_bin / "timeout",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'count=0; [[ ! -f "$CANARY_COUNT" ]] || count="$(cat "$CANARY_COUNT")"\n'
+        'count=$((count + 1)); printf "%s\\n" "$count" > "$CANARY_COUNT"\n'
+        'if [[ "$CANARY_RESULT" == "failed" ]]; then\n'
+        '  printf "patroni_role_agent_status=failed role=primary error=hidden\\n"\n'
+        "  exit 1\n"
+        "fi\n"
+        'if [[ "$CANARY_RESULT" == "empty" ]]; then exit 0; fi\n'
+        'if [[ "$CANARY_RESULT" == "warning" ]]; then\n'
+        '  printf "patroni_role_agent_status=warning patroni_unavailable=hidden\\n"\n'
+        '  printf "patroni_role_agent_once_status=verified role=primary\\n"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [[ "$CANARY_RESULT" == "duplicate" ]]; then\n'
+        '  printf "patroni_role_agent_once_status=verified role=primary\\n"\n'
+        '  printf "patroni_role_agent_once_status=verified role=primary\\n"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [[ "$CANARY_RESULT" == "always_deferred" '
+        '|| ( "$CANARY_RESULT" == "deferred_once" && "$count" -eq 1 ) ]]; then\n'
+        '  printf "patroni_role_agent_status=deferred '
+        'reason=deployment_lock_busy\\n"\n'
+        "  exit 75\n"
+        "fi\n"
+        'if [[ "$CANARY_RESULT" == "changed" ]]; then\n'
+        '  printf "patroni_role_agent_status=reconciled role=primary '
+        'app_service=app reasons=communications_worker_role_drift '
+        'actions=recreate_communications_worker\\n"\n'
+        "fi\n"
+        'if [[ "$CANARY_RESULT" == "wrong_changed_role" ]]; then\n'
+        '  printf "patroni_role_agent_status=reconciled role=standby '
+        'app_service=app reasons=role_state actions=write_role_state\\n"\n'
+        "fi\n"
+        'printf "patroni_role_agent_once_status=verified role=primary\\n"\n',
+    )
+
+    result = subprocess.run(
+        ["bash", str(REMOTE), "verify"],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "API_NODE_HOST": "example.invalid",
+            "API_NODE_USER": "deploy",
+            "API_NODE_PROJECT_DIR": str(project),
+            "API_NODE_SSH_HOST_KEY_SOURCE": str(
+                REPO_ROOT / "deploy/ha/security/mvn-api-ssh-host-key.pub"
+            ),
+            "API_EXPECTED_PATRONI_ROLE": "primary",
+            "SSH_PRIVATE_KEY": "test-private-key",
+            "BACKEND_IMAGE": NEW_IMAGE,
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_RUN_ID": "verify-test",
+            "GITHUB_JOB": "verify",
+            "API_PITR_MAINTENANCE_MARKER": str(tmp_path / "absent-maintenance"),
+            "RUNTIME_APP_ROLE": runtime_role,
+            "RUNTIME_WORKER_ENABLED": runtime_enabled,
+            "RUNTIME_ALLOW_ALL_MODE": "false",
+            "SYSTEMCTL_RESTART_DRIFT": restart_drift,
+            "SYSTEMCTL_COUNT": str(systemctl_count),
+            "REMOTE_DOCKER_LOG": str(remote_docker_log),
+            "CANARY_RESULT": canary_result,
+            "CANARY_COUNT": str(canary_count),
+            "FINAL_ROLE_FLIP": final_role_flip,
+            "CURL_COUNT": str(curl_count),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == expected_code, result.stderr
+    if expected_code == 0:
+        assert "API/worker parity confirmed" in result.stdout
+    else:
+        assert "API/worker parity confirmed" not in result.stdout
+        assert "error=hidden" not in result.stdout + result.stderr
+
+
+def test_release_contract_never_materializes_effective_environment():
+    paths = (
+        NODE_DEPLOY,
+        CANDIDATE,
+        RECONCILE,
+        RELEASE_CONTRACT,
+        CANDIDATE_LIFECYCLE,
+        REMOTE,
+    )
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+    assert "communications-worker-compose" not in combined
+    assert "config --format json >" not in combined
+    assert "config --services" in RELEASE_CONTRACT.read_text(encoding="utf-8")
+    assert 'grep -Fxq "${COMMUNICATIONS_WORKER_SERVICE}"' in (
+        RELEASE_CONTRACT.read_text(encoding="utf-8")
+    )
+    assert RELEASE_CONTRACT.as_posix() not in combined
+    assert "communications_worker_release_contract.sh" in REMOTE.read_text(
+        encoding="utf-8"
+    )
+    assert "patroni_communications_candidate_lifecycle.sh" in REMOTE.read_text(
+        encoding="utf-8"
+    )
+    assert len(CANDIDATE.read_text(encoding="utf-8").splitlines()) <= 650

--- a/tests/unit/test_patroni_local_identity.py
+++ b/tests/unit/test_patroni_local_identity.py
@@ -1,5 +1,7 @@
 import json
+import os
 import subprocess
+import sys
 import time
 import urllib.error
 from types import SimpleNamespace
@@ -7,6 +9,67 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ha import patroni_local_identity
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        (
+            {
+                "APP_ROLE": "primary",
+                "COMMUNICATIONS_WORKER_ENABLED": "false",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+            },
+            True,
+        ),
+        (
+            {
+                "APP_ROLE": "standby",
+                "COMMUNICATIONS_WORKER_ENABLED": "false",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+            },
+            False,
+        ),
+        (
+            {
+                "APP_ROLE": "primary",
+                "COMMUNICATIONS_WORKER_ENABLED": "true",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+            },
+            False,
+        ),
+        (
+            {
+                "APP_ROLE": "primary",
+                "COMMUNICATIONS_WORKER_ENABLED": "false",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "true",
+            },
+            False,
+        ),
+    ],
+)
+def test_communications_worker_probe_requires_all_no_delivery_gates(
+    environment, expected
+):
+    outputs = []
+
+    def compose_runner(_config, *args, **kwargs):
+        result = subprocess.run(
+            [sys.executable, "-c", args[5], args[6]],
+            env={**os.environ, **environment},
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        outputs.append((result.stdout, result.stderr, kwargs))
+        return result
+
+    assert patroni_local_identity.communications_worker_role_matches(
+        SimpleNamespace(),
+        "primary",
+        compose_runner=compose_runner,
+    ) is expected
+    assert outputs == [("", "", {"check": False, "timeout": 10})]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -210,14 +210,21 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
         "API_BLUE_GREEN_SAFETY_HELPER=$(quote" in text
     )
     assert "scripts/ha/patroni_role_agent.py" in text
+    assert "scripts/ha/patroni_compose_runtime.py" in text
+    assert "scripts/ha/patroni_role_agent_config.py" in text
     assert "scripts/ha/patroni_local_identity.py" in text
     assert "/usr/local/sbin/mvn-patroni-role-agent" in text
+    assert "/usr/local/sbin/patroni_compose_runtime.py" in text
+    assert "/usr/local/sbin/patroni_role_agent_config.py" in text
     assert "/usr/local/sbin/patroni_local_identity.py" in text
     transaction_runner = TRANSACTION_RUNNER.read_text(encoding="utf-8")
+    role_asset_helper = (
+        REPO_ROOT / "scripts/ha/patroni_role_agent_candidate_assets.sh"
+    ).read_text(encoding="utf-8")
     assert "PATRONI_ROLE_IDENTITY_SOURCE" in transaction_runner
-    assert 'install -m 0644 "${ROLE_IDENTITY_SOURCE}"' in transaction_runner
-    assert "systemctl restart" in transaction_runner
-    assert "systemctl is-active --quiet" in transaction_runner
+    assert "patroni_role_assets_install" in transaction_runner
+    assert "systemctl restart" in role_asset_helper
+    assert "systemctl is-active --quiet" in role_asset_helper
     assert 'API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}"' in transaction_runner
     assert "API_DEPLOY_LOCK_ALREADY_HELD=true" not in transaction_runner
     assert 'transaction cleanup' in transaction_runner
@@ -243,8 +250,12 @@ def test_remote_orchestrator_passes_token_over_stdin_not_command_line():
 def test_installed_role_agent_loads_its_pinned_sibling_module(tmp_path):
     target = tmp_path / "mvn-patroni-role-agent"
     identity = tmp_path / "patroni_local_identity.py"
+    config = tmp_path / "patroni_role_agent_config.py"
+    compose_runtime = tmp_path / "patroni_compose_runtime.py"
     shutil.copy2(REPO_ROOT / "scripts/ha/patroni_role_agent.py", target)
     shutil.copy2(REPO_ROOT / "scripts/ha/patroni_local_identity.py", identity)
+    shutil.copy2(REPO_ROOT / "scripts/ha/patroni_role_agent_config.py", config)
+    shutil.copy2(REPO_ROOT / "scripts/ha/patroni_compose_runtime.py", compose_runtime)
 
     result = subprocess.run(
         [sys.executable, "-E", str(target), "--help"],

--- a/tests/unit/test_patroni_role_agent.py
+++ b/tests/unit/test_patroni_role_agent.py
@@ -21,6 +21,15 @@ def _no_host_maintenance_marker(monkeypatch):
     monkeypatch.setattr(
         patroni_role_agent, "read_maintenance_transaction_id", lambda: None
     )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_run_docker",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
 
 
 def _config(tmp_path: Path, *, app_service_override: str = "") -> AgentConfig:
@@ -424,7 +433,7 @@ def test_busy_deploy_lock_keeps_fencing_state_until_raced_app_is_recreated(
     monkeypatch.setattr(patroni_role_agent, "_cancel_pitr_operations", lambda _config: [])
     monkeypatch.setattr(patroni_role_agent.fcntl, "flock", flock)
 
-    assert reconcile(config, "standby") is False
+    assert reconcile(config, "standby") is None
     assert config.state_file.read_text() == "fencing\n"
     assert runtime.services == {"app"}
 
@@ -696,7 +705,7 @@ def test_network_error_is_treated_as_standby(tmp_path, monkeypatch):
     monkeypatch.setattr(
         patroni_role_agent,
         "reconcile",
-        lambda _config, role: roles.append(role),
+        lambda _config, role: roles.append(role) or False,
     )
 
     assert patroni_role_agent.run(config, once=True) == 0

--- a/tests/unit/test_patroni_role_agent_communications.py
+++ b/tests/unit/test_patroni_role_agent_communications.py
@@ -1,0 +1,686 @@
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import patroni_role_agent
+from scripts.ha.patroni_local_identity import COMMUNICATIONS_WORKER_SERVICE
+from scripts.ha.patroni_role_agent import AgentConfig
+
+
+@pytest.fixture(autouse=True)
+def _safe_host_contracts(monkeypatch):
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "read_maintenance_transaction_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_cancel_pitr_operations",
+        lambda _config: [],
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_run_docker",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+
+def _config(tmp_path: Path) -> AgentConfig:
+    return AgentConfig(
+        project_dir=tmp_path,
+        compose_file="compose.yml",
+        patroni_url="http://127.0.0.1:8008/patroni",
+        patroni_scope="mvn-postgres",
+        patroni_name="mvn-api",
+        max_dcs_age_seconds=20,
+        ready_url="http://127.0.0.1:18080/api/ready",
+        app_role_env=tmp_path / ".ha-app-role.env",
+        bot_role_env=tmp_path / ".ha-bot-role.env",
+        state_file=tmp_path / ".ha-runtime-role",
+        deploy_lock=tmp_path / ".deploy.lock",
+        active_slot_file=tmp_path / ".active-api-slot",
+        app_service="app",
+        primary_systemd_units=(),
+        poll_seconds=3,
+        promotion_delay_seconds=0,
+        ready_attempts=2,
+    )
+
+
+class _ComposeRuntime:
+    def __init__(
+        self,
+        events: list[object],
+        *,
+        defined_services: set[str],
+        running_services: set[str],
+        worker_start_succeeds: bool = True,
+        worker_role: str | None = None,
+        worker_role_on_start: str | None = None,
+        definition_error: Exception | None = None,
+        role_probe_error: Exception | None = None,
+        worker_enabled: bool = False,
+        worker_allow_all: bool = False,
+    ):
+        self.events = events
+        self.defined_services = set(defined_services)
+        self.running_services = set(running_services)
+        self.worker_start_succeeds = worker_start_succeeds
+        self.worker_role = worker_role
+        self.worker_role_on_start = worker_role_on_start
+        self.definition_error = definition_error
+        self.role_probe_error = role_probe_error
+        self.worker_enabled = worker_enabled
+        self.worker_allow_all = worker_allow_all
+
+    def __call__(self, config, *args, **_kwargs):
+        self.events.append(("compose", args))
+        if args == ("config", "--services"):
+            if self.definition_error is not None:
+                raise self.definition_error
+            return SimpleNamespace(
+                returncode=0,
+                stdout="\n".join(sorted(self.defined_services)) + "\n",
+                stderr="",
+            )
+        if args[:3] == ("ps", "--status", "running"):
+            stdout = "\n".join(
+                json.dumps(
+                    {
+                        "Service": service,
+                        "Labels": "com.docker.compose.oneoff=False",
+                    }
+                )
+                for service in sorted(self.running_services)
+            )
+            return SimpleNamespace(
+                returncode=0,
+                stdout=stdout + ("\n" if stdout else ""),
+                stderr="",
+            )
+        if args[:3] == ("ps", "--all", "--quiet"):
+            service = args[-1]
+            container_id = (
+                f"id-{service}\n" if service in self.running_services else ""
+            )
+            return SimpleNamespace(returncode=0, stdout=container_id, stderr="")
+        if args[:3] == ("exec", "-T", COMMUNICATIONS_WORKER_SERVICE):
+            if self.role_probe_error is not None:
+                raise self.role_probe_error
+            expected_role = args[-1]
+            return SimpleNamespace(
+                returncode=(
+                    0
+                    if (
+                        self.worker_role == expected_role
+                        and not self.worker_enabled
+                        and not self.worker_allow_all
+                    )
+                    else 1
+                ),
+                stdout="",
+                stderr="",
+            )
+        if args[0] == "up":
+            service = args[-1]
+            if service != COMMUNICATIONS_WORKER_SERVICE or self.worker_start_succeeds:
+                self.running_services.add(service)
+                if service == COMMUNICATIONS_WORKER_SERVICE:
+                    self.worker_role = (
+                        self.worker_role_on_start
+                        or next(
+                            line.split("=", 1)[1]
+                            for line in config.app_role_env.read_text(
+                                encoding="utf-8"
+                            ).splitlines()
+                            if line.startswith("APP_ROLE=")
+                        )
+                    )
+                    self.worker_enabled = False
+                    self.worker_allow_all = False
+        elif args[0] in {"rm", "kill", "stop"}:
+            self.running_services.discard(args[-1])
+            if args[-1] == COMMUNICATIONS_WORKER_SERVICE:
+                self.worker_role = None
+                self.worker_enabled = False
+                self.worker_allow_all = False
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def docker(self, *args, **_kwargs):
+        self.events.append(("docker", args))
+        if args[:2] == ("ps", "--all"):
+            container_id = (
+                "c" * 12 + "\n"
+                if COMMUNICATIONS_WORKER_SERVICE in self.running_services
+                else ""
+            )
+            return SimpleNamespace(returncode=0, stdout=container_id, stderr="")
+        if args[0] == "rm":
+            self.running_services.discard(COMMUNICATIONS_WORKER_SERVICE)
+            self.worker_role = None
+            self.worker_enabled = False
+            self.worker_allow_all = False
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _command_index(events: list[object], command: tuple[str, ...]) -> int:
+    return events.index(("compose", command))
+
+
+def _docker_command_index(events: list[object], command: tuple[str, ...]) -> int:
+    return events.index(("docker", command))
+
+
+def test_worker_is_fenced_then_recreated_across_primary_standby_primary(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+    )
+    real_atomic_write = patroni_role_agent._atomic_write
+
+    def atomic_write(path, content, **kwargs):
+        events.append(("write", path.name, content.splitlines()[0]))
+        real_atomic_write(path, content, **kwargs)
+
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(patroni_role_agent, "_atomic_write", atomic_write)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda _config, role: events.append(("systemd_check", role)) or True,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_reconcile_primary_systemd_units",
+        lambda _config, role, **_kwargs: events.append(("systemd_reconcile", role)),
+    )
+    monkeypatch.setattr(
+        patroni_role_agent.fcntl,
+        "flock",
+        lambda _lock, _operation: events.append("deploy_lock"),
+    )
+
+    assert patroni_role_agent.reconcile(config, "standby") is True
+
+    worker_stop = _docker_command_index(
+        events,
+        ("stop", "--timeout", "10", "c" * 12),
+    )
+    standby_env = events.index(
+        ("write", ".ha-app-role.env", "APP_ROLE=standby")
+    )
+    deploy_lock = events.index("deploy_lock")
+    worker_recreate = _command_index(
+        events,
+        (
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+            COMMUNICATIONS_WORKER_SERVICE,
+        ),
+    )
+    first_systemd = next(
+        index
+        for index, event in enumerate(events)
+        if isinstance(event, tuple) and event[0].startswith("systemd_")
+    )
+    assert worker_stop < standby_env < first_systemd < deploy_lock < worker_recreate
+    assert runtime.running_services == {"app", COMMUNICATIONS_WORKER_SERVICE}
+    assert config.state_file.read_text(encoding="utf-8") == "standby\n"
+
+    events.clear()
+    proofs: list[str] = []
+
+    def primary_proof(_config, boundary):
+        proofs.append(boundary)
+        events.append(("primary_proof", boundary))
+
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        primary_proof,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_wait_ready",
+        lambda _config: events.append("app_ready"),
+    )
+
+    assert patroni_role_agent.reconcile(config, "primary") is True
+
+    app_recreate = _command_index(
+        events,
+        ("up", "-d", "--no-deps", "--force-recreate", "app"),
+    )
+    worker_recreate = _command_index(
+        events,
+        (
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+            COMMUNICATIONS_WORKER_SERVICE,
+        ),
+    )
+    app_ready = events.index("app_ready")
+    worker_proof = events.index(
+        ("primary_proof", "communications_worker_activation")
+    )
+    assert app_recreate < app_ready < worker_proof < worker_recreate
+    assert "primary_app_env" in proofs
+    assert "primary_postcondition" in proofs
+    assert runtime.running_services == {"app", COMMUNICATIONS_WORKER_SERVICE}
+    assert config.state_file.read_text(encoding="utf-8") == "primary\n"
+
+
+@pytest.mark.parametrize("role", ["primary", "standby"])
+def test_old_compose_without_worker_remains_rolling_compatible(
+    tmp_path, monkeypatch, role
+):
+    config = _config(tmp_path)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app"},
+        running_services={"app"},
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda _config, _boundary: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+
+    assert patroni_role_agent.reconcile(config, role) is True
+    assert not any(
+        isinstance(event, tuple)
+        and event[0] == "compose"
+        and event[1][-1:] == (COMMUNICATIONS_WORKER_SERVICE,)
+        for event in events
+    )
+    assert runtime.running_services == {"app"}
+
+
+def test_old_canonical_ignores_candidate_worker_until_compose_promotion(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app"},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda *_args: True,
+    )
+
+    assert patroni_role_agent.reconcile(config, "primary") is False
+    assert COMMUNICATIONS_WORKER_SERVICE in runtime.running_services
+    assert not any(
+        event[0] == "docker" for event in events if isinstance(event, tuple)
+    )
+
+    runtime.defined_services.add(COMMUNICATIONS_WORKER_SERVICE)
+    events.clear()
+
+    assert patroni_role_agent.reconcile(config, "primary") is False
+    assert COMMUNICATIONS_WORKER_SERVICE in runtime.running_services
+    assert any(
+        event[0] == "compose"
+        and event[1][:3] == ("exec", "-T", COMMUNICATIONS_WORKER_SERVICE)
+        and event[1][-1] == "primary"
+        for event in events
+        if isinstance(event, tuple)
+    )
+    assert not any(
+        event[0] == "docker" for event in events if isinstance(event, tuple)
+    )
+
+
+def test_defined_worker_must_be_running_at_final_postcondition(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app"},
+        worker_start_succeeds=False,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda _config, _boundary: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="primary communications worker role postcondition failed",
+    ):
+        patroni_role_agent.reconcile(config, "primary")
+
+
+def test_defined_worker_must_have_expected_role_at_final_postcondition(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app"},
+        worker_role_on_start="standby",
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda _config, _boundary: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="primary communications worker role postcondition failed",
+    ):
+        patroni_role_agent.reconcile(config, "primary")
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
+
+
+def test_stale_running_worker_role_fences_all_side_effect_owners_before_systemd(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("standby", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "standby",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("standby\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", "bot", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", "bot", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda _config, role: events.append(("systemd_check", role)) or True,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_reconcile_primary_systemd_units",
+        lambda _config, role, **_kwargs: events.append(("systemd_reconcile", role)),
+    )
+
+    assert patroni_role_agent.reconcile(config, "standby") is True
+
+    worker_stop = _docker_command_index(
+        events,
+        ("stop", "--timeout", "10", "c" * 12),
+    )
+    app_stop = _command_index(
+        events,
+        ("rm", "--stop", "--force", "app"),
+    )
+    bot_stop = _command_index(
+        events,
+        ("rm", "--stop", "--force", "bot"),
+    )
+    first_systemd = next(
+        index
+        for index, event in enumerate(events)
+        if isinstance(event, tuple) and event[0].startswith("systemd_")
+    )
+    assert max(worker_stop, app_stop, bot_stop) < first_systemd
+    assert runtime.running_services == {"app", COMMUNICATIONS_WORKER_SERVICE}
+    assert runtime.worker_role == "standby"
+    assert config.state_file.read_text(encoding="utf-8") == "standby\n"
+
+
+def test_definition_probe_failure_fences_labeled_worker_before_later_checks(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("standby", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "standby",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("standby\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        definition_error=subprocess.TimeoutExpired("compose config", 20),
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda *_args: events.append("systemd_check") or True,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent.fcntl,
+        "flock",
+        lambda *_args: events.append("deploy_lock"),
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        patroni_role_agent.reconcile(config, "standby")
+
+    worker_remove = _docker_command_index(
+        events,
+        ("rm", "--force", "c" * 12),
+    )
+    assert worker_remove < len(events)
+    assert "systemd_check" not in events
+    assert "deploy_lock" not in events
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
+
+
+def test_role_probe_timeout_fences_worker_before_primary_later_checks(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        role_probe_error=subprocess.TimeoutExpired("worker role probe", 10),
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda *_args: events.append("systemd_check") or True,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="primary communications worker role postcondition failed",
+    ):
+        patroni_role_agent.reconcile(config, "primary")
+
+    first_worker_remove = _docker_command_index(
+        events,
+        ("rm", "--force", "c" * 12),
+    )
+    first_systemd = events.index("systemd_check")
+    assert first_worker_remove < first_systemd
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
+
+
+@pytest.mark.parametrize(
+    "drift",
+    [
+        {"worker_enabled": True},
+        {"worker_allow_all": True},
+    ],
+)
+def test_delivery_gate_drift_fences_and_recreates_worker(
+    tmp_path, monkeypatch, capsys, drift
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        **drift,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        lambda *_args: True,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_fetch_configured_patroni_role",
+        lambda _config: "primary",
+    )
+
+    assert patroni_role_agent.run(config, once=True) == 0
+
+    worker_remove = _docker_command_index(
+        events,
+        ("rm", "--force", "c" * 12),
+    )
+    worker_recreate = _command_index(
+        events,
+        (
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+            COMMUNICATIONS_WORKER_SERVICE,
+        ),
+    )
+    assert worker_remove < worker_recreate
+    assert runtime.worker_role == "primary"
+    assert runtime.worker_enabled is False
+    assert runtime.worker_allow_all is False
+    output = capsys.readouterr().out.splitlines()
+    assert len(output) == 2
+    assert output[0].startswith(
+        "patroni_role_agent_status=reconciled role=primary "
+    )
+    assert "communications_worker_role_drift" in output[0]
+    assert "recreate_communications_worker" in output[0]
+    assert output[1] == "patroni_role_agent_once_status=verified role=primary"

--- a/tests/unit/test_patroni_role_agent_compose_runtime.py
+++ b/tests/unit/test_patroni_role_agent_compose_runtime.py
@@ -1,0 +1,326 @@
+import json
+import subprocess
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import patroni_compose_runtime
+
+
+def _config(tmp_path, *, ready_attempts=2):
+    return SimpleNamespace(
+        project_dir=tmp_path,
+        compose_file="compose.yml",
+        ready_url="http://127.0.0.1:18080/api/ready",
+        ready_attempts=ready_attempts,
+    )
+
+
+def _runtime(
+    tmp_path,
+    runner,
+    writer=lambda *_args, **_kwargs: None,
+    *,
+    docker_runner=None,
+):
+    kwargs = {
+        "compose_runner": runner,
+        "atomic_writer": writer,
+    }
+    if docker_runner is not None:
+        kwargs["docker_runner"] = docker_runner
+    return patroni_compose_runtime.ComposeRuntime(_config(tmp_path), **kwargs)
+
+
+def test_run_compose_preserves_reviewed_command_and_working_directory(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(patroni_compose_runtime.subprocess, "run", run)
+
+    result = patroni_compose_runtime.run_compose(
+        _config(tmp_path),
+        "ps",
+        "--quiet",
+        check=False,
+        timeout=17,
+    )
+
+    assert result.returncode == 0
+    assert calls == [
+        (
+            [
+                "docker",
+                "compose",
+                "--profile",
+                "bluegreen",
+                "-f",
+                "compose.yml",
+                "ps",
+                "--quiet",
+            ],
+            {
+                "cwd": tmp_path,
+                "check": False,
+                "text": True,
+                "capture_output": True,
+                "timeout": 17,
+            },
+        )
+    ]
+
+
+def test_running_services_filters_oneoff_records_and_accepts_json_lines(tmp_path):
+    records = [
+        {
+            "Service": "app-blue",
+            "Labels": "com.docker.compose.oneoff=False,other=value",
+        },
+        {
+            "Service": "restore-drill",
+            "Labels": {"com.docker.compose.oneoff": "True"},
+        },
+    ]
+
+    def runner(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout="\n".join(json.dumps(record) for record in records),
+            stderr="",
+        )
+
+    assert _runtime(tmp_path, runner).running_services() == {"app-blue"}
+
+
+def test_running_services_fails_closed_without_oneoff_identity(tmp_path):
+    def runner(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"Service": "app", "Labels": "other=value"}),
+            stderr="",
+        )
+
+    with pytest.raises(RuntimeError, match="one-off identity"):
+        _runtime(tmp_path, runner).running_services()
+
+
+def test_labeled_service_fence_uses_exact_project_and_service_filters(tmp_path):
+    calls = []
+    container_exists = True
+    container_id = "a" * 12
+
+    def docker(*args, **_kwargs):
+        nonlocal container_exists
+        calls.append(args)
+        if args[:2] == ("ps", "--all"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"{container_id}\n" if container_exists else "",
+                stderr="",
+            )
+        if args[0] == "rm":
+            container_exists = False
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    runtime = _runtime(
+        tmp_path,
+        lambda *_args, **_kwargs: None,
+        docker_runner=docker,
+    )
+
+    assert runtime.fence_labeled_service_containers("communications-worker")
+    assert calls[0] == (
+        "ps",
+        "--all",
+        "--quiet",
+        "--filter",
+        f"label=com.docker.compose.project={tmp_path.name}",
+        "--filter",
+        "label=com.docker.compose.service=communications-worker",
+    )
+    assert ("stop", "--timeout", "10", container_id) in calls
+    assert ("rm", "--force", container_id) in calls
+    assert calls[-1][:2] == ("ps", "--all")
+    assert container_exists is False
+
+
+def test_genuinely_absent_worker_in_old_compose_is_safe(tmp_path):
+    docker_calls = []
+
+    def docker(*args, **_kwargs):
+        docker_calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    runtime = _runtime(
+        tmp_path,
+        lambda *_args, **_kwargs: None,
+        docker_runner=docker,
+    )
+
+    state = runtime.worker_runtime_state(
+        service="communications-worker",
+        role="standby",
+        running_services=set(),
+        definition_probe=lambda *_args, **_kwargs: False,
+        role_probe=lambda *_args, **_kwargs: pytest.fail("role probe must not run"),
+    )
+
+    assert state == patroni_compose_runtime.WorkerRuntimeState(
+        defined=False,
+        running=False,
+        role_matches=False,
+        unsafe_mismatch=False,
+    )
+    assert docker_calls == []
+
+
+@pytest.mark.parametrize(
+    ("recreate", "expected"),
+    [
+        (False, ("up", "-d", "--no-deps", "app")),
+        (True, ("up", "-d", "--no-deps", "--force-recreate", "app")),
+    ],
+)
+def test_start_service_preserves_recreate_contract(
+    tmp_path, recreate, expected
+):
+    calls = []
+
+    def runner(_config, *args, **_kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    _runtime(tmp_path, runner).start_service("app", recreate=recreate)
+
+    assert calls == [expected]
+
+
+def test_stop_service_escalates_and_verifies_exact_service(tmp_path):
+    calls = []
+    inventories = iter(["container-id\n", ""])
+
+    def runner(_config, *args, **_kwargs):
+        calls.append(args)
+        if args[:3] == ("ps", "--all", "--quiet"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=next(inventories),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="still running")
+
+    _runtime(tmp_path, runner).stop_service_verified("communications-worker")
+
+    assert calls == [
+        ("rm", "--stop", "--force", "communications-worker"),
+        ("ps", "--all", "--quiet", "communications-worker"),
+        ("kill", "--signal", "SIGKILL", "communications-worker"),
+        ("rm", "--force", "communications-worker"),
+        ("ps", "--all", "--quiet", "communications-worker"),
+    ]
+
+
+def test_stop_service_fails_when_container_survives_force_removal(tmp_path):
+    def runner(_config, *args, **_kwargs):
+        if args[:3] == ("ps", "--all", "--quiet"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout="container-id\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="still running")
+
+    with pytest.raises(RuntimeError, match="could not fence.*communications-worker"):
+        _runtime(tmp_path, runner).stop_service_verified("communications-worker")
+
+
+def test_proxy_reconciliation_is_atomic_and_restart_is_runtime_gated(tmp_path):
+    writes = []
+    calls = []
+
+    def writer(path, content, **kwargs):
+        writes.append((path, content, kwargs))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def runner(_config, *args, **_kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    runtime = _runtime(tmp_path, runner, writer)
+    running = {"app-green", "api-proxy"}
+
+    assert runtime.reconcile_container_proxy_upstream(
+        "app-green",
+        running_services=running,
+    )
+    assert writes == [
+        (
+            tmp_path / "api-proxy" / "upstream.conf",
+            "proxy_pass http://app-green:8000;\n",
+            {"mode": 0o644},
+        )
+    ]
+    assert runtime.refresh_container_proxy_dns(running_services=running)
+    assert calls == [("restart", "api-proxy")]
+    assert not runtime.refresh_container_proxy_dns(running_services={"app-green"})
+
+
+class _ReadyResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return BytesIO(
+            json.dumps(
+                {
+                    "api": "ready",
+                    "database_writable": True,
+                    "scheduler_runtime": {
+                        "expected": True,
+                        "status": "running",
+                    },
+                }
+            ).encode()
+        ).read()
+
+
+def test_scheduler_probe_accepts_only_ready_owned_runtime(tmp_path, monkeypatch):
+    calls = []
+
+    def urlopen(url, *, timeout):
+        calls.append((url, timeout))
+        return _ReadyResponse()
+
+    monkeypatch.setattr(patroni_compose_runtime.urllib.request, "urlopen", urlopen)
+
+    patroni_compose_runtime.wait_scheduler_running(_config(tmp_path))
+
+    assert calls == [("http://127.0.0.1:18080/api/ready", 5)]
+
+
+def test_scheduler_probe_exhaustion_keeps_original_error_contract(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        patroni_compose_runtime.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline")),
+    )
+    monkeypatch.setattr(patroni_compose_runtime.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="did not acquire runtime ownership"):
+        patroni_compose_runtime.wait_scheduler_running(
+            _config(tmp_path, ready_attempts=2)
+        )

--- a/tests/unit/test_patroni_role_agent_once.py
+++ b/tests/unit/test_patroni_role_agent_once.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import patroni_role_agent
+
+
+@pytest.fixture
+def config():
+    return SimpleNamespace(poll_seconds=0)
+
+
+def _fixed_primary(monkeypatch):
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_fetch_configured_patroni_role",
+        lambda _config: "primary",
+    )
+
+
+@pytest.mark.parametrize("changed", [False, True])
+def test_once_success_emits_one_fixed_receipt(
+    config, monkeypatch, capsys, changed
+):
+    _fixed_primary(monkeypatch)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "reconcile",
+        lambda *_args: changed,
+    )
+
+    assert patroni_role_agent.run(config, once=True) == 0
+
+    lines = capsys.readouterr().out.splitlines()
+    assert lines == ["patroni_role_agent_once_status=verified role=primary"]
+
+
+def test_once_deferred_returns_temporary_failure_without_receipt(
+    config, monkeypatch, capsys
+):
+    _fixed_primary(monkeypatch)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "reconcile",
+        lambda *_args: None,
+    )
+
+    assert patroni_role_agent.run(config, once=True) == 75
+
+    assert "patroni_role_agent_once_status=verified" not in capsys.readouterr().out
+
+
+def test_once_failure_returns_nonzero_without_receipt(config, monkeypatch, capsys):
+    _fixed_primary(monkeypatch)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "reconcile",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("unsafe runtime")),
+    )
+
+    assert patroni_role_agent.run(config, once=True) == 1
+
+    output = capsys.readouterr().out
+    assert "patroni_role_agent_status=failed role=primary" in output
+    assert "patroni_role_agent_once_status=verified" not in output

--- a/tests/unit/test_patroni_role_agent_proxy_recovery.py
+++ b/tests/unit/test_patroni_role_agent_proxy_recovery.py
@@ -26,6 +26,15 @@ def _safe_host_contracts(monkeypatch):
     monkeypatch.setattr(
         patroni_role_agent, "_wait_scheduler_running", lambda _config: None
     )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_run_docker",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
 
 
 def _config(tmp_path: Path) -> AgentConfig:
@@ -267,7 +276,7 @@ def test_primary_defers_proxy_drift_repair_while_deploy_lock_is_busy(
 
     with config.deploy_lock.open("a+", encoding="utf-8") as lock:
         fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        assert reconcile(config, "primary") is False
+        assert reconcile(config, "primary") is None
 
     assert upstream.read_text(encoding="utf-8") == (
         "proxy_pass http://app-blue:8000;\n"

--- a/tests/unit/test_patroni_role_agent_release_fence.py
+++ b/tests/unit/test_patroni_role_agent_release_fence.py
@@ -1,0 +1,242 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import patroni_role_agent
+from scripts.ha.patroni_local_identity import COMMUNICATIONS_WORKER_SERVICE
+from scripts.ha.patroni_role_agent_config import (
+    COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME,
+    AgentConfig,
+)
+
+
+def _config(tmp_path: Path) -> AgentConfig:
+    return AgentConfig(
+        project_dir=tmp_path,
+        compose_file="compose.yml",
+        patroni_url="http://127.0.0.1:8008/patroni",
+        patroni_scope="mvn-postgres",
+        patroni_name="mvn-api",
+        max_dcs_age_seconds=20,
+        ready_url="http://127.0.0.1:18080/api/ready",
+        app_role_env=tmp_path / ".ha-app-role.env",
+        bot_role_env=tmp_path / ".ha-bot-role.env",
+        state_file=tmp_path / ".ha-runtime-role",
+        deploy_lock=tmp_path / ".deploy.lock",
+        active_slot_file=tmp_path / ".active-api-slot",
+        app_service="app",
+        primary_systemd_units=(),
+        poll_seconds=3,
+        promotion_delay_seconds=0,
+        ready_attempts=2,
+    )
+
+
+def _prime_role(config: AgentConfig, role: str) -> None:
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env(role, bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            role,
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text(f"{role}\n", encoding="utf-8")
+
+
+class _Runtime:
+    container_id = "d" * 12
+
+    def __init__(self, *, worker_running: bool):
+        self.services = {"app"}
+        if worker_running:
+            self.services.add(COMMUNICATIONS_WORKER_SERVICE)
+        self.events: list[tuple[str, tuple[str, ...]]] = []
+
+    def compose(self, _config, *args, **_kwargs):
+        self.events.append(("compose", args))
+        if args == ("config", "--services"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"app\n{COMMUNICATIONS_WORKER_SERVICE}\n",
+                stderr="",
+            )
+        if args[:3] == ("ps", "--status", "running"):
+            payload = "\n".join(
+                json.dumps(
+                    {
+                        "Service": service,
+                        "Labels": "com.docker.compose.oneoff=False",
+                    }
+                )
+                for service in sorted(self.services)
+            )
+            return SimpleNamespace(
+                returncode=0,
+                stdout=payload + ("\n" if payload else ""),
+                stderr="",
+            )
+        if args[:3] == ("ps", "--all", "--quiet"):
+            service = args[-1]
+            output = f"id-{service}\n" if service in self.services else ""
+            return SimpleNamespace(returncode=0, stdout=output, stderr="")
+        if args[:3] == ("exec", "-T", COMMUNICATIONS_WORKER_SERVICE):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if args[0] == "up":
+            self.services.add(args[-1])
+        elif args[0] in {"rm", "kill", "stop"}:
+            self.services.discard(args[-1])
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def docker(self, *args, **_kwargs):
+        self.events.append(("docker", args))
+        if args[:2] == ("ps", "--all"):
+            output = (
+                f"{self.container_id}\n"
+                if COMMUNICATIONS_WORKER_SERVICE in self.services
+                else ""
+            )
+            return SimpleNamespace(returncode=0, stdout=output, stderr="")
+        if args[0] == "rm":
+            self.services.discard(COMMUNICATIONS_WORKER_SERVICE)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def _patch_runtime(monkeypatch, runtime: _Runtime, later_checks: list[str]) -> None:
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime.compose)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "read_maintenance_transaction_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_cancel_pitr_operations",
+        lambda _config: [],
+    )
+    def systemd_units_match(*_args):
+        later_checks.append("systemd")
+        runtime.events.append(("later", ("systemd",)))
+        return True
+
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_systemd_units_match",
+        systemd_units_match,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+
+
+@pytest.mark.parametrize("role", ["primary", "standby"])
+def test_release_marker_fences_worker_and_suppresses_restarts_on_repeated_polls(
+    tmp_path, monkeypatch, capsys, role
+):
+    config = _config(tmp_path)
+    _prime_role(config, role)
+    marker = tmp_path / COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME
+    marker.touch()
+    runtime = _Runtime(worker_running=True)
+    later_checks: list[str] = []
+    _patch_runtime(monkeypatch, runtime, later_checks)
+
+    assert patroni_role_agent.reconcile(config, role) is True
+
+    remove_event = ("docker", ("rm", "--force", runtime.container_id))
+    assert runtime.events.index(remove_event) < runtime.events.index(
+        ("later", ("systemd",))
+    )
+    assert later_checks
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.services
+    assert not any(
+        event[0] == "compose"
+        and event[1][0] == "up"
+        and event[1][-1] == COMMUNICATIONS_WORKER_SERVICE
+        for event in runtime.events
+    )
+    output = capsys.readouterr().out
+    assert "communications_worker_release_fenced" in output
+    assert "fence_communications_worker_release" in output
+    assert marker.name not in output
+
+    runtime.events.clear()
+    later_checks.clear()
+    assert patroni_role_agent.reconcile(config, role) is True
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.services
+    assert not any(
+        event[0] == "compose"
+        and event[1][0] == "up"
+        and event[1][-1] == COMMUNICATIONS_WORKER_SERVICE
+        for event in runtime.events
+    )
+    assert marker.exists()
+
+
+def test_broken_symlink_marker_is_honored_without_reading_target(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    _prime_role(config, "primary")
+    marker = tmp_path / COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME
+    marker.symlink_to(tmp_path / "missing-release-owner")
+    runtime = _Runtime(worker_running=True)
+    _patch_runtime(monkeypatch, runtime, [])
+
+    assert patroni_role_agent.reconcile(config, "primary") is True
+
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.services
+    assert marker.is_symlink()
+
+
+def test_absent_marker_keeps_normal_worker_requirement(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    _prime_role(config, "primary")
+    runtime = _Runtime(worker_running=False)
+    _patch_runtime(monkeypatch, runtime, [])
+
+    assert patroni_role_agent.reconcile(config, "primary") is True
+
+    assert COMMUNICATIONS_WORKER_SERVICE in runtime.services
+    assert any(
+        event[0] == "compose"
+        and event[1][0] == "up"
+        and event[1][-1] == COMMUNICATIONS_WORKER_SERVICE
+        for event in runtime.events
+    )
+
+
+def test_release_marker_inventory_failure_is_fail_closed_before_slow_checks(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    _prime_role(config, "primary")
+    (tmp_path / COMMUNICATIONS_WORKER_RELEASE_FENCE_BASENAME).touch()
+    runtime = _Runtime(worker_running=True)
+    later_checks: list[str] = []
+    _patch_runtime(monkeypatch, runtime, later_checks)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_run_docker",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="docker unavailable",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="docker unavailable"):
+        patroni_role_agent.reconcile(config, "primary")
+
+    assert later_checks == []
+    assert not runtime.events

--- a/tests/unit/test_patroni_rollout_remote.py
+++ b/tests/unit/test_patroni_rollout_remote.py
@@ -47,6 +47,8 @@ def test_remote_executor_compiles_and_contains_required_fail_closed_contracts():
     assert "pg_is_in_recovery" in REMOTE_EXECUTOR
     assert "dcs_baseline_sha256" in REMOTE_EXECUTOR
     assert "role_unit_sha256" in REMOTE_EXECUTOR
+    assert "role_compose_runtime_sha256" in REMOTE_EXECUTOR
+    assert "role_agent_config_sha256" in REMOTE_EXECUTOR
     assert "exact_role_env" in REMOTE_EXECUTOR
     assert "attest_container_role_environment" in REMOTE_EXECUTOR
     assert '"CLOUDFLARE_PURGE_DRY_RUN": "true"' in REMOTE_EXECUTOR
@@ -102,6 +104,8 @@ def test_rollout_modules_stay_small_and_all_composed_sources_are_reviewed():
         "scripts/ha/patroni_rollout_remote_executor.py",
         "scripts/ha/patroni_rollout_remote_prelude.py",
         "scripts/ha/patroni_rollout_remote_runtime.py",
+        "scripts/ha/patroni_compose_runtime.py",
+        "scripts/ha/patroni_role_agent_config.py",
         "deploy/ha/patroni/mvn-patroni-role-agent.service",
     ):
         assert required in REVIEWED_ASSETS

--- a/tests/unit/test_pitr_remote_execution_split.py
+++ b/tests/unit/test_pitr_remote_execution_split.py
@@ -355,6 +355,8 @@ def test_role_agent_remote_command_is_pinned_and_attests_exact_assets(tmp_path):
     manifest = json.loads(command[7])
     assert set(manifest) == {
         "/usr/local/sbin/mvn-patroni-role-agent",
+        "/usr/local/sbin/patroni_compose_runtime.py",
+        "/usr/local/sbin/patroni_role_agent_config.py",
         "/usr/local/sbin/patroni_local_identity.py",
         "/etc/systemd/system/mvn-patroni-role-agent.service",
         "/usr/local/sbin/mvn_postgres_pitr_operation_guard.py",


### PR DESCRIPTION
## Summary

Implements issue #848 Phase 2A as a dormant, fail-closed HA release contract for `communications-worker`.

- defines the worker on both Patroni API nodes from the exact immutable backend image;
- hardcodes `COMMUNICATIONS_WORKER_ENABLED=false` and `COMMUNICATIONS_WORKER_ALLOW_ALL_MODE=false`;
- reconciles worker runtime with the local Patroni role without extending the Telegram bot;
- adds a durable release-fence marker, exact-label emergency fencing, transactional install/rollback, and first-rollout compatibility with the old Compose model;
- installs and attests the modular role-agent bundle across deploy, Patroni, and PITR paths;
- verifies both nodes after deploy: canonical regular Compose file, API/worker image parity, actual role and false/false gates, active stable role-agent, absent fence marker, and an installed-code `--once` success receipt;
- documents the Phase 2A operator contract.

## Safety boundary

This PR does **not** enable delivery, consume the backlog, or perform a production canary. Token ownership, bounded activation, retry/ack verification, and backlog policy remain Phase 2B.

## Validation

- `568 passed, 3 skipped` across Patroni, PITR, candidate transaction, Compose, and communications deploy suites;
- focused deploy/candidate/Compose suite: `69 passed`;
- focused role-agent suites: `107 passed`;
- ShellCheck, Bash syntax, Python compile, and `git diff --check` pass;
- independent adversarial review found no remaining P0/P1/P2 findings.

Closes the infrastructure portion of #848; Phase 2B remains separate.