### PR TITLE
fix: attest role agent with node environment

### DIFF
--- a/scripts/ha/patroni_role_agent_once_env.py
+++ b/scripts/ha/patroni_role_agent_once_env.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Run the installed Patroni role agent once with its attested node environment."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+ROLE_ENV_PATH = Path("/etc/default/mvn-patroni-role-agent")
+ROLE_AGENT_PATH = Path("/usr/local/sbin/mvn-patroni-role-agent")
+PYTHON_PATH = Path("/usr/bin/python3")
+MAX_ENVIRONMENT_BYTES = 16_384
+MAX_AGENT_BYTES = 1_048_576
+PRODUCTION_NODE_NAMES = {
+    "/opt/air-api": "mvn-api",
+    "/opt/mvn-reserve": "zakup",
+}
+BASE_EXEC_ENVIRONMENT = {
+    "HOME": "/root",
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "PYTHONNOUSERSITE": "1",
+}
+
+
+def expected_role_environment(project_dir: str) -> dict[str, str]:
+    patroni_name = PRODUCTION_NODE_NAMES.get(project_dir)
+    if patroni_name is None:
+        raise ValueError("unreviewed role-agent project directory")
+    return {
+        "HA_PROJECT_DIR": project_dir,
+        "HA_COMPOSE_FILE": "docker-compose.patroni.yml",
+        "HA_PATRONI_URL": "http://127.0.0.1:8008/patroni",
+        "HA_PATRONI_SCOPE": "mvn-postgres",
+        "HA_PATRONI_NAME": patroni_name,
+        "HA_PATRONI_MAX_DCS_AGE_SECONDS": "20",
+        "HA_READY_URL": "http://127.0.0.1:18080/api/ready",
+        "HA_APP_SERVICE": "",
+        "HA_PRIMARY_SYSTEMD_UNITS": (
+            "mvn-postgres-wal-upload.timer mvn-postgres-basebackup.timer"
+        ),
+        "HA_ROLE_POLL_SECONDS": "3",
+        "HA_PROMOTION_DELAY_SECONDS": "8",
+        "HA_READY_ATTEMPTS": "30",
+    }
+
+
+def _read_root_regular(
+    path: Path,
+    *,
+    mode: int,
+    maximum: int,
+    expected_uid: int = 0,
+    expected_gid: int = 0,
+) -> bytes:
+    descriptor = os.open(
+        path,
+        os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != expected_uid
+            or metadata.st_gid != expected_gid
+            or stat.S_IMODE(metadata.st_mode) != mode
+            or metadata.st_nlink != 1
+            or metadata.st_size > maximum
+        ):
+            raise ValueError(f"unsafe role-agent asset: {path}")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            content = stream.read(maximum + 1)
+        if len(content) > maximum:
+            raise ValueError(f"oversized role-agent asset: {path}")
+        return content
+    finally:
+        os.close(descriptor)
+
+
+def attest_role_environment(
+    project_dir: str,
+    *,
+    path: Path = ROLE_ENV_PATH,
+    expected_uid: int = 0,
+    expected_gid: int = 0,
+) -> dict[str, str]:
+    content = _read_root_regular(
+        path,
+        mode=0o600,
+        maximum=MAX_ENVIRONMENT_BYTES,
+        expected_uid=expected_uid,
+        expected_gid=expected_gid,
+    )
+    try:
+        lines = content.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ValueError("role-agent environment is not UTF-8") from exc
+    actual: dict[str, str] = {}
+    for line in lines:
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError("role-agent environment contains an invalid line")
+        name, value = line.split("=", 1)
+        if not name or name in actual:
+            raise ValueError("role-agent environment contains an invalid key set")
+        actual[name] = value
+    if actual != expected_role_environment(project_dir):
+        raise ValueError("role-agent environment differs from the reviewed node contract")
+    return actual
+
+
+def run_once(
+    project_dir: str,
+    expected_agent_sha256: str,
+    *,
+    environment_path: Path = ROLE_ENV_PATH,
+    agent_path: Path = ROLE_AGENT_PATH,
+    python_path: Path = PYTHON_PATH,
+    expected_uid: int = 0,
+    expected_gid: int = 0,
+) -> None:
+    if len(expected_agent_sha256) != 64 or any(
+        character not in "0123456789abcdef" for character in expected_agent_sha256
+    ):
+        raise ValueError("invalid expected role-agent digest")
+    role_environment = attest_role_environment(
+        project_dir,
+        path=environment_path,
+        expected_uid=expected_uid,
+        expected_gid=expected_gid,
+    )
+    agent_content = _read_root_regular(
+        agent_path,
+        mode=0o755,
+        maximum=MAX_AGENT_BYTES,
+        expected_uid=expected_uid,
+        expected_gid=expected_gid,
+    )
+    if hashlib.sha256(agent_content).hexdigest() != expected_agent_sha256:
+        raise ValueError("installed role-agent digest differs from the reviewed source")
+    clean_environment = {**BASE_EXEC_ENVIRONMENT, **role_environment}
+    os.execve(
+        python_path,
+        [str(python_path), str(agent_path), "--once"],
+        clean_environment,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise ValueError(
+            "usage: patroni_role_agent_once_env.py "
+            "/opt/air-api|/opt/mvn-reserve EXPECTED_AGENT_SHA256"
+        )
+    run_once(sys.argv[1], sys.argv[2])
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError) as exc:
+        print(f"role-agent one-shot environment attestation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -25,6 +25,7 @@ ROLE_AGENT_CONFIG_SOURCE="scripts/ha/patroni_role_agent_config.py"
 ROLE_AGENT_CONFIG_TARGET="/usr/local/sbin/patroni_role_agent_config.py"
 ROLE_IDENTITY_SOURCE="scripts/ha/patroni_local_identity.py"
 ROLE_IDENTITY_TARGET="/usr/local/sbin/patroni_local_identity.py"
+ROLE_AGENT_ONCE_ENV_SOURCE="scripts/ha/patroni_role_agent_once_env.py"
 ROLE_UNIT_SOURCE="deploy/ha/patroni/mvn-patroni-role-agent.service"
 ROLE_UNIT_TARGET="/etc/systemd/system/mvn-patroni-role-agent.service"
 ROLE_AGENT_UNIT="mvn-patroni-role-agent.service"
@@ -34,6 +35,7 @@ DEPLOY_CAPACITY_HELPER_SOURCE="scripts/ha/require_deploy_capacity.sh"
 COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE="scripts/ha/communications_worker_release_contract.sh"
 PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE="scripts/ha/patroni_communications_candidate_lifecycle.sh"
 PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE="scripts/ha/patroni_role_agent_candidate_assets.sh"
+ROLE_AGENT_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${ROLE_AGENT_SOURCE}")"
 DEPLOY_LOCK_HELPER_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${DEPLOY_LOCK_HELPER_SOURCE}")"
 DB_CONTRACT_HELPER_SOURCE="scripts/ha/patroni_compose_db_contract.py"
 TRANSACTION_SOURCE="scripts/compose_candidate_transaction.sh"
@@ -116,6 +118,11 @@ fi
 if [[ "${OPERATION}" == "verify" ]]; then
   [[ -n "${PROJECT_DIR}" ]] || {
     log error "API_NODE_PROJECT_DIR is required for runtime verification"
+    exit 1
+  }
+  [[ -f "${ROLE_AGENT_ONCE_ENV_SOURCE}" \
+    && ! -L "${ROLE_AGENT_ONCE_ENV_SOURCE}" ]] || {
+    log error "role-agent one-shot environment helper is missing or unsafe"
     exit 1
   }
   [[ "${BACKEND_IMAGE}" =~ (@sha256:[0-9a-f]{64}|:[0-9a-f]{40})$ ]] || {
@@ -230,6 +237,7 @@ if [[ "${OPERATION}" == "probe" ]]; then
 fi
 
 if [[ "${OPERATION}" == "verify" ]]; then
+  role_agent_once_env_code="$(<"${ROLE_AGENT_ONCE_ENV_SOURCE}")"
   verify_config_code='
 import json
 import sys
@@ -383,7 +391,8 @@ print(normalized)
       for canary_attempt in 1 2 3; do
         role_agent_canary_rc=0
         role_agent_canary_output=\$(
-          timeout 120 $(quote "${ROLE_AGENT_TARGET}") --once 2>/dev/null
+          timeout 120 python3 -I -c $(quote "${role_agent_once_env_code}") \
+            $(quote "${PROJECT_DIR}") $(quote "${ROLE_AGENT_SHA256}") 2>/dev/null
         ) || role_agent_canary_rc=\$?
         if test \"\${role_agent_canary_rc}\" -eq 0 \
           && printf '%s' \"\${role_agent_canary_output}\" \
@@ -398,6 +407,7 @@ print(normalized)
           sleep 1
           continue
         fi
+        echo \"role-agent one-shot attestation failed: rc=\${role_agent_canary_rc}\" >&2
         exit 1
       done
       test \"\${role_agent_canary_passed}\" = true

--- a/tests/unit/test_patroni_communications_deploy.py
+++ b/tests/unit/test_patroni_communications_deploy.py
@@ -296,6 +296,10 @@ def test_remote_verify_requires_exact_images_running_and_false_phase2a_gates():
     assert "NRestarts" in verify
     assert ".ha-communications-worker-release-fenced" in verify
     assert "test ! -L ${CANONICAL_REMOTE_COMPOSE_FILE}" in verify
+    assert "patroni_role_agent_once_env.py" in text
+    assert 'role_agent_once_env_code="$(<"${ROLE_AGENT_ONCE_ENV_SOURCE}")"' in verify
+    assert "timeout 120 python3 -I -c" in verify
+    assert 'timeout 120 $(quote "${ROLE_AGENT_TARGET}") --once' not in verify
     assert "API/worker parity confirmed" in verify
     assert "GHCR_PAT" not in verify.split(
         'ssh "${SSH_OPTS[@]}" "${REMOTE}" \\\n'

--- a/tests/unit/test_patroni_role_agent_once_env.py
+++ b/tests/unit/test_patroni_role_agent_once_env.py
@@ -1,0 +1,165 @@
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.ha import patroni_role_agent_once_env as once_env
+
+
+def _write_environment(path: Path, values: dict[str, str]) -> None:
+    path.write_text(
+        "".join(f"{name}={value}\n" for name, value in values.items()),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+
+
+def test_expected_environment_is_node_specific():
+    api = once_env.expected_role_environment("/opt/air-api")
+    reserve = once_env.expected_role_environment("/opt/mvn-reserve")
+
+    assert api["HA_PROJECT_DIR"] == "/opt/air-api"
+    assert api["HA_PATRONI_NAME"] == "mvn-api"
+    assert reserve["HA_PROJECT_DIR"] == "/opt/mvn-reserve"
+    assert reserve["HA_PATRONI_NAME"] == "zakup"
+    assert api["HA_COMPOSE_FILE"] == reserve["HA_COMPOSE_FILE"]
+    assert api["HA_COMPOSE_FILE"] == "docker-compose.patroni.yml"
+
+
+def test_environment_attestation_accepts_exact_reviewed_contract(tmp_path):
+    path = tmp_path / "role-agent.env"
+    expected = once_env.expected_role_environment("/opt/mvn-reserve")
+    _write_environment(path, expected)
+
+    actual = once_env.attest_role_environment(
+        "/opt/mvn-reserve",
+        path=path,
+        expected_uid=os.getuid(),
+        expected_gid=os.getgid(),
+    )
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda values: values.__setitem__("HA_PATRONI_NAME", "mvn-api"),
+        lambda values: values.__setitem__("EXTRA_SETTING", "unsafe"),
+        lambda values: values.pop("HA_PROJECT_DIR"),
+    ),
+)
+def test_environment_attestation_rejects_contract_drift(tmp_path, mutation):
+    path = tmp_path / "role-agent.env"
+    values = once_env.expected_role_environment("/opt/mvn-reserve")
+    mutation(values)
+    _write_environment(path, values)
+
+    with pytest.raises(ValueError, match="differs from the reviewed"):
+        once_env.attest_role_environment(
+            "/opt/mvn-reserve",
+            path=path,
+            expected_uid=os.getuid(),
+            expected_gid=os.getgid(),
+        )
+
+
+def test_environment_attestation_rejects_symlink(tmp_path):
+    target = tmp_path / "target.env"
+    link = tmp_path / "role-agent.env"
+    _write_environment(
+        target,
+        once_env.expected_role_environment("/opt/mvn-reserve"),
+    )
+    link.symlink_to(target)
+
+    with pytest.raises(OSError):
+        once_env.attest_role_environment(
+            "/opt/mvn-reserve",
+            path=link,
+            expected_uid=os.getuid(),
+            expected_gid=os.getgid(),
+        )
+
+
+def test_environment_attestation_rejects_unsafe_mode(tmp_path):
+    path = tmp_path / "role-agent.env"
+    _write_environment(
+        path,
+        once_env.expected_role_environment("/opt/mvn-reserve"),
+    )
+    path.chmod(0o644)
+
+    with pytest.raises(ValueError, match="unsafe role-agent asset"):
+        once_env.attest_role_environment(
+            "/opt/mvn-reserve",
+            path=path,
+            expected_uid=os.getuid(),
+            expected_gid=os.getgid(),
+        )
+
+
+def test_run_once_executes_agent_with_attested_clean_environment(
+    tmp_path, monkeypatch
+):
+    environment_path = tmp_path / "role-agent.env"
+    agent_path = tmp_path / "mvn-patroni-role-agent"
+    python_path = Path("/usr/bin/python3")
+    expected = once_env.expected_role_environment("/opt/mvn-reserve")
+    _write_environment(environment_path, expected)
+    agent_path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    agent_path.chmod(0o755)
+    agent_digest = hashlib.sha256(agent_path.read_bytes()).hexdigest()
+    captured: dict[str, object] = {}
+
+    def fake_execve(path, arguments, environment):
+        captured.update(
+            path=path,
+            arguments=arguments,
+            environment=environment,
+        )
+        raise RuntimeError("exec captured")
+
+    monkeypatch.setattr(os, "execve", fake_execve)
+
+    with pytest.raises(RuntimeError, match="exec captured"):
+        once_env.run_once(
+            "/opt/mvn-reserve",
+            agent_digest,
+            environment_path=environment_path,
+            agent_path=agent_path,
+            python_path=python_path,
+            expected_uid=os.getuid(),
+            expected_gid=os.getgid(),
+        )
+
+    assert captured["path"] == python_path
+    assert captured["arguments"] == [
+        str(python_path),
+        str(agent_path),
+        "--once",
+    ]
+    assert captured["environment"] == {
+        **once_env.BASE_EXEC_ENVIRONMENT,
+        **expected,
+    }
+
+
+def test_run_once_rejects_unreviewed_agent_digest(tmp_path):
+    environment_path = tmp_path / "role-agent.env"
+    agent_path = tmp_path / "mvn-patroni-role-agent"
+    expected = once_env.expected_role_environment("/opt/mvn-reserve")
+    _write_environment(environment_path, expected)
+    agent_path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    agent_path.chmod(0o755)
+
+    with pytest.raises(ValueError, match="digest differs"):
+        once_env.run_once(
+            "/opt/mvn-reserve",
+            "0" * 64,
+            environment_path=environment_path,
+            agent_path=agent_path,
+            expected_uid=os.getuid(),
+            expected_gid=os.getgid(),
+        )


### PR DESCRIPTION
## Incident

Production rollout for #852 ([run 30221637169](https://github.com/mvnby/air-api/actions/runs/30221637169)) deployed the tested image and dormant worker to both Patroni nodes, but the final verifier failed on the reserve node.

Root cause: the verifier invoked `/usr/local/sbin/mvn-patroni-role-agent --once` directly, outside the systemd `EnvironmentFile`. Defaults happen to match `/opt/air-api`, but they are wrong for `/opt/mvn-reserve` (`zakup`). The installed daemon itself remained correctly configured and healthy.

## Fix

- attest the exact root-owned `/etc/default/mvn-patroni-role-agent` node contract before one-shot execution;
- reject symlink/hardlink, unsafe ownership/mode, duplicate/missing/extra settings, and unknown project directories;
- verify the installed role-agent SHA-256 against the exact CI-tested source;
- execute once with a clean allowlisted environment, preserving the strict receipt parser and fail-closed behavior;
- emit a generic stage/return-code error without leaking environment values.

## Validation

- production dry attestation against the current installed release:
  - `/opt/mvn-reserve`: `verified role=primary`;
  - `/opt/air-api`: `verified role=standby`;
- focused tests: 43 passed;
- expanded HA/PITR/communications/deploy suite: 1076 passed, 4 skipped;
- Bash syntax, ShellCheck, Python compile, Ruff/Black where available, and `git diff --check`: clean;
- independent security review: no remaining P0/P1/P2 findings.

## Safety

This does not enable communications delivery or allow-all mode. Both Phase 2A gates remain hardcoded `false`.