### PR TITLE
Activate safe installation notifications through managed communications

### DIFF
--- a/.github/workflows/deploy-api-patroni.yml
+++ b/.github/workflows/deploy-api-patroni.yml
@@ -372,4 +372,4 @@ jobs:
             echo "::error::No validated Patroni primary branch completed"
             exit 1
           fi
-          echo "Patroni-aware API and dormant worker release verified on both nodes through ${PRIMARY_NODE}"
+          echo "Patroni-aware API and communications worker release verified on both nodes through ${PRIMARY_NODE}"

--- a/alembic/versions/d8e7f6a5b4c3_add_installation_notification_watermark.py
+++ b/alembic/versions/d8e7f6a5b4c3_add_installation_notification_watermark.py
@@ -1,0 +1,67 @@
+"""add immutable installation notification activation watermark
+
+Revision ID: d8e7f6a5b4c3
+Revises: f4d5e6f7a8b9
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "d8e7f6a5b4c3"
+down_revision: str | None = "f4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("communication_runtime_state") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "installation_estimate_watermark_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            )
+        )
+
+    # A legacy ``all`` row has no defensible cutover. Never infer one during
+    # schema rollout: return it to the fail-closed mode and require the typed
+    # activation command to perform a fresh safety transaction.
+    op.execute(
+        sa.text(
+            "UPDATE communication_runtime_state "
+            "SET mode = 'off', canary_run_id = NULL, "
+            "control_revision = control_revision + 1, "
+            "control_updated_at = CURRENT_TIMESTAMP, "
+            "updated_at = CURRENT_TIMESTAMP "
+            "WHERE mode = 'all'"
+        )
+    )
+
+    with op.batch_alter_table("communication_runtime_state") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_communication_runtime_all_watermark_required",
+            "mode <> 'all' OR installation_estimate_watermark_at IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    # ``all`` cannot exist without the column that fences its event horizon.
+    op.execute(
+        sa.text(
+            "UPDATE communication_runtime_state "
+            "SET mode = 'off', canary_run_id = NULL, "
+            "control_revision = control_revision + 1, "
+            "control_updated_at = CURRENT_TIMESTAMP, "
+            "updated_at = CURRENT_TIMESTAMP "
+            "WHERE mode = 'all'"
+        )
+    )
+    with op.batch_alter_table("communication_runtime_state") as batch_op:
+        batch_op.drop_constraint(
+            "ck_communication_runtime_all_watermark_required",
+            type_="check",
+        )
+        batch_op.drop_column("installation_estimate_watermark_at")

--- a/alembic/versions/e9a1b2c3d4e5_add_delivery_provider_boundary.py
+++ b/alembic/versions/e9a1b2c3d4e5_add_delivery_provider_boundary.py
@@ -1,0 +1,61 @@
+"""add durable communication provider-call boundary
+
+Revision ID: e9a1b2c3d4e5
+Revises: d8e7f6a5b4c3
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "e9a1b2c3d4e5"
+down_revision: str | None = "d8e7f6a5b4c3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("communication_delivery_attempt") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "provider_started_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_attempt_provider_after_started",
+            "provider_started_at IS NULL "
+            "OR provider_started_at >= started_at",
+        )
+        batch_op.create_check_constraint(
+            "ck_delivery_attempt_provider_before_finished",
+            "provider_started_at IS NULL OR finished_at IS NULL "
+            "OR provider_started_at <= finished_at",
+        )
+
+    # An old worker may already have crossed Telegram's acceptance boundary.
+    # Conservatively mark every in-flight legacy attempt before new recovery
+    # logic is allowed to classify a NULL boundary as retry-safe.
+    op.execute(
+        sa.text(
+            "UPDATE communication_delivery_attempt "
+            "SET provider_started_at = started_at "
+            "WHERE outcome = 'running' AND provider_started_at IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("communication_delivery_attempt") as batch_op:
+        batch_op.drop_constraint(
+            "ck_delivery_attempt_provider_before_finished",
+            type_="check",
+        )
+        batch_op.drop_constraint(
+            "ck_delivery_attempt_provider_after_started",
+            type_="check",
+        )
+        batch_op.drop_column("provider_started_at")

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -370,8 +370,9 @@ export HA_SSH_IDENTITY_FILE="$HOME/.ssh/id_ed25519"
 python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py --probe-only
 
 # Generate one cluster transaction ID and record it in the operator log. Reuse
-# this exact value after any interrupted migration; never start a second
-# transaction to work around an ambiguous result.
+# this exact value after an ambiguous interruption. If the controller proves
+# that rollback is durable, let that same transaction finish recovery cleanup;
+# its terminal error then explicitly requires a newly generated transaction ID.
 export PITR_TRANSACTION_ID="$(openssl rand -hex 16)"
 
 # First verify the local input shape without touching either node.
@@ -383,6 +384,21 @@ python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
   --no-prompt
 
 # Run the complete two-node transaction. It attests and installs the exact
+# helper bundle only after a pinned communications cutover preflight on the
+# sole primary has atomically proved database mode off, zero running
+# installation deliveries, a completed drain, and a stopped release-fenced
+# worker. The preflight owns a root-only receipt plus the PITR marker under the
+# same global/deploy locks. A same-transaction retry verifies those artifacts;
+# another transaction cannot consume them. Deploy the dormant compatibility
+# release containing this preflight before using this command for a profile
+# change.
+#
+# For a communications profile change, run this command from an otherwise
+# Compose-only, fully CI-green PR head while production deployment is frozen.
+# Immediately after success, merge that unchanged head and deploy it. Do not
+# mix not-yet-installed role-agent/PITR code into the profile PR.
+#
+# The transaction attests and installs the exact
 # helper bundle standby-first, validates the private destination from both
 # nodes, then runs a separate quiesce/provision/resume window for the standby and
 # a fail-closed-fence/provision/resume window for the primary. The first
@@ -406,10 +422,21 @@ python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
 # asset bundles back. From that first stop attempt onward the command
 # deliberately enters roll-forward, including an ambiguous timeout or lost SSH
 # response: repair the reported cause and rerun the same command with the same
-# transaction ID. If the interrupted per-node window cannot prove both fences
-# and a fresh unchanged topology, it deliberately leaves the runtime fenced and
-# names the exact failed proof. Do not manually roll back files, config,
-# archive state, agents, fences, or timers in that state.
+# transaction ID. A retry that finds any exact durable rollback receipt cannot
+# resume the migration: it rejects a finalized peer, otherwise rolls back or
+# cleans every active/rolled-back/preflight-fenced peer, skips fresh peers, and
+# stops only after instructing the operator to generate a new transaction ID.
+# If that cleanup is interrupted, retry it with the old ID. If the interrupted
+# per-node window cannot prove both fences and a fresh unchanged topology, it
+# deliberately leaves the runtime fenced and names the exact failed proof. Do
+# not manually roll back files, config, archive state, agents, fences, or timers.
+#
+# A failure after a finalized profile migration is not repaired with an app
+# rollback: ordinary deploys accept only byte-identical PITR-attested Compose.
+# Roll forward the same head, or prepare a CI-green Compose-only rollback head
+# and apply it with a new official atomic PITR transaction. Keep the deployment
+# freeze through immediate deploy, both-node verification, strict HA/PITR
+# checks, and a 30-minute alert window.
 
 # PostgreSQL archive parameters are Patroni DCS configuration for an existing
 # cluster. The migration requires the reviewed archive settings to be active on

--- a/docs/communications-installation-estimate-rollout.md
+++ b/docs/communications-installation-estimate-rollout.md
@@ -12,7 +12,7 @@ The production website scope is deliberately exact:
 Public order/contact events and the operations canary are excluded. Expanding
 the scope requires a separate reviewed rollout.
 
-## Stale backlog decision
+## Dormant compatibility-stage backlog suppression
 
 Old installation-estimate events are not sent automatically after the worker
 is enabled. Inventory covers both:
@@ -21,15 +21,32 @@ is enabled. Inventory covers both:
 - stale `published`/`processing` target events with `queued`, `retry`, or
   `running` Telegram deliveries.
 
-Inventory and suppression use the immutable backend image. Before execution,
-the managed communications worker must be fully stopped, not merely paused:
-the durable Telegram runtime state must report both `mode=off` and
-`status=stopped`.
+This suppression is performed only in the earlier dormant (`false/false`)
+compatibility stage, before the active worker profile is deployed. The managed
+communications worker must be fully stopped, not merely paused: durable
+Telegram state must report `mode=off` and `status=stopped`.
+
+Production hosts are image-only. Resolve the current Patroni primary from a
+trusted operator checkout, SSH to that node, and from its Compose project
+directory resolve the active API slot:
 
 ```bash
-cd /opt/air-api
-docker compose -f docker-compose.prod.yml exec -T app \
-  python3 scripts/reconcile_installation_estimate_backlog.py \
+python3 scripts/ha/check_patroni_production.py --resolve-primary
+
+active_service=app
+if test -f .active-api-slot; then
+  active_slot="$(tr -d '\r\n' < .active-api-slot)"
+  case "${active_slot}" in
+    blue|green) active_service="app-${active_slot}" ;;
+    *) echo "invalid active API slot" >&2; exit 1 ;;
+  esac
+fi
+BACKEND=(
+  docker compose -f docker-compose.patroni.yml --profile bluegreen exec -T
+  "${active_service}" python3
+)
+
+"${BACKEND[@]}" scripts/reconcile_installation_estimate_backlog.py \
   --cutoff 2026-07-26T00:00:00+03:00 \
   --limit 100
 ```
@@ -41,9 +58,7 @@ IDs, destinations, payloads, customer data or raw database errors.
 After reviewing the dry-run, suppress the same bounded selection explicitly:
 
 ```bash
-cd /opt/air-api
-docker compose -f docker-compose.prod.yml exec -T app \
-  python3 scripts/reconcile_installation_estimate_backlog.py \
+"${BACKEND[@]}" scripts/reconcile_installation_estimate_backlog.py \
   --cutoff 2026-07-26T00:00:00+03:00 \
   --limit 100 \
   --execute
@@ -79,21 +94,169 @@ delivery until `candidate_total=0`, `remaining_candidate_count=0`, and
 `activation_safe=true`. The output contains counts and fixed codes only; it
 must never contain event IDs, destinations, payloads, or customer data.
 
-## Production activation order
+## Typed production control
 
-1. Deploy the managed worker dormant and prove one HA-fenced instance.
-2. Set database runtime mode to `off`, fully stop the managed worker, and
-   verify durable status `stopped`.
-3. Run the backlog dry-run and the approved bounded suppression until the
-   privacy-safe inventory reports zero and `activation_safe=true`.
-4. Execute the existing operations Telegram canary and return mode to `off`.
-5. Enable only the installation-estimate website scope.
-6. Submit one new synthetic multipart request.
-7. Verify one event, one delivery per active owner, provider acknowledgements
-   and no duplicate after replaying the same `Idempotency-Key`.
-8. On any anomaly, set database mode to `off`, disable the immutable gate and
-   stop the worker.
+There is no generic `all` switch. `CommunicationRuntimeStateService.set_mode`
+rejects `all`, and operators must not replace the typed command with SQL or an
+ad-hoc Python snippet. The only activation path is fixed to:
 
-Telegram does not offer provider-side idempotency. A lost acknowledgement after
-Telegram accepted a message is therefore an ambiguous outcome, not a safe
-automatic retry or proof of exactly-once delivery.
+- event `crm.installation_estimate_lead.created`;
+- template `telegram.installation_estimate_lead_created`;
+- channel `telegram`;
+- every active `StaffUser` whose primary role is `owner`.
+
+Managers and `ADMIN_IDS` are never a fallback. Activation fails closed if
+there are no active owners, if any active owner lacks a positive Telegram ID,
+or if recipient keys or Telegram destinations are not unique.
+
+Resolve the current primary and active API container as described in the HA
+runbook, then define a command that runs inside the immutable backend image:
+
+```bash
+INSTALLATION_NOTIFICATIONS=(
+  docker compose -f docker-compose.patroni.yml --profile bluegreen exec -T
+  "${active_service}"
+  python3 scripts/communications_installation_notifications.py
+)
+```
+
+The CLI accepts exactly one of `--plan`, `--enable`, `--status`, and `--off`.
+It has no event, destination, template, message, retry, or watermark argument.
+
+`--plan` and `--status` remain available in dormant, canary, and active
+deployment profiles. They return fixed codes and aggregate counts only. In a
+canary (`true/false`) or dormant (`false/false`) profile, `--enable` is always
+blocked:
+
+```bash
+"${INSTALLATION_NOTIFICATIONS[@]}" --plan
+"${INSTALLATION_NOTIFICATIONS[@]}" --status
+```
+
+The status inventory always includes these explicit buckets, including zeros:
+
+- outbox: `pending`, `processing`, `published`, `dead`;
+- delivery: `queued`, `running`, `retry`, `sent`, `dead`, `canceled`;
+- attempts: `running`, `sent`, `retry`, `dead`, `canceled`;
+- provider acknowledgement count;
+- `ambiguous_nonterminal_count`, `ambiguous_terminal_count`, and
+  `ambiguous_total_count`.
+
+It never prints event IDs, order IDs, destinations, payloads, rendered content,
+customer data, tokens, connection strings, raw provider responses, or exception
+messages.
+
+## Activation transaction
+
+Deploy the active (`true/true`) profile while durable runtime control is still
+`off`. Then run `--plan`. Do not continue unless `enable_allowed=true` and the
+blocker list is empty:
+
+```bash
+"${INSTALLATION_NOTIFICATIONS[@]}" --plan
+"${INSTALLATION_NOTIFICATIONS[@]}" --enable
+"${INSTALLATION_NOTIFICATIONS[@]}" --status
+```
+
+`--enable` locks the durable Telegram control row and proves all gates in one
+database transaction:
+
+- deployment profile is exactly active: worker enabled and `allow_all=true`;
+- `APP_ROLE=primary`;
+- PostgreSQL is the writable primary, not read-only or in recovery;
+- transaction isolation is exactly PostgreSQL `read committed`;
+- a non-placeholder Telegram token is configured;
+- database runtime locks are enabled;
+- exactly one fresh worker instance owns the expected advisory lock;
+- runtime mode is `off` and lifecycle status is `disabled`;
+- the exact owner audience is valid;
+- no currently committed pending/interrupted target event, non-terminal target
+  delivery, running target attempt, or ambiguous attempt attached to a
+  non-terminal target delivery remains unreconciled, regardless of its stored
+  `created_at`.
+
+Every normal target-event enqueue first takes a shared transaction advisory
+fence, then assigns the event `created_at` from the PostgreSQL clock. Shared
+holders do not serialize ordinary requests. `--enable` makes a non-blocking
+attempt to take the exclusive side of the same fence. If an enqueue transaction
+is still open, activation fails immediately with
+`installation_activation_fence_busy`, mutates no control state, and must be
+rerun after that request finishes. It never waits indefinitely behind a stalled
+request.
+
+A request that reaches the enqueue fence while `--enable` holds its exclusive
+side waits for at most one second. If activation does not finish in that bound,
+the whole intake transaction and private attachment writes are rolled back and
+the endpoint returns retryable HTTP `503` with `Retry-After: 1`. A client must
+resubmit the same `Idempotency-Key`; the server never partially creates an
+order or outbox event.
+
+With `read committed` isolation, a successful exclusive fence proves that
+earlier enqueue transactions are visible to the safety inventory; later
+enqueues cannot obtain their database timestamp until activation commits. The
+command then reads its cutoff from the same database clock. On the first
+successful activation it stores that value as the immutable activation
+watermark and increments the control revision. Dispatcher selection, delivery
+claim, and expired-lease recovery all require
+`IntegrationOutboxEvent.created_at >= watermark`; older events can never be
+sent. Emergency `off` retains the watermark. A reviewed re-enable reuses the
+same value and never moves it, and it first requires the whole currently
+committed unsafe target inventory to be reconciled. This all-row inventory
+also prevents a future-skewed timestamp from bypassing activation safety. Once
+runtime mode is `all`, a missing watermark fails closed. A persisted future or
+otherwise invalid watermark also blocks activation.
+
+After activation:
+
+1. Submit one new synthetic multipart request.
+2. Verify one outbox event and exactly one delivery per current active owner.
+3. Require a provider acknowledgement for every delivery and zero
+   queued/running/retry/dead/canceled rows for the synthetic request.
+4. Replay the identical request with the same `Idempotency-Key`.
+5. Verify the replay creates no event, delivery, attempt, or provider call.
+6. Have each owner confirm exactly one received message.
+
+## Emergency off and ambiguity policy
+
+`--off` is the independent emergency path. It does not require the active
+profile, token, owner audience, or activation gates:
+
+```bash
+"${INSTALLATION_NOTIFICATIONS[@]}" --off
+```
+
+It commits `mode=off` first, retains the activation watermark, then waits for a
+bounded drain and reports durable runtime mode/status, running delivery count,
+ambiguous count, and whether drain completed. A timed-out drain is not a
+successful operator result. Re-run it on the newly resolved writable primary
+after a role change.
+
+Telegram does not offer provider-side idempotency. Each attempt therefore has
+a durable provider boundary committed under its exact worker lease, after
+rendering, owner revalidation, and the final runtime safety check, immediately
+before network I/O. `off` and the provider boundary serialize on the same
+runtime-control row. If `off` commits first, the exact pre-provider claim is
+released with no ambiguity, its lease is cleared, and it becomes a delayed
+retry (or terminal non-ambiguous failure when attempts are exhausted). This
+keeps the off drain live while leaving the retry backlog visible to the next
+reviewed activation. An expired lease before that boundary is likewise provably
+unsent and follows the same retry/exhaustion policy. An expired
+lease after the boundary may have been accepted by Telegram and is always
+terminal `dead` with `ambiguous=true`. A timeout, connection loss, server
+failure, or malformed acknowledgement after the boundary follows the same
+terminal policy. Authentication and Telegram 400-series request failures are
+terminal as well.
+
+The standalone staff bot receives a delivery payload from the API in another
+process. That committed API handoff is itself its provider boundary. During a
+rolling upgrade, even a legacy staff-bot claim with no marker is recovered
+conservatively as post-boundary. Lost responses and bot crashes can therefore
+never turn into an automatic duplicate send.
+
+The sole automatic provider retry is an explicit Telegram 429 response with a
+valid positive `retry_after`, because Telegram has proven that request was not
+accepted for delivery. A historical terminal ambiguous attempt is permanently
+counted, alerted, and retained for manual follow-up; claim selection can never
+resurrect it. It does not become an eternal global re-enable blocker. Before
+activation, `ambiguous_nonterminal_count` must be zero; terminal and total
+counters must still be reviewed explicitly.

--- a/docs/communications-telegram-canary.md
+++ b/docs/communications-telegram-canary.md
@@ -6,7 +6,7 @@ Each intentional run has an immutable, canonical lowercase UUIDv4 identifier.
 
 Do not execute a live canary merely because this script exists. Before the
 first production run, deploy one release consistently across API/migration and
-the communications worker, verify Alembic revision `6c0d3e5f7a21`, prove the
+the communications worker, verify Alembic revision `e9a1b2c3d4e5`, prove the
 worker owns the writable-primary advisory lock, keep
 `COMMUNICATIONS_WORKER_ALLOW_ALL_MODE=false`, and confirm there is no older
 worker process. This follow-up has not itself performed a production deploy or
@@ -110,14 +110,19 @@ executing a later transaction; after an emergency, first establish that no
 execute command remains in flight and then repeat `--off` on the current
 primary.
 
-`--off` prevents new claims and fences later state changes, but it cannot recall
-a Telegram request that already entered the provider call. Wait at least the
-bounded provider/shutdown window and verify the managed worker has stopped or
-reported disabled before treating the drain as complete. A delivery interrupted
-after claim may remain `running` with an expired lease while the scope is off.
-For this max-attempts-one canary, classify that historical result as ambiguous;
-do not re-arm, recover, requeue, or create a replacement run merely to make the
-status terminal.
+`--off` serializes on the same runtime-control row as the provider boundary. A
+boundary transaction that observes committed `off` fails closed before network
+I/O; an `off` transaction waits for any earlier boundary transaction to commit.
+It still cannot recall a Telegram request that already crossed that durable
+boundary. A rejected exact pre-provider claim is released without ambiguity and
+cannot strand the off drain as `running`. Wait at least the bounded
+provider/shutdown window and verify the managed worker has
+stopped or reported disabled before treating the drain as complete. An expired
+pre-boundary canary attempt is provably unsent, but `max_attempts=1` closes it
+terminally without ambiguity or replay. An expired post-boundary attempt is
+terminal `dead` with `ambiguous=true`. Reconcile that historical result
+manually. Do not re-arm, requeue, or create a replacement run merely to make
+the status look successful.
 
 Direct `canary -> all`, `all -> canary`, and `canary A -> canary B` transitions
 are rejected; every scope change must pass through `off`. There is deliberately

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -290,14 +290,34 @@ agent continues reconciling primary app/bot traffic while this marker is valid,
 but keeps all PITR timers and their services fenced. Unsafe marker metadata or
 content causes a full standby fence.
 
-### Communications Worker Phase 2A
+### Communications Worker Release Profiles
 
 Both Patroni API nodes define `communications-worker` from the exact immutable
 `BACKEND_IMAGE` used by the API. It uses that node's local PostgreSQL service
 and the same role-resolved `.ha-app-role.env`; deploy and verification reject
-any image or `APP_ROLE` mismatch. During Phase 2A both delivery gates,
-`COMMUNICATIONS_WORKER_ENABLED` and `COMMUNICATIONS_WORKER_ALLOW_ALL_MODE`,
-must remain exactly `false`.
+any image, API/worker parity, or `APP_ROLE` mismatch. The production Compose
+files remain in the Phase 2A `dormant` profile, with both
+`COMMUNICATIONS_WORKER_ENABLED` and
+`COMMUNICATIONS_WORKER_ALLOW_ALL_MODE` exactly `false`.
+
+Release tooling recognizes only this closed profile set:
+
+- `dormant`: `false/false`;
+- `canary`: `true/false`, which starts the worker but keeps `all` delivery
+  blocked while the database-owned canary scope is exercised;
+- `active`: `true/true`.
+
+`false/true`, uppercase spellings, and every other non-literal combination are
+invalid and fenced. The ordinary image transaction accepts a staged Patroni
+Compose only when it is byte-identical to the current PITR-attested canonical
+file and both are root-owned regular non-symlinks in exact mode `0644`. It also
+reconstructs the finalized root-only
+`/var/lib/mvn-postgres-pitr/release-manifest.json` from every currently
+installed manifest asset, verifies its canonical schema and release digest,
+and requires the canonical Compose mode and digest to match its exact entry.
+Therefore an image rollout may retain `dormant`, `canary`, or `active`, but it
+cannot change profile or any other Compose byte. Every Compose change first
+uses the official atomic PITR cluster migration.
 
 The root-owned project marker
 `.ha-communications-worker-release-fenced` is a durable fail-closed latch.
@@ -309,18 +329,67 @@ restores both the previous marker state and the previous worker running state;
 it never starts a worker that was already fenced.
 
 After each node deploy, the verifier proves the canonical Compose file is a
-regular non-symlink, API/worker image parity, false delivery gates, the expected
-runtime role, a stable active role-agent unit, and an absent release latch. It
-then runs `/usr/local/sbin/mvn-patroni-role-agent --once`. A successful no-op
-or reconciliation must end with exactly:
+regular non-symlink, API/worker image parity, one reviewed gate profile with an
+exactly matching runtime profile, the expected runtime role, a stable active
+role-agent unit, and an absent release latch. The role agent accepts any
+reviewed runtime profile independently of the still-canonical Compose profile:
+this prevents the newly installed agent from stopping a valid candidate before
+atomic promotion. It still fences an invalid profile before waiting for the
+deploy lock. The verifier then runs
+`/usr/local/sbin/mvn-patroni-role-agent --once`. A successful no-op or
+reconciliation must end with exactly:
 
 ```text
 patroni_role_agent_once_status=verified role=<primary|standby>
 ```
 
-Do not enable either delivery gate manually during Phase 2A. Delivery
-activation, token ownership, retry/ack canaries, and accumulated-event policy
-belong to the separately approved Phase 2B transaction.
+Do not edit either delivery gate manually.
+
+#### Reviewed profile cutover sequence
+
+1. Merge and deploy the compatibility release while both production Compose
+   files remain byte-identical and `dormant`. It must install the typed
+   installation-notification operator, the pinned PITR communications
+   preflight, and the profile-aware role agent on both nodes. Complete the
+   usual strict readiness/PITR/replication checks first.
+2. Open a separate Compose-only PR for the next profile (`canary`, then later
+   `active`). It must contain no role-agent, PITR-controller, application, or
+   migration changes. Wait for every CI check to pass. Do not merge it yet.
+3. Freeze production deployments and unrelated PITR operations. From that
+   exact CI-green PR head, run the official atomic PITR cluster migration with
+   one recorded transaction ID. Before its first remote mutation, the
+   controller validates the exact Compose bytes already pinned into both
+   release bundles: all API services and the worker must share one image, both
+   nodes must use the same reviewed exact-lowercase profile, and YAML booleans
+   or any structural drift are rejected. The controller then invokes the already
+   deployed typed operator on the sole primary, requires database mode `off`,
+   zero running installation deliveries, and a completed drain, then latches
+   the communications release fence and the transaction-owned PITR marker
+   under the host/deploy locks. Only then may it replace either canonical
+   Compose file.
+4. If the migration succeeds, immediately merge the unchanged PR and deploy
+   that exact head. The image transaction now sees byte-identical attested
+   Compose, proves the exact lowercase profile, and clears the communications
+   release fence only for its controlled start. Database mode remains `off`;
+   enable it later only through the typed canary/activation command.
+5. Keep the deployment freeze through both-node verification, strict HA/PITR
+   checks, and a 30-minute alert window. For `canary`, execute and replay the
+   bounded canary during this window. For `active`, require a clean operator
+   status before the synthetic website request.
+
+An interrupted preflight or migration is fail-closed. Re-run an ambiguous
+attempt with the same transaction ID; do not delete its receipt, maintenance
+marker, or communications fence. Before the role-agent/configuration
+roll-forward boundary, the controller may restore its recorded release
+bundles. If any node proves that rollback is durable, the old transaction can
+only finish rollback/preflight cleanup across both nodes; after that cleanup it
+stops and explicitly requires a new transaction ID. Retry the old ID only when
+that cleanup itself is interrupted. The communications fence remains latched
+until a reviewed deploy. After the roll-forward boundary, repair and roll
+forward with the same transaction. If a finalized profile must be reverted,
+prepare a separate CI-green Compose-only rollback head and run a new official
+PITR transaction from that head; an ordinary app rollback is rejected because
+it would replace the attested Compose.
 
 ## Production Cutover
 

--- a/manager_frontend/src/client/services/ApiService.ts
+++ b/manager_frontend/src/client/services/ApiService.ts
@@ -333,6 +333,7 @@ export class ApiService {
                 400: `Invalid image or upload limits exceeded`,
                 409: `Idempotency key reused with different content`,
                 422: `Validation Error`,
+                503: `Request can be retried after a short delay`,
             },
         });
     }

--- a/models/communication.py
+++ b/models/communication.py
@@ -176,6 +176,15 @@ class CommunicationDeliveryAttempt(SQLModel, table=True):
             name="ck_delivery_attempt_finished_after_started",
         ),
         CheckConstraint(
+            "provider_started_at IS NULL OR provider_started_at >= started_at",
+            name="ck_delivery_attempt_provider_after_started",
+        ),
+        CheckConstraint(
+            "provider_started_at IS NULL OR finished_at IS NULL "
+            "OR provider_started_at <= finished_at",
+            name="ck_delivery_attempt_provider_before_finished",
+        ),
+        CheckConstraint(
             "(outcome IN ('running', 'sent') AND error_category IS NULL "
             "AND error_code IS NULL) OR "
             "(outcome IN ('retry', 'dead', 'canceled') "
@@ -234,6 +243,10 @@ class CommunicationDeliveryAttempt(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     finished_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    provider_started_at: Optional[datetime] = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )

--- a/models/communication_runtime.py
+++ b/models/communication_runtime.py
@@ -39,6 +39,10 @@ class CommunicationRuntimeState(SQLModel, table=True):
             name="ck_communication_runtime_control_revision_non_negative",
         ),
         CheckConstraint(
+            "mode <> 'all' OR installation_estimate_watermark_at IS NOT NULL",
+            name="ck_communication_runtime_all_watermark_required",
+        ),
+        CheckConstraint(
             "status IN ('stopped', 'fencing', 'disabled', 'paused', "
             "'running', 'stopping', 'faulted')",
             name="ck_communication_runtime_status_valid",
@@ -61,6 +65,10 @@ class CommunicationRuntimeState(SQLModel, table=True):
     control_revision: int = Field(
         default=0,
         sa_column=Column(BigInteger, nullable=False),
+    )
+    installation_estimate_watermark_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )
     status: str = Field(
         default="stopped",

--- a/openapi.json
+++ b/openapi.json
@@ -2539,6 +2539,9 @@
           "409": {
             "description": "Idempotency key reused with different content"
           },
+          "503": {
+            "description": "Request can be retried after a short delay"
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/routers/api_leads.py
+++ b/routers/api_leads.py
@@ -26,6 +26,7 @@ from services.repair_diagnostic_service import (
 from services.installation_estimate_lead_service import (
     InstallationEstimateIdempotencyConflict,
     InstallationEstimateLeadService,
+    InstallationEstimateTemporarilyUnavailable,
 )
 from services.website_lead_service import WebsiteLeadService
 
@@ -79,6 +80,7 @@ async def create_public_contact_lead(
     responses={
         400: {"description": "Invalid image or upload limits exceeded"},
         409: {"description": "Idempotency key reused with different content"},
+        503: {"description": "Request can be retried after a short delay"},
     },
 )
 async def create_installation_estimate_lead(
@@ -120,6 +122,12 @@ async def create_installation_estimate_lead(
         )
     except InstallationEstimateIdempotencyConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except InstallationEstimateTemporarilyUnavailable as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Приём заявки временно занят. Повторите отправку.",
+            headers={"Retry-After": "1"},
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/scripts/communications_installation_notifications.py
+++ b/scripts/communications_installation_notifications.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Safely plan, enable, inspect, or disable installation notifications."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any, Literal
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+CommandMode = Literal["plan", "enable", "status", "off"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Operate the fixed crm.installation_estimate_lead.created Telegram "
+            "delivery contract. Event type and destinations are not configurable."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--plan",
+        action="store_true",
+        help="Inspect activation gates without changing runtime control",
+    )
+    mode.add_argument(
+        "--enable",
+        action="store_true",
+        help="Atomically activate the fixed owner-only delivery scope",
+    )
+    mode.add_argument(
+        "--status",
+        action="store_true",
+        help="Show privacy-safe runtime and outcome counts",
+    )
+    mode.add_argument(
+        "--off",
+        action="store_true",
+        help="Emergency-disable delivery and wait for in-flight work to drain",
+    )
+    return parser
+
+
+def _mode(args: argparse.Namespace) -> CommandMode:
+    if args.plan:
+        return "plan"
+    if args.enable:
+        return "enable"
+    if args.status:
+        return "status"
+    return "off"
+
+
+async def run_command(
+    mode: CommandMode,
+    *,
+    session_factory=None,
+    config=None,
+    bot_token: str | None = None,
+    runtime_locks_enabled: bool | None = None,
+    off_wait_seconds: float = 30.0,
+) -> dict[str, Any]:
+    from core.config import settings
+    from core.database import async_session_maker
+    from services.communications.installation_notifications import (
+        InstallationNotificationOperations,
+    )
+    from services.communications.runtime_config import CommunicationRuntimeConfig
+    from services.communications.runtime_state import (
+        CommunicationRuntimeMode,
+        CommunicationRuntimeStateService,
+    )
+
+    effective_factory = session_factory or async_session_maker
+    if mode == "off":
+        async with effective_factory() as session:
+            try:
+                previous = await CommunicationRuntimeStateService.read_control(
+                    session,
+                    channel=InstallationNotificationOperations.CHANNEL,
+                )
+                control = await CommunicationRuntimeStateService.set_mode(
+                    session,
+                    channel=InstallationNotificationOperations.CHANNEL,
+                    mode=CommunicationRuntimeMode.OFF,
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+        drain = await InstallationNotificationOperations.wait_until_off_drained(
+            effective_factory,
+            wait_seconds=off_wait_seconds,
+        )
+        return {
+            "command": "off",
+            "previous_mode": previous.mode.value,
+            "control_revision": control.control_revision,
+            "activation_watermark": (
+                control.installation_estimate_watermark_at.isoformat()
+                if control.installation_estimate_watermark_at is not None
+                else None
+            ),
+            **drain,
+        }
+
+    effective_config = config or CommunicationRuntimeConfig.from_settings()
+    effective_token = settings.BOT_TOKEN if bot_token is None else bot_token
+    effective_locks_enabled = (
+        settings.RUNTIME_DB_LOCKS_ENABLED
+        if runtime_locks_enabled is None
+        else bool(runtime_locks_enabled)
+    )
+
+    async with effective_factory() as session:
+        try:
+            if mode in {"plan", "status"}:
+                inspection = await InstallationNotificationOperations.inspect(
+                    session,
+                    config=effective_config,
+                    bot_token=effective_token,
+                    runtime_locks_enabled=effective_locks_enabled,
+                )
+                await session.rollback()
+                return {
+                    "command": mode,
+                    **inspection.to_dict(),
+                }
+
+            inspection, revision, watermark = (
+                await InstallationNotificationOperations.activate_installation_from_off(
+                    session,
+                    config=effective_config,
+                    bot_token=effective_token,
+                    runtime_locks_enabled=effective_locks_enabled,
+                )
+            )
+            await session.commit()
+            return {
+                "command": "enable",
+                "profile": inspection.profile,
+                "runtime_mode": CommunicationRuntimeMode.ALL.value,
+                "control_revision": revision,
+                "activation_watermark": watermark.isoformat(),
+                "owner_recipient_count": inspection.owner_recipient_count,
+                "ambiguous_nonterminal_count": (
+                    inspection.ambiguous_nonterminal_count
+                ),
+                "ambiguous_terminal_count": (
+                    inspection.ambiguous_terminal_count
+                ),
+                "ambiguous_total_count": inspection.ambiguous_total_count,
+            }
+        except Exception:
+            await session.rollback()
+            raise
+
+
+def _print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(run_command(_mode(args)))
+    except Exception as error:
+        from services.communications.installation_notifications import (
+            InstallationNotificationControlRejected,
+        )
+
+        error_code = (
+            error.error_code
+            if isinstance(error, InstallationNotificationControlRejected)
+            else "installation_notification_command_failed"
+        )
+        # Never print exception text: provider/database details can contain
+        # secrets, destinations, or customer data.
+        _print_json({"ok": False, "error_code": str(error_code)})
+        return 2 if isinstance(error, InstallationNotificationControlRejected) else 1
+
+    if result.get("command") == "off" and not result.get("drained", False):
+        _print_json(
+            {
+                "ok": False,
+                "error_code": "installation_notification_drain_incomplete",
+                **result,
+            }
+        )
+        return 3
+    _print_json({"ok": True, **result})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
+++ b/scripts/ha/apply_postgres_pitr_primary_prerequisites.py
@@ -405,7 +405,8 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=os.environ.get("PITR_TRANSACTION_ID") or "",
         help=(
             "Required 32-character lowercase hexadecimal cluster transaction ID "
-            "for every live or dry-run mutation phase. Reuse it to resume."
+            "for every live or dry-run mutation phase. Reuse it for ambiguous "
+            "resume or cleanup; use a new ID after durable rollback completes."
         ),
     )
     execution_mode = parser.add_mutually_exclusive_group()
@@ -479,6 +480,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "dry-run",
                 f"would run {DEFAULT_BOOTSTRAP_HELPER} {args.phase} on the sole primary",
             )
+            if args.phase == "migrate-cluster":
+                log(
+                    "dry-run",
+                    "would first prove communications runtime off and drained, "
+                    "then latch its release fence under the PITR transaction",
+                )
             return 0
 
         identity_file = validate_identity_file(args.identity_file)

--- a/scripts/ha/communications_worker_release_contract.sh
+++ b/scripts/ha/communications_worker_release_contract.sh
@@ -4,6 +4,30 @@
 # COMMUNICATIONS_WORKER_SERVICE.
 
 COMMUNICATIONS_WORKER_FENCE_MARKER="${COMMUNICATIONS_WORKER_FENCE_MARKER:-${PROJECT_DIR}/.ha-communications-worker-release-fenced}"
+COMMUNICATIONS_WORKER_CONTRACT_PROFILE=""
+COMMUNICATIONS_WORKER_PROFILE_ENABLED=""
+COMMUNICATIONS_WORKER_PROFILE_ALLOW_ALL=""
+
+communications_worker_set_profile_gates() {
+  case "$1" in
+    dormant)
+      COMMUNICATIONS_WORKER_PROFILE_ENABLED=false
+      COMMUNICATIONS_WORKER_PROFILE_ALLOW_ALL=false
+      ;;
+    canary)
+      COMMUNICATIONS_WORKER_PROFILE_ENABLED=true
+      COMMUNICATIONS_WORKER_PROFILE_ALLOW_ALL=false
+      ;;
+    active)
+      COMMUNICATIONS_WORKER_PROFILE_ENABLED=true
+      COMMUNICATIONS_WORKER_PROFILE_ALLOW_ALL=true
+      ;;
+    *)
+      echo "communications worker gate profile is not reviewed" >&2
+      return 1
+      ;;
+  esac
+}
 
 communications_worker_require_safe_fence_marker() {
   [[ ! -e "${COMMUNICATIONS_WORKER_FENCE_MARKER}" \
@@ -65,7 +89,12 @@ communications_worker_has_service() {
 }
 
 communications_worker_require_contract() {
+  local expected_profile="${1:-}"
+  local actual_profile=""
   local service_status=0
+  if [[ -n "${expected_profile}" ]]; then
+    communications_worker_set_profile_gates "${expected_profile}"
+  fi
   communications_worker_has_service || service_status=$?
   [[ "${service_status}" -eq 0 ]] || {
     if [[ "${service_status}" -eq 3 ]]; then
@@ -73,7 +102,7 @@ communications_worker_require_contract() {
     fi
     return "${service_status}"
   }
-  "${COMPOSE[@]}" config --format json \
+  actual_profile="$("${COMPOSE[@]}" config --format json \
     | python3 -c '
 import json
 import sys
@@ -88,17 +117,33 @@ if service.get("image") != expected_image:
 environment = service.get("environment") or {}
 if not isinstance(environment, dict):
     raise SystemExit("communications worker environment is not a mapping")
-for key in (
-    "COMMUNICATIONS_WORKER_ENABLED",
-    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE",
-):
-    if str(environment.get(key, "")).lower() != "false":
-        raise SystemExit(f"{key} must remain false during Phase 2A")
-' "${COMMUNICATIONS_WORKER_SERVICE}" "${BACKEND_IMAGE}"
+gates = (
+    environment.get("COMMUNICATIONS_WORKER_ENABLED"),
+    environment.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+)
+profiles = {
+    ("false", "false"): "dormant",
+    ("true", "false"): "canary",
+    ("true", "true"): "active",
+}
+profile = profiles.get(gates)
+if profile is None:
+    raise SystemExit("communications worker gate profile is not reviewed")
+print(profile)
+' "${COMMUNICATIONS_WORKER_SERVICE}" "${BACKEND_IMAGE}")" || return 1
+  communications_worker_set_profile_gates "${actual_profile}"
+  if [[ -n "${expected_profile}" && "${actual_profile}" != "${expected_profile}" ]]; then
+    echo "communications worker gate profile differs from the expected release" >&2
+    return 1
+  fi
+  COMMUNICATIONS_WORKER_CONTRACT_PROFILE="${actual_profile}"
 }
 
 communications_worker_require_runtime() {
   local expected_role="${1:-${EXPECTED_ROLE:-}}"
+  local expected_profile="${2:-}"
+  local expected_enabled=""
+  local expected_allow_all=""
   local container_ids=""
   local runtime=""
   communications_worker_require_release_unfenced
@@ -106,6 +151,11 @@ communications_worker_require_runtime() {
     echo "communications worker runtime role expectation is invalid" >&2
     return 1
   }
+  communications_worker_require_contract "${expected_profile}"
+  expected_profile="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
+  communications_worker_set_profile_gates "${expected_profile}"
+  expected_enabled="${COMMUNICATIONS_WORKER_PROFILE_ENABLED}"
+  expected_allow_all="${COMMUNICATIONS_WORKER_PROFILE_ALLOW_ALL}"
   container_ids="$("${COMPOSE[@]}" ps -q "${COMMUNICATIONS_WORKER_SERVICE}")"
   [[ -n "${container_ids}" && "${container_ids}" != *$'\n'* ]] || {
     echo "expected exactly one running communications worker container" >&2
@@ -122,25 +172,32 @@ communications_worker_require_runtime() {
 import os
 import sys
 
-expected_role = sys.argv[1]
+expected_role, expected_enabled, expected_allow_all = sys.argv[1:]
 valid = (
     os.environ.get("APP_ROLE") == expected_role
-    and os.environ.get("COMMUNICATIONS_WORKER_ENABLED", "").lower() == "false"
-    and os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE", "").lower() == "false"
+    and os.environ.get("COMMUNICATIONS_WORKER_ENABLED") == expected_enabled
+    and os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE")
+    == expected_allow_all
 )
 raise SystemExit(0 if valid else 1)
-' "${expected_role}" >/dev/null; then
-    echo "communications worker runtime role or Phase 2A gates drifted" >&2
+' "${expected_role}" "${expected_enabled}" "${expected_allow_all}" >/dev/null; then
+    echo "communications worker runtime role or gate profile drifted" >&2
     return 1
   fi
 }
 
 communications_worker_start_controlled() {
   local expected_role="$1"
+  local expected_profile="${2:-}"
+  if ! communications_worker_require_contract "${expected_profile}"; then
+    communications_worker_set_release_fence || true
+    return 1
+  fi
+  expected_profile="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
   communications_worker_clear_release_fence
   if ! "${COMPOSE[@]}" up -d --no-deps --force-recreate \
     "${COMMUNICATIONS_WORKER_SERVICE}" \
-    || ! communications_worker_require_runtime "${expected_role}"; then
+    || ! communications_worker_require_runtime "${expected_role}" "${expected_profile}"; then
     communications_worker_set_release_fence || true
     "${COMPOSE[@]}" stop "${COMMUNICATIONS_WORKER_SERVICE}" >/dev/null 2>&1 || true
     return 1

--- a/scripts/ha/deploy_patroni_api_node.sh
+++ b/scripts/ha/deploy_patroni_api_node.sh
@@ -26,12 +26,15 @@ HEALTH_ATTEMPTS="${API_HEALTH_ATTEMPTS:-30}"
 GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT="${GOOGLE_OAUTH_TOKEN_PREPARE_SCRIPT:-${SCRIPT_DIR}/../prepare_google_oauth_token_dir.sh}"
 COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
 COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/communications_worker_release_contract.sh}"
+EXPECTED_COMMUNICATIONS_WORKER_PROFILE="${API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE:-}"
+ROLLBACK_COMMUNICATIONS_WORKER_PROFILE="${API_COMMUNICATIONS_WORKER_ROLLBACK_PROFILE:-}"
 
 previous_image=""
 active_service="app"
 env_updated=false
 TMP_DIR=""
 worker_supported=false
+worker_gate_profile=""
 
 log() {
   printf '[patroni-node-deploy][%s] %s\n' "$1" "$2"
@@ -111,11 +114,12 @@ fence_communications_worker() {
 }
 
 deploy_communications_worker() {
-  communications_worker_require_contract
+  communications_worker_require_contract "${EXPECTED_COMMUNICATIONS_WORKER_PROFILE}"
+  worker_gate_profile="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
   fence_communications_worker
   "${COMPOSE[@]}" pull "${COMMUNICATIONS_WORKER_SERVICE}"
   require_deploy_capacity
-  communications_worker_start_controlled "${EXPECTED_ROLE}"
+  communications_worker_start_controlled "${EXPECTED_ROLE}" "${worker_gate_profile}"
 }
 
 wait_fenced_standby() {
@@ -177,7 +181,8 @@ rollback_standby() {
     fi
     if [[ "${worker_supported}" == "true" ]]; then
       if require_expected_role; then
-        communications_worker_start_controlled "${EXPECTED_ROLE}" || true
+        communications_worker_start_controlled \
+          "${EXPECTED_ROLE}" "${ROLLBACK_COMMUNICATIONS_WORKER_PROFILE}" || true
       fi
     fi
   fi
@@ -282,7 +287,7 @@ if [[ "${EXPECTED_ROLE}" == "primary" ]]; then
   worker_supported=true
   deploy_communications_worker
   require_expected_role
-  log "done" "primary API and dormant communications worker deployment completed"
+  log "done" "primary API and communications worker deployment completed"
   exit 0
 fi
 
@@ -304,7 +309,8 @@ fi
 
 trap rollback_standby ERR
 reconcile_standby_proxy
-communications_worker_require_contract
+communications_worker_require_contract "${EXPECTED_COMMUNICATIONS_WORKER_PROFILE}"
+worker_gate_profile="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
 log standby "updating fenced service ${active_service}"
 "${COMPOSE[@]}" pull "${active_service}"
 "${COMPOSE[@]}" pull "${COMMUNICATIONS_WORKER_SERVICE}"
@@ -316,9 +322,9 @@ env_updated=true
 "${COMPOSE[@]}" up -d --no-deps --force-recreate "${active_service}"
 require_expected_role
 wait_fenced_standby
-communications_worker_start_controlled "${EXPECTED_ROLE}"
+communications_worker_start_controlled "${EXPECTED_ROLE}" "${worker_gate_profile}"
 require_expected_role
 printf '%s\n' "${previous_image}" > "${PREVIOUS_IMAGE_FILE}"
 chmod 600 "${PREVIOUS_IMAGE_FILE}"
 trap - ERR
-log "done" "standby image updated without enabling traffic; dormant communications worker aligned"
+log "done" "standby image updated without enabling traffic; communications worker aligned"

--- a/scripts/ha/patroni_attested_compose_guard.sh
+++ b/scripts/ha/patroni_attested_compose_guard.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+# Shell library. The caller supplies CANONICAL_FILE and CANDIDATE_FILE.
+
+require_pitr_attested_candidate() {
+  local release_manifest="${PATRONI_FINALIZED_RELEASE_MANIFEST:-/var/lib/mvn-postgres-pitr/release-manifest.json}"
+  python3 - \
+    "${release_manifest}" "${CANONICAL_FILE}" "${CANDIDATE_FILE}" <<'PY'
+import base64
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+
+manifest_path, canonical_path, candidate_path = sys.argv[1:]
+MAX_MANIFEST_BYTES = 2 * 1024 * 1024
+MAX_ASSET_BYTES = 1024 * 1024
+MAX_RELEASE_BYTES = 2 * 1024 * 1024
+HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
+HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def require_canonical_path(path: str, label: str) -> None:
+    if not os.path.isabs(path) or os.path.normpath(path) != path:
+        raise SystemExit(f"{label} path is not canonical")
+
+
+def read_owned(
+    path: str,
+    label: str,
+    *,
+    exact_mode: int,
+    max_bytes: int,
+) -> bytes:
+    require_canonical_path(path, label)
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"{label} is missing") from exc
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != os.geteuid()
+        or before.st_gid != os.getegid()
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != exact_mode
+        or before.st_size > max_bytes
+    ):
+        raise SystemExit(
+            f"{label} must be current-user-and-group-owned regular "
+            f"non-symlink with mode {exact_mode:04o}, one link, and bounded size"
+        )
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        fields = (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_uid",
+            "st_gid",
+            "st_nlink",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        if tuple(getattr(opened, field) for field in fields) != tuple(
+            getattr(before, field) for field in fields
+        ):
+            raise SystemExit(f"{label} changed while opening")
+        chunks = []
+        size = 0
+        while True:
+            chunk = os.read(descriptor, 131072)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > max_bytes:
+                raise SystemExit(f"{label} exceeds its size bound")
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+        if tuple(getattr(after, field) for field in fields) != tuple(
+            getattr(opened, field) for field in fields
+        ):
+            raise SystemExit(f"{label} changed while reading")
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+manifest_raw = read_owned(
+    manifest_path,
+    "finalized PITR release manifest",
+    exact_mode=0o600,
+    max_bytes=MAX_MANIFEST_BYTES,
+)
+try:
+    manifest = json.loads(manifest_raw)
+except (UnicodeDecodeError, ValueError) as exc:
+    raise SystemExit("finalized PITR release manifest is invalid") from exc
+try:
+    canonical_manifest = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("ascii")
+        + b"\n"
+    )
+except (TypeError, UnicodeEncodeError) as exc:
+    raise SystemExit("finalized PITR release manifest is invalid") from exc
+if manifest_raw != canonical_manifest:
+    raise SystemExit("finalized PITR release manifest is not canonical JSON")
+if (
+    not isinstance(manifest, dict)
+    or set(manifest)
+    != {"files", "project_dir", "release_sha256", "txid", "version"}
+    or type(manifest.get("version")) is not int
+    or manifest["version"] != 1
+    or manifest.get("project_dir") != os.path.dirname(canonical_path)
+    or not isinstance(manifest.get("txid"), str)
+    or HEX_32.fullmatch(manifest["txid"]) is None
+    or not isinstance(manifest.get("release_sha256"), str)
+    or HEX_64.fullmatch(manifest["release_sha256"]) is None
+    or not isinstance(manifest.get("files"), list)
+    or not manifest["files"]
+):
+    raise SystemExit("finalized PITR release manifest contract is invalid")
+
+files = manifest["files"]
+paths = []
+compose_entry = None
+for item in files:
+    if (
+        not isinstance(item, dict)
+        or set(item) != {"mode", "path", "sha256"}
+        or type(item.get("mode")) is not int
+        or item["mode"] not in {0o644, 0o755}
+        or not isinstance(item.get("path"), str)
+        or not os.path.isabs(item["path"])
+        or os.path.normpath(item["path"]) != item["path"]
+        or not isinstance(item.get("sha256"), str)
+        or HEX_64.fullmatch(item["sha256"]) is None
+    ):
+        raise SystemExit("finalized PITR release manifest file contract is invalid")
+    paths.append(item["path"])
+    if item["path"] == canonical_path:
+        compose_entry = item
+if paths != sorted(paths) or len(paths) != len(set(paths)):
+    raise SystemExit(
+        "finalized PITR release manifest files must be sorted and unique"
+    )
+
+release_files = []
+audited_contents = {}
+for item in files:
+    content = read_owned(
+        item["path"],
+        "finalized PITR release asset",
+        exact_mode=item["mode"],
+        max_bytes=MAX_ASSET_BYTES,
+    )
+    if hashlib.sha256(content).hexdigest() != item["sha256"]:
+        raise SystemExit(
+            "finalized PITR release asset differs from its manifest digest"
+        )
+    audited_contents[item["path"]] = content
+    release_files.append(
+        {
+            "content": base64.b64encode(content).decode("ascii"),
+            "mode": item["mode"],
+            "path": item["path"],
+            "sha256": item["sha256"],
+        }
+    )
+release_body = {
+    "files": release_files,
+    "project_dir": manifest["project_dir"],
+    "version": 1,
+}
+release_body_raw = json.dumps(
+    release_body,
+    sort_keys=True,
+    separators=(",", ":"),
+).encode("ascii")
+if (
+    len(release_body_raw) > MAX_RELEASE_BYTES
+    or hashlib.sha256(release_body_raw).hexdigest()
+    != manifest["release_sha256"]
+):
+    raise SystemExit("finalized PITR release digest does not match its exact files")
+
+canonical = read_owned(
+    canonical_path,
+    "canonical compose",
+    exact_mode=0o644,
+    max_bytes=MAX_ASSET_BYTES,
+)
+if (
+    compose_entry is None
+    or compose_entry["mode"] != 0o644
+    or audited_contents.get(canonical_path) != canonical
+    or compose_entry["sha256"] != hashlib.sha256(canonical).hexdigest()
+):
+    raise SystemExit(
+        "canonical Compose is not the exact finalized PITR release generation"
+    )
+candidate = read_owned(
+    candidate_path,
+    "candidate compose",
+    exact_mode=0o644,
+    max_bytes=MAX_ASSET_BYTES,
+)
+if candidate != canonical:
+    raise SystemExit(
+        "candidate Compose is not byte-identical to the PITR-attested canonical "
+        "Compose; run the official atomic PITR cluster migration first"
+    )
+PY
+}

--- a/scripts/ha/patroni_communications_candidate_lifecycle.sh
+++ b/scripts/ha/patroni_communications_candidate_lifecycle.sh
@@ -8,7 +8,9 @@
 COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
 PREVIOUS_WORKER_SUPPORTED=false
 PREVIOUS_WORKER_RUNNING=false
+PREVIOUS_WORKER_GATE_PROFILE=""
 CANDIDATE_WORKER_SUPPORTED=false
+CANDIDATE_WORKER_GATE_PROFILE=""
 CANONICAL_WORKER_PROJECT=""
 CANDIDATE_WORKER_PROJECT=""
 PREVIOUS_WORKER_FENCE_MARKER_PRESENT=false
@@ -85,12 +87,14 @@ patroni_communications_compose_has_worker() {
 patroni_communications_require_runtime() {
   local compose_file="$1"
   local expected_image="$2"
+  local expected_profile="$3"
 
   API_RECONCILE_OPERATION=verify \
     API_DEPLOY_SERVICES="${COMMUNICATIONS_WORKER_SERVICE}" \
     API_COMPOSE_FILE="$(basename "${compose_file}")" \
     API_RECONCILE_BACKEND_IMAGE="${expected_image}" \
     API_EXPECTED_PATRONI_ROLE="${EXPECTED_ROLE}" \
+    API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE="${expected_profile}" \
     bash "${RECONCILE_SCRIPT}"
 }
 
@@ -113,6 +117,7 @@ patroni_communications_capture_previous() {
   )
   export BACKEND_IMAGE
   communications_worker_require_contract
+  PREVIOUS_WORKER_GATE_PROFILE="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
 
   if [[ "${PREVIOUS_WORKER_FENCE_MARKER_PRESENT}" == "true" ]]; then
     container_ids="$(docker compose -f "${CANONICAL_FILE}" --profile bluegreen \
@@ -140,6 +145,7 @@ patroni_communications_capture_previous() {
 }
 
 patroni_communications_detect_candidate_support() {
+  local candidate_image="${BACKEND_IMAGE}"
   CANDIDATE_WORKER_PROJECT="$(
     patroni_communications_compose_project "${CANDIDATE_FILE}"
   )" || {
@@ -148,6 +154,14 @@ patroni_communications_detect_candidate_support() {
   }
   if patroni_communications_compose_has_worker "${CANDIDATE_FILE}"; then
     CANDIDATE_WORKER_SUPPORTED=true
+    local BACKEND_IMAGE="${candidate_image}"
+    # shellcheck disable=SC2034  # consumed by the release-contract helper
+    local -a COMPOSE=(
+      docker compose -f "${CANDIDATE_FILE}" --profile bluegreen
+    )
+    export BACKEND_IMAGE
+    communications_worker_require_contract
+    CANDIDATE_WORKER_GATE_PROFILE="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
   fi
 }
 

--- a/scripts/ha/patroni_local_identity.py
+++ b/scripts/ha/patroni_local_identity.py
@@ -14,6 +14,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -21,6 +22,11 @@ from typing import Any, Callable
 PRIMARY_ROLES = {"leader", "master", "primary"}
 REPLICA_ROLES = {"replica", "standby"}
 COMMUNICATIONS_WORKER_SERVICE = "communications-worker"
+COMMUNICATIONS_WORKER_GATE_PROFILES = {
+    ("false", "false"): "dormant",
+    ("true", "false"): "canary",
+    ("true", "true"): "active",
+}
 EXPECTED_CLUSTER_NAMES = frozenset({"mvn-api", "zakup"})
 MAINTENANCE_MARKER_PATH = Path("/run/mvn-postgres-pitr-maintenance")
 MAINTENANCE_TRANSACTION_RE = re.compile(rb"[0-9a-f]{32}\n\Z")
@@ -125,21 +131,85 @@ def compose_service_is_defined(
     return service in services
 
 
+def communications_worker_gate_profile(
+    enabled: object,
+    allow_all: object,
+) -> str | None:
+    if not isinstance(enabled, str) or not isinstance(allow_all, str):
+        return None
+    return COMMUNICATIONS_WORKER_GATE_PROFILES.get(
+        (enabled, allow_all)
+    )
+
+
+def communications_worker_compose_profile(
+    config: Any,
+    *,
+    compose_runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> str:
+    """Return only the reviewed profile name; never log the rendered env."""
+
+    result = compose_runner(
+        config,
+        "config",
+        "--format",
+        "json",
+        check=False,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("communications worker Compose profile is unavailable")
+    try:
+        payload = json.loads(result.stdout)
+        worker = (payload.get("services") or {}).get(
+            COMMUNICATIONS_WORKER_SERVICE
+        )
+        environment = worker.get("environment") if isinstance(worker, dict) else None
+    except (AttributeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "communications worker Compose profile is invalid"
+        ) from exc
+    if not isinstance(environment, dict):
+        raise RuntimeError("communications worker Compose profile is invalid")
+    profile = communications_worker_gate_profile(
+        environment.get("COMMUNICATIONS_WORKER_ENABLED"),
+        environment.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+    )
+    if profile is None:
+        raise RuntimeError("communications worker Compose profile is not reviewed")
+    return profile
+
+
 def communications_worker_role_matches(
     config: Any,
     role: str,
     *,
     compose_runner: Callable[..., subprocess.CompletedProcess[str]],
+    expected_profile: str | None = None,
 ) -> bool:
-    """Check the worker's effective APP_ROLE without reading or logging its env."""
+    """Check APP_ROLE and the closed gate set without reading or logging env."""
 
     if role not in {"primary", "standby"}:
         raise ValueError(f"unsupported communications worker role: {role}")
+    if expected_profile is None:
+        allowed_gates = frozenset(COMMUNICATIONS_WORKER_GATE_PROFILES)
+    else:
+        allowed_gates = frozenset(
+            gates
+            for gates, profile in COMMUNICATIONS_WORKER_GATE_PROFILES.items()
+            if profile == expected_profile
+        )
+        if not allowed_gates:
+            raise ValueError(
+                f"unsupported communications worker profile: {expected_profile}"
+            )
+    allowed_profiles = repr(allowed_gates)
     probe = (
         "import os,sys;"
         "ok=os.environ.get('APP_ROLE')==sys.argv[1]"
-        " and os.environ.get('COMMUNICATIONS_WORKER_ENABLED')=='false'"
-        " and os.environ.get('COMMUNICATIONS_WORKER_ALLOW_ALL_MODE')=='false';"
+        " and (os.environ.get('COMMUNICATIONS_WORKER_ENABLED'),"
+        "os.environ.get('COMMUNICATIONS_WORKER_ALLOW_ALL_MODE'))"
+        f" in {allowed_profiles};"
         "raise SystemExit(0 if ok else 1)"
     )
     result = compose_runner(
@@ -155,6 +225,62 @@ def communications_worker_role_matches(
         timeout=10,
     )
     return result.returncode == 0
+
+
+@dataclass(frozen=True)
+class CommunicationsWorkerContractState:
+    defined: bool
+    running: bool
+    role_matches: bool
+    unsafe_mismatch: bool
+    canonical_profile_matches: bool
+
+
+def communications_worker_contract_state(
+    config: Any,
+    role: str,
+    *,
+    compose: Any,
+    running_services: set[str],
+    release_fenced: bool,
+) -> CommunicationsWorkerContractState:
+    runtime = compose.worker_runtime_state(
+        service=COMMUNICATIONS_WORKER_SERVICE,
+        role=role,
+        running_services=running_services,
+        definition_probe=compose_service_is_defined,
+        role_probe=communications_worker_role_matches,
+        release_fenced=release_fenced,
+    )
+    if not runtime.defined:
+        return CommunicationsWorkerContractState(
+            runtime.defined,
+            runtime.running,
+            runtime.role_matches,
+            runtime.unsafe_mismatch,
+            True,
+        )
+    try:
+        canonical_profile = communications_worker_compose_profile(
+            config,
+            compose_runner=compose.compose_runner,
+        )
+    except Exception:
+        compose.fence_labeled_service_containers(COMMUNICATIONS_WORKER_SERVICE)
+        raise
+    canonical_matches = not runtime.running or communications_worker_role_matches(
+        config,
+        role,
+        compose_runner=compose.compose_runner,
+        expected_profile=canonical_profile,
+    )
+    return CommunicationsWorkerContractState(
+        runtime.defined,
+        runtime.running,
+        runtime.role_matches,
+        runtime.unsafe_mismatch,
+        canonical_matches,
+    )
 
 
 def wait_primary_ready(config: Any) -> None:

--- a/scripts/ha/patroni_role_agent.py
+++ b/scripts/ha/patroni_role_agent.py
@@ -24,8 +24,7 @@ try:
     from scripts.ha.patroni_local_identity import (
         COMMUNICATIONS_WORKER_SERVICE,
         atomic_write as _atomic_write,
-        compose_service_is_defined as _compose_service_is_defined,
-        communications_worker_role_matches as _communications_worker_role_matches,
+        communications_worker_contract_state as _communications_worker_contract_state,
         read_maintenance_transaction_id,
         reconcile_primary_systemd_units as _reconcile_systemd_units,
         render_role_env as role_env,
@@ -50,8 +49,7 @@ except ModuleNotFoundError:
     from patroni_local_identity import (
         COMMUNICATIONS_WORKER_SERVICE,
         atomic_write as _atomic_write,
-        compose_service_is_defined as _compose_service_is_defined,
-        communications_worker_role_matches as _communications_worker_role_matches,
+        communications_worker_contract_state as _communications_worker_contract_state,
         read_maintenance_transaction_id,
         reconcile_primary_systemd_units as _reconcile_systemd_units,
         render_role_env as role_env,
@@ -245,8 +243,7 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
     bot_env_changed = not bot_matches
     fast_fenced = False
     if role == "standby" and (role_changed or app_env_changed or bot_env_changed):
-        # Losing primary ownership is an emergency path: fence by exact service
-        # name before trusting Docker inventory, which can itself fail or hang.
+        # Demotion fast-fences exact side-effect owners before fallible inventory.
         _fence_lost_primary(config)
         fast_fenced = True
     service = app_service(config)
@@ -254,18 +251,18 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
     release_fenced = compose.enforce_worker_release_fence(
         COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
     )
-    worker_state = compose.worker_runtime_state(
-        service=COMMUNICATIONS_WORKER_SERVICE,
-        role=role,
+    worker_state = _communications_worker_contract_state(
+        config,
+        role,
+        compose=compose,
         running_services=running,
-        definition_probe=_compose_service_is_defined,
-        role_probe=_communications_worker_role_matches,
         release_fenced=release_fenced,
     )
     worker_defined = worker_state.defined
     worker_running = worker_state.running
     worker_role_matches = worker_state.role_matches
     worker_role_drift = worker_state.unsafe_mismatch
+    worker_profile_drift = not worker_state.canonical_profile_matches
     if not worker_running:
         running.discard(COMMUNICATIONS_WORKER_SERVICE)
     if role == "standby" and worker_role_drift:
@@ -287,16 +284,11 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
         running_services=running,
     )
     bot_running = "bot" in running
-    bot_expected = False
-    # On demotion, Docker singleton fencing must happen before any fallible or
-    # slow systemd D-Bus inspection.  A ten-second query timeout is already too
-    # long to leave old-primary workers live beside a new primary.
     systemd_matches = (
         False
         if role == "standby"
         else _systemd_units_match(config, pitr_role)
     )
-
     reasons: list[str] = []
     if role_changed:
         reasons.append("role_state")
@@ -316,6 +308,8 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
         reasons.append("communications_worker_not_running")
     if worker_role_drift:
         reasons.append("communications_worker_role_drift")
+    if worker_profile_drift:
+        reasons.append("communications_worker_profile_drift")
     if not systemd_matches:
         reasons.append("systemd_units")
     if maintenance_transaction is not None:
@@ -336,9 +330,7 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
         bot_running = False
         actions.append("stop_legacy_bot_prelock")
     if role == "standby":
-        # Demotion fencing has priority over deploys and long-running PITR jobs.
-        # Persist the fenced environment first, then stop every local side-effect
-        # owner before attempting the shared deploy lock.
+        # Persist and fence standby ownership before waiting for the deploy lock.
         if app_env_changed:
             _atomic_write(config.app_role_env, desired_app)
             actions.append("write_app_env_prelock")
@@ -379,8 +371,11 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
         or app_env_changed
         or bot_env_changed
         or not app_running
-        or bot_running != bot_expected
-        or (worker_defined and (not worker_running or worker_role_drift))
+        or bot_running
+        or (
+            worker_defined
+            and (not worker_running or worker_role_drift or worker_profile_drift)
+        )
         or (role == "primary" and bool(extra_running_apps))
         or (role == "primary" and proxy_upstream_drift)
     )
@@ -417,24 +412,23 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
                 _atomic_write(config.bot_role_env, desired_bot)
                 actions.append("write_bot_env")
 
-        # Re-read after acquiring the lock: a concurrent deploy may have changed
-        # the concrete containers while fail-safe pre-lock fencing was running.
+        # Re-read after the lock because a candidate may have promoted meanwhile.
         service = app_service(config)
         running = compose.running_services()
         release_fenced = compose.enforce_worker_release_fence(
             COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
         )
-        worker_state = compose.worker_runtime_state(
-            service=COMMUNICATIONS_WORKER_SERVICE,
-            role=role,
+        worker_state = _communications_worker_contract_state(
+            config,
+            role,
+            compose=compose,
             running_services=running,
-            definition_probe=_compose_service_is_defined,
-            role_probe=_communications_worker_role_matches,
             release_fenced=release_fenced,
         )
         worker_defined = worker_state.defined
         worker_running = worker_state.running
         worker_role_matches = worker_state.role_matches
+        worker_profile_drift = not worker_state.canonical_profile_matches
         if not worker_running:
             running.discard(COMMUNICATIONS_WORKER_SERVICE)
         app_running = service in running
@@ -471,12 +465,14 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
                 or role_changed
                 or not worker_running
                 or not worker_role_matches
+                or worker_profile_drift
             ):
                 recreate_worker = (
                     fast_fenced
                     or app_env_changed
                     or role_changed
                     or not worker_role_matches
+                    or worker_profile_drift
                 )
                 compose.start_service(
                     COMMUNICATIONS_WORKER_SERVICE,
@@ -491,16 +487,17 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
             release_fenced = compose.enforce_worker_release_fence(
                 COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
             )
-            final_worker_state = compose.worker_runtime_state(
-                service=COMMUNICATIONS_WORKER_SERVICE,
-                role=role,
+            final_worker_state = _communications_worker_contract_state(
+                config,
+                role,
+                compose=compose,
                 running_services=final_running,
-                definition_probe=_compose_service_is_defined,
-                role_probe=_communications_worker_role_matches,
                 release_fenced=release_fenced,
             )
-            if final_worker_state.unsafe_mismatch or (
-                worker_defined and not final_worker_state.running
+            if (
+                final_worker_state.unsafe_mismatch
+                or not final_worker_state.canonical_profile_matches
+                or (worker_defined and not final_worker_state.running)
             ):
                 _fence_lost_primary(config)
                 raise RuntimeError(
@@ -543,10 +540,10 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
                 or not worker_running
                 or not worker_role_matches
                 or worker_role_drift
+                or worker_profile_drift
             )
             if worker_needs_start:
-                # Delivery activation is downstream of both the fresh
-                # Patroni/DCS proof and the writable/ready API proof.
+                # Activation follows both writable API readiness and fresh DCS proof.
                 if not (app_needs_start or proxy_upstream_changed):
                     _wait_ready(config)
                     actions.append("wait_ready_for_communications_worker")
@@ -554,7 +551,11 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
                     config,
                     "communications_worker_activation",
                 )
-                recreate_worker = worker_role_drift or not worker_role_matches
+                recreate_worker = (
+                    worker_role_drift
+                    or worker_profile_drift
+                    or not worker_role_matches
+                )
                 recreate_worker = recreate_worker or role_changed or app_env_changed
                 compose.start_service(
                     COMMUNICATIONS_WORKER_SERVICE,
@@ -604,16 +605,17 @@ def reconcile(config: AgentConfig, role: str) -> bool | None:
             release_fenced = compose.enforce_worker_release_fence(
                 COMMUNICATIONS_WORKER_SERVICE, latched=release_fenced
             )
-            final_worker_state = compose.worker_runtime_state(
-                service=COMMUNICATIONS_WORKER_SERVICE,
-                role=role,
+            final_worker_state = _communications_worker_contract_state(
+                config,
+                role,
+                compose=compose,
                 running_services=final_running,
-                definition_probe=_compose_service_is_defined,
-                role_probe=_communications_worker_role_matches,
                 release_fenced=release_fenced,
             )
-            if final_worker_state.unsafe_mismatch or (
-                worker_defined and not final_worker_state.running
+            if (
+                final_worker_state.unsafe_mismatch
+                or not final_worker_state.canonical_profile_matches
+                or (worker_defined and not final_worker_state.running)
             ):
                 if COMMUNICATIONS_WORKER_SERVICE in final_running:
                     compose.stop_service_verified(COMMUNICATIONS_WORKER_SERVICE)

--- a/scripts/ha/pitr_bundle_executor_source.py
+++ b/scripts/ha/pitr_bundle_executor_source.py
@@ -2,16 +2,24 @@
 from __future__ import annotations
 
 try:
+    from scripts.ha.pitr_communications_cutover import REMOTE_COMMUNICATIONS_CUTOVER_RECEIPT_SUPPORT
     from scripts.ha.pitr_bundle_executor_prelude import (
         REMOTE_RELEASE_BUNDLE_PRELUDE,
     )
+    from scripts.ha.pitr_rollback_recovery_source import (
+        REMOTE_ROLLBACK_RECOVERY_SUPPORT,
+    )
 except ModuleNotFoundError:  # pragma: no cover - direct script import fallback
+    from pitr_communications_cutover import REMOTE_COMMUNICATIONS_CUTOVER_RECEIPT_SUPPORT  # type: ignore[no-redef]
     from pitr_bundle_executor_prelude import (  # type: ignore[no-redef]
         REMOTE_RELEASE_BUNDLE_PRELUDE,
     )
+    from pitr_rollback_recovery_source import (  # type: ignore[no-redef]
+        REMOTE_ROLLBACK_RECOVERY_SUPPORT,
+    )
 
 
-REMOTE_RELEASE_BUNDLE_EXECUTOR = REMOTE_RELEASE_BUNDLE_PRELUDE + r'''def canonical(value):
+REMOTE_RELEASE_BUNDLE_EXECUTOR = REMOTE_RELEASE_BUNDLE_PRELUDE + REMOTE_COMMUNICATIONS_CUTOVER_RECEIPT_SUPPORT + r'''def canonical(value):
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("ascii")
 def expected_modes(project_dir, compose_file):
     compose = PROJECT_COMPOSE.get(project_dir)
@@ -412,79 +420,7 @@ def release_manifest(journal):
     files = [{key: entry[key] for key in ("mode", "path", "sha256")} for entry in journal["entries"]]
     return {"files": files, "project_dir": journal["project_dir"],
             "release_sha256": journal["release_sha256"], "txid": journal["txid"], "version": 1}
-def rollback_receipt(journal):
-    generations = []
-    for entry in journal["entries"]:
-        old = entry["old"]
-        generations.append({"mode": entry["mode"], "path": entry["path"],
-                            "present": old["present"], "sha256": old.get("sha256")})
-    return {"old_generations": generations, "project_dir": journal["project_dir"],
-            "release_sha256": journal["release_sha256"], "txid": journal["txid"], "version": 1}
-def validate_rollback_receipt(receipt, txid, project_dir, modes):
-    release_digest = receipt.get("release_sha256") if isinstance(receipt, dict) else None
-    if (not isinstance(receipt, dict)
-            or set(receipt) != {"old_generations", "project_dir", "release_sha256", "txid", "version"}
-            or type(receipt["version"]) is not int or receipt["version"] != 1
-            or receipt["txid"] != txid
-            or receipt["project_dir"] != project_dir
-            or not isinstance(release_digest, str)
-            or not re.fullmatch(r"[0-9a-f]{64}", release_digest)
-            or not isinstance(receipt["old_generations"], list)):
-        raise RuntimeError("rollback receipt contract is invalid")
-    paths = []
-    for generation in receipt["old_generations"]:
-        path = generation.get("path") if isinstance(generation, dict) else None
-        if (not isinstance(generation, dict)
-                or set(generation) != {"mode", "path", "present", "sha256"}
-                or not isinstance(path, str) or path not in modes or path in paths
-                or generation["mode"] != modes[path]
-                or type(generation["present"]) is not bool):
-            raise RuntimeError("rollback receipt generation is invalid")
-        if generation["present"]:
-            if (not isinstance(generation["sha256"], str)
-                    or not re.fullmatch(r"[0-9a-f]{64}", generation["sha256"])):
-                raise RuntimeError("rollback receipt generation digest is invalid")
-        elif generation["sha256"] is not None:
-            raise RuntimeError("absent rollback generation has a digest")
-        paths.append(path)
-    if paths != sorted(modes):
-        raise RuntimeError("rollback receipt path set is incomplete")
-def rollback_receipt_path(txid):
-    return os.path.join(ROLLBACK_RECEIPT_ROOT, txid + ".json")
-def read_rollback_receipt(txid, project_dir, modes):
-    content, _ = read_regular(rollback_receipt_path(txid), exact_mode=0o600, max_bytes=MAX_BUNDLE)
-    try:
-        receipt = json.loads(content)
-    except (UnicodeDecodeError, ValueError) as exc:
-        raise RuntimeError("rollback receipt is invalid") from exc
-    if content != canonical(receipt) + b"\n":
-        raise RuntimeError("rollback receipt is not canonical")
-    validate_rollback_receipt(receipt, txid, project_dir, modes)
-    return receipt
-def write_rollback_receipt(receipt, modes):
-    validate_rollback_receipt(receipt, receipt["txid"], receipt["project_dir"], modes)
-    path = rollback_receipt_path(receipt["txid"])
-    expected = canonical(receipt) + b"\n"
-    try:
-        existing, _ = read_regular(path, exact_mode=0o600, max_bytes=MAX_BUNDLE)
-    except FileNotFoundError:
-        atomic_write(path, expected, 0o600)
-    else:
-        if existing != expected:
-            raise RuntimeError("rollback receipt conflicts with this transaction")
-    return read_rollback_receipt(receipt["txid"], receipt["project_dir"], modes)
-def verify_rollback_generations(receipt):
-    for generation in receipt["old_generations"]:
-        try:
-            content, _ = read_regular(generation["path"], exact_mode=generation["mode"])
-        except FileNotFoundError:
-            if generation["present"]:
-                raise RuntimeError("recorded rollback generation is missing: " + generation["path"])
-            continue
-        if (not generation["present"]
-                or hashlib.sha256(content).hexdigest() != generation["sha256"]):
-            raise RuntimeError("recorded rollback generation does not match: " + generation["path"])
-def read_release_manifest(modes, project_dir, allow_previous=False, target_files=()):
+''' + REMOTE_ROLLBACK_RECOVERY_SUPPORT + r'''def read_release_manifest(modes, project_dir, allow_previous=False, target_files=()):
     try:
         content, _ = read_regular(RELEASE_MANIFEST, exact_mode=0o600, max_bytes=MAX_BUNDLE)
     except FileNotFoundError:
@@ -530,24 +466,35 @@ def read_release_manifest(modes, project_dir, allow_previous=False, target_files
         if digest != item["sha256"] and (not target or target["mode"] != item["mode"] or digest != target["sha256"]):
             raise RuntimeError("current file does not match the release manifest: " + item["path"])
     return manifest
-def clear_completed_marker(txid):
+def clear_completed_marker(txid, project_dir):
     marker = marker_value()
-    if marker is None:
-        return
-    if marker != txid:
-        raise RuntimeError("another release transaction owns the maintenance marker")
-    remove_marker(txid)
-def inspect_release(txid, project_dir, modes, release, descriptors):
+    if marker is not None:
+        if marker != txid:
+            raise RuntimeError("another release transaction owns the maintenance marker")
+        remove_marker(txid)
+    remove_communications_cutover_receipt(project_dir, txid)
+def inspect_release(
+        txid, project_dir, modes, release, descriptors, preflight_fenced):
     txdir = os.path.join(TRANSACTION_ROOT, txid)
     has_tx = transaction_exists(txdir)
     marker = marker_value()
     expected = [{key: item[key] for key in ("mode", "path", "sha256")} for item in descriptors]
     try:
-        read_rollback_receipt(txid, project_dir, modes)
+        receipt = read_rollback_receipt(txid, project_dir, modes, release)
     except FileNotFoundError:
         pass
     else:
-        raise RuntimeError("release transaction id already has a rollback receipt")
+        verify_rollback_generations(receipt)
+        completed = read_release_manifest(
+            modes, project_dir, allow_previous=True, target_files=descriptors
+        )
+        if completed is not None and completed["txid"] == txid:
+            raise RuntimeError(
+                "release transaction cannot be both finalized and rolled back"
+            )
+        if marker not in {None, txid}:
+            raise RuntimeError("another release transaction owns the maintenance marker")
+        return "matching-rolled-back"
     if has_tx:
         if marker != txid:
             raise RuntimeError("active release transaction is missing its exact marker")
@@ -564,6 +511,10 @@ def inspect_release(txid, project_dir, modes, release, descriptors):
         if marker not in {None, txid}:
             raise RuntimeError("another release transaction owns the maintenance marker")
         return "matching-finalized"
+    if preflight_fenced:
+        if marker not in {None, txid}:
+            raise RuntimeError("another release transaction owns the maintenance marker")
+        return "preflight-fenced"
     if marker is not None:
         raise RuntimeError("maintenance marker has no compatible release transaction")
     return "fresh"
@@ -579,19 +530,47 @@ def execute(action, txid, project_dir, compose_file, payload):
     deploy_fd = None
     try:
         deploy_fd = open_lock(os.path.join(project_dir, ".deploy.lock"))
+        preflight_fenced = communications_cutover_receipt_valid(
+            project_dir, txid
+        )
         if action == "inspect":
             reject_operation_records()
-            return inspect_release(txid, project_dir, modes, release, descriptors)
-        ensure_roots()
+            return inspect_release(
+                txid, project_dir, modes, release, descriptors,
+                preflight_fenced
+            )
         reject_operation_records()
         txdir = os.path.join(TRANSACTION_ROOT, txid)
         has_tx = transaction_exists(txdir)
+        try:
+            rollback_state = read_rollback_receipt(
+                txid, project_dir, modes,
+                release if action == "apply" else None
+            )
+        except FileNotFoundError:
+            rollback_state = None
+        if rollback_state is not None and action != "rollback":
+            raise RuntimeError(
+                "release transaction id already has a rollback receipt"
+            )
         completed = None if has_tx else read_release_manifest(
-            modes, project_dir, allow_previous=action == "apply", target_files=descriptors
+            modes, project_dir, allow_previous=action in {"apply", "rollback"},
+            target_files=descriptors
         )
+        marker = marker_value()
+        if has_tx and marker != txid:
+            if marker is not None:
+                raise RuntimeError(
+                    "another release transaction owns the maintenance marker"
+                )
+            raise RuntimeError(
+                "active release transaction is missing its exact marker"
+            )
         if completed is not None and completed["txid"] == txid:
             if has_tx:
                 raise RuntimeError("completed release still has a transaction directory")
+            if marker not in {None, txid}:
+                raise RuntimeError("another release transaction owns the maintenance marker")
             if action == "rollback":
                 raise RuntimeError("cannot roll back a finalized release transaction")
             if action == "apply":
@@ -602,32 +581,38 @@ def execute(action, txid, project_dir, compose_file, payload):
                 # Re-open the fence for idempotent controller replay after a crash.
                 ensure_marker(txid)
                 return "reopened"
-            clear_completed_marker(txid)
+            clear_completed_marker(txid, project_dir)
             return "already-finalized"
+        if marker is not None and marker != txid:
+            raise RuntimeError("another release transaction owns the maintenance marker")
         if action == "apply":
-            try:
-                read_rollback_receipt(txid, project_dir, modes)
-            except FileNotFoundError:
-                pass
-            else:
-                raise RuntimeError("release transaction id already has a rollback receipt")
+            if not has_tx and marker == txid and not preflight_fenced:
+                raise RuntimeError(
+                    "maintenance marker has no compatible release transaction"
+                )
         if action == "rollback":
-            try:
-                receipt = read_rollback_receipt(txid, project_dir, modes)
-            except FileNotFoundError:
+            if rollback_state is None:
                 if not has_tx:
-                    raise
+                    if not preflight_fenced:
+                        raise FileNotFoundError(rollback_receipt_path(txid))
+                    if marker not in {None, txid}:
+                        raise RuntimeError("another release transaction owns the maintenance marker")
+                    if marker is not None:
+                        remove_marker(txid)
+                    remove_communications_cutover_receipt(project_dir, txid)
+                    return "preflight-rolled-back"
             else:
-                verify_rollback_generations(receipt)
+                verify_rollback_generations(rollback_state)
                 if has_tx:
                     safe_remove_transaction(txdir)
-                verify_rollback_generations(receipt)
-                marker = marker_value()
+                verify_rollback_generations(rollback_state)
                 if marker is not None:
-                    if marker != txid:
-                        raise RuntimeError("another release transaction owns the maintenance marker")
                     remove_marker(txid)
+                remove_communications_cutover_receipt(project_dir, txid)
                 return "already-rolled-back"
+        if action == "finalize" and not has_tx:
+            raise RuntimeError("release transaction does not exist")
+        ensure_roots()
         created_marker = ensure_marker(txid)
         try:
             if action == "apply":
@@ -653,6 +638,7 @@ def execute(action, txid, project_dir, compose_file, payload):
                 safe_remove_transaction(txdir)
                 verify_rollback_generations(receipt)
                 remove_marker(txid)
+                remove_communications_cutover_receipt(project_dir, txid)
                 return "rolled-back"
             for entry in journal["entries"]:
                 if file_generation(entry["path"], entry["old"], entry["sha256"], entry["mode"]) not in {"new", "both"}:
@@ -661,6 +647,7 @@ def execute(action, txid, project_dir, compose_file, payload):
             atomic_write(RELEASE_MANIFEST, canonical(release_manifest(journal)) + b"\n", 0o600)
             safe_remove_transaction(txdir)
             remove_marker(txid)
+            remove_communications_cutover_receipt(project_dir, txid)
             return "finalized"
         except BaseException:
             if action != "rollback" and created_marker and not transaction_exists(txdir):

--- a/scripts/ha/pitr_bundle_transport.py
+++ b/scripts/ha/pitr_bundle_transport.py
@@ -227,8 +227,18 @@ def run_remote_release_action(
         raise RuntimeError(detail)
     expected = {
         "apply": {"applied\n", "resumed\n", "reopened\n"},
-        "inspect": {"fresh\n", "matching-active\n", "matching-finalized\n"},
-        "rollback": {"rolled-back\n", "already-rolled-back\n"},
+        "inspect": {
+            "fresh\n",
+            "matching-active\n",
+            "matching-finalized\n",
+            "matching-rolled-back\n",
+            "preflight-fenced\n",
+        },
+        "rollback": {
+            "rolled-back\n",
+            "already-rolled-back\n",
+            "preflight-rolled-back\n",
+        },
         "finalize": {"finalized\n", "already-finalized\n"},
     }[action]
     if result.stdout not in expected or result.stderr:

--- a/scripts/ha/pitr_cluster_migration.py
+++ b/scripts/ha/pitr_cluster_migration.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass
 from typing import Callable, Sequence
 
 try:
+    from scripts.ha.pitr_communications_cutover import (
+        run_remote_communications_cutover_preflight,
+    )
+    from scripts.ha.pitr_target_compose import validate_target_compose_bundles
     from scripts.ha.pitr_cluster_topology import (
         ClusterTopology,
         discover_cluster_topology,
@@ -27,6 +31,12 @@ try:
         run_remote_secret_phase,
     )
 except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_communications_cutover import (  # type: ignore[no-redef]
+        run_remote_communications_cutover_preflight,
+    )
+    from pitr_target_compose import (  # type: ignore[no-redef]
+        validate_target_compose_bundles,
+    )
     from pitr_cluster_topology import (  # type: ignore[no-redef]
         ClusterTopology,
         discover_cluster_topology,
@@ -54,9 +64,23 @@ SecretPhase = Callable[..., None]
 MaintenancePhase = Callable[..., None]
 FencedProvisionPhase = Callable[..., None]
 RoleAgentPhase = Callable[..., None]
+CommunicationsCutover = Callable[..., None]
+TargetComposeValidator = Callable[..., str]
 
 TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 DEFAULT_BOOTSTRAP_HELPER = "/usr/local/sbin/mvn-postgres-pitr-bootstrap"
+RELEASE_COMPATIBILITY_STATES = {
+    "fresh",
+    "matching-active",
+    "matching-finalized",
+    "matching-rolled-back",
+    "preflight-fenced",
+}
+ROLLBACK_RECOVERY_STATES = {
+    "matching-active",
+    "matching-rolled-back",
+    "preflight-fenced",
+}
 
 
 @dataclass(frozen=True)
@@ -77,6 +101,10 @@ class MigrationDependencies:
     maintenance: MaintenancePhase = run_remote_maintenance_phase
     fenced_provision: FencedProvisionPhase = run_remote_fenced_provision_phase
     role_agent: RoleAgentPhase = run_remote_role_agent_phase
+    communications_cutover: CommunicationsCutover = (
+        run_remote_communications_cutover_preflight
+    )
+    target_compose: TargetComposeValidator = validate_target_compose_bundles
 
 
 def validate_transaction_id(transaction_id: str) -> str:
@@ -237,6 +265,14 @@ class _MigrationOrchestrator:
             runner=self.runner,
         )
 
+    def _communications_cutover(self, node: PatroniNode) -> None:
+        self.dependencies.communications_cutover(
+            node=node,
+            context=self.context,
+            transaction_id=self.transaction_id,
+            runner=self.runner,
+        )
+
     def _run_with_standby_agent_quiesced(
         self,
         *,
@@ -275,6 +311,44 @@ class _MigrationOrchestrator:
                 f"cluster migration failed before configuration: {original_error}; "
                 "bundle rollback was incomplete: " + "; ".join(failures)
             ) from original_error
+
+    def _recover_durable_rollback(
+        self,
+        ordered_nodes: Sequence[PatroniNode],
+        compatibility: dict[str, str],
+    ) -> None:
+        states = set(compatibility.values())
+        unexpected = states - RELEASE_COMPATIBILITY_STATES
+        if unexpected:
+            raise RuntimeError(
+                "release compatibility returned an unsupported state: "
+                + ", ".join(sorted(unexpected))
+            )
+        if "matching-rolled-back" not in states:
+            return
+        if "matching-finalized" in states:
+            raise RuntimeError(
+                "durable rollback conflicts with a finalized peer; automatic "
+                "cleanup was not attempted"
+            )
+        try:
+            for node in reversed(ordered_nodes):
+                if compatibility[node.alias] not in ROLLBACK_RECOVERY_STATES:
+                    continue
+                self._mutate(
+                    stage=f"durable rollback recovery {node.alias}",
+                    action=lambda node=node: self._release("rollback", node),
+                )
+        except BaseException as exc:
+            raise RuntimeError(
+                "durable rollback recovery is incomplete; retry with the same "
+                f"transaction ID {self.transaction_id}: {exc}"
+            ) from exc
+        raise RuntimeError(
+            f"release transaction {self.transaction_id} was durably rolled back "
+            "and recovery cleanup completed; start the next migration with a "
+            "new transaction ID"
+        )
 
     def _resume_role_agents_after_failure(
         self,
@@ -349,6 +423,7 @@ class _MigrationOrchestrator:
         self.release_bundles = self.dependencies.bundles(ordered_nodes)
         if set(self.release_bundles) != {node.project_dir for node in ordered_nodes}:
             raise RuntimeError("pinned release bundle set does not match cluster nodes")
+        self.dependencies.target_compose(ordered_nodes, self.release_bundles)
         compatibility: dict[str, str] = {}
         for node in ordered_nodes:
             self._mutate(
@@ -357,8 +432,23 @@ class _MigrationOrchestrator:
                     node.alias, self._release("inspect", node)
                 ),
             )
+        self._recover_durable_rollback(ordered_nodes, compatibility)
         if any(state != "fresh" for state in compatibility.values()):
             self.roll_forward = True
+        try:
+            self._mutate(
+                stage=f"communications cutover preflight {baseline.primary.alias}",
+                action=lambda: self._communications_cutover(baseline.primary),
+            )
+        except BaseException as exc:
+            # A lost SSH response may have durably written both fences and its
+            # receipt. The exact transaction is the only safe retry identity.
+            self.roll_forward = True
+            raise RuntimeError(
+                "communications cutover preflight may have changed durable "
+                "state; resume with the same transaction ID "
+                f"{self.transaction_id}: {exc}"
+            ) from exc
         release_nodes = tuple(
             sorted(
                 ordered_nodes,

--- a/scripts/ha/pitr_communications_cutover.py
+++ b/scripts/ha/pitr_communications_cutover.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Pinned, fail-closed communications drain before a PITR release cutover."""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from typing import Callable, Sequence
+
+try:
+    from scripts.ha.pitr_pinned_ssh import (
+        PatroniNode,
+        PinnedSshContext,
+        ssh_args,
+    )
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_pinned_ssh import (  # type: ignore[no-redef]
+        PatroniNode,
+        PinnedSshContext,
+        ssh_args,
+    )
+
+
+Runner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
+TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+# This fragment is included in the separately pinned release executor. A
+# receipt is accepted only with the exact release fence and either the matching
+# marker or no marker (the durable marker-first cleanup crash window). It is
+# removed when that release is finalized/rolled back. The communications
+# release fence deliberately survives until the immediately following API
+# deployment has re-verified the new profile.
+REMOTE_COMMUNICATIONS_CUTOVER_RECEIPT_SUPPORT = r'''
+COMMUNICATIONS_CUTOVER_RECEIPT_NAME = ".ha-communications-cutover-preflight"
+COMMUNICATIONS_RELEASE_FENCE_NAME = ".ha-communications-worker-release-fenced"
+def communications_cutover_receipt_path(project_dir):
+    return os.path.join(project_dir, COMMUNICATIONS_CUTOVER_RECEIPT_NAME)
+def communications_cutover_receipt_valid(project_dir, txid):
+    try:
+        content, _ = read_regular(
+            communications_cutover_receipt_path(project_dir),
+            exact_mode=0o600,
+            max_bytes=96,
+        )
+    except FileNotFoundError:
+        return False
+    expected = ("communications-off-drained-v1\n" + txid + "\n").encode("ascii")
+    if content != expected:
+        raise RuntimeError(
+            "communications cutover receipt belongs to another transaction"
+        )
+    try:
+        fence, _ = read_regular(
+            os.path.join(project_dir, COMMUNICATIONS_RELEASE_FENCE_NAME),
+            exact_mode=0o600,
+            max_bytes=16,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "communications cutover receipt is missing its release fence"
+        ) from exc
+    if fence != b"fenced\n":
+        raise RuntimeError("communications cutover release fence is invalid")
+    return True
+def remove_communications_cutover_receipt(project_dir, txid):
+    path = communications_cutover_receipt_path(project_dir)
+    try:
+        content, _ = read_regular(path, exact_mode=0o600, max_bytes=96)
+    except FileNotFoundError:
+        return
+    if content != ("communications-off-drained-v1\n" + txid + "\n").encode("ascii"):
+        raise RuntimeError("communications cutover receipt ownership changed")
+    os.unlink(path)
+    fsync_dir(project_dir)
+'''.strip() + "\n"
+
+
+REMOTE_COMMUNICATIONS_CUTOVER_PREFLIGHT = r'''
+import fcntl
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+
+ROOT_UID = ROOT_GID = 0
+GLOBAL_LOCK = "/run/lock/mvn-postgres-pitr-prerequisites.lock"
+MAINTENANCE_MARKER = "/run/mvn-postgres-pitr-maintenance"
+PROJECT_COMPOSE = {
+    "/opt/air-api": "/opt/air-api/docker-compose.patroni.yml",
+    "/opt/mvn-reserve": "/opt/mvn-reserve/docker-compose.patroni.yml",
+}
+RECEIPT_NAME = ".ha-communications-cutover-preflight"
+RELEASE_FENCE_NAME = ".ha-communications-worker-release-fenced"
+WORKER_SERVICE = "communications-worker"
+
+
+def validate_parent(path):
+    if not path.startswith("/") or os.path.normpath(path) != path:
+        raise RuntimeError("communications cutover path is not canonical")
+    current = "/"
+    for part in os.path.dirname(path).split("/")[1:]:
+        current = os.path.join(current, part)
+        metadata = os.lstat(current)
+        writable = stat.S_IMODE(metadata.st_mode) & 0o022
+        sticky_lock_dir = (
+            current == "/run/lock"
+            and writable == 0o022
+            and bool(metadata.st_mode & stat.S_ISVTX)
+        )
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != ROOT_UID
+            or metadata.st_gid != ROOT_GID
+            or (writable and not sticky_lock_dir)
+        ):
+            raise RuntimeError("communications cutover parent metadata is unsafe")
+
+
+def read_regular(path, *, exact_mode, max_bytes):
+    before = os.lstat(path)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_ISLNK(before.st_mode)
+        or before.st_uid != ROOT_UID
+        or before.st_gid != ROOT_GID
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != exact_mode
+        or before.st_size > max_bytes
+    ):
+        raise RuntimeError("communications cutover file metadata is unsafe")
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        opened = os.fstat(descriptor)
+        fields = (
+            "st_dev", "st_ino", "st_mode", "st_uid", "st_gid", "st_nlink",
+            "st_size", "st_mtime_ns", "st_ctime_ns",
+        )
+        if tuple(getattr(opened, name) for name in fields) != tuple(
+            getattr(before, name) for name in fields
+        ):
+            raise RuntimeError("communications cutover file changed while opening")
+        payload = os.read(descriptor, max_bytes + 1)
+        if len(payload) > max_bytes or os.read(descriptor, 1):
+            raise RuntimeError("communications cutover file is too large")
+        after = os.fstat(descriptor)
+        if tuple(getattr(after, name) for name in fields) != tuple(
+            getattr(opened, name) for name in fields
+        ):
+            raise RuntimeError("communications cutover file changed while reading")
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write(path, content, mode):
+    validate_parent(path)
+    try:
+        existing = os.lstat(path)
+    except FileNotFoundError:
+        pass
+    else:
+        if (
+            not stat.S_ISREG(existing.st_mode)
+            or stat.S_ISLNK(existing.st_mode)
+            or existing.st_uid != ROOT_UID
+            or existing.st_gid != ROOT_GID
+            or existing.st_nlink != 1
+        ):
+            raise RuntimeError("communications cutover target metadata is unsafe")
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=".mvn-communications-cutover-",
+        dir=os.path.dirname(path),
+    )
+    try:
+        os.fchmod(descriptor, mode)
+        os.fchown(descriptor, ROOT_UID, ROOT_GID)
+        if os.write(descriptor, content) != len(content):
+            raise RuntimeError("short communications cutover write")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.replace(temporary, path)
+        directory = os.open(
+            os.path.dirname(path),
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def open_lock(path):
+    validate_parent(path)
+    descriptor = os.open(
+        path,
+        os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o600,
+    )
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != ROOT_UID
+        or metadata.st_gid != ROOT_GID
+        or metadata.st_nlink != 1
+        or metadata.st_mode & 0o022
+    ):
+        os.close(descriptor)
+        raise RuntimeError("communications cutover lock metadata is unsafe")
+    os.fchmod(descriptor, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(descriptor)
+        raise RuntimeError("another PITR or deploy operation is active") from exc
+    return descriptor
+
+
+def run_checked(args, *, timeout, capture=True):
+    environment = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOME": "/root",
+        "LANG": "C",
+        "LC_ALL": "C",
+    }
+    result = subprocess.run(
+        args,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        capture_output=capture,
+        check=False,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("communications cutover command failed")
+    return result
+
+
+def prove_operator_off_drained(compose_path, app_service):
+    command = run_checked(
+        [
+            "docker", "compose", "-f", compose_path, "--profile", "bluegreen",
+            "exec", "-T", app_service, "python3",
+            "scripts/communications_installation_notifications.py", "--off",
+        ],
+        timeout=90,
+    )
+    if command.stderr or len(command.stdout.splitlines()) != 1:
+        raise RuntimeError("communications off command returned unsafe output")
+    try:
+        result = json.loads(command.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("communications off receipt is invalid") from exc
+    if (
+        not isinstance(result, dict)
+        or result.get("ok") is not True
+        or result.get("command") != "off"
+        or result.get("drained") is not True
+        or result.get("runtime_mode") != "off"
+        or result.get("runtime_status")
+        not in {"disabled", "stopped", "paused", "faulted"}
+        or type(result.get("running_delivery_count")) is not int
+        or result.get("running_delivery_count") != 0
+        or type(result.get("control_revision")) is not int
+        or result.get("control_revision") < 0
+    ):
+        raise RuntimeError("communications runtime did not prove off and drained")
+
+
+def prove_worker_zero_running(compose_path):
+    running = run_checked(
+        [
+            "docker", "compose", "-f", compose_path, "--profile", "bluegreen",
+            "ps", "--status", "running", "-q", WORKER_SERVICE,
+        ],
+        timeout=30,
+    )
+    if running.stdout or running.stderr:
+        raise RuntimeError("communications worker remained running")
+
+
+def execute(txid, project_dir, compose_file):
+    if os.geteuid() != ROOT_UID or not hasattr(os, "O_NOFOLLOW"):
+        raise RuntimeError("root Linux execution is required")
+    if re.fullmatch(r"[0-9a-f]{32}", txid) is None:
+        raise RuntimeError("transaction id must be 32 lowercase hexadecimal characters")
+    compose_path = PROJECT_COMPOSE.get(project_dir)
+    if compose_path != os.path.join(project_dir, compose_file):
+        raise RuntimeError("unreviewed communications cutover node")
+    read_regular(compose_path, exact_mode=0o644, max_bytes=1048576)
+    deploy_lock = os.path.join(project_dir, ".deploy.lock")
+    global_fd = open_lock(GLOBAL_LOCK)
+    deploy_fd = None
+    try:
+        deploy_fd = open_lock(deploy_lock)
+        marker_txid = None
+        try:
+            marker = read_regular(
+                MAINTENANCE_MARKER, exact_mode=0o600, max_bytes=34
+            )
+            marker_text = marker.decode("ascii")
+            if re.fullmatch(r"[0-9a-f]{32}\n", marker_text) is None:
+                raise RuntimeError("PITR maintenance marker is invalid")
+            marker_txid = marker_text[:-1]
+        except FileNotFoundError:
+            pass
+        if marker_txid is not None and marker_txid != txid:
+            raise RuntimeError("another PITR release owns the maintenance marker")
+
+        receipt_path = os.path.join(project_dir, RECEIPT_NAME)
+        receipt = ("communications-off-drained-v1\n" + txid + "\n").encode("ascii")
+        try:
+            prior_receipt = read_regular(
+                receipt_path, exact_mode=0o600, max_bytes=96
+            )
+        except FileNotFoundError:
+            prior_receipt = None
+        if prior_receipt is not None and prior_receipt != receipt:
+            raise RuntimeError("another communications cutover receipt is active")
+        if marker_txid == txid and prior_receipt != receipt:
+            raise RuntimeError("PITR marker lacks its communications cutover receipt")
+
+        rendered = run_checked(
+            [
+                "docker", "compose", "-f", compose_path, "--profile", "bluegreen",
+                "config", "--format", "json",
+            ],
+            timeout=30,
+        )
+        try:
+            payload = json.loads(rendered.stdout)
+            services = payload.get("services") or {}
+            worker = services.get(WORKER_SERVICE)
+            environment = worker.get("environment") if isinstance(worker, dict) else None
+            gates = (
+                environment.get("COMMUNICATIONS_WORKER_ENABLED"),
+                environment.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+            )
+        except (AttributeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("communications worker profile is unavailable") from exc
+        if gates not in {
+            ("false", "false"),
+            ("true", "false"),
+            ("true", "true"),
+        }:
+            raise RuntimeError("communications worker profile is not reviewed")
+
+        active_slot_path = os.path.join(project_dir, ".active-api-slot")
+        try:
+            active_slot = read_regular(
+                active_slot_path, exact_mode=0o600, max_bytes=8
+            ).decode("ascii")
+        except FileNotFoundError:
+            app_service = "app"
+        else:
+            if active_slot not in {"blue\n", "green\n"}:
+                raise RuntimeError("active API slot is invalid")
+            app_service = "app-" + active_slot.strip()
+
+        prove_operator_off_drained(compose_path, app_service)
+
+        fence_path = os.path.join(project_dir, RELEASE_FENCE_NAME)
+        atomic_write(fence_path, b"fenced\n", 0o600)
+        run_checked(
+            [
+                "docker", "compose", "-f", compose_path, "--profile", "bluegreen",
+                "stop", WORKER_SERVICE,
+            ],
+            timeout=60,
+        )
+        prove_worker_zero_running(compose_path)
+
+        # The first database proof may have become stale while the host worker
+        # was being fenced. Re-issue the typed OFF command and repeat the
+        # zero-running proof immediately before the durable receipt/marker.
+        prove_operator_off_drained(compose_path, app_service)
+        prove_worker_zero_running(compose_path)
+        atomic_write(receipt_path, receipt, 0o600)
+        atomic_write(MAINTENANCE_MARKER, (txid + "\n").encode("ascii"), 0o600)
+    finally:
+        if deploy_fd is not None:
+            os.close(deploy_fd)
+        os.close(global_fd)
+
+
+if len(sys.argv) != 4:
+    raise SystemExit("invalid communications cutover invocation")
+try:
+    execute(*sys.argv[1:])
+except (OSError, RuntimeError, subprocess.SubprocessError, UnicodeError):
+    print("communications cutover preflight failed", file=sys.stderr)
+    raise SystemExit(1)
+print("communications_cutover_preflight=verified")
+'''.strip()
+
+
+def run_remote_communications_cutover_preflight(
+    *,
+    node: PatroniNode,
+    context: PinnedSshContext,
+    transaction_id: str,
+    runner: Runner,
+) -> None:
+    """Prove DB control is off/drained and durably fence worker activation."""
+
+    if TRANSACTION_ID_RE.fullmatch(transaction_id) is None:
+        raise RuntimeError(
+            "PITR transaction ID must be 32 lowercase hexadecimal characters"
+        )
+    command = " ".join(
+        [
+            "/usr/bin/python3",
+            "-I",
+            "-c",
+            shlex.quote(REMOTE_COMMUNICATIONS_CUTOVER_PREFLIGHT),
+            transaction_id,
+            shlex.quote(node.project_dir),
+            shlex.quote(node.compose_file),
+        ]
+    )
+    result = runner([*ssh_args(node, context), command], None)
+    if (
+        result.returncode != 0
+        or result.stdout != "communications_cutover_preflight=verified\n"
+        or result.stderr
+    ):
+        raise RuntimeError(
+            "pinned communications cutover preflight did not prove off and drained"
+        )

--- a/scripts/ha/pitr_rollback_recovery_source.py
+++ b/scripts/ha/pitr_rollback_recovery_source.py
@@ -1,0 +1,80 @@
+"""Rollback receipt support embedded in the remote PITR release executor."""
+from __future__ import annotations
+
+
+REMOTE_ROLLBACK_RECOVERY_SUPPORT = r'''
+def rollback_receipt(journal):
+    generations = []
+    for entry in journal["entries"]:
+        old = entry["old"]
+        generations.append({"mode": entry["mode"], "path": entry["path"],
+                            "present": old["present"], "sha256": old.get("sha256")})
+    return {"old_generations": generations, "project_dir": journal["project_dir"],
+            "release_sha256": journal["release_sha256"], "txid": journal["txid"], "version": 1}
+def validate_rollback_receipt(receipt, txid, project_dir, modes, release=None):
+    release_digest = receipt.get("release_sha256") if isinstance(receipt, dict) else None
+    if (not isinstance(receipt, dict)
+            or set(receipt) != {"old_generations", "project_dir", "release_sha256", "txid", "version"}
+            or type(receipt["version"]) is not int or receipt["version"] != 1
+            or receipt["txid"] != txid
+            or receipt["project_dir"] != project_dir
+            or not isinstance(release_digest, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", release_digest)
+            or not isinstance(receipt["old_generations"], list)):
+        raise RuntimeError("rollback receipt contract is invalid")
+    if release is not None and release_digest != release:
+        raise RuntimeError("rollback receipt belongs to another release")
+    paths = []
+    for generation in receipt["old_generations"]:
+        path = generation.get("path") if isinstance(generation, dict) else None
+        if (not isinstance(generation, dict)
+                or set(generation) != {"mode", "path", "present", "sha256"}
+                or not isinstance(path, str) or path not in modes or path in paths
+                or generation["mode"] != modes[path]
+                or type(generation["present"]) is not bool):
+            raise RuntimeError("rollback receipt generation is invalid")
+        if generation["present"]:
+            if (not isinstance(generation["sha256"], str)
+                    or not re.fullmatch(r"[0-9a-f]{64}", generation["sha256"])):
+                raise RuntimeError("rollback receipt generation digest is invalid")
+        elif generation["sha256"] is not None:
+            raise RuntimeError("absent rollback generation has a digest")
+        paths.append(path)
+    if paths != sorted(modes):
+        raise RuntimeError("rollback receipt path set is incomplete")
+def rollback_receipt_path(txid):
+    return os.path.join(ROLLBACK_RECEIPT_ROOT, txid + ".json")
+def read_rollback_receipt(txid, project_dir, modes, release=None):
+    content, _ = read_regular(rollback_receipt_path(txid), exact_mode=0o600, max_bytes=MAX_BUNDLE)
+    try:
+        receipt = json.loads(content)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise RuntimeError("rollback receipt is invalid") from exc
+    if content != canonical(receipt) + b"\n":
+        raise RuntimeError("rollback receipt is not canonical")
+    validate_rollback_receipt(receipt, txid, project_dir, modes, release)
+    return receipt
+def write_rollback_receipt(receipt, modes):
+    validate_rollback_receipt(receipt, receipt["txid"], receipt["project_dir"], modes)
+    path = rollback_receipt_path(receipt["txid"])
+    expected = canonical(receipt) + b"\n"
+    try:
+        existing, _ = read_regular(path, exact_mode=0o600, max_bytes=MAX_BUNDLE)
+    except FileNotFoundError:
+        atomic_write(path, expected, 0o600)
+    else:
+        if existing != expected:
+            raise RuntimeError("rollback receipt conflicts with this transaction")
+    return read_rollback_receipt(receipt["txid"], receipt["project_dir"], modes)
+def verify_rollback_generations(receipt):
+    for generation in receipt["old_generations"]:
+        try:
+            content, _ = read_regular(generation["path"], exact_mode=generation["mode"])
+        except FileNotFoundError:
+            if generation["present"]:
+                raise RuntimeError("recorded rollback generation is missing: " + generation["path"])
+            continue
+        if (not generation["present"]
+                or hashlib.sha256(content).hexdigest() != generation["sha256"]):
+            raise RuntimeError("recorded rollback generation does not match: " + generation["path"])
+'''.strip() + "\n"

--- a/scripts/ha/pitr_target_compose.py
+++ b/scripts/ha/pitr_target_compose.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Validate the exact Patroni Compose bytes pinned into a PITR release."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import yaml
+
+try:
+    from scripts.ha.pitr_pinned_ssh import PatroniNode
+except ModuleNotFoundError:  # Direct execution from scripts/ha.
+    from pitr_pinned_ssh import PatroniNode  # type: ignore[no-redef]
+
+
+MAX_COMPOSE_BYTES = 1024 * 1024
+API_SERVICES = ("app", "app-blue", "app-green")
+WORKER_SERVICE = "communications-worker"
+WORKER_COMMAND = "python -m services.communications.runtime"
+WORKER_ENV_FILES = {
+    (".env", ".ha-app-role.env"),
+    ("${MVN_RESERVE_ENV_FILE:-.env}", ".ha-app-role.env"),
+}
+REVIEWED_PROFILES = {
+    ("false", "false"): "dormant",
+    ("true", "false"): "canary",
+    ("true", "true"): "active",
+}
+HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def _decode_compose_from_bundle(node: PatroniNode, rendered: str) -> bytes:
+    if not isinstance(rendered, str):
+        raise RuntimeError("pinned PITR release bundle is invalid")
+    try:
+        bundle = json.loads(rendered)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("pinned PITR release bundle is invalid") from exc
+    compose_path = f"{node.project_dir}/{node.compose_file}"
+    if (
+        not isinstance(bundle, dict)
+        or set(bundle)
+        != {"files", "project_dir", "release_sha256", "version"}
+        or type(bundle.get("version")) is not int
+        or bundle.get("version") != 1
+        or bundle.get("project_dir") != node.project_dir
+        or not isinstance(bundle.get("files"), list)
+        or not isinstance(bundle.get("release_sha256"), str)
+        or HEX_64.fullmatch(bundle["release_sha256"]) is None
+    ):
+        raise RuntimeError("pinned PITR release bundle contract is invalid")
+    try:
+        canonical = json.dumps(
+            bundle,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+    except (TypeError, UnicodeEncodeError) as exc:
+        raise RuntimeError("pinned PITR release bundle is invalid") from exc
+    body = {
+        "files": bundle["files"],
+        "project_dir": node.project_dir,
+        "version": 1,
+    }
+    body_digest = hashlib.sha256(
+        json.dumps(body, sort_keys=True, separators=(",", ":")).encode("ascii")
+    ).hexdigest()
+    if rendered.encode("ascii") != canonical or bundle["release_sha256"] != body_digest:
+        raise RuntimeError("pinned PITR release bundle digest is invalid")
+    matches = [
+        item
+        for item in bundle["files"]
+        if isinstance(item, dict) and item.get("path") == compose_path
+    ]
+    if len(matches) != 1:
+        raise RuntimeError("pinned PITR release bundle has no exact Compose source")
+    descriptor = matches[0]
+    digest = descriptor.get("sha256")
+    if (
+        set(descriptor) != {"content", "mode", "path", "sha256"}
+        or type(descriptor.get("mode")) is not int
+        or descriptor["mode"] != 0o644
+        or not isinstance(descriptor.get("content"), str)
+        or not isinstance(digest, str)
+        or HEX_64.fullmatch(digest) is None
+    ):
+        raise RuntimeError("pinned PITR Compose descriptor is invalid")
+    try:
+        content = base64.b64decode(descriptor["content"], validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise RuntimeError("pinned PITR Compose payload is invalid") from exc
+    if (
+        not content
+        or len(content) > MAX_COMPOSE_BYTES
+        or hashlib.sha256(content).hexdigest() != digest
+    ):
+        raise RuntimeError("pinned PITR Compose digest is invalid")
+    return content
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RuntimeError(f"pinned PITR Compose {label} is not a mapping")
+    return value
+
+
+def _profile_from_compose(content: bytes) -> str:
+    try:
+        document = yaml.safe_load(content)
+    except (UnicodeError, yaml.YAMLError) as exc:
+        raise RuntimeError("pinned PITR Compose YAML is invalid") from exc
+    root = _mapping(document, "document")
+    services = _mapping(root.get("services"), "services")
+    worker = _mapping(services.get(WORKER_SERVICE), "communications worker")
+    environment = _mapping(
+        worker.get("environment"),
+        "communications worker environment",
+    )
+    gates = (
+        environment.get("COMMUNICATIONS_WORKER_ENABLED"),
+        environment.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+    )
+    profile = REVIEWED_PROFILES.get(gates)
+    if profile is None:
+        raise RuntimeError("pinned PITR Compose worker profile is not reviewed")
+    if (
+        worker.get("command") != WORKER_COMMAND
+        or not isinstance(worker.get("env_file"), list)
+        or tuple(worker["env_file"]) not in WORKER_ENV_FILES
+        or not isinstance(worker.get("depends_on"), Mapping)
+        or "db" not in worker["depends_on"]
+    ):
+        raise RuntimeError("pinned PITR Compose worker structure is not reviewed")
+    worker_image = worker.get("image")
+    if not isinstance(worker_image, str) or not worker_image:
+        raise RuntimeError("pinned PITR Compose worker image is invalid")
+    for service_name in API_SERVICES:
+        service = _mapping(
+            services.get(service_name),
+            f"{service_name} service",
+        )
+        image = service.get("image")
+        if not isinstance(image, str) or not image or image != worker_image:
+            raise RuntimeError("pinned PITR Compose API/worker image mismatch")
+    return profile
+
+
+def validate_target_compose_bundles(
+    nodes: Sequence[PatroniNode],
+    bundles: Mapping[str, str],
+) -> str:
+    """Return the one reviewed profile shared by both exact bundle payloads."""
+
+    ordered_nodes = tuple(nodes)
+    expected_projects = {node.project_dir for node in ordered_nodes}
+    if (
+        len(ordered_nodes) != 2
+        or len(expected_projects) != 2
+        or set(bundles) != expected_projects
+    ):
+        raise RuntimeError("PITR profile cutover requires two exact node bundles")
+    profiles = {
+        _profile_from_compose(
+            _decode_compose_from_bundle(node, bundles[node.project_dir])
+        )
+        for node in ordered_nodes
+    }
+    if len(profiles) != 1:
+        raise RuntimeError("pinned PITR Compose profiles differ across cluster nodes")
+    return profiles.pop()

--- a/scripts/ha/run_patroni_candidate_transaction.sh
+++ b/scripts/ha/run_patroni_candidate_transaction.sh
@@ -2,6 +2,9 @@
 # shellcheck disable=SC2034  # globals are consumed by sourced lifecycle modules
 set -Eeuo pipefail
 
+VOICE_SECRET="${BOT_VOICE_TRANSCRIPTION_API_KEY:-}"
+export -n VOICE_SECRET
+unset BOT_VOICE_TRANSCRIPTION_API_KEY
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OPERATION="${PATRONI_CANDIDATE_OPERATION:-}"
 PROJECT_DIR="${API_PROJECT_DIR:-/opt/air-api}"
@@ -27,6 +30,9 @@ RECONCILE_SCRIPT="${API_RECONCILE_SCRIPT:-/tmp/reconcile_backend_compose_runtime
 COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/communications_worker_release_contract.sh}"
 PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE="${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE:-${SCRIPT_DIR}/patroni_communications_candidate_lifecycle.sh}"
 PATRONI_ROLE_AGENT_CANDIDATE_ASSETS="${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS:-${SCRIPT_DIR}/patroni_role_agent_candidate_assets.sh}"
+PATRONI_ATTESTED_COMPOSE_GUARD="${PATRONI_ATTESTED_COMPOSE_GUARD:-${SCRIPT_DIR}/patroni_attested_compose_guard.sh}"
+VOICE_ENV_SYNC="${PATRONI_VOICE_ENV_SYNC:-}"
+VOICE_ENV_FILE="${PATRONI_VOICE_ENV_FILE:-${PROJECT_DIR}/.env}"
 DEPLOY_LOCK_FILE="${API_DEPLOY_LOCK_FILE:-${PROJECT_DIR}/.deploy.lock}"
 DEPLOY_LOCK_FD="${API_DEPLOY_LOCK_FD:-}"
 DEPLOY_LOCK_HELPER="${API_DEPLOY_LOCK_HELPER:-${SCRIPT_DIR}/safe_deploy_lock.py}"
@@ -53,7 +59,12 @@ PROXY_UPSTREAM_CREATED=false
 PROXY_FILES_CHANGED=false
 PROXY_DIR_CREATED=false
 PROXY_RUNTIME_STATE=not-applicable
-
+if [[ "${DEPLOY_LOCK_FD}" == "9" && -z "${VOICE_SECRET}" ]]; then
+  IFS= read -r VOICE_SECRET || {
+    echo "voice transcription API key transport is missing" >&2
+    exit 1
+  }
+fi
 [[ -f "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" \
   && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER}" ]] \
   || { echo "communications worker release helper is missing or unsafe" >&2; exit 1; }
@@ -63,13 +74,34 @@ PROXY_RUNTIME_STATE=not-applicable
 [[ -f "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}" \
   && ! -L "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}" ]] \
   || { echo "Patroni role-agent candidate assets helper is missing or unsafe" >&2; exit 1; }
+[[ -f "${PATRONI_ATTESTED_COMPOSE_GUARD}" \
+  && ! -L "${PATRONI_ATTESTED_COMPOSE_GUARD}" ]] \
+  || { echo "PITR-attested Compose guard is missing or unsafe" >&2; exit 1; }
+[[ -f "${VOICE_ENV_SYNC}" && ! -L "${VOICE_ENV_SYNC}" ]] \
+  || { echo "voice env sync helper is missing or unsafe" >&2; exit 1; }
 # shellcheck disable=SC1090
 source "${COMMUNICATIONS_WORKER_RELEASE_HELPER}"
 # shellcheck disable=SC1090
 source "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE}"
 # shellcheck disable=SC1090
 source "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS}"
-
+# shellcheck disable=SC1090
+source "${PATRONI_ATTESTED_COMPOSE_GUARD}"
+sync_bot_voice_env_locked() {
+  local secret="${VOICE_SECRET}"
+  local status=0
+  VOICE_SECRET=""
+  unset VOICE_SECRET
+  [[ -n "${secret}" ]] || {
+    echo "voice transcription API key is missing" >&2
+    return 1
+  }
+  printf '%s' "${secret}" \
+    | python3 -I "${VOICE_ENV_SYNC}" --env-file "${VOICE_ENV_FILE}" \
+    || status=$?
+  secret=""
+  [[ "${status}" -eq 0 ]]
+}
 [[ "${DEPLOY_LOCK_HELPER_SHA256}" =~ ^[0-9a-f]{64}$ ]] || {
   echo "safe deployment lock helper digest is missing" >&2; exit 1;
 }
@@ -94,7 +126,13 @@ if ((opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino)
     raise SystemExit("safe deployment lock helper source is unreviewed")
 PY
 if [[ -z "${DEPLOY_LOCK_FD}" ]]; then
-  exec python3 "${DEPLOY_LOCK_HELPER}" exec "${DEPLOY_LOCK_FILE}" bash "$0" "$@"
+  lock_status=0
+  printf '%s\n' "${VOICE_SECRET}" \
+    | python3 "${DEPLOY_LOCK_HELPER}" exec "${DEPLOY_LOCK_FILE}" bash "$0" "$@" \
+    || lock_status=$?
+  VOICE_SECRET=""
+  unset VOICE_SECRET
+  exit "${lock_status}"
 fi
 [[ "${DEPLOY_LOCK_FD}" == "9" ]] || {
   echo "candidate transaction requires inherited deployment lock fd 9" >&2
@@ -443,7 +481,7 @@ reconcile_failed_deploy() {
       echo "CRITICAL: promoted communications worker could not be fenced" >&2
       exit 90
     fi
-    echo "Patroni candidate compose promotion committed; fenced the dormant worker for inspection" >&2
+    echo "Patroni candidate compose promotion committed; fenced the promoted communications worker for inspection" >&2
     patroni_role_assets_cleanup_backups \
       || echo "warning: stale Patroni role asset backup remains" >&2
     [[ -z "${PROXY_CONFIG_BACKUP}" ]] || rm -f -- "${PROXY_CONFIG_BACKUP}"
@@ -478,6 +516,7 @@ reconcile_failed_deploy() {
     if ! API_DEPLOY_SERVICES="${recovery_services}" \
       API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
       API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
+      API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE="${PREVIOUS_WORKER_GATE_PROFILE}" \
       API_READY_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}" \
       bash "${RECONCILE_SCRIPT}"; then
       restoration_failed=true
@@ -491,6 +530,7 @@ reconcile_failed_deploy() {
       API_STOP_SERVICES_AFTER_DEPLOY="bot" \
       API_COMPOSE_FILE="$(basename "${CANONICAL_FILE}")" \
       API_RECONCILE_BACKEND_IMAGE="${PREVIOUS_BACKEND_IMAGE}" \
+      API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE="${PREVIOUS_WORKER_GATE_PROFILE}" \
       API_READY_URL="${API_HEALTH_URL:-http://127.0.0.1:18080/api/health}" \
       bash "${RECONCILE_SCRIPT}"; then
       restoration_failed=true
@@ -556,8 +596,10 @@ fi
 require_no_pitr_maintenance
 require_no_patroni_cutover
 stage_candidate_compose
+require_pitr_attested_candidate
 CANDIDATE_CHECKSUM="$(cksum < "${CANDIDATE_FILE}")"
 trap cleanup_candidate_only EXIT
+sync_bot_voice_env_locked
 if [[ "${OPERATION}" == "migrate" ]]; then
   trap cleanup_migration_candidate EXIT
   API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}" \
@@ -586,15 +628,19 @@ stage_proxy_files
 
 API_COMPOSE_FILE="$(basename "${CANDIDATE_FILE}")" \
   API_DEPLOY_LOCK_FD="${DEPLOY_LOCK_FD}" \
+  API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE="${CANDIDATE_WORKER_GATE_PROFILE}" \
+  API_COMMUNICATIONS_WORKER_ROLLBACK_PROFILE="${PREVIOUS_WORKER_GATE_PROFILE}" \
 bash "${DEPLOY_SCRIPT}"
 require_no_patroni_cutover
 require_unchanged_db_contract
 if [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]]; then
-  patroni_communications_require_runtime "${CANDIDATE_FILE}" "${BACKEND_IMAGE}"
+  patroni_communications_require_runtime \
+    "${CANDIDATE_FILE}" "${BACKEND_IMAGE}" "${CANDIDATE_WORKER_GATE_PROFILE}"
 fi
 transaction promote
 if [[ "${CANDIDATE_WORKER_SUPPORTED}" == "true" ]]; then
-  patroni_communications_require_runtime "${CANONICAL_FILE}" "${BACKEND_IMAGE}"
+  patroni_communications_require_runtime \
+    "${CANONICAL_FILE}" "${BACKEND_IMAGE}" "${CANDIDATE_WORKER_GATE_PROFILE}"
 fi
 trap - EXIT
 patroni_role_assets_cleanup_backups \

--- a/scripts/ha/run_patroni_node_remote.sh
+++ b/scripts/ha/run_patroni_node_remote.sh
@@ -35,6 +35,7 @@ DEPLOY_CAPACITY_HELPER_SOURCE="scripts/ha/require_deploy_capacity.sh"
 COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE="scripts/ha/communications_worker_release_contract.sh"
 PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE="scripts/ha/patroni_communications_candidate_lifecycle.sh"
 PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE="scripts/ha/patroni_role_agent_candidate_assets.sh"
+PATRONI_ATTESTED_COMPOSE_GUARD_SOURCE="scripts/ha/patroni_attested_compose_guard.sh"
 ROLE_AGENT_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${ROLE_AGENT_SOURCE}")"
 DEPLOY_LOCK_HELPER_SHA256="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "${DEPLOY_LOCK_HELPER_SOURCE}")"
 DB_CONTRACT_HELPER_SOURCE="scripts/ha/patroni_compose_db_contract.py"
@@ -151,6 +152,8 @@ if [[ "${OPERATION}" == "migrate" || "${OPERATION}" == "deploy" ]]; then
     && ! -L "${COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE}" \
     && -f "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}" \
     && ! -L "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}" \
+    && -f "${PATRONI_ATTESTED_COMPOSE_GUARD_SOURCE}" \
+    && ! -L "${PATRONI_ATTESTED_COMPOSE_GUARD_SOURCE}" \
     && -f "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}" \
     && ! -L "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}" \
     && -f "${DEPLOY_LOCK_HELPER_SOURCE}" && -f "${BUNDLE_VERIFIER_SOURCE}" \
@@ -254,22 +257,39 @@ if worker.get("image") != expected_image or app.get("image") != expected_image:
 environment = worker.get("environment") or {}
 if not isinstance(environment, dict):
     raise SystemExit(1)
-for key in (
-    "COMMUNICATIONS_WORKER_ENABLED",
-    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE",
-):
-    if str(environment.get(key, "")).lower() != "false":
-        raise SystemExit(1)
+gates = (
+    environment.get("COMMUNICATIONS_WORKER_ENABLED"),
+    environment.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+)
+profiles = {
+    ("false", "false"): "dormant",
+    ("true", "false"): "canary",
+    ("true", "true"): "active",
+}
+profile = profiles.get(gates)
+if profile is None:
+    raise SystemExit(1)
+print(profile)
 '
   verify_worker_runtime_code='
 import os
 import sys
 
-expected_role = sys.argv[1]
+expected_role, expected_profile = sys.argv[1:]
+profiles = {
+    "dormant": ("false", "false"),
+    "canary": ("true", "false"),
+    "active": ("true", "true"),
+}
+expected_gates = profiles.get(expected_profile)
 valid = (
-    os.environ.get("APP_ROLE") == expected_role
-    and os.environ.get("COMMUNICATIONS_WORKER_ENABLED", "").lower() == "false"
-    and os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE", "").lower() == "false"
+    expected_gates is not None
+    and os.environ.get("APP_ROLE") == expected_role
+    and (
+        os.environ.get("COMMUNICATIONS_WORKER_ENABLED"),
+        os.environ.get("COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"),
+    )
+    == expected_gates
 )
 raise SystemExit(0 if valid else 1)
 '
@@ -337,10 +357,16 @@ print(normalized)
       fi
       export BACKEND_IMAGE=$(quote "${BACKEND_IMAGE}")
       docker_command=docker
-      \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} --profile bluegreen \
-        config --format json \
-        | python3 -c $(quote "${verify_config_code}") \
-          communications-worker \"\${active_service}\" $(quote "${BACKEND_IMAGE}")
+      worker_profile=\$(
+        \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} --profile bluegreen \
+          config --format json \
+          | python3 -c $(quote "${verify_config_code}") \
+            communications-worker \"\${active_service}\" $(quote "${BACKEND_IMAGE}")
+      )
+      case \"\${worker_profile}\" in
+        dormant|canary|active) ;;
+        *) exit 1 ;;
+      esac
       set -- \$(\"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
         --profile bluegreen ps -q \"\${active_service}\")
       test \"\$#\" -eq 1
@@ -359,7 +385,8 @@ print(normalized)
       fi
       if ! \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
         --profile bluegreen exec -T communications-worker \
-        python3 -c $(quote "${verify_worker_runtime_code}") \"\${role}\" >/dev/null; then
+        python3 -c $(quote "${verify_worker_runtime_code}") \
+          \"\${role}\" \"\${worker_profile}\" >/dev/null; then
         exit 1
       fi
       if ! systemctl is-active --quiet mvn-patroni-role-agent.service; then
@@ -421,6 +448,13 @@ print(normalized)
         || test -L .ha-communications-worker-release-fenced; then
         exit 1
       fi
+      final_worker_profile=\$(
+        \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} --profile bluegreen \
+          config --format json \
+          | python3 -c $(quote "${verify_config_code}") \
+            communications-worker \"\${active_service}\" $(quote "${BACKEND_IMAGE}")
+      )
+      test \"\${final_worker_profile}\" = \"\${worker_profile}\"
       set -- \$(\"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
         --profile bluegreen ps -q communications-worker)
       test \"\$#\" -eq 1
@@ -429,7 +463,8 @@ print(normalized)
         = $(quote "${BACKEND_IMAGE}|true")
       if ! \"\${docker_command}\" compose -f ${CANONICAL_REMOTE_COMPOSE_FILE} \
         --profile bluegreen exec -T communications-worker \
-        python3 -c $(quote "${verify_worker_runtime_code}") \"\${final_role}\" >/dev/null; then
+        python3 -c $(quote "${verify_worker_runtime_code}") \
+          \"\${final_role}\" \"\${worker_profile}\" >/dev/null; then
         exit 1
       fi
       if ! systemctl is-active --quiet mvn-patroni-role-agent.service; then
@@ -478,6 +513,7 @@ BUNDLE_SOURCES=(
   "${COMMUNICATIONS_WORKER_RELEASE_HELPER_SOURCE}"
   "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_SOURCE}"
   "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_SOURCE}"
+  "${PATRONI_ATTESTED_COMPOSE_GUARD_SOURCE}"
   "${TRANSACTION_SOURCE}"
   "${VOICE_ENV_SYNC_SOURCE}"
 )
@@ -509,6 +545,7 @@ VOICE_ENV_SYNC_REMOTE="${REMOTE_BUNDLE_DIR}/sync_bot_voice_env.py"
 COMMUNICATIONS_WORKER_RELEASE_HELPER_REMOTE="${REMOTE_BUNDLE_DIR}/communications_worker_release_contract.sh"
 PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_communications_candidate_lifecycle.sh"
 PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_role_agent_candidate_assets.sh"
+PATRONI_ATTESTED_COMPOSE_GUARD_REMOTE="${REMOTE_BUNDLE_DIR}/patroni_attested_compose_guard.sh"
 REMOTE_COMPOSE_SOURCE="${REMOTE_BUNDLE_DIR}/$(basename "${COMPOSE_SOURCE}")"
 scp "${SSH_OPTS[@]}" "${BUNDLE_SOURCES[@]}" "${REMOTE}:${REMOTE_BUNDLE_DIR}/"
 
@@ -525,15 +562,13 @@ printf '%s\n%s\n' "${GHCR_PAT:-}" "${BOT_VOICE_TRANSCRIPTION_API_KEY}" | ssh "${
   IFS= read -r GHCR_PAT
   IFS= read -r BOT_VOICE_TRANSCRIPTION_API_KEY
   export GHCR_PAT
-  trap $(quote "rm -rf -- ${REMOTE_BUNDLE_DIR}") EXIT
+  trap $(quote "unset BOT_VOICE_TRANSCRIPTION_API_KEY; rm -rf -- ${REMOTE_BUNDLE_DIR}") EXIT
   python3 -I -c $(quote "${BUNDLE_VERIFIER_CODE}") verify \
     $(quote "${REMOTE_BUNDLE_DIR}") $(quote "${BUNDLE_MANIFEST_B64}")
   chmod 0755 $(quote "${REMOTE_BUNDLE_DIR}")/*.sh \
     $(quote "${REMOTE_BUNDLE_DIR}/safe_deploy_lock.py")
-  printf '%s' \"\${BOT_VOICE_TRANSCRIPTION_API_KEY}\" | \
-    python3 -I $(quote "${VOICE_ENV_SYNC_REMOTE}") \
-      --env-file $(quote "${PROJECT_DIR}/.env")
-  unset BOT_VOICE_TRANSCRIPTION_API_KEY
+  export BOT_VOICE_TRANSCRIPTION_API_KEY
+  candidate_status=0
   API_PROJECT_DIR=$(quote "${PROJECT_DIR}") \
   API_EXPECTED_PATRONI_ROLE=$(quote "${EXPECTED_ROLE}") \
   API_READY_URL=http://127.0.0.1:18080/api/ready \
@@ -573,9 +608,15 @@ printf '%s\n%s\n' "${GHCR_PAT:-}" "${BOT_VOICE_TRANSCRIPTION_API_KEY}" | ssh "${
   COMMUNICATIONS_WORKER_RELEASE_HELPER=$(quote "${COMMUNICATIONS_WORKER_RELEASE_HELPER_REMOTE}") \
   PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE=$(quote "${PATRONI_COMMUNICATIONS_CANDIDATE_LIFECYCLE_REMOTE}") \
   PATRONI_ROLE_AGENT_CANDIDATE_ASSETS=$(quote "${PATRONI_ROLE_AGENT_CANDIDATE_ASSETS_REMOTE}") \
+  PATRONI_ATTESTED_COMPOSE_GUARD=$(quote "${PATRONI_ATTESTED_COMPOSE_GUARD_REMOTE}") \
+  PATRONI_VOICE_ENV_SYNC=$(quote "${VOICE_ENV_SYNC_REMOTE}") \
+  PATRONI_VOICE_ENV_FILE=$(quote "${PROJECT_DIR}/.env") \
   API_DEPLOY_LOCK_HELPER_SHA256=$(quote "${DEPLOY_LOCK_HELPER_SHA256}") \
   ${proxy_env} \
-  bash $(quote "${REMOTE_BUNDLE_DIR}/run_patroni_candidate_transaction.sh")
+  bash $(quote "${REMOTE_BUNDLE_DIR}/run_patroni_candidate_transaction.sh") \
+    || candidate_status=\$?
+  unset BOT_VOICE_TRANSCRIPTION_API_KEY
+  exit \"\${candidate_status}\"
 "
 REMOTE_BUNDLE_DIR=""
 log "done" "${OPERATION} completed on ${NODE_HOST}"

--- a/scripts/reconcile_backend_compose_runtime.sh
+++ b/scripts/reconcile_backend_compose_runtime.sh
@@ -14,6 +14,7 @@ RECONCILE_BACKEND_IMAGE="${API_RECONCILE_BACKEND_IMAGE:-}"
 COMMUNICATIONS_WORKER_SERVICE="${API_COMMUNICATIONS_WORKER_SERVICE:-communications-worker}"
 RECONCILE_OPERATION="${API_RECONCILE_OPERATION:-reconcile}"
 EXPECTED_ROLE="${API_EXPECTED_PATRONI_ROLE:-}"
+EXPECTED_COMMUNICATIONS_WORKER_PROFILE="${API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE:-}"
 COMMUNICATIONS_WORKER_RELEASE_HELPER="${COMMUNICATIONS_WORKER_RELEASE_HELPER:-${SCRIPT_DIR}/ha/communications_worker_release_contract.sh}"
 
 write_backend_image() {
@@ -92,14 +93,16 @@ reconcile_failure() {
 }
 trap reconcile_failure ERR
 if [[ "${requested_communications_worker}" == "true" ]]; then
-  communications_worker_require_contract
+  communications_worker_require_contract "${EXPECTED_COMMUNICATIONS_WORKER_PROFILE}"
+  EXPECTED_COMMUNICATIONS_WORKER_PROFILE="${COMMUNICATIONS_WORKER_CONTRACT_PROFILE}"
 fi
 if [[ "${RECONCILE_OPERATION}" == "verify" ]]; then
   [[ "${requested_communications_worker}" == "true" ]] || {
     echo "verify operation requires ${COMMUNICATIONS_WORKER_SERVICE}" >&2
     exit 2
   }
-  communications_worker_require_runtime "${EXPECTED_ROLE}"
+  communications_worker_require_runtime \
+    "${EXPECTED_ROLE}" "${EXPECTED_COMMUNICATIONS_WORKER_PROFILE}"
   echo "canonical communications worker runtime verified"
   exit 0
 fi
@@ -121,7 +124,8 @@ if [[ "${#app_services[@]}" -gt 0 ]]; then
   "${COMPOSE[@]}" up -d --no-deps --force-recreate "${app_services[@]}"
 fi
 if [[ "${requested_communications_worker}" == "true" ]]; then
-  communications_worker_start_controlled "${EXPECTED_ROLE}"
+  communications_worker_start_controlled \
+    "${EXPECTED_ROLE}" "${EXPECTED_COMMUNICATIONS_WORKER_PROFILE}"
 fi
 if [[ -n "${STOP_SERVICES}" ]]; then
   read -r -a stop_services <<<"${STOP_SERVICES}"

--- a/services/bot_staff_notification_api_service.py
+++ b/services/bot_staff_notification_api_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -111,7 +111,7 @@ class BotStaffNotificationApiService:
         worker_id: str,
         visibility_timeout_seconds: int,
     ) -> dict | None:
-        claim_time = datetime.now(timezone.utc)
+        claim_time = await CommunicationDeliveryService.database_now(session)
         await cls._materialize_pending(
             session,
             worker_id=worker_id,
@@ -159,6 +159,18 @@ class BotStaffNotificationApiService:
                 )
                 await session.commit()
                 continue
+            # Returning the payload to another process is the provider
+            # ambiguity boundary: the remote bot may send successfully and
+            # disappear before it can acknowledge this lease.
+            lease_expires_at = (
+                await CommunicationDeliveryService.mark_provider_started(
+                    session,
+                    delivery_id=claim.delivery_id,
+                    worker_id=worker_id,
+                    lease_token=claim.lease_token,
+                    lease_seconds=visibility_timeout_seconds,
+                )
+            )
             await session.commit()
             return {
                 "delivery_id": claim.delivery_id,
@@ -168,7 +180,7 @@ class BotStaffNotificationApiService:
                 "attempt": claim.attempts,
                 "max_attempts": claim.max_attempts,
                 "lease_token": claim.lease_token,
-                "lease_expires_at": claim.lease_expires_at,
+                "lease_expires_at": lease_expires_at,
             }
         return None
 
@@ -197,7 +209,6 @@ class BotStaffNotificationApiService:
                 worker_id=worker_id,
                 lease_token=lease_token,
                 lease_seconds=visibility_timeout_seconds,
-                now=datetime.now(timezone.utc),
             )
             await session.commit()
         except (CommunicationDeliveryNotFound, CommunicationDeliveryLeaseLost) as exc:
@@ -228,7 +239,6 @@ class BotStaffNotificationApiService:
                 lease_token=lease_token,
                 provider_message_id=f"telegram:{telegram_message_id}",
                 provider_latency_ms=provider_latency_ms,
-                now=datetime.now(timezone.utc),
             )
             await session.commit()
         except (CommunicationDeliveryNotFound, CommunicationDeliveryLeaseLost) as exc:
@@ -257,12 +267,22 @@ class BotStaffNotificationApiService:
                 code=error_code,
                 message="Telegram delivery failed permanently",
             )
-        else:
+        elif (
+            error_code == "telegram_retry_after"
+            and retry_after_seconds is not None
+            and int(retry_after_seconds) > 0
+        ):
             provider_result = ProviderDeliveryResult.transient_failure(
-                category="telegram",
+                category="rate_limit",
                 code=error_code,
-                message="Telegram delivery failed transiently",
+                message="Telegram rejected the request before acceptance",
                 retry_after_seconds=retry_after_seconds,
+            )
+        else:
+            provider_result = ProviderDeliveryResult.ambiguous_failure(
+                category="provider",
+                code=error_code,
+                message="Telegram delivery outcome requires manual reconciliation",
             )
         try:
             outcome = await CommunicationDeliveryService.mark_failed(
@@ -271,7 +291,6 @@ class BotStaffNotificationApiService:
                 worker_id=worker_id,
                 lease_token=lease_token,
                 result=provider_result,
-                now=datetime.now(timezone.utc),
             )
             await session.commit()
         except (CommunicationDeliveryNotFound, CommunicationDeliveryLeaseLost) as exc:

--- a/services/communications/audience_resolver.py
+++ b/services/communications/audience_resolver.py
@@ -8,6 +8,7 @@ from services.communications.contracts import (
     TelegramCanaryRequestedPayloadV1,
 )
 from services.communications.recipient_directory import (
+    InstallationEstimateOwnerRecipientDirectory,
     ManagementRecipientDirectory,
     OperationsCanaryRecipientDirectory,
 )
@@ -29,6 +30,10 @@ class CommunicationAudienceResolver:
     ) -> list[CommunicationRecipientV1]:
         if plan.audience == "management":
             return await ManagementRecipientDirectory.list_telegram(session)
+        if plan.audience == "installation_estimate_owners":
+            return await InstallationEstimateOwnerRecipientDirectory.list_telegram(
+                session
+            )
         if plan.audience == "operations_canary":
             payload = TelegramCanaryRequestedPayloadV1.model_validate(
                 plan.render_context

--- a/services/communications/contracts.py
+++ b/services/communications/contracts.py
@@ -165,9 +165,12 @@ class CommunicationRecipientV1(_ContractV1):
 
 class CommunicationTemplatePlanV1(_ContractV1):
     channel: Literal["telegram"] = "telegram"
-    audience: Literal["management", "operations_canary", "staff_assignee"] = (
-        "management"
-    )
+    audience: Literal[
+        "management",
+        "installation_estimate_owners",
+        "operations_canary",
+        "staff_assignee",
+    ] = "management"
     template_key: str = Field(
         min_length=3,
         max_length=120,

--- a/services/communications/delivery_attempt_service.py
+++ b/services/communications/delivery_attempt_service.py
@@ -35,19 +35,24 @@ class CommunicationDeliveryAttemptService:
         {
             "delivery_failed",
             "lease_expired",
+            "lease_expired_after_provider",
+            "lease_expired_before_provider",
             "provider_call_failed",
             "provider_result_invalid",
             "recipient_inactive",
+            "runtime_control_fenced_before_provider",
             "telegram_api_error",
             "telegram_bad_request",
             "telegram_chat_migrated",
             "telegram_destination_invalid",
             "telegram_entity_too_large",
+            "telegram_forbidden",
             "telegram_network_error",
             "telegram_provider_auth_or_conflict",
             "telegram_recipient_unavailable",
             "telegram_retry_after",
             "telegram_text_invalid",
+            "telegram_transport_error",
             "telegram_unexpected_error",
             "template_render_failed",
             "timeout",
@@ -149,6 +154,39 @@ class CommunicationDeliveryAttemptService:
         attempt.ambiguous = bool(ambiguous)
         session.add(attempt)
 
+    @classmethod
+    async def mark_provider_started(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery: CommunicationDelivery,
+        started_at: datetime,
+    ) -> None:
+        """Persist the acceptance-ambiguity boundary for the current attempt."""
+
+        attempt_no = int(delivery.attempts)
+        statement = select(CommunicationDeliveryAttempt).where(
+            CommunicationDeliveryAttempt.delivery_id == delivery.delivery_id,
+            CommunicationDeliveryAttempt.attempt_no == attempt_no,
+        )
+        if session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update()
+        attempt = (await session.execute(statement)).scalar_one_or_none()
+        if (
+            attempt is None
+            or attempt.outcome != "running"
+            or attempt.finished_at is not None
+        ):
+            raise CommunicationDeliveryAttemptStateError(
+                f"Communication delivery {delivery.delivery_id!r} attempt "
+                f"{attempt_no} is not running"
+            )
+        # Idempotency matters when the commit acknowledgement itself times out:
+        # an already durable boundary is still safe to proceed from.
+        if attempt.provider_started_at is None:
+            attempt.provider_started_at = started_at
+            session.add(attempt)
+
     @staticmethod
     def is_ambiguous_provider_failure(
         *,
@@ -158,11 +196,31 @@ class CommunicationDeliveryAttemptService:
     ) -> bool:
         normalized_category = str(category or "").strip().lower()
         normalized_code = str(code or "").strip().lower()
-        if normalized_code == "provider_result_invalid":
+        if (
+            result.disposition == ProviderDeliveryDisposition.AMBIGUOUS_FAILURE
+            or normalized_code == "provider_result_invalid"
+        ):
             return True
         return (
             result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
             and normalized_category in {"network", "provider"}
+        )
+
+    @staticmethod
+    def is_provably_retry_safe(
+        *,
+        result: ProviderDeliveryResult,
+        category: str,
+        code: str,
+    ) -> bool:
+        """Only retry outcomes that prove Telegram rejected before acceptance."""
+
+        return (
+            result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
+            and str(category or "").strip().lower() == "rate_limit"
+            and str(code or "").strip().lower() == "telegram_retry_after"
+            and result.retry_after_seconds is not None
+            and int(result.retry_after_seconds) > 0
         )
 
     @classmethod

--- a/services/communications/delivery_lease_recovery.py
+++ b/services/communications/delivery_lease_recovery.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    IntegrationOutboxEvent,
+)
+from services.communications.delivery_attempt_service import (
+    CommunicationDeliveryAttemptService,
+)
+from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.delivery_retry_policy import (
+    delivery_retry_delay_seconds,
+)
+
+
+@dataclass(frozen=True)
+class ExpiredLeaseRecoveryResult:
+    retry_count: int
+    dead_count: int
+
+
+async def recover_expired_delivery_leases(
+    session: AsyncSession,
+    *,
+    scope: CommunicationProcessingScope,
+    channel: str,
+    recovered_at: datetime,
+    limit: int,
+) -> ExpiredLeaseRecoveryResult:
+    """Recover only with evidence about whether provider I/O may have begun."""
+
+    statement = (
+        select(CommunicationDelivery)
+        .join(
+            IntegrationOutboxEvent,
+            IntegrationOutboxEvent.event_id == CommunicationDelivery.event_id,
+        )
+        .where(
+            CommunicationDelivery.channel == channel,
+            CommunicationDelivery.status == "running",
+            CommunicationDelivery.lease_expires_at.is_not(None),
+            CommunicationDelivery.lease_expires_at <= recovered_at,
+            CommunicationDelivery.template_key.in_(
+                scope.delivery_template_keys
+            ),
+            IntegrationOutboxEvent.event_type.in_(scope.outbox_event_types),
+            IntegrationOutboxEvent.status == "published",
+        )
+        .order_by(
+            CommunicationDelivery.lease_expires_at.asc(),
+            CommunicationDelivery.created_at.asc(),
+            CommunicationDelivery.delivery_id.asc(),
+        )
+        .limit(limit)
+    )
+    if scope.exact_event_id is not None:
+        statement = statement.where(
+            CommunicationDelivery.event_id == scope.exact_event_id
+        )
+    if scope.event_created_at_watermark is not None:
+        statement = statement.where(
+            IntegrationOutboxEvent.created_at
+            >= scope.event_created_at_watermark
+        )
+    if session.get_bind().dialect.name == "postgresql":
+        statement = statement.with_for_update(
+            of=CommunicationDelivery,
+            skip_locked=True,
+        )
+
+    deliveries = list((await session.execute(statement)).scalars().all())
+    retry_count = 0
+    dead_count = 0
+    for delivery in deliveries:
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery.delivery_id, int(delivery.attempts)),
+        )
+        if (
+            attempt is None
+            or attempt.outcome != "running"
+            or attempt.finished_at is not None
+        ):
+            # The attempt service raises a fixed state error below. Keeping this
+            # branch explicit avoids guessing a provider boundary from damage.
+            provider_started = True
+        else:
+            provider_started = (
+                attempt.provider_started_at is not None
+                # Rolling compatibility: an old API can hand a staff-bot
+                # claim to the remote process after this migration but before
+                # it learns to persist the marker. Remote handoff itself is
+                # always an ambiguity boundary.
+                or scope.mode == "staff_bot"
+            )
+
+        ambiguous_history_count = int(
+            (
+                await session.scalar(
+                    select(
+                        func.count(CommunicationDeliveryAttempt.attempt_no)
+                    ).where(
+                        CommunicationDeliveryAttempt.delivery_id
+                        == delivery.delivery_id,
+                        CommunicationDeliveryAttempt.ambiguous.is_(True),
+                    )
+                )
+            )
+            or 0
+        )
+        ambiguous = provider_started or ambiguous_history_count > 0
+        exhausted = int(delivery.attempts) >= int(delivery.max_attempts)
+        outcome = "dead" if ambiguous or exhausted else "retry"
+        error_code = (
+            "lease_expired_after_provider"
+            if ambiguous
+            else "lease_expired_before_provider"
+        )
+
+        await CommunicationDeliveryAttemptService.finish(
+            session,
+            delivery=delivery,
+            finished_at=recovered_at,
+            outcome=outcome,
+            error_category="lease",
+            error_code=error_code,
+            ambiguous=ambiguous,
+        )
+        delivery.worker_id = None
+        delivery.lease_token = None
+        delivery.lease_expires_at = None
+        delivery.last_error_category = "lease"
+        delivery.last_error_code = error_code
+        delivery.updated_at = recovered_at
+        delivery.provider_message_id = None
+        delivery.sent_at = None
+        if outcome == "retry":
+            delivery.status = "retry"
+            delivery.available_at = recovered_at + timedelta(
+                seconds=delivery_retry_delay_seconds(
+                    delivery_id=delivery.delivery_id,
+                    attempts=delivery.attempts,
+                )
+            )
+            delivery.finished_at = None
+            delivery.last_error_message = (
+                "Delivery lease expired before provider call"
+            )
+            retry_count += 1
+        else:
+            delivery.status = "dead"
+            delivery.finished_at = recovered_at
+            delivery.last_error_message = (
+                "Delivery lease expired after provider boundary"
+                if ambiguous
+                else "Delivery attempts exhausted before provider call"
+            )
+            dead_count += 1
+        session.add(delivery)
+
+    await session.flush()
+    return ExpiredLeaseRecoveryResult(
+        retry_count=retry_count,
+        dead_count=dead_count,
+    )

--- a/services/communications/delivery_pre_provider_release.py
+++ b/services/communications/delivery_pre_provider_release.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from services.communications.delivery_attempt_service import (
+    CommunicationDeliveryAttemptService,
+)
+from services.communications.delivery_retry_policy import (
+    delivery_retry_delay_seconds,
+)
+from services.communications.delivery_service import (
+    DELIVERY_STATUS_DEAD,
+    DELIVERY_STATUS_RETRY,
+    DELIVERY_STATUS_RUNNING,
+    CommunicationDeliveryLeaseLost,
+    CommunicationDeliveryNotFound,
+    CommunicationDeliveryService,
+    DeliveryFailureOutcome,
+)
+
+
+async def release_pre_provider_claim(
+    session: AsyncSession,
+    *,
+    delivery_id: str,
+    worker_id: str,
+    lease_token: str,
+) -> DeliveryFailureOutcome:
+    """Release an exact owned claim only while provider I/O is provably absent."""
+
+    normalized_delivery_id = CommunicationDeliveryService._normalize_delivery_id(
+        delivery_id
+    )
+    normalized_worker_id = CommunicationDeliveryService._normalize_worker_id(
+        worker_id
+    )
+    normalized_lease_token = CommunicationDeliveryService._normalize_lease_token(
+        lease_token
+    )
+    statement = select(CommunicationDelivery).where(
+        CommunicationDelivery.delivery_id == normalized_delivery_id,
+        CommunicationDelivery.status == DELIVERY_STATUS_RUNNING,
+        CommunicationDelivery.worker_id == normalized_worker_id,
+        CommunicationDelivery.lease_token == normalized_lease_token,
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        statement = statement.with_for_update()
+    delivery = (await session.execute(statement)).scalar_one_or_none()
+    if delivery is None:
+        if await session.get(CommunicationDelivery, normalized_delivery_id) is None:
+            raise CommunicationDeliveryNotFound(
+                f"Communication delivery {normalized_delivery_id!r} was not found"
+            )
+        raise CommunicationDeliveryLeaseLost(
+            f"Communication delivery {normalized_delivery_id!r} is no longer owned"
+        )
+
+    attempt_statement = select(CommunicationDeliveryAttempt).where(
+        CommunicationDeliveryAttempt.delivery_id == normalized_delivery_id,
+        CommunicationDeliveryAttempt.attempt_no == int(delivery.attempts),
+    )
+    if session.get_bind().dialect.name == "postgresql":
+        attempt_statement = attempt_statement.with_for_update()
+    attempt = (await session.execute(attempt_statement)).scalar_one_or_none()
+    if (
+        attempt is None
+        or attempt.outcome != DELIVERY_STATUS_RUNNING
+        or attempt.finished_at is not None
+        or attempt.provider_started_at is not None
+    ):
+        raise CommunicationDeliveryLeaseLost(
+            f"Communication delivery {normalized_delivery_id!r} "
+            "cannot be released before provider"
+        )
+
+    released_at = await CommunicationDeliveryService.database_now(session)
+    exhausted = int(delivery.attempts) >= int(delivery.max_attempts)
+    outcome = DELIVERY_STATUS_DEAD if exhausted else DELIVERY_STATUS_RETRY
+    error_code = "runtime_control_fenced_before_provider"
+    await CommunicationDeliveryAttemptService.finish(
+        session,
+        delivery=delivery,
+        finished_at=released_at,
+        outcome=outcome,
+        error_category="lease",
+        error_code=error_code,
+        ambiguous=False,
+    )
+    delivery.status = outcome
+    delivery.worker_id = None
+    delivery.lease_token = None
+    delivery.lease_expires_at = None
+    delivery.provider_message_id = None
+    delivery.last_error_category = "lease"
+    delivery.last_error_code = error_code
+    delivery.last_error_message = "Runtime control fenced delivery before provider"
+    delivery.sent_at = None
+    delivery.finished_at = released_at if exhausted else None
+    delivery.updated_at = released_at
+    next_attempt_at = None
+    if not exhausted:
+        next_attempt_at = released_at + timedelta(
+            seconds=delivery_retry_delay_seconds(
+                delivery_id=delivery.delivery_id,
+                attempts=delivery.attempts,
+            )
+        )
+        delivery.available_at = next_attempt_at
+    session.add(delivery)
+    await session.flush()
+    return DeliveryFailureOutcome(
+        status=outcome,
+        attempts=int(delivery.attempts),
+        next_attempt_at=next_attempt_at,
+    )

--- a/services/communications/delivery_retry_policy.py
+++ b/services/communications/delivery_retry_policy.py
@@ -1,0 +1,32 @@
+import hashlib
+
+
+RETRY_BASE_SECONDS = 30
+RETRY_MAX_SECONDS = 3600
+RETRY_JITTER_PERCENT = 20
+
+
+def delivery_retry_delay_seconds(
+    *,
+    delivery_id: str,
+    attempts: int,
+) -> int:
+    safe_attempts = max(1, int(attempts))
+    exponential_delay = min(
+        RETRY_MAX_SECONDS,
+        RETRY_BASE_SECONDS * (2 ** min(safe_attempts - 1, 16)),
+    )
+    if exponential_delay >= RETRY_MAX_SECONDS:
+        return RETRY_MAX_SECONDS
+    jitter_window = max(
+        1,
+        (exponential_delay * RETRY_JITTER_PERCENT) // 100,
+    )
+    digest = hashlib.sha256(
+        f"{delivery_id}:{safe_attempts}".encode("utf-8")
+    ).digest()
+    return min(
+        RETRY_MAX_SECONDS,
+        exponential_delay
+        + int.from_bytes(digest[:4], "big") % (jitter_window + 1),
+    )

--- a/services/communications/delivery_service.py
+++ b/services/communications/delivery_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import re
 import secrets
 from collections.abc import Mapping
@@ -12,9 +11,23 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from models import CommunicationDelivery, IntegrationOutboxEvent
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    IntegrationOutboxEvent,
+)
 from services.communications.delivery_attempt_service import (
     CommunicationDeliveryAttemptService,
+)
+from services.communications.delivery_lease_recovery import (
+    ExpiredLeaseRecoveryResult,
+    recover_expired_delivery_leases,
+)
+from services.communications.delivery_retry_policy import (
+    RETRY_BASE_SECONDS as DELIVERY_RETRY_BASE_SECONDS,
+    RETRY_JITTER_PERCENT as DELIVERY_RETRY_JITTER_PERCENT,
+    RETRY_MAX_SECONDS as DELIVERY_RETRY_MAX_SECONDS,
+    delivery_retry_delay_seconds,
 )
 from services.communications.delivery_limits import (
     MAX_DELIVERY_LEASE_SECONDS,
@@ -83,12 +96,6 @@ class ClaimedCommunicationDelivery:
 
 
 @dataclass(frozen=True)
-class ExpiredLeaseRecoveryResult:
-    retry_count: int
-    dead_count: int
-
-
-@dataclass(frozen=True)
 class DeliveryFailureOutcome:
     status: str
     attempts: int
@@ -101,9 +108,9 @@ class CommunicationDeliveryService:
     MIN_LEASE_SECONDS = MIN_DELIVERY_LEASE_SECONDS
     MAX_LEASE_SECONDS = MAX_DELIVERY_LEASE_SECONDS
     MAX_RECOVERY_LIMIT = 1000
-    RETRY_BASE_SECONDS = 30
-    RETRY_MAX_SECONDS = 3600
-    RETRY_JITTER_PERCENT = 20
+    RETRY_BASE_SECONDS = DELIVERY_RETRY_BASE_SECONDS
+    RETRY_MAX_SECONDS = DELIVERY_RETRY_MAX_SECONDS
+    RETRY_JITTER_PERCENT = DELIVERY_RETRY_JITTER_PERCENT
 
     @classmethod
     async def claim_next(
@@ -139,6 +146,13 @@ class CommunicationDeliveryService:
                 ),
                 IntegrationOutboxEvent.event_type.in_(scope.outbox_event_types),
                 IntegrationOutboxEvent.status == "published",
+                ~select(CommunicationDeliveryAttempt.delivery_id)
+                .where(
+                    CommunicationDeliveryAttempt.delivery_id
+                    == CommunicationDelivery.delivery_id,
+                    CommunicationDeliveryAttempt.ambiguous.is_(True),
+                )
+                .exists(),
             )
             .order_by(
                 CommunicationDelivery.priority.asc(),
@@ -151,6 +165,11 @@ class CommunicationDeliveryService:
         if scope.exact_event_id is not None:
             statement = statement.where(
                 CommunicationDelivery.event_id == scope.exact_event_id
+            )
+        if scope.event_created_at_watermark is not None:
+            statement = statement.where(
+                IntegrationOutboxEvent.created_at
+                >= scope.event_created_at_watermark
             )
         if session.get_bind().dialect.name == "postgresql":
             statement = statement.with_for_update(
@@ -213,87 +232,47 @@ class CommunicationDeliveryService:
         normalized_channel = cls._normalize_channel(channel)
         recovered_at = await cls._resolve_now(session, now)
         safe_limit = max(1, min(cls.MAX_RECOVERY_LIMIT, int(limit)))
-        statement = (
-            select(CommunicationDelivery)
-            .join(
-                IntegrationOutboxEvent,
-                IntegrationOutboxEvent.event_id == CommunicationDelivery.event_id,
-            )
-            .where(
-                CommunicationDelivery.channel == normalized_channel,
-                CommunicationDelivery.status == DELIVERY_STATUS_RUNNING,
-                CommunicationDelivery.lease_expires_at.is_not(None),
-                CommunicationDelivery.lease_expires_at <= recovered_at,
-                CommunicationDelivery.template_key.in_(
-                    scope.delivery_template_keys
-                ),
-                IntegrationOutboxEvent.event_type.in_(scope.outbox_event_types),
-                IntegrationOutboxEvent.status == "published",
-            )
-            .order_by(
-                CommunicationDelivery.lease_expires_at.asc(),
-                CommunicationDelivery.created_at.asc(),
-                CommunicationDelivery.delivery_id.asc(),
-            )
-            .limit(safe_limit)
+        return await recover_expired_delivery_leases(
+            session,
+            scope=scope,
+            channel=normalized_channel,
+            recovered_at=recovered_at,
+            limit=safe_limit,
         )
-        if scope.exact_event_id is not None:
-            statement = statement.where(
-                CommunicationDelivery.event_id == scope.exact_event_id
-            )
-        if session.get_bind().dialect.name == "postgresql":
-            statement = statement.with_for_update(
-                of=CommunicationDelivery,
-                skip_locked=True,
-            )
 
-        deliveries = list((await session.execute(statement)).scalars().all())
-        retry_count = 0
-        dead_count = 0
-        for delivery in deliveries:
-            await CommunicationDeliveryAttemptService.finish(
-                session,
-                delivery=delivery,
-                finished_at=recovered_at,
-                outcome=(
-                    DELIVERY_STATUS_DEAD
-                    if int(delivery.attempts) >= int(delivery.max_attempts)
-                    else DELIVERY_STATUS_RETRY
-                ),
-                error_category="lease",
-                error_code="lease_expired",
-                ambiguous=True,
-            )
-            delivery.worker_id = None
-            delivery.lease_token = None
-            delivery.lease_expires_at = None
-            delivery.last_error_category = "lease"
-            delivery.last_error_code = "lease_expired"
-            delivery.last_error_message = "Delivery worker lease expired before completion"
-            delivery.updated_at = recovered_at
-            if int(delivery.attempts) >= int(delivery.max_attempts):
-                delivery.status = DELIVERY_STATUS_DEAD
-                delivery.sent_at = None
-                delivery.finished_at = recovered_at
-                dead_count += 1
-            else:
-                delivery.status = DELIVERY_STATUS_RETRY
-                delivery.available_at = recovered_at + timedelta(
-                    seconds=cls.retry_delay_seconds(
-                        delivery_id=delivery.delivery_id,
-                        attempts=delivery.attempts,
-                    )
-                )
-                delivery.sent_at = None
-                delivery.finished_at = None
-                retry_count += 1
-            session.add(delivery)
+    @classmethod
+    async def mark_provider_started(
+        cls,
+        session: AsyncSession,
+        *,
+        delivery_id: str,
+        worker_id: str,
+        lease_token: str,
+        lease_seconds: int = 90,
+        now: datetime | None = None,
+    ) -> datetime:
+        """Durably cross the provider-call boundary under the exact lease."""
 
+        delivery, started_at = await cls._lock_owned_delivery(
+            session,
+            delivery_id=delivery_id,
+            worker_id=worker_id,
+            lease_token=lease_token,
+            now=now,
+        )
+        await CommunicationDeliveryAttemptService.mark_provider_started(
+            session,
+            delivery=delivery,
+            started_at=started_at,
+        )
+        lease_expires_at = started_at + timedelta(
+            seconds=cls._normalize_lease_seconds(lease_seconds)
+        )
+        delivery.lease_expires_at = lease_expires_at
+        delivery.updated_at = started_at
+        session.add(delivery)
         await session.flush()
-        return ExpiredLeaseRecoveryResult(
-            retry_count=retry_count,
-            dead_count=dead_count,
-        )
+        return lease_expires_at
 
     @classmethod
     async def renew_lease(
@@ -391,8 +370,22 @@ class CommunicationDeliveryService:
             now=now,
         )
         category, code, message = cls._sanitize_provider_error(result)
+        ambiguous = (
+            CommunicationDeliveryAttemptService.is_ambiguous_provider_failure(
+                result=result,
+                category=category,
+                code=code,
+            )
+        )
+        retry_safe = CommunicationDeliveryAttemptService.is_provably_retry_safe(
+            result=result,
+            category=category,
+            code=code,
+        )
         terminal = (
             result.disposition == ProviderDeliveryDisposition.PERMANENT_FAILURE
+            or ambiguous
+            or not retry_safe
             or int(delivery.attempts) >= int(delivery.max_attempts)
         )
         next_attempt_at: datetime | None = None
@@ -420,11 +413,7 @@ class CommunicationDeliveryService:
             error_code=code,
             retry_after_seconds=result.retry_after_seconds,
             provider_latency_ms=provider_latency_ms,
-            ambiguous=CommunicationDeliveryAttemptService.is_ambiguous_provider_failure(
-                result=result,
-                category=category,
-                code=code,
-            ),
+            ambiguous=ambiguous,
         )
 
         delivery.status = failure_status
@@ -506,23 +495,9 @@ class CommunicationDeliveryService:
 
     @classmethod
     def retry_delay_seconds(cls, *, delivery_id: str, attempts: int) -> int:
-        safe_attempts = max(1, int(attempts))
-        exponential_delay = min(
-            cls.RETRY_MAX_SECONDS,
-            cls.RETRY_BASE_SECONDS * (2 ** min(safe_attempts - 1, 16)),
-        )
-        if exponential_delay >= cls.RETRY_MAX_SECONDS:
-            return cls.RETRY_MAX_SECONDS
-        jitter_window = max(
-            1,
-            (exponential_delay * cls.RETRY_JITTER_PERCENT) // 100,
-        )
-        digest = hashlib.sha256(
-            f"{delivery_id}:{safe_attempts}".encode("utf-8")
-        ).digest()
-        return min(
-            cls.RETRY_MAX_SECONDS,
-            exponential_delay + int.from_bytes(digest[:4], "big") % (jitter_window + 1),
+        return delivery_retry_delay_seconds(
+            delivery_id=delivery_id,
+            attempts=attempts,
         )
 
     @classmethod
@@ -581,13 +556,23 @@ class CommunicationDeliveryService:
 
     @classmethod
     async def _database_now(cls, session: AsyncSession) -> datetime:
-        clock = (
-            func.clock_timestamp()
-            if session.get_bind().dialect.name == "postgresql"
-            else func.current_timestamp()
-        )
+        dialect_name = session.get_bind().dialect.name
+        if dialect_name == "postgresql":
+            clock = func.clock_timestamp()
+        elif dialect_name == "sqlite":
+            # CURRENT_TIMESTAMP is only second-precision in SQLite and can
+            # make a row created moments earlier appear artificially future.
+            clock = func.strftime("%Y-%m-%d %H:%M:%f", "now")
+        else:
+            clock = func.current_timestamp()
         value = (await session.execute(select(clock))).scalar_one()
         return cls._coerce_database_datetime(value)
+
+    @classmethod
+    async def database_now(cls, session: AsyncSession) -> datetime:
+        """Return the authoritative delivery lifecycle clock."""
+
+        return await cls._database_now(session)
 
     @staticmethod
     def _coerce_database_datetime(value: object) -> datetime:

--- a/services/communications/delivery_worker.py
+++ b/services/communications/delivery_worker.py
@@ -11,7 +11,9 @@ from datetime import datetime
 from typing import Any, Literal, TypeVar
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
+from models import CommunicationDelivery
 from services.communications.audience_resolver import CommunicationAudienceResolver
 from services.communications.canary_errors import CommunicationsCanarySafetyError
 from services.communications.contracts import CommunicationTemplatePlanV1
@@ -22,17 +24,19 @@ from services.communications.delivery_service import (
     DeliveryFailureOutcome,
     ExpiredLeaseRecoveryResult,
 )
+from services.communications.delivery_pre_provider_release import (
+    release_pre_provider_claim,
+)
 from services.communications.providers.base import (
     CommunicationDeliveryProvider,
     ProviderDeliveryDisposition,
     ProviderDeliveryResult,
 )
 from services.communications.processing_scope import CommunicationProcessingScope
-from services.communications.recipient_directory import ManagementRecipientDirectory
+from services.communications.templates import TemplateRenderError
 from services.communications.template_registry import (
     TELEGRAM_CANARY_MAX_ATTEMPTS,
     TELEGRAM_CANARY_TEMPLATE_KEY,
-    InvalidCommunicationEventPayload,
     UnsupportedCommunicationEvent,
     WebsiteTemplateRegistry,
 )
@@ -51,6 +55,12 @@ class _ProviderResultDuringCancellation(RuntimeError):
         super().__init__("Provider result completed during worker cancellation")
         self.result = result
         self.cancellation = cancellation
+
+
+class _ProviderBoundaryCheckFailed(RuntimeError):
+    def __init__(self, error: BaseException) -> None:
+        super().__init__("Provider boundary safety check failed")
+        self.error = error
 
 
 @dataclass(frozen=True)
@@ -87,6 +97,9 @@ class CommunicationDeliveryWorker:
         lease_seconds: int = 90,
         recovery_limit: int = 100,
         safety_check: Callable[[], Awaitable[None]] | None = None,
+        provider_boundary_check: (
+            Callable[[AsyncSession], Awaitable[None]] | None
+        ) = None,
         db_operation_timeout_seconds: float | None = None,
     ) -> None:
         self._session_factory = session_factory
@@ -102,6 +115,7 @@ class CommunicationDeliveryWorker:
             min(CommunicationDeliveryService.MAX_RECOVERY_LIMIT, int(recovery_limit)),
         )
         self._safety_check = safety_check
+        self._provider_boundary_check = provider_boundary_check
         if db_operation_timeout_seconds is None:
             self._db_operation_timeout_seconds = None
         else:
@@ -125,24 +139,9 @@ class CommunicationDeliveryWorker:
                 recovered_dead_count=recovery.dead_count,
             )
 
-        if not await self._recipient_is_current(claim):
-            try:
-                await self._finish_terminal_despite_cancellation(
-                    self._cancel_inactive_recipient(claim),
-                    delivery_id=claim.delivery_id,
-                )
-            except CommunicationDeliveryLeaseLost:
-                return self._lease_lost_outcome(claim, recovery)
-            return DeliveryRunOutcome(
-                outcome="canceled",
-                delivery_id=claim.delivery_id,
-                attempts=claim.attempts,
-                recovered_retry_count=recovery.retry_count,
-                recovered_dead_count=recovery.dead_count,
-            )
-
         try:
-            rendered_text = self._render(claim)
+            plan = self._plan(claim)
+            rendered_text = WebsiteTemplateRegistry.render(plan)
         except Exception as exc:
             logger.warning(
                 "Communication delivery render failed delivery_id=%s error_type=%s",
@@ -159,16 +158,39 @@ class CommunicationDeliveryWorker:
                 delivery_id=claim.delivery_id,
             )
 
+        if not await self._recipient_is_current(claim, plan):
+            try:
+                await self._finish_terminal_despite_cancellation(
+                    self._cancel_inactive_recipient(claim),
+                    delivery_id=claim.delivery_id,
+                )
+            except CommunicationDeliveryLeaseLost:
+                return self._lease_lost_outcome(claim, recovery)
+            return DeliveryRunOutcome(
+                outcome="canceled",
+                delivery_id=claim.delivery_id,
+                attempts=claim.attempts,
+                recovered_retry_count=recovery.retry_count,
+                recovered_dead_count=recovery.dead_count,
+            )
+
+        # Complete every check that can fail before durably crossing the
+        # provider-call boundary. A crash before that boundary is retry-safe.
         try:
-            await self._renew_before_send(claim)
+            await self._assert_safe_to_continue()
+        except BaseException:
+            await self._release_pre_provider_claim_despite_cancellation(claim)
+            raise
+        try:
+            await self._mark_provider_started_before_send(claim)
+        except _ProviderBoundaryCheckFailed as rejected:
+            await self._release_pre_provider_claim_despite_cancellation(claim)
+            raise rejected.error
         except CommunicationDeliveryLeaseLost:
-            # Rendering and recipient resolution are deliberately outside the
-            # claim transaction. Re-fence immediately before any network I/O.
             return self._lease_lost_outcome(claim, recovery)
 
-        # Ownership, primary role and process stop are rechecked after the
-        # durable lease renewal and immediately before provider network I/O.
-        await self._assert_safe_to_continue()
+        # There are deliberately no further safety or database awaits between
+        # this committed boundary and construction of the provider task.
         cancellation_after_finalize: asyncio.CancelledError | None = None
         provider_started_ns = time.monotonic_ns()
         try:
@@ -187,10 +209,10 @@ class CommunicationDeliveryWorker:
                 claim.delivery_id,
                 type(exc).__name__,
             )
-            result = ProviderDeliveryResult.transient_failure(
+            result = ProviderDeliveryResult.ambiguous_failure(
                 category="provider",
                 code="provider_call_failed",
-                message="Communication provider failed unexpectedly",
+                message="Communication provider outcome requires manual reconciliation",
             )
         provider_latency_ms = max(
             0,
@@ -199,10 +221,10 @@ class CommunicationDeliveryWorker:
 
         if result.disposition == ProviderDeliveryDisposition.SENT:
             if not result.provider_message_id:
-                result = ProviderDeliveryResult.permanent_failure(
+                result = ProviderDeliveryResult.ambiguous_failure(
                     category="provider",
                     code="provider_result_invalid",
-                    message="Communication provider returned an invalid success result",
+                    message="Communication provider success requires manual reconciliation",
                 )
             else:
                 try:
@@ -282,29 +304,57 @@ class CommunicationDeliveryWorker:
                 await session.commit()
                 return claim
 
-    async def _recipient_is_current(self, claim: ClaimedCommunicationDelivery) -> bool:
+    async def _recipient_is_current(
+        self,
+        claim: ClaimedCommunicationDelivery,
+        plan: CommunicationTemplatePlanV1,
+    ) -> bool:
         async with self._bounded_db_operation():
             async with self._session_factory() as session:
-                if claim.template_key == TELEGRAM_CANARY_TEMPLATE_KEY:
-                    if claim.max_attempts != TELEGRAM_CANARY_MAX_ATTEMPTS:
-                        return False
-                    try:
-                        recipients = await CommunicationAudienceResolver.list_telegram(
-                            session,
-                            plan=self._plan(claim),
-                        )
-                    except (
-                        CommunicationsCanarySafetyError,
-                        InvalidCommunicationEventPayload,
-                        UnsupportedCommunicationEvent,
+                try:
+                    if (
+                        claim.template_key == TELEGRAM_CANARY_TEMPLATE_KEY
+                        and claim.max_attempts != TELEGRAM_CANARY_MAX_ATTEMPTS
                     ):
-                        # A changed or incomplete owner pair cancels canary delivery;
-                        # it must never fall back to management or legacy recipients.
                         return False
-                else:
-                    recipients = await ManagementRecipientDirectory.list_telegram(
-                        session
+                    recipients = await CommunicationAudienceResolver.list_telegram(
+                        session,
+                        plan=plan,
                     )
+                except (
+                    CommunicationsCanarySafetyError,
+                    TemplateRenderError,
+                    UnsupportedCommunicationEvent,
+                    ValueError,
+                ):
+                    # Exact audiences never fall back to management or legacy
+                    # recipients when their current routing contract is unsafe.
+                    return False
+                if plan.audience == "installation_estimate_owners":
+                    deliveries = list(
+                        (
+                            await session.execute(
+                                select(CommunicationDelivery).where(
+                                    CommunicationDelivery.event_id == claim.event_id,
+                                    CommunicationDelivery.channel == claim.channel,
+                                    CommunicationDelivery.template_key
+                                    == claim.template_key,
+                                    CommunicationDelivery.template_version
+                                    == claim.template_version,
+                                )
+                            )
+                        ).scalars()
+                    )
+                    expected_routing = {
+                        (recipient.recipient_key, recipient.destination)
+                        for recipient in recipients
+                    }
+                    materialized_routing = {
+                        (delivery.recipient_key, delivery.destination)
+                        for delivery in deliveries
+                    }
+                    if materialized_routing != expected_routing:
+                        return False
         return any(
             recipient.recipient_key == claim.recipient_key
             and recipient.destination == claim.destination
@@ -331,11 +381,6 @@ class CommunicationDeliveryWorker:
             template_version=claim.template_version,
             render_context=claim.render_context_dict(),
         )
-
-    @classmethod
-    def _render(cls, claim: ClaimedCommunicationDelivery) -> str:
-        plan = cls._plan(claim)
-        return WebsiteTemplateRegistry.render(plan)
 
     async def _send_with_heartbeat(
         self,
@@ -430,10 +475,12 @@ class CommunicationDeliveryWorker:
                         claim.delivery_id,
                         type(exc).__name__,
                     )
-                    completed_result = ProviderDeliveryResult.transient_failure(
+                    completed_result = ProviderDeliveryResult.ambiguous_failure(
                         category="provider",
                         code="provider_call_failed",
-                        message="Communication provider failed unexpectedly",
+                        message=(
+                            "Communication provider outcome requires manual reconciliation"
+                        ),
                     )
                 raise _ProviderResultDuringCancellation(
                     result=completed_result,
@@ -453,17 +500,57 @@ class CommunicationDeliveryWorker:
                 with suppress(asyncio.CancelledError):
                     await heartbeat_task
 
-    async def _renew_before_send(self, claim: ClaimedCommunicationDelivery) -> None:
+    async def _mark_provider_started_before_send(
+        self,
+        claim: ClaimedCommunicationDelivery,
+    ) -> None:
+        boundary_pending = self._provider_boundary_check is not None
+        try:
+            async with self._bounded_db_operation():
+                async with self._session_factory() as session:
+                    if self._provider_boundary_check is not None:
+                        await self._provider_boundary_check(session)
+                        boundary_pending = False
+                    await CommunicationDeliveryService.mark_provider_started(
+                        session,
+                        delivery_id=claim.delivery_id,
+                        worker_id=self._worker_id,
+                        lease_token=claim.lease_token,
+                        lease_seconds=self._lease_seconds,
+                    )
+                    await session.commit()
+        except BaseException as error:
+            if boundary_pending:
+                raise _ProviderBoundaryCheckFailed(error) from error
+            raise
+
+    async def _release_pre_provider_claim_despite_cancellation(
+        self,
+        claim: ClaimedCommunicationDelivery,
+    ) -> None:
+        try:
+            await self._finish_terminal_despite_cancellation(
+                self._release_pre_provider_claim(claim),
+                delivery_id=claim.delivery_id,
+            )
+        except CommunicationDeliveryLeaseLost:
+            # Another exact-lease transition already made the claim non-running.
+            return
+
+    async def _release_pre_provider_claim(
+        self,
+        claim: ClaimedCommunicationDelivery,
+    ) -> DeliveryFailureOutcome:
         async with self._bounded_db_operation():
             async with self._session_factory() as session:
-                await CommunicationDeliveryService.renew_lease(
+                outcome = await release_pre_provider_claim(
                     session,
                     delivery_id=claim.delivery_id,
                     worker_id=self._worker_id,
                     lease_token=claim.lease_token,
-                    lease_seconds=self._lease_seconds,
                 )
                 await session.commit()
+                return outcome
 
     @staticmethod
     async def _finish_terminal_despite_cancellation(

--- a/services/communications/dispatcher.py
+++ b/services/communications/dispatcher.py
@@ -16,6 +16,9 @@ from services.communications.delivery_materializer import (
     NoEligibleCommunicationRecipients,
 )
 from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.runtime_state import (
+    CommunicationRuntimeStateService,
+)
 from services.communications.template_registry import (
     CONSUMER_NAME,
     HANDLER_VERSION,
@@ -72,6 +75,11 @@ class CommunicationOutboxDispatcher:
         if scope.exact_event_id is not None:
             query = query.where(
                 IntegrationOutboxEvent.event_id == scope.exact_event_id
+            )
+        if scope.event_created_at_watermark is not None:
+            query = query.where(
+                IntegrationOutboxEvent.created_at
+                >= scope.event_created_at_watermark
             )
         if session.get_bind().dialect.name == "postgresql":
             query = query.with_for_update(skip_locked=True)
@@ -171,7 +179,11 @@ class CommunicationOutboxDispatcher:
             raise ConsumerInboxConsistencyError(
                 "Consumer inbox exists without materialized deliveries"
             )
-        if plan.audience in {"operations_canary", "staff_assignee"}:
+        if plan.audience in {
+            "installation_estimate_owners",
+            "operations_canary",
+            "staff_assignee",
+        }:
             expected_recipients = await CommunicationAudienceResolver.list_telegram(
                 session,
                 plan=plan,
@@ -186,7 +198,7 @@ class CommunicationOutboxDispatcher:
             }
             if actual_routing != expected_routing:
                 raise ConsumerInboxConsistencyError(
-                    "Canary inbox delivery recipients are inconsistent"
+                    "Exact-audience inbox delivery recipients are inconsistent"
                 )
         for delivery in deliveries:
             if (
@@ -227,7 +239,16 @@ class CommunicationOutboxDispatcher:
             raise ValueError("Communication dispatcher_id is required")
         if len(normalized_dispatcher_id) > 128:
             raise ValueError("Communication dispatcher_id is too long")
-        dispatch_time = now or cls._utc_now()
+        if (
+            now is None
+            and scope.mode == "all"
+            and session.get_bind().dialect.name == "postgresql"
+        ):
+            dispatch_time = await CommunicationRuntimeStateService.database_now(
+                session
+            )
+        else:
+            dispatch_time = now or cls._utc_now()
 
         event = await cls._select_next(
             session,

--- a/services/communications/installation_activation_fence.py
+++ b/services/communications/installation_activation_fence.py
@@ -1,0 +1,82 @@
+"""Commit-order fence for installation event enqueue and activation."""
+
+import asyncio
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT = (
+    "crm.installation_estimate_lead.created"
+)
+INSTALLATION_ACTIVATION_FENCE_LOCK = (
+    "mvn:communications:installation-estimate-activation"
+)
+INSTALLATION_ENQUEUE_FENCE_TIMEOUT_SECONDS = 1.0
+INSTALLATION_ENQUEUE_FENCE_POLL_SECONDS = 0.02
+
+
+class InstallationEventEnqueueFenceBusy(RuntimeError):
+    """A bounded target enqueue could not cross an active control fence."""
+
+    error_code = "installation_activation_fence_busy"
+
+    def __init__(self) -> None:
+        super().__init__(self.error_code)
+
+
+async def acquire_installation_enqueue_fence(
+    session: AsyncSession,
+) -> datetime:
+    """Take a shared fence and return the authoritative event creation time."""
+
+    if session.get_bind().dialect.name != "postgresql":
+        return datetime.now(timezone.utc)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + INSTALLATION_ENQUEUE_FENCE_TIMEOUT_SECONDS
+    while True:
+        acquired = await session.scalar(
+            text(
+                "SELECT pg_try_advisory_xact_lock_shared("
+                "hashtext(:lock_name))"
+            ),
+            {"lock_name": INSTALLATION_ACTIVATION_FENCE_LOCK},
+        )
+        if acquired is True:
+            break
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise InstallationEventEnqueueFenceBusy()
+        await asyncio.sleep(
+            min(INSTALLATION_ENQUEUE_FENCE_POLL_SECONDS, remaining)
+        )
+    value = await session.scalar(text("SELECT clock_timestamp()"))
+    if not isinstance(value, datetime):
+        raise TypeError("Database clock did not return a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def acquire_installation_activation_fence(
+    session: AsyncSession,
+) -> bool:
+    """Try to take the exclusive activation side of the commit-order fence.
+
+    Normal event enqueues share the lock and remain concurrent with each other.
+    A successful activation attempt temporarily excludes later timestamp
+    creation until its control transaction commits.
+
+    The operator command must never hang behind a stalled request transaction,
+    so this is deliberately a non-blocking attempt. The caller reports a fixed
+    blocker and can be rerun after the in-flight enqueue finishes.
+    """
+
+    if session.get_bind().dialect.name != "postgresql":
+        return True
+    acquired = await session.scalar(
+        text("SELECT pg_try_advisory_xact_lock(hashtext(:lock_name))"),
+        {"lock_name": INSTALLATION_ACTIVATION_FENCE_LOCK},
+    )
+    return acquired is True

--- a/services/communications/installation_notifications.py
+++ b/services/communications/installation_notifications.py
@@ -1,0 +1,631 @@
+"""Typed safety control for installation-estimate Telegram notifications."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func, or_, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    CommunicationRuntimeState,
+    IntegrationOutboxEvent,
+)
+from services.communications.canary_errors import CommunicationsCanarySafetyError
+from services.communications.installation_activation_fence import (
+    acquire_installation_activation_fence,
+)
+from services.communications.recipient_directory import (
+    InstallationEstimateOwnerRecipientDirectory,
+)
+from services.communications.runtime_config import CommunicationRuntimeConfig
+from services.communications.runtime_state import (
+    CommunicationRuntimeMode,
+    CommunicationRuntimeStateService,
+    CommunicationRuntimeStatus,
+)
+from services.communications.template_registry import (
+    INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+)
+from services.staff_user_service import StaffUserService
+
+
+class InstallationNotificationControlRejected(RuntimeError):
+    """Privacy-safe rejection suitable for operator output."""
+
+    def __init__(self, error_code: str) -> None:
+        self.error_code = str(error_code)
+        super().__init__(self.error_code)
+
+
+@dataclass(frozen=True)
+class InstallationNotificationInspection:
+    profile: str
+    cutoff: datetime
+    runtime_mode: str
+    runtime_status: str
+    control_revision: int
+    activation_watermark: datetime | None
+    owner_recipient_count: int
+    runtime_lock_owner_count: int | None
+    heartbeat_fresh: bool
+    backlog_count: int
+    running_count: int
+    ambiguous_nonterminal_count: int
+    ambiguous_terminal_count: int
+    ambiguous_total_count: int
+    outbox_status_counts: dict[str, int]
+    delivery_status_counts: dict[str, int]
+    attempt_outcome_counts: dict[str, int]
+    provider_ack_count: int
+    blockers: tuple[str, ...]
+
+    @property
+    def enable_allowed(self) -> bool:
+        return not self.blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "cutoff": self.cutoff.isoformat(),
+            "runtime_mode": self.runtime_mode,
+            "runtime_status": self.runtime_status,
+            "control_revision": self.control_revision,
+            "activation_watermark": (
+                self.activation_watermark.isoformat()
+                if self.activation_watermark is not None
+                else None
+            ),
+            "owner_recipient_count": self.owner_recipient_count,
+            "runtime_lock_owner_count": self.runtime_lock_owner_count,
+            "heartbeat_fresh": self.heartbeat_fresh,
+            "backlog_count": self.backlog_count,
+            "running_count": self.running_count,
+            "ambiguous_nonterminal_count": self.ambiguous_nonterminal_count,
+            "ambiguous_terminal_count": self.ambiguous_terminal_count,
+            "ambiguous_total_count": self.ambiguous_total_count,
+            "outbox_status_counts": dict(self.outbox_status_counts),
+            "delivery_status_counts": dict(self.delivery_status_counts),
+            "attempt_outcome_counts": dict(self.attempt_outcome_counts),
+            "provider_ack_count": self.provider_ack_count,
+            "enable_allowed": self.enable_allowed,
+            "blockers": list(self.blockers),
+        }
+
+
+class InstallationNotificationOperations:
+    """Inspect, activate, and emergency-disable one fixed website event."""
+
+    CHANNEL = "telegram"
+    EVENT_TYPE = INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT
+    NONTERMINAL_DELIVERY_STATUSES = ("queued", "retry", "running")
+    DRAINED_RUNTIME_STATUSES = frozenset(
+        {
+            CommunicationRuntimeStatus.DISABLED.value,
+            CommunicationRuntimeStatus.STOPPED.value,
+            CommunicationRuntimeStatus.PAUSED.value,
+            CommunicationRuntimeStatus.FAULTED.value,
+        }
+    )
+
+    @staticmethod
+    def deployment_profile(config: CommunicationRuntimeConfig) -> str:
+        if config.enabled and config.allow_all_mode:
+            return "active"
+        if config.enabled and not config.allow_all_mode:
+            return "canary"
+        if not config.enabled and not config.allow_all_mode:
+            return "dormant"
+        return "invalid"
+
+    @staticmethod
+    def _as_utc(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    @classmethod
+    async def _database_primary_blocker(
+        cls,
+        session: AsyncSession,
+    ) -> str | None:
+        if session.get_bind().dialect.name != "postgresql":
+            return "database_dialect_not_postgresql"
+        try:
+            async with session.begin_nested():
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT pg_is_in_recovery() AS in_recovery, "
+                            "current_setting('transaction_read_only') AS read_only, "
+                            "current_setting('transaction_isolation') "
+                            "AS isolation_level"
+                        )
+                    )
+                ).one()
+        except Exception:
+            return "database_writability_unknown"
+        if bool(row.in_recovery) or str(row.read_only).strip().lower() != "off":
+            return "database_not_writable_primary"
+        if str(row.isolation_level).strip().lower() != "read committed":
+            return "database_isolation_not_read_committed"
+        return None
+
+    @classmethod
+    async def _runtime_lock_owner_count(
+        cls,
+        session: AsyncSession,
+        *,
+        lock_name: str,
+    ) -> int | None:
+        if session.get_bind().dialect.name != "postgresql":
+            return None
+        async with session.begin_nested():
+            value = await session.scalar(
+                text(
+                    """
+                    WITH lock_key AS (
+                        SELECT hashtext(:lock_name)::bigint AS value
+                    )
+                    SELECT count(*)
+                    FROM pg_locks, lock_key
+                    WHERE locktype = 'advisory'
+                      AND granted
+                      AND classid = (((lock_key.value >> 32) & 4294967295)::oid)
+                      AND objid = ((lock_key.value & 4294967295)::oid)
+                      AND objsubid = 1
+                    """
+                ),
+                {"lock_name": lock_name},
+            )
+        return int(value or 0)
+
+    @classmethod
+    async def _backlog_count(
+        cls,
+        session: AsyncSession,
+        *,
+        cutoff: datetime | None,
+    ) -> int:
+        nonterminal_delivery_exists = (
+            select(CommunicationDelivery.delivery_id)
+            .where(
+                CommunicationDelivery.event_id
+                == IntegrationOutboxEvent.event_id,
+                CommunicationDelivery.status.in_(
+                    cls.NONTERMINAL_DELIVERY_STATUSES
+                ),
+            )
+            .exists()
+        )
+        statement = select(func.count(IntegrationOutboxEvent.event_id)).where(
+            IntegrationOutboxEvent.event_type == cls.EVENT_TYPE,
+            or_(
+                IntegrationOutboxEvent.status.in_(("pending", "processing")),
+                nonterminal_delivery_exists,
+            ),
+        )
+        if cutoff is not None:
+            statement = statement.where(
+                IntegrationOutboxEvent.created_at < cutoff
+            )
+        value = await session.scalar(statement)
+        return int(value or 0)
+
+    @classmethod
+    async def _running_count(
+        cls,
+        session: AsyncSession,
+        *,
+        cutoff: datetime | None,
+    ) -> int:
+        statement = (
+            select(
+                func.count(func.distinct(CommunicationDelivery.delivery_id))
+            )
+            .join(
+                IntegrationOutboxEvent,
+                IntegrationOutboxEvent.event_id
+                == CommunicationDelivery.event_id,
+            )
+            .outerjoin(
+                CommunicationDeliveryAttempt,
+                CommunicationDeliveryAttempt.delivery_id
+                == CommunicationDelivery.delivery_id,
+            )
+            .where(
+                IntegrationOutboxEvent.event_type == cls.EVENT_TYPE,
+                or_(
+                    CommunicationDelivery.status == "running",
+                    CommunicationDeliveryAttempt.outcome == "running",
+                ),
+            )
+        )
+        if cutoff is not None:
+            statement = statement.where(
+                IntegrationOutboxEvent.created_at < cutoff
+            )
+        return int((await session.scalar(statement)) or 0)
+
+    @classmethod
+    async def _ambiguous_count(
+        cls,
+        session: AsyncSession,
+        *,
+        cutoff: datetime | None,
+        delivery_statuses: tuple[str, ...] | None = None,
+    ) -> int:
+        statement = (
+            select(func.count(CommunicationDeliveryAttempt.delivery_id))
+            .join(
+                CommunicationDelivery,
+                CommunicationDelivery.delivery_id
+                == CommunicationDeliveryAttempt.delivery_id,
+            )
+            .join(
+                IntegrationOutboxEvent,
+                IntegrationOutboxEvent.event_id
+                == CommunicationDelivery.event_id,
+            )
+            .where(
+                IntegrationOutboxEvent.event_type == cls.EVENT_TYPE,
+                CommunicationDeliveryAttempt.ambiguous.is_(True),
+            )
+        )
+        if cutoff is not None:
+            statement = statement.where(
+                IntegrationOutboxEvent.created_at < cutoff
+            )
+        if delivery_statuses is not None:
+            statement = statement.where(
+                CommunicationDelivery.status.in_(delivery_statuses)
+            )
+        return int((await session.scalar(statement)) or 0)
+
+    @classmethod
+    async def _status_counts(
+        cls,
+        session: AsyncSession,
+    ) -> tuple[dict[str, int], dict[str, int], dict[str, int], int]:
+        outbox_statuses = ("pending", "processing", "published", "dead")
+        delivery_statuses = (
+            "queued",
+            "running",
+            "retry",
+            "sent",
+            "dead",
+            "canceled",
+        )
+        attempt_outcomes = ("running", "sent", "retry", "dead", "canceled")
+
+        outbox_rows = (
+            await session.execute(
+                select(
+                    IntegrationOutboxEvent.status,
+                    func.count(IntegrationOutboxEvent.event_id),
+                )
+                .where(IntegrationOutboxEvent.event_type == cls.EVENT_TYPE)
+                .group_by(IntegrationOutboxEvent.status)
+            )
+        ).all()
+        delivery_rows = (
+            await session.execute(
+                select(
+                    CommunicationDelivery.status,
+                    func.count(CommunicationDelivery.delivery_id),
+                )
+                .join(
+                    IntegrationOutboxEvent,
+                    IntegrationOutboxEvent.event_id
+                    == CommunicationDelivery.event_id,
+                )
+                .where(IntegrationOutboxEvent.event_type == cls.EVENT_TYPE)
+                .group_by(CommunicationDelivery.status)
+            )
+        ).all()
+        attempt_rows = (
+            await session.execute(
+                select(
+                    CommunicationDeliveryAttempt.outcome,
+                    func.count(),
+                )
+                .join(
+                    CommunicationDelivery,
+                    CommunicationDelivery.delivery_id
+                    == CommunicationDeliveryAttempt.delivery_id,
+                )
+                .join(
+                    IntegrationOutboxEvent,
+                    IntegrationOutboxEvent.event_id
+                    == CommunicationDelivery.event_id,
+                )
+                .where(IntegrationOutboxEvent.event_type == cls.EVENT_TYPE)
+                .group_by(CommunicationDeliveryAttempt.outcome)
+            )
+        ).all()
+        provider_ack_count = int(
+            (
+                await session.scalar(
+                    select(func.count(CommunicationDelivery.delivery_id))
+                    .join(
+                        IntegrationOutboxEvent,
+                        IntegrationOutboxEvent.event_id
+                        == CommunicationDelivery.event_id,
+                    )
+                    .where(
+                        IntegrationOutboxEvent.event_type == cls.EVENT_TYPE,
+                        CommunicationDelivery.status == "sent",
+                        CommunicationDelivery.provider_message_id.is_not(None),
+                    )
+                )
+            )
+            or 0
+        )
+        return (
+            {
+                status: int(dict(outbox_rows).get(status, 0))
+                for status in outbox_statuses
+            },
+            {
+                status: int(dict(delivery_rows).get(status, 0))
+                for status in delivery_statuses
+            },
+            {
+                outcome: int(dict(attempt_rows).get(outcome, 0))
+                for outcome in attempt_outcomes
+            },
+            provider_ack_count,
+        )
+
+    @classmethod
+    async def inspect(
+        cls,
+        session: AsyncSession,
+        *,
+        config: CommunicationRuntimeConfig,
+        bot_token: str | None,
+        runtime_locks_enabled: bool,
+        cutoff: datetime | None = None,
+        locked_state: CommunicationRuntimeState | None = None,
+    ) -> InstallationNotificationInspection:
+        inspection_time = cutoff or await CommunicationRuntimeStateService.database_now(
+            session
+        )
+        inspection_time = CommunicationRuntimeStateService._as_utc(
+            inspection_time
+        )
+        state = locked_state or await session.get(
+            CommunicationRuntimeState,
+            cls.CHANNEL,
+        )
+        blockers: list[str] = []
+        profile = cls.deployment_profile(config)
+        if profile != "active":
+            blockers.append("communications_active_profile_required")
+        if config.app_role != "primary":
+            blockers.append("app_role_not_primary")
+        normalized_token = str(bot_token or "").strip()
+        if (
+            not normalized_token
+            or normalized_token
+            == StaffUserService.DISABLED_BOT_TOKEN_PLACEHOLDER
+        ):
+            blockers.append("telegram_bot_token_missing")
+        if not runtime_locks_enabled:
+            blockers.append("runtime_database_locks_required")
+
+        database_blocker = await cls._database_primary_blocker(session)
+        if database_blocker is not None:
+            blockers.append(database_blocker)
+
+        owner_count = 0
+        try:
+            owner_count = len(
+                await InstallationEstimateOwnerRecipientDirectory.list_telegram(
+                    session
+                )
+            )
+        except CommunicationsCanarySafetyError as error:
+            blockers.append(error.error_code)
+
+        runtime_mode = "missing"
+        runtime_status = "missing"
+        control_revision = 0
+        watermark: datetime | None = None
+        heartbeat_fresh = False
+        if state is None:
+            blockers.append("communications_runtime_state_missing")
+        else:
+            runtime_mode = str(state.mode)
+            runtime_status = str(state.status)
+            control_revision = int(state.control_revision)
+            watermark = cls._as_utc(
+                state.installation_estimate_watermark_at
+            )
+            if watermark is not None and watermark > inspection_time:
+                blockers.append("installation_activation_watermark_invalid")
+            if runtime_mode != CommunicationRuntimeMode.OFF.value:
+                blockers.append("communications_runtime_mode_not_off")
+            if runtime_status != CommunicationRuntimeStatus.DISABLED.value:
+                blockers.append("communications_runtime_not_dormant")
+            heartbeat = cls._as_utc(state.heartbeat_at)
+            heartbeat_age = (
+                (inspection_time - heartbeat).total_seconds()
+                if heartbeat is not None
+                else None
+            )
+            max_age = max(30.0, 3.0 * config.heartbeat_seconds)
+            heartbeat_fresh = bool(
+                state.instance_id
+                and heartbeat_age is not None
+                and 0 <= heartbeat_age <= max_age
+            )
+            if not heartbeat_fresh:
+                blockers.append("communications_runtime_owner_not_fresh")
+
+        try:
+            lock_owner_count = await cls._runtime_lock_owner_count(
+                session,
+                lock_name=config.lock_name,
+            )
+        except Exception:
+            lock_owner_count = None
+            blockers.append("communications_runtime_lock_ownership_unknown")
+        if lock_owner_count != 1:
+            blockers.append("communications_runtime_owner_count_invalid")
+
+        backlog_count = await cls._backlog_count(
+            session,
+            cutoff=None,
+        )
+        running_count = await cls._running_count(
+            session,
+            cutoff=None,
+        )
+        ambiguous_total = await cls._ambiguous_count(
+            session,
+            cutoff=None,
+        )
+        ambiguous_nonterminal = await cls._ambiguous_count(
+            session,
+            cutoff=None,
+            delivery_statuses=cls.NONTERMINAL_DELIVERY_STATUSES,
+        )
+        ambiguous_terminal = max(
+            0,
+            ambiguous_total - ambiguous_nonterminal,
+        )
+        (
+            outbox_status_counts,
+            delivery_status_counts,
+            attempt_outcome_counts,
+            provider_ack_count,
+        ) = await cls._status_counts(session)
+        if backlog_count:
+            blockers.append("installation_backlog_not_reconciled")
+        if running_count:
+            blockers.append("installation_delivery_running")
+        if ambiguous_nonterminal:
+            blockers.append("installation_ambiguous_outcomes_unreconciled")
+
+        return InstallationNotificationInspection(
+            profile=profile,
+            cutoff=inspection_time,
+            runtime_mode=runtime_mode,
+            runtime_status=runtime_status,
+            control_revision=control_revision,
+            activation_watermark=watermark,
+            owner_recipient_count=owner_count,
+            runtime_lock_owner_count=lock_owner_count,
+            heartbeat_fresh=heartbeat_fresh,
+            backlog_count=backlog_count,
+            running_count=running_count,
+            ambiguous_nonterminal_count=ambiguous_nonterminal,
+            ambiguous_terminal_count=ambiguous_terminal,
+            ambiguous_total_count=ambiguous_total,
+            outbox_status_counts=outbox_status_counts,
+            delivery_status_counts=delivery_status_counts,
+            attempt_outcome_counts=attempt_outcome_counts,
+            provider_ack_count=provider_ack_count,
+            blockers=tuple(dict.fromkeys(blockers)),
+        )
+
+    @classmethod
+    async def activate_installation_from_off(
+        cls,
+        session: AsyncSession,
+        *,
+        config: CommunicationRuntimeConfig,
+        bot_token: str | None,
+        runtime_locks_enabled: bool,
+    ) -> tuple[InstallationNotificationInspection, int, datetime]:
+        """Atomically prove safety and arm the immutable ``all`` scope."""
+
+        state = await CommunicationRuntimeStateService._lock_state(
+            session,
+            channel=cls.CHANNEL,
+        )
+        # Serialize with target event creation before reading the DB cutoff.
+        # Fail fast instead of hanging an operator behind a stalled enqueue;
+        # rerunning after that transaction finishes inventories its event.
+        if not await acquire_installation_activation_fence(session):
+            raise InstallationNotificationControlRejected(
+                "installation_activation_fence_busy"
+            )
+        cutoff = await CommunicationRuntimeStateService.database_now(session)
+        inspection = await cls.inspect(
+            session,
+            config=config,
+            bot_token=bot_token,
+            runtime_locks_enabled=runtime_locks_enabled,
+            cutoff=cutoff,
+            locked_state=state,
+        )
+        if inspection.blockers:
+            raise InstallationNotificationControlRejected(
+                inspection.blockers[0]
+            )
+
+        # This timestamp is a one-way event horizon. Emergency ``off`` retains
+        # it, and a reviewed re-enable reuses it after proving the entire newer
+        # backlog safe; no operator argument can move it backwards or forwards.
+        watermark = inspection.activation_watermark or inspection.cutoff
+        CommunicationRuntimeStateService._apply_control(
+            state,
+            mode=CommunicationRuntimeMode.ALL,
+            canary_run_id=None,
+            now=inspection.cutoff,
+            installation_estimate_watermark_at=watermark,
+        )
+        await session.flush()
+        return inspection, int(state.control_revision), watermark
+
+    @classmethod
+    async def wait_until_off_drained(
+        cls,
+        session_factory,
+        *,
+        wait_seconds: float = 30.0,
+        poll_seconds: float = 0.25,
+    ) -> dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(0.0, min(float(wait_seconds), 60.0))
+        while True:
+            async with session_factory() as session:
+                state = await session.get(
+                    CommunicationRuntimeState,
+                    cls.CHANNEL,
+                )
+                mode = str(state.mode) if state is not None else "missing"
+                status = str(state.status) if state is not None else "missing"
+                running_count = await cls._running_count(
+                    session,
+                    cutoff=None,
+                )
+                ambiguous_count = await cls._ambiguous_count(
+                    session,
+                    cutoff=None,
+                )
+                await session.rollback()
+            drained = (
+                mode == CommunicationRuntimeMode.OFF.value
+                and status in cls.DRAINED_RUNTIME_STATUSES
+                and running_count == 0
+            )
+            if drained or loop.time() >= deadline:
+                return {
+                    "drained": drained,
+                    "runtime_mode": mode,
+                    "runtime_status": status,
+                    "running_delivery_count": running_count,
+                    "ambiguous_total_count": ambiguous_count,
+                }
+            await asyncio.sleep(max(0.05, min(float(poll_seconds), 1.0)))

--- a/services/communications/outbox_service.py
+++ b/services/communications/outbox_service.py
@@ -17,6 +17,10 @@ from sqlmodel import select
 
 from models import IntegrationOutboxEvent
 from services.communications.contracts import IntegrationEventEnvelopeV1
+from services.communications.installation_activation_fence import (
+    INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+    acquire_installation_enqueue_fence,
+)
 
 
 class OutboxEventConflictError(ValueError):
@@ -157,6 +161,14 @@ class IntegrationOutboxService:
 
         normalized_payload = cls._normalize_payload(payload)
         normalized_event_type = str(event_type).strip()
+        authoritative_created_at: datetime | None = None
+        if normalized_event_type == INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT:
+            # Acquire before constructing the model: its ``created_at`` default
+            # must be a DB timestamp ordered after any committed activation
+            # watermark that won the exclusive side of this fence.
+            authoritative_created_at = (
+                await acquire_installation_enqueue_fence(session)
+            )
         normalized_aggregate_type = str(aggregate_type).strip()
         normalized_aggregate_id = str(aggregate_id).strip()
         normalized_idempotency_key = (
@@ -173,6 +185,11 @@ class IntegrationOutboxService:
             idempotency_key=normalized_idempotency_key,
         )
         event_id = cls.build_event_id(deduplication_key)
+        normalized_occurred_at = (
+            occurred_at
+            or authoritative_created_at
+            or datetime.now(timezone.utc)
+        )
         envelope = IntegrationEventEnvelopeV1(
             event_id=event_id,
             event_type=normalized_event_type,
@@ -180,7 +197,7 @@ class IntegrationOutboxService:
             aggregate_type=normalized_aggregate_type,
             aggregate_id=normalized_aggregate_id,
             aggregate_version=aggregate_version,
-            occurred_at=occurred_at or datetime.now(timezone.utc),
+            occurred_at=normalized_occurred_at,
             actor_id=actor_id,
             correlation_id=correlation_id,
             causation_id=causation_id,
@@ -214,6 +231,14 @@ class IntegrationOutboxService:
             max_attempts=max(1, int(max_attempts)),
             occurred_at=envelope.occurred_at,
             available_at=envelope.occurred_at,
+            **(
+                {
+                    "created_at": authoritative_created_at,
+                    "updated_at": authoritative_created_at,
+                }
+                if authoritative_created_at is not None
+                else {}
+            ),
         )
         dialect_name = session.get_bind().dialect.name
         event_values = event.model_dump()

--- a/services/communications/processing_scope.py
+++ b/services/communications/processing_scope.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Literal
 
 from services.communications.canary_run_id import normalize_canary_run_id
@@ -39,6 +40,7 @@ class CommunicationProcessingScope:
     delivery_template_keys: tuple[str, ...]
     exact_event_id: str | None = None
     canary_run_id: str | None = None
+    event_created_at_watermark: datetime | None = None
 
     def __post_init__(self) -> None:
         if self.mode not in {"canary", "all", "staff_bot"}:
@@ -54,7 +56,11 @@ class CommunicationProcessingScope:
         if len(set(self.delivery_template_keys)) != len(self.delivery_template_keys):
             raise ValueError("Communication template scope contains duplicates")
         if self.mode == "canary":
-            if self.canary_run_id is None or self.exact_event_id is None:
+            if (
+                self.canary_run_id is None
+                or self.exact_event_id is None
+                or self.event_created_at_watermark is not None
+            ):
                 raise ValueError("Canary processing scope requires an exact run")
             normalized_run_id = normalize_canary_run_id(self.canary_run_id)
             if (
@@ -68,17 +74,25 @@ class CommunicationProcessingScope:
             if (
                 self.canary_run_id is not None
                 or self.exact_event_id is not None
+                or self.event_created_at_watermark is not None
                 or self.outbox_event_types != STAFF_BOT_EVENT_TYPES
                 or self.delivery_template_keys != STAFF_BOT_TEMPLATE_KEYS
             ):
                 raise ValueError("Staff bot processing scope allowlist is inconsistent")
-        elif (
-            self.canary_run_id is not None
-            or self.exact_event_id is not None
-            or self.outbox_event_types != ALL_EVENT_TYPES
-            or self.delivery_template_keys != ALL_TEMPLATE_KEYS
-        ):
-            raise ValueError("Full processing scope allowlist is inconsistent")
+        else:
+            watermark = self.event_created_at_watermark
+            if (
+                self.canary_run_id is not None
+                or self.exact_event_id is not None
+                or self.outbox_event_types != ALL_EVENT_TYPES
+                or self.delivery_template_keys != ALL_TEMPLATE_KEYS
+                or watermark is None
+                or watermark.tzinfo is None
+                or watermark.utcoffset() is None
+            ):
+                raise ValueError("Full processing scope allowlist is inconsistent")
+            if watermark.utcoffset() != timedelta(0):
+                raise ValueError("Full processing watermark must be normalized to UTC")
 
     @classmethod
     def canary(
@@ -98,7 +112,12 @@ class CommunicationProcessingScope:
         )
 
     @classmethod
-    def all(cls, *, control_revision: int) -> "CommunicationProcessingScope":
+    def all(
+        cls,
+        *,
+        control_revision: int,
+        event_created_at_watermark: datetime,
+    ) -> "CommunicationProcessingScope":
         # Keep this list explicit: adding a renderer must never widen runtime
         # delivery without a separately reviewed rollout change.
         return cls(
@@ -106,6 +125,7 @@ class CommunicationProcessingScope:
             control_revision=control_revision,
             outbox_event_types=ALL_EVENT_TYPES,
             delivery_template_keys=ALL_TEMPLATE_KEYS,
+            event_created_at_watermark=event_created_at_watermark,
         )
 
     @classmethod
@@ -123,9 +143,14 @@ class CommunicationProcessingScope:
         mode: str,
         canary_run_id: str | None,
         control_revision: int,
+        event_created_at_watermark: datetime | None = None,
     ) -> bool:
         return (
             self.mode == mode
             and self.canary_run_id == canary_run_id
             and self.control_revision == int(control_revision)
+            and (
+                self.mode != "all"
+                or self.event_created_at_watermark == event_created_at_watermark
+            )
         )

--- a/services/communications/providers/base.py
+++ b/services/communications/providers/base.py
@@ -9,6 +9,7 @@ class ProviderDeliveryDisposition(str, Enum):
     SENT = "sent"
     TRANSIENT_FAILURE = "transient_failure"
     PERMANENT_FAILURE = "permanent_failure"
+    AMBIGUOUS_FAILURE = "ambiguous_failure"
     PROVIDER_UNAVAILABLE = "provider_unavailable"
 
 
@@ -58,6 +59,23 @@ class ProviderDeliveryResult:
     ) -> "ProviderDeliveryResult":
         return cls(
             disposition=ProviderDeliveryDisposition.PERMANENT_FAILURE,
+            error_category=category,
+            error_code=code,
+            error_message=message,
+        )
+
+    @classmethod
+    def ambiguous_failure(
+        cls,
+        *,
+        category: str,
+        code: str,
+        message: str,
+    ) -> "ProviderDeliveryResult":
+        """Record an outcome that may have crossed the provider boundary."""
+
+        return cls(
+            disposition=ProviderDeliveryDisposition.AMBIGUOUS_FAILURE,
             error_category=category,
             error_code=code,
             error_message=message,

--- a/services/communications/providers/telegram.py
+++ b/services/communications/providers/telegram.py
@@ -115,22 +115,24 @@ class TelegramDeliveryProvider:
                 message="Telegram rejected the delivery request",
             )
         except (TelegramUnauthorizedError, TelegramConflictError):
-            return ProviderDeliveryResult.provider_unavailable(
+            return ProviderDeliveryResult.permanent_failure(
+                category="provider",
                 code="telegram_provider_auth_or_conflict",
                 message="Telegram provider authentication or ownership is unavailable",
-                retry_after_seconds=300,
             )
         except (TelegramNetworkError, TelegramServerError, TimeoutError):
-            return ProviderDeliveryResult.transient_failure(
+            return ProviderDeliveryResult.ambiguous_failure(
                 category="network",
                 code="telegram_network_error",
-                message="Telegram network request failed",
+                message=(
+                    "Telegram network outcome requires manual reconciliation"
+                ),
             )
         except TelegramAPIError:
-            return ProviderDeliveryResult.transient_failure(
+            return ProviderDeliveryResult.ambiguous_failure(
                 category="provider",
                 code="telegram_api_error",
-                message="Telegram API returned an unexpected error",
+                message="Telegram API outcome requires manual reconciliation",
             )
         except asyncio.CancelledError:
             raise
@@ -141,8 +143,8 @@ class TelegramDeliveryProvider:
                 normalized_delivery_id,
                 type(exc).__name__,
             )
-            return ProviderDeliveryResult.transient_failure(
+            return ProviderDeliveryResult.ambiguous_failure(
                 category="provider",
                 code="telegram_unexpected_error",
-                message="Telegram provider failed unexpectedly",
+                message="Telegram provider outcome requires manual reconciliation",
             )

--- a/services/communications/recipient_directory.py
+++ b/services/communications/recipient_directory.py
@@ -72,6 +72,68 @@ class ManagementRecipientDirectory:
         return recipients
 
 
+class InstallationEstimateOwnerRecipientDirectory:
+    """Resolve every active owner from StaffUser, or fail closed.
+
+    This production audience deliberately has no manager or ``ADMIN_IDS``
+    compatibility fallback. One malformed active owner invalidates the whole
+    routing snapshot so a partial recipient set can never be materialized.
+    """
+
+    @classmethod
+    async def list_telegram(
+        cls,
+        session: AsyncSession,
+    ) -> list[CommunicationRecipientV1]:
+        result = await session.execute(select(StaffUser).order_by(StaffUser.id.asc()))
+        active_owners = [
+            staff_user
+            for staff_user in result.scalars().all()
+            if staff_user.status == StaffUserService.STATUS_ACTIVE
+            and staff_user.primary_role == StaffUserService.ROLE_OWNER
+        ]
+        if not active_owners:
+            raise CommunicationsCanarySafetyError(
+                "installation_owner_recipient_count_invalid"
+            )
+
+        recipients: list[CommunicationRecipientV1] = []
+        recipient_keys: set[str] = set()
+        destinations: set[str] = set()
+        for staff_user in active_owners:
+            if staff_user.id is None or staff_user.telegram_id is None:
+                raise CommunicationsCanarySafetyError(
+                    "installation_owner_recipient_invalid"
+                )
+            try:
+                telegram_id = int(staff_user.telegram_id)
+            except (TypeError, ValueError, OverflowError):
+                raise CommunicationsCanarySafetyError(
+                    "installation_owner_recipient_invalid"
+                ) from None
+            if telegram_id <= 0:
+                raise CommunicationsCanarySafetyError(
+                    "installation_owner_recipient_invalid"
+                )
+            recipient_key = f"staff:{int(staff_user.id)}"
+            destination = str(telegram_id)
+            if recipient_key in recipient_keys or destination in destinations:
+                raise CommunicationsCanarySafetyError(
+                    "installation_owner_recipient_duplicate"
+                )
+            recipient_keys.add(recipient_key)
+            destinations.add(destination)
+            recipients.append(
+                CommunicationRecipientV1(
+                    recipient_key=recipient_key,
+                    destination=destination,
+                    source="staff",
+                    staff_user_id=int(staff_user.id),
+                )
+            )
+        return recipients
+
+
 class OperationsCanaryRecipientDirectory:
     """Resolve one immutable pair of active owner StaffUsers, or fail closed."""
 

--- a/services/communications/runtime_pipeline.py
+++ b/services/communications/runtime_pipeline.py
@@ -93,6 +93,14 @@ class CommunicationRuntimePipeline:
             scope=scope,
             lease_seconds=self._config.lease_seconds,
             safety_check=lambda: self._safety_check(scope),
+            provider_boundary_check=lambda session: (
+                CommunicationRuntimeStateService.lock_owned_processing_scope(
+                    session,
+                    channel=self._config.channel,
+                    instance_id=self._config.instance_id,
+                    scope=scope,
+                )
+            ),
             db_operation_timeout_seconds=self._config.db_probe_timeout_seconds,
         )
 
@@ -152,9 +160,20 @@ class CommunicationRuntimePipeline:
             if not self._config.allow_all_mode:
                 await self._pause_for_mode(control.mode)
                 return None
-            return CommunicationProcessingScope.all(
-                control_revision=control.control_revision
-            )
+            try:
+                return CommunicationProcessingScope.all(
+                    control_revision=control.control_revision,
+                    event_created_at_watermark=(
+                        control.installation_estimate_watermark_at
+                    ),
+                )
+            except (TypeError, ValueError):
+                await self._close_provider()
+                await self._record_status(
+                    CommunicationRuntimeStatus.PAUSED,
+                    last_error_code="installation_activation_watermark_invalid",
+                )
+                return None
         try:
             return CommunicationProcessingScope.canary(
                 run_id=control.canary_run_id or "",

--- a/services/communications/runtime_state.py
+++ b/services/communications/runtime_state.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 
-from sqlalchemy import update
+from sqlalchemy import func, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from models import CommunicationRuntimeState
 from services.communications.canary_run_id import normalize_canary_run_id
@@ -62,6 +63,7 @@ class CommunicationRuntimeControl:
     status: CommunicationRuntimeStatus
     instance_id: str | None
     heartbeat_at: datetime | None
+    installation_estimate_watermark_at: datetime | None
 
 
 class CommunicationRuntimeStateService:
@@ -75,6 +77,26 @@ class CommunicationRuntimeStateService:
     @staticmethod
     def _now() -> datetime:
         return datetime.now(timezone.utc)
+
+    @classmethod
+    async def database_now(cls, session: AsyncSession) -> datetime:
+        clock = (
+            func.clock_timestamp()
+            if session.get_bind().dialect.name == "postgresql"
+            else func.current_timestamp()
+        )
+        value = (await session.execute(select(clock))).scalar_one()
+        return cls._as_utc(value)
+
+    @staticmethod
+    def _as_utc(value: object) -> datetime:
+        if isinstance(value, str):
+            value = datetime.fromisoformat(value.replace(" ", "T"))
+        if not isinstance(value, datetime):
+            raise TypeError("Database clock did not return a datetime")
+        if value.tzinfo is None or value.utcoffset() is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
     @staticmethod
     def _normalize_channel(channel: str) -> str:
@@ -116,6 +138,7 @@ class CommunicationRuntimeStateService:
             mode=CommunicationRuntimeMode.OFF.value,
             canary_run_id=None,
             control_revision=0,
+            installation_estimate_watermark_at=None,
             status=CommunicationRuntimeStatus.STOPPED.value,
             control_updated_at=now,
             created_at=now,
@@ -180,11 +203,37 @@ class CommunicationRuntimeStateService:
         *,
         mode: CommunicationRuntimeMode,
         canary_run_id: str | None,
+        now: datetime,
+        installation_estimate_watermark_at: datetime | None,
     ) -> None:
-        now = cls._now()
+        current_watermark = (
+            cls._as_utc(state.installation_estimate_watermark_at)
+            if state.installation_estimate_watermark_at is not None
+            else None
+        )
+        requested_watermark = (
+            cls._as_utc(installation_estimate_watermark_at)
+            if installation_estimate_watermark_at is not None
+            else None
+        )
+        if (
+            current_watermark is not None
+            and requested_watermark != current_watermark
+        ):
+            raise CommunicationRuntimeControlConflict(
+                "installation_activation_watermark_immutable"
+            )
+        if (
+            mode == CommunicationRuntimeMode.ALL
+            and requested_watermark is None
+        ):
+            raise CommunicationRuntimeControlConflict(
+                "installation_activation_watermark_required"
+            )
         state.mode = mode.value
         state.canary_run_id = canary_run_id
         state.control_revision = int(state.control_revision) + 1
+        state.installation_estimate_watermark_at = requested_watermark
         state.control_updated_at = now
         state.updated_at = now
 
@@ -198,6 +247,10 @@ class CommunicationRuntimeStateService:
         canary_run_id: str | None = None,
     ) -> CommunicationRuntimeControl:
         normalized_mode = CommunicationRuntimeMode(mode)
+        if normalized_mode == CommunicationRuntimeMode.ALL:
+            raise CommunicationRuntimeControlConflict(
+                "installation_activation_requires_typed_control"
+            )
         normalized_run_id = cls._normalize_canary_scope(
             normalized_mode,
             canary_run_id,
@@ -213,10 +266,15 @@ class CommunicationRuntimeStateService:
             raise CommunicationRuntimeControlConflict(
                 "runtime_control_transition_requires_off"
             )
+        now = await cls.database_now(session)
         cls._apply_control(
             state,
             mode=normalized_mode,
             canary_run_id=normalized_run_id,
+            now=now,
+            installation_estimate_watermark_at=(
+                state.installation_estimate_watermark_at
+            ),
         )
         await session.flush()
         return cls._to_control(state)
@@ -233,10 +291,15 @@ class CommunicationRuntimeStateService:
         state = await cls._lock_state(session, channel=channel)
         if CommunicationRuntimeMode(state.mode) != CommunicationRuntimeMode.OFF:
             raise CommunicationRuntimeControlConflict("canary_runtime_not_off")
+        now = await cls.database_now(session)
         cls._apply_control(
             state,
             mode=CommunicationRuntimeMode.CANARY,
             canary_run_id=normalized_run_id,
+            now=now,
+            installation_estimate_watermark_at=(
+                state.installation_estimate_watermark_at
+            ),
         )
         await session.flush()
         return cls._to_control(state)
@@ -308,6 +371,42 @@ class CommunicationRuntimeStateService:
             mode=control.mode.value,
             canary_run_id=control.canary_run_id,
             control_revision=control.control_revision,
+            event_created_at_watermark=(
+                control.installation_estimate_watermark_at
+            ),
+        ):
+            raise CommunicationRuntimeModeBlocked(
+                control.mode,
+                canary_run_id=control.canary_run_id,
+                control_revision=control.control_revision,
+            )
+        return control
+
+    @classmethod
+    async def lock_owned_processing_scope(
+        cls,
+        session: AsyncSession,
+        *,
+        channel: str,
+        instance_id: str,
+        scope: CommunicationProcessingScope,
+    ) -> CommunicationRuntimeControl:
+        """Linearize the provider boundary against operator control changes."""
+
+        normalized_instance_id = cls._normalize_instance_id(instance_id)
+        state = await cls._lock_state(session, channel=channel)
+        if state.instance_id != normalized_instance_id:
+            raise CommunicationRuntimeStateOwnershipLost(
+                "Communication runtime state ownership was lost"
+            )
+        control = cls._to_control(state)
+        if not scope.matches_control(
+            mode=control.mode.value,
+            canary_run_id=control.canary_run_id,
+            control_revision=control.control_revision,
+            event_created_at_watermark=(
+                control.installation_estimate_watermark_at
+            ),
         ):
             raise CommunicationRuntimeModeBlocked(
                 control.mode,
@@ -362,4 +461,11 @@ class CommunicationRuntimeStateService:
             status=CommunicationRuntimeStatus(state.status),
             instance_id=state.instance_id,
             heartbeat_at=state.heartbeat_at,
+            installation_estimate_watermark_at=(
+                CommunicationRuntimeStateService._as_utc(
+                    state.installation_estimate_watermark_at
+                )
+                if state.installation_estimate_watermark_at is not None
+                else None
+            ),
         )

--- a/services/communications/template_registry.py
+++ b/services/communications/template_registry.py
@@ -11,6 +11,9 @@ from services.communications.contracts import (
     PublicOrderCreatedPayloadV1,
     TelegramCanaryRequestedPayloadV1,
 )
+from services.communications.installation_activation_fence import (
+    INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+)
 from services.communications.outbox_service import IntegrationOutboxService
 from services.communications.templates.operations import render_telegram_canary_v1
 from services.communications.templates.website import (
@@ -31,7 +34,6 @@ from services.communications.staff_task_templates import (
 
 PUBLIC_ORDER_CREATED_EVENT = "crm.public_order.created"
 PUBLIC_CONTACT_LEAD_CREATED_EVENT = "crm.public_contact_lead.created"
-INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT = "crm.installation_estimate_lead.created"
 TELEGRAM_CANARY_REQUESTED_EVENT = "ops.communications.telegram_canary.requested"
 TELEGRAM_CANARY_AGGREGATE_TYPE = "communications_canary"
 TELEGRAM_CANARY_AGGREGATE_VERSION = 1
@@ -119,7 +121,7 @@ class WebsiteTemplateRegistry:
                 payload = InstallationEstimateLeadCreatedPayloadV1.model_validate(
                     render_context
                 )
-                audience = "management"
+                audience = "installation_estimate_owners"
             elif template_key == TELEGRAM_CANARY_TEMPLATE_KEY:
                 payload = TelegramCanaryRequestedPayloadV1.model_validate(
                     render_context

--- a/services/installation_estimate_lead_service.py
+++ b/services/installation_estimate_lead_service.py
@@ -27,6 +27,9 @@ from services.communications.contracts import (
     InstallationEstimateLeadCreatedPayloadV1,
 )
 from services.communications.outbox_service import IntegrationOutboxService
+from services.communications.installation_activation_fence import (
+    InstallationEventEnqueueFenceBusy,
+)
 from services.communications.template_registry import (
     INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
 )
@@ -42,6 +45,10 @@ logger = logging.getLogger(__name__)
 
 
 class InstallationEstimateIdempotencyConflict(ValueError):
+    pass
+
+
+class InstallationEstimateTemporarilyUnavailable(RuntimeError):
     pass
 
 
@@ -284,13 +291,17 @@ class InstallationEstimateLeadService:
             if existing is None:
                 raise
             return cls._replay_response(existing, payload_hash=payload_hash)
-        except Exception:
+        except Exception as exc:
             await session.rollback()
             await cls._cleanup_failed_uploads(
                 session,
                 storage=selected_storage,
                 storage_keys=created_storage_keys,
             )
+            if isinstance(exc, InstallationEventEnqueueFenceBusy):
+                raise InstallationEstimateTemporarilyUnavailable(
+                    "installation_estimate_temporarily_unavailable"
+                ) from exc
             raise
 
         return InstallationEstimateLeadResponse(

--- a/tests/integration/test_communication_delivery_concurrency.py
+++ b/tests/integration/test_communication_delivery_concurrency.py
@@ -29,7 +29,10 @@ from services.communications.template_registry import (
     telegram_canary_event_id,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 RUN_ID_A = "123e4567-e89b-42d3-a456-426614174000"
 RUN_ID_B = "123e4567-e89b-42d3-a456-426614174001"
 
@@ -278,7 +281,9 @@ async def test_postgres_concurrent_recovery_skips_locked_expired_delivery(
             timeout=3,
         )
         assert recovery_a.retry_count == 1
+        assert recovery_a.dead_count == 0
         assert recovery_b.retry_count == 1
+        assert recovery_b.dead_count == 0
         await session_b.commit()
         await session_a.commit()
 
@@ -299,8 +304,8 @@ async def test_postgres_concurrent_recovery_skips_locked_expired_delivery(
         assert all(
             attempt is not None
             and attempt.outcome == "retry"
-            and attempt.error_code == "lease_expired"
-            and attempt.ambiguous is True
+            and attempt.error_code == "lease_expired_before_provider"
+            and attempt.ambiguous is False
             for attempt in attempts
         )
 
@@ -476,7 +481,7 @@ async def test_postgres_canary_scope_isolates_claim_and_recovery_mixed_queue(
 
 
 @pytest.mark.asyncio
-async def test_postgres_recovery_rotates_token_and_fences_stale_attempt(
+async def test_postgres_pre_provider_recovery_fences_stale_lease_and_retries(
     communication_db_engine,
 ):
     assert communication_db_engine.dialect.name == "postgresql"
@@ -492,10 +497,12 @@ async def test_postgres_recovery_rotates_token_and_fences_stale_attempt(
     async with factory() as session:
         recovery = await CommunicationDeliveryService.recover_expired_leases(session, scope=ALL_SCOPE)
         assert recovery.retry_count == 1
+        assert recovery.dead_count == 0
         await session.commit()
         recovered = await session.get(CommunicationDelivery, f"{1:032x}")
         assert recovered is not None
-        retry_at = recovered.available_at
+        assert recovered.status == "retry"
+        due_at = recovered.available_at
 
     async with factory() as session:
         claim = await CommunicationDeliveryService.claim_next(
@@ -503,47 +510,32 @@ async def test_postgres_recovery_rotates_token_and_fences_stale_attempt(
             scope=ALL_SCOPE,
             worker_id=stale_worker,
             lease_seconds=60,
-            now=retry_at,
+            now=due_at + timedelta(seconds=1),
         )
         assert claim is not None
-        assert claim.lease_token != stale_token
         assert claim.attempts == 2
-        await session.commit()
+        await session.rollback()
 
     async with factory() as session:
         with pytest.raises(CommunicationDeliveryLeaseLost):
             await CommunicationDeliveryService.mark_sent(
                 session,
-                delivery_id=claim.delivery_id,
+                delivery_id=f"{1:032x}",
                 worker_id=stale_worker,
                 lease_token=stale_token,
                 provider_message_id="stale-message",
-                now=retry_at + timedelta(seconds=1),
             )
         await session.rollback()
 
     async with factory() as session:
-        await CommunicationDeliveryService.mark_sent(
-            session,
-            delivery_id=claim.delivery_id,
-            worker_id=stale_worker,
-            lease_token=claim.lease_token,
-            provider_message_id="current-message",
-            now=retry_at + timedelta(seconds=1),
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (f"{1:032x}", 1),
         )
-        await session.commit()
-        attempts = [
-            await session.get(
-                CommunicationDeliveryAttempt,
-                (claim.delivery_id, attempt_no),
-            )
-            for attempt_no in (1, 2)
-        ]
-        assert [attempt.outcome for attempt in attempts if attempt is not None] == [
-            "retry",
-            "sent",
-        ]
-        assert attempts[0] is not None and attempts[0].ambiguous is True
+        assert attempt is not None
+        assert attempt.outcome == "retry"
+        assert attempt.error_code == "lease_expired_before_provider"
+        assert attempt.ambiguous is False
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_communication_provider_boundary_postgres.py
+++ b/tests/integration/test_communication_provider_boundary_postgres.py
@@ -1,0 +1,342 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    CommunicationRuntimeState,
+)
+from services.communications.delivery_service import CommunicationDeliveryService
+from services.communications.delivery_worker import CommunicationDeliveryWorker
+from services.communications.installation_notifications import (
+    InstallationNotificationOperations,
+)
+from services.communications.providers.base import ProviderDeliveryResult
+from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.runtime_state import (
+    CommunicationRuntimeMode,
+    CommunicationRuntimeModeBlocked,
+    CommunicationRuntimeStateService,
+)
+from tests.integration.test_communication_delivery_concurrency import (
+    ALL_SCOPE,
+    _seed_deliveries,
+    communication_db_engine,
+)
+from tests.unit.test_communication_delivery_worker import (
+    RecordingProvider,
+    _seed_delivery,
+)
+
+
+RUNTIME_INSTANCE_ID = "provider-boundary-runtime"
+
+
+async def _seed_owned_all_runtime(factory) -> CommunicationProcessingScope:
+    async with factory() as session:
+        state = await CommunicationRuntimeStateService.ensure_state(
+            session,
+            channel="telegram",
+        )
+        watermark = await CommunicationRuntimeStateService.database_now(session)
+        CommunicationRuntimeStateService._apply_control(
+            state,
+            mode=CommunicationRuntimeMode.ALL,
+            canary_run_id=None,
+            now=watermark,
+            installation_estimate_watermark_at=watermark,
+        )
+        state.status = "running"
+        state.instance_id = RUNTIME_INSTANCE_ID
+        await session.flush()
+        control = CommunicationRuntimeStateService._to_control(state)
+        await session.commit()
+    assert control.installation_estimate_watermark_at is not None
+    return CommunicationProcessingScope.all(
+        control_revision=control.control_revision,
+        event_created_at_watermark=control.installation_estimate_watermark_at,
+    )
+
+
+async def _switch_runtime_off(factory) -> None:
+    async with factory() as session:
+        await CommunicationRuntimeStateService.set_mode(
+            session,
+            channel="telegram",
+            mode=CommunicationRuntimeMode.OFF,
+        )
+        await session.commit()
+
+
+def _runtime_boundary_check(scope):
+    async def check(session):
+        await CommunicationRuntimeStateService.lock_owned_processing_scope(
+            session,
+            channel="telegram",
+            instance_id=RUNTIME_INSTANCE_ID,
+            scope=scope,
+        )
+
+    return check
+
+
+@pytest.mark.asyncio
+async def test_concurrent_failover_recovers_one_expired_attempt_once(
+    communication_db_engine,
+):
+    await _seed_deliveries(communication_db_engine, 1, expired=True)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with factory() as first, factory() as second:
+        first_result = (
+            await CommunicationDeliveryService.recover_expired_leases(
+                first,
+                scope=ALL_SCOPE,
+            )
+        )
+        second_result = await asyncio.wait_for(
+            CommunicationDeliveryService.recover_expired_leases(
+                second,
+                scope=ALL_SCOPE,
+            ),
+            timeout=2,
+        )
+        assert first_result.retry_count == 1
+        assert second_result.retry_count == 0
+        assert first_result.dead_count == second_result.dead_count == 0
+        await second.commit()
+        await first.commit()
+
+    async with factory() as session:
+        delivery = await session.get(CommunicationDelivery, f"{1:032x}")
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (f"{1:032x}", 1),
+        )
+        assert delivery is not None and delivery.status == "retry"
+        assert attempt is not None and attempt.outcome == "retry"
+        assert attempt.ambiguous is False
+
+
+@pytest.mark.asyncio
+async def test_post_provider_expiry_is_dead_ambiguous_and_never_reclaimed(
+    communication_db_engine,
+):
+    await _seed_deliveries(communication_db_engine, 1)
+    factory = sessionmaker(
+        communication_db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    now = datetime.now(timezone.utc)
+    async with factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            scope=ALL_SCOPE,
+            worker_id="provider-boundary-worker",
+            lease_seconds=60,
+            now=now,
+        )
+        assert claim is not None
+        await session.commit()
+    async with factory() as session:
+        await CommunicationDeliveryService.mark_provider_started(
+            session,
+            delivery_id=claim.delivery_id,
+            worker_id="provider-boundary-worker",
+            lease_token=claim.lease_token,
+            lease_seconds=60,
+            now=now + timedelta(seconds=1),
+        )
+        await session.commit()
+    recovery_time = now + timedelta(seconds=62)
+    async with factory() as session:
+        result = await CommunicationDeliveryService.recover_expired_leases(
+            session,
+            scope=ALL_SCOPE,
+            now=recovery_time,
+        )
+        await session.commit()
+        assert result.retry_count == 0
+        assert result.dead_count == 1
+
+    async with factory() as session:
+        claim_again = await CommunicationDeliveryService.claim_next(
+            session,
+            scope=ALL_SCOPE,
+            worker_id="replacement-worker",
+            now=recovery_time + timedelta(seconds=1),
+        )
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (claim.delivery_id, 1),
+        )
+        assert claim_again is None
+        assert attempt is not None
+        assert attempt.provider_started_at is not None
+        assert attempt.outcome == "dead"
+        assert attempt.ambiguous is True
+        assert attempt.error_code == "lease_expired_after_provider"
+
+
+@pytest.mark.asyncio
+async def test_committed_off_between_preflight_and_boundary_prevents_provider_call(
+    db_engine,
+):
+    factory = sessionmaker(
+        db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    scope = await _seed_owned_all_runtime(factory)
+    _, delivery_id = await _seed_delivery(
+        factory,
+        sequence=501,
+        telegram_id=501501,
+    )
+    provider = RecordingProvider(
+        factory,
+        {"501501": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    final_preflight = asyncio.Event()
+    release_preflight = asyncio.Event()
+    safety_calls = 0
+
+    async def safety_check():
+        nonlocal safety_calls
+        safety_calls += 1
+        if safety_calls == 3:
+            final_preflight.set()
+            await release_preflight.wait()
+
+    worker = CommunicationDeliveryWorker(
+        session_factory=factory,
+        scope=scope,
+        provider=provider,
+        worker_id=RUNTIME_INSTANCE_ID,
+        lease_seconds=60,
+        safety_check=safety_check,
+        provider_boundary_check=_runtime_boundary_check(scope),
+    )
+    worker_task = asyncio.create_task(worker.run_once())
+    await asyncio.wait_for(final_preflight.wait(), timeout=3)
+    await _switch_runtime_off(factory)
+    release_preflight.set()
+
+    with pytest.raises(CommunicationRuntimeModeBlocked):
+        await asyncio.wait_for(worker_task, timeout=3)
+
+    assert provider.calls == []
+    async with factory() as session:
+        await CommunicationRuntimeStateService.record_status(
+            session,
+            channel="telegram",
+            instance_id=RUNTIME_INSTANCE_ID,
+            status="disabled",
+        )
+        await session.commit()
+    drain = await InstallationNotificationOperations.wait_until_off_drained(
+        factory,
+        wait_seconds=0,
+    )
+    assert drain["drained"] is True
+    assert drain["running_delivery_count"] == 0
+    async with factory() as session:
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        delivery = await session.get(CommunicationDelivery, delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert state is not None and state.mode == "off"
+        assert delivery is not None
+        assert delivery.status == "retry"
+        assert delivery.worker_id is None
+        assert delivery.lease_token is None
+        assert delivery.lease_expires_at is None
+        assert attempt is not None
+        assert attempt.outcome == "retry"
+        assert attempt.provider_started_at is None
+        assert attempt.ambiguous is False
+        assert attempt.error_code == "runtime_control_fenced_before_provider"
+        assert (
+            await InstallationNotificationOperations._backlog_count(
+                session,
+                cutoff=None,
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_boundary_lock_commits_before_concurrent_off_and_sends_once(
+    db_engine,
+):
+    factory = sessionmaker(
+        db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    scope = await _seed_owned_all_runtime(factory)
+    _, delivery_id = await _seed_delivery(
+        factory,
+        sequence=502,
+        telegram_id=502502,
+    )
+    provider = RecordingProvider(
+        factory,
+        {"502502": ProviderDeliveryResult.sent("boundary-before-off")},
+    )
+    boundary_locked = asyncio.Event()
+    release_boundary = asyncio.Event()
+
+    async def holding_boundary_check(session):
+        await CommunicationRuntimeStateService.lock_owned_processing_scope(
+            session,
+            channel="telegram",
+            instance_id=RUNTIME_INSTANCE_ID,
+            scope=scope,
+        )
+        boundary_locked.set()
+        await release_boundary.wait()
+
+    worker = CommunicationDeliveryWorker(
+        session_factory=factory,
+        scope=scope,
+        provider=provider,
+        worker_id=RUNTIME_INSTANCE_ID,
+        lease_seconds=60,
+        provider_boundary_check=holding_boundary_check,
+    )
+    worker_task = asyncio.create_task(worker.run_once())
+    await asyncio.wait_for(boundary_locked.wait(), timeout=3)
+    off_task = asyncio.create_task(_switch_runtime_off(factory))
+    await asyncio.sleep(0.05)
+    assert off_task.done() is False
+
+    release_boundary.set()
+    outcome, _ = await asyncio.wait_for(
+        asyncio.gather(worker_task, off_task),
+        timeout=5,
+    )
+
+    assert outcome.outcome == "sent"
+    assert len(provider.calls) == 1
+    async with factory() as session:
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert state is not None and state.mode == "off"
+        assert attempt is not None
+        assert attempt.outcome == "sent"
+        assert attempt.provider_started_at is not None

--- a/tests/integration/test_communications_dispatcher_concurrency.py
+++ b/tests/integration/test_communications_dispatcher_concurrency.py
@@ -33,7 +33,10 @@ from services.communications.template_registry import (
     WebsiteTemplateRegistry,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 RUN_ID_A = "123e4567-e89b-42d3-a456-426614174000"
 RUN_ID_B = "123e4567-e89b-42d3-a456-426614174001"
 

--- a/tests/integration/test_communications_installation_activation_postgres.py
+++ b/tests/integration/test_communications_installation_activation_postgres.py
@@ -1,0 +1,401 @@
+import asyncio
+from datetime import datetime, timezone
+from time import monotonic
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from core.config import settings
+from models import (
+    CommunicationDelivery,
+    CommunicationRuntimeState,
+    IntegrationOutboxEvent,
+    StaffUser,
+)
+from services.communications.contracts import (
+    InstallationEstimateLeadCreatedPayloadV1,
+)
+from services.communications.dispatcher import CommunicationOutboxDispatcher
+from services.communications.installation_notifications import (
+    InstallationNotificationControlRejected,
+    InstallationNotificationOperations,
+)
+from services.communications.installation_activation_fence import (
+    INSTALLATION_ACTIVATION_FENCE_LOCK,
+    InstallationEventEnqueueFenceBusy,
+)
+from services.communications.outbox_service import IntegrationOutboxService
+from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.runtime_config import CommunicationRuntimeConfig
+from services.communications.runtime_state import (
+    CommunicationRuntimeStateService,
+)
+from services.communications.template_registry import (
+    INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+)
+from services.runtime_lock_service import RuntimeLockService
+
+
+def _config(lock_name: str) -> CommunicationRuntimeConfig:
+    return CommunicationRuntimeConfig(
+        enabled=True,
+        app_role="primary",
+        allow_all_mode=True,
+        lock_name=lock_name,
+        instance_id="installation-activation-test",
+        poll_seconds=0.01,
+        heartbeat_seconds=10,
+        lock_retry_seconds=0.01,
+        lock_check_seconds=0.01,
+        db_probe_timeout_seconds=0.1,
+        fencing_seconds=3,
+        shutdown_seconds=0.2,
+        provider_timeout_seconds=1,
+        provider_close_seconds=0.1,
+        lease_seconds=30,
+    )
+
+
+def _payload(order_id: int) -> InstallationEstimateLeadCreatedPayloadV1:
+    return InstallationEstimateLeadCreatedPayloadV1(
+        order_id=order_id,
+        status="new_lead",
+        name="Activation fence test",
+        phone="+375291112233",
+        description="Commit ordering",
+        attachment_count=1,
+        photo_categories=("Место внутреннего блока",),
+    )
+
+
+async def _enqueue(
+    factory,
+    *,
+    order_id: int,
+    occurred_at: datetime | None = None,
+):
+    async with factory() as session:
+        result = await IntegrationOutboxService.enqueue_with_result(
+            session,
+            event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+            aggregate_type="order",
+            aggregate_id=order_id,
+            payload=_payload(order_id),
+            idempotency_key=f"activation-fence:{order_id}",
+            occurred_at=occurred_at,
+        )
+        await session.commit()
+        return result
+
+
+@pytest.fixture
+async def activation_context(db_engine, monkeypatch):
+    assert db_engine.dialect.name == "postgresql"
+    monkeypatch.setattr(
+        settings,
+        "RUNTIME_DB_LOCKS_ENABLED",
+        True,
+        raising=False,
+    )
+    factory = sessionmaker(
+        db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    config = _config(f"mvn:test:installation-activation:{uuid4()}")
+    runtime_lock = await RuntimeLockService.try_acquire(
+        factory,
+        config.lock_name,
+        required=True,
+    )
+    assert runtime_lock.acquired
+    try:
+        async with factory() as session:
+            now = await CommunicationRuntimeStateService.database_now(session)
+            state = await CommunicationRuntimeStateService.ensure_state(
+                session,
+                channel="telegram",
+            )
+            state.status = "disabled"
+            state.instance_id = config.instance_id
+            state.started_at = now
+            state.heartbeat_at = now
+            state.updated_at = now
+            session.add_all(
+                [
+                    state,
+                    StaffUser(
+                        display_name="Owner",
+                        status="active",
+                        roles=["owner"],
+                        primary_role="owner",
+                        telegram_id=90001,
+                    ),
+                ]
+            )
+            await session.commit()
+        yield factory, config
+    finally:
+        await runtime_lock.release()
+
+
+async def _activate(factory, config):
+    async with factory() as session:
+        try:
+            inspection, revision, watermark = (
+                await InstallationNotificationOperations.activate_installation_from_off(
+                    session,
+                    config=config,
+                    bot_token="valid-token",
+                    runtime_locks_enabled=True,
+                )
+            )
+        except InstallationNotificationControlRejected as error:
+            await session.rollback()
+            return error.error_code
+        await session.commit()
+        return inspection, revision, watermark
+
+
+@pytest.mark.asyncio
+async def test_activation_fails_fast_behind_uncommitted_enqueue_then_inventories_it(
+    activation_context,
+):
+    factory, config = activation_context
+    async with factory() as enqueue_session:
+        enqueued = await IntegrationOutboxService.enqueue_with_result(
+            enqueue_session,
+            event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+            aggregate_type="order",
+            aggregate_id=701,
+            payload=_payload(701),
+            idempotency_key="activation-fence:701",
+        )
+        assert enqueued.created is True
+
+        activation_task = asyncio.create_task(_activate(factory, config))
+        result = await asyncio.wait_for(activation_task, timeout=1)
+        assert result == "installation_activation_fence_busy"
+        await enqueue_session.commit()
+
+    assert await _activate(factory, config) == "installation_backlog_not_reconciled"
+    async with factory() as session:
+        event = await session.get(
+            IntegrationOutboxEvent,
+            enqueued.event.event_id,
+        )
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        assert event is not None and event.status == "pending"
+        assert state is not None and state.mode == "off"
+        assert state.installation_estimate_watermark_at is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_after_activation_is_in_scope_and_replay_is_unique(
+    activation_context,
+    monkeypatch,
+):
+    factory, config = activation_context
+    activation_inside_inventory = asyncio.Event()
+    release_activation = asyncio.Event()
+    original_backlog_count = InstallationNotificationOperations._backlog_count
+
+    async def paused_backlog_count(cls, session, *, cutoff):
+        activation_inside_inventory.set()
+        await release_activation.wait()
+        return await original_backlog_count(session, cutoff=cutoff)
+
+    monkeypatch.setattr(
+        InstallationNotificationOperations,
+        "_backlog_count",
+        classmethod(paused_backlog_count),
+    )
+
+    activation_task = asyncio.create_task(_activate(factory, config))
+    await asyncio.wait_for(activation_inside_inventory.wait(), timeout=3)
+    enqueue_task = asyncio.create_task(
+        _enqueue(
+            factory,
+            order_id=702,
+            occurred_at=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    await asyncio.sleep(0.1)
+    assert enqueue_task.done() is False
+
+    release_activation.set()
+    activation = await asyncio.wait_for(activation_task, timeout=3)
+    assert not isinstance(activation, str)
+    _, revision, watermark = activation
+    enqueued = await asyncio.wait_for(enqueue_task, timeout=3)
+    assert enqueued.created is True
+
+    replay = await _enqueue(factory, order_id=702)
+    assert replay.created is False
+    assert replay.event.event_id == enqueued.event.event_id
+
+    async with factory() as session:
+        event = await session.get(
+            IntegrationOutboxEvent,
+            enqueued.event.event_id,
+        )
+        assert event is not None
+        assert CommunicationRuntimeStateService._as_utc(
+            event.created_at
+        ) >= watermark
+        assert CommunicationRuntimeStateService._as_utc(
+            event.occurred_at
+        ) < watermark
+        monkeypatch.setattr(
+            CommunicationOutboxDispatcher,
+            "_utc_now",
+            staticmethod(
+                lambda: datetime(1990, 1, 1, tzinfo=timezone.utc)
+            ),
+        )
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            scope=CommunicationProcessingScope.all(
+                control_revision=revision,
+                event_created_at_watermark=watermark,
+            ),
+            dispatcher_id="activation-fence-dispatcher",
+        )
+        await session.commit()
+        assert outcome is not None
+        assert outcome.outcome == "materialized"
+        assert outcome.delivery_count == 1
+        assert (
+            await session.scalar(
+                select(func.count(IntegrationOutboxEvent.event_id)).where(
+                    IntegrationOutboxEvent.event_id == event.event_id
+                )
+            )
+        ) == 1
+        assert (
+            await session.scalar(
+                select(func.count(CommunicationDelivery.delivery_id)).where(
+                    CommunicationDelivery.event_id == event.event_id
+                )
+            )
+        ) == 1
+
+
+@pytest.mark.asyncio
+async def test_normal_enqueues_share_the_fence_without_serializing(
+    activation_context,
+):
+    factory, _ = activation_context
+    async with factory() as first_session:
+        first = await IntegrationOutboxService.enqueue_with_result(
+            first_session,
+            event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+            aggregate_type="order",
+            aggregate_id=703,
+            payload=_payload(703),
+            idempotency_key="activation-fence:703",
+        )
+        assert first.created is True
+
+        second = await asyncio.wait_for(
+            _enqueue(factory, order_id=704),
+            timeout=1,
+        )
+        assert second.created is True
+        await first_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_activation_rejects_repeatable_read_before_control_mutation(
+    activation_context,
+):
+    factory, config = activation_context
+    async with factory() as session:
+        await session.execute(
+            text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        )
+        with pytest.raises(
+            InstallationNotificationControlRejected,
+            match="database_isolation_not_read_committed",
+        ):
+            await InstallationNotificationOperations.activate_installation_from_off(
+                session,
+                config=config,
+                bot_token="valid-token",
+                runtime_locks_enabled=True,
+            )
+        await session.rollback()
+
+    async with factory() as session:
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        assert state is not None
+        assert state.mode == "off"
+        assert state.control_revision == 0
+        assert state.installation_estimate_watermark_at is None
+
+
+@pytest.mark.asyncio
+async def test_short_exclusive_holder_delays_enqueue_then_db_stamps_it(
+    activation_context,
+):
+    factory, _ = activation_context
+    async with factory() as holder:
+        await holder.execute(
+            text(
+                "SELECT pg_advisory_xact_lock(hashtext(:lock_name))"
+            ),
+            {"lock_name": INSTALLATION_ACTIVATION_FENCE_LOCK},
+        )
+        enqueue_task = asyncio.create_task(
+            _enqueue(factory, order_id=705)
+        )
+        await asyncio.sleep(0.1)
+        assert enqueue_task.done() is False
+        await holder.commit()
+
+    result = await asyncio.wait_for(enqueue_task, timeout=2)
+    assert result.created is True
+    async with factory() as session:
+        event = await session.get(
+            IntegrationOutboxEvent,
+            result.event.event_id,
+        )
+        assert event is not None
+        assert event.occurred_at == event.created_at
+        assert event.available_at == event.created_at
+
+
+@pytest.mark.asyncio
+async def test_long_exclusive_holder_aborts_enqueue_with_bounded_error(
+    activation_context,
+):
+    factory, _ = activation_context
+    async with factory() as holder:
+        await holder.execute(
+            text(
+                "SELECT pg_advisory_xact_lock(hashtext(:lock_name))"
+            ),
+            {"lock_name": INSTALLATION_ACTIVATION_FENCE_LOCK},
+        )
+        started = monotonic()
+        with pytest.raises(InstallationEventEnqueueFenceBusy):
+            await asyncio.wait_for(
+                _enqueue(factory, order_id=706),
+                timeout=2,
+            )
+        elapsed = monotonic() - started
+        assert 0.8 <= elapsed < 1.8
+        await holder.rollback()
+
+    async with factory() as session:
+        assert (
+            await session.scalar(
+                select(func.count(IntegrationOutboxEvent.event_id)).where(
+                    IntegrationOutboxEvent.aggregate_id == "706"
+                )
+            )
+        ) == 0

--- a/tests/integration/test_communications_runtime_postgres.py
+++ b/tests/integration/test_communications_runtime_postgres.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import replace
+from datetime import timezone
 from uuid import uuid4
 
 import pytest
@@ -244,14 +245,26 @@ async def test_postgres_failover_never_overlaps_provider_calls(
         expire_on_commit=False,
     )
     async with session_factory() as session:
-        control = await CommunicationRuntimeStateService.set_mode(
+        state = await CommunicationRuntimeStateService.ensure_state(
             session,
             channel="telegram",
-            mode=CommunicationRuntimeMode.ALL,
         )
+        watermark = await CommunicationRuntimeStateService.database_now(session)
+        CommunicationRuntimeStateService._apply_control(
+            state,
+            mode=CommunicationRuntimeMode.ALL,
+            canary_run_id=None,
+            now=watermark,
+            installation_estimate_watermark_at=watermark,
+        )
+        await session.flush()
+        control = CommunicationRuntimeStateService._to_control(state)
         await session.commit()
     expected_scope = CommunicationProcessingScope.all(
-        control_revision=control.control_revision
+        control_revision=control.control_revision,
+        event_created_at_watermark=(
+            control.installation_estimate_watermark_at
+        ),
     )
 
     acquired_locks = []

--- a/tests/integration/test_installation_estimate_api.py
+++ b/tests/integration/test_installation_estimate_api.py
@@ -2,8 +2,13 @@ import io
 
 import pytest
 from PIL import Image
+from sqlmodel import func, select
 
-from models import Order
+from models import Order, ServiceAttachment
+from services.communications.installation_activation_fence import (
+    InstallationEventEnqueueFenceBusy,
+)
+from services.communications.outbox_service import IntegrationOutboxService
 from services.private_attachment_storage_service import StoredPrivateObject
 
 
@@ -123,3 +128,46 @@ async def test_public_installation_estimate_rejects_invalid_file(
 
     assert response.status_code == 400
     assert "JPEG, PNG и WebP" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_activation_fence_returns_retryable_503_and_rolls_back_intake(
+    async_client,
+    db,
+    monkeypatch,
+):
+    storage = FakePrivateStorage()
+    monkeypatch.setattr(
+        "services.installation_estimate_lead_service.get_private_attachment_storage",
+        lambda: storage,
+    )
+
+    async def busy_enqueue(*args, **kwargs):
+        raise InstallationEventEnqueueFenceBusy()
+
+    monkeypatch.setattr(
+        IntegrationOutboxService,
+        "enqueue",
+        busy_enqueue,
+    )
+    response = await async_client.post(
+        "/api/v1/leads/installation-estimate",
+        data={
+            "name": "Анна",
+            "phone": "+375291112233",
+            "consent": "true",
+        },
+        files=[
+            ("facade", ("facade.png", _png_bytes(), "image/png")),
+        ],
+        headers={"Idempotency-Key": "browser-estimate-request-0003"},
+    )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "1"
+    assert response.json() == {
+        "detail": "Приём заявки временно занят. Повторите отправку."
+    }
+    assert await db.scalar(select(func.count(Order.id))) == 0
+    assert await db.scalar(select(func.count(ServiceAttachment.id))) == 0
+    assert storage.objects == {}

--- a/tests/integration/test_installation_estimate_backlog_reconciliation_postgres.py
+++ b/tests/integration/test_installation_estimate_backlog_reconciliation_postgres.py
@@ -141,6 +141,9 @@ async def _seed_stopped_runtime(factory, *, mode: str = "off") -> None:
             CommunicationRuntimeState(
                 channel="telegram",
                 mode=mode,
+                installation_estimate_watermark_at=(
+                    now if mode == "all" else None
+                ),
                 status="stopped",
                 control_revision=1,
                 control_updated_at=now,

--- a/tests/integration/test_installation_estimate_communications_e2e.py
+++ b/tests/integration/test_installation_estimate_communications_e2e.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+from datetime import datetime, timezone
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -203,7 +204,12 @@ async def test_installation_estimate_public_intake_is_materialized_and_sent_once
         assert event.aggregate_id == str(first["order_id"])
         assert event.status == "pending"
 
-        scope = CommunicationProcessingScope.all(control_revision=0)
+        scope = CommunicationProcessingScope.all(
+            control_revision=0,
+            event_created_at_watermark=datetime(
+                2000, 1, 1, tzinfo=timezone.utc
+            ),
+        )
         materialized = await CommunicationOutboxDispatcher.dispatch_next(
             session,
             dispatcher_id="installation-estimate-e2e-dispatcher",

--- a/tests/unit/communications_runtime_test_support.py
+++ b/tests/unit/communications_runtime_test_support.py
@@ -1,0 +1,51 @@
+import asyncio
+from datetime import datetime, timezone
+
+from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.runtime_state import (
+    CommunicationRuntimeMode,
+    CommunicationRuntimeStateService,
+)
+
+
+async def allow_safety(_scope: CommunicationProcessingScope) -> None:
+    return None
+
+
+async def instant_fencing(
+    stop_event: asyncio.Event,
+    _seconds: float,
+) -> bool:
+    return stop_event.is_set()
+
+
+async def set_runtime_mode_for_test(
+    session,
+    *,
+    channel: str,
+    mode: CommunicationRuntimeMode,
+    canary_run_id: str | None = None,
+):
+    """Use the typed public path except when a test needs an armed all scope."""
+
+    if mode != CommunicationRuntimeMode.ALL:
+        return await CommunicationRuntimeStateService.set_mode(
+            session,
+            channel=channel,
+            mode=mode,
+            canary_run_id=canary_run_id,
+        )
+    state = await CommunicationRuntimeStateService.ensure_state(
+        session,
+        channel=channel,
+    )
+    state.mode = CommunicationRuntimeMode.ALL.value
+    state.canary_run_id = None
+    state.control_revision = int(state.control_revision) + 1
+    state.installation_estimate_watermark_at = (
+        state.installation_estimate_watermark_at
+        or datetime(2000, 1, 1, tzinfo=timezone.utc)
+    )
+    session.add(state)
+    await session.flush()
+    return CommunicationRuntimeStateService._to_control(state)

--- a/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
+++ b/tests/unit/test_apply_cloudflare_lb_github_prerequisites.py
@@ -69,7 +69,9 @@ def test_load_env_file_sets_missing_values_without_overriding(tmp_path, monkeypa
         ),
         encoding="utf-8",
     )
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN_LB_AUDIT", raising=False)
     monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "existing-account")
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
 
     module.load_env_file(

--- a/tests/unit/test_bot_staff_notification_outbox.py
+++ b/tests/unit/test_bot_staff_notification_outbox.py
@@ -20,6 +20,8 @@ from models import (
 from services.bot_staff_notification_api_service import (
     BotStaffNotificationApiService,
 )
+import services.bot_staff_notification_api_service as bot_api_module
+from services.communications.delivery_service import CommunicationDeliveryService
 from services.staff_task_notification_event_service import (
     StaffTaskNotificationEventService,
 )
@@ -77,7 +79,16 @@ async def _seed_task(session: AsyncSession) -> OrderWorkStage:
 
 
 @pytest.mark.asyncio
-async def test_assignment_event_claim_and_ack_are_end_to_end(staff_outbox_session):
+async def test_assignment_event_claim_and_ack_use_database_clock(
+    staff_outbox_session,
+    monkeypatch,
+):
+    class AppClockMustNotBeRead:
+        @classmethod
+        def now(cls, *args, **kwargs):
+            raise AssertionError("staff lifecycle must use the database clock")
+
+    monkeypatch.setattr(bot_api_module, "datetime", AppClockMustNotBeRead)
     stage = await _seed_task(staff_outbox_session)
     created = await StaffTaskNotificationEventService.enqueue_assigned(
         staff_outbox_session,
@@ -172,7 +183,7 @@ async def test_nack_schedules_retry_and_next_claim_increments_attempt(
         worker_id="bot-1",
         lease_token=first["lease_token"],
         permanent=False,
-        error_code="telegram_timeout",
+        error_code="telegram_retry_after",
         retry_after_seconds=1,
     )
     assert failed.status == "retry"
@@ -188,6 +199,149 @@ async def test_nack_schedules_retry_and_next_claim_increments_attempt(
     )
     assert second is not None
     assert second["attempt"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transport_nack_is_terminal_ambiguous_after_remote_handoff(
+    staff_outbox_session,
+):
+    stage = await _seed_task(staff_outbox_session)
+    await StaffTaskNotificationEventService.enqueue_assigned(
+        staff_outbox_session,
+        stage=stage,
+        previous_installer_id=None,
+    )
+    await staff_outbox_session.commit()
+    claim = await BotStaffNotificationApiService.claim(
+        staff_outbox_session,
+        worker_id="bot-transport-failure",
+        visibility_timeout_seconds=90,
+    )
+    assert claim is not None
+
+    failed = await BotStaffNotificationApiService.nack(
+        staff_outbox_session,
+        delivery_id=claim["delivery_id"],
+        worker_id="bot-transport-failure",
+        lease_token=claim["lease_token"],
+        permanent=False,
+        error_code="telegram_transport_error",
+        retry_after_seconds=None,
+    )
+    attempt = await staff_outbox_session.get(
+        CommunicationDeliveryAttempt,
+        (claim["delivery_id"], 1),
+    )
+
+    assert failed.status == "dead"
+    assert attempt is not None
+    assert attempt.outcome == "dead"
+    assert attempt.ambiguous is True
+    assert attempt.error_code == "telegram_transport_error"
+
+
+@pytest.mark.asyncio
+async def test_claim_handoff_expiry_is_terminal_and_never_claimed_again(
+    staff_outbox_session,
+):
+    stage = await _seed_task(staff_outbox_session)
+    await StaffTaskNotificationEventService.enqueue_assigned(
+        staff_outbox_session,
+        stage=stage,
+        previous_installer_id=None,
+    )
+    await staff_outbox_session.commit()
+    first = await BotStaffNotificationApiService.claim(
+        staff_outbox_session,
+        worker_id="bot-that-disappears",
+        visibility_timeout_seconds=90,
+    )
+    assert first is not None
+
+    delivery = await staff_outbox_session.get(
+        CommunicationDelivery,
+        first["delivery_id"],
+    )
+    assert delivery is not None
+    delivery.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    staff_outbox_session.add(delivery)
+    await staff_outbox_session.commit()
+
+    second = await BotStaffNotificationApiService.claim(
+        staff_outbox_session,
+        worker_id="replacement-bot",
+        visibility_timeout_seconds=90,
+    )
+    await staff_outbox_session.refresh(delivery)
+    attempt = await staff_outbox_session.get(
+        CommunicationDeliveryAttempt,
+        (delivery.delivery_id, 1),
+    )
+
+    assert second is None
+    assert delivery.status == "dead"
+    assert attempt is not None
+    assert attempt.provider_started_at is not None
+    assert attempt.outcome == "dead"
+    assert attempt.ambiguous is True
+    assert attempt.error_code == "lease_expired_after_provider"
+
+
+@pytest.mark.asyncio
+async def test_old_api_null_boundary_handoff_is_conservatively_terminal(
+    staff_outbox_session,
+):
+    stage = await _seed_task(staff_outbox_session)
+    await StaffTaskNotificationEventService.enqueue_assigned(
+        staff_outbox_session,
+        stage=stage,
+        previous_installer_id=None,
+    )
+    await staff_outbox_session.commit()
+    now = await CommunicationDeliveryService.database_now(
+        staff_outbox_session
+    )
+    await BotStaffNotificationApiService._materialize_pending(
+        staff_outbox_session,
+        worker_id="old-api",
+        now=now,
+    )
+    old_claim = await CommunicationDeliveryService.claim_next(
+        staff_outbox_session,
+        worker_id="old-api",
+        scope=BotStaffNotificationApiService._SCOPE,
+        channel="telegram",
+        lease_seconds=90,
+        now=now,
+    )
+    assert old_claim is not None
+    await staff_outbox_session.commit()
+    delivery = await staff_outbox_session.get(
+        CommunicationDelivery,
+        old_claim.delivery_id,
+    )
+    assert delivery is not None
+    delivery.lease_expires_at = now - timedelta(seconds=1)
+    staff_outbox_session.add(delivery)
+    await staff_outbox_session.commit()
+
+    replacement = await BotStaffNotificationApiService.claim(
+        staff_outbox_session,
+        worker_id="new-api",
+        visibility_timeout_seconds=90,
+    )
+    attempt = await staff_outbox_session.get(
+        CommunicationDeliveryAttempt,
+        (old_claim.delivery_id, 1),
+    )
+
+    assert replacement is None
+    assert delivery.status == "dead"
+    assert attempt is not None
+    assert attempt.provider_started_at is None
+    assert attempt.outcome == "dead"
+    assert attempt.ambiguous is True
+    assert attempt.error_code == "lease_expired_after_provider"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_communication_delivery_ambiguity_fence.py
+++ b/tests/unit/test_communication_delivery_ambiguity_fence.py
@@ -1,0 +1,114 @@
+from datetime import timedelta
+
+import pytest
+
+from models import CommunicationDeliveryAttempt
+from services.communications.delivery_service import CommunicationDeliveryService
+from tests.unit.test_communication_delivery_service import (
+    ALL_SCOPE,
+    NOW,
+    _delivery,
+    delivery_session_factory,
+)
+
+
+def _retry_attempt(
+    sequence: int,
+    *,
+    ambiguous: bool,
+) -> CommunicationDeliveryAttempt:
+    return CommunicationDeliveryAttempt(
+        delivery_id=f"{sequence:032x}",
+        attempt_no=1,
+        started_at=NOW - timedelta(seconds=2),
+        finished_at=NOW - timedelta(seconds=1),
+        outcome="retry",
+        error_category="provider" if ambiguous else "rate_limit",
+        error_code=(
+            "provider_call_failed"
+            if ambiguous
+            else "telegram_retry_after"
+        ),
+        retry_after_seconds=None if ambiguous else 1,
+        ambiguous=ambiguous,
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_skips_retry_with_ambiguous_history_but_claims_retry_after(
+    delivery_session_factory,
+):
+    async with delivery_session_factory() as session:
+        session.add_all(
+            [
+                _delivery(81, status="retry", attempts=1, priority=1),
+                _retry_attempt(81, ambiguous=True),
+                _delivery(82, status="retry", attempts=1, priority=2),
+                _retry_attempt(82, ambiguous=False),
+            ]
+        )
+        await session.commit()
+
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            scope=ALL_SCOPE,
+            worker_id="ambiguity-fence-worker",
+            now=NOW,
+        )
+
+        assert claim is not None
+        assert claim.delivery_id == f"{82:032x}"
+        ambiguous_delivery = await session.get(
+            type(_delivery(81)),
+            f"{81:032x}",
+        )
+        assert ambiguous_delivery is not None
+        assert ambiguous_delivery.status == "retry"
+        assert ambiguous_delivery.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_recovery_terminally_closes_ambiguous_history(
+    delivery_session_factory,
+):
+    running = _delivery(
+        83,
+        status="running",
+        attempts=2,
+        worker_id="corrupt-worker",
+        lease_token="x" * 43,
+        lease_expires_at=NOW - timedelta(seconds=1),
+    )
+    async with delivery_session_factory() as session:
+        session.add_all(
+            [
+                running,
+                _retry_attempt(83, ambiguous=True),
+                CommunicationDeliveryAttempt(
+                    delivery_id=running.delivery_id,
+                    attempt_no=2,
+                    started_at=NOW - timedelta(seconds=1),
+                    outcome="running",
+                ),
+            ]
+        )
+        await session.commit()
+
+        result = await CommunicationDeliveryService.recover_expired_leases(
+            session,
+            scope=ALL_SCOPE,
+            now=NOW,
+        )
+
+        assert result.retry_count == 0
+        assert result.dead_count == 1
+        await session.refresh(running)
+        assert running.status == "dead"
+        current = await session.get(
+            CommunicationDeliveryAttempt,
+            (running.delivery_id, 2),
+        )
+        assert current is not None
+        assert current.outcome == "dead"
+        assert current.ambiguous is True
+        assert current.error_code == "lease_expired_after_provider"

--- a/tests/unit/test_communication_delivery_attempt_migration.py
+++ b/tests/unit/test_communication_delivery_attempt_migration.py
@@ -24,7 +24,10 @@ from services.communications.template_registry import (
     INSTALLATION_ESTIMATE_TEMPLATE_KEY,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 
 FOUNDATION_PATH = Path(
     "alembic/versions/3f7a9c1d2e04_add_communications_outbox_foundation.py"
@@ -35,6 +38,10 @@ LEASE_PATH = Path(
 ATTEMPT_REVISION = "5b9c2d3e4f06"
 ATTEMPT_PATH = Path(
     "alembic/versions/5b9c2d3e4f06_add_communication_delivery_attempt_journal.py"
+)
+PROVIDER_BOUNDARY_REVISION = "e9a1b2c3d4e5"
+PROVIDER_BOUNDARY_PATH = Path(
+    "alembic/versions/e9a1b2c3d4e5_add_delivery_provider_boundary.py"
 )
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc).isoformat()
 SQLITE_RUNNING_NOW = "2026-07-13 12:00:00.000000"
@@ -201,6 +208,9 @@ def _insert_attempt(
 def test_attempt_journal_stays_in_single_alembic_chain_after_lease_hardening():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(ATTEMPT_REVISION)
+    provider_boundary_revision = script.get_revision(
+        PROVIDER_BOUNDARY_REVISION
+    )
     heads = script.get_heads()
     assert len(heads) == 1
     revision_ids = {
@@ -211,12 +221,18 @@ def test_attempt_journal_stays_in_single_alembic_chain_after_lease_hardening():
     assert "6c0d3e5f7a21" in revision_ids
     assert revision is not None
     assert revision.down_revision == "4a8b1c2d3e05"
+    assert provider_boundary_revision is not None
+    assert provider_boundary_revision.down_revision == "d8e7f6a5b4c3"
 
 
 def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
     foundation = _load_migration("foundation_for_attempt", FOUNDATION_PATH)
     lease = _load_migration("lease_for_attempt", LEASE_PATH)
     attempt = _load_migration("attempt_journal_migration", ATTEMPT_PATH)
+    provider_boundary = _load_migration(
+        "provider_boundary_migration",
+        PROVIDER_BOUNDARY_PATH,
+    )
     engine = create_engine("sqlite:///:memory:")
 
     with engine.begin() as connection:
@@ -224,14 +240,22 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
         foundation.op = operations
         lease.op = operations
         attempt.op = operations
+        provider_boundary.op = operations
         foundation.upgrade()
         delivery_id = _insert_queued_delivery(connection, 1)
         running_delivery_id = _insert_running_delivery(connection, 2)
         lease.upgrade()
         attempt.upgrade()
+        provider_boundary.upgrade()
 
         inspector = inspect(connection)
         assert "communication_delivery_attempt" in inspector.get_table_names()
+        assert "provider_started_at" in {
+            column["name"]
+            for column in inspector.get_columns(
+                "communication_delivery_attempt"
+            )
+        }
         assert connection.execute(
             text(
                 "SELECT status, attempts FROM communication_delivery "
@@ -279,7 +303,17 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
             "ck_delivery_attempt_outcome_valid",
             "ck_delivery_attempt_retry_after_positive",
             "ck_delivery_attempt_retry_after_state",
+            "ck_delivery_attempt_provider_after_started",
+            "ck_delivery_attempt_provider_before_finished",
         }.issubset(constraint_names)
+        assert connection.execute(
+            text(
+                "SELECT provider_started_at "
+                "FROM communication_delivery_attempt "
+                "WHERE delivery_id = :delivery_id"
+            ),
+            {"delivery_id": running_delivery_id},
+        ).scalar_one() == SQLITE_RUNNING_NOW
         assert {
             "ix_delivery_attempt_ambiguous_finished",
             "ix_delivery_attempt_error_finished",
@@ -350,6 +384,13 @@ def test_attempt_journal_migration_replays_and_downgrades_on_sqlite():
                         **values,
                     )
 
+        provider_boundary.downgrade()
+        assert "provider_started_at" not in {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "communication_delivery_attempt"
+            )
+        }
         attempt.downgrade()
         downgraded = inspect(connection)
         assert "communication_delivery_attempt" not in downgraded.get_table_names()
@@ -380,6 +421,10 @@ async def test_attempt_journal_backfills_running_row_for_lease_recovery(tmp_path
     foundation = _load_migration("foundation_for_recovery", FOUNDATION_PATH)
     lease = _load_migration("lease_for_recovery", LEASE_PATH)
     attempt = _load_migration("attempt_journal_for_recovery", ATTEMPT_PATH)
+    provider_boundary = _load_migration(
+        "provider_boundary_for_recovery",
+        PROVIDER_BOUNDARY_PATH,
+    )
     database_path = tmp_path / "attempt-migration-recovery.sqlite3"
     engine = create_engine(f"sqlite:///{database_path}")
 
@@ -388,10 +433,12 @@ async def test_attempt_journal_backfills_running_row_for_lease_recovery(tmp_path
         foundation.op = operations
         lease.op = operations
         attempt.op = operations
+        provider_boundary.op = operations
         foundation.upgrade()
         delivery_id = _insert_running_delivery(connection, 9)
         lease.upgrade()
         attempt.upgrade()
+        provider_boundary.upgrade()
     engine.dispose()
 
     async_engine = create_async_engine(f"sqlite+aiosqlite:///{database_path}")
@@ -408,8 +455,8 @@ async def test_attempt_journal_backfills_running_row_for_lease_recovery(tmp_path
                 now=datetime(2026, 7, 13, 12, 6, tzinfo=timezone.utc),
             )
             await session.commit()
-            assert recovery.retry_count == 1
-            assert recovery.dead_count == 0
+            assert recovery.retry_count == 0
+            assert recovery.dead_count == 1
 
         async with factory() as session:
             delivery = await session.get(CommunicationDelivery, delivery_id)
@@ -417,11 +464,12 @@ async def test_attempt_journal_backfills_running_row_for_lease_recovery(tmp_path
                 CommunicationDeliveryAttempt,
                 (delivery_id, 1),
             )
-            assert delivery is not None and delivery.status == "retry"
-            assert journal is not None and journal.outcome == "retry"
+            assert delivery is not None and delivery.status == "dead"
+            assert journal is not None and journal.outcome == "dead"
             assert journal.error_category == "lease"
-            assert journal.error_code == "lease_expired"
+            assert journal.error_code == "lease_expired_after_provider"
             assert journal.ambiguous is True
+            assert journal.provider_started_at is not None
             assert journal.finished_at is not None
     finally:
         await async_engine.dispose()

--- a/tests/unit/test_communication_delivery_attempt_service.py
+++ b/tests/unit/test_communication_delivery_attempt_service.py
@@ -31,7 +31,10 @@ from services.communications.template_registry import (
 )
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 
 
 @pytest.fixture
@@ -113,6 +116,7 @@ def test_attempt_model_contains_only_pii_free_operational_fields():
         "attempt_no",
         "started_at",
         "finished_at",
+        "provider_started_at",
         "outcome",
         "error_category",
         "error_code",

--- a/tests/unit/test_communication_delivery_provider_boundary.py
+++ b/tests/unit/test_communication_delivery_provider_boundary.py
@@ -1,0 +1,274 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from services.communications.delivery_service import CommunicationDeliveryService
+from services.communications.delivery_worker import CommunicationDeliveryWorker
+from services.communications.providers.base import ProviderDeliveryResult
+from tests.unit.test_communication_delivery_worker import (
+    ALL_SCOPE,
+    RecordingProvider,
+    _seed_delivery,
+    worker_session_factory,
+)
+
+
+async def _claim_then_expire(
+    session_factory,
+    *,
+    delivery_id: str,
+    mark_provider_started: bool,
+) -> None:
+    now = datetime.now(timezone.utc)
+    async with session_factory() as session:
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            scope=ALL_SCOPE,
+            worker_id="crashed-worker",
+            lease_seconds=60,
+            now=now,
+        )
+        assert claim is not None
+        await session.commit()
+    async with session_factory() as session:
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        attempt.started_at = now - timedelta(seconds=2)
+        session.add(attempt)
+        await session.commit()
+    if mark_provider_started:
+        async with session_factory() as session:
+            await CommunicationDeliveryService.mark_provider_started(
+                session,
+                delivery_id=delivery_id,
+                worker_id="crashed-worker",
+                lease_token=claim.lease_token,
+                lease_seconds=60,
+                now=now - timedelta(seconds=1),
+            )
+            await session.commit()
+    async with session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        row.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        session.add(row)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_crash_before_provider_boundary_retries_then_sends_once(
+    worker_session_factory,
+    monkeypatch,
+):
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=91,
+        telegram_id=910091,
+    )
+    await _claim_then_expire(
+        worker_session_factory,
+        delivery_id=delivery_id,
+        mark_provider_started=False,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"910091": ProviderDeliveryResult.sent("provider-boundary-safe-retry")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="replacement-worker",
+        lease_seconds=60,
+    )
+
+    recovered = await worker.run_once()
+    assert recovered.outcome == "idle"
+    assert recovered.recovered_retry_count == 1
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None and row.status == "retry"
+        due_at = CommunicationDeliveryService._coerce_database_datetime(
+            row.available_at
+        )
+        first_attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert first_attempt is not None
+        assert first_attempt.outcome == "retry"
+        assert first_attempt.provider_started_at is None
+        assert first_attempt.ambiguous is False
+        assert first_attempt.error_code == "lease_expired_before_provider"
+
+    async def after_backoff(cls, session):
+        return due_at + timedelta(seconds=1)
+
+    monkeypatch.setattr(
+        CommunicationDeliveryService,
+        "_database_now",
+        classmethod(after_backoff),
+    )
+    sent = await worker.run_once()
+    idle = await worker.run_once()
+
+    assert sent.outcome == "sent"
+    assert idle.outcome == "idle"
+    assert len(provider.calls) == 1
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "sent"
+        assert row.attempts == 2
+        second_attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 2),
+        )
+        assert second_attempt is not None
+        assert second_attempt.outcome == "sent"
+        assert second_attempt.provider_started_at is not None
+
+
+@pytest.mark.asyncio
+async def test_crash_after_provider_boundary_is_terminal_and_never_calls_again(
+    worker_session_factory,
+):
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=92,
+        telegram_id=920092,
+    )
+    await _claim_then_expire(
+        worker_session_factory,
+        delivery_id=delivery_id,
+        mark_provider_started=True,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"920092": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="replacement-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "idle"
+    assert outcome.recovered_dead_count == 1
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert row is not None and row.status == "dead"
+        assert attempt is not None
+        assert attempt.outcome == "dead"
+        assert attempt.provider_started_at is not None
+        assert attempt.ambiguous is True
+        assert attempt.error_code == "lease_expired_after_provider"
+
+
+@pytest.mark.asyncio
+async def test_provider_boundary_database_failure_prevents_network_call(
+    worker_session_factory,
+    monkeypatch,
+):
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=93,
+        telegram_id=930093,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"930093": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="boundary-failure-worker",
+        lease_seconds=60,
+    )
+
+    async def fail_boundary(cls, session, **kwargs):
+        raise RuntimeError("simulated provider-boundary database failure")
+
+    monkeypatch.setattr(
+        CommunicationDeliveryService,
+        "mark_provider_started",
+        classmethod(fail_boundary),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="simulated provider-boundary database failure",
+    ):
+        await worker.run_once()
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "running"
+        assert attempt.provider_started_at is None
+
+
+@pytest.mark.asyncio
+async def test_boundary_control_rejection_exhausts_without_ambiguity(
+    worker_session_factory,
+):
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=94,
+        telegram_id=940094,
+        max_attempts=1,
+    )
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"940094": ProviderDeliveryResult.sent("must-not-send")},
+    )
+
+    async def reject_boundary(_session):
+        raise RuntimeError("runtime control changed")
+
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="boundary-control-rejected-worker",
+        lease_seconds=60,
+        provider_boundary_check=reject_boundary,
+    )
+
+    with pytest.raises(RuntimeError, match="runtime control changed"):
+        await worker.run_once()
+
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        delivery = await session.get(CommunicationDelivery, delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert delivery is not None
+        assert delivery.status == "dead"
+        assert delivery.worker_id is None
+        assert delivery.lease_token is None
+        assert delivery.lease_expires_at is None
+        assert attempt is not None
+        assert attempt.outcome == "dead"
+        assert attempt.provider_started_at is None
+        assert attempt.ambiguous is False
+        assert attempt.error_code == "runtime_control_fenced_before_provider"

--- a/tests/unit/test_communication_delivery_scope_integrity.py
+++ b/tests/unit/test_communication_delivery_scope_integrity.py
@@ -44,7 +44,12 @@ def _scope_case(
 ) -> tuple[CommunicationProcessingScope, str, str]:
     if mode == "all":
         return (
-            CommunicationProcessingScope.all(control_revision=1),
+            CommunicationProcessingScope.all(
+                control_revision=1,
+                event_created_at_watermark=datetime(
+                    2000, 1, 1, tzinfo=timezone.utc
+                ),
+            ),
             INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
             INSTALLATION_ESTIMATE_TEMPLATE_KEY,
         )
@@ -57,6 +62,7 @@ def _event(
     event_id: str,
     event_type: str,
     status: str = "published",
+    created_at: datetime = NOW,
 ) -> IntegrationOutboxEvent:
     return IntegrationOutboxEvent(
         event_id=event_id,
@@ -70,7 +76,7 @@ def _event(
         available_at=NOW,
         occurred_at=NOW,
         published_at=NOW if status == "published" else None,
-        created_at=NOW,
+        created_at=created_at,
         updated_at=NOW,
     )
 
@@ -271,11 +277,110 @@ async def test_recovery_requires_published_allowed_event_and_allowed_template(
         )
         await session.commit()
 
-        assert recovered.retry_count == 1
-        assert recovered.dead_count == 0
+        assert recovered.retry_count == (1 if mode == "all" else 0)
+        assert recovered.dead_count == (1 if mode == "staff_bot" else 0)
         await session.refresh(deliveries[-1])
-        assert deliveries[-1].status == "retry"
+        assert deliveries[-1].status == (
+            "dead" if mode == "staff_bot" else "retry"
+        )
         for excluded in deliveries[:-1]:
             await session.refresh(excluded)
             assert excluded.status == "running"
             assert excluded.worker_id == "expired-worker"
+
+
+@pytest.mark.asyncio
+async def test_all_scope_watermark_fences_claim_and_expired_lease_recovery(
+    session_factory,
+):
+    scope = CommunicationProcessingScope.all(
+        control_revision=2,
+        event_created_at_watermark=NOW,
+    )
+    before_event = _event(
+        event_id="a" * 32,
+        event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+        created_at=NOW - timedelta(microseconds=1),
+    )
+    current_event = _event(
+        event_id="b" * 32,
+        event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+        created_at=NOW,
+    )
+    before_queued = _delivery(
+        21,
+        event_id=before_event.event_id,
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        status="queued",
+        priority=-100,
+    )
+    current_queued = _delivery(
+        22,
+        event_id=current_event.event_id,
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        status="queued",
+        priority=100,
+    )
+    before_running = _delivery(
+        23,
+        event_id=before_event.event_id,
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        status="running",
+        priority=-100,
+    )
+    current_running = _delivery(
+        24,
+        event_id=current_event.event_id,
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        status="running",
+        priority=100,
+    )
+    async with session_factory() as session:
+        session.add_all(
+            [
+                before_event,
+                current_event,
+                before_queued,
+                current_queued,
+                before_running,
+                current_running,
+                CommunicationDeliveryAttempt(
+                    delivery_id=before_running.delivery_id,
+                    attempt_no=1,
+                    started_at=NOW - timedelta(minutes=1),
+                    outcome="running",
+                ),
+                CommunicationDeliveryAttempt(
+                    delivery_id=current_running.delivery_id,
+                    attempt_no=1,
+                    started_at=NOW - timedelta(minutes=1),
+                    outcome="running",
+                ),
+            ]
+        )
+        await session.commit()
+
+        recovery = await CommunicationDeliveryService.recover_expired_leases(
+            session,
+            scope=scope,
+            now=NOW,
+        )
+        assert recovery.retry_count == 1
+        assert recovery.dead_count == 0
+        await session.refresh(before_running)
+        await session.refresh(current_running)
+        assert before_running.status == "running"
+        assert current_running.status == "retry"
+
+        claim = await CommunicationDeliveryService.claim_next(
+            session,
+            scope=scope,
+            worker_id="watermark-worker",
+            now=NOW,
+        )
+        await session.commit()
+
+        assert claim is not None
+        assert claim.delivery_id == current_queued.delivery_id
+        await session.refresh(before_queued)
+        assert before_queued.status == "queued"

--- a/tests/unit/test_communication_delivery_service.py
+++ b/tests/unit/test_communication_delivery_service.py
@@ -31,7 +31,10 @@ from services.communications.template_registry import (
 )
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 
 
 @pytest.fixture
@@ -235,7 +238,7 @@ async def test_claim_snapshot_is_frozen_and_redacts_lease_token(
 
 
 @pytest.mark.asyncio
-async def test_expired_running_is_recovered_before_it_can_be_claimed(
+async def test_expired_pre_provider_running_is_retried_after_backoff(
     delivery_session_factory,
 ):
     expired_token = "x" * 43
@@ -286,6 +289,7 @@ async def test_expired_running_is_recovered_before_it_can_be_claimed(
         assert recovered is not None
         assert recovered.status == "retry"
         assert recovered.attempts == 1
+        assert recovered.finished_at is None
         assert recovered.available_at > NOW.replace(tzinfo=None)
         recovered_attempt = await session.get(
             CommunicationDeliveryAttempt,
@@ -294,8 +298,11 @@ async def test_expired_running_is_recovered_before_it_can_be_claimed(
         assert recovered_attempt is not None
         assert recovered_attempt.outcome == "retry"
         assert recovered_attempt.error_category == "lease"
-        assert recovered_attempt.error_code == "lease_expired"
-        assert recovered_attempt.ambiguous is True
+        assert (
+            recovered_attempt.error_code
+            == "lease_expired_before_provider"
+        )
+        assert recovered_attempt.ambiguous is False
 
 
 @pytest.mark.asyncio
@@ -401,9 +408,9 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
         await session.commit()
 
     result = ProviderDeliveryResult.transient_failure(
-        category="rate_limit\nsecret",
-        code="plaintextsecret123",
-        message="Safe\nmessage",
+        category="rate_limit",
+        code="telegram_retry_after",
+        message="Telegram rejected the request before acceptance",
         retry_after_seconds=900,
     )
     async with delivery_session_factory() as session:
@@ -426,9 +433,12 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
         assert row.status == "retry"
         assert row.attempts == 1
         assert row.finished_at is None
-        assert row.last_error_category == "rate_limit secret"
-        assert row.last_error_code == "plaintextsecret123"
-        assert row.last_error_message == "Safe message"
+        assert row.last_error_category == "rate_limit"
+        assert row.last_error_code == "telegram_retry_after"
+        assert (
+            row.last_error_message
+            == "Telegram rejected the request before acceptance"
+        )
         assert row.worker_id is None
         attempt = await session.get(
             CommunicationDeliveryAttempt,
@@ -436,8 +446,8 @@ async def test_transient_failure_has_deterministic_backoff_and_retry_after_lower
         )
         assert attempt is not None
         assert attempt.outcome == "retry"
-        assert attempt.error_category == "unknown"
-        assert attempt.error_code == "delivery_failed"
+        assert attempt.error_category == "rate_limit"
+        assert attempt.error_code == "telegram_retry_after"
         assert attempt.retry_after_seconds == 900
         assert attempt.provider_latency_ms == 125
         assert attempt.ambiguous is False
@@ -599,7 +609,12 @@ async def test_recovery_is_limited_ordered_and_separates_retry_from_dead(
                 )
             ).scalars()
         )
-        assert [row.status for row in rows] == ["retry", "dead", "running", "running"]
+        assert [row.status for row in rows] == [
+            "retry",
+            "dead",
+            "running",
+            "running",
+        ]
         assert [row.attempts for row in rows] == [1, 3, 1, 1]
         attempts = list(
             (
@@ -617,12 +632,17 @@ async def test_recovery_is_limited_ordered_and_separates_retry_from_dead(
             "running",
         ]
         assert [attempt.error_code for attempt in attempts] == [
-            "lease_expired",
-            "lease_expired",
+            "lease_expired_before_provider",
+            "lease_expired_before_provider",
             None,
             None,
         ]
-        assert [attempt.ambiguous for attempt in attempts] == [True, True, False, False]
+        assert [attempt.ambiguous for attempt in attempts] == [
+            False,
+            False,
+            False,
+            False,
+        ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_communication_delivery_worker.py
+++ b/tests/unit/test_communication_delivery_worker.py
@@ -30,7 +30,10 @@ from services.communications.template_registry import (
     INSTALLATION_ESTIMATE_TEMPLATE_KEY,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 
 
 @pytest.fixture
@@ -124,16 +127,24 @@ class RecordingProvider:
         self._outcomes = outcomes
         self.calls: list[tuple[str, str, str]] = []
         self.claim_was_durable = False
+        self.provider_boundary_was_durable = False
 
     async def send(self, *, destination: str, text: str, delivery_id: str):
         async with self._session_factory() as session:
             row = await session.get(CommunicationDelivery, delivery_id)
+            attempt = await session.get(
+                CommunicationDeliveryAttempt,
+                (delivery_id, int(row.attempts) if row is not None else 0),
+            )
             self.claim_was_durable = bool(
                 row
                 and row.status == "running"
                 and row.worker_id
                 and row.lease_token
                 and row.lease_expires_at
+            )
+            self.provider_boundary_was_durable = bool(
+                attempt and attempt.provider_started_at is not None
             )
         self.calls.append((destination, text, delivery_id))
         outcome = self._outcomes[destination]
@@ -241,6 +252,7 @@ async def test_worker_commits_claim_before_provider_and_marks_sent(
     assert outcome.outcome == "sent"
     assert outcome.delivery_id == delivery_id
     assert provider.claim_was_durable is True
+    assert provider.provider_boundary_was_durable is True
     assert len(provider.calls) == 1
     assert "Lead 1" in provider.calls[0][1]
     async with worker_session_factory() as session:
@@ -311,8 +323,8 @@ async def test_worker_refences_expired_lease_before_network_call(
     )
     original_recipient_check = worker._recipient_is_current
 
-    async def expire_after_recipient_check(claim):
-        is_current = await original_recipient_check(claim)
+    async def expire_after_recipient_check(claim, plan):
+        is_current = await original_recipient_check(claim, plan)
         async with worker_session_factory() as session:
             row = await session.get(CommunicationDelivery, claim.delivery_id)
             assert row is not None
@@ -501,67 +513,17 @@ async def test_cancellation_inside_failure_finalizer_commits_then_propagates(
     async with worker_session_factory() as session:
         row = await session.get(CommunicationDelivery, delivery_id)
         assert row is not None
-        assert row.status == "retry"
+        assert row.status == "dead"
         assert row.last_error_code == "timeout"
         attempt = await session.get(
             CommunicationDeliveryAttempt,
             (delivery_id, 1),
         )
         assert attempt is not None
-        assert attempt.outcome == "retry"
+        assert attempt.outcome == "dead"
         assert attempt.provider_latency_ms is not None
         assert attempt.provider_latency_ms >= 0
         assert attempt.ambiguous is True
-
-
-@pytest.mark.asyncio
-async def test_worker_revalidates_recipient_and_cancels_without_network(
-    worker_session_factory,
-    monkeypatch,
-):
-    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
-    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
-    owner_id, delivery_id = await _seed_delivery(
-        worker_session_factory,
-        sequence=2,
-        telegram_id=202002,
-    )
-    async with worker_session_factory() as session:
-        owner = await session.get(StaffUser, owner_id)
-        assert owner is not None
-        owner.status = "blocked"
-        session.add(owner)
-        await session.commit()
-
-    provider = RecordingProvider(
-        worker_session_factory,
-        {"202002": ProviderDeliveryResult.sent("must-not-send")},
-    )
-    worker = CommunicationDeliveryWorker(
-        session_factory=worker_session_factory,
-        scope=ALL_SCOPE,
-        provider=provider,
-        worker_id="test-worker",
-        lease_seconds=60,
-    )
-
-    outcome = await worker.run_once()
-
-    assert outcome.outcome == "canceled"
-    assert provider.calls == []
-    async with worker_session_factory() as session:
-        row = await session.get(CommunicationDelivery, delivery_id)
-        assert row is not None
-        assert row.status == "canceled"
-        assert row.last_error_code == "recipient_inactive"
-        assert row.finished_at is not None
-        attempt = await session.get(
-            CommunicationDeliveryAttempt,
-            (delivery_id, 1),
-        )
-        assert attempt is not None
-        assert attempt.outcome == "canceled"
-        assert attempt.provider_latency_ms is None
 
 
 @pytest.mark.asyncio
@@ -571,18 +533,49 @@ async def test_worker_keeps_recipient_failures_independent(
 ):
     monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
     monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
-    _, retry_delivery_id = await _seed_delivery(
+    _, ambiguous_delivery_id = await _seed_delivery(
         worker_session_factory,
         sequence=3,
         telegram_id=303003,
         priority=1,
     )
-    _, sent_delivery_id = await _seed_delivery(
-        worker_session_factory,
-        sequence=4,
-        telegram_id=404004,
-        priority=2,
-    )
+    sent_delivery_id = f"{4:032x}"
+    async with worker_session_factory() as session:
+        second_owner = StaffUser(
+            display_name="Owner 4",
+            status="active",
+            roles=["owner"],
+            primary_role="owner",
+            telegram_id=404004,
+        )
+        session.add(second_owner)
+        await session.flush()
+        assert second_owner.id is not None
+        existing = await session.get(
+            CommunicationDelivery,
+            ambiguous_delivery_id,
+        )
+        assert existing is not None
+        session.add(
+            CommunicationDelivery(
+                delivery_id=sent_delivery_id,
+                event_id=existing.event_id,
+                channel=existing.channel,
+                recipient_key=f"staff:{second_owner.id}",
+                destination="404004",
+                template_key=existing.template_key,
+                template_version=existing.template_version,
+                render_context=existing.render_context,
+                status="queued",
+                priority=2,
+                attempts=0,
+                max_attempts=existing.max_attempts,
+                available_at=existing.available_at,
+                created_at=existing.created_at,
+                updated_at=existing.updated_at,
+            )
+        )
+        await session.commit()
     provider = RecordingProvider(
         worker_session_factory,
         {
@@ -605,8 +598,8 @@ async def test_worker_keeps_recipient_failures_independent(
     first = await worker.run_once()
     second = await worker.run_once()
 
-    assert first.outcome == "retry"
-    assert first.delivery_id == retry_delivery_id
+    assert first.outcome == "dead"
+    assert first.delivery_id == ambiguous_delivery_id
     assert second.outcome == "sent"
     assert second.delivery_id == sent_delivery_id
     async with worker_session_factory() as session:
@@ -619,7 +612,7 @@ async def test_worker_keeps_recipient_failures_independent(
                 )
             ).scalars()
         )
-        assert [row.status for row in rows] == ["retry", "sent"]
+        assert [row.status for row in rows] == ["dead", "sent"]
         assert [row.attempts for row in rows] == [1, 1]
 
 

--- a/tests/unit/test_communication_installation_audience_safety.py
+++ b/tests/unit/test_communication_installation_audience_safety.py
@@ -1,0 +1,377 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func
+from sqlmodel import select
+
+from core.config import settings
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    ConsumerInbox,
+    StaffUser,
+)
+from services.communications.canary_errors import CommunicationsCanarySafetyError
+from services.communications.contracts import CommunicationRecipientV1
+from services.communications.delivery_materializer import (
+    CommunicationDeliveryMaterializer,
+)
+from services.communications.delivery_worker import CommunicationDeliveryWorker
+from services.communications.dispatcher import CommunicationOutboxDispatcher
+from services.communications.processing_scope import CommunicationProcessingScope
+from services.communications.providers.base import ProviderDeliveryResult
+from services.communications.recipient_directory import (
+    InstallationEstimateOwnerRecipientDirectory,
+)
+from services.communications.template_registry import (
+    CONSUMER_NAME,
+    WebsiteTemplateRegistry,
+)
+from tests.unit.test_communication_delivery_worker import (
+    RecordingProvider,
+    _seed_delivery,
+    worker_session_factory,
+)
+from tests.unit.test_communications_dispatcher import (
+    ALL_SCOPE,
+    _event,
+    _owner,
+    communications_session_factory,
+)
+
+
+@pytest.mark.asyncio
+async def test_installation_owner_directory_rejects_duplicate_destination():
+    owners = [_owner(303), _owner(303, name="Duplicate")]
+    owners[0].id = 1
+    owners[1].id = 2
+
+    class StaticResult:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return owners
+
+    class StaticSession:
+        async def execute(self, statement):
+            return StaticResult()
+
+    with pytest.raises(
+        CommunicationsCanarySafetyError,
+        match="installation_owner_recipient_duplicate",
+    ):
+        await InstallationEstimateOwnerRecipientDirectory.list_telegram(
+            StaticSession()  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "noncanonical_user",
+    [
+        StaffUser(
+            display_name="Canonical admin",
+            status="active",
+            roles=["admin"],
+            primary_role="admin",
+            telegram_id=91001,
+        ),
+        StaffUser(
+            display_name="Legacy admin",
+            status="active",
+            roles=["admin"],
+            primary_role="installer",
+            telegram_id=91002,
+        ),
+        StaffUser(
+            display_name="Unknown status owner",
+            status="legacy-active",
+            roles=["owner"],
+            primary_role="owner",
+            telegram_id=91003,
+        ),
+    ],
+)
+async def test_installation_owner_directory_rejects_normalized_legacy_audience(
+    communications_session_factory,
+    noncanonical_user,
+):
+    async with communications_session_factory() as session:
+        session.add(noncanonical_user)
+        await session.commit()
+
+        with pytest.raises(
+            CommunicationsCanarySafetyError,
+            match="installation_owner_recipient_count_invalid",
+        ):
+            await InstallationEstimateOwnerRecipientDirectory.list_telegram(
+                session
+            )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_all_scope_never_selects_an_event_before_the_watermark(
+    communications_session_factory,
+):
+    watermark = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    scope = CommunicationProcessingScope.all(
+        control_revision=1,
+        event_created_at_watermark=watermark,
+    )
+    async with communications_session_factory() as session:
+        before = _event(
+            22,
+            now=watermark - timedelta(seconds=1),
+            priority=-100,
+        )
+        at_watermark = _event(23, now=watermark, priority=100)
+        session.add_all([before, at_watermark, _owner(303)])
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            scope=scope,
+            dispatcher_id="dispatcher-a",
+            now=watermark,
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.event_id == at_watermark.event_id
+        assert outcome.outcome == "materialized"
+        await session.refresh(before)
+        assert before.status == "pending"
+        assert before.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_installation_audience_excludes_managers_and_admin_fallback(
+    communications_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "700,701", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 702, raising=False)
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        session.add_all(
+            [
+                _event(24, now=now),
+                _owner(303),
+                StaffUser(
+                    display_name="Manager",
+                    status="active",
+                    roles=["manager"],
+                    primary_role="manager",
+                    telegram_id=404,
+                ),
+            ]
+        )
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            scope=ALL_SCOPE,
+            dispatcher_id="dispatcher-a",
+            now=now,
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "materialized"
+        destinations = list(
+            (
+                await session.execute(
+                    select(CommunicationDelivery.destination)
+                )
+            ).scalars()
+        )
+        assert destinations == ["303"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_fails_closed_when_any_active_owner_is_invalid(
+    communications_session_factory,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(25, now=now, max_attempts=2)
+        session.add_all(
+            [
+                event,
+                _owner(303),
+                StaffUser(
+                    display_name="Owner without Telegram",
+                    status="active",
+                    roles=["owner"],
+                    primary_role="owner",
+                    telegram_id=None,
+                ),
+            ]
+        )
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            scope=ALL_SCOPE,
+            dispatcher_id="dispatcher-a",
+            now=now,
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "retry_scheduled"
+        assert event.last_error_code == "installation_owner_recipient_invalid"
+        assert (
+            await session.execute(
+                select(func.count(CommunicationDelivery.delivery_id))
+            )
+        ).scalar_one() == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_existing_inbox_after_exact_owner_set_drift(
+    communications_session_factory,
+):
+    now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
+    async with communications_session_factory() as session:
+        event = _event(62, now=now)
+        first_owner = _owner(700)
+        session.add_all([event, first_owner])
+        await session.flush()
+        plan = WebsiteTemplateRegistry.plan(event)
+        await CommunicationDeliveryMaterializer.materialize(
+            session,
+            event=event,
+            plan=plan,
+            recipients=[
+                CommunicationRecipientV1(
+                    recipient_key=f"staff:{first_owner.id}",
+                    destination="700",
+                    source="staff",
+                    staff_user_id=first_owner.id,
+                )
+            ],
+            now=now,
+        )
+        session.add(
+            ConsumerInbox(
+                consumer_name=CONSUMER_NAME,
+                event_id=event.event_id,
+                handler_version=1,
+                received_at=now,
+                processed_at=now,
+            )
+        )
+        session.add(_owner(701, name="New owner"))
+        await session.commit()
+
+        outcome = await CommunicationOutboxDispatcher.dispatch_next(
+            session,
+            scope=ALL_SCOPE,
+            dispatcher_id="dispatcher-a",
+            now=now,
+        )
+        await session.commit()
+
+        assert outcome is not None
+        assert outcome.outcome == "dead"
+        assert event.status == "dead"
+        assert event.last_error_code == "ConsumerInboxConsistencyError"
+
+
+@pytest.mark.asyncio
+async def test_worker_revalidates_recipient_and_cancels_without_network(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
+    owner_id, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=2,
+        telegram_id=202002,
+    )
+    async with worker_session_factory() as session:
+        owner = await session.get(StaffUser, owner_id)
+        assert owner is not None
+        owner.status = "blocked"
+        session.add(owner)
+        await session.commit()
+
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"202002": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="test-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "canceled"
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "canceled"
+        assert row.last_error_code == "recipient_inactive"
+        assert row.finished_at is not None
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
+        assert attempt is not None
+        assert attempt.outcome == "canceled"
+        assert attempt.provider_latency_ms is None
+
+
+@pytest.mark.asyncio
+async def test_worker_cancels_when_materialized_set_no_longer_matches_all_owners(
+    worker_session_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ADMIN_IDS", "999999", raising=False)
+    monkeypatch.setattr(settings, "ADMIN_ID", 999998, raising=False)
+    _, delivery_id = await _seed_delivery(
+        worker_session_factory,
+        sequence=22,
+        telegram_id=220022,
+    )
+    async with worker_session_factory() as session:
+        session.add(
+            StaffUser(
+                display_name="Owner added after materialization",
+                status="active",
+                roles=["owner"],
+                primary_role="owner",
+                telegram_id=220023,
+            )
+        )
+        await session.commit()
+
+    provider = RecordingProvider(
+        worker_session_factory,
+        {"220022": ProviderDeliveryResult.sent("must-not-send")},
+    )
+    worker = CommunicationDeliveryWorker(
+        session_factory=worker_session_factory,
+        scope=ALL_SCOPE,
+        provider=provider,
+        worker_id="exact-owner-set-worker",
+        lease_seconds=60,
+    )
+
+    outcome = await worker.run_once()
+
+    assert outcome.outcome == "canceled"
+    assert provider.calls == []
+    async with worker_session_factory() as session:
+        row = await session.get(CommunicationDelivery, delivery_id)
+        assert row is not None
+        assert row.status == "canceled"
+        assert row.last_error_code == "recipient_inactive"

--- a/tests/unit/test_communication_installation_watermark_migration.py
+++ b/tests/unit/test_communication_installation_watermark_migration.py
@@ -1,0 +1,143 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect
+
+
+REVISION = "d8e7f6a5b4c3"
+MIGRATION_PATH = Path(
+    "alembic/versions/d8e7f6a5b4c3_add_installation_notification_watermark.py"
+)
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "installation_notification_watermark_migration",
+        MIGRATION_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_installation_watermark_precedes_the_single_provider_boundary_head():
+    script = ScriptDirectory.from_config(Config("alembic.ini"))
+    revision = script.get_revision(REVISION)
+
+    assert script.get_heads() == ["e9a1b2c3d4e5"]
+    assert revision is not None
+    assert revision.down_revision == "f4d5e6f7a8b9"
+
+
+def test_watermark_migration_fails_legacy_all_closed_and_is_reversible():
+    migration = _load_migration_module()
+    engine = create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    runtime_state = sa.Table(
+        "communication_runtime_state",
+        metadata,
+        sa.Column("channel", sa.String(32), primary_key=True),
+        sa.Column("mode", sa.String(16), nullable=False),
+        sa.Column("canary_run_id", sa.String(36), nullable=True),
+        sa.Column("control_revision", sa.BigInteger(), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column("instance_id", sa.String(128), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_activity_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_code", sa.String(100), nullable=True),
+        sa.Column("control_updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "(mode = 'canary' AND canary_run_id IS NOT NULL "
+            "AND length(canary_run_id) = 36) OR "
+            "(mode IN ('off', 'all') AND canary_run_id IS NULL)",
+            name="ck_communication_runtime_canary_scope_valid",
+        ),
+        sa.CheckConstraint(
+            "control_revision >= 0",
+            name="ck_communication_runtime_control_revision_non_negative",
+        ),
+    )
+    now = datetime(2026, 7, 27, tzinfo=timezone.utc)
+
+    with engine.begin() as connection:
+        metadata.create_all(connection)
+        connection.execute(
+            runtime_state.insert().values(
+                channel="telegram",
+                mode="all",
+                canary_run_id=None,
+                control_revision=7,
+                status="stopped",
+                control_updated_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        migration.op = Operations(MigrationContext.configure(connection))
+        migration.upgrade()
+
+        columns = {
+            column["name"]: column
+            for column in inspect(connection).get_columns(
+                "communication_runtime_state"
+            )
+        }
+        checks = {
+            check["name"]
+            for check in inspect(connection).get_check_constraints(
+                "communication_runtime_state"
+            )
+        }
+        assert columns["installation_estimate_watermark_at"]["nullable"] is True
+        assert "ck_communication_runtime_all_watermark_required" in checks
+        row = connection.execute(
+            sa.text(
+                "SELECT mode, control_revision, "
+                "installation_estimate_watermark_at "
+                "FROM communication_runtime_state WHERE channel = 'telegram'"
+            )
+        ).one()
+        assert tuple(row) == ("off", 8, None)
+
+        with pytest.raises(sa.exc.IntegrityError):
+            connection.execute(
+                sa.text(
+                    "UPDATE communication_runtime_state "
+                    "SET mode = 'all' WHERE channel = 'telegram'"
+                )
+            )
+        connection.execute(
+            sa.text(
+                "UPDATE communication_runtime_state "
+                "SET mode = 'all', "
+                "installation_estimate_watermark_at = :watermark "
+                "WHERE channel = 'telegram'"
+            ),
+            {"watermark": now.isoformat()},
+        )
+
+        migration.downgrade()
+        assert "installation_estimate_watermark_at" not in {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "communication_runtime_state"
+            )
+        }
+        downgraded = connection.execute(
+            sa.text(
+                "SELECT mode, control_revision "
+                "FROM communication_runtime_state WHERE channel = 'telegram'"
+            )
+        ).one()
+        assert tuple(downgraded) == ("off", 9)

--- a/tests/unit/test_communication_processing_scope.py
+++ b/tests/unit/test_communication_processing_scope.py
@@ -165,7 +165,10 @@ def test_processing_scope_factories_are_closed_immutable_allowlists():
         run_id=RUN_ID_A,
         control_revision=7,
     )
-    full = CommunicationProcessingScope.all(control_revision=8)
+    full = CommunicationProcessingScope.all(
+        control_revision=8,
+        event_created_at_watermark=NOW,
+    )
     staff_bot = CommunicationProcessingScope.staff_bot(control_revision=9)
 
     assert canary.outbox_event_types == CANARY_EVENT_TYPES
@@ -187,6 +190,24 @@ def test_processing_scope_factories_are_closed_immutable_allowlists():
     assert not set(STAFF_BOT_TEMPLATE_KEYS).intersection(ALL_TEMPLATE_KEYS)
     with pytest.raises(FrozenInstanceError):
         canary.control_revision = 9  # type: ignore[misc]
+
+
+def test_all_scope_requires_an_aware_exact_utc_activation_watermark():
+    with pytest.raises(ValueError, match="inconsistent"):
+        CommunicationProcessingScope.all(
+            control_revision=1,
+            event_created_at_watermark=datetime(2026, 7, 27),
+        )
+    with pytest.raises(ValueError, match="normalized to UTC"):
+        CommunicationProcessingScope.all(
+            control_revision=1,
+            event_created_at_watermark=datetime(
+                2026,
+                7,
+                27,
+                tzinfo=timezone(timedelta(hours=3)),
+            ),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_communication_runtime_state.py
+++ b/tests/unit/test_communication_runtime_state.py
@@ -1,4 +1,4 @@
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -19,6 +19,29 @@ from services.communications.runtime_state import (
 
 RUN_ID_A = "123e4567-e89b-42d3-a456-426614174000"
 RUN_ID_B = "123e4567-e89b-42d3-a456-426614174001"
+
+
+def test_control_application_cannot_remove_or_move_an_existing_watermark():
+    watermark = datetime(2026, 7, 27, tzinfo=timezone.utc)
+    state = CommunicationRuntimeState(
+        channel="telegram",
+        installation_estimate_watermark_at=watermark,
+    )
+
+    for replacement in (None, watermark + timedelta(seconds=1)):
+        with pytest.raises(
+            CommunicationRuntimeControlConflict,
+            match="installation_activation_watermark_immutable",
+        ):
+            CommunicationRuntimeStateService._apply_control(
+                state,
+                mode=CommunicationRuntimeMode.OFF,
+                canary_run_id=None,
+                now=watermark,
+                installation_estimate_watermark_at=replacement,
+            )
+        assert state.control_revision == 0
+        assert state.installation_estimate_watermark_at == watermark
 
 
 @pytest_asyncio.fixture
@@ -106,7 +129,10 @@ async def test_control_transitions_are_explicit_and_revisioned(
                 channel="telegram",
                 mode=CommunicationRuntimeMode.CANARY,
             )
-        with pytest.raises(ValueError, match="Only canary"):
+        with pytest.raises(
+            CommunicationRuntimeControlConflict,
+            match="installation_activation_requires_typed_control",
+        ):
             await CommunicationRuntimeStateService.set_mode(
                 session,
                 channel="telegram",
@@ -121,20 +147,25 @@ async def test_control_transitions_are_explicit_and_revisioned(
         )
         assert canary.control_revision == 1
 
-        for mode, run_id in (
-            (CommunicationRuntimeMode.ALL, None),
-            (CommunicationRuntimeMode.CANARY, RUN_ID_B),
+        with pytest.raises(
+            CommunicationRuntimeControlConflict,
+            match="installation_activation_requires_typed_control",
         ):
-            with pytest.raises(
-                CommunicationRuntimeControlConflict,
-                match="runtime_control_transition_requires_off",
-            ):
-                await CommunicationRuntimeStateService.set_mode(
-                    session,
-                    channel="telegram",
-                    mode=mode,
-                    canary_run_id=run_id,
-                )
+            await CommunicationRuntimeStateService.set_mode(
+                session,
+                channel="telegram",
+                mode=CommunicationRuntimeMode.ALL,
+            )
+        with pytest.raises(
+            CommunicationRuntimeControlConflict,
+            match="runtime_control_transition_requires_off",
+        ):
+            await CommunicationRuntimeStateService.set_mode(
+                session,
+                channel="telegram",
+                mode=CommunicationRuntimeMode.CANARY,
+                canary_run_id=RUN_ID_B,
+            )
 
         with pytest.raises(
             CommunicationRuntimeControlConflict,
@@ -153,20 +184,16 @@ async def test_control_transitions_are_explicit_and_revisioned(
         )
         assert off.canary_run_id is None
         assert off.control_revision == 2
-        all_control = await CommunicationRuntimeStateService.set_mode(
-            session,
-            channel="telegram",
-            mode=CommunicationRuntimeMode.ALL,
-        )
-        assert all_control.control_revision == 3
-        assert all_control.canary_run_id is None
-
-        idempotent = await CommunicationRuntimeStateService.set_mode(
-            session,
-            channel="telegram",
-            mode=CommunicationRuntimeMode.ALL,
-        )
-        assert idempotent.control_revision == 3
+        with pytest.raises(
+            CommunicationRuntimeControlConflict,
+            match="installation_activation_requires_typed_control",
+        ):
+            await CommunicationRuntimeStateService.set_mode(
+                session,
+                channel="telegram",
+                mode=CommunicationRuntimeMode.ALL,
+            )
+        assert off.control_revision == 2
         await session.commit()
 
 

--- a/tests/unit/test_communication_runtime_worker_fences.py
+++ b/tests/unit/test_communication_runtime_worker_fences.py
@@ -34,7 +34,10 @@ from services.communications.template_registry import (
     PUBLIC_ORDER_CREATED_EVENT,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 RUN_ID_A = "123e4567-e89b-42d3-a456-426614174000"
 
 
@@ -60,11 +63,16 @@ async def seed_delivery(
 ) -> str:
     now = datetime.now(timezone.utc)
     async with session_factory() as session:
+        recipient_role = (
+            "owner"
+            if template_key == INSTALLATION_ESTIMATE_TEMPLATE_KEY
+            else "manager"
+        )
         owner = StaffUser(
             display_name=f"Owner {sequence}",
             status="active",
-            roles=["owner"],
-            primary_role="owner",
+            roles=[recipient_role],
+            primary_role=recipient_role,
             telegram_id=telegram_id,
         )
         session.add(owner)
@@ -181,11 +189,20 @@ async def test_runtime_scope_leaves_contact_and_order_deliveries_untouched(
 
 async def own_runtime_mode(session_factory) -> CommunicationProcessingScope:
     async with session_factory() as session:
-        control = await CommunicationRuntimeStateService.set_mode(
+        state = await CommunicationRuntimeStateService.ensure_state(
             session,
             channel="telegram",
-            mode=CommunicationRuntimeMode.ALL,
         )
+        state.mode = CommunicationRuntimeMode.ALL.value
+        state.canary_run_id = None
+        state.control_revision = int(state.control_revision) + 1
+        state.installation_estimate_watermark_at = (
+            state.installation_estimate_watermark_at
+            or datetime(2000, 1, 1, tzinfo=timezone.utc)
+        )
+        session.add(state)
+        await session.flush()
+        control = CommunicationRuntimeStateService._to_control(state)
         await CommunicationRuntimeStateService.take_ownership(
             session,
             channel="telegram",
@@ -193,7 +210,10 @@ async def own_runtime_mode(session_factory) -> CommunicationProcessingScope:
         )
         await session.commit()
         return CommunicationProcessingScope.all(
-            control_revision=control.control_revision
+            control_revision=control.control_revision,
+            event_created_at_watermark=(
+                control.installation_estimate_watermark_at
+            ),
         )
 
 
@@ -256,7 +276,7 @@ class ImmediateProvider:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("blocked_call", "expected_status", "expected_attempts"),
-    [(2, "queued", 0), (3, "running", 1)],
+    [(2, "queued", 0), (3, "retry", 1)],
 )
 async def test_runtime_safety_check_fences_claim_and_provider_send(
     worker_session_factory,
@@ -352,7 +372,7 @@ async def test_db_mode_flip_before_claim_leaves_delivery_queued(
     "blocked_mode",
     [CommunicationRuntimeMode.OFF, CommunicationRuntimeMode.CANARY],
 )
-async def test_db_mode_flip_before_provider_send_leaves_durable_claim(
+async def test_db_mode_flip_before_provider_send_releases_pre_provider_claim(
     worker_session_factory,
     monkeypatch,
     blocked_mode,
@@ -374,13 +394,18 @@ async def test_db_mode_flip_before_provider_send_leaves_durable_claim(
         lease_seconds=60,
         safety_check=active_mode_safety_check(worker_session_factory, scope),
     )
-    original_renewal = worker._renew_before_send
+    original_recipient_check = worker._recipient_is_current
 
-    async def renew_then_flip_mode(claim):
-        await original_renewal(claim)
+    async def check_then_flip_mode(claim, plan):
+        is_current = await original_recipient_check(claim, plan)
         await set_runtime_mode(worker_session_factory, blocked_mode)
+        return is_current
 
-    monkeypatch.setattr(worker, "_renew_before_send", renew_then_flip_mode)
+    monkeypatch.setattr(
+        worker,
+        "_recipient_is_current",
+        check_then_flip_mode,
+    )
 
     with pytest.raises(CommunicationRuntimeModeBlocked) as blocked:
         await worker.run_once()
@@ -388,9 +413,21 @@ async def test_db_mode_flip_before_provider_send_leaves_durable_claim(
     assert provider.calls == 0
     async with worker_session_factory() as session:
         row = await session.get(CommunicationDelivery, delivery_id)
+        attempt = await session.get(
+            CommunicationDeliveryAttempt,
+            (delivery_id, 1),
+        )
         assert row is not None
-        assert row.status == "running"
+        assert row.status == "retry"
         assert row.attempts == 1
+        assert row.worker_id is None
+        assert row.lease_token is None
+        assert row.lease_expires_at is None
+        assert attempt is not None
+        assert attempt.outcome == "retry"
+        assert attempt.provider_started_at is None
+        assert attempt.ambiguous is False
+        assert attempt.error_code == "runtime_control_fenced_before_provider"
 
 
 @pytest.mark.asyncio
@@ -488,14 +525,15 @@ async def test_terminal_db_timeout_is_recovered_as_ambiguous_attempt(
             now=recovery_time,
         )
         await session.commit()
-        assert recovered.retry_count == 1
+        assert recovered.retry_count == 0
+        assert recovered.dead_count == 1
 
     async with worker_session_factory() as session:
         row = await session.get(CommunicationDelivery, delivery_id)
         attempt = await session.get(CommunicationDeliveryAttempt, (delivery_id, 1))
         assert row is not None
-        assert row.status == "retry"
+        assert row.status == "dead"
         assert attempt is not None
-        assert attempt.outcome == "retry"
+        assert attempt.outcome == "dead"
         assert attempt.ambiguous is True
-        assert attempt.error_code == "lease_expired"
+        assert attempt.error_code == "lease_expired_after_provider"

--- a/tests/unit/test_communications_canary.py
+++ b/tests/unit/test_communications_canary.py
@@ -476,5 +476,5 @@ async def test_canary_worker_cancels_injected_render_context_without_provider_ca
     )
     outcome = await worker.run_once()
 
-    assert outcome.outcome == "canceled"
+    assert outcome.outcome == "dead"
     assert provider.calls == 0

--- a/tests/unit/test_communications_dispatcher.py
+++ b/tests/unit/test_communications_dispatcher.py
@@ -31,7 +31,10 @@ from services.communications.template_registry import (
     WebsiteTemplateRegistry,
 )
 
-ALL_SCOPE = CommunicationProcessingScope.all(control_revision=0)
+ALL_SCOPE = CommunicationProcessingScope.all(
+    control_revision=0,
+    event_created_at_watermark=datetime(2000, 1, 1, tzinfo=timezone.utc),
+)
 
 
 @pytest.fixture
@@ -221,7 +224,7 @@ async def test_dispatch_ignores_out_of_scope_events_and_respects_priority(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_retries_or_dead_letters_when_management_audience_is_empty(
+async def test_dispatch_retries_or_dead_letters_when_owner_audience_is_empty(
     communications_session_factory,
     monkeypatch,
 ):
@@ -242,7 +245,10 @@ async def test_dispatch_retries_or_dead_letters_when_management_audience_is_empt
         assert retry.outcome == "retry_scheduled"
         assert retry.next_attempt_at is not None
         assert retry_event.status == "pending"
-        assert retry_event.last_error_code == "NoEligibleCommunicationRecipients"
+        assert (
+            retry_event.last_error_code
+            == "installation_owner_recipient_count_invalid"
+        )
         assert await session.get(
             ConsumerInbox, (CONSUMER_NAME, retry_event.event_id)
         ) is None
@@ -458,6 +464,7 @@ async def test_dispatch_materializer_conflict_rolls_back_new_recipient_savepoint
             recipients=existing_recipients,
             now=now,
         )
+        session.add_all([_owner(700), _owner(702, name="Second")])
         await session.commit()
         monkeypatch.setattr(settings, "ADMIN_IDS", "700,702", raising=False)
         monkeypatch.setattr(settings, "ADMIN_ID", 0, raising=False)
@@ -492,14 +499,15 @@ async def test_dispatch_recovers_existing_inbox_without_duplicate_delivery(
     now = datetime(2026, 7, 12, 3, 0, tzinfo=timezone.utc)
     async with communications_session_factory() as session:
         event = _event(61, now=now)
-        plan = CommunicationTemplatePlanV1(
-            template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
-            render_context=event.payload,
-        )
+        owner = _owner(700)
+        session.add(owner)
+        await session.flush()
+        plan = WebsiteTemplateRegistry.plan(event)
         recipient = CommunicationRecipientV1(
-            recipient_key="legacy-telegram:700",
+            recipient_key=f"staff:{owner.id}",
             destination="700",
-            source="legacy",
+            source="staff",
+            staff_user_id=owner.id,
         )
         session.add(event)
         await session.flush()

--- a/tests/unit/test_communications_installation_notification_safety_queries.py
+++ b/tests/unit/test_communications_installation_notification_safety_queries.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from models import CommunicationDelivery, CommunicationDeliveryAttempt
+from scripts.communications_installation_notifications import run_command
+from services.communications.installation_notifications import (
+    InstallationNotificationControlRejected,
+)
+from services.communications.template_registry import (
+    INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+)
+from tests.unit.test_communications_installation_notifications_command import (
+    _event,
+    _runtime_config,
+    _seed_dormant_runtime,
+    _terminal_delivery,
+    allow_sqlite_operator_checks,
+    operator_session_factory,
+)
+
+
+@pytest.mark.asyncio
+async def test_activation_counts_future_skewed_unsafe_rows_fail_closed(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    pending = _event(51, status="pending", created_at=future)
+    running_event = _event(52, status="published", created_at=future)
+    ambiguous_event = _event(53, status="published", created_at=future)
+    running = CommunicationDelivery(
+        delivery_id=f"{251:032x}",
+        event_id=running_event.event_id,
+        channel="telegram",
+        recipient_key="staff:owner",
+        destination="90001",
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        template_version=1,
+        render_context={},
+        status="running",
+        attempts=1,
+        max_attempts=3,
+        available_at=future,
+        worker_id="future-worker",
+        lease_token="x" * 43,
+        lease_expires_at=future + timedelta(minutes=1),
+        created_at=future,
+        updated_at=future,
+    )
+    ambiguous = _terminal_delivery(
+        53,
+        event_id=ambiguous_event.event_id,
+        status="dead",
+        now=future,
+    )
+    ambiguous.status = "retry"
+    ambiguous.finished_at = None
+    async with operator_session_factory() as session:
+        session.add_all(
+            [
+                pending,
+                running_event,
+                ambiguous_event,
+                running,
+                ambiguous,
+                CommunicationDeliveryAttempt(
+                    delivery_id=running.delivery_id,
+                    attempt_no=1,
+                    started_at=future,
+                    outcome="running",
+                ),
+                CommunicationDeliveryAttempt(
+                    delivery_id=ambiguous.delivery_id,
+                    attempt_no=1,
+                    started_at=future,
+                    finished_at=future,
+                    outcome="retry",
+                    error_category="provider",
+                    error_code="provider_ack_unknown",
+                    ambiguous=True,
+                ),
+            ]
+        )
+        await session.commit()
+
+    plan = await run_command(
+        "plan",
+        session_factory=operator_session_factory,
+        config=_runtime_config(),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert plan["backlog_count"] == 3
+    assert plan["running_count"] == 1
+    assert plan["ambiguous_nonterminal_count"] == 1
+    assert plan["ambiguous_terminal_count"] == 0
+    assert plan["ambiguous_total_count"] == 1
+    assert "installation_backlog_not_reconciled" in plan["blockers"]
+    assert "installation_delivery_running" in plan["blockers"]
+    assert "installation_ambiguous_outcomes_unreconciled" in plan["blockers"]
+
+    with pytest.raises(
+        InstallationNotificationControlRejected,
+        match="installation_backlog_not_reconciled",
+    ):
+        await run_command(
+            "enable",
+            session_factory=operator_session_factory,
+            config=_runtime_config(),
+            bot_token="valid-token",
+            runtime_locks_enabled=True,
+        )

--- a/tests/unit/test_communications_installation_notifications_command.py
+++ b/tests/unit/test_communications_installation_notifications_command.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models import (
+    CommunicationDelivery,
+    CommunicationDeliveryAttempt,
+    CommunicationRuntimeState,
+    IntegrationOutboxEvent,
+    StaffUser,
+)
+import scripts.communications_installation_notifications as command_module
+from scripts.communications_installation_notifications import (
+    build_parser,
+    run_command,
+)
+from services.communications.installation_notifications import (
+    InstallationNotificationControlRejected,
+    InstallationNotificationOperations,
+)
+from services.communications.runtime_config import CommunicationRuntimeConfig
+from services.communications.template_registry import (
+    INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+    INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+)
+
+
+def _runtime_config(**overrides) -> CommunicationRuntimeConfig:
+    config = CommunicationRuntimeConfig(
+        enabled=True,
+        app_role="primary",
+        allow_all_mode=True,
+        instance_id="installation-operator-test",
+        poll_seconds=0.01,
+        heartbeat_seconds=10,
+        lock_retry_seconds=0.01,
+        lock_check_seconds=0.01,
+        db_probe_timeout_seconds=0.1,
+        fencing_seconds=3,
+        shutdown_seconds=0.2,
+        provider_timeout_seconds=1,
+        provider_close_seconds=0.1,
+        lease_seconds=30,
+    )
+    return replace(config, **overrides)
+
+
+@pytest.fixture
+async def operator_session_factory(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'installation-operator.sqlite3'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(StaffUser.__table__.create)
+        await connection.run_sync(IntegrationOutboxEvent.__table__.create)
+        await connection.run_sync(CommunicationDelivery.__table__.create)
+        await connection.run_sync(CommunicationDeliveryAttempt.__table__.create)
+        await connection.run_sync(CommunicationRuntimeState.__table__.create)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def allow_sqlite_operator_checks(monkeypatch):
+    async def writable_primary(cls, session):
+        return None
+
+    async def sole_lock_owner(cls, session, *, lock_name):
+        return 1
+
+    monkeypatch.setattr(
+        InstallationNotificationOperations,
+        "_database_primary_blocker",
+        classmethod(writable_primary),
+    )
+    monkeypatch.setattr(
+        InstallationNotificationOperations,
+        "_runtime_lock_owner_count",
+        classmethod(sole_lock_owner),
+    )
+
+
+async def _seed_dormant_runtime(session_factory) -> None:
+    now = datetime.now(timezone.utc) - timedelta(seconds=1)
+    async with session_factory() as session:
+        session.add_all(
+            [
+                StaffUser(
+                    display_name="Owner",
+                    status="active",
+                    roles=["owner"],
+                    primary_role="owner",
+                    telegram_id=90001,
+                ),
+                CommunicationRuntimeState(
+                    channel="telegram",
+                    mode="off",
+                    status="disabled",
+                    instance_id="communications-worker",
+                    heartbeat_at=now,
+                    control_updated_at=now,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+        await session.commit()
+
+
+def _event(
+    sequence: int,
+    *,
+    status: str,
+    created_at: datetime,
+) -> IntegrationOutboxEvent:
+    return IntegrationOutboxEvent(
+        event_id=f"{sequence:032x}",
+        event_type=INSTALLATION_ESTIMATE_LEAD_CREATED_EVENT,
+        schema_version=1,
+        aggregate_type="order",
+        aggregate_id=str(sequence),
+        deduplication_key=f"installation-operator:{sequence}",
+        payload={},
+        status=status,
+        attempts=1 if status != "pending" else 0,
+        available_at=created_at,
+        occurred_at=created_at,
+        published_at=created_at if status == "published" else None,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _terminal_delivery(
+    sequence: int,
+    *,
+    event_id: str,
+    status: str,
+    now: datetime,
+) -> CommunicationDelivery:
+    sent = status == "sent"
+    return CommunicationDelivery(
+        delivery_id=f"{sequence + 100:032x}",
+        event_id=event_id,
+        channel="telegram",
+        recipient_key="staff:owner",
+        destination="90001",
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        template_version=1,
+        render_context={},
+        status=status,
+        attempts=1,
+        max_attempts=3,
+        available_at=now,
+        provider_message_id="provider-ack" if sent else None,
+        sent_at=now if sent else None,
+        finished_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_sets_once_and_reuses_the_database_activation_watermark(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    config = _runtime_config()
+
+    first = await run_command(
+        "enable",
+        session_factory=operator_session_factory,
+        config=config,
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert first["runtime_mode"] == "all"
+    assert first["control_revision"] == 1
+    assert first["owner_recipient_count"] == 1
+    first_watermark = first["activation_watermark"]
+
+    disabled = await run_command(
+        "off",
+        session_factory=operator_session_factory,
+        config=replace(config, enabled=False, allow_all_mode=False),
+        bot_token=None,
+        runtime_locks_enabled=False,
+        off_wait_seconds=0,
+    )
+    assert disabled["drained"] is True
+    assert disabled["runtime_mode"] == "off"
+    assert disabled["activation_watermark"] is not None
+
+    second = await run_command(
+        "enable",
+        session_factory=operator_session_factory,
+        config=config,
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert second["control_revision"] == 3
+    assert second["activation_watermark"] == first_watermark
+
+    async with operator_session_factory() as session:
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        assert state is not None
+        assert state.mode == "all"
+        assert state.installation_estimate_watermark_at is not None
+
+
+@pytest.mark.asyncio
+async def test_canary_profile_can_plan_and_status_but_cannot_enable(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    canary_config = _runtime_config(allow_all_mode=False)
+
+    for mode in ("plan", "status"):
+        result = await run_command(
+            mode,
+            session_factory=operator_session_factory,
+            config=canary_config,
+            bot_token="valid-token",
+            runtime_locks_enabled=True,
+        )
+        assert result["profile"] == "canary"
+        assert "communications_active_profile_required" in result["blockers"]
+
+    dormant = await run_command(
+        "plan",
+        session_factory=operator_session_factory,
+        config=replace(
+            canary_config,
+            enabled=False,
+            allow_all_mode=False,
+        ),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert dormant["profile"] == "dormant"
+    assert "communications_active_profile_required" in dormant["blockers"]
+
+    with pytest.raises(
+        InstallationNotificationControlRejected,
+        match="communications_active_profile_required",
+    ):
+        await run_command(
+            "enable",
+            session_factory=operator_session_factory,
+            config=canary_config,
+            bot_token="valid-token",
+            runtime_locks_enabled=True,
+        )
+
+    emergency = await run_command(
+        "off",
+        session_factory=operator_session_factory,
+        config=object(),
+        bot_token=None,
+        runtime_locks_enabled=False,
+        off_wait_seconds=0,
+    )
+    assert emergency["runtime_mode"] == "off"
+    assert emergency["drained"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_has_fixed_aggregate_buckets_and_blocks_unsafe_backlog(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    now = datetime.now(timezone.utc) - timedelta(seconds=1)
+    pending = _event(1, status="pending", created_at=now)
+    published_sent = _event(2, status="published", created_at=now)
+    published_dead = _event(3, status="published", created_at=now)
+    dead = _event(4, status="dead", created_at=now)
+    sent_delivery = _terminal_delivery(
+        1,
+        event_id=published_sent.event_id,
+        status="sent",
+        now=now,
+    )
+    dead_delivery = _terminal_delivery(
+        2,
+        event_id=published_dead.event_id,
+        status="dead",
+        now=now,
+    )
+    queued_on_dead_outbox = CommunicationDelivery(
+        delivery_id=f"{203:032x}",
+        event_id=dead.event_id,
+        channel="telegram",
+        recipient_key="staff:owner",
+        destination="90001",
+        template_key=INSTALLATION_ESTIMATE_TEMPLATE_KEY,
+        template_version=1,
+        render_context={},
+        status="queued",
+        attempts=0,
+        max_attempts=3,
+        available_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    async with operator_session_factory() as session:
+        session.add_all(
+            [
+                pending,
+                published_sent,
+                published_dead,
+                dead,
+                sent_delivery,
+                dead_delivery,
+                queued_on_dead_outbox,
+                CommunicationDeliveryAttempt(
+                    delivery_id=sent_delivery.delivery_id,
+                    attempt_no=1,
+                    started_at=now,
+                    finished_at=now,
+                    outcome="sent",
+                ),
+                CommunicationDeliveryAttempt(
+                    delivery_id=dead_delivery.delivery_id,
+                    attempt_no=1,
+                    started_at=now,
+                    finished_at=now,
+                    outcome="dead",
+                    error_category="provider",
+                    error_code="provider_ack_unknown",
+                    ambiguous=True,
+                ),
+                CommunicationDeliveryAttempt(
+                    delivery_id=dead_delivery.delivery_id,
+                    attempt_no=2,
+                    started_at=now,
+                    outcome="running",
+                ),
+                CommunicationDeliveryAttempt(
+                    delivery_id=dead_delivery.delivery_id,
+                    attempt_no=3,
+                    started_at=now,
+                    finished_at=now,
+                    outcome="dead",
+                    error_category="provider",
+                    error_code="provider_ack_unknown_again",
+                    ambiguous=True,
+                ),
+            ]
+        )
+        await session.commit()
+
+    status = await run_command(
+        "status",
+        session_factory=operator_session_factory,
+        config=_runtime_config(),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert status["outbox_status_counts"] == {
+        "pending": 1,
+        "processing": 0,
+        "published": 2,
+        "dead": 1,
+    }
+    assert status["delivery_status_counts"] == {
+        "queued": 1,
+        "running": 0,
+        "retry": 0,
+        "sent": 1,
+        "dead": 1,
+        "canceled": 0,
+    }
+    assert status["attempt_outcome_counts"] == {
+        "running": 1,
+        "sent": 1,
+        "retry": 0,
+        "dead": 2,
+        "canceled": 0,
+    }
+    assert status["provider_ack_count"] == 1
+    assert status["ambiguous_nonterminal_count"] == 0
+    assert status["ambiguous_terminal_count"] == 2
+    assert status["ambiguous_total_count"] == 2
+    assert status["backlog_count"] == 2
+    assert status["running_count"] == 1
+    assert "installation_backlog_not_reconciled" in status["blockers"]
+    assert "installation_delivery_running" in status["blockers"]
+    assert (
+        "installation_ambiguous_outcomes_unreconciled"
+        not in status["blockers"]
+    )
+    assert "90001" not in json.dumps(status)
+
+    with pytest.raises(
+        InstallationNotificationControlRejected,
+        match="installation_backlog_not_reconciled",
+    ):
+        await run_command(
+            "enable",
+            session_factory=operator_session_factory,
+            config=_runtime_config(),
+            bot_token="valid-token",
+            runtime_locks_enabled=True,
+        )
+
+    async with operator_session_factory() as session:
+        state = await session.get(CommunicationRuntimeState, "telegram")
+        assert state is not None
+        assert state.mode == "off"
+        assert state.control_revision == 0
+        assert state.installation_estimate_watermark_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "expected_blocker"),
+    [
+        ("wrong_role", "app_role_not_primary"),
+        ("read_only", "database_not_writable_primary"),
+        ("locks_disabled", "runtime_database_locks_required"),
+        ("lock_zero", "communications_runtime_owner_count_invalid"),
+        ("lock_two", "communications_runtime_owner_count_invalid"),
+        ("missing_token", "telegram_bot_token_missing"),
+        ("stale_heartbeat", "communications_runtime_owner_not_fresh"),
+        ("mode_not_off", "communications_runtime_mode_not_off"),
+        ("runtime_not_dormant", "communications_runtime_not_dormant"),
+        ("future_watermark", "installation_activation_watermark_invalid"),
+    ],
+)
+async def test_enable_rejects_each_safety_gate_without_mutating_control(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+    monkeypatch,
+    case,
+    expected_blocker,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    config = _runtime_config()
+    token = "valid-token"
+    locks_enabled = True
+
+    if case == "wrong_role":
+        config = replace(config, app_role="replica")
+    elif case == "read_only":
+        async def read_only(cls, session):
+            return "database_not_writable_primary"
+
+        monkeypatch.setattr(
+            InstallationNotificationOperations,
+            "_database_primary_blocker",
+            classmethod(read_only),
+        )
+    elif case == "locks_disabled":
+        locks_enabled = False
+    elif case in {"lock_zero", "lock_two"}:
+        owner_count = 0 if case == "lock_zero" else 2
+
+        async def lock_owners(cls, session, *, lock_name):
+            return owner_count
+
+        monkeypatch.setattr(
+            InstallationNotificationOperations,
+            "_runtime_lock_owner_count",
+            classmethod(lock_owners),
+        )
+    elif case == "missing_token":
+        token = ""
+    else:
+        async with operator_session_factory() as session:
+            state = await session.get(CommunicationRuntimeState, "telegram")
+            assert state is not None
+            if case == "stale_heartbeat":
+                state.heartbeat_at = datetime.now(timezone.utc) - timedelta(
+                    minutes=10
+                )
+            elif case == "mode_not_off":
+                state.mode = "canary"
+                state.canary_run_id = "123e4567-e89b-42d3-a456-426614174000"
+            elif case == "runtime_not_dormant":
+                state.status = "running"
+            elif case == "future_watermark":
+                state.installation_estimate_watermark_at = (
+                    datetime.now(timezone.utc) + timedelta(days=1)
+                )
+            await session.commit()
+
+    async with operator_session_factory() as session:
+        before = await session.get(CommunicationRuntimeState, "telegram")
+        assert before is not None
+        before_control = (
+            before.mode,
+            before.canary_run_id,
+            before.control_revision,
+            before.installation_estimate_watermark_at,
+        )
+
+    plan = await run_command(
+        "plan",
+        session_factory=operator_session_factory,
+        config=config,
+        bot_token=token,
+        runtime_locks_enabled=locks_enabled,
+    )
+    assert expected_blocker in plan["blockers"]
+    with pytest.raises(
+        InstallationNotificationControlRejected,
+        match=expected_blocker,
+    ):
+        await run_command(
+            "enable",
+            session_factory=operator_session_factory,
+            config=config,
+            bot_token=token,
+            runtime_locks_enabled=locks_enabled,
+        )
+
+    async with operator_session_factory() as session:
+        after = await session.get(CommunicationRuntimeState, "telegram")
+        assert after is not None
+        assert (
+            after.mode,
+            after.canary_run_id,
+            after.control_revision,
+            after.installation_estimate_watermark_at,
+        ) == before_control
+
+
+@pytest.mark.asyncio
+async def test_enable_rejects_non_postgresql_even_when_other_inputs_are_safe(
+    operator_session_factory,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    plan = await run_command(
+        "plan",
+        session_factory=operator_session_factory,
+        config=_runtime_config(),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert "database_dialect_not_postgresql" in plan["blockers"]
+
+    with pytest.raises(
+        InstallationNotificationControlRejected,
+        match="database_dialect_not_postgresql",
+    ):
+        await run_command(
+            "enable",
+            session_factory=operator_session_factory,
+            config=_runtime_config(),
+            bot_token="valid-token",
+            runtime_locks_enabled=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_enable_reports_terminal_ambiguity_without_retrying_or_blocking(
+    operator_session_factory,
+    allow_sqlite_operator_checks,
+):
+    await _seed_dormant_runtime(operator_session_factory)
+    now = datetime.now(timezone.utc) - timedelta(seconds=1)
+    event = _event(40, status="published", created_at=now)
+    delivery = _terminal_delivery(
+        40,
+        event_id=event.event_id,
+        status="dead",
+        now=now,
+    )
+    async with operator_session_factory() as session:
+        session.add_all(
+            [
+                event,
+                delivery,
+                CommunicationDeliveryAttempt(
+                    delivery_id=delivery.delivery_id,
+                    attempt_no=1,
+                    started_at=now,
+                    finished_at=now,
+                    outcome="dead",
+                    error_category="provider",
+                    error_code="provider_ack_unknown",
+                    ambiguous=True,
+                ),
+            ]
+        )
+        await session.commit()
+
+    plan = await run_command(
+        "plan",
+        session_factory=operator_session_factory,
+        config=_runtime_config(),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert plan["backlog_count"] == 0
+    assert plan["running_count"] == 0
+    assert plan["ambiguous_nonterminal_count"] == 0
+    assert plan["ambiguous_terminal_count"] == 1
+    assert plan["ambiguous_total_count"] == 1
+    assert (
+        "installation_ambiguous_outcomes_unreconciled"
+        not in plan["blockers"]
+    )
+
+    enabled = await run_command(
+        "enable",
+        session_factory=operator_session_factory,
+        config=_runtime_config(),
+        bot_token="valid-token",
+        runtime_locks_enabled=True,
+    )
+    assert enabled["runtime_mode"] == "all"
+    assert enabled["ambiguous_terminal_count"] == 1
+
+
+def test_cli_accepts_only_the_four_typed_modes():
+    parser = build_parser()
+    for flag in ("--plan", "--enable", "--status", "--off"):
+        assert vars(parser.parse_args([flag]))[flag.removeprefix("--")] is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--plan", "--event-type", "anything"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--plan", "--enable"])
+
+
+def test_cli_reports_incomplete_off_drain_as_safe_nonzero_result(
+    monkeypatch,
+    capsys,
+):
+    async def incomplete_off(mode):
+        assert mode == "off"
+        return {
+            "command": "off",
+            "drained": False,
+            "runtime_mode": "off",
+            "runtime_status": "stopping",
+            "running_delivery_count": 1,
+            "ambiguous_total_count": 1,
+        }
+
+    monkeypatch.setattr(command_module, "run_command", incomplete_off)
+
+    assert command_module.main(["--off"]) == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "error_code": "installation_notification_drain_incomplete",
+        "command": "off",
+        "drained": False,
+        "runtime_mode": "off",
+        "runtime_status": "stopping",
+        "running_delivery_count": 1,
+        "ambiguous_total_count": 1,
+    }
+
+
+def test_cli_redacts_unexpected_exception_details(monkeypatch, capsys):
+    secret = "bot-token-and-destination-90001"
+
+    async def fail_with_secret(mode):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(command_module, "run_command", fail_with_secret)
+
+    assert command_module.main(["--status"]) == 1
+    output = capsys.readouterr().out
+    assert secret not in output
+    assert json.loads(output) == {
+        "ok": False,
+        "error_code": "installation_notification_command_failed",
+    }

--- a/tests/unit/test_communications_runtime.py
+++ b/tests/unit/test_communications_runtime.py
@@ -32,6 +32,11 @@ from services.communications.runtime_state import (
     CommunicationRuntimeStatus,
 )
 from services.runtime_lock_service import RuntimeLock
+from tests.unit.communications_runtime_test_support import (
+    allow_safety,
+    instant_fencing,
+    set_runtime_mode_for_test,
+)
 
 
 ASYNC_TEST_TIMEOUT_SECONDS = 5
@@ -138,14 +143,6 @@ def test_runtime_rejects_invalid_or_non_finite_lease(invalid_lease):
         runtime_config(lease_seconds=invalid_lease)
 
 
-async def allow_safety(_scope: CommunicationProcessingScope) -> None:
-    return None
-
-
-async def instant_fencing(stop_event: asyncio.Event, _seconds: float) -> bool:
-    return stop_event.is_set()
-
-
 async def own_mode(
     session_factory,
     mode: CommunicationRuntimeMode,
@@ -153,7 +150,7 @@ async def own_mode(
     canary_run_id: str | None = None,
 ):
     async with session_factory() as session:
-        control = await CommunicationRuntimeStateService.set_mode(
+        control = await set_runtime_mode_for_test(
             session,
             channel="telegram",
             mode=mode,

--- a/tests/unit/test_communications_runtime_safety_fences.py
+++ b/tests/unit/test_communications_runtime_safety_fences.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
@@ -60,11 +61,21 @@ def runtime_config(**overrides):
 
 async def own_mode(session_factory, mode: CommunicationRuntimeMode):
     async with session_factory() as session:
-        control = await CommunicationRuntimeStateService.set_mode(
+        state = await CommunicationRuntimeStateService.ensure_state(
             session,
             channel="telegram",
-            mode=mode,
         )
+        assert mode == CommunicationRuntimeMode.ALL
+        state.mode = CommunicationRuntimeMode.ALL.value
+        state.canary_run_id = None
+        state.control_revision = int(state.control_revision) + 1
+        state.installation_estimate_watermark_at = (
+            state.installation_estimate_watermark_at
+            or datetime(2000, 1, 1, tzinfo=timezone.utc)
+        )
+        session.add(state)
+        await session.flush()
+        control = CommunicationRuntimeStateService._to_control(state)
         await CommunicationRuntimeStateService.take_ownership(
             session,
             channel="telegram",
@@ -72,7 +83,10 @@ async def own_mode(session_factory, mode: CommunicationRuntimeMode):
         )
         await session.commit()
         return CommunicationProcessingScope.all(
-            control_revision=control.control_revision
+            control_revision=control.control_revision,
+            event_created_at_watermark=(
+                control.installation_estimate_watermark_at
+            ),
         )
 
 
@@ -91,14 +105,28 @@ async def set_mode(session_factory, mode: CommunicationRuntimeMode) -> None:
                 channel="telegram",
                 mode=CommunicationRuntimeMode.OFF,
             )
-        await CommunicationRuntimeStateService.set_mode(
-            session,
-            channel="telegram",
-            mode=mode,
-            canary_run_id=(
-                RUN_ID_A if mode == CommunicationRuntimeMode.CANARY else None
-            ),
-        )
+        if mode == CommunicationRuntimeMode.ALL:
+            state = await CommunicationRuntimeStateService._lock_state(
+                session,
+                channel="telegram",
+            )
+            state.mode = CommunicationRuntimeMode.ALL.value
+            state.canary_run_id = None
+            state.control_revision = int(state.control_revision) + 1
+            state.installation_estimate_watermark_at = (
+                state.installation_estimate_watermark_at
+                or datetime(2000, 1, 1, tzinfo=timezone.utc)
+            )
+            session.add(state)
+        else:
+            await CommunicationRuntimeStateService.set_mode(
+                session,
+                channel="telegram",
+                mode=mode,
+                canary_run_id=(
+                    RUN_ID_A if mode == CommunicationRuntimeMode.CANARY else None
+                ),
+            )
         await session.commit()
 
 

--- a/tests/unit/test_communications_runtime_scope.py
+++ b/tests/unit/test_communications_runtime_scope.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
@@ -65,12 +66,28 @@ async def own_mode(
     canary_run_id: str | None = None,
 ):
     async with session_factory() as session:
-        control = await CommunicationRuntimeStateService.set_mode(
-            session,
-            channel="telegram",
-            mode=mode,
-            canary_run_id=canary_run_id,
-        )
+        if mode == CommunicationRuntimeMode.ALL:
+            state = await CommunicationRuntimeStateService.ensure_state(
+                session,
+                channel="telegram",
+            )
+            state.mode = CommunicationRuntimeMode.ALL.value
+            state.canary_run_id = None
+            state.control_revision = int(state.control_revision) + 1
+            state.installation_estimate_watermark_at = (
+                state.installation_estimate_watermark_at
+                or datetime(2000, 1, 1, tzinfo=timezone.utc)
+            )
+            session.add(state)
+            await session.flush()
+            control = CommunicationRuntimeStateService._to_control(state)
+        else:
+            control = await CommunicationRuntimeStateService.set_mode(
+                session,
+                channel="telegram",
+                mode=mode,
+                canary_run_id=canary_run_id,
+            )
         owned = await CommunicationRuntimeStateService.take_ownership(
             session,
             channel="telegram",

--- a/tests/unit/test_order_source_fingerprint_migration.py
+++ b/tests/unit/test_order_source_fingerprint_migration.py
@@ -26,13 +26,14 @@ def _load_migration_module():
     return module
 
 
-def test_order_source_fingerprint_is_the_single_alembic_head():
+def test_order_source_fingerprint_remains_in_the_single_alembic_chain():
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     revision = script.get_revision(REVISION)
 
-    assert script.get_heads() == [REVISION]
+    assert script.get_heads() == ["e9a1b2c3d4e5"]
     assert revision is not None
     assert revision.down_revision == "f3c4d5e6f7a8"
+    assert set(revision.nextrev) == {"d8e7f6a5b4c3"}
 
 
 def test_order_source_fingerprint_migration_upgrades_and_downgrades_sqlite():

--- a/tests/unit/test_patroni_candidate_attestation.py
+++ b/tests/unit/test_patroni_candidate_attestation.py
@@ -1,0 +1,308 @@
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_patroni_candidate_transactions import (
+    DEPLOY_LOCK_HELPER,
+    PATRONI_RUNNER,
+    TRANSACTION,
+    _compose_pair,
+    _executable,
+    _patroni_runner_env,
+    _voice_sync_env,
+    _write_release_manifest,
+)
+
+
+def test_profile_changing_candidate_requires_official_pitr_before_any_mutation(
+    tmp_path,
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    canonical = (project / "compose.yml").read_bytes()
+    (project / "compose.yml.candidate").write_bytes(
+        canonical
+        + b'  communications-worker:\n    environment:\n'
+        + b'      COMMUNICATIONS_WORKER_ENABLED: "true"\n'
+    )
+    Path(env["WORKER_RUNTIME_STATE"]).touch()
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "official atomic PITR cluster migration first" in result.stderr
+    assert (project / "compose.yml").read_bytes() == canonical
+    assert not (project / "compose.yml.candidate").exists()
+    assert not Path(env["CHILD_LOG"]).exists()
+    assert not Path(env["RECONCILE_LOG"]).exists()
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+    assert not (project / ".ha-communications-worker-release-fenced").exists()
+    assert not Path(env["VOICE_SYNC_LOG"]).exists()
+    assert Path(env["WORKER_RUNTIME_STATE"]).exists()
+    assert not Path(env["PATRONI_COMMAND_LOG"]).read_text(encoding="utf-8")
+    assert not Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("operation", ["deploy", "migrate"])
+def test_different_compose_is_rejected_before_either_child(tmp_path, operation):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    (project / "compose.yml.candidate").write_text(
+        "services:\n  app:\n    image: changed\n",
+        encoding="utf-8",
+    )
+    env["PATRONI_CANDIDATE_OPERATION"] = operation
+    if operation == "migrate":
+        env["PATRONI_MIGRATION_SCRIPT"] = env["PATRONI_DEPLOY_SCRIPT"]
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "official atomic PITR cluster migration first" in result.stderr
+    assert not Path(env["CHILD_LOG"]).exists()
+    assert not Path(env["RECONCILE_LOG"]).exists()
+    assert not Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("profile", "enabled", "allow_all"),
+    [
+        ("dormant", "false", "false"),
+        ("active", "true", "true"),
+    ],
+)
+def test_identical_attested_compose_allows_same_profile_image_rollout(
+    tmp_path, profile, enabled, allow_all
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    Path(env["WORKER_RUNTIME_STATE"]).touch()
+    env.update(
+        {
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+            "FAKE_CANONICAL_WORKER_ENABLED": enabled,
+            "FAKE_CANONICAL_WORKER_ALLOW_ALL": allow_all,
+            "FAKE_CANDIDATE_WORKER_ENABLED": enabled,
+            "FAKE_CANDIDATE_WORKER_ALLOW_ALL": allow_all,
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(env["CHILD_PROFILE_LOG"]).read_text(encoding="utf-8") == (
+        f"{profile}|{profile}\n"
+    )
+    assert Path(env["RECONCILE_PROFILE_LOG"]).read_text(
+        encoding="utf-8"
+    ).splitlines() == [
+        f"compose.yml.candidate|communications-worker|{profile}",
+        f"compose.yml|communications-worker|{profile}",
+    ]
+    assert "/app/token.json" in (project / "compose.yml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_failed_image_rollout_restores_the_same_active_profile(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    Path(env["WORKER_RUNTIME_STATE"]).touch()
+    env.update(
+        {
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+            "FAKE_CANONICAL_WORKER_ENABLED": "true",
+            "FAKE_CANONICAL_WORKER_ALLOW_ALL": "true",
+            "FAKE_CANDIDATE_WORKER_ENABLED": "true",
+            "FAKE_CANDIDATE_WORKER_ALLOW_ALL": "true",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert Path(env["CHILD_PROFILE_LOG"]).read_text(encoding="utf-8") == (
+        "active|active\n"
+    )
+    assert Path(env["RECONCILE_PROFILE_LOG"]).read_text(
+        encoding="utf-8"
+    ).splitlines() == [
+        "compose.yml|app communications-worker|active",
+    ]
+
+
+def test_secret_is_absent_from_attestation_and_transaction_children(tmp_path):
+    env, _project = _patroni_runner_env(tmp_path, child_exit=0)
+    transaction_driver = tmp_path / "audited-transaction.sh"
+    transaction_log = tmp_path / "transaction-actions.log"
+    _executable(
+        transaction_driver,
+        """#!/usr/bin/env bash
+set -euo pipefail
+test -z "${BOT_VOICE_TRANSCRIPTION_API_KEY+x}"
+test -z "${VOICE_SECRET+x}"
+printf '%s\n' "$1" >> "$TRANSACTION_ACTIONS_LOG"
+exec bash "$REAL_TRANSACTION" "$@"
+""",
+    )
+    env.update(
+        {
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
+            "REAL_TRANSACTION": str(TRANSACTION),
+            "TRANSACTION_ACTIONS_LOG": str(transaction_log),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert transaction_log.read_text(encoding="utf-8").splitlines() == [
+        "stage",
+        "promote",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "allow_all"),
+    [("false", "true"), ("TRUE", "false"), ("false", "FALSE")],
+)
+def test_candidate_rejects_noncanonical_gate_profile_before_host_mutation(
+    tmp_path, enabled, allow_all
+):
+    env, _project = _patroni_runner_env(tmp_path, child_exit=0)
+    Path(env["WORKER_RUNTIME_STATE"]).touch()
+    env.update(
+        {
+            "FAKE_CANONICAL_WORKER_SUPPORTED": "true",
+            "FAKE_CANDIDATE_WORKER_SUPPORTED": "true",
+            "FAKE_CANONICAL_WORKER_ENABLED": enabled,
+            "FAKE_CANONICAL_WORKER_ALLOW_ALL": allow_all,
+            "FAKE_CANDIDATE_WORKER_ENABLED": enabled,
+            "FAKE_CANDIDATE_WORKER_ALLOW_ALL": allow_all,
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "gate profile is not reviewed" in result.stderr
+    assert not Path(env["CHILD_LOG"]).exists()
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+    assert Path(env["WORKER_RUNTIME_STATE"]).exists()
+    assert not Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8")
+
+
+def _run_wrong_metadata_migration(
+    tmp_path, *, target_name="compose.yml.candidate", mode=None, group=None
+):
+    project = _compose_pair(tmp_path)
+    release_manifest = _write_release_manifest(tmp_path, project)
+    voice_env = _voice_sync_env(tmp_path)
+    candidate = project / "compose.yml.candidate"
+    target = project / target_name
+    if mode is not None:
+        target.chmod(mode)
+    if group is not None:
+        os.chown(target, -1, group)
+    migration = tmp_path / "migration.sh"
+    migration_log = tmp_path / "migration.log"
+    _executable(migration, "#!/usr/bin/env bash\n: > \"$MIGRATION_LOG\"\n")
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env={
+            **os.environ,
+            **voice_env,
+            "PATRONI_CANDIDATE_OPERATION": "migrate",
+            "API_PROJECT_DIR": str(project),
+            "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+            "PATRONI_CANDIDATE_COMPOSE_FILE": str(candidate),
+            "PATRONI_FINALIZED_RELEASE_MANIFEST": str(release_manifest),
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
+            "PATRONI_MIGRATION_SCRIPT": str(migration),
+            "MIGRATION_LOG": str(migration_log),
+            "API_DEPLOY_LOCK_HELPER": str(DEPLOY_LOCK_HELPER),
+            "API_DEPLOY_LOCK_HELPER_SHA256": hashlib.sha256(
+                DEPLOY_LOCK_HELPER.read_bytes()
+            ).hexdigest(),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert not migration_log.exists()
+    assert not candidate.exists()
+    return result
+
+
+@pytest.mark.parametrize(
+    ("target_name", "unsafe_mode"),
+    [
+        ("compose.yml", 0o600),
+        ("compose.yml", 0o664),
+        ("compose.yml", 0o755),
+        ("compose.yml.candidate", 0o600),
+        ("compose.yml.candidate", 0o664),
+        ("compose.yml.candidate", 0o755),
+    ],
+)
+def test_candidate_rejects_wrong_mode_before_migrate_or_runtime_mutation(
+    tmp_path, target_name, unsafe_mode
+):
+    result = _run_wrong_metadata_migration(
+        tmp_path,
+        target_name=target_name,
+        mode=unsafe_mode,
+    )
+    assert result.returncode != 0
+    assert "mode 0644" in result.stderr
+
+
+def test_candidate_rejects_wrong_group_before_migrate_or_runtime_mutation(
+    tmp_path,
+):
+    alternate_group = next(
+        (group for group in os.getgroups() if group != os.getegid()),
+        None,
+    )
+    if alternate_group is None:
+        pytest.skip("current user has no alternate group for metadata test")
+    result = _run_wrong_metadata_migration(tmp_path, group=alternate_group)
+    assert result.returncode != 0
+    assert "mode 0644" in result.stderr

--- a/tests/unit/test_patroni_candidate_recovery.py
+++ b/tests/unit/test_patroni_candidate_recovery.py
@@ -1,0 +1,200 @@
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_patroni_candidate_transactions import (
+    DEPLOY_LOCK_HELPER,
+    PATRONI_RUNNER,
+    REPO_ROOT,
+    TRANSACTION,
+    _compose_pair,
+    _executable,
+    _patroni_runner_env,
+    _voice_sync_env,
+    _write_release_manifest,
+)
+
+
+def test_patroni_role_drift_fences_all_api_slots_and_bot_without_reconcile(tmp_path):
+    env, project = _patroni_runner_env(
+        tmp_path,
+        child_exit=42,
+        expected_role="primary",
+        current_role="standby",
+    )
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "Patroni role changed during deployment" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8").splitlines()
+    assert any(
+        " stop app app-blue app-green bot" in command for command in commands
+    )
+
+
+def test_patroni_unknown_live_role_fences_runtime_instead_of_assuming_standby(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=42)
+    env.pop("API_CURRENT_PATRONI_ROLE")
+    _executable(
+        tmp_path / "bin/curl",
+        "#!/usr/bin/env bash\nprintf '%s\n' '{\"state\":\"running\",\"role\":\"mystery\"}'\n",
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 90
+    assert "could not establish live Patroni role" in result.stderr
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
+    assert " stop app app-blue app-green bot" in commands
+
+
+@pytest.mark.parametrize("migration_exit", [0, 48])
+def test_patroni_migration_always_cleans_candidate_without_promoting(
+    tmp_path,
+    migration_exit,
+):
+    project = _compose_pair(tmp_path)
+    release_manifest = _write_release_manifest(tmp_path, project)
+    voice_env = _voice_sync_env(tmp_path)
+    old = (project / "compose.yml").read_text(encoding="utf-8")
+    migration_log = tmp_path / "migration.log"
+    migration = tmp_path / "migration.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
+    _executable(
+        migration,
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+test -z "${{BOT_VOICE_TRANSCRIPTION_API_KEY+x}}"
+test -f "$VOICE_SYNC_LOG"
+printf '%s\n' "$API_COMPOSE_FILE" > "$MIGRATION_LOG"
+exit {migration_exit}
+""",
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env={
+            **os.environ,
+            **voice_env,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "PATRONI_CANDIDATE_OPERATION": "migrate",
+            "API_PROJECT_DIR": str(project),
+            "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
+            "PATRONI_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+            "PATRONI_FINALIZED_RELEASE_MANIFEST": str(release_manifest),
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
+            "PATRONI_MIGRATION_SCRIPT": str(migration),
+            "MIGRATION_LOG": str(migration_log),
+            "API_DEPLOY_LOCK_HELPER": str(DEPLOY_LOCK_HELPER),
+            "API_DEPLOY_LOCK_HELPER_SHA256": hashlib.sha256(
+                DEPLOY_LOCK_HELPER.read_bytes()
+            ).hexdigest(),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == migration_exit, result.stderr
+    assert migration_log.read_text(encoding="utf-8").strip() == "compose.yml.candidate"
+    assert (project / "compose.yml").read_text(encoding="utf-8") == old
+    assert not (project / "compose.yml.candidate").exists()
+
+
+def test_patroni_post_rename_promotion_error_preserves_new_canonical(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
+    transaction_driver = tmp_path / "patroni-transaction.sh"
+    _executable(
+        transaction_driver,
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "promote" ]]; then
+  bash "$REAL_TRANSACTION" "$1"
+  exit 46
+fi
+exec bash "$REAL_TRANSACTION" "$@"
+""",
+    )
+    env.update(
+        {
+            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
+            "REAL_TRANSACTION": str(TRANSACTION),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 46
+    assert "promotion committed" in result.stderr
+    assert (project / "compose.yml").read_text(encoding="utf-8") == new
+    assert not (project / "compose.yml.candidate").exists()
+    assert not (tmp_path / "reconcile.log").exists()
+
+
+def test_legacy_source_bind_deploy_is_retired():
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "deploy_api.sh")],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "retired" in result.stderr
+    assert "GitHub Actions image workflow" in result.stderr
+
+
+@pytest.mark.parametrize("operation", ["deploy", "migrate"])
+def test_patroni_candidate_rejects_database_rollout_marker_before_mutation(
+    tmp_path, operation
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    marker = project / ".patroni-cutover-in-progress"
+    marker.write_text("0" * 32 + "\n", encoding="ascii")
+    env["PATRONI_CANDIDATE_OPERATION"] = operation
+    if operation == "migrate":
+        env["PATRONI_MIGRATION_SCRIPT"] = env["PATRONI_DEPLOY_SCRIPT"]
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Patroni database rollout is in progress" in result.stderr
+    assert not (tmp_path / "child.log").exists()
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")

--- a/tests/unit/test_patroni_candidate_release_safety.py
+++ b/tests/unit/test_patroni_candidate_release_safety.py
@@ -69,9 +69,7 @@ def test_patroni_candidate_refuses_pitr_maintenance_before_runtime_mutation(
     assert result.returncode != 0
     assert "PITR release maintenance is active" in result.stderr
     assert (project / "compose.yml").read_text(encoding="utf-8") == old
-    assert "/app/google-oauth" in (project / "compose.yml.candidate").read_text(
-        encoding="utf-8"
-    )
+    assert (project / "compose.yml.candidate").read_text(encoding="utf-8") == old
     assert not (tmp_path / "child.log").exists()
     assert not (tmp_path / "reconcile.log").exists()
     assert not (tmp_path / "systemctl.log").read_text(encoding="utf-8")

--- a/tests/unit/test_patroni_candidate_runtime_assets.py
+++ b/tests/unit/test_patroni_candidate_runtime_assets.py
@@ -497,7 +497,7 @@ exec bash "$REAL_TRANSACTION" "$@"
 
     assert result.returncode == 46, result.stderr
     assert not (project / "compose.yml.candidate").exists()
-    assert "/app/google-oauth" in (project / "compose.yml").read_text(encoding="utf-8")
+    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")
     marker = project / ".ha-communications-worker-release-fenced"
     assert marker.read_text(encoding="utf-8") == "fenced\n"
     assert marker.stat().st_mode & 0o777 == 0o600

--- a/tests/unit/test_patroni_candidate_transactions.py
+++ b/tests/unit/test_patroni_candidate_transactions.py
@@ -1,7 +1,11 @@
+import base64
 import copy
+import hashlib
 import json
 import os
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,15 +28,87 @@ def _executable(path: Path, content: str) -> None:
 def _compose_pair(tmp_path: Path) -> Path:
     project = tmp_path / "project"
     project.mkdir()
-    (project / "compose.yml").write_text(
-        "services:\n  app:\n    volumes:\n      - ./token.json:/app/token.json\n",
-        encoding="utf-8",
-    )
-    (project / "compose.yml.candidate").write_text(
-        "services:\n  app:\n    volumes:\n      - ./google-oauth:/app/google-oauth\n",
-        encoding="utf-8",
-    )
+    compose = "services:\n  app:\n    volumes:\n      - ./token.json:/app/token.json\n"
+    (project / "compose.yml").write_text(compose, encoding="utf-8")
+    (project / "compose.yml.candidate").write_text(compose, encoding="utf-8")
     return project
+
+
+def _write_release_manifest(tmp_path: Path, project: Path) -> Path:
+    compose = project / "compose.yml"
+    release_tool = tmp_path / "release-tool"
+    release_tool.write_bytes(b"reviewed release tool\n")
+    release_tool.chmod(0o755)
+    sources = {
+        str(compose): (0o644, compose.read_bytes()),
+        str(release_tool): (0o755, release_tool.read_bytes()),
+    }
+    files = [
+        {
+            "mode": mode,
+            "path": path,
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+        for path, (mode, content) in sorted(sources.items())
+    ]
+    release_files = [
+        {
+            **item,
+            "content": base64.b64encode(sources[item["path"]][1]).decode("ascii"),
+        }
+        for item in files
+    ]
+    release_body = {
+        "files": release_files,
+        "project_dir": str(project),
+        "version": 1,
+    }
+    manifest = {
+        "files": files,
+        "project_dir": str(project),
+        "release_sha256": hashlib.sha256(
+            json.dumps(
+                release_body,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("ascii")
+        ).hexdigest(),
+        "txid": "1" * 32,
+        "version": 1,
+    }
+    path = tmp_path / "release-manifest.json"
+    path.write_text(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="ascii",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def _voice_sync_env(tmp_path: Path) -> dict[str, str]:
+    helper = tmp_path / "sync-voice-env.py"
+    helper.write_text(
+        """import os
+import pathlib
+import sys
+
+assert "BOT_VOICE_TRANSCRIPTION_API_KEY" not in os.environ
+assert "VOICE_SECRET" not in os.environ
+assert sys.stdin.read() == "test-voice-secret"
+pathlib.Path(os.environ["VOICE_SYNC_LOG"]).write_text("synced\\n")
+print("voice transcription settings synchronized")
+""",
+        encoding="utf-8",
+    )
+    env_file = tmp_path / "voice.env"
+    env_file.write_text("ENVIRONMENT=test\n", encoding="utf-8")
+    env_file.chmod(0o600)
+    return {
+        "PATRONI_VOICE_ENV_SYNC": str(helper),
+        "PATRONI_VOICE_ENV_FILE": str(env_file),
+        "BOT_VOICE_TRANSCRIPTION_API_KEY": "test-voice-secret",
+        "VOICE_SYNC_LOG": str(tmp_path / "voice-sync.log"),
+    }
 
 
 def _db_compose_config() -> dict:
@@ -75,10 +151,20 @@ def _patroni_runner_env(
     discover_previous: bool = False,
 ) -> tuple[dict[str, str], Path]:
     project = _compose_pair(tmp_path)
+    release_manifest = _write_release_manifest(tmp_path, project)
     if discover_previous:
         (project / ".active-api-slot").write_text("green\n", encoding="utf-8")
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
+    _executable(
+        fake_bin / "python3",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+test -z "${{BOT_VOICE_TRANSCRIPTION_API_KEY+x}}"
+test -z "${{VOICE_SECRET+x}}"
+exec {shlex.quote(sys.executable)} "$@"
+""",
+    )
     _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
     command_log = tmp_path / "patroni-commands.log"
     command_log.touch()
@@ -105,8 +191,16 @@ if [[ "$1" == "compose" && "$*" == *" config --services" ]]; then
     printf 'communications-worker\n'
   fi
 elif [[ "$1" == "compose" && "$*" == *" config --format json" ]]; then
-  printf '{"name":"air-api","services":{"communications-worker":{"image":"%s","environment":{"COMMUNICATIONS_WORKER_ENABLED":"false","COMMUNICATIONS_WORKER_ALLOW_ALL_MODE":"false"}}}}\n' \
-    "${BACKEND_IMAGE:-$EXPECTED_PREVIOUS_IMAGE}"
+  worker_enabled="${FAKE_CANONICAL_WORKER_ENABLED:-false}"
+  worker_allow_all="${FAKE_CANONICAL_WORKER_ALLOW_ALL:-false}"
+  if [[ "$*" == *"compose.yml.candidate"* ]] \
+    || grep -Fq '/app/google-oauth' "$API_PROJECT_DIR/compose.yml"; then
+    worker_enabled="${FAKE_CANDIDATE_WORKER_ENABLED:-false}"
+    worker_allow_all="${FAKE_CANDIDATE_WORKER_ALLOW_ALL:-false}"
+  fi
+  printf '{"name":"air-api","services":{"communications-worker":{"image":"%s","environment":{"COMMUNICATIONS_WORKER_ENABLED":"%s","COMMUNICATIONS_WORKER_ALLOW_ALL_MODE":"%s"}}}}\n' \
+    "${BACKEND_IMAGE:-$EXPECTED_PREVIOUS_IMAGE}" \
+    "$worker_enabled" "$worker_allow_all"
 elif [[ "$1" == "compose" && "$*" == *" config --no-env-resolution --no-interpolate --format json" ]]; then
   if [[ "$*" == *"compose.yml.candidate"* ]]; then
     config_path="$CANDIDATE_DB_CONTRACT"
@@ -231,9 +325,14 @@ esac
 set -euo pipefail
 grep -Fq '/app/token.json' "$API_PROJECT_DIR/compose.yml"
 printf "%s|%s\n" "$API_COMPOSE_FILE" "${{API_DEPLOY_LOCK_FD:-}}" > "$CHILD_LOG"
+printf "%s|%s\n" \
+  "${{API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE:-}}" \
+  "${{API_COMMUNICATIONS_WORKER_ROLLBACK_PROFILE:-}}" > "$CHILD_PROFILE_LOG"
 if [[ -n "${{PROXY_RUNTIME_CONFIG:-}}" ]]; then
   cp "$API_PROXY_CONFIG_FILE" "$PROXY_RUNTIME_CONFIG"
 fi
+test -z "${{BOT_VOICE_TRANSCRIPTION_API_KEY+x}}"
+test -f "$VOICE_SYNC_LOG"
 : > "$DEPLOY_CHILD_RAN"
 exit {child_exit}
 ''',
@@ -257,6 +356,9 @@ if [[ "${API_RECONCILE_OPERATION:-reconcile}" != "verify" ]]; then
   grep -Fq '/app/token.json' "$API_PROJECT_DIR/$API_COMPOSE_FILE"
 fi
 printf '%s|%s\n' "$API_COMPOSE_FILE" "$API_DEPLOY_SERVICES" > "$RECONCILE_LOG"
+printf '%s|%s|%s\n' \
+  "$API_COMPOSE_FILE" "$API_DEPLOY_SERVICES" \
+  "${API_COMMUNICATIONS_WORKER_EXPECTED_PROFILE:-}" >> "$RECONCILE_PROFILE_LOG"
 printf 'reconcile:%s\n' "$API_COMPOSE_FILE" >> "$PATRONI_COMMAND_LOG"
 if [[ "${API_RECONCILE_OPERATION:-reconcile}" == "verify" ]]; then
   test "$API_RECONCILE_BACKEND_IMAGE" = "$EXPECTED_CANDIDATE_IMAGE"
@@ -272,11 +374,13 @@ exit 0
     )
     env = {
         **os.environ,
+        **_voice_sync_env(tmp_path),
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "PATRONI_CANDIDATE_OPERATION": "deploy",
         "API_PROJECT_DIR": str(project),
         "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
         "PATRONI_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
+        "PATRONI_FINALIZED_RELEASE_MANIFEST": str(release_manifest),
         "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
         "PATRONI_DEPLOY_SCRIPT": str(child),
         "API_RECONCILE_SCRIPT": str(reconcile),
@@ -299,7 +403,9 @@ exit 0
         "PATRONI_DB_CONTRACT_HELPER": str(DB_CONTRACT_HELPER),
         "PATRONI_ROLE_AGENT_UNIT": "test.service",
         "CHILD_LOG": str(tmp_path / "child.log"),
+        "CHILD_PROFILE_LOG": str(tmp_path / "child-profile.log"),
         "RECONCILE_LOG": str(tmp_path / "reconcile.log"),
+        "RECONCILE_PROFILE_LOG": str(tmp_path / "reconcile-profile.log"),
         "PATRONI_COMMAND_LOG": str(command_log),
         "SYSTEMCTL_LOG": str(systemctl_log),
         "SYSTEMCTL_STATE": str(systemctl_state),
@@ -340,8 +446,6 @@ def test_patroni_candidate_failure_leaves_canonical_old(tmp_path):
     assert not (project / "compose.yml.candidate").exists()
     assert (tmp_path / "child.log").read_text(encoding="utf-8").strip() == "compose.yml.candidate|9"
     assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == "compose.yml|app"
-
-
 
 
 def test_patroni_candidate_rejects_db_service_drift_before_host_mutation(tmp_path):
@@ -505,179 +609,3 @@ def test_patroni_discovers_previous_runtime_image_from_active_slot_before_reconc
     assert (tmp_path / "reconcile.log").read_text(encoding="utf-8").strip() == (
         "compose.yml|app"
     )
-
-
-def test_patroni_role_drift_fences_all_api_slots_and_bot_without_reconcile(tmp_path):
-    env, project = _patroni_runner_env(
-        tmp_path,
-        child_exit=42,
-        expected_role="primary",
-        current_role="standby",
-    )
-    old = (project / "compose.yml").read_text(encoding="utf-8")
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 90
-    assert "Patroni role changed during deployment" in result.stderr
-    assert (project / "compose.yml").read_text(encoding="utf-8") == old
-    assert not (project / "compose.yml.candidate").exists()
-    assert not (tmp_path / "reconcile.log").exists()
-    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8").splitlines()
-    assert any(
-        " stop app app-blue app-green bot" in command for command in commands
-    )
-
-
-def test_patroni_unknown_live_role_fences_runtime_instead_of_assuming_standby(tmp_path):
-    env, project = _patroni_runner_env(tmp_path, child_exit=42)
-    env.pop("API_CURRENT_PATRONI_ROLE")
-    _executable(
-        tmp_path / "bin/curl",
-        "#!/usr/bin/env bash\nprintf '%s\n' '{\"state\":\"running\",\"role\":\"mystery\"}'\n",
-    )
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 90
-    assert "could not establish live Patroni role" in result.stderr
-    assert not (project / "compose.yml.candidate").exists()
-    assert not (tmp_path / "reconcile.log").exists()
-    commands = (tmp_path / "patroni-commands.log").read_text(encoding="utf-8")
-    assert " stop app app-blue app-green bot" in commands
-
-
-@pytest.mark.parametrize("migration_exit", [0, 48])
-def test_patroni_migration_always_cleans_candidate_without_promoting(
-    tmp_path,
-    migration_exit,
-):
-    project = _compose_pair(tmp_path)
-    old = (project / "compose.yml").read_text(encoding="utf-8")
-    migration_log = tmp_path / "migration.log"
-    migration = tmp_path / "migration.sh"
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    _executable(fake_bin / "flock", "#!/usr/bin/env bash\nexit 0\n")
-    _executable(
-        migration,
-        f"""#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$API_COMPOSE_FILE" > "$MIGRATION_LOG"
-exit {migration_exit}
-""",
-    )
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env={
-            **os.environ,
-            "PATH": f"{fake_bin}:{os.environ['PATH']}",
-            "PATRONI_CANDIDATE_OPERATION": "migrate",
-            "API_PROJECT_DIR": str(project),
-            "PATRONI_CANONICAL_COMPOSE_FILE": str(project / "compose.yml"),
-            "PATRONI_CANDIDATE_COMPOSE_FILE": str(project / "compose.yml.candidate"),
-            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(TRANSACTION),
-            "PATRONI_MIGRATION_SCRIPT": str(migration),
-                "MIGRATION_LOG": str(migration_log),
-                "API_DEPLOY_LOCK_HELPER": str(DEPLOY_LOCK_HELPER),
-                "API_DEPLOY_LOCK_HELPER_SHA256": __import__("hashlib").sha256(
-                    DEPLOY_LOCK_HELPER.read_bytes()
-                ).hexdigest(),
-        },
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == migration_exit, result.stderr
-    assert migration_log.read_text(encoding="utf-8").strip() == "compose.yml.candidate"
-    assert (project / "compose.yml").read_text(encoding="utf-8") == old
-    assert not (project / "compose.yml.candidate").exists()
-
-
-def test_patroni_post_rename_promotion_error_preserves_new_canonical(tmp_path):
-    env, project = _patroni_runner_env(tmp_path, child_exit=0)
-    new = (project / "compose.yml.candidate").read_text(encoding="utf-8")
-    transaction_driver = tmp_path / "patroni-transaction.sh"
-    _executable(
-        transaction_driver,
-        """#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$1" == "promote" ]]; then
-  bash "$REAL_TRANSACTION" "$1"
-  exit 46
-fi
-exec bash "$REAL_TRANSACTION" "$@"
-""",
-    )
-    env.update(
-        {
-            "COMPOSE_CANDIDATE_TRANSACTION_SCRIPT": str(transaction_driver),
-            "REAL_TRANSACTION": str(TRANSACTION),
-        }
-    )
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 46
-    assert "promotion committed" in result.stderr
-    assert (project / "compose.yml").read_text(encoding="utf-8") == new
-    assert not (project / "compose.yml.candidate").exists()
-    assert not (tmp_path / "reconcile.log").exists()
-
-
-def test_legacy_source_bind_deploy_is_retired():
-    result = subprocess.run(
-        ["bash", str(REPO_ROOT / "deploy_api.sh")],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert "retired" in result.stderr
-    assert "GitHub Actions image workflow" in result.stderr
-
-
-@pytest.mark.parametrize("operation", ["deploy", "migrate"])
-def test_patroni_candidate_rejects_database_rollout_marker_before_mutation(
-    tmp_path, operation
-):
-    env, project = _patroni_runner_env(tmp_path, child_exit=0)
-    marker = project / ".patroni-cutover-in-progress"
-    marker.write_text("0" * 32 + "\n", encoding="ascii")
-    env["PATRONI_CANDIDATE_OPERATION"] = operation
-    if operation == "migrate":
-        env["PATRONI_MIGRATION_SCRIPT"] = env["PATRONI_DEPLOY_SCRIPT"]
-
-    result = subprocess.run(
-        ["bash", str(PATRONI_RUNNER)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode != 0
-    assert "Patroni database rollout is in progress" in result.stderr
-    assert not (tmp_path / "child.log").exists()
-    assert "/app/token.json" in (project / "compose.yml").read_text(encoding="utf-8")

--- a/tests/unit/test_patroni_communications_deploy.py
+++ b/tests/unit/test_patroni_communications_deploy.py
@@ -28,7 +28,7 @@ def _executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
-def test_node_deploy_keeps_api_cutover_separate_and_worker_dormant():
+def test_node_deploy_keeps_api_cutover_separate_and_worker_profile_gated():
     text = NODE_DEPLOY.read_text(encoding="utf-8")
     contract = RELEASE_CONTRACT.read_text(encoding="utf-8")
     primary = text.index('bash "${BLUE_GREEN_SCRIPT}"')
@@ -43,7 +43,9 @@ def test_node_deploy_keeps_api_cutover_separate_and_worker_dormant():
     assert '"${runtime}" == "${BACKEND_IMAGE}|true"' in contract
     assert "COMMUNICATIONS_WORKER_ENABLED" in contract
     assert "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE" in contract
-    assert "must remain false during Phase 2A" in contract
+    assert '("false", "false"): "dormant"' in contract
+    assert '("true", "false"): "canary"' in contract
+    assert '("true", "true"): "active"' in contract
 
 
 def test_candidate_rollback_fences_worker_before_old_compose_and_image_restore():
@@ -57,11 +59,11 @@ def test_candidate_rollback_fences_worker_before_old_compose_and_image_restore()
     assert "PREVIOUS_WORKER_RUNNING" in recovery
     assert 'recovery_services+=" ${COMMUNICATIONS_WORKER_SERVICE}"' in recovery
     assert 'API_DEPLOY_SERVICES="${recovery_services}"' in recovery
-    assert 'patroni_communications_require_runtime "${CANDIDATE_FILE}"' in text
+    assert '"${CANDIDATE_FILE}" "${BACKEND_IMAGE}" "${CANDIDATE_WORKER_GATE_PROFILE}"' in text
     assert 'transaction promote' in text
-    assert 'patroni_communications_require_runtime "${CANONICAL_FILE}"' in text
+    assert '"${CANONICAL_FILE}" "${BACKEND_IMAGE}" "${CANDIDATE_WORKER_GATE_PROFILE}"' in text
     assert text.index('transaction promote') < text.index(
-        'patroni_communications_require_runtime "${CANONICAL_FILE}"'
+        '"${CANONICAL_FILE}" "${BACKEND_IMAGE}" "${CANDIDATE_WORKER_GATE_PROFILE}"'
     )
     assert "patroni_communications_capture_previous()" in lifecycle
     assert "patroni_communications_fence_candidate()" in lifecycle
@@ -132,10 +134,12 @@ if [[ "$1" == "inspect" ]]; then
   exit 0
 fi
 if [[ "$1" == "compose" && "$*" == *"exec -T communications-worker"* ]]; then
-  expected_role="${!#}"
+  expected_role="${@: -3:1}"
+  expected_enabled="${@: -2:1}"
+  expected_allow_all="${!#}"
   [[ "${RUNTIME_APP_ROLE:-primary}" == "$expected_role" ]]
-  [[ "${RUNTIME_WORKER_ENABLED:-false}" == "false" ]]
-  [[ "${RUNTIME_ALLOW_ALL_MODE:-false}" == "false" ]]
+  [[ "${RUNTIME_WORKER_ENABLED:-false}" == "$expected_enabled" ]]
+  [[ "${RUNTIME_ALLOW_ALL_MODE:-false}" == "$expected_allow_all" ]]
   exit 0
 fi
 exit 0
@@ -278,10 +282,11 @@ def test_workflow_verifies_release_parity_on_every_deployed_node():
             "&& bash scripts/ha/run_patroni_node_remote.sh verify"
         )
     final = jobs["deployment-complete"]["steps"][-1]["run"]
-    assert "dormant worker release verified on both nodes" in final
+    assert "communications worker release verified on both nodes" in final
+    assert "dormant worker release" not in final
 
 
-def test_remote_verify_requires_exact_images_running_and_false_phase2a_gates():
+def test_remote_verify_requires_exact_images_runtime_and_closed_gate_profile():
     text = REMOTE.read_text(encoding="utf-8")
     verify = text[text.index('if [[ "${OPERATION}" == "verify" ]]') :]
 
@@ -310,7 +315,7 @@ def test_remote_verify_requires_exact_images_running_and_false_phase2a_gates():
 @pytest.mark.parametrize(
     (
         "runtime_role",
-        "runtime_enabled",
+        "gate_case",
         "restart_drift",
         "stale_marker",
         "canary_result",
@@ -318,32 +323,55 @@ def test_remote_verify_requires_exact_images_running_and_false_phase2a_gates():
         "expected_code",
     ),
     [
-        ("primary", "false", "false", False, "verified", "false", 0),
-        ("primary", "false", "false", False, "changed", "false", 0),
-        ("primary", "false", "false", False, "deferred_once", "false", 0),
-        ("standby", "false", "false", False, "verified", "false", 1),
-        ("primary", "true", "false", False, "verified", "false", 1),
-        ("primary", "false", "true", False, "verified", "false", 1),
-        ("primary", "false", "false", True, "verified", "false", 1),
-        ("primary", "false", "false", False, "failed", "false", 1),
-        ("primary", "false", "false", False, "empty", "false", 1),
-        ("primary", "false", "false", False, "duplicate", "false", 1),
-        ("primary", "false", "false", False, "warning", "false", 1),
-        ("primary", "false", "false", False, "wrong_changed_role", "false", 1),
-        ("primary", "false", "false", False, "always_deferred", "false", 1),
-        ("primary", "false", "false", False, "verified", "true", 1),
+        ("primary", "dormant", "false", False, "verified", "false", 0),
+        ("primary", "canary", "false", False, "verified", "false", 0),
+        ("primary", "active", "false", False, "verified", "false", 0),
+        ("primary", "dormant", "false", False, "changed", "false", 0),
+        ("primary", "dormant", "false", False, "deferred_once", "false", 0),
+        ("standby", "dormant", "false", False, "verified", "false", 1),
+        ("primary", "runtime_mismatch", "false", False, "verified", "false", 1),
+        ("primary", "invalid", "false", False, "verified", "false", 1),
+        ("primary", "uppercase_compose", "false", False, "verified", "false", 1),
+        ("primary", "uppercase_runtime", "false", False, "verified", "false", 1),
+        ("primary", "dormant", "true", False, "verified", "false", 1),
+        ("primary", "dormant", "false", True, "verified", "false", 1),
+        ("primary", "dormant", "false", False, "failed", "false", 1),
+        ("primary", "dormant", "false", False, "empty", "false", 1),
+        ("primary", "dormant", "false", False, "duplicate", "false", 1),
+        ("primary", "dormant", "false", False, "warning", "false", 1),
+        ("primary", "dormant", "false", False, "wrong_changed_role", "false", 1),
+        ("primary", "dormant", "false", False, "always_deferred", "false", 1),
+        ("primary", "dormant", "false", False, "verified", "true", 1),
     ],
 )
 def test_remote_verify_path_executes_against_canonical_compose(
     tmp_path,
     runtime_role,
-    runtime_enabled,
+    gate_case,
     restart_drift,
     stale_marker,
     canary_result,
     final_role_flip,
     expected_code,
 ):
+    compose_gates = {
+        "dormant": ("false", "false"),
+        "canary": ("true", "false"),
+        "active": ("true", "true"),
+        "runtime_mismatch": ("false", "false"),
+        "invalid": ("false", "true"),
+        "uppercase_compose": ("TRUE", "false"),
+        "uppercase_runtime": ("false", "false"),
+    }[gate_case]
+    runtime_gates = (
+        ("true", "false")
+        if gate_case == "runtime_mismatch"
+        else (
+            ("TRUE", "false")
+            if gate_case == "uppercase_runtime"
+            else compose_gates
+        )
+    )
     project = tmp_path / "project"
     project.mkdir()
     (project / "docker-compose.patroni.yml").write_text(
@@ -385,8 +413,8 @@ def test_remote_verify_path_executes_against_canonical_compose(
                 "communications-worker": {
                     "image": NEW_IMAGE,
                     "environment": {
-                        "COMMUNICATIONS_WORKER_ENABLED": "false",
-                        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+                        "COMMUNICATIONS_WORKER_ENABLED": compose_gates[0],
+                        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": compose_gates[1],
                     },
                 },
             }
@@ -406,10 +434,17 @@ def test_remote_verify_path_executes_against_canonical_compose(
             'elif [[ "$1" == "inspect" ]]; then\n'
             f"  printf '%s|true\\n' {repr(NEW_IMAGE)}\n"
         'elif [[ "$1" == "compose" && "$*" == *"exec -T communications-worker"* ]]; then\n'
-        '  expected_role="${!#}"\n'
+        '  expected_profile="${!#}"\n'
+        '  expected_role="${@: -2:1}"\n'
+        '  case "$expected_profile" in\n'
+        '    dormant) expected_enabled=false; expected_allow_all=false ;;\n'
+        '    canary) expected_enabled=true; expected_allow_all=false ;;\n'
+        '    active) expected_enabled=true; expected_allow_all=true ;;\n'
+        '    *) exit 1 ;;\n'
+        '  esac\n'
         '  if [[ "$RUNTIME_APP_ROLE" != "$expected_role" '
-        '|| "$RUNTIME_WORKER_ENABLED" != "false" '
-        '|| "$RUNTIME_ALLOW_ALL_MODE" != "false" ]]; then exit 1; fi\n'
+        '|| "$RUNTIME_WORKER_ENABLED" != "$expected_enabled" '
+        '|| "$RUNTIME_ALLOW_ALL_MODE" != "$expected_allow_all" ]]; then exit 1; fi\n'
             "else\n"
             "  exit 91\n"
             "fi\n",
@@ -495,8 +530,8 @@ def test_remote_verify_path_executes_against_canonical_compose(
             "GITHUB_JOB": "verify",
             "API_PITR_MAINTENANCE_MARKER": str(tmp_path / "absent-maintenance"),
             "RUNTIME_APP_ROLE": runtime_role,
-            "RUNTIME_WORKER_ENABLED": runtime_enabled,
-            "RUNTIME_ALLOW_ALL_MODE": "false",
+            "RUNTIME_WORKER_ENABLED": runtime_gates[0],
+            "RUNTIME_ALLOW_ALL_MODE": runtime_gates[1],
             "SYSTEMCTL_RESTART_DRIFT": restart_drift,
             "SYSTEMCTL_COUNT": str(systemctl_count),
             "REMOTE_DOCKER_LOG": str(remote_docker_log),
@@ -513,6 +548,10 @@ def test_remote_verify_path_executes_against_canonical_compose(
     assert result.returncode == expected_code, result.stderr
     if expected_code == 0:
         assert "API/worker parity confirmed" in result.stdout
+        assert sum(
+            "config --format json" in line
+            for line in remote_docker_log.read_text(encoding="utf-8").splitlines()
+        ) == 2
     else:
         assert "API/worker parity confirmed" not in result.stdout
         assert "error=hidden" not in result.stdout + result.stderr

--- a/tests/unit/test_patroni_local_identity.py
+++ b/tests/unit/test_patroni_local_identity.py
@@ -36,7 +36,15 @@ from scripts.ha import patroni_local_identity
                 "COMMUNICATIONS_WORKER_ENABLED": "true",
                 "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
             },
-            False,
+            True,
+        ),
+        (
+            {
+                "APP_ROLE": "primary",
+                "COMMUNICATIONS_WORKER_ENABLED": "true",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "true",
+            },
+            True,
         ),
         (
             {
@@ -46,9 +54,17 @@ from scripts.ha import patroni_local_identity
             },
             False,
         ),
+        (
+            {
+                "APP_ROLE": "primary",
+                "COMMUNICATIONS_WORKER_ENABLED": "TRUE",
+                "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+            },
+            False,
+        ),
     ],
 )
-def test_communications_worker_probe_requires_all_no_delivery_gates(
+def test_communications_worker_probe_requires_role_and_closed_gate_profile(
     environment, expected
 ):
     outputs = []
@@ -70,6 +86,43 @@ def test_communications_worker_probe_requires_all_no_delivery_gates(
         compose_runner=compose_runner,
     ) is expected
     assert outputs == [("", "", {"check": False, "timeout": 10})]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "allow_all"),
+    [
+        ("false", "true"),
+        ("TRUE", "false"),
+        ("false", "FALSE"),
+    ],
+)
+def test_compose_profile_rejects_noncanonical_gates_without_echoing_environment(
+    enabled, allow_all
+):
+    rendered = {
+        "services": {
+            "communications-worker": {
+                "environment": {
+                    "COMMUNICATIONS_WORKER_ENABLED": enabled,
+                    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": allow_all,
+                    "SECRET_TOKEN": "must-not-appear",
+                }
+            }
+        }
+    }
+
+    def compose_runner(_config, *args, **_kwargs):
+        assert args == ("config", "--format", "json")
+        return subprocess.CompletedProcess(args, 0, json.dumps(rendered), "")
+
+    with pytest.raises(RuntimeError) as error:
+        patroni_local_identity.communications_worker_compose_profile(
+            SimpleNamespace(),
+            compose_runner=compose_runner,
+        )
+
+    assert "profile is not reviewed" in str(error.value)
+    assert "must-not-appear" not in str(error.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_patroni_release_manifest_attestation.py
+++ b/tests/unit/test_patroni_release_manifest_attestation.py
@@ -1,0 +1,167 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_patroni_candidate_transactions import (
+    PATRONI_RUNNER,
+    _patroni_runner_env,
+)
+
+
+def _manifest(env):
+    return Path(env["PATRONI_FINALIZED_RELEASE_MANIFEST"])
+
+
+def _read_manifest(path):
+    return json.loads(path.read_text(encoding="ascii"))
+
+
+def _write_manifest(path, value):
+    path.write_text(
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="ascii",
+    )
+    path.chmod(0o600)
+
+
+def _run_guard_failure(env, project):
+    canonical = (project / "compose.yml").read_bytes()
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert (project / "compose.yml").read_bytes() == canonical
+    assert not (project / "compose.yml.candidate").exists()
+    assert not Path(env["CHILD_LOG"]).exists()
+    assert not Path(env["RECONCILE_LOG"]).exists()
+    assert not Path(env["PATRONI_ROLE_AGENT_TARGET"]).exists()
+    assert not Path(env["VOICE_SYNC_LOG"]).exists()
+    assert not Path(env["SYSTEMCTL_LOG"]).read_text(encoding="utf-8")
+    return result
+
+
+@pytest.mark.parametrize(
+    "damage",
+    [
+        "missing",
+        "corrupt",
+        "noncanonical",
+        "wrong-project",
+        "wrong-path",
+        "wrong-entry-mode",
+        "wrong-compose-digest",
+        "wrong-release-digest",
+        "other-asset-mode",
+        "other-asset-content",
+        "duplicate-path",
+        "unsorted-paths",
+        "unsafe-manifest-mode",
+        "symlink",
+        "hardlink",
+    ],
+)
+def test_candidate_requires_exact_finalized_release_manifest(
+    tmp_path,
+    damage,
+):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    path = _manifest(env)
+    manifest = _read_manifest(path)
+    compose_entry = next(
+        item
+        for item in manifest["files"]
+        if item["path"] == str(project / "compose.yml")
+    )
+    other_entry = next(
+        item
+        for item in manifest["files"]
+        if item["path"] != str(project / "compose.yml")
+    )
+
+    if damage == "missing":
+        path.unlink()
+    elif damage == "corrupt":
+        path.write_text("{", encoding="ascii")
+    elif damage == "noncanonical":
+        path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="ascii")
+    elif damage == "wrong-project":
+        manifest["project_dir"] = str(tmp_path / "other-project")
+        _write_manifest(path, manifest)
+    elif damage == "wrong-path":
+        compose_entry["path"] = str(project / "other-compose.yml")
+        _write_manifest(path, manifest)
+    elif damage == "wrong-entry-mode":
+        compose_entry["mode"] = 0o755
+        _write_manifest(path, manifest)
+    elif damage == "wrong-compose-digest":
+        compose_entry["sha256"] = "0" * 64
+        _write_manifest(path, manifest)
+    elif damage == "wrong-release-digest":
+        manifest["release_sha256"] = "0" * 64
+        _write_manifest(path, manifest)
+    elif damage == "other-asset-mode":
+        Path(other_entry["path"]).chmod(0o700)
+    elif damage == "other-asset-content":
+        Path(other_entry["path"]).write_bytes(b"tampered release tool\n")
+    elif damage == "duplicate-path":
+        manifest["files"].append(dict(compose_entry))
+        _write_manifest(path, manifest)
+    elif damage == "unsorted-paths":
+        manifest["files"].insert(
+            0,
+            {
+                "mode": 0o644,
+                "path": str(project / "z-last"),
+                "sha256": "2" * 64,
+            },
+        )
+        _write_manifest(path, manifest)
+    elif damage == "unsafe-manifest-mode":
+        path.chmod(0o644)
+    elif damage == "symlink":
+        target = tmp_path / "manifest-target.json"
+        path.replace(target)
+        path.symlink_to(target)
+    elif damage == "hardlink":
+        os.link(path, tmp_path / "manifest-hardlink.json")
+
+    result = _run_guard_failure(env, project)
+    assert "finalized PITR release" in result.stderr
+
+
+def test_candidate_rejects_release_manifest_wrong_group(tmp_path):
+    alternate_group = next(
+        (group for group in os.getgroups() if group != os.getegid()),
+        None,
+    )
+    if alternate_group is None:
+        pytest.skip("current user has no alternate group for metadata test")
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+    path = _manifest(env)
+    os.chown(path, -1, alternate_group)
+
+    result = _run_guard_failure(env, project)
+
+    assert "current-user-and-group-owned" in result.stderr
+
+
+def test_candidate_accepts_canonical_finalized_manifest(tmp_path):
+    env, project = _patroni_runner_env(tmp_path, child_exit=0)
+
+    result = subprocess.run(
+        ["bash", str(PATRONI_RUNNER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (project / "compose.yml.candidate").exists()

--- a/tests/unit/test_patroni_remote_script.py
+++ b/tests/unit/test_patroni_remote_script.py
@@ -238,13 +238,37 @@ def test_remote_orchestrator_has_strict_operations_and_never_manages_database():
 
 def test_remote_orchestrator_passes_token_over_stdin_not_command_line():
     text = SCRIPT.read_text(encoding="utf-8")
+    transaction = TRANSACTION_RUNNER.read_text(encoding="utf-8")
 
     assert "IFS= read -r GHCR_PAT" in text
     assert "IFS= read -r BOT_VOICE_TRANSCRIPTION_API_KEY" in text
     assert "export GHCR_PAT" in text
+    assert "export BOT_VOICE_TRANSCRIPTION_API_KEY" in text
     assert "GHCR_PAT='" not in text
     assert "BOT_VOICE_TRANSCRIPTION_API_KEY='" not in text
     assert "sync_bot_voice_env.py" in text
+    assert "PATRONI_VOICE_ENV_SYNC=" in text
+    assert text.index("export BOT_VOICE_TRANSCRIPTION_API_KEY") < text.rindex(
+        "run_patroni_candidate_transaction.sh"
+    )
+    assert text.rindex("run_patroni_candidate_transaction.sh") < text.rindex(
+        "unset BOT_VOICE_TRANSCRIPTION_API_KEY"
+    )
+    assert transaction.index("require_pitr_attested_candidate") < transaction.rindex(
+        "\nsync_bot_voice_env_locked\n"
+    )
+    locked_sync = transaction.split("sync_bot_voice_env_locked() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+    assert transaction.index(
+        'VOICE_SECRET="${BOT_VOICE_TRANSCRIPTION_API_KEY:-}"'
+    ) < transaction.index("SCRIPT_DIR=")
+    assert transaction.index("unset BOT_VOICE_TRANSCRIPTION_API_KEY") < (
+        transaction.index("SCRIPT_DIR=")
+    )
+    assert locked_sync.index("unset VOICE_SECRET") < (
+        locked_sync.index('python3 -I "${VOICE_ENV_SYNC}"')
+    )
 
 
 def test_installed_role_agent_loads_its_pinned_sibling_module(tmp_path):

--- a/tests/unit/test_patroni_role_agent_communication_profiles.py
+++ b/tests/unit/test_patroni_role_agent_communication_profiles.py
@@ -1,0 +1,272 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ha import patroni_role_agent
+from scripts.ha.patroni_local_identity import COMMUNICATIONS_WORKER_SERVICE
+from tests.unit.test_patroni_role_agent_communications import (
+    _ComposeRuntime,
+    _command_index,
+    _config,
+    _docker_command_index,
+)
+
+
+@pytest.fixture(autouse=True)
+def _safe_host_contracts(monkeypatch):
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "read_maintenance_transaction_id",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_cancel_pitr_operations",
+        lambda _config: [],
+    )
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_run_docker",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+
+def _write_primary_state(config):
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env("primary", bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            "primary",
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text("primary\n", encoding="utf-8")
+
+
+def test_invalid_mixed_delivery_gate_fences_and_recreates_worker(
+    tmp_path, monkeypatch, capsys
+):
+    config = _config(tmp_path)
+    _write_primary_state(config)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        worker_allow_all=True,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(patroni_role_agent, "_systemd_units_match", lambda *_args: True)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_fetch_configured_patroni_role",
+        lambda _config: "primary",
+    )
+
+    assert patroni_role_agent.run(config, once=True) == 0
+
+    worker_remove = _docker_command_index(
+        events,
+        ("rm", "--force", "c" * 12),
+    )
+    worker_recreate = _command_index(
+        events,
+        (
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+            COMMUNICATIONS_WORKER_SERVICE,
+        ),
+    )
+    assert worker_remove < worker_recreate
+    assert runtime.worker_role == "primary"
+    assert runtime.worker_enabled is False
+    assert runtime.worker_allow_all is False
+    output = capsys.readouterr().out.splitlines()
+    assert len(output) == 2
+    assert output[0].startswith(
+        "patroni_role_agent_status=reconciled role=primary "
+    )
+    assert "communications_worker_role_drift" in output[0]
+    assert "recreate_communications_worker" in output[0]
+    assert output[1] == "patroni_role_agent_once_status=verified role=primary"
+
+
+@pytest.mark.parametrize(
+    ("role", "worker_enabled", "worker_allow_all"),
+    [
+        ("primary", True, False),
+        ("primary", True, True),
+        ("standby", True, False),
+        ("standby", True, True),
+    ],
+)
+def test_reviewed_candidate_profile_is_not_fenced_while_deploy_lock_is_busy(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    role,
+    worker_enabled,
+    worker_allow_all,
+):
+    config = _config(tmp_path)
+    config.app_role_env.write_text(
+        patroni_role_agent.role_env(role, bot_process=False),
+        encoding="utf-8",
+    )
+    config.bot_role_env.write_text(
+        patroni_role_agent.role_env(
+            role,
+            bot_process=True,
+            bot_enabled=False,
+        ),
+        encoding="utf-8",
+    )
+    config.state_file.write_text(f"{role}\n", encoding="utf-8")
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={COMMUNICATIONS_WORKER_SERVICE},
+        worker_role=role,
+        worker_enabled=worker_enabled,
+        worker_allow_all=worker_allow_all,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(patroni_role_agent, "_systemd_units_match", lambda *_args: True)
+
+    def lock_busy(*_args):
+        events.append("deploy_lock_busy")
+        raise BlockingIOError
+
+    monkeypatch.setattr(patroni_role_agent.fcntl, "flock", lock_busy)
+
+    assert patroni_role_agent.reconcile(config, role) is None
+    assert COMMUNICATIONS_WORKER_SERVICE in runtime.running_services
+    assert "deploy_lock_busy" in events
+    assert not any(
+        isinstance(event, tuple) and event[0] == "docker"
+        for event in events
+    )
+    assert capsys.readouterr().out.strip() == (
+        "patroni_role_agent_status=deferred reason=deployment_lock_busy"
+    )
+
+
+@pytest.mark.parametrize(
+    ("worker_enabled", "worker_allow_all"),
+    [(True, False), (True, True)],
+)
+def test_reviewed_but_noncanonical_profile_reconciles_after_deploy_window(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    worker_enabled,
+    worker_allow_all,
+):
+    config = _config(tmp_path)
+    _write_primary_state(config)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        worker_enabled=worker_enabled,
+        worker_allow_all=worker_allow_all,
+        canonical_worker_enabled=False,
+        canonical_worker_allow_all=False,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(patroni_role_agent, "_systemd_units_match", lambda *_args: True)
+    monkeypatch.setattr(
+        patroni_role_agent,
+        "_require_fresh_primary_or_fence",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
+    monkeypatch.setattr(
+        patroni_role_agent.fcntl,
+        "flock",
+        lambda *_args: events.append("deploy_lock_acquired"),
+    )
+
+    assert patroni_role_agent.reconcile(config, "primary") is True
+    assert runtime.worker_enabled is False
+    assert runtime.worker_allow_all is False
+    assert "deploy_lock_acquired" in events
+    worker_recreate = _command_index(
+        events,
+        (
+            "up",
+            "-d",
+            "--no-deps",
+            "--force-recreate",
+            COMMUNICATIONS_WORKER_SERVICE,
+        ),
+    )
+    assert events.index("deploy_lock_acquired") < worker_recreate
+    assert not any(
+        isinstance(event, tuple) and event[0] == "docker"
+        for event in events
+    )
+    output = capsys.readouterr().out.strip()
+    assert "communications_worker_profile_drift" in output
+    assert "recreate_communications_worker" in output
+
+
+def test_invalid_mixed_profile_is_fenced_before_busy_deploy_lock(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    config = _config(tmp_path)
+    _write_primary_state(config)
+    events: list[object] = []
+    runtime = _ComposeRuntime(
+        events,
+        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
+        worker_role="primary",
+        worker_enabled=False,
+        worker_allow_all=True,
+    )
+    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
+    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
+    monkeypatch.setattr(patroni_role_agent, "_systemd_units_match", lambda *_args: True)
+
+    def lock_busy(*_args):
+        events.append("deploy_lock_busy")
+        raise BlockingIOError
+
+    monkeypatch.setattr(patroni_role_agent.fcntl, "flock", lock_busy)
+
+    assert patroni_role_agent.reconcile(config, "primary") is None
+    worker_stop = _docker_command_index(
+        events,
+        ("stop", "--timeout", "10", "c" * 12),
+    )
+    assert worker_stop < events.index("deploy_lock_busy")
+    assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
+    assert capsys.readouterr().out.strip() == (
+        "patroni_role_agent_status=deferred reason=deployment_lock_busy"
+    )

--- a/tests/unit/test_patroni_role_agent_communications.py
+++ b/tests/unit/test_patroni_role_agent_communications.py
@@ -1,5 +1,7 @@
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -69,6 +71,8 @@ class _ComposeRuntime:
         role_probe_error: Exception | None = None,
         worker_enabled: bool = False,
         worker_allow_all: bool = False,
+        canonical_worker_enabled: bool = False,
+        canonical_worker_allow_all: bool = False,
     ):
         self.events = events
         self.defined_services = set(defined_services)
@@ -80,6 +84,8 @@ class _ComposeRuntime:
         self.role_probe_error = role_probe_error
         self.worker_enabled = worker_enabled
         self.worker_allow_all = worker_allow_all
+        self.canonical_worker_enabled = canonical_worker_enabled
+        self.canonical_worker_allow_all = canonical_worker_allow_all
 
     def __call__(self, config, *args, **_kwargs):
         self.events.append(("compose", args))
@@ -89,6 +95,27 @@ class _ComposeRuntime:
             return SimpleNamespace(
                 returncode=0,
                 stdout="\n".join(sorted(self.defined_services)) + "\n",
+                stderr="",
+            )
+        if args == ("config", "--format", "json"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "services": {
+                            COMMUNICATIONS_WORKER_SERVICE: {
+                                "environment": {
+                                    "COMMUNICATIONS_WORKER_ENABLED": str(
+                                        self.canonical_worker_enabled
+                                    ).lower(),
+                                    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": str(
+                                        self.canonical_worker_allow_all
+                                    ).lower(),
+                                }
+                            }
+                        }
+                    }
+                ),
                 stderr="",
             )
         if args[:3] == ("ps", "--status", "running"):
@@ -115,19 +142,21 @@ class _ComposeRuntime:
         if args[:3] == ("exec", "-T", COMMUNICATIONS_WORKER_SERVICE):
             if self.role_probe_error is not None:
                 raise self.role_probe_error
-            expected_role = args[-1]
-            return SimpleNamespace(
-                returncode=(
-                    0
-                    if (
-                        self.worker_role == expected_role
-                        and not self.worker_enabled
-                        and not self.worker_allow_all
-                    )
-                    else 1
-                ),
-                stdout="",
-                stderr="",
+            return subprocess.run(
+                [sys.executable, "-c", args[5], args[6]],
+                env={
+                    **os.environ,
+                    "APP_ROLE": self.worker_role or "",
+                    "COMMUNICATIONS_WORKER_ENABLED": str(
+                        self.worker_enabled
+                    ).lower(),
+                    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": str(
+                        self.worker_allow_all
+                    ).lower(),
+                },
+                text=True,
+                capture_output=True,
+                check=False,
             )
         if args[0] == "up":
             service = args[-1]
@@ -144,8 +173,8 @@ class _ComposeRuntime:
                             if line.startswith("APP_ROLE=")
                         )
                     )
-                    self.worker_enabled = False
-                    self.worker_allow_all = False
+                    self.worker_enabled = self.canonical_worker_enabled
+                    self.worker_allow_all = self.canonical_worker_allow_all
         elif args[0] in {"rm", "kill", "stop"}:
             self.running_services.discard(args[-1])
             if args[-1] == COMMUNICATIONS_WORKER_SERVICE:
@@ -437,7 +466,6 @@ def test_defined_worker_must_have_expected_role_at_final_postcondition(
         patroni_role_agent.reconcile(config, "primary")
     assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
 
-
 def test_stale_running_worker_role_fences_all_side_effect_owners_before_systemd(
     tmp_path, monkeypatch
 ):
@@ -603,84 +631,3 @@ def test_role_probe_timeout_fences_worker_before_primary_later_checks(
     first_systemd = events.index("systemd_check")
     assert first_worker_remove < first_systemd
     assert COMMUNICATIONS_WORKER_SERVICE not in runtime.running_services
-
-
-@pytest.mark.parametrize(
-    "drift",
-    [
-        {"worker_enabled": True},
-        {"worker_allow_all": True},
-    ],
-)
-def test_delivery_gate_drift_fences_and_recreates_worker(
-    tmp_path, monkeypatch, capsys, drift
-):
-    config = _config(tmp_path)
-    config.app_role_env.write_text(
-        patroni_role_agent.role_env("primary", bot_process=False),
-        encoding="utf-8",
-    )
-    config.bot_role_env.write_text(
-        patroni_role_agent.role_env(
-            "primary",
-            bot_process=True,
-            bot_enabled=False,
-        ),
-        encoding="utf-8",
-    )
-    config.state_file.write_text("primary\n", encoding="utf-8")
-    events: list[object] = []
-    runtime = _ComposeRuntime(
-        events,
-        defined_services={"app", COMMUNICATIONS_WORKER_SERVICE},
-        running_services={"app", COMMUNICATIONS_WORKER_SERVICE},
-        worker_role="primary",
-        **drift,
-    )
-    monkeypatch.setattr(patroni_role_agent, "_run_compose", runtime)
-    monkeypatch.setattr(patroni_role_agent, "_run_docker", runtime.docker)
-    monkeypatch.setattr(
-        patroni_role_agent,
-        "_systemd_units_match",
-        lambda *_args: True,
-    )
-    monkeypatch.setattr(
-        patroni_role_agent,
-        "_require_fresh_primary_or_fence",
-        lambda *_args: None,
-    )
-    monkeypatch.setattr(patroni_role_agent, "_wait_ready", lambda _config: None)
-    monkeypatch.setattr(
-        patroni_role_agent,
-        "_fetch_configured_patroni_role",
-        lambda _config: "primary",
-    )
-
-    assert patroni_role_agent.run(config, once=True) == 0
-
-    worker_remove = _docker_command_index(
-        events,
-        ("rm", "--force", "c" * 12),
-    )
-    worker_recreate = _command_index(
-        events,
-        (
-            "up",
-            "-d",
-            "--no-deps",
-            "--force-recreate",
-            COMMUNICATIONS_WORKER_SERVICE,
-        ),
-    )
-    assert worker_remove < worker_recreate
-    assert runtime.worker_role == "primary"
-    assert runtime.worker_enabled is False
-    assert runtime.worker_allow_all is False
-    output = capsys.readouterr().out.splitlines()
-    assert len(output) == 2
-    assert output[0].startswith(
-        "patroni_role_agent_status=reconciled role=primary "
-    )
-    assert "communications_worker_role_drift" in output[0]
-    assert "recreate_communications_worker" in output[0]
-    assert output[1] == "patroni_role_agent_once_status=verified role=primary"

--- a/tests/unit/test_patroni_role_agent_release_fence.py
+++ b/tests/unit/test_patroni_role_agent_release_fence.py
@@ -67,6 +67,23 @@ class _Runtime:
                 stdout=f"app\n{COMMUNICATIONS_WORKER_SERVICE}\n",
                 stderr="",
             )
+        if args == ("config", "--format", "json"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "services": {
+                            COMMUNICATIONS_WORKER_SERVICE: {
+                                "environment": {
+                                    "COMMUNICATIONS_WORKER_ENABLED": "false",
+                                    "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+                                }
+                            }
+                        }
+                    }
+                ),
+                stderr="",
+            )
         if args[:3] == ("ps", "--status", "running"):
             payload = "\n".join(
                 json.dumps(

--- a/tests/unit/test_pitr_bundle_resume_safety.py
+++ b/tests/unit/test_pitr_bundle_resume_safety.py
@@ -112,7 +112,7 @@ def test_inspect_barrier_classifies_without_mutating_release_state(tmp_path):
     assert not Path(namespace["MAINTENANCE_MARKER"]).exists()
 
 
-def test_inspect_rejects_receipt_even_when_transaction_directory_remains(tmp_path):
+def test_inspect_recovers_durable_receipt_when_transaction_directory_remains(tmp_path):
     namespace, project, compose, tool = _remote_namespace(tmp_path)
     _write(compose, b"old-compose", 0o644)
     _write(tool, b"old-tool", 0o755)
@@ -128,12 +128,16 @@ def test_inspect_rejects_receipt_even_when_transaction_directory_remains(tmp_pat
         )
     namespace["safe_remove_transaction"] = remove_transaction
 
-    assert (Path(namespace["TRANSACTION_ROOT"]) / TXID).exists()
+    txdir = Path(namespace["TRANSACTION_ROOT"]) / TXID
+    assert txdir.exists()
     assert (Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{TXID}.json").exists()
-    with pytest.raises(RuntimeError, match="already has a rollback receipt"):
-        namespace["execute"](
-            "inspect", TXID, str(project), compose.name, payload
-        )
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "matching-rolled-back"
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "already-rolled-back"
+    assert not txdir.exists()
 
 
 def test_pinned_bundle_bytes_survive_source_changes_between_inspect_and_apply(

--- a/tests/unit/test_pitr_cluster_migration.py
+++ b/tests/unit/test_pitr_cluster_migration.py
@@ -54,6 +54,9 @@ class FakeOperations:
         self.maintenance_failure = None
         self.fenced_provision_failure = False
         self.role_agent_failure = None
+        self.communications_cutover_failure = False
+        self.target_compose_failure = False
+        self.target_compose_validated = False
         self.role_agent_fail_once = set()
         self.release_results = {}
         self.release_payloads = []
@@ -71,6 +74,13 @@ class FakeOperations:
 
     def bundles(self, nodes):
         return {node.project_dir: f"pinned:{node.alias}" for node in nodes}
+
+    def target_compose(self, nodes, bundles):
+        self.target_compose_validated = True
+        if self.target_compose_failure:
+            raise RuntimeError("simulated target Compose failure")
+        assert set(bundles) == {node.project_dir for node in nodes}
+        return "dormant"
 
     def release(self, *, node, context, action, txid, release_bundle, runner):
         event = ("release", action, node.alias, txid)
@@ -149,6 +159,20 @@ class FakeOperations:
         if self.fenced_provision_failure:
             raise RuntimeError("simulated fenced provision failure")
 
+    def communications_cutover(
+        self,
+        *,
+        node,
+        context,
+        transaction_id,
+        runner,
+    ):
+        self.events.append(
+            ("communications-cutover", node.alias, transaction_id)
+        )
+        if self.communications_cutover_failure:
+            raise RuntimeError("simulated communications cutover failure")
+
     def dependencies(self):
         return MigrationDependencies(
             discover=self.discover,
@@ -158,6 +182,8 @@ class FakeOperations:
             maintenance=self.maintenance,
             fenced_provision=self.fenced_provision,
             role_agent=self.role_agent,
+            communications_cutover=self.communications_cutover,
+            target_compose=self.target_compose,
         )
 
 
@@ -181,9 +207,11 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
     assert result.primary_alias == "mvn-api"
     assert result.standby_alias == "zakup"
     assert result.transaction_id == TXID
+    assert operations.target_compose_validated is True
     assert _mutation_events(operations.events) == [
         ("release", "inspect", "zakup", TXID),
         ("release", "inspect", "mvn-api", TXID),
+        ("communications-cutover", "mvn-api", TXID),
         ("release", "apply", "zakup", TXID),
         ("release", "apply", "mvn-api", TXID),
         ("role-agent", "quiesce-standby", "zakup", TXID),
@@ -216,7 +244,7 @@ def test_migration_runs_exact_order_with_topology_around_every_remote_operation(
         ("role-agent", "resume-primary", "mvn-api", TXID),
         ("maintenance", "verify", "mvn-api", TXID),
     ]
-    assert len(operations.events) == 1 + 3 * 33
+    assert len(operations.events) == 1 + 3 * 34
     assert operations.events[0] == ("topology",)
     for index in range(1, len(operations.events), 3):
         assert operations.events[index] == ("topology",)
@@ -246,7 +274,34 @@ def test_bundle_apply_failure_preserves_all_journals_for_exact_resume(
         ("release", "apply", "zakup", TXID),
         ("release", "apply", "mvn-api", TXID),
     ]
-    assert len([event for event in operations.events if event[0] == "topology"]) == 9
+    assert len([event for event in operations.events if event[0] == "topology"]) == 11
+
+
+def test_communications_cutover_failure_blocks_every_bundle_apply(tmp_path):
+    operations = FakeOperations()
+    operations.communications_cutover_failure = True
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"resume with the same transaction ID {TXID}",
+    ):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event[1] for event in operations.events if event[0] == "release"] == [
+        "inspect",
+        "inspect",
+    ]
+    assert (
+        "communications-cutover",
+        "mvn-api",
+        TXID,
+    ) in operations.events
 
 
 def test_first_bundle_digest_rejection_never_authorizes_rollback(tmp_path):
@@ -477,7 +532,7 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
     operations = FakeOperations()
     operations.maintenance_failure = ("provision-node", "zakup")
     # The compatibility barrier adds two proved read-only operations.
-    operations.discover_failures.add(22)
+    operations.discover_failures.add(24)
 
     with pytest.raises(RuntimeError, match="neither node was resumed"):
         migrate_cluster(
@@ -494,7 +549,7 @@ def test_recovery_keeps_both_nodes_fenced_when_fresh_topology_is_unavailable(
 
 def test_topology_failure_before_first_agent_quiesce_still_rolls_back_assets(tmp_path):
     operations = FakeOperations()
-    operations.topologies = [_topology()] * 9 + [_topology(timeline=10)]
+    operations.topologies = [_topology()] * 11 + [_topology(timeline=10)]
 
     with pytest.raises(RuntimeError, match="release bundles were rolled back"):
         migrate_cluster(
@@ -621,106 +676,3 @@ def test_same_transaction_id_can_resume_through_idempotent_remote_helpers(tmp_pa
 def test_transaction_id_is_canonical_lowercase_hex(transaction_id):
     with pytest.raises(RuntimeError, match="32 lowercase hexadecimal"):
         validate_transaction_id(transaction_id)
-
-
-def _controller_input():
-    return controller.PitrInput(
-        cluster="mvn-api",
-        bucket="mvn-postgres-pitr",
-        endpoint_url="https://reviewed.r2.cloudflarestorage.com",
-        region="auto",
-        access_key_id="access",
-        secret_access_key="secret",
-        key_prefix="postgres/pitr",
-    )
-
-
-def _patch_controller_connection(monkeypatch, tmp_path):
-    context = _context(tmp_path)
-    monkeypatch.setattr(controller, "validate_identity_file", lambda _path: tmp_path / "id")
-    monkeypatch.setattr(controller, "create_context", lambda *_args: context)
-    monkeypatch.setattr(controller, "validate_effective_config", lambda *_args: None)
-    return context
-
-
-def test_controller_migrate_cluster_entrypoint_passes_one_env_and_root_txid(
-    tmp_path, monkeypatch
-):
-    context = _patch_controller_connection(monkeypatch, tmp_path)
-    captured = []
-    monkeypatch.setattr(
-        controller,
-        "collect_inputs",
-        lambda **_kwargs: _controller_input(),
-    )
-
-    def fake_migrate(**kwargs):
-        captured.append(kwargs)
-        return MigrationResult(
-            transaction_id=TXID,
-            primary_alias="mvn-api",
-            standby_alias="zakup",
-            system_identifier="7423456789012345678",
-            timeline=9,
-        )
-
-    monkeypatch.setattr(controller, "migrate_cluster", fake_migrate)
-
-    assert controller.main(
-        [
-            "--phase",
-            "migrate-cluster",
-            "--transaction-id",
-            TXID,
-            "--identity-file",
-            str(tmp_path / "id"),
-            "--no-prompt",
-        ]
-    ) == 0
-    assert len(captured) == 1
-    assert captured[0]["context"] == context
-    assert captured[0]["transaction_id"] == TXID
-    assert captured[0]["env_text"] == controller.render_env(_controller_input())
-
-
-def test_controller_standalone_phase_requires_and_propagates_root_txid(
-    tmp_path, monkeypatch
-):
-    context = _patch_controller_connection(monkeypatch, tmp_path)
-    calls = []
-    monkeypatch.setattr(controller, "discover_cluster_topology", lambda **_kwargs: _topology())
-    monkeypatch.setattr(
-        controller,
-        "run_remote_maintenance_phase",
-        lambda **kwargs: calls.append(kwargs),
-    )
-
-    assert controller.main(
-        [
-            "--phase",
-            "verify",
-            "--transaction-id",
-            TXID,
-            "--identity-file",
-            str(tmp_path / "id"),
-            "--no-prompt",
-        ]
-    ) == 0
-    assert len(calls) == 1
-    assert calls[0]["context"] == context
-    assert calls[0]["transaction_id"] == TXID
-    assert calls[0]["phase"] == "verify"
-
-
-def test_controller_probe_only_is_the_only_live_mode_without_transaction_id(
-    tmp_path, monkeypatch
-):
-    _patch_controller_connection(monkeypatch, tmp_path)
-    monkeypatch.setattr(controller, "discover_cluster_topology", lambda **_kwargs: _topology())
-
-    assert controller.main(
-        ["--probe-only", "--identity-file", str(tmp_path / "id")]
-    ) == 0
-    assert controller.main(
-        ["--phase", "verify", "--identity-file", str(tmp_path / "id")]
-    ) == 1

--- a/tests/unit/test_pitr_cluster_migration_controller.py
+++ b/tests/unit/test_pitr_cluster_migration_controller.py
@@ -1,0 +1,128 @@
+from scripts.ha import apply_postgres_pitr_primary_prerequisites as controller
+from scripts.ha.pitr_cluster_migration import MigrationResult
+from scripts.ha.pitr_cluster_topology import ClusterTopology
+from scripts.ha.pitr_pinned_ssh import PATRONI_NODES, PinnedSshContext
+
+
+TXID = "0123456789abcdef0123456789abcdef"
+
+
+def _context(tmp_path):
+    return PinnedSshContext(
+        identity_file=tmp_path / "identity",
+        known_hosts_file=tmp_path / "known-hosts",
+        config_file=tmp_path / "config",
+    )
+
+
+def _topology():
+    by_alias = {node.alias: node for node in PATRONI_NODES}
+    return ClusterTopology(
+        primary=by_alias["mvn-api"],
+        standby=by_alias["zakup"],
+        system_identifier="7423456789012345678",
+        timeline=9,
+    )
+
+
+def _controller_input():
+    return controller.PitrInput(
+        cluster="mvn-api",
+        bucket="mvn-postgres-pitr",
+        endpoint_url="https://reviewed.r2.cloudflarestorage.com",
+        region="auto",
+        access_key_id="access",
+        secret_access_key="secret",
+        key_prefix="postgres/pitr",
+    )
+
+
+def _patch_controller_connection(monkeypatch, tmp_path):
+    context = _context(tmp_path)
+    monkeypatch.setattr(controller, "validate_identity_file", lambda _path: tmp_path / "id")
+    monkeypatch.setattr(controller, "create_context", lambda *_args: context)
+    monkeypatch.setattr(controller, "validate_effective_config", lambda *_args: None)
+    return context
+
+
+def test_controller_migrate_cluster_entrypoint_passes_one_env_and_root_txid(
+    tmp_path, monkeypatch
+):
+    context = _patch_controller_connection(monkeypatch, tmp_path)
+    captured = []
+    monkeypatch.setattr(
+        controller,
+        "collect_inputs",
+        lambda **_kwargs: _controller_input(),
+    )
+
+    def fake_migrate(**kwargs):
+        captured.append(kwargs)
+        return MigrationResult(
+            transaction_id=TXID,
+            primary_alias="mvn-api",
+            standby_alias="zakup",
+            system_identifier="7423456789012345678",
+            timeline=9,
+        )
+
+    monkeypatch.setattr(controller, "migrate_cluster", fake_migrate)
+
+    assert controller.main(
+        [
+            "--phase",
+            "migrate-cluster",
+            "--transaction-id",
+            TXID,
+            "--identity-file",
+            str(tmp_path / "id"),
+            "--no-prompt",
+        ]
+    ) == 0
+    assert len(captured) == 1
+    assert captured[0]["context"] == context
+    assert captured[0]["transaction_id"] == TXID
+    assert captured[0]["env_text"] == controller.render_env(_controller_input())
+
+
+def test_controller_standalone_phase_requires_and_propagates_root_txid(
+    tmp_path, monkeypatch
+):
+    context = _patch_controller_connection(monkeypatch, tmp_path)
+    calls = []
+    monkeypatch.setattr(controller, "discover_cluster_topology", lambda **_kwargs: _topology())
+    monkeypatch.setattr(
+        controller,
+        "run_remote_maintenance_phase",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    assert controller.main(
+        [
+            "--phase",
+            "verify",
+            "--transaction-id",
+            TXID,
+            "--identity-file",
+            str(tmp_path / "id"),
+            "--no-prompt",
+        ]
+    ) == 0
+    assert len(calls) == 1
+    assert calls[0]["context"] == context
+    assert calls[0]["transaction_id"] == TXID
+    assert calls[0]["phase"] == "verify"
+
+
+def test_controller_probe_only_is_the_only_live_mode_without_transaction_id(
+    tmp_path, monkeypatch
+):
+    _patch_controller_connection(monkeypatch, tmp_path)
+    monkeypatch.setattr(controller, "discover_cluster_topology", lambda **_kwargs: _topology())
+
+    assert controller.main(
+        ["--probe-only", "--identity-file", str(tmp_path / "id")]
+    ) == 0
+    assert controller.main(
+        ["--phase", "verify", "--identity-file", str(tmp_path / "id")]
+    ) == 1

--- a/tests/unit/test_pitr_communications_cutover.py
+++ b/tests/unit/test_pitr_communications_cutover.py
@@ -1,0 +1,248 @@
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ha import pitr_communications_cutover as cutover
+from scripts.ha.pitr_pinned_ssh import PatroniNode, PinnedSshContext
+
+
+TXID = "0123456789abcdef0123456789abcdef"
+
+
+def _remote_namespace(
+    tmp_path: Path,
+    *,
+    gates: tuple[str, str] = ("false", "false"),
+    drained: bool = True,
+    proof_overrides: list[dict] | None = None,
+):
+    source = cutover.REMOTE_COMMUNICATIONS_CUTOVER_PREFLIGHT.rsplit(
+        "\nif len(sys.argv)", 1
+    )[0]
+    namespace = {"__name__": "cutover_test"}
+    exec(source, namespace)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    compose = project / "docker-compose.patroni.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    compose.chmod(0o644)
+    calls = []
+    proof_call_count = 0
+
+    def fake_run_checked(args, **_kwargs):
+        nonlocal proof_call_count
+        calls.append(tuple(args))
+        if args[-3:] == ["config", "--format", "json"]:
+            payload = {
+                "services": {
+                    "communications-worker": {
+                        "environment": {
+                            "COMMUNICATIONS_WORKER_ENABLED": gates[0],
+                            "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": gates[1],
+                        }
+                    }
+                }
+            }
+            return subprocess.CompletedProcess(args, 0, json.dumps(payload) + "\n", "")
+        if "exec" in args:
+            payload = {
+                "ok": True,
+                "command": "off",
+                "drained": drained,
+                "runtime_mode": "off",
+                "runtime_status": "stopped" if drained else "running",
+                "running_delivery_count": 0 if drained else 1,
+                "control_revision": 1,
+            }
+            if proof_overrides is not None:
+                if proof_call_count >= len(proof_overrides):
+                    raise AssertionError("unexpected extra off/drained proof")
+                payload.update(proof_overrides[proof_call_count])
+            proof_call_count += 1
+            return subprocess.CompletedProcess(args, 0, json.dumps(payload) + "\n", "")
+        if "stop" in args or "ps" in args:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(args)
+
+    namespace.update(
+        {
+            "ROOT_UID": os.geteuid(),
+            "ROOT_GID": os.getegid(),
+            "GLOBAL_LOCK": str(tmp_path / "global.lock"),
+            "MAINTENANCE_MARKER": str(tmp_path / "maintenance"),
+            "PROJECT_COMPOSE": {str(project): str(compose)},
+            "validate_parent": lambda _path: None,
+        }
+    )
+    namespace["run_checked"] = fake_run_checked
+    return namespace, project, calls
+
+
+def test_remote_preflight_proves_off_drained_and_latches_both_fences(tmp_path):
+    namespace, project, calls = _remote_namespace(tmp_path)
+
+    namespace["execute"](TXID, str(project), "docker-compose.patroni.yml")
+
+    receipt = project / ".ha-communications-cutover-preflight"
+    release_fence = project / ".ha-communications-worker-release-fenced"
+    maintenance = tmp_path / "maintenance"
+    assert receipt.read_text(encoding="ascii") == (
+        f"communications-off-drained-v1\n{TXID}\n"
+    )
+    assert release_fence.read_text(encoding="ascii") == "fenced\n"
+    assert maintenance.read_text(encoding="ascii") == f"{TXID}\n"
+    for path in (receipt, release_fence, maintenance):
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert any("exec" in command for command in calls)
+    assert any("stop" in command for command in calls)
+    assert any("ps" in command for command in calls)
+    assert sum("exec" in command for command in calls) == 2
+    assert sum("ps" in command for command in calls) == 2
+
+
+def test_remote_preflight_same_transaction_reproves_and_other_tx_is_fenced(
+    tmp_path,
+):
+    namespace, project, calls = _remote_namespace(tmp_path)
+    namespace["execute"](TXID, str(project), "docker-compose.patroni.yml")
+
+    calls.clear()
+    namespace["execute"](TXID, str(project), "docker-compose.patroni.yml")
+    assert any("exec" in command for command in calls)
+    assert (tmp_path / "maintenance").read_text(encoding="ascii") == f"{TXID}\n"
+
+    calls.clear()
+    with pytest.raises(
+        RuntimeError,
+        match="another PITR release owns the maintenance marker",
+    ):
+        namespace["execute"](
+            "1" * 32,
+            str(project),
+            "docker-compose.patroni.yml",
+        )
+    assert not calls
+    assert (tmp_path / "maintenance").read_text(encoding="ascii") == f"{TXID}\n"
+
+
+def test_remote_preflight_rejects_concurrent_enable_after_first_proof(tmp_path):
+    namespace, project, calls = _remote_namespace(
+        tmp_path,
+        proof_overrides=[
+            {},
+            {
+                "drained": False,
+                "runtime_mode": "all",
+                "runtime_status": "running",
+                "running_delivery_count": 1,
+                "control_revision": 2,
+            },
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="did not prove off and drained"):
+        namespace["execute"](TXID, str(project), "docker-compose.patroni.yml")
+
+    assert sum("exec" in command for command in calls) == 2
+    assert sum("ps" in command for command in calls) == 1
+    assert (project / ".ha-communications-worker-release-fenced").read_text(
+        encoding="ascii"
+    ) == "fenced\n"
+    assert not (project / ".ha-communications-cutover-preflight").exists()
+    assert not (tmp_path / "maintenance").exists()
+
+
+@pytest.mark.parametrize(
+    ("gates", "drained", "message"),
+    [
+        (("TRUE", "false"), True, "profile is not reviewed"),
+        (("false", "FALSE"), True, "profile is not reviewed"),
+        (("false", "false"), False, "did not prove off and drained"),
+    ],
+)
+def test_remote_preflight_rejects_uppercase_or_incomplete_drain_without_markers(
+    tmp_path, gates, drained, message
+):
+    namespace, project, _calls = _remote_namespace(
+        tmp_path,
+        gates=gates,
+        drained=drained,
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        namespace["execute"](TXID, str(project), "docker-compose.patroni.yml")
+
+    assert not (project / ".ha-communications-cutover-preflight").exists()
+    assert not (project / ".ha-communications-worker-release-fenced").exists()
+    assert not (tmp_path / "maintenance").exists()
+
+
+def test_local_wrapper_accepts_only_exact_privacy_safe_receipt(tmp_path):
+    node = PatroniNode(
+        alias="test",
+        physical_host="example.invalid",
+        user="root",
+        project_dir="/opt/air-api",
+        compose_file="docker-compose.patroni.yml",
+        compose_source=tmp_path / "compose.yml",
+        host_key_source=tmp_path / "host-key.pub",
+    )
+    context = PinnedSshContext(
+        identity_file=tmp_path / "id",
+        known_hosts_file=tmp_path / "known-hosts",
+        config_file=tmp_path / "config",
+    )
+    calls = []
+
+    def runner(args, stdin):
+        calls.append((args, stdin))
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            "communications_cutover_preflight=verified\n",
+            "",
+        )
+
+    cutover.run_remote_communications_cutover_preflight(
+        node=node,
+        context=context,
+        transaction_id=TXID,
+        runner=runner,
+    )
+    assert len(calls) == 1
+    assert calls[0][1] is None
+
+
+def test_local_wrapper_redacts_remote_failure_detail(tmp_path):
+    node = PatroniNode(
+        alias="test",
+        physical_host="example.invalid",
+        user="root",
+        project_dir="/opt/air-api",
+        compose_file="docker-compose.patroni.yml",
+        compose_source=tmp_path / "compose.yml",
+        host_key_source=tmp_path / "host-key.pub",
+    )
+    context = PinnedSshContext(
+        identity_file=tmp_path / "id",
+        known_hosts_file=tmp_path / "known-hosts",
+        config_file=tmp_path / "config",
+    )
+    secret = "telegram-token-and-customer-data"
+
+    def runner(args, stdin):
+        return subprocess.CompletedProcess(args, 1, "", secret)
+
+    with pytest.raises(RuntimeError) as error:
+        cutover.run_remote_communications_cutover_preflight(
+            node=node,
+            context=context,
+            transaction_id=TXID,
+            runner=runner,
+        )
+    assert secret not in str(error.value)

--- a/tests/unit/test_pitr_communications_receipt_handoff.py
+++ b/tests/unit/test_pitr_communications_receipt_handoff.py
@@ -1,0 +1,179 @@
+import stat
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_pitr_bundle_transport import (
+    TXID,
+    _payload,
+    _remote_namespace,
+    _write,
+)
+
+
+def _seed_preflight_receipt(namespace, project):
+    marker = Path(namespace["MAINTENANCE_MARKER"])
+    _write(marker, (TXID + "\n").encode("ascii"), 0o600)
+    receipt = project / ".ha-communications-cutover-preflight"
+    _write(
+        receipt,
+        f"communications-off-drained-v1\n{TXID}\n".encode("ascii"),
+        0o600,
+    )
+    fence = project / ".ha-communications-worker-release-fenced"
+    _write(fence, b"fenced\n", 0o600)
+    return marker, receipt, fence
+
+
+def test_preflight_receipt_hands_off_to_apply_and_finalize(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    marker, receipt, fence = _seed_preflight_receipt(namespace, project)
+
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "preflight-fenced"
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert receipt.exists()
+    assert namespace["execute"](
+        "finalize", TXID, str(project), compose.name, b""
+    ) == "finalized"
+
+    assert not marker.exists()
+    assert not receipt.exists()
+    assert fence.read_bytes() == b"fenced\n"
+    assert stat.S_IMODE(fence.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("damage", ["missing-fence", "unsafe-receipt"])
+def test_preflight_receipt_handoff_rejects_incomplete_or_unsafe_proof(
+    tmp_path, damage
+):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    marker, receipt, fence = _seed_preflight_receipt(namespace, project)
+    if damage == "missing-fence":
+        fence.unlink()
+    else:
+        receipt.chmod(0o644)
+
+    with pytest.raises(RuntimeError):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, payload
+        )
+
+    assert marker.read_text(encoding="ascii") == TXID + "\n"
+    assert receipt.exists()
+
+
+def test_preflight_receipt_is_removed_on_owned_bundle_rollback(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    marker, receipt, fence = _seed_preflight_receipt(namespace, project)
+
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "rolled-back"
+
+    assert not marker.exists()
+    assert not receipt.exists()
+    assert fence.read_bytes() == b"fenced\n"
+
+
+def test_finalize_crash_after_marker_unlink_replays_receipt_cleanup(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    marker, receipt, fence = _seed_preflight_receipt(namespace, project)
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+
+    fsync_paths = []
+    real_fsync = namespace["fsync_dir"]
+    real_remove_receipt = namespace["remove_communications_cutover_receipt"]
+
+    def recording_fsync(path):
+        fsync_paths.append(path)
+        real_fsync(path)
+
+    def crash_after_marker(project_dir, txid):
+        assert project_dir == str(project)
+        assert txid == TXID
+        assert not marker.exists()
+        assert receipt.exists()
+        raise RuntimeError("injected crash after marker unlink")
+
+    namespace["fsync_dir"] = recording_fsync
+    namespace["remove_communications_cutover_receipt"] = crash_after_marker
+    with pytest.raises(RuntimeError, match="injected crash"):
+        namespace["execute"](
+            "finalize", TXID, str(project), compose.name, b""
+        )
+
+    assert not marker.exists()
+    assert receipt.exists()
+    assert str(marker.parent) in fsync_paths
+    namespace["remove_communications_cutover_receipt"] = real_remove_receipt
+    assert namespace["execute"](
+        "finalize", TXID, str(project), compose.name, b""
+    ) == "already-finalized"
+    assert not receipt.exists()
+    assert str(project) in fsync_paths
+    assert fence.read_bytes() == b"fenced\n"
+
+
+def test_rollback_crash_after_marker_unlink_replays_receipt_cleanup(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    marker, receipt, fence = _seed_preflight_receipt(namespace, project)
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+
+    fsync_paths = []
+    real_fsync = namespace["fsync_dir"]
+    real_remove_receipt = namespace["remove_communications_cutover_receipt"]
+
+    def recording_fsync(path):
+        fsync_paths.append(path)
+        real_fsync(path)
+
+    def crash_after_marker(project_dir, txid):
+        assert project_dir == str(project)
+        assert txid == TXID
+        assert not marker.exists()
+        assert receipt.exists()
+        raise RuntimeError("injected crash after marker unlink")
+
+    namespace["fsync_dir"] = recording_fsync
+    namespace["remove_communications_cutover_receipt"] = crash_after_marker
+    with pytest.raises(RuntimeError, match="injected crash"):
+        namespace["execute"](
+            "rollback", TXID, str(project), compose.name, b""
+        )
+
+    assert not marker.exists()
+    assert receipt.exists()
+    assert str(marker.parent) in fsync_paths
+    namespace["remove_communications_cutover_receipt"] = real_remove_receipt
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "already-rolled-back"
+    assert not receipt.exists()
+    assert str(project) in fsync_paths
+    assert fence.read_bytes() == b"fenced\n"

--- a/tests/unit/test_pitr_rollback_recovery.py
+++ b/tests/unit/test_pitr_rollback_recovery.py
@@ -1,0 +1,670 @@
+import json
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ha import pitr_remote_execution
+from scripts.ha.pitr_cluster_migration import migrate_cluster
+from scripts.ha.pitr_pinned_ssh import PATRONI_NODES
+from tests.unit.test_pitr_bundle_transport import (
+    TXID,
+    _context,
+    _payload,
+    _remote_namespace,
+    _write,
+)
+from tests.unit.test_pitr_cluster_migration import (
+    ENV_TEXT,
+    FakeOperations,
+    _unused_runner,
+)
+
+
+NEW_TXID = "2" * 32
+
+
+def _seed_preflight(namespace, project, *, marker=True, txid=TXID):
+    marker_path = Path(namespace["MAINTENANCE_MARKER"])
+    if marker:
+        _write(marker_path, (txid + "\n").encode("ascii"), 0o600)
+    receipt = project / ".ha-communications-cutover-preflight"
+    _write(
+        receipt,
+        f"communications-off-drained-v1\n{txid}\n".encode("ascii"),
+        0o600,
+    )
+    fence = project / ".ha-communications-worker-release-fenced"
+    _write(fence, b"fenced\n", 0o600)
+    return marker_path, receipt, fence
+
+
+def _release_store(tmp_path):
+    tmp_path.mkdir()
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"old-compose", 0o644)
+    _write(tool, b"old-tool", 0o755)
+    payload, value = _payload(namespace, project, compose, tool)
+    return namespace, project, compose, tool, payload, value
+
+
+def _snapshot_files(*paths):
+    snapshots = {}
+    for path in paths:
+        path = Path(path)
+        try:
+            metadata = path.stat()
+        except FileNotFoundError:
+            snapshots[str(path)] = None
+        else:
+            snapshots[str(path)] = (
+                metadata.st_ino,
+                metadata.st_mode,
+                metadata.st_mtime_ns,
+                path.read_bytes(),
+            )
+    return snapshots
+
+
+def _release_state_paths(namespace, project, compose, tool, txid):
+    return (
+        compose,
+        tool,
+        Path(namespace["RELEASE_MANIFEST"]),
+        Path(namespace["MAINTENANCE_MARKER"]),
+        project / ".ha-communications-cutover-preflight",
+        project / ".ha-communications-worker-release-fenced",
+        Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{txid}.json",
+        Path(namespace["TRANSACTION_ROOT"]) / txid / "journal.json",
+    )
+
+
+def _seed_conflicting_preflight(namespace, project, *, kind, txid):
+    owner = TXID if kind == "foreign" else txid
+    _marker, receipt, fence = _seed_preflight(
+        namespace, project, marker=False, txid=owner
+    )
+    if kind == "missing-fence":
+        fence.unlink()
+    elif kind == "invalid-fence":
+        _write(fence, b"not-fenced\n", 0o600)
+    return receipt, fence
+
+
+def test_matching_rolled_back_requires_exact_release_contract_and_old_generations(
+    tmp_path,
+):
+    namespace, project, compose, tool, payload, _ = _release_store(tmp_path / "node")
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "rolled-back"
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "matching-rolled-back"
+
+    changed, _ = _payload(
+        namespace,
+        project,
+        compose,
+        tool,
+        compose_content=b"another-release",
+    )
+    with pytest.raises(RuntimeError, match="belongs to another release"):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, changed
+        )
+
+    _write(compose, b"tampered-old-generation", 0o644)
+    with pytest.raises(RuntimeError, match="does not match"):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, payload
+        )
+    _write(compose, b"old-compose", 0o644)
+
+    receipt_path = Path(namespace["ROLLBACK_RECEIPT_ROOT"]) / f"{TXID}.json"
+    receipt = json.loads(receipt_path.read_text())
+    receipt["old_generations"][0]["mode"] = 0o600
+    _write(receipt_path, namespace["canonical"](receipt) + b"\n", 0o600)
+    with pytest.raises(RuntimeError, match="generation is invalid"):
+        namespace["execute"](
+            "inspect", TXID, str(project), compose.name, payload
+        )
+
+
+def test_same_node_finalized_and_rolled_back_state_is_rejected(tmp_path):
+    namespace, project, compose, tool = _remote_namespace(tmp_path)
+    _write(compose, b"new-compose", 0o644)
+    _write(tool, b"new-tool", 0o755)
+    payload, _ = _payload(namespace, project, compose, tool)
+    assert namespace["execute"](
+        "apply", TXID, str(project), compose.name, payload
+    ) == "applied"
+    txdir = Path(namespace["TRANSACTION_ROOT"]) / TXID
+    journal = json.loads((txdir / "journal.json").read_text())
+    manifest = namespace["release_manifest"](journal)
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "rolled-back"
+    _write(
+        Path(namespace["RELEASE_MANIFEST"]),
+        namespace["canonical"](manifest) + b"\n",
+        0o600,
+    )
+
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, TXID
+    )
+    before = _snapshot_files(*state_paths)
+    cases = [
+        ("inspect", payload, "both finalized and rolled back"),
+        ("apply", payload, "already has a rollback receipt"),
+        ("finalize", b"", "already has a rollback receipt"),
+        ("rollback", b"", "cannot roll back a finalized"),
+    ]
+    for action, action_payload, error in cases:
+        with pytest.raises(RuntimeError, match=error):
+            namespace["execute"](
+                action, TXID, str(project), compose.name, action_payload
+            )
+        assert _snapshot_files(*state_paths) == before
+
+
+@pytest.mark.parametrize("receipt_only", [False, True])
+def test_preflight_only_state_is_inspectable_and_has_distinct_rollback_result(
+    tmp_path, receipt_only
+):
+    namespace, project, compose, tool, payload, _ = _release_store(tmp_path / "node")
+    marker, receipt, fence = _seed_preflight(namespace, project)
+    if receipt_only:
+        marker.unlink()
+
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "preflight-fenced"
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "preflight-rolled-back"
+
+    assert not marker.exists()
+    assert not receipt.exists()
+    assert fence.read_bytes() == b"fenced\n"
+    assert stat.S_IMODE(fence.stat().st_mode) == 0o600
+
+
+def test_preflight_cleanup_crash_replays_marker_first_with_both_directory_fsyncs(
+    tmp_path,
+):
+    namespace, project, compose, _tool, payload, _ = _release_store(tmp_path / "node")
+    marker, receipt, fence = _seed_preflight(namespace, project)
+    fsync_paths = []
+    real_fsync = namespace["fsync_dir"]
+    real_remove_receipt = namespace["remove_communications_cutover_receipt"]
+
+    def recording_fsync(path):
+        fsync_paths.append(path)
+        real_fsync(path)
+
+    def crash_after_marker(project_dir, txid):
+        assert project_dir == str(project)
+        assert txid == TXID
+        assert not marker.exists()
+        assert receipt.exists()
+        raise RuntimeError("injected preflight cleanup crash")
+
+    namespace["fsync_dir"] = recording_fsync
+    namespace["remove_communications_cutover_receipt"] = crash_after_marker
+    with pytest.raises(RuntimeError, match="injected preflight cleanup crash"):
+        namespace["execute"](
+            "rollback", TXID, str(project), compose.name, b""
+        )
+
+    assert not marker.exists()
+    assert receipt.exists()
+    assert namespace["execute"](
+        "inspect", TXID, str(project), compose.name, payload
+    ) == "preflight-fenced"
+    namespace["remove_communications_cutover_receipt"] = real_remove_receipt
+    assert namespace["execute"](
+        "rollback", TXID, str(project), compose.name, b""
+    ) == "preflight-rolled-back"
+
+    assert fsync_paths[-2:] == [str(marker.parent), str(project)]
+    assert not receipt.exists()
+    assert fence.read_bytes() == b"fenced\n"
+
+
+class _ExecutorOperations(FakeOperations):
+    def __init__(self, stores):
+        super().__init__()
+        self.stores = stores
+
+    def bundles(self, nodes):
+        return {
+            node.project_dir: self.stores[node.alias]["payload"]
+            for node in nodes
+        }
+
+    def release(self, *, node, context, action, txid, release_bundle, runner):
+        self.events.append(("release", action, node.alias, txid))
+        store = self.stores[node.alias]
+        return store["namespace"]["execute"](
+            action,
+            txid,
+            str(store["project"]),
+            store["compose"].name,
+            release_bundle if action in {"inspect", "apply"} else b"",
+        )
+
+
+def test_controller_e2e_cleans_receipt_only_peer_and_requires_new_txid(tmp_path):
+    by_alias = {node.alias: node for node in PATRONI_NODES}
+    stores = {}
+    for alias in by_alias:
+        namespace, project, compose, tool, payload, _ = _release_store(
+            tmp_path / alias
+        )
+        stores[alias] = {
+            "namespace": namespace,
+            "project": project,
+            "compose": compose,
+            "tool": tool,
+            "payload": payload,
+        }
+
+    standby = stores["zakup"]
+    assert standby["namespace"]["execute"](
+        "apply",
+        TXID,
+        str(standby["project"]),
+        standby["compose"].name,
+        standby["payload"],
+    ) == "applied"
+    assert standby["namespace"]["execute"](
+        "rollback",
+        TXID,
+        str(standby["project"]),
+        standby["compose"].name,
+        b"",
+    ) == "rolled-back"
+    primary = stores["mvn-api"]
+    marker, receipt, fence = _seed_preflight(
+        primary["namespace"], primary["project"]
+    )
+    marker.unlink()
+
+    operations = _ExecutorOperations(stores)
+    with pytest.raises(RuntimeError, match="new transaction ID"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert [event[1:3] for event in operations.events if event[0] == "release"] == [
+        ("inspect", "zakup"),
+        ("inspect", "mvn-api"),
+        ("rollback", "mvn-api"),
+        ("rollback", "zakup"),
+    ]
+    assert not receipt.exists()
+    assert fence.read_bytes() == b"fenced\n"
+    for store in stores.values():
+        assert store["namespace"]["execute"](
+            "inspect",
+            NEW_TXID,
+            str(store["project"]),
+            store["compose"].name,
+            store["payload"],
+        ) == "fresh"
+
+
+def test_role_flipped_foreign_receipt_blocks_new_tx_before_any_apply_or_finalize(
+    tmp_path,
+):
+    stores = {}
+    for node in PATRONI_NODES:
+        namespace, project, compose, tool, payload, _ = _release_store(
+            tmp_path / node.alias
+        )
+        stores[node.alias] = {
+            "namespace": namespace,
+            "project": project,
+            "compose": compose,
+            "tool": tool,
+            "payload": payload,
+        }
+    former_primary = stores["zakup"]
+    marker, receipt, fence = _seed_preflight(
+        former_primary["namespace"],
+        former_primary["project"],
+        marker=False,
+    )
+    assert not marker.exists()
+    assert receipt.exists()
+    assert fence.exists()
+
+    operations = _ExecutorOperations(stores)
+    with pytest.raises(RuntimeError, match="belongs to another transaction"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=NEW_TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    release_events = [
+        event for event in operations.events if event[0] == "release"
+    ]
+    assert release_events == [
+        ("release", "inspect", "zakup", NEW_TXID),
+    ]
+    assert not any(
+        event[1] in {"apply", "finalize"} for event in release_events
+    )
+    assert not any(
+        event[0] == "communications-cutover" for event in operations.events
+    )
+    for store in stores.values():
+        assert not (
+            Path(store["namespace"]["TRANSACTION_ROOT"]) / NEW_TXID
+        ).exists()
+
+
+@pytest.mark.parametrize(
+    ("artifact_kind", "error"),
+    [
+        ("foreign", "belongs to another transaction"),
+        ("missing-fence", "missing its release fence"),
+        ("invalid-fence", "release fence is invalid"),
+    ],
+)
+def test_apply_barrier_rejects_conflict_without_state_mutation(
+    tmp_path, artifact_kind, error
+):
+    namespace, project, compose, tool, payload, _ = _release_store(
+        tmp_path / "node"
+    )
+    _seed_conflicting_preflight(
+        namespace,
+        project,
+        kind=artifact_kind,
+        txid=NEW_TXID,
+    )
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, NEW_TXID
+    )
+    before = _snapshot_files(*state_paths)
+
+    with pytest.raises(RuntimeError, match=error):
+        namespace["execute"](
+            "apply", NEW_TXID, str(project), compose.name, payload
+        )
+
+    assert _snapshot_files(*state_paths) == before
+    assert not Path(namespace["STATE_ROOT"]).exists()
+
+
+@pytest.mark.parametrize(
+    "marker_owner",
+    [
+        NEW_TXID,
+        TXID,
+    ],
+)
+def test_marker_only_state_cannot_bypass_inspect_or_mutation_barrier(
+    tmp_path, marker_owner
+):
+    namespace, project, compose, tool, payload, _ = _release_store(
+        tmp_path / "node"
+    )
+    marker = Path(namespace["MAINTENANCE_MARKER"])
+    _write(marker, (marker_owner + "\n").encode("ascii"), 0o600)
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, NEW_TXID
+    )
+    before = _snapshot_files(*state_paths)
+
+    actions = [("inspect", payload), ("apply", payload)]
+    if marker_owner != NEW_TXID:
+        actions.extend([("rollback", b""), ("finalize", b"")])
+    for action, action_payload in actions:
+        with pytest.raises(
+            RuntimeError,
+            match="maintenance marker|another release transaction owns",
+        ):
+            namespace["execute"](
+                action,
+                NEW_TXID,
+                str(project),
+                compose.name,
+                action_payload,
+            )
+        assert _snapshot_files(*state_paths) == before
+        assert not Path(namespace["STATE_ROOT"]).exists()
+
+
+def test_active_state_missing_marker_is_rejected_before_every_action_mutation(
+    tmp_path,
+):
+    namespace, project, compose, tool, payload, _ = _release_store(
+        tmp_path / "node"
+    )
+    assert namespace["execute"](
+        "apply", NEW_TXID, str(project), compose.name, payload
+    ) == "applied"
+    marker = Path(namespace["MAINTENANCE_MARKER"])
+    marker.unlink()
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, NEW_TXID
+    )
+    before = _snapshot_files(*state_paths)
+
+    for action, action_payload in [
+        ("inspect", payload),
+        ("apply", payload),
+        ("rollback", b""),
+        ("finalize", b""),
+    ]:
+        with pytest.raises(RuntimeError, match="missing its exact marker"):
+            namespace["execute"](
+                action,
+                NEW_TXID,
+                str(project),
+                compose.name,
+                action_payload,
+            )
+        assert _snapshot_files(*state_paths) == before
+
+
+@pytest.mark.parametrize("release_state", ["active", "rolled-back"])
+def test_foreign_receipt_is_not_masked_by_active_or_rolled_back_state(
+    tmp_path, release_state
+):
+    namespace, project, compose, tool, payload, _ = _release_store(
+        tmp_path / "node"
+    )
+    assert namespace["execute"](
+        "apply", NEW_TXID, str(project), compose.name, payload
+    ) == "applied"
+    if release_state == "rolled-back":
+        assert namespace["execute"](
+            "rollback", NEW_TXID, str(project), compose.name, b""
+        ) == "rolled-back"
+    _seed_conflicting_preflight(
+        namespace, project, kind="foreign", txid=NEW_TXID
+    )
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, NEW_TXID
+    )
+    before = _snapshot_files(*state_paths)
+
+    for action, action_payload in [
+        ("inspect", payload),
+        ("apply", payload),
+        ("rollback", b""),
+    ]:
+        with pytest.raises(RuntimeError, match="belongs to another transaction"):
+            namespace["execute"](
+                action,
+                NEW_TXID,
+                str(project),
+                compose.name,
+                action_payload,
+            )
+        assert _snapshot_files(*state_paths) == before
+
+
+@pytest.mark.parametrize(
+    ("artifact_kind", "error"),
+    [
+        ("foreign", "belongs to another transaction"),
+        ("missing-fence", "missing its release fence"),
+        ("invalid-fence", "release fence is invalid"),
+    ],
+)
+def test_finalized_state_cannot_mask_conflict_or_mutate_manifest_on_replay(
+    tmp_path, artifact_kind, error
+):
+    namespace, project, compose, tool, payload, _ = _release_store(
+        tmp_path / "node"
+    )
+    assert namespace["execute"](
+        "apply", NEW_TXID, str(project), compose.name, payload
+    ) == "applied"
+    assert namespace["execute"](
+        "finalize", NEW_TXID, str(project), compose.name, b""
+    ) == "finalized"
+    _seed_conflicting_preflight(
+        namespace,
+        project,
+        kind=artifact_kind,
+        txid=NEW_TXID,
+    )
+    state_paths = _release_state_paths(
+        namespace, project, compose, tool, NEW_TXID
+    )
+    before = _snapshot_files(*state_paths)
+
+    for action, action_payload in [("inspect", payload), ("finalize", b"")]:
+        with pytest.raises(RuntimeError, match=error):
+            namespace["execute"](
+                action,
+                NEW_TXID,
+                str(project),
+                compose.name,
+                action_payload,
+            )
+        assert _snapshot_files(*state_paths) == before
+
+
+def test_controller_rolls_back_active_peer_and_skips_fresh_peer(tmp_path):
+    for peer_state, expected_cleanup in [
+        ("matching-active", ["mvn-api", "zakup"]),
+        ("fresh", ["zakup"]),
+    ]:
+        operations = FakeOperations()
+        operations.release_results[("inspect", "zakup")] = "matching-rolled-back"
+        operations.release_results[("inspect", "mvn-api")] = peer_state
+
+        with pytest.raises(RuntimeError, match="new transaction ID"):
+            migrate_cluster(
+                context=_context(tmp_path),
+                env_text=ENV_TEXT,
+                transaction_id=TXID,
+                runner=_unused_runner,
+                dependencies=operations.dependencies(),
+            )
+
+        assert [
+            event[2]
+            for event in operations.events
+            if event[:2] == ("release", "rollback")
+        ] == expected_cleanup
+        assert not any(
+            event[0] == "communications-cutover" for event in operations.events
+        )
+
+
+def test_controller_rejects_rolled_back_and_finalized_mix_without_cleanup(tmp_path):
+    operations = FakeOperations()
+    operations.release_results[("inspect", "zakup")] = "matching-rolled-back"
+    operations.release_results[("inspect", "mvn-api")] = "matching-finalized"
+
+    with pytest.raises(RuntimeError, match="conflicts with a finalized peer"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert not any(
+        event[:2] == ("release", "rollback") for event in operations.events
+    )
+    assert not any(
+        event[0] == "communications-cutover" for event in operations.events
+    )
+
+
+def test_controller_replays_interrupted_cleanup_with_same_tx_then_stops(tmp_path):
+    operations = FakeOperations()
+    operations.release_results[("inspect", "zakup")] = "matching-rolled-back"
+    operations.release_results[("inspect", "mvn-api")] = "preflight-fenced"
+    operations.release_failure = ("rollback", "mvn-api")
+
+    with pytest.raises(RuntimeError, match="retry with the same transaction ID"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    operations.release_failure = None
+    with pytest.raises(RuntimeError, match="new transaction ID"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    rollbacks = [
+        event[2]
+        for event in operations.events
+        if event[:2] == ("release", "rollback")
+    ]
+    assert rollbacks == ["mvn-api", "mvn-api", "zakup"]
+
+
+@pytest.mark.parametrize(
+    ("action", "output", "expected"),
+    [
+        ("inspect", "matching-rolled-back\n", "matching-rolled-back"),
+        ("rollback", "preflight-rolled-back\n", "preflight-rolled-back"),
+    ],
+)
+def test_remote_transport_accepts_recovery_state_outputs(
+    tmp_path, action, output, expected
+):
+    def runner(args, stdin):
+        return subprocess.CompletedProcess(args, 0, stdout=output, stderr="")
+
+    assert pitr_remote_execution.run_remote_release_action(
+        node=PATRONI_NODES[0],
+        context=_context(tmp_path),
+        action=action,
+        txid=TXID,
+        release_bundle="{}" if action == "inspect" else None,
+        runner=runner,
+    ) == expected

--- a/tests/unit/test_pitr_target_compose.py
+++ b/tests/unit/test_pitr_target_compose.py
@@ -1,0 +1,177 @@
+import base64
+import hashlib
+import json
+
+import pytest
+
+from scripts.ha.pitr_cluster_migration import migrate_cluster
+from scripts.ha.pitr_pinned_ssh import PATRONI_NODES
+from scripts.ha.pitr_remote_execution import prepare_host_release_bundles
+from scripts.ha.pitr_target_compose import validate_target_compose_bundles
+from tests.unit.test_pitr_cluster_migration import (
+    ENV_TEXT,
+    TXID,
+    FakeOperations,
+    _context,
+    _unused_runner,
+)
+
+
+def _compose(
+    *,
+    enabled='"false"',
+    allow_all='"false"',
+    missing_service=None,
+    worker_image="'${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}'",
+):
+    image = "'${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}'"
+    services = {
+        "app": f"  app:\n    image: {image}\n",
+        "app-blue": f"  app-blue:\n    image: {image}\n",
+        "app-green": f"  app-green:\n    image: {image}\n",
+        "communications-worker": (
+            "  communications-worker:\n"
+            f"    image: {worker_image}\n"
+            "    depends_on:\n"
+            "      db:\n"
+            "        condition: service_healthy\n"
+            "    env_file:\n"
+            "      - .env\n"
+            "      - .ha-app-role.env\n"
+            "    environment:\n"
+            f"      COMMUNICATIONS_WORKER_ENABLED: {enabled}\n"
+            f"      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: {allow_all}\n"
+            "    command: python -m services.communications.runtime\n"
+        ),
+    }
+    return (
+        "services:\n"
+        + "  db: {}\n"
+        + "".join(
+            value for name, value in services.items() if name != missing_service
+        )
+    ).encode("utf-8")
+
+
+def _bundle(node, compose):
+    compose_path = f"{node.project_dir}/{node.compose_file}"
+    descriptor = {
+        "content": base64.b64encode(compose).decode("ascii"),
+        "mode": 0o644,
+        "path": compose_path,
+        "sha256": hashlib.sha256(compose).hexdigest(),
+    }
+    body = {
+        "files": [descriptor],
+        "project_dir": node.project_dir,
+        "version": 1,
+    }
+    bundle = {
+        **body,
+        "release_sha256": hashlib.sha256(
+            json.dumps(body, sort_keys=True, separators=(",", ":")).encode("ascii")
+        ).hexdigest(),
+    }
+    return json.dumps(bundle, sort_keys=True, separators=(",", ":"))
+
+
+def _bundles(first, second):
+    return {
+        PATRONI_NODES[0].project_dir: _bundle(PATRONI_NODES[0], first),
+        PATRONI_NODES[1].project_dir: _bundle(PATRONI_NODES[1], second),
+    }
+
+
+@pytest.mark.parametrize(
+    ("enabled", "allow_all", "profile"),
+    [
+        ('"false"', '"false"', "dormant"),
+        ('"true"', '"false"', "canary"),
+        ('"true"', '"true"', "active"),
+    ],
+)
+def test_target_compose_accepts_only_closed_profiles(
+    enabled,
+    allow_all,
+    profile,
+):
+    compose = _compose(enabled=enabled, allow_all=allow_all)
+    assert validate_target_compose_bundles(
+        PATRONI_NODES,
+        _bundles(compose, compose),
+    ) == profile
+
+
+@pytest.mark.parametrize(
+    ("enabled", "allow_all"),
+    [
+        ('"false"', '"true"'),
+        ('"TRUE"', '"false"'),
+        ('"false"', '"FALSE"'),
+        ("true", "false"),
+        ("false", "false"),
+    ],
+)
+def test_target_compose_rejects_invalid_uppercase_or_boolean_gates(
+    enabled,
+    allow_all,
+):
+    compose = _compose(enabled=enabled, allow_all=allow_all)
+    with pytest.raises(RuntimeError, match="profile is not reviewed"):
+        validate_target_compose_bundles(
+            PATRONI_NODES,
+            _bundles(compose, compose),
+        )
+
+
+@pytest.mark.parametrize(
+    "missing_service",
+    ["app", "app-blue", "app-green", "communications-worker"],
+)
+def test_target_compose_rejects_missing_reviewed_service(missing_service):
+    compose = _compose(missing_service=missing_service)
+    with pytest.raises(RuntimeError):
+        validate_target_compose_bundles(
+            PATRONI_NODES,
+            _bundles(compose, compose),
+        )
+
+
+def test_target_compose_rejects_api_worker_image_mismatch():
+    compose = _compose(worker_image="'different-image'")
+    with pytest.raises(RuntimeError, match="image mismatch"):
+        validate_target_compose_bundles(
+            PATRONI_NODES,
+            _bundles(compose, compose),
+        )
+
+
+def test_target_compose_rejects_cross_node_profile_mismatch():
+    dormant = _compose()
+    active = _compose(enabled='"true"', allow_all='"true"')
+    with pytest.raises(RuntimeError, match="differ across cluster nodes"):
+        validate_target_compose_bundles(
+            PATRONI_NODES,
+            _bundles(dormant, active),
+        )
+
+
+def test_tracked_production_compose_sources_share_reviewed_profile():
+    bundles = prepare_host_release_bundles(PATRONI_NODES)
+    assert validate_target_compose_bundles(PATRONI_NODES, bundles) == "dormant"
+
+
+def test_target_compose_rejection_precedes_every_remote_mutation(tmp_path):
+    operations = FakeOperations()
+    operations.target_compose_failure = True
+
+    with pytest.raises(RuntimeError, match="target Compose failure"):
+        migrate_cluster(
+            context=_context(tmp_path),
+            env_text=ENV_TEXT,
+            transaction_id=TXID,
+            runner=_unused_runner,
+            dependencies=operations.dependencies(),
+        )
+
+    assert operations.events == [("topology",)]

--- a/tests/unit/test_safe_deploy_lock.py
+++ b/tests/unit/test_safe_deploy_lock.py
@@ -111,6 +111,7 @@ def test_candidate_rejects_writable_lock_helper_before_execution(tmp_path):
             "API_PROJECT_DIR": str(project),
             "API_DEPLOY_LOCK_HELPER": str(helper),
             "API_DEPLOY_LOCK_HELPER_SHA256": hashlib.sha256(helper.read_bytes()).hexdigest(),
+            "PATRONI_VOICE_ENV_SYNC": str(HELPER),
         },
         text=True,
         capture_output=True,

--- a/tests/unit/test_storefront_cutover.py
+++ b/tests/unit/test_storefront_cutover.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 
@@ -6,7 +7,14 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_api_repository_keeps_storefront_as_an_external_service():
     """Prevent an accidental return to an embedded storefront publisher."""
-    assert not (ROOT / "web").exists()
+    tracked_web_files = subprocess.run(
+        ["git", "ls-files", "--", "web"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert tracked_web_files == []
     assert not (ROOT / "docker-compose.web.yml").exists()
     assert not (ROOT / ".github/workflows/deploy-web.yml").exists()
     assert not (ROOT / ".github/workflows/rebuild-web.yml").exists()

--- a/tests/unit/test_storefront_cutover.py
+++ b/tests/unit/test_storefront_cutover.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 
 
@@ -7,14 +6,22 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_api_repository_keeps_storefront_as_an_external_service():
     """Prevent an accidental return to an embedded storefront publisher."""
-    tracked_web_files = subprocess.run(
-        ["git", "ls-files", "--", "web"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.splitlines()
-    assert tracked_web_files == []
+    legacy_web = ROOT / "web"
+    allowed_runtime_roots = (
+        legacy_web / "node_modules",
+        legacy_web / "public" / "media",
+    )
+    embedded_storefront_files = (
+        []
+        if not legacy_web.exists()
+        else [
+            path.relative_to(ROOT)
+            for path in legacy_web.rglob("*")
+            if (path.is_file() or path.is_symlink())
+            and not any(path.is_relative_to(root) for root in allowed_runtime_roots)
+        ]
+    )
+    assert embedded_storefront_files == []
     assert not (ROOT / "docker-compose.web.yml").exists()
     assert not (ROOT / ".github/workflows/deploy-web.yml").exists()
     assert not (ROOT / ".github/workflows/rebuild-web.yml").exists()

--- a/tests/unit/test_telegram_delivery_provider.py
+++ b/tests/unit/test_telegram_delivery_provider.py
@@ -104,7 +104,7 @@ async def test_telegram_provider_preserves_retry_after():
         ),
         (
             TelegramUnauthorizedError,
-            ProviderDeliveryDisposition.PROVIDER_UNAVAILABLE,
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
             "telegram_provider_auth_or_conflict",
         ),
     ],
@@ -159,27 +159,27 @@ async def test_telegram_provider_classifies_recipient_and_provider_failures(
         ),
         (
             lambda method: TelegramConflictError(method=method, message="conflict"),
-            ProviderDeliveryDisposition.PROVIDER_UNAVAILABLE,
+            ProviderDeliveryDisposition.PERMANENT_FAILURE,
             "telegram_provider_auth_or_conflict",
         ),
         (
             lambda method: TelegramNetworkError(method=method, message="network"),
-            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            ProviderDeliveryDisposition.AMBIGUOUS_FAILURE,
             "telegram_network_error",
         ),
         (
             lambda method: TelegramServerError(method=method, message="server"),
-            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            ProviderDeliveryDisposition.AMBIGUOUS_FAILURE,
             "telegram_network_error",
         ),
         (
             lambda _method: TimeoutError("timeout"),
-            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            ProviderDeliveryDisposition.AMBIGUOUS_FAILURE,
             "telegram_network_error",
         ),
         (
             lambda method: TelegramAPIError(method=method, message="generic API"),
-            ProviderDeliveryDisposition.TRANSIENT_FAILURE,
+            ProviderDeliveryDisposition.AMBIGUOUS_FAILURE,
             "telegram_api_error",
         ),
     ],
@@ -251,6 +251,9 @@ async def test_telegram_provider_does_not_expose_unknown_exception_message(caplo
         delivery_id="6" * 32,
     )
 
-    assert result.disposition == ProviderDeliveryDisposition.TRANSIENT_FAILURE
-    assert result.error_message == "Telegram provider failed unexpectedly"
+    assert result.disposition == ProviderDeliveryDisposition.AMBIGUOUS_FAILURE
+    assert (
+        result.error_message
+        == "Telegram provider outcome requires manual reconciliation"
+    )
     assert "secret-token" not in caplog.text


### PR DESCRIPTION
## What changed

- makes the managed communications worker the single delivery owner for `crm.installation_estimate_lead.created`;
- restricts recipients to the exact active owner audience and introduces an immutable activation watermark for bounded backlog handling;
- adds provider-boundary, retry, lease-recovery, emergency-off and idempotency fences to prevent ambiguous Telegram retries and duplicate delivery;
- adds the typed `--plan/--enable/--status/--off` operator and privacy-safe runbooks;
- installs strict dormant/canary/active Patroni release contracts plus attested atomic PITR cutover and rollback recovery;
- keeps both production Compose profiles dormant in this PR (`false/false`); live canary and activation remain separate reviewed changes after deployment;
- makes two local tests independent of ambient Cloudflare variables and empty Codex workspace mounts.

## Why

Issue #848 confirmed that installation-estimate events were written to the outbox but had no active production consumer. The fix must provide one owner, observable ACK/retry behavior and safe failover without enabling a second direct-send path.

The HA hardening also closes crash/replay and role-flip windows where foreign or incomplete receipt/fence/marker state could otherwise be mistaken for a clean release transaction. All mutating phases now fail closed under the global and deploy locks before file mutation.

## Validation

- full repository: `2781 passed, 4 skipped, 0 failed`;
- expanded HA/PITR/Patroni: `1026 passed, 4 skipped, 0 failed`;
- final adversarial rollback/recovery review: SHIP, including 104-state receipt/fence/marker matrix and zero-mutation snapshots;
- communications unit/integration suites, PostgreSQL concurrency coverage, Vue typecheck and production build: passed;
- Python compile, embedded executor AST, shell syntax/shellcheck and `git diff --check`: passed;
- no production delivery gate or Compose profile is enabled by this PR.

Refs #848. Do not close until the compatibility deploy, production canary, Telegram ACK, idempotent replay, restart/failover proof and bounded backlog decision are complete.