### PR TITLE
test(ha): make communications profile checks phase-aware

### DIFF
--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -295,10 +295,10 @@ content causes a full standby fence.
 Both Patroni API nodes define `communications-worker` from the exact immutable
 `BACKEND_IMAGE` used by the API. It uses that node's local PostgreSQL service
 and the same role-resolved `.ha-app-role.env`; deploy and verification reject
-any image, API/worker parity, or `APP_ROLE` mismatch. The production Compose
-files remain in the Phase 2A `dormant` profile, with both
-`COMMUNICATIONS_WORKER_ENABLED` and
-`COMMUNICATIONS_WORKER_ALLOW_ALL_MODE` exactly `false`.
+any image, API/worker parity, or `APP_ROLE` mismatch. The compatibility release
+starts with the production Compose files in the `dormant` profile. Later
+profile changes must follow the reviewed atomic cutover sequence below;
+ordinary deploys cannot change either gate.
 
 Release tooling recognizes only this closed profile set:
 

--- a/tests/unit/test_patroni_communications_compose.py
+++ b/tests/unit/test_patroni_communications_compose.py
@@ -9,6 +9,11 @@ PRIMARY_COMPOSE = REPO_ROOT / "deploy/ha/mvn-api/docker-compose.patroni.yml"
 RESERVE_COMPOSE = REPO_ROOT / "deploy/ha/zakup/docker-compose.patroni.yml"
 IMMUTABLE_BACKEND_IMAGE = "${BACKEND_IMAGE:?set immutable BACKEND_IMAGE in .env}"
 WORKER_COMMAND = "python -m services.communications.runtime"
+REVIEWED_WORKER_PROFILES = {
+    ("false", "false"): "dormant",
+    ("true", "false"): "canary",
+    ("true", "true"): "active",
+}
 
 
 @pytest.mark.parametrize(
@@ -34,7 +39,7 @@ WORKER_COMMAND = "python -m services.communications.runtime"
         ),
     ],
 )
-def test_patroni_communications_worker_is_dormant_and_role_driven(
+def test_patroni_communications_worker_uses_reviewed_profile_and_role_driven(
     compose_path: Path,
     expected_env_file: list[str],
     expected_database_url: str,
@@ -49,11 +54,14 @@ def test_patroni_communications_worker_is_dormant_and_role_driven(
     assert worker["restart"] == "unless-stopped"
     assert worker["depends_on"] == {"db": {"condition": "service_healthy"}}
     assert worker["env_file"] == services["app"]["env_file"] == expected_env_file
+    enabled = worker["environment"]["COMMUNICATIONS_WORKER_ENABLED"]
+    allow_all = worker["environment"]["COMMUNICATIONS_WORKER_ALLOW_ALL_MODE"]
+    assert (enabled, allow_all) in REVIEWED_WORKER_PROFILES
     assert worker["environment"] == {
         "DATABASE_URL": expected_database_url,
         "ENVIRONMENT": "production",
-        "COMMUNICATIONS_WORKER_ENABLED": "false",
-        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": "false",
+        "COMMUNICATIONS_WORKER_ENABLED": enabled,
+        "COMMUNICATIONS_WORKER_ALLOW_ALL_MODE": allow_all,
     }
     assert (
         worker["environment"]["DATABASE_URL"]

--- a/tests/unit/test_pitr_target_compose.py
+++ b/tests/unit/test_pitr_target_compose.py
@@ -156,9 +156,13 @@ def test_target_compose_rejects_cross_node_profile_mismatch():
         )
 
 
-def test_tracked_production_compose_sources_share_reviewed_profile():
+def test_tracked_production_compose_sources_share_same_reviewed_profile():
     bundles = prepare_host_release_bundles(PATRONI_NODES)
-    assert validate_target_compose_bundles(PATRONI_NODES, bundles) == "dormant"
+    assert validate_target_compose_bundles(PATRONI_NODES, bundles) in {
+        "dormant",
+        "canary",
+        "active",
+    }
 
 
 def test_target_compose_rejection_precedes_every_remote_mutation(tmp_path):


### PR DESCRIPTION
## Summary
- keep production Compose validation restricted to the reviewed dormant/canary/active profiles
- remove the test-only hard dependency on the current dormant phase
- document that profile changes require the atomic PITR cutover path

## Safety
- no application or production Compose behavior changes
- cross-node mismatches, false/true, uppercase values, YAML booleans, extra worker environment keys, image drift, and public/host surfaces remain rejected

## Validation
- 111 targeted HA/PITR tests passed
- simulated future canary true/false profile: 64 tests passed
- independent review: SHIP; 97 tests passed