### PR TITLE
Enable communications worker canary profile

### DIFF
--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -98,7 +98,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
       ENVIRONMENT: production
-      COMMUNICATIONS_WORKER_ENABLED: "false"
+      COMMUNICATIONS_WORKER_ENABLED: "true"
       COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
     command: python -m services.communications.runtime
     mem_limit: ${MVN_PATRONI_COMMUNICATIONS_WORKER_MEMORY:-256m}

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -105,7 +105,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
       ENVIRONMENT: production
-      COMMUNICATIONS_WORKER_ENABLED: "false"
+      COMMUNICATIONS_WORKER_ENABLED: "true"
       COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
     command: python -m services.communications.runtime
     mem_limit: ${MVN_RESERVE_COMMUNICATIONS_WORKER_MEMORY:-256m}

--- a/docs/api-ha-runbook.md
+++ b/docs/api-ha-runbook.md
@@ -393,10 +393,12 @@ python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
 # release containing this preflight before using this command for a profile
 # change.
 #
-# For a communications profile change, run this command from an otherwise
-# Compose-only, fully CI-green PR head while production deployment is frozen.
-# Immediately after success, merge that unchanged head and deploy it. Do not
-# mix not-yet-installed role-agent/PITR code into the profile PR.
+# For a communications profile change, run this command from a profile-only,
+# fully CI-green PR head while production deployment is frozen. That head
+# contains only both Patroni Compose gate changes and their exact derived
+# EXPECTED_COMPOSE_DIGESTS pins; verifier logic remains unchanged. Immediately
+# after success, merge that unchanged head and deploy it. Do not mix
+# not-yet-installed role-agent/PITR code into the profile PR.
 #
 # The transaction attests and installs the exact
 # helper bundle standby-first, validates the private destination from both
@@ -433,10 +435,11 @@ python3 scripts/ha/apply_postgres_pitr_primary_prerequisites.py \
 #
 # A failure after a finalized profile migration is not repaired with an app
 # rollback: ordinary deploys accept only byte-identical PITR-attested Compose.
-# Roll forward the same head, or prepare a CI-green Compose-only rollback head
-# and apply it with a new official atomic PITR transaction. Keep the deployment
-# freeze through immediate deploy, both-node verification, strict HA/PITR
-# checks, and a 30-minute alert window.
+# Roll forward the same head, or prepare a CI-green profile-only rollback head
+# with matching derived EXPECTED_COMPOSE_DIGESTS pins and apply it with a new
+# official atomic PITR transaction. Keep the deployment freeze through immediate
+# deploy, both-node verification, strict HA/PITR checks, and a 30-minute alert
+# window.
 
 # PostgreSQL archive parameters are Patroni DCS configuration for an existing
 # cluster. The migration requires the reviewed archive settings to be active on

--- a/docs/postgres-quorum-runbook.md
+++ b/docs/postgres-quorum-runbook.md
@@ -352,9 +352,12 @@ Do not edit either delivery gate manually.
    installation-notification operator, the pinned PITR communications
    preflight, and the profile-aware role agent on both nodes. Complete the
    usual strict readiness/PITR/replication checks first.
-2. Open a separate Compose-only PR for the next profile (`canary`, then later
-   `active`). It must contain no role-agent, PITR-controller, application, or
-   migration changes. Wait for every CI check to pass. Do not merge it yet.
+2. Open a separate profile-only PR for the next profile (`canary`, then later
+   `active`). It contains only both Patroni Compose gate changes and their exact
+   derived `EXPECTED_COMPOSE_DIGESTS` pins in
+   `verify_postgres_pitr_runtime.py`; the verifier logic must remain unchanged.
+   It must contain no role-agent, PITR-controller, application, or migration
+   logic changes. Wait for every CI check to pass. Do not merge it yet.
 3. Freeze production deployments and unrelated PITR operations. From that
    exact CI-green PR head, run the official atomic PITR cluster migration with
    one recorded transaction ID. Before its first remote mutation, the
@@ -387,9 +390,10 @@ stops and explicitly requires a new transaction ID. Retry the old ID only when
 that cleanup itself is interrupted. The communications fence remains latched
 until a reviewed deploy. After the roll-forward boundary, repair and roll
 forward with the same transaction. If a finalized profile must be reverted,
-prepare a separate CI-green Compose-only rollback head and run a new official
-PITR transaction from that head; an ordinary app rollback is rejected because
-it would replace the attested Compose.
+prepare a separate CI-green profile-only rollback head with matching derived
+`EXPECTED_COMPOSE_DIGESTS` pins and run a new official PITR transaction from
+that head; an ordinary app rollback is rejected because it would replace the
+attested Compose.
 
 ## Production Cutover
 

--- a/scripts/ha/verify_postgres_pitr_runtime.py
+++ b/scripts/ha/verify_postgres_pitr_runtime.py
@@ -27,10 +27,10 @@ PITR_ENV_POLICIES = (*PUBLIC_PITR_ENV_POLICIES, *MIGRATION_PITR_ENV_POLICIES)
 SECRETS_FILE = Path("/etc/mvn-postgres-pitr.secrets.env")
 EXPECTED_COMPOSE_DIGESTS = {
     "/opt/air-api/docker-compose.patroni.yml": (
-        "5a63addfd1b00a0bf30346b11625beedb19204563e6f02fa63c6af35667da477"
+        "5b8c2b532eac642d3bb9c4fd568f622efc84b68e6316c9eff5394cba59e4d0fd"
     ),
     "/opt/mvn-reserve/docker-compose.patroni.yml": (
-        "b0662d4736d78442fcf68073249643c58b1452c5c6059055ca7de3fc227d83a2"
+        "94f625870ce4373a26861afb153ef544a9cbd1aff9912002973854de6d0b1905"
     ),
 }
 EXPECTED_PITR_CLUSTERS = {


### PR DESCRIPTION
## What changed

- switch the managed communications worker on in both Patroni production Compose files while keeping `COMMUNICATIONS_WORKER_ALLOW_ALL_MODE=false`;
- update the two exact fail-closed Compose SHA-256 pins used by the PITR runtime verifier;
- clarify both HA runbooks that profile cutovers include only the gate bytes, their derived digest pins, and documentation—never new controller or application logic.

## Why

This is the bounded `canary` (`true/false`) phase for #848. The worker may run, but unrestricted website-event delivery remains blocked and database-owned runtime mode remains off until the typed canary operator is used.

The derived digest pins must change atomically with Compose. Leaving the old pins would cause the first PITR bootstrap preflight to fail after the release bundle had already entered its roll-forward path.

## Safety and rollout gate

**Do not merge this PR before the official atomic PITR cluster migration succeeds from this exact CI-green head.** Production deploys and unrelated PITR operations must remain frozen from migration start through merge, deploy, both-node verification, strict HA/PITR/replication checks, bounded canary replay, and the 30-minute observation window.

No verifier logic, worker logic, role-agent logic, migration logic, database schema, or application API changes are included.

## Validation

- full local suite: `2781 passed, 4 skipped`;
- focused HA/PITR/communications suite: `1054 passed, 4 skipped`;
- independent profile/hash and bundle/manifest/rollback reviews: SHIP;
- both generated production bundles validate as the exact closed `canary` profile;
- `git diff --check` clean.