### PR TITLE
Activate communications worker all-events profile

### DIFF
--- a/deploy/ha/mvn-api/docker-compose.patroni.yml
+++ b/deploy/ha/mvn-api/docker-compose.patroni.yml
@@ -99,7 +99,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}
       ENVIRONMENT: production
       COMMUNICATIONS_WORKER_ENABLED: "true"
-      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
+      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "true"
     command: python -m services.communications.runtime
     mem_limit: ${MVN_PATRONI_COMMUNICATIONS_WORKER_MEMORY:-256m}
 

--- a/deploy/ha/zakup/docker-compose.patroni.yml
+++ b/deploy/ha/zakup/docker-compose.patroni.yml
@@ -106,7 +106,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB:-air_conditioners}
       ENVIRONMENT: production
       COMMUNICATIONS_WORKER_ENABLED: "true"
-      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "false"
+      COMMUNICATIONS_WORKER_ALLOW_ALL_MODE: "true"
     command: python -m services.communications.runtime
     mem_limit: ${MVN_RESERVE_COMMUNICATIONS_WORKER_MEMORY:-256m}
     networks: [reserve]

--- a/scripts/ha/verify_postgres_pitr_runtime.py
+++ b/scripts/ha/verify_postgres_pitr_runtime.py
@@ -27,10 +27,10 @@ PITR_ENV_POLICIES = (*PUBLIC_PITR_ENV_POLICIES, *MIGRATION_PITR_ENV_POLICIES)
 SECRETS_FILE = Path("/etc/mvn-postgres-pitr.secrets.env")
 EXPECTED_COMPOSE_DIGESTS = {
     "/opt/air-api/docker-compose.patroni.yml": (
-        "5b8c2b532eac642d3bb9c4fd568f622efc84b68e6316c9eff5394cba59e4d0fd"
+        "f75669a92e4861224048ed26b64c07db7745e5bb76a20d2461e6b1f8b753592e"
     ),
     "/opt/mvn-reserve/docker-compose.patroni.yml": (
-        "94f625870ce4373a26861afb153ef544a9cbd1aff9912002973854de6d0b1905"
+        "186a0cad6c4b6d65b5d7376861c4ccef93dba69e42fe8488bc59d7e2b4a76ae2"
     ),
 }
 EXPECTED_PITR_CLUSTERS = {


### PR DESCRIPTION
## Что изменено

- Переводит managed communications worker на обоих HA-узлах из canary-профиля `true/false` в active-capable профиль `true/true`.
- Обновляет точные SHA-256 пины обоих Patroni Compose-файлов в PITR runtime verifier.

## Зачем

Это следующий gated-этап #848 после успешного canary: один managed worker должен стать единственным владельцем доставки website-событий. Сам runtime control остаётся выключенным до отдельного typed enable после CI, атомарного cutover, merge и production deploy.

## Влияние и безопасность

- Сам по себе PR не включает обработку всех событий в БД: runtime остаётся `off`.
- Одинаковый профиль задаётся обоим узлам для failover-совместимости; фактический запуск по-прежнему ограждён ролью Patroni и advisory lock.
- Compose-digest contract обновлён атомарно с изменениями профиля.

## Проверки

- Полный suite: `2781 passed, 4 skipped`.
- Focused infrastructure/runtime suite: `223 passed`.
- PITR runtime contract: `23 passed`.
- Rollback/recovery: `23 passed`.
- Независимая проверка active-profile/digest barriers: `41 + 17 passed`.
- `git diff --check`.

## План выпуска

1. Дождаться зелёного CI именно для commit `91d17a7d`.
2. Выполнить официальную атомарную PITR/Compose migration из неизменённого PR head с новым transaction id.
3. Смержить неизменённый PR и дождаться production deploy точного merge SHA.
4. Проверить HA/PITR/ownership и только затем выполнить typed enable.
5. Провести synthetic website request + idempotency replay и доказать ACK/no-duplicate перед закрытием #848.

Closes no issue yet; #848 закрывается только после live synthetic smoke и подтверждения доставки.