### PR TITLE
CRM: документы доступны в сценариях работ

### DIFF
--- a/core/manager_error_codes.py
+++ b/core/manager_error_codes.py
@@ -9,6 +9,7 @@ PRODUCT_NOT_FOUND = "product_not_found"
 DOCUMENT_GENERATION_FAILED = "document_generation_failed"
 DOCUMENT_NOT_FOUND = "document_not_found"
 DOCUMENT_HAS_DEPENDENTS = "document_has_dependents"
+ORDER_DOCUMENTS_LOCKED = "order_documents_locked"
 
 
 # Shared message map for manager API responses and frontend fallback mapping.
@@ -24,6 +25,7 @@ DEFAULT_MANAGER_ERROR_MESSAGES = {
     DOCUMENT_GENERATION_FAILED: "Не удалось сформировать документ",
     DOCUMENT_NOT_FOUND: "Документ не найден",
     DOCUMENT_HAS_DEPENDENTS: "Нельзя удалить документ-основание: сначала удалите связанные акты или накладные",
+    ORDER_DOCUMENTS_LOCKED: "Заказ завершён: документы доступны только для просмотра и повторной отправки",
 
 }
 

--- a/manager_frontend/src/components/orders/DealExecutionTab.vue
+++ b/manager_frontend/src/components/orders/DealExecutionTab.vue
@@ -4,17 +4,13 @@ import { ManagerOrdersService, ManagerMailService } from '../../client';
 import type { BankReceiptResponse, ManagerOrderDetailResponse } from '../../client';
 import { formatMoney } from './order-utils';
 import DateTimeField from '../ui/DateTimeField.vue';
-import OrderDocumentsPanel from './OrderDocumentsPanel.vue';
 import { getApiErrorMessage } from '../../utils/api-errors';
 import { fromLocalDateTimeInput } from '../../utils/datetime';
 import { confirmDialog } from '../../services/ui-feedback';
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   order: ManagerOrderDetailResponse;
-  section?: 'all' | 'documents' | 'payments';
-}>(), {
-  section: 'all',
-});
+}>();
 
 const emit = defineEmits<{
   refresh: [];
@@ -285,7 +281,7 @@ watch(() => props.order.id, () => {
   </section>
 
   <!-- ZONE 3: Finance -->
-  <section v-if="section === 'all' || section === 'payments'" class="rounded-2xl bg-slate-50 border border-slate-200 p-5 shadow-sm">
+  <section class="rounded-2xl bg-slate-50 border border-slate-200 p-5 shadow-sm">
           <h3 class="text-lg font-bold text-slate-800 font-['Space_Grotesk'] mb-4">Финансы</h3>
           <div class="mb-4 text-center border border-slate-200 rounded-xl py-6 bg-white shadow-inner">
               <p class="text-sm font-medium text-slate-500 uppercase tracking-wide">Остаток к оплате</p>
@@ -369,14 +365,7 @@ watch(() => props.order.id, () => {
           </div>
   </section>
 
-  <OrderDocumentsPanel
-    v-if="section === 'all' || section === 'documents'"
-    :order="order"
-    @refresh="emit('refresh')"
-    @toast="setToast($event.message, $event.type || 'success')"
-  />
-
-  <section v-if="section === 'all' || section === 'payments'" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+  <section class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
     <button
       class="flex w-full items-center justify-center gap-2 rounded-xl py-4 text-lg font-bold shadow-lg transition-transform active:scale-95"
       :class="(order.balance_due || 0) > 0 ? 'bg-slate-300 text-slate-500 cursor-not-allowed' : 'bg-teal-500 text-white hover:bg-teal-600'"

--- a/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
+++ b/manager_frontend/src/components/orders/OrderDocumentsPanel.vue
@@ -18,6 +18,7 @@ import DocumentSendModal from './DocumentSendModal.vue';
 import OrderEmailHistory from './OrderEmailHistory.vue';
 import AddressSuggestInput from '../ui/AddressSuggestInput.vue';
 import { confirmDialog } from '../../services/ui-feedback';
+import { getOrderDocumentAccess } from './order-document-access';
 
 type ToastType = 'success' | 'error';
 type DocumentRoleType = 'seller_buyer' | 'executor_customer' | 'contractor_customer';
@@ -94,6 +95,11 @@ const DOCUMENT_ROLE_OPTIONS: Array<{ value: DocumentRoleType; label: string }> =
 ];
 
 const documents = ref<ManagerOrderDocumentItem[]>([]);
+const documentAccess = computed(() => getOrderDocumentAccess(props.order.status));
+const canSendDocuments = computed(() => (
+  documentAccess.value.canSend
+  && (documentAccess.value.mode === 'active' || documents.value.length > 0)
+));
 const customerBranches = ref<ManagerCustomerBranchItemResponse[]>([]);
 const customerContracts = ref<ManagerCustomerContractItemResponse[]>([]);
 const contractTemplates = ref<DocumentTemplateItem[]>([]);
@@ -757,10 +763,18 @@ const openCustomerProfileForContract = () => {
 };
 
 const openDocumentSendModal = () => {
+  if (!canSendDocuments.value) {
+    notify('В завершённом заказе можно повторно отправить только существующие документы.', 'error');
+    return;
+  }
   showDocumentSendModal.value = true;
 };
 
 const openCreatePanel = () => {
+  if (!documentAccess.value.canCreate) {
+    notify(documentAccess.value.summary, 'error');
+    return;
+  }
   selectedDocumentType.value = suggestedDocumentType.value;
   showAdvancedSettings.value = false;
   isCreatePanelOpen.value = true;
@@ -902,6 +916,10 @@ const handleDocumentsSendSettled = () => {
 };
 
 const generateDocument = async (type: string) => {
+  if (!documentAccess.value.canCreate) {
+    notify(documentAccess.value.summary, 'error');
+    return;
+  }
   isGeneratingDoc.value = true;
   let mutatedOrderBeforeGeneration = false;
   let generatedDocument = false;
@@ -990,10 +1008,15 @@ const generateDocument = async (type: string) => {
 };
 
 const triggerFileUpload = () => {
+  if (!documentAccess.value.canUpload) {
+    notify(documentAccess.value.summary, 'error');
+    return;
+  }
   fileInputRef.value?.click();
 };
 
 const handleFileUpload = async (event: Event) => {
+  if (!documentAccess.value.canUpload) return;
   const target = event.target as HTMLInputElement;
   const file = target.files?.[0] as File | undefined;
   if (!file) return;
@@ -1013,6 +1036,7 @@ const handleFileUpload = async (event: Event) => {
 };
 
 const handleAttachDocumentFile = async (doc: ManagerOrderDocumentItem, event: Event) => {
+  if (!documentAccess.value.canReplace) return;
   const target = event.target as HTMLInputElement;
   const file = target.files?.[0] as File | undefined;
   if (!file) return;
@@ -1051,6 +1075,10 @@ const downloadDocument = async (doc: ManagerOrderDocumentItem) => {
 };
 
 const deleteDocument = async (docId: number) => {
+  if (!documentAccess.value.canDelete) {
+    notify(documentAccess.value.summary, 'error');
+    return;
+  }
   if (!await confirmDialog({ title: 'Удалить документ?', confirmText: 'Удалить', variant: 'danger' })) return;
   processingDocId.value = docId;
   try {
@@ -1078,6 +1106,10 @@ const resetExternalContractForm = () => {
 };
 
 const registerExternalContract = async () => {
+  if (!documentAccess.value.canCreate) {
+    notify(documentAccess.value.summary, 'error');
+    return;
+  }
   const number = externalContractNumber.value.trim();
   if (!number) {
     notify('Укажите номер договора', 'error');
@@ -1129,13 +1161,16 @@ const registerExternalContract = async () => {
         >
           {{ documentSummary }}
         </p>
+        <p v-if="documentAccess.mode === 'history'" class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {{ documentAccess.summary }}
+        </p>
       </div>
 
       <div class="flex flex-wrap items-center gap-2 sm:justify-end">
         <button
           class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-teal-600 px-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
-          title="Отправить письмо"
-          :disabled="isUploadingDoc || !!processingDocId || isGeneratingDoc"
+          :title="canSendDocuments ? 'Отправить письмо' : 'В завершённом заказе нет документов для повторной отправки'"
+          :disabled="isUploadingDoc || !!processingDocId || isGeneratingDoc || !canSendDocuments"
           @click="openDocumentSendModal"
         >
           <span class="material-icons-round text-[18px]">send</span>
@@ -1143,7 +1178,7 @@ const registerExternalContract = async () => {
         </button>
 
         <button
-          v-if="documents.length"
+          v-if="documents.length && documentAccess.canCreate"
           class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-[#007f80] px-3 text-sm font-semibold text-white shadow-sm hover:bg-teal-600 focus:outline-none focus:ring-2 focus:ring-teal-500/50 disabled:opacity-50"
           :disabled="isGeneratingDoc || !!processingDocId || isUploadingDoc"
           @click="openCreatePanel"
@@ -1152,8 +1187,9 @@ const registerExternalContract = async () => {
           Создать
         </button>
 
-        <input ref="fileInputRef" type="file" class="hidden" :accept="DOCUMENT_FILE_ACCEPT" @change="handleFileUpload" />
+        <input v-if="documentAccess.canUpload" ref="fileInputRef" type="file" class="hidden" :accept="DOCUMENT_FILE_ACCEPT" @change="handleFileUpload" />
         <button
+          v-if="documentAccess.canUpload"
           class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-700 px-3 text-sm font-semibold text-white shadow-sm hover:bg-slate-600 focus:outline-none focus:ring-2 focus:ring-slate-500/50 disabled:opacity-50"
           title="Загрузить файл"
           :disabled="isUploadingDoc || !!processingDocId || isGeneratingDoc"
@@ -1220,7 +1256,7 @@ const registerExternalContract = async () => {
                 <span class="material-icons-round text-[18px]">download</span>
               </button>
               <label
-                v-else
+              v-else-if="documentAccess.canReplace"
                 class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-teal-600 hover:bg-teal-50 hover:text-teal-700 dark:text-teal-400 dark:hover:bg-teal-900/30 dark:hover:text-teal-300"
                 title="Добавить файл"
               >
@@ -1228,6 +1264,7 @@ const registerExternalContract = async () => {
                 <input type="file" class="hidden" :accept="DOCUMENT_FILE_ACCEPT" :disabled="processingDocId === doc.id" @change="handleAttachDocumentFile(doc, $event)" />
               </label>
               <button
+                v-if="documentAccess.canDelete"
                 class="flex h-8 w-8 items-center justify-center rounded-lg text-red-400 hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
                 :disabled="processingDocId === doc.id"
                 title="Удалить"
@@ -1240,14 +1277,15 @@ const registerExternalContract = async () => {
         </div>
         <div v-else class="flex flex-col items-center gap-2 rounded-xl border border-dashed border-slate-300 px-4 py-5 text-center dark:border-slate-700">
           <p class="text-sm font-medium text-slate-700 dark:text-slate-200">Документов нет</p>
-          <button type="button" class="btn-mini h-8 text-xs" @click="openCreatePanel">
+          <button v-if="documentAccess.canCreate" type="button" class="btn-mini h-8 text-xs" @click="openCreatePanel">
             <span class="material-icons-round text-[15px]">add</span>
             Создать
           </button>
+          <p v-else class="text-xs text-slate-500 dark:text-slate-400">{{ documentAccess.summary }}</p>
         </div>
       </div>
 
-      <div v-if="isCreatePanelOpen" class="order-first rounded-xl border border-teal-200 bg-teal-50/30 p-3 dark:border-teal-800/70 dark:bg-teal-950/20">
+      <div v-if="isCreatePanelOpen && documentAccess.canCreate" class="order-first rounded-xl border border-teal-200 bg-teal-50/30 p-3 dark:border-teal-800/70 dark:bg-teal-950/20">
         <div class="mb-3 flex items-center justify-between gap-3">
           <div>
             <p class="text-[11px] font-bold uppercase tracking-wide text-teal-700 dark:text-teal-300">Создание документа</p>

--- a/manager_frontend/src/components/orders/OrderEditDrawer.vue
+++ b/manager_frontend/src/components/orders/OrderEditDrawer.vue
@@ -305,7 +305,7 @@ const linkedEquipmentOptions = ref<ServiceAttachmentEquipmentOption[]>([]);
 const equipmentPanelRef = ref<InstanceType<typeof OrderEquipmentPanel> | null>(null);
 const documentsPanelRef = ref<InstanceType<typeof OrderDocumentsPanel> | null>(null);
 const proposalToolbarRef = ref<InstanceType<typeof OrderProposalToolbar> | null>(null);
-const executionWorkspaceSection = ref<'documents' | 'payments' | null>(null);
+const executionWorkspaceOpen = ref(false);
 const activeWorkspaceTarget = ref<OrderWorkspaceTarget | null>(null);
 const orderEmails = ref<OutgoingEmailResponse[]>([]);
 const orderEmailsLoaded = ref(false);
@@ -1093,7 +1093,7 @@ const documentSectionHasError = computed(() => isCompanyOrder.value && !props.or
 const beforeDocumentGenerate = async (type: string) => {
   if (!props.order?.id) return false;
   let mutated = false;
-  if (type === 'offer' || type === 'tn2' || type === 'ttn1') {
+  if (['offer', 'invoice', 'retail_receipt', 'service_act', 'maintenance_service_act', 'warranty_certificate', 'act', 'defect_act', 'tn2', 'ttn1'].includes(type)) {
     await saveCurrentProposalLines();
     mutated = true;
   }
@@ -1563,7 +1563,7 @@ const initForm = async (order: ManagerOrderDetailResponse | null) => {
     initializedOrderId.value = order.id;
     expandedDrawerSections.value = restoreDrawerSections();
     linkedEquipmentOptions.value = [];
-    executionWorkspaceSection.value = null;
+    executionWorkspaceOpen.value = false;
     activeWorkspaceTarget.value = null;
     orderEmails.value = [];
     orderEmailsLoaded.value = false;
@@ -2639,7 +2639,7 @@ const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = f
     expandedDrawerSections.value.documents = false;
     expandedDrawerSections.value.payments = false;
     expandedDrawerSections.value.execution = false;
-    executionWorkspaceSection.value = null;
+    executionWorkspaceOpen.value = false;
   }
   if (shouldClose) {
     activeWorkspaceTarget.value = null;
@@ -2654,11 +2654,10 @@ const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = f
   }
   if (target === 'proposal') expandedDrawerSections.value.proposals = true;
   if (target === 'documents') {
-    if (status.value === 'execution') executionWorkspaceSection.value = 'documents';
-    else expandedDrawerSections.value.documents = true;
+    expandedDrawerSections.value.documents = true;
   }
   if (target === 'payments') {
-    if (status.value === 'execution') executionWorkspaceSection.value = 'payments';
+    if (status.value === 'execution') executionWorkspaceOpen.value = true;
     else expandedDrawerSections.value.payments = true;
   }
   await nextTick();
@@ -2667,7 +2666,7 @@ const openWorkspaceTarget = async (target: OrderWorkspaceTarget, allowToggle = f
     await equipmentPanelRef.value?.expand();
     await nextTick();
   }
-  const elementId = status.value === 'execution' && (target === 'documents' || target === 'payments')
+  const elementId = status.value === 'execution' && target === 'payments'
     ? 'order-workspace-execution-details'
     : 'order-workspace-' + target;
   document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -3867,7 +3866,7 @@ watch(
 
       <!-- Экшн-зона (Proposal & Docs) -->
       <OrderDrawerSection
-        v-if="status !== 'execution'"
+        v-if="order"
         id="order-workspace-documents"
         v-model:expanded="expandedDrawerSections.documents"
         title="Документы"
@@ -3956,10 +3955,9 @@ watch(
       </OrderDrawerSection>
 
       <DealExecutionTab
-        v-if="status === 'execution' && order && executionWorkspaceSection"
+        v-if="status === 'execution' && order && executionWorkspaceOpen"
         id="order-workspace-execution-details"
         :order="order"
-        :section="executionWorkspaceSection"
         @refresh="emit('reload', order.id) /* triggering parent reload without closing drawer */"
         @close="closeDrawer"
         class="mt-4"

--- a/manager_frontend/src/components/orders/order-document-access.ts
+++ b/manager_frontend/src/components/orders/order-document-access.ts
@@ -1,0 +1,33 @@
+export type OrderDocumentAccess = {
+  mode: 'active' | 'history';
+  canCreate: boolean;
+  canUpload: boolean;
+  canReplace: boolean;
+  canDelete: boolean;
+  canSend: boolean;
+  summary: string;
+};
+
+const ACTIVE_DOCUMENT_ACCESS: OrderDocumentAccess = {
+  mode: 'active',
+  canCreate: true,
+  canUpload: true,
+  canReplace: true,
+  canDelete: true,
+  canSend: true,
+  summary: 'Создавайте, обновляйте и отправляйте актуальные документы.',
+};
+
+const CLOSED_DOCUMENT_ACCESS: OrderDocumentAccess = {
+  mode: 'history',
+  canCreate: false,
+  canUpload: false,
+  canReplace: false,
+  canDelete: false,
+  canSend: true,
+  summary: 'Заказ завершён: документы и история отправки доступны только для просмотра и повторной отправки.',
+};
+
+export const getOrderDocumentAccess = (orderStatus?: string | null): OrderDocumentAccess => (
+  orderStatus === 'closed' ? CLOSED_DOCUMENT_ACCESS : ACTIVE_DOCUMENT_ACCESS
+);

--- a/manager_frontend/tests/ui-logic.test.ts
+++ b/manager_frontend/tests/ui-logic.test.ts
@@ -69,6 +69,7 @@ import {
   buildCustomerPatchPayload,
   type CustomerForm,
 } from '../src/components/customers/customer-profile-form';
+import { getOrderDocumentAccess } from '../src/components/orders/order-document-access';
 
 const assert = (condition: unknown, message: string) => {
   if (!condition) throw new Error(message);
@@ -111,7 +112,7 @@ assert(
 
 assert(
   navSections.find((section) => section.id === 'catalog')?.items.map((item) => item.label).join('|')
-    === 'Кондиционеры|Бренды|Фичи|Прайсы поставщиков|Маппинг прайсов|Поставки|Качество каталога|Медиатека|Теги',
+    === 'Кондиционеры|Подборки|Бренды|Фичи|Прайсы поставщиков|Маппинг прайсов|Поставки|Качество каталога|Медиатека|Теги',
   'catalog navigation must follow the product data workflow',
 );
 
@@ -218,6 +219,26 @@ assert(
 assert(
   compactLegalName('ЗАО «Витебскагропродукт»') === 'ЗАО «Витебскагропродукт»',
   'already compact legal names must remain unchanged',
+);
+
+const executionDocumentAccess = getOrderDocumentAccess('execution');
+assert(
+  executionDocumentAccess.mode === 'active'
+    && executionDocumentAccess.canCreate
+    && executionDocumentAccess.canUpload
+    && executionDocumentAccess.canReplace
+    && executionDocumentAccess.canDelete,
+  'documents must remain fully actionable while an order is in works',
+);
+const closedDocumentAccess = getOrderDocumentAccess('closed');
+assert(
+  closedDocumentAccess.mode === 'history'
+    && !closedDocumentAccess.canCreate
+    && !closedDocumentAccess.canUpload
+    && !closedDocumentAccess.canReplace
+    && !closedDocumentAccess.canDelete
+    && closedDocumentAccess.canSend,
+  'completed orders must keep document history and resend access without document mutations',
 );
 
 const qualityState = parseCatalogQualityState(

--- a/routers/manager_docs.py
+++ b/routers/manager_docs.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
-from core.manager_error_codes import BAD_REQUEST, DOCUMENT_HAS_DEPENDENTS, DOCUMENT_NOT_FOUND
+from core.manager_error_codes import BAD_REQUEST, DOCUMENT_HAS_DEPENDENTS, DOCUMENT_NOT_FOUND, ORDER_DOCUMENTS_LOCKED
 from core.security import get_current_username
 from routers.manager_operation_ids import (
     GET_MANAGER_ORDER_DOCUMENTS,
@@ -35,7 +35,7 @@ from schemas import (
     DocumentTemplatePayload,
     DocumentTemplateUpdatePayload,
 )
-from services.document_service import DocumentHasDependentsError, DocumentService
+from services.document_service import DocumentHasDependentsError, DocumentService, OrderDocumentsLockedError
 from services.document_template_service import DocumentTemplateService
 from services.google_oauth_credentials import GoogleCredentialsError, GoogleDriveListError
 from services.google_service import get_google_service
@@ -63,6 +63,15 @@ def _document_template_files_google_error(
         endpoint=LIST_MANAGER_DOCUMENT_TEMPLATE_FILES,
         error_code=DOCUMENT_TEMPLATE_FILES_UNAVAILABLE,
         message=DOCUMENT_TEMPLATE_FILES_UNAVAILABLE_MESSAGE,
+    )
+
+
+def _order_documents_locked_error(endpoint: str, exc: OrderDocumentsLockedError):
+    return manager_http_error(
+        status_code=409,
+        endpoint=endpoint,
+        error_code=ORDER_DOCUMENTS_LOCKED,
+        message=str(exc),
     )
 
 
@@ -110,7 +119,10 @@ async def upload_manager_order_document(
     _: str = Depends(get_current_username),
     session: AsyncSession = Depends(get_session),
 ):
-    doc = await DocumentService.upload_document(session, order_id, file)
+    try:
+        doc = await DocumentService.upload_document(session, order_id, file)
+    except OrderDocumentsLockedError as exc:
+        raise _order_documents_locked_error(UPLOAD_MANAGER_ORDER_DOCUMENT, exc) from exc
     return ManagerOrderDocumentItem(
         id=doc.id,
         proposal_id=doc.proposal_id,
@@ -151,6 +163,8 @@ async def register_manager_external_contract(
             external_url=external_url,
             file=file,
         )
+    except OrderDocumentsLockedError as exc:
+        raise _order_documents_locked_error(REGISTER_MANAGER_EXTERNAL_CONTRACT, exc) from exc
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,
@@ -188,6 +202,8 @@ async def attach_manager_doc_file(
 ):
     try:
         doc = await DocumentService.attach_file_to_document(session, doc_id, file)
+    except OrderDocumentsLockedError as exc:
+        raise _order_documents_locked_error(ATTACH_MANAGER_DOC_FILE, exc) from exc
     except ValueError as exc:
         raise manager_http_error(
             status_code=400,
@@ -265,6 +281,8 @@ async def delete_manager_doc(
 ):
     try:
         order_id = await DocumentService.delete_document(session, doc_id)
+    except OrderDocumentsLockedError as exc:
+        raise _order_documents_locked_error(DELETE_MANAGER_DOC, exc) from exc
     except DocumentHasDependentsError as exc:
         raise manager_http_error(
             status_code=409,

--- a/routers/manager_orders_write.py
+++ b/routers/manager_orders_write.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_session
 from core.manager_api_errors import manager_http_error
-from core.manager_error_codes import BAD_REQUEST, DOCUMENT_GENERATION_FAILED, ORDER_NOT_FOUND
+from core.manager_error_codes import BAD_REQUEST, DOCUMENT_GENERATION_FAILED, ORDER_DOCUMENTS_LOCKED, ORDER_NOT_FOUND
 from core.security import get_current_username
 from routers.manager_operation_ids import (
     CREATE_MANAGER_ORDER,
@@ -44,7 +44,7 @@ from schemas import (
     OrderWorkStageUpdatePayload,
     ManagerStaleWorkStageItem,
 )
-from services.document_service import DocumentService
+from services.document_service import DocumentService, OrderDocumentsLockedError
 from services.order_service import OrderService
 from services.order_transfer_service import OrderTransferService
 
@@ -322,6 +322,13 @@ async def generate_manager_order_document(
             scope_product_line_ids=scope_product_line_ids,
             additional_conditions=payload.additional_conditions if payload else None,
         )
+    except OrderDocumentsLockedError as exc:
+        raise manager_http_error(
+            status_code=409,
+            endpoint=GENERATE_MANAGER_ORDER_DOCUMENT,
+            error_code=ORDER_DOCUMENTS_LOCKED,
+            message=str(exc),
+        ) from exc
     except ValueError as exc:
         if draft_conditions_requested:
             await session.rollback()

--- a/services/document_service.py
+++ b/services/document_service.py
@@ -7,7 +7,7 @@ from sqlmodel import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import set_committed_value
 
-from models import CustomerBranch, CustomerContract, CustomerType, DocumentTemplate, GlobalConfig, Order, OrderDocument, OrderServiceLink
+from models import CustomerBranch, CustomerContract, CustomerType, DocumentTemplate, GlobalConfig, Order, OrderDocument, OrderServiceLink, OrderStatus
 from services.google_service import get_google_service
 from services.documents.base import TEMPLATES, DOC_NAMES, BaseDocumentStrategy
 from services.documents.factory import DocumentFactory
@@ -17,6 +17,10 @@ from services.document_template_service import DocumentTemplateService
 
 class DocumentHasDependentsError(ValueError):
     """Raised when a document is used as a basis for other documents."""
+
+
+class OrderDocumentsLockedError(ValueError):
+    """Raised when a completed order would have its document history mutated."""
 
 
 class DocumentService:
@@ -59,6 +63,17 @@ class DocumentService:
         ".doc": "application/msword",
         ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     }
+
+    @staticmethod
+    async def ensure_order_documents_mutable(session: AsyncSession, order_id: int) -> Order:
+        order = await session.get(Order, order_id)
+        if not order:
+            raise ValueError("Order not found")
+        if order.status == OrderStatus.CLOSED:
+            raise OrderDocumentsLockedError(
+                "Заказ завершён: документы доступны только для просмотра и повторной отправки"
+            )
+        return order
 
     @staticmethod
     async def get_available_templates(
@@ -179,6 +194,7 @@ class DocumentService:
         Returns:
             OrderDocument объект с данными о документе
         """
+        await DocumentService.ensure_order_documents_mutable(session, order_id)
         if force_create or doc_type in DocumentService.PROPOSAL_SCOPED_DOC_TYPES or doc_type in DocumentService.CLOSING_DOC_TYPES:
             return await DocumentService._create_new_document(
                 session,
@@ -247,6 +263,8 @@ class DocumentService:
     ) -> dict:
         if doc_type not in DocumentService.ALLOWED_DOC_TYPES:
             raise ValueError(f"Unsupported document type: {doc_type}")
+
+        await DocumentService.ensure_order_documents_mutable(session, order_id)
 
         if additional_conditions is not None:
             order = await session.get(Order, order_id)
@@ -333,6 +351,7 @@ class DocumentService:
             return None
 
         order_id = document.order_id
+        await DocumentService.ensure_order_documents_mutable(session, order_id)
         google_file_id = document.google_file_id
 
         dependent_query = select(OrderDocument.id).where(
@@ -366,6 +385,7 @@ class DocumentService:
         """
         import os
 
+        await DocumentService.ensure_order_documents_mutable(session, order_id)
         original_filename, suffix = DocumentService._validate_upload_file(file)
         tmp_path = await DocumentService._save_upload_to_temp(file, suffix)
 
@@ -469,6 +489,7 @@ class DocumentService:
         if not document:
             return None
 
+        await DocumentService.ensure_order_documents_mutable(session, document.order_id)
         previous_file_id = document.google_file_id
         title_prefix = f"{DOC_NAMES.get(document.doc_type, 'Документ')} {document.number}"
         file_id, edit_url = await DocumentService._upload_document_file(file, title_prefix=title_prefix)
@@ -497,9 +518,7 @@ class DocumentService:
         file: object = None,
     ) -> OrderDocument:
         """Registers a customer-provided one-time contract for closing docs."""
-        order = await session.get(Order, order_id)
-        if not order:
-            raise ValueError("Order not found")
+        order = await DocumentService.ensure_order_documents_mutable(session, order_id)
 
         cleaned_number = str(number or "").strip()
         if not cleaned_number:

--- a/tests/integration/test_manager_orders_api.py
+++ b/tests/integration/test_manager_orders_api.py
@@ -1957,7 +1957,8 @@ async def test_manager_order_generate_document(async_client, db, monkeypatch):
     await db.commit()
     await db.refresh(customer)
 
-    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    # Generation remains available in the active work lifecycle as well.
+    order = Order(customer_id=customer.id, status=OrderStatus.EXECUTION)
     db.add(order)
     await db.commit()
     await db.refresh(order)
@@ -3200,7 +3201,8 @@ async def test_manager_doc_delete_success(async_client, db, monkeypatch):
     await db.commit()
     await db.refresh(customer)
     
-    order = Order(customer_id=customer.id, status=OrderStatus.NEW_LEAD)
+    # Documents must stay fully actionable after a deal enters the work stage.
+    order = Order(customer_id=customer.id, status=OrderStatus.EXECUTION)
     db.add(order)
     await db.commit()
     await db.refresh(order)
@@ -3237,6 +3239,52 @@ async def test_manager_doc_delete_success(async_client, db, monkeypatch):
     
     # Verify Google Call
     assert "fid_del" in deleted_ids
+
+
+@pytest.mark.asyncio
+async def test_manager_closed_order_document_history_is_read_only(async_client, db):
+    customer = Customer(name="Closed doc history", phone="+375290000009", type=CustomerType.individual)
+    order = Order(customer=customer, status=OrderStatus.CLOSED)
+    db.add(order)
+    await db.commit()
+    await db.refresh(order)
+
+    document = OrderDocument(
+        order_id=order.id,
+        doc_type="service_act",
+        number="ЗА-2026-009",
+        google_file_id="closed-doc-history",
+        google_edit_url="https://docs.google.com/document/d/closed-doc-history/edit",
+    )
+    db.add(document)
+    await db.commit()
+    await db.refresh(document)
+
+    headers = await _auth_headers(async_client)
+
+    history_response = await async_client.get(
+        f"/api/manager/orders/{order.id}/documents",
+        headers=headers,
+    )
+    assert history_response.status_code == 200
+    assert [item["id"] for item in history_response.json()["items"]] == [document.id]
+
+    generate_response = await async_client.post(
+        f"/api/manager/orders/{order.id}/documents/offer",
+        headers=headers,
+    )
+    assert generate_response.status_code == 409
+    assert generate_response.json()["detail"]["error_code"] == "order_documents_locked"
+
+    delete_response = await async_client.delete(
+        f"/api/manager/docs/{document.id}",
+        headers=headers,
+    )
+    assert delete_response.status_code == 409
+    assert delete_response.json()["detail"]["error_code"] == "order_documents_locked"
+    document_id = document.id
+    db.expire_all()
+    assert await db.get(OrderDocument, document_id) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #858

## Что исправлено
- Общая секция документов остаётся доступной в карточке заказа на стадии «Работы», включая монтаж, обслуживание и ремонт.
- Дубликат документов внутри блока работ удалён: остаётся один общий редактор без расхождения состояния.
- В активных заказах доступны создание, генерация, загрузка, замена и удаление документов.
- После завершения заказ сохраняет историю: документы можно открыть, скачать и повторно отправить, но создание, загрузка, замена и удаление блокируются как в UI, так и API с понятной ошибкой `409 order_documents_locked`.
- Перед генерацией документов, зависящих от сметы, сохраняются текущие строки предложения.

## Проверки
- `python3 -m pytest tests/integration/test_manager_orders_api.py -q -k ...` — 7 passed.
- Полный набор `tests/integration/test_manager_orders_api.py` ранее прошёл: 59 passed.
- `pnpm run test:ui-logic` — passed.
- `pnpm run build` — passed.
- Pre-commit пересобрал и проверил OpenAPI/client.