### PR TITLE
Manager Leads: preview photos before qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build and Test Manager Frontend
+      - name: Build Manager Frontend and Run Component Tests
         working-directory: ./manager_frontend
         run: |
           npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,12 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build Manager Frontend
+      - name: Build and Test Manager Frontend
         working-directory: ./manager_frontend
         run: |
           npm ci
           npm run build
+          npm run test:components
 
       - name: Start Services
         run: docker compose up -d --build

--- a/manager_frontend/package-lock.json
+++ b/manager_frontend/package-lock.json
@@ -21,13 +21,16 @@
       "devDependencies": {
         "@types/node": "^24.10.1",
         "@vitejs/plugin-vue": "^6.0.1",
+        "@vue/test-utils": "2.2.7",
         "@vue/tsconfig": "^0.8.1",
         "autoprefixer": "^10.4.24",
+        "jsdom": "^26.1.0",
         "openapi-typescript-codegen": "^0.30.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
         "vite": "^7.2.4",
+        "vitest": "^3.2.7",
         "vue-tsc": "^3.1.4"
       }
     },
@@ -59,6 +62,20 @@
       },
       "peerDependencies": {
         "@types/json-schema": "^7.0.15"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -112,6 +129,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -974,6 +1106,24 @@
         "win32"
       ]
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1015,6 +1165,131 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1149,6 +1424,16 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
       "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.2.7.tgz",
+      "integrity": "sha512-BMuoruUFTEqhLoOgsMcgNVMiByYbfHCKGr2C4CPdGtz/affUtDVX5zr1RnPuq0tYSiaqq+Enw5voUpG6JY8Q7g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.1"
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
@@ -1202,6 +1487,16 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/alien-signals": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
@@ -1250,6 +1545,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -1353,6 +1658,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -1393,6 +1708,33 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1461,10 +1803,73 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1494,6 +1899,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -1549,6 +1961,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1717,6 +2139,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
@@ -1785,6 +2261,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1793,6 +2276,13 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -1804,6 +2294,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsonfile": {
@@ -1835,6 +2365,20 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lucide-vue-next": {
       "version": "0.563.0",
@@ -1895,6 +2439,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
@@ -1950,6 +2501,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1993,6 +2551,32 @@
         "node": ">=20"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -2004,6 +2588,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2197,6 +2798,16 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2324,6 +2935,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2347,6 +2965,33 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2362,6 +3007,33 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/sucrase": {
@@ -2397,6 +3069,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
@@ -2456,6 +3135,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2472,6 +3165,56 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2482,6 +3225,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -2641,6 +3410,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -2683,11 +3548,128 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/manager_frontend/package.json
+++ b/manager_frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "test:ui-logic": "node scripts/audit-native-dialogs.mjs && node scripts/run-ui-logic-tests.mjs",
+    "test:components": "vitest run --environment jsdom tests/lead-inbox-attachments.spec.ts",
     "preview": "vite preview",
     "gen:api": "openapi --input ../openapi.json --output ./src/client --client fetch --useUnionTypes"
   },
@@ -24,13 +25,16 @@
   "devDependencies": {
     "@types/node": "^24.10.1",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vue/test-utils": "2.2.7",
     "@vue/tsconfig": "^0.8.1",
     "autoprefixer": "^10.4.24",
+    "jsdom": "^26.1.0",
     "openapi-typescript-codegen": "^0.30.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
+    "vitest": "^3.2.7",
     "vue-tsc": "^3.1.4"
   }
 }

--- a/manager_frontend/src/components/leads/LeadInboxCard.vue
+++ b/manager_frontend/src/components/leads/LeadInboxCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import type { LeadsInboxItemResponse } from '../../api';
+import OrderAttachmentsPanel from '../service-attachments/OrderAttachmentsPanel.vue';
 
 const props = defineProps<{
   item: LeadsInboxItemResponse;
@@ -14,6 +15,8 @@ const emit = defineEmits<{
 }>();
 
 const isCommentExpanded = ref(false);
+const attachmentsOpen = ref(false);
+const attachmentsRegionId = computed(() => `lead-attachments-${props.item.id}`);
 
 const sourceLabel: Record<string, string> = {
   site: 'Сайт',
@@ -176,13 +179,36 @@ const hasLongComment = computed(() => (props.item.comment || '').length > 140);
       <span class="text-xs text-slate-400 dark:text-slate-500 ml-auto">
         {{ formatDate(displayDate) }}
       </span>
-      <span
+      <button
         v-if="item.attachment_count"
-        class="inline-flex items-center gap-1 rounded-full bg-cyan-50 px-2 py-1 text-xs font-semibold text-cyan-700 dark:bg-cyan-500/10 dark:text-cyan-300"
+        type="button"
+        class="inline-flex min-h-9 items-center gap-1 rounded-full bg-cyan-50 px-2.5 py-1.5 text-xs font-semibold text-cyan-700 transition hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:bg-cyan-500/10 dark:text-cyan-300 dark:hover:bg-cyan-500/20 dark:focus-visible:ring-offset-slate-800"
+        :aria-expanded="attachmentsOpen"
+        :aria-controls="attachmentsRegionId"
+        :aria-label="`${attachmentsOpen ? 'Скрыть' : 'Показать'} фото заявки: ${item.attachment_count}`"
+        @click="attachmentsOpen = !attachmentsOpen"
       >
-        <span class="material-icons-round text-[14px]">photo_library</span>
-        {{ item.attachment_count }}
-      </span>
+        <span class="material-icons-round text-[15px]" aria-hidden="true">photo_library</span>
+        Фото: {{ item.attachment_count }}
+        <span class="material-icons-round text-[15px]" aria-hidden="true">{{ attachmentsOpen ? 'expand_less' : 'expand_more' }}</span>
+      </button>
+    </div>
+
+    <div
+      v-if="attachmentsOpen"
+      :id="attachmentsRegionId"
+      class="mx-4 mb-3 rounded-lg bg-slate-50/80 px-3 dark:bg-slate-900/40"
+      role="region"
+      :aria-label="`Фото заявки #${item.id}`"
+      data-testid="lead-readonly-attachments"
+    >
+      <OrderAttachmentsPanel
+        :order-id="item.id"
+        :initial-count="item.attachment_count"
+        :default-expanded="true"
+        :readonly="true"
+        :embedded="true"
+      />
     </div>
 
     <!-- Comment (the core decision-making field) -->

--- a/manager_frontend/src/components/service-attachments/OrderAttachmentsPanel.vue
+++ b/manager_frontend/src/components/service-attachments/OrderAttachmentsPanel.vue
@@ -21,11 +21,13 @@ const props = withDefaults(defineProps<{
   initialCount?: number | null;
   defaultExpanded?: boolean;
   readonly?: boolean;
+  embedded?: boolean;
   equipmentOptions?: ServiceAttachmentEquipmentOption[];
 }>(), {
   initialCount: null,
   defaultExpanded: false,
   readonly: false,
+  embedded: false,
   equipmentOptions: () => [],
 });
 
@@ -38,7 +40,7 @@ const emit = defineEmits<{
 }>();
 
 const fileInput = ref<HTMLInputElement | null>(null);
-const expanded = ref(props.defaultExpanded);
+const expanded = ref(props.embedded || props.defaultExpanded);
 const loaded = ref(false);
 const loading = ref(false);
 const loadError = ref('');
@@ -149,6 +151,11 @@ const hydrateMediaUrls = (attachmentItems: ServiceAttachmentItem[]) => {
   }
 };
 
+const clearMediaUrls = () => {
+  for (const key of Object.keys(previewUrls)) delete previewUrls[key];
+  for (const key of Object.keys(audioUrls)) delete audioUrls[key];
+};
+
 const loadAttachments = async (force = false) => {
   if (loading.value || (loaded.value && !force)) return;
   const requestId = ++listRequestId;
@@ -157,6 +164,7 @@ const loadAttachments = async (force = false) => {
   try {
     const response = await serviceAttachmentsApi.list(props.orderId);
     if (requestId !== listRequestId) return;
+    if (force) clearMediaUrls();
     items.value = response.items || [];
     total.value = Number(response.total ?? items.value.length);
     loaded.value = true;
@@ -176,7 +184,10 @@ const toggleExpanded = () => {
   if (expanded.value) void loadAttachments();
 };
 
-const chooseFiles = () => fileInput.value?.click();
+const chooseFiles = () => {
+  if (props.readonly) return;
+  fileInput.value?.click();
+};
 
 const uploadFiles = async (fileList: FileList | File[]) => {
   const files = Array.from(fileList);
@@ -219,12 +230,17 @@ const uploadFiles = async (fileList: FileList | File[]) => {
 
 const onFileChange = (event: Event) => {
   const input = event.target as HTMLInputElement;
+  if (props.readonly) {
+    input.value = '';
+    return;
+  }
   if (input.files?.length) void uploadFiles(input.files);
   input.value = '';
 };
 
 const onDrop = (event: DragEvent) => {
   event.preventDefault();
+  if (props.readonly) return;
   if (event.dataTransfer?.files?.length) void uploadFiles(event.dataTransfer.files);
 };
 
@@ -242,6 +258,7 @@ const onPaste = (event: ClipboardEvent) => {
 };
 
 const pasteFromClipboard = async () => {
+  if (props.readonly) return;
   actionError.value = '';
   if (!navigator.clipboard?.read) {
     actionError.value = 'Нажмите Ctrl+V или Cmd+V внутри блока: браузер не даёт прямой доступ к буферу.';
@@ -279,6 +296,7 @@ const openViewer = (item: ServiceAttachmentItem) => {
 };
 
 const beginEdit = (item: ServiceAttachmentItem) => {
+  if (props.readonly) return;
   const attachmentId = persistedId(item);
   if (attachmentId === null) return;
   editingId.value = attachmentId;
@@ -290,6 +308,7 @@ const beginEdit = (item: ServiceAttachmentItem) => {
 };
 
 const saveEdit = async () => {
+  if (props.readonly) return;
   const item = editingItem.value;
   if (!item) return;
   const attachmentId = persistedId(item);
@@ -317,6 +336,7 @@ const saveEdit = async () => {
 };
 
 const deleteAttachment = async (item: ServiceAttachmentItem) => {
+  if (props.readonly) return;
   const attachmentId = persistedId(item);
   if (attachmentId === null) return;
   if (!await confirmDialog({ title: 'Архивировать файл?', description: item.filename, confirmText: 'Архивировать', variant: 'warning' })) return;
@@ -355,8 +375,7 @@ watch(() => props.orderId, () => {
   actionError.value = '';
   viewerAttachmentId.value = null;
   editingId.value = null;
-  for (const key of Object.keys(previewUrls)) delete previewUrls[key];
-  for (const key of Object.keys(audioUrls)) delete audioUrls[key];
+  clearMediaUrls();
   if (expanded.value) void loadAttachments();
 });
 
@@ -375,13 +394,16 @@ defineExpose({ refresh, expand });
 
 <template>
   <section
-    class="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/70"
-    tabindex="0"
+    :class="embedded
+      ? 'bg-transparent'
+      : 'rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/70'"
+    :tabindex="readonly ? undefined : 0"
     @paste="onPaste"
     @dragover.prevent
     @drop="onDrop"
   >
     <button
+      v-if="!embedded"
       type="button"
       class="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60 sm:px-4"
       :aria-expanded="expanded"
@@ -391,7 +413,7 @@ defineExpose({ refresh, expand });
       <span class="min-w-0 flex-1">
         <span class="block text-sm font-semibold text-slate-900 dark:text-slate-100">Фото и файлы</span>
         <span class="block truncate text-xs text-slate-500 dark:text-slate-400">
-          {{ loaded ? (total ? `${total} файлов` : 'Файлов пока нет') : (visibleCount ? `${visibleCount} файлов` : 'Откройте, чтобы загрузить') }}
+          {{ loaded ? (total ? `${total} файлов` : 'Файлов пока нет') : (visibleCount ? `${visibleCount} файлов` : (readonly ? 'Откройте для просмотра' : 'Откройте, чтобы загрузить')) }}
         </span>
       </span>
       <span class="inline-flex min-w-7 items-center justify-center rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
@@ -400,7 +422,12 @@ defineExpose({ refresh, expand });
       <span class="material-icons-round text-[21px] text-slate-500" aria-hidden="true">{{ expanded ? 'expand_less' : 'expand_more' }}</span>
     </button>
 
-    <div v-if="expanded" class="border-t border-slate-200 px-3 pb-4 pt-3 dark:border-slate-700 sm:px-4">
+    <div
+      v-if="expanded"
+      :class="embedded
+        ? 'pb-2 pt-2'
+        : 'border-t border-slate-200 px-3 pb-4 pt-3 dark:border-slate-700 sm:px-4'"
+    >
       <div v-if="loadError" class="flex items-start gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-200" role="alert">
         <span class="material-icons-round mt-0.5 text-[18px]" aria-hidden="true">error</span>
         <span class="min-w-0 flex-1">{{ loadError }}</span>
@@ -454,6 +481,20 @@ defineExpose({ refresh, expand });
         Можно перетащить файлы сюда или вставить изображение через Ctrl+V / Cmd+V.
       </p>
 
+      <div v-if="readonly && loaded" class="flex justify-end">
+        <button
+          type="button"
+          class="inline-flex min-h-10 items-center gap-1.5 rounded-lg px-2.5 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100 hover:text-teal-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-teal-300"
+          :disabled="loading"
+          title="Обновить защищённые ссылки на файлы"
+          aria-label="Обновить фото и файлы"
+          @click="refresh"
+        >
+          <span class="material-icons-round text-[18px]" :class="loading ? 'animate-spin' : ''" aria-hidden="true">refresh</span>
+          Обновить
+        </button>
+      </div>
+
       <div v-if="actionError" class="mt-3 flex items-start gap-2 text-sm text-red-600 dark:text-red-300" role="alert">
         <span class="material-icons-round mt-0.5 text-[18px]" aria-hidden="true">warning</span>
         <span>{{ actionError }}</span>
@@ -463,23 +504,35 @@ defineExpose({ refresh, expand });
         <span>{{ actionMessage }}</span>
       </div>
 
-      <div v-if="loading && !loaded" class="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4" aria-label="Загрузка файлов">
+      <div
+        v-if="loading && !loaded"
+        class="mt-4 grid grid-cols-2 gap-2"
+        :class="{ 'sm:grid-cols-3 lg:grid-cols-4': !embedded }"
+        aria-label="Загрузка файлов"
+      >
         <div v-for="index in 4" :key="index" class="aspect-[4/3] animate-pulse rounded-lg bg-slate-100 dark:bg-slate-800" />
       </div>
 
       <div v-else-if="loaded && !items.length" class="mt-4 border-t border-dashed border-slate-300 py-8 text-center dark:border-slate-700">
         <span class="material-icons-round text-[34px] text-slate-300 dark:text-slate-600" aria-hidden="true">add_photo_alternate</span>
         <p class="mt-1 text-sm font-semibold text-slate-800 dark:text-slate-200">Фото и документов пока нет</p>
-        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Первый загруженный файл сразу появится здесь.</p>
+        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          {{ readonly ? 'В этой заявке нет доступных вложений.' : 'Первый загруженный файл сразу появится здесь.' }}
+        </p>
       </div>
 
       <div v-if="imageItems.length" class="mt-4">
         <h4 class="mb-2 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">Изображения</h4>
-        <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        <div class="grid grid-cols-2 gap-2" :class="{ 'sm:grid-cols-3 lg:grid-cols-4': !embedded }">
           <article v-for="item in imageItems" :key="attachmentKey(item)" class="group relative min-w-0 overflow-hidden rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50">
-            <button type="button" class="block w-full text-left" @click="openViewer(item)">
+            <button
+              type="button"
+              class="block w-full text-left"
+              :aria-label="`Открыть ${item.caption || item.filename}`"
+              @click="openViewer(item)"
+            >
               <span class="flex aspect-[4/3] items-center justify-center overflow-hidden bg-slate-100 dark:bg-slate-950">
-                <img v-if="previewUrls[attachmentKey(item)]" :src="previewUrls[attachmentKey(item)]" :alt="item.caption || item.filename" loading="lazy" class="h-full w-full object-cover" @error="delete previewUrls[attachmentKey(item)]" />
+                <img v-if="previewUrls[attachmentKey(item)]" :src="previewUrls[attachmentKey(item)]" :alt="item.caption || item.filename" loading="lazy" referrerpolicy="no-referrer" class="h-full w-full object-cover" @error="delete previewUrls[attachmentKey(item)]" />
                 <span v-else class="material-icons-round text-[34px] text-slate-300 dark:text-slate-600" aria-hidden="true">image</span>
               </span>
               <span class="block min-w-0 p-2">

--- a/manager_frontend/src/components/service-attachments/ServiceAttachmentViewer.vue
+++ b/manager_frontend/src/components/service-attachments/ServiceAttachmentViewer.vue
@@ -123,7 +123,8 @@ const downloadOriginal = async () => {
     if (requestId !== downloadRequestId || activeItem.value?.id !== attachmentId) return;
     const anchor = document.createElement('a');
     anchor.href = response.url;
-    anchor.rel = 'noopener';
+    anchor.rel = 'noopener noreferrer';
+    anchor.referrerPolicy = 'no-referrer';
     anchor.download = item.filename;
     document.body.appendChild(anchor);
     anchor.click();
@@ -138,10 +139,31 @@ const downloadOriginal = async () => {
 
 const onKeydown = (event: KeyboardEvent) => {
   if (!isOpen.value) return;
-  if (event.key === 'ArrowLeft') showPrevious();
-  if (event.key === 'ArrowRight') showNext();
-  if (isImage.value && (event.key === '+' || event.key === '=')) setZoom(zoom.value + 0.25);
-  if (isImage.value && event.key === '-') setZoom(zoom.value - 0.25);
+  if (event.ctrlKey || event.metaKey || event.altKey) return;
+  const target = event.target;
+  if (
+    target instanceof HTMLElement
+    && (target.matches('input, textarea, select, audio, video, [contenteditable="true"]') || target.isContentEditable)
+  ) return;
+
+  let handled = false;
+  if (event.key === 'ArrowLeft' && hasPrevious.value) {
+    showPrevious();
+    handled = true;
+  }
+  if (event.key === 'ArrowRight' && hasNext.value) {
+    showNext();
+    handled = true;
+  }
+  if (isImage.value && (event.key === '+' || event.key === '=')) {
+    setZoom(zoom.value + 0.25);
+    handled = true;
+  }
+  if (isImage.value && event.key === '-') {
+    setZoom(zoom.value - 0.25);
+    handled = true;
+  }
+  if (handled) event.preventDefault();
 };
 
 useDialogA11y({
@@ -176,7 +198,7 @@ onBeforeUnmount(() => {
     <div
       v-if="isOpen && activeItem"
       ref="dialogRef"
-      class="fixed inset-0 z-[120] flex flex-col bg-slate-950/95 text-white"
+      class="fixed inset-0 z-[120] flex min-h-[100dvh] flex-col bg-slate-950/95 text-white"
       role="dialog"
       aria-modal="true"
       :aria-label="`Просмотр файла ${activeItem.filename}`"
@@ -204,7 +226,7 @@ onBeforeUnmount(() => {
 
         <button
           v-if="accessUrl"
-          class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-white/10"
+          class="inline-flex h-11 w-11 items-center justify-center rounded-lg hover:bg-white/10 sm:h-9 sm:w-9"
           type="button"
           :disabled="downloadLoading"
           title="Скачать оригинал"
@@ -213,7 +235,7 @@ onBeforeUnmount(() => {
         >
           <span class="material-icons-round text-[21px]" :class="{ 'animate-pulse': downloadLoading }" aria-hidden="true">download</span>
         </button>
-        <button ref="closeButtonRef" type="button" class="inline-flex h-9 w-9 items-center justify-center rounded-lg hover:bg-white/10" title="Закрыть" aria-label="Закрыть" @click="close">
+        <button ref="closeButtonRef" type="button" class="inline-flex h-11 w-11 items-center justify-center rounded-lg hover:bg-white/10 sm:h-9 sm:w-9" title="Закрыть" aria-label="Закрыть" @click="close">
           <span class="material-icons-round text-[22px]" aria-hidden="true">close</span>
         </button>
       </header>
@@ -239,6 +261,7 @@ onBeforeUnmount(() => {
           <img
             :src="accessUrl"
             :alt="activeItem.caption || activeItem.filename"
+            referrerpolicy="no-referrer"
             class="max-h-full max-w-full select-none object-contain transition-transform duration-150"
             :style="{ transform: `scale(${zoom})` }"
             draggable="false"
@@ -246,7 +269,7 @@ onBeforeUnmount(() => {
         </div>
 
         <div v-else-if="accessUrl && isPdf" class="h-full p-2 sm:p-4">
-          <iframe :src="accessUrl" :title="activeItem.filename" class="h-full w-full rounded-lg bg-white" />
+          <iframe :src="accessUrl" :title="activeItem.filename" referrerpolicy="no-referrer" class="h-full w-full rounded-lg bg-white" />
         </div>
 
         <div v-else-if="accessUrl && isAudio" class="flex h-full items-center justify-center p-5">
@@ -265,7 +288,7 @@ onBeforeUnmount(() => {
             <span class="material-icons-round text-[64px] text-slate-300" aria-hidden="true">{{ fileIcon }}</span>
             <p class="mt-3 truncate text-base font-semibold">{{ activeItem.filename }}</p>
             <p class="mt-1 text-sm text-slate-300">Предпросмотр этого формата недоступен.</p>
-            <a :href="accessUrl" target="_blank" rel="noopener" class="mt-5 inline-flex items-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-slate-900">
+            <a :href="accessUrl" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer" class="mt-5 inline-flex items-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-slate-900">
               <span class="material-icons-round text-[19px]" aria-hidden="true">open_in_new</span>
               Открыть файл
             </a>
@@ -302,11 +325,11 @@ onBeforeUnmount(() => {
             <span v-if="formatAttachmentSize(activeItem.size_bytes)"> · {{ formatAttachmentSize(activeItem.size_bytes) }}</span>
           </p>
           <div v-if="isImage" class="flex items-center gap-1 sm:hidden">
-            <button type="button" class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-white/10 disabled:opacity-40" :disabled="zoom <= 0.5" aria-label="Уменьшить" @click="setZoom(zoom - 0.25)"><span class="material-icons-round text-[18px]" aria-hidden="true">remove</span></button>
+            <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/10 disabled:opacity-40" :disabled="zoom <= 0.5" aria-label="Уменьшить" @click="setZoom(zoom - 0.25)"><span class="material-icons-round text-[18px]" aria-hidden="true">remove</span></button>
             <button type="button" class="min-w-12 text-xs font-semibold" @click="setZoom(1)">{{ Math.round(zoom * 100) }}%</button>
-            <button type="button" class="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-white/10 disabled:opacity-40" :disabled="zoom >= 3" aria-label="Увеличить" @click="setZoom(zoom + 0.25)"><span class="material-icons-round text-[18px]" aria-hidden="true">add</span></button>
+            <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-white/10 disabled:opacity-40" :disabled="zoom >= 3" aria-label="Увеличить" @click="setZoom(zoom + 0.25)"><span class="material-icons-round text-[18px]" aria-hidden="true">add</span></button>
           </div>
-          <button type="button" class="inline-flex h-8 w-8 items-center justify-center rounded-lg hover:bg-white/10" :aria-expanded="detailsOpen" title="Сведения о файле" aria-label="Сведения о файле" @click="detailsOpen = !detailsOpen">
+          <button type="button" class="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-white/10" :aria-expanded="detailsOpen" title="Сведения о файле" aria-label="Сведения о файле" @click="detailsOpen = !detailsOpen">
             <span class="material-icons-round text-[20px]" aria-hidden="true">info</span>
           </button>
         </div>

--- a/manager_frontend/tests/lead-inbox-attachments.spec.ts
+++ b/manager_frontend/tests/lead-inbox-attachments.spec.ts
@@ -1,0 +1,239 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LeadsInboxItemResponse } from '../src/api';
+import LeadInboxCard from '../src/components/leads/LeadInboxCard.vue';
+import { serviceAttachmentsApi } from '../src/components/service-attachments/api';
+import type { ServiceAttachmentItem } from '../src/components/service-attachments/types';
+
+vi.mock('../src/components/service-attachments/api', () => ({
+  serviceAttachmentsApi: {
+    list: vi.fn(),
+    listEquipment: vi.fn(),
+    upload: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    getAccess: vi.fn(),
+  },
+}));
+
+const lead: LeadsInboxItemResponse = {
+  id: 42,
+  status: 'new_lead',
+  is_new: true,
+  customer_name: 'Анна',
+  phone: '+375291112233',
+  source: 'site',
+  comment: 'Нужно оценить место монтажа',
+  created_at: '2026-07-28T09:00:00Z',
+  attachment_count: 1,
+};
+
+const attachment: ServiceAttachmentItem = {
+  id: 701,
+  file_kind: 'image',
+  category: 'installation_indoor',
+  filename: 'indoor-unit.webp',
+  mime_type: 'image/webp',
+  size_bytes: 128_000,
+  caption: 'Место внутреннего блока',
+  transcript: null,
+  source: 'website_installation_estimate',
+  processing_status: 'ready',
+  processing_error: null,
+  captured_at: null,
+  created_at: '2026-07-28T09:00:00Z',
+  preview_available: true,
+};
+
+const secondAttachment: ServiceAttachmentItem = {
+  ...attachment,
+  id: 702,
+  filename: 'facade.webp',
+  caption: 'Фасад здания',
+  category: 'installation_facade',
+};
+
+const listMock = vi.mocked(serviceAttachmentsApi.list);
+const getAccessMock = vi.mocked(serviceAttachmentsApi.getAccess);
+const uploadMock = vi.mocked(serviceAttachmentsApi.upload);
+const updateMock = vi.mocked(serviceAttachmentsApi.update);
+const removeMock = vi.mocked(serviceAttachmentsApi.remove);
+const mountedWrappers: VueWrapper[] = [];
+
+const mountCard = () => {
+  const wrapper = mount(LeadInboxCard, {
+    attachTo: document.body,
+    props: { item: lead },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+};
+
+const openAttachments = async (wrapper: VueWrapper) => {
+  const trigger = wrapper.get(`button[aria-controls="lead-attachments-${lead.id}"]`);
+  await trigger.trigger('click');
+  await flushPromises();
+  return trigger;
+};
+
+const expectNoWrites = () => {
+  expect(uploadMock).not.toHaveBeenCalled();
+  expect(updateMock).not.toHaveBeenCalled();
+  expect(removeMock).not.toHaveBeenCalled();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listMock.mockResolvedValue({ items: [attachment], total: 1 });
+  getAccessMock.mockImplementation(async (_attachmentId, variant) => ({
+    url: `https://private.example/${variant}.webp`,
+    expires_at: '2026-07-28T09:05:00Z',
+    variant,
+  }));
+});
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) wrapper.unmount();
+  document.body.innerHTML = '';
+});
+
+describe('LeadInboxCard read-only attachments', () => {
+  it('opens photos before qualification and restores focus after the viewer closes', async () => {
+    const wrapper = mountCard();
+    expect(wrapper.find('[data-testid="lead-readonly-attachments"]').exists()).toBe(false);
+
+    const disclosure = await openAttachments(wrapper);
+
+    expect(disclosure.attributes('aria-expanded')).toBe('true');
+    expect(listMock).toHaveBeenCalledWith(lead.id);
+    expect(wrapper.get('[data-testid="lead-readonly-attachments"]').text()).toContain(attachment.caption);
+    expect(wrapper.find('input[type="file"]').exists()).toBe(false);
+
+    const panel = wrapper.get('[data-testid="lead-readonly-attachments"] section');
+    const droppedFile = new File(['image'], 'dropped.png', { type: 'image/png' });
+    await panel.trigger('drop', { dataTransfer: { files: [droppedFile] } });
+    await panel.trigger('paste', {
+      clipboardData: {
+        items: [{ kind: 'file', type: 'image/png', getAsFile: () => droppedFile }],
+      },
+    });
+
+    const photoButton = wrapper.get(`button[aria-label="Открыть ${attachment.caption}"]`);
+    (photoButton.element as HTMLButtonElement).focus();
+    await photoButton.trigger('click');
+    await flushPromises();
+
+    const viewer = document.body.querySelector<HTMLElement>('[role="dialog"]');
+    expect(viewer).not.toBeNull();
+    expect(viewer?.querySelector('img')?.getAttribute('src')).toBe('https://private.example/original.webp');
+    expect(viewer?.querySelector('img')?.getAttribute('referrerpolicy')).toBe('no-referrer');
+
+    viewer?.querySelector<HTMLButtonElement>('button[aria-label="Закрыть"]')?.click();
+    await flushPromises();
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(photoButton.element);
+    expect(wrapper.emitted('qualify')).toBeUndefined();
+    expect(wrapper.emitted('reject')).toBeUndefined();
+    expect(wrapper.emitted('no-answer')).toBeUndefined();
+    expectNoWrites();
+
+    listMock.mockRejectedValueOnce(new Error('Обновление временно недоступно'));
+    await wrapper.get('button[aria-label="Обновить фото и файлы"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.get('img[referrerpolicy="no-referrer"]').attributes('src'))
+      .toBe('https://private.example/preview.webp');
+
+    await disclosure.trigger('click');
+    expect(wrapper.find('[data-testid="lead-readonly-attachments"]').exists()).toBe(false);
+    await wrapper.get('button[title="Квалифицировать (в сделку)"]').trigger('click');
+    await wrapper.get('button[title="Отмена / В архив"]').trigger('click');
+    expect(wrapper.emitted('qualify')).toEqual([[lead]]);
+    expect(wrapper.emitted('reject')).toEqual([[lead]]);
+    expectNoWrites();
+  });
+
+  it('shows a retryable list error without changing CRM state', async () => {
+    listMock
+      .mockRejectedValueOnce(new Error('Список временно недоступен'))
+      .mockResolvedValueOnce({ items: [], total: 0 });
+    const wrapper = mountCard();
+
+    await openAttachments(wrapper);
+
+    expect(wrapper.get('[role="alert"]').text()).toContain('Список временно недоступен');
+    const retry = wrapper.findAll('button').find((button) => button.text().includes('Повторить'));
+    expect(retry).toBeDefined();
+    await retry?.trigger('click');
+    await flushPromises();
+
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).toContain('В этой заявке нет доступных вложений');
+    expectNoWrites();
+  });
+
+  it('keeps access failures inside the viewer and retries with GET only', async () => {
+    getAccessMock.mockImplementation(async (_attachmentId, variant) => {
+      if (variant === 'preview') {
+        return {
+          url: 'https://private.example/preview.webp',
+          expires_at: '2026-07-28T09:05:00Z',
+          variant,
+        };
+      }
+      throw new Error('Приватный файл временно недоступен');
+    });
+    const wrapper = mountCard();
+
+    await openAttachments(wrapper);
+    await wrapper.get(`button[aria-label="Открыть ${attachment.caption}"]`).trigger('click');
+    await flushPromises();
+
+    const viewer = document.body.querySelector<HTMLElement>('[role="dialog"]');
+    expect(viewer?.textContent).toContain('Файл не открылся');
+    expect(viewer?.textContent).toContain('Приватный файл временно недоступен');
+
+    viewer?.querySelector<HTMLButtonElement>('button')?.focus();
+    const retry = [...(viewer?.querySelectorAll<HTMLButtonElement>('button') || [])]
+      .find((button) => button.textContent?.includes('Повторить'));
+    retry?.click();
+    await flushPromises();
+
+    const originalAccessCalls = getAccessMock.mock.calls
+      .filter(([, variant]) => variant === 'original');
+    expect(originalAccessCalls).toHaveLength(2);
+    expectNoWrites();
+  });
+
+  it('leaves browser shortcuts untouched while the viewer is open', async () => {
+    listMock.mockResolvedValue({ items: [attachment, secondAttachment], total: 2 });
+    const wrapper = mountCard();
+
+    await openAttachments(wrapper);
+    await wrapper.get(`button[aria-label="Открыть ${attachment.caption}"]`).trigger('click');
+    await flushPromises();
+
+    const ctrlZoom = new KeyboardEvent('keydown', {
+      key: '+',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(ctrlZoom);
+    const altNext = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(altNext);
+    await flushPromises();
+
+    const viewer = document.body.querySelector<HTMLElement>('[role="dialog"]');
+    expect(ctrlZoom.defaultPrevented).toBe(false);
+    expect(altNext.defaultPrevented).toBe(false);
+    expect(viewer?.textContent).toContain(attachment.filename);
+    expect(viewer?.textContent).toContain('100%');
+    expectNoWrites();
+  });
+});


### PR DESCRIPTION
## Summary

- make `Фото: N` on an incoming lead a keyboard-accessible disclosure
- show the existing attachment panel inline in strict read-only mode before qualification
- reuse the protected Manager list/access endpoints and the existing fullscreen viewer
- harden read-only handlers against upload, paste, drop, edit, and delete paths
- keep signed media URLs in memory only, add no-referrer handling, GET-only refresh, focus return, and mobile touch improvements
- add Vue component tests to CI for opening, retryable errors, focus/shortcuts, independent qualification/rejection events, and absence of attachment writes

## Safety

Viewing, closing, retrying, and navigating perform only attachment `GET` requests. The flow does not patch the lead, create a customer/order, or submit qualification state. No public URL, storage layer, or second attachment contract was added.

## Validation

- `npm ci`
- `npm run build`
- `npm run test:components` — 4 passed
- `.venv/bin/pytest tests/unit/test_service_attachment_service.py tests/unit/test_installation_estimate_lead_service.py -q` — 11 passed
- `git diff --check`
- independent UI, test, and security reviews

Closes #847