### PR TITLE
fix: complete Yandex feed image backfill

### DIFF
--- a/docs/yandex-business-feed.md
+++ b/docs/yandex-business-feed.md
@@ -66,6 +66,12 @@ python3 scripts/backfill_yandex_feed_images.py --execute --limit 100
 повторно. Для точечной проверки доступны `--product-id`, а `--force` нужен
 только при намеренной пересборке.
 
+Legacy-товары со сторонним `main_image` при execute сначала проходят общую
+SSRF-защищённую загрузку MediaLibrary. Исходник сохраняется как `original` в
+настроенном product-media storage, но `Product.main_image` и URL изображения
+на сайте не изменяются. Для feed-варианта разрешены старые исходники до 70 MP;
+общий лимит остальных product-вариантов остаётся 40 MP.
+
 Описания преобразуются в plain text: удаляются `style`, `script`, `noscript`,
 HTML-разметка и ведущие CSS-блоки, декодируются entities, после чего текст
 нормализуется и ограничивается по длине.

--- a/services/media_library_service.py
+++ b/services/media_library_service.py
@@ -162,13 +162,7 @@ class MediaLibraryService:
         tags: list[str] | None,
         created_by: str | None,
     ) -> dict:
-        normalized_url = MediaLibraryService._validate_remote_image_url(url)
-        try:
-            content, filename = await MediaLibraryService._download_remote_image(normalized_url)
-        except httpx.HTTPStatusError as exc:
-            raise ValueError(f"Remote image returned HTTP {exc.response.status_code}") from exc
-        except httpx.HTTPError as exc:
-            raise ValueError("Remote image could not be downloaded") from exc
+        content, filename = await MediaLibraryService.download_remote_image(url)
         return await MediaLibraryService.upload_assets(
             session=session,
             files=[(filename, content)],
@@ -176,6 +170,19 @@ class MediaLibraryService:
             tags=tags,
             created_by=created_by,
         )
+
+    @staticmethod
+    async def download_remote_image(url: str) -> tuple[bytes, str]:
+        """Download an operator-supplied image through the shared SSRF guard."""
+        normalized_url = MediaLibraryService._validate_remote_image_url(url)
+        try:
+            return await MediaLibraryService._download_remote_image(normalized_url)
+        except httpx.HTTPStatusError as exc:
+            raise ValueError(
+                f"Remote image returned HTTP {exc.response.status_code}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ValueError("Remote image could not be downloaded") from exc
 
     @staticmethod
     async def backfill_referenced_assets(

--- a/services/product_image_processing_provider.py
+++ b/services/product_image_processing_provider.py
@@ -33,6 +33,7 @@ FULL_MAX_EDGE = 1800
 YANDEX_FEED_CANVAS_SIZE = (800, 800)
 YANDEX_FEED_JPEG_QUALITY = 85
 MAX_SOURCE_PIXELS = 40_000_000
+MAX_YANDEX_FEED_SOURCE_PIXELS = 70_000_000
 BACKGROUND_REMOVAL_PROVIDER_ENV = "BACKGROUND_REMOVAL_PROVIDER"
 BACKGROUND_REMOVAL_REMBG_MODEL_ENV = "BACKGROUND_REMOVAL_REMBG_MODEL"
 BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS_ENV = "BACKGROUND_REMOVAL_REMBG_PRELOAD_MODELS"
@@ -548,7 +549,15 @@ def _process_image_bytes(
         if context is not None
         else ProductImageVariantType.PROCESSED.value
     )
-    image = _open_source_image(source_content)
+    max_source_pixels = (
+        MAX_YANDEX_FEED_SOURCE_PIXELS
+        if variant_type == ProductImageVariantType.YANDEX_FEED.value
+        else MAX_SOURCE_PIXELS
+    )
+    image = _open_source_image(
+        source_content,
+        max_source_pixels=max_source_pixels,
+    )
     image = _trim_transparent_borders(image)
 
     if variant_type == ProductImageVariantType.YANDEX_FEED.value:
@@ -576,13 +585,17 @@ def _process_image_bytes(
     )
 
 
-def _open_source_image(source_content: bytes) -> Image.Image:
+def _open_source_image(
+    source_content: bytes,
+    *,
+    max_source_pixels: int = MAX_SOURCE_PIXELS,
+) -> Image.Image:
     if not source_content:
         raise ValueError("Source image is empty")
 
     try:
         with Image.open(BytesIO(source_content)) as image:
-            if image.width * image.height > MAX_SOURCE_PIXELS:
+            if image.width * image.height > max_source_pixels:
                 raise ValueError("Source image is too large for safe processing")
             transposed = ImageOps.exif_transpose(image)
             srgb = _convert_to_srgb(transposed)

--- a/services/product_image_variant_service.py
+++ b/services/product_image_variant_service.py
@@ -260,6 +260,7 @@ class ProductImageVariantService:
         processor: ProductImageProcessor | None = None,
         rembg_model: str | None = None,
         source_url_override: str | None = None,
+        source_content_override: bytes | None = None,
         force: bool = False,
         commit: bool = True,
     ) -> dict[str, Any]:
@@ -286,7 +287,11 @@ class ProductImageVariantService:
 
         source_url = str(source_url_override or image.url or "").strip()
         try:
-            source_content = await ProductImageVariantService._source_content_for_url(source_url)
+            source_content = (
+                source_content_override
+                if source_content_override is not None
+                else await ProductImageVariantService._source_content_for_url(source_url)
+            )
         except Exception as exc:
             variant.processing_status = ProductImageProcessingStatus.FAILED.value
             variant.processing_stage = ProductImageProcessingStage.ORIGINAL_INGEST.value

--- a/services/yandex_feed_image_service.py
+++ b/services/yandex_feed_image_service.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from io import BytesIO
 from typing import Any
 from urllib.parse import urlsplit
 
+from PIL import Image
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from models import Product, ProductImage, ProductImageVariant
+from services.media_library_service import MediaLibraryService
 from services.media_storage_service import ProductMediaStorage
 from services.product_image_processing_contract import (
     ProductImageProcessingProvider,
@@ -83,13 +86,23 @@ class YandexFeedImageService:
                         )
                         session.add(image)
                         await session.flush()
+                    source_url = item["source_url"]
+                    source_content: bytes | None = None
+                    if cls._is_external_source(source_url):
+                        source_url, source_content = await cls._ingest_external_original(
+                            session,
+                            image=image,
+                            source_url=source_url,
+                            storage=storage,
+                        )
                     variant = await ProductImageVariantService.reprocess_variant(
                         session,
                         product_image_id=int(image.id),
                         variant_type=cls.VARIANT_TYPE,
                         provider=ProductImageProcessingProvider.NOOP.value,
                         storage=storage,
-                        source_url_override=item["source_url"],
+                        source_url_override=source_url,
+                        source_content_override=source_content,
                         force=force,
                         commit=False,
                     )
@@ -229,6 +242,49 @@ class YandexFeedImageService:
             ),
             None,
         )
+
+    @staticmethod
+    def _is_external_source(url: str) -> bool:
+        normalized = str(url or "").strip()
+        return normalized.startswith(("http://", "https://")) and not (
+            ProductImageVariantService._is_configured_remote_media_url(normalized)
+        )
+
+    @classmethod
+    async def _ingest_external_original(
+        cls,
+        session: AsyncSession,
+        *,
+        image: ProductImage,
+        source_url: str,
+        storage: ProductMediaStorage | None,
+    ) -> tuple[str, bytes]:
+        content, _ = await MediaLibraryService.download_remote_image(source_url)
+        extension, width, height = cls._source_image_metadata(content)
+        original = await ProductImageVariantService.ensure_original_variant(
+            session,
+            image,
+            storage=storage,
+            source_content=content,
+            extension=extension,
+            width=width,
+            height=height,
+        )
+        await session.flush()
+        return str(original.url), content
+
+    @staticmethod
+    def _source_image_metadata(content: bytes) -> tuple[str, int, int]:
+        with Image.open(BytesIO(content)) as image:
+            image_format = str(image.format or "").strip().lower()
+            extension = {
+                "jpeg": "jpg",
+                "png": "png",
+                "webp": "webp",
+            }.get(image_format)
+            if extension is None:
+                raise ValueError("Remote source image format is not supported")
+            return extension, image.width, image.height
 
     @classmethod
     def _source_for_image(

--- a/tests/unit/test_yandex_feed_images.py
+++ b/tests/unit/test_yandex_feed_images.py
@@ -9,6 +9,8 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel, select
 
 from models import Product, ProductImage, ProductImageVariant
+from services import product_image_processing_provider
+from services.media_library_service import MediaLibraryService
 from services.media_storage_service import StoredMediaObject
 from services.product_image_processing_contract import (
     ProductImageProcessingStatus,
@@ -209,6 +211,38 @@ async def test_yandex_feed_applies_exif_orientation_and_strips_metadata():
 
 
 @pytest.mark.asyncio
+async def test_yandex_feed_has_a_separate_legacy_source_pixel_limit(monkeypatch):
+    monkeypatch.setattr(product_image_processing_provider, "MAX_SOURCE_PIXELS", 100)
+    monkeypatch.setattr(
+        product_image_processing_provider,
+        "MAX_YANDEX_FEED_SOURCE_PIXELS",
+        200,
+    )
+    source = _image_bytes()
+    processor = NoopProductImageProcessor()
+
+    result = await processor.process(
+        source_content=source,
+        context=ProductImageProcessingContext(
+            product_image_id=1,
+            source_url="/media/products/shared/legacy-source.png",
+            variant_type=ProductImageVariantType.YANDEX_FEED.value,
+        ),
+    )
+
+    assert result.extension == "jpg"
+    with pytest.raises(ValueError, match="too large for safe processing"):
+        await processor.process(
+            source_content=source,
+            context=ProductImageProcessingContext(
+                product_image_id=1,
+                source_url="/media/products/shared/legacy-source.png",
+                variant_type=ProductImageVariantType.CARD.value,
+            ),
+        )
+
+
+@pytest.mark.asyncio
 async def test_yandex_feed_backfill_is_idempotent(
     sqlite_session,
     tmp_path: Path,
@@ -245,6 +279,60 @@ async def test_yandex_feed_backfill_is_idempotent(
     assert second["planned"] == 0
     assert second["up_to_date"] == 1
     assert len(storage.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_yandex_feed_ingests_external_source_without_changing_product_urls(
+    sqlite_session,
+    monkeypatch,
+):
+    product = await _make_product(sqlite_session, 97)
+    source_url = "https://supplier.example.test/product.png"
+    product.main_image = source_url
+    image = ProductImage(product_id=product.id, url=source_url)
+    sqlite_session.add_all([product, image])
+    await sqlite_session.commit()
+    source_content = _image_bytes()
+
+    async def download_remote_image(url: str):
+        assert url == source_url
+        return source_content, "product.png"
+
+    monkeypatch.setattr(
+        MediaLibraryService,
+        "download_remote_image",
+        download_remote_image,
+    )
+    storage = _FakeProductMediaStorage()
+
+    result = await YandexFeedImageService.backfill(
+        sqlite_session,
+        execute=True,
+        product_id=product.id,
+        storage=storage,
+    )
+    variants = (
+        await sqlite_session.execute(
+            select(ProductImageVariant)
+            .where(ProductImageVariant.product_image_id == image.id)
+            .order_by(ProductImageVariant.variant_type)
+        )
+    ).scalars().all()
+    variants_by_type = {variant.variant_type: variant for variant in variants}
+    original = variants_by_type[ProductImageVariantType.ORIGINAL.value]
+    yandex_feed = variants_by_type[ProductImageVariantType.YANDEX_FEED.value]
+
+    assert result["processed"] == 1
+    assert result["errors"] == []
+    assert product.main_image == source_url
+    assert image.url == source_url
+    assert original.url.endswith(".png")
+    assert yandex_feed.url.endswith(".jpg")
+    assert yandex_feed.source_url == original.url
+    assert [call["variant_type"] for call in storage.calls] == [
+        ProductImageVariantType.ORIGINAL.value,
+        ProductImageVariantType.YANDEX_FEED.value,
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ingest legacy external product images through the existing SSRF-protected MediaLibrary downloader before generating Yandex variants
- preserve Product.main_image and ProductImage.url while storing an R2 original variant
- allow up to 70 MP only for the 800x800 Yandex feed derivative; keep the general 40 MP product-image limit

## Production evidence
- initial backfill produced 978/1137 ready JPEG variants
- remaining failures: 130 legacy sources between 40 MP and 62.52 MP, 29 external URLs not yet ingested
- R2 credentials on the writable primary were synchronized from the verified standby pair; write/delete probe passed

## Validation
- 70 focused unit tests passed
- 4 PostgreSQL Yandex Business integration tests passed
- compileall and git diff --check passed