### PR TITLE
feat: safely backfill Lead and Order tenant scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,13 @@ Production server intentionally runs from Docker images only (no git checkout in
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_customer_branches.py --min-orders 2 --execute`
    - CRM branch backfill for one customer (recommended first run):
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/backfill_customer_branches.py --customer-id 123 --execute`
+   - Lead/Order tenant-scope backfill (manual-only; run inside the active app
+     container on the current Patroni primary):
+     - Canary dry-run: `python3 scripts/backfill_lead_order_tenant_scope.py --limit 1`
+     - Canary execute: paste the exact `reviewed_execute_command` printed by
+       the dry-run.
+     - Final bounded batch: repeat dry-run/execute with `--limit 1000` until
+       the report prints `contract_ready=true`.
    - Normalize:
      - `docker compose -f /opt/air-api/docker-compose.prod.yml exec -T app python3 scripts/normalize_legacy.py`
    - Backfill brand/series:
@@ -161,6 +168,8 @@ Production server intentionally runs from Docker images only (no git checkout in
 4. Policy:
    - Cleanup is manual and explicit only.
    - CRM branch backfill is manual-only and starts from dry-run.
+   - Tenant-scope backfill is manual-only, primary-only, starts from dry-run
+     and requires its exact plan token for execute.
    - Post-deploy smoke-check must pass (`/health`, `/api/v1/products?limit=5`, `/api/v1/filters/config`) before considering deploy successful.
 
 ## Notes

--- a/crud/tenant_scope_backfill.py
+++ b/crud/tenant_scope_backfill.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Sequence
+
+from sqlalchemy import and_, exists, func, or_, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models import Lead, Order, Storefront, Tenant
+from models.tenancy import TenantScope
+
+
+@dataclass(frozen=True)
+class TenantScopeEntityCounts:
+    entity: str
+    total: int
+    legacy_null: int
+    target_scoped: int
+    partial: int
+    unexpected_scoped: int
+    unknown_tenant: int
+    unknown_storefront: int
+    cross_tenant: int
+
+    def to_dict(self) -> dict[str, int | str]:
+        return asdict(self)
+
+
+class TenantScopeBackfillDAO:
+    """Persistence primitives for the bounded Lead/Order provenance backfill."""
+
+    LOCK_KEY = "mvn:lead-order-tenant-scope-backfill:v1"
+
+    @staticmethod
+    def entity_name(entity: Any) -> str:
+        if entity is Lead:
+            return "lead"
+        if entity is Order:
+            return "order"
+        raise ValueError("Tenant scope backfill supports only Lead and Order")
+
+    @staticmethod
+    def legacy_clause(entity: Any):
+        return and_(
+            entity.tenant_id.is_(None),
+            entity.storefront_id.is_(None),
+        )
+
+    @staticmethod
+    async def try_acquire_transaction_lock(session: AsyncSession) -> bool:
+        if session.get_bind().dialect.name != "postgresql":
+            return True
+        acquired = await session.scalar(
+            text("SELECT pg_try_advisory_xact_lock(hashtext(:lock_key))"),
+            {"lock_key": TenantScopeBackfillDAO.LOCK_KEY},
+        )
+        return bool(acquired)
+
+    @staticmethod
+    async def inspect(
+        session: AsyncSession,
+        *,
+        entity: Any,
+        tenant_scope: TenantScope,
+    ) -> TenantScopeEntityCounts:
+        legacy = TenantScopeBackfillDAO.legacy_clause(entity)
+        partial = or_(
+            and_(
+                entity.tenant_id.is_(None),
+                entity.storefront_id.is_not(None),
+            ),
+            and_(
+                entity.tenant_id.is_not(None),
+                entity.storefront_id.is_(None),
+            ),
+        )
+        target_scoped = and_(
+            entity.tenant_id == tenant_scope.tenant_id,
+            entity.storefront_id == tenant_scope.storefront_id,
+        )
+        unexpected_scoped = and_(
+            entity.tenant_id.is_not(None),
+            entity.storefront_id.is_not(None),
+            or_(
+                entity.tenant_id != tenant_scope.tenant_id,
+                entity.storefront_id != tenant_scope.storefront_id,
+            ),
+        )
+
+        tenant_exists = exists(
+            select(Tenant.id).where(Tenant.id == entity.tenant_id)
+        ).correlate(entity)
+        storefront_exists = exists(
+            select(Storefront.id).where(Storefront.id == entity.storefront_id)
+        ).correlate(entity)
+        storefront_matches_tenant = exists(
+            select(Storefront.id).where(
+                Storefront.id == entity.storefront_id,
+                Storefront.tenant_id == entity.tenant_id,
+            )
+        ).correlate(entity)
+
+        row = (
+            await session.execute(
+                select(
+                    func.count(entity.id),
+                    func.count(entity.id).filter(legacy),
+                    func.count(entity.id).filter(target_scoped),
+                    func.count(entity.id).filter(partial),
+                    func.count(entity.id).filter(unexpected_scoped),
+                    func.count(entity.id).filter(
+                        entity.tenant_id.is_not(None),
+                        ~tenant_exists,
+                    ),
+                    func.count(entity.id).filter(
+                        entity.storefront_id.is_not(None),
+                        ~storefront_exists,
+                    ),
+                    func.count(entity.id).filter(
+                        entity.tenant_id.is_not(None),
+                        entity.storefront_id.is_not(None),
+                        tenant_exists,
+                        storefront_exists,
+                        ~storefront_matches_tenant,
+                    ),
+                ).select_from(entity)
+            )
+        ).one()
+        values = [int(value or 0) for value in row]
+        return TenantScopeEntityCounts(
+            entity=TenantScopeBackfillDAO.entity_name(entity),
+            total=values[0],
+            legacy_null=values[1],
+            target_scoped=values[2],
+            partial=values[3],
+            unexpected_scoped=values[4],
+            unknown_tenant=values[5],
+            unknown_storefront=values[6],
+            cross_tenant=values[7],
+        )
+
+    @staticmethod
+    async def list_legacy_ids(
+        session: AsyncSession,
+        *,
+        entity: Any,
+        limit: int,
+        lock_rows: bool,
+    ) -> list[int]:
+        statement = (
+            select(entity.id)
+            .where(TenantScopeBackfillDAO.legacy_clause(entity))
+            .order_by(entity.id.asc())
+            .limit(limit)
+        )
+        if lock_rows and session.get_bind().dialect.name == "postgresql":
+            statement = statement.with_for_update(nowait=True)
+        rows = (await session.execute(statement)).scalars().all()
+        return [int(row_id) for row_id in rows]
+
+    @staticmethod
+    async def assign_scope(
+        session: AsyncSession,
+        *,
+        entity: Any,
+        ids: Sequence[int],
+        tenant_scope: TenantScope,
+    ) -> list[int]:
+        expected_ids = sorted({int(row_id) for row_id in ids})
+        if not expected_ids:
+            return []
+
+        result = await session.execute(
+            update(entity)
+            .where(
+                entity.id.in_(expected_ids),
+                TenantScopeBackfillDAO.legacy_clause(entity),
+            )
+            .values(
+                tenant_id=tenant_scope.tenant_id,
+                storefront_id=tenant_scope.storefront_id,
+            )
+            .returning(entity.id)
+        )
+        return sorted(int(row_id) for row_id in result.scalars().all())

--- a/docs/tenant-scope-rollout.md
+++ b/docs/tenant-scope-rollout.md
@@ -62,6 +62,48 @@ receive that scope before entering those boundaries.
 
 Public DTOs and Manager command payloads deliberately expose neither ID.
 
+## Controlled historical backfill
+
+`scripts/backfill_lead_order_tenant_scope.py` is the only supported write path
+for historical Lead/Order provenance. It is dry-run by default and must run
+inside the active API container on the current Patroni primary.
+
+The dry-run:
+
+- resolves `mvn/main` through the same fail-closed server resolver;
+- reports legacy-null, target, partial, unexpected, unknown and cross-tenant
+  rows independently for Lead and Order;
+- selects at most `--limit` rows from each table;
+- prints the exact candidate IDs and a SHA-256 plan token.
+
+Example canary:
+
+```bash
+python3 scripts/backfill_lead_order_tenant_scope.py --limit 1
+```
+
+Execute only the `reviewed_execute_command` printed by that dry-run. The
+command includes the resolved tenant/storefront IDs and plan token. Execute
+rebuilds the plan under a transaction-scoped advisory lock, rejects a stale
+token or any provenance anomaly, locks the selected rows and commits Lead and
+Order updates together.
+
+After the canary, repeat dry-run/execute with a larger bounded batch:
+
+```bash
+python3 scripts/backfill_lead_order_tenant_scope.py --limit 1000
+```
+
+Normal new writes already carrying the correct scope do not invalidate a
+reviewed plan. A new legacy row, changed candidate set, partial pair, unknown
+reference, cross-tenant pair or unexpected tenant/storefront does.
+
+The backfill phase is complete only when a final dry-run prints:
+
+- `legacy_null=0` for both tables;
+- zero partial, unexpected, unknown and cross-tenant rows;
+- `contract_ready=true`.
+
 ## What this release does not claim
 
 The expand release records ownership provenance; it does not yet provide

--- a/scripts/backfill_lead_order_tenant_scope.py
+++ b/scripts/backfill_lead_order_tenant_scope.py
@@ -1,0 +1,173 @@
+"""Backfill legacy Lead/Order rows with the reviewed server-owned scope.
+
+Dry-run is the default. Execute requires the exact plan token and resolved IDs
+printed by a fresh dry-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shlex
+import sys
+
+sys.path.append(".")
+
+from services.tenant_scope_backfill_service import (  # noqa: E402
+    TenantScopeBackfillBlockedError,
+    TenantScopeBackfillService,
+)
+from services.tenant_scope_service import TenantScopeResolutionError  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Assign fully legacy-null Lead and Order rows to a reviewed canonical "
+            "tenant/storefront scope. Dry-run is the default."
+        )
+    )
+    parser.add_argument("--execute", action="store_true", help="Persist the reviewed batch.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum rows selected from each table, 1-1000 (default: 100).",
+    )
+    parser.add_argument("--expected-tenant-id", type=int)
+    parser.add_argument("--expected-storefront-id", type=int)
+    parser.add_argument("--plan-token")
+    return parser
+
+
+def validate_args(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> None:
+    if args.limit < TenantScopeBackfillService.MIN_LIMIT:
+        parser.error("--limit must be at least 1")
+    if args.limit > TenantScopeBackfillService.MAX_LIMIT:
+        parser.error("--limit cannot exceed 1000")
+    if args.execute:
+        missing = [
+            flag
+            for flag, value in (
+                ("--expected-tenant-id", args.expected_tenant_id),
+                ("--expected-storefront-id", args.expected_storefront_id),
+                ("--plan-token", args.plan_token),
+            )
+            if value in (None, "")
+        ]
+        if missing:
+            parser.error("--execute requires " + ", ".join(missing))
+
+
+async def run(args: argparse.Namespace) -> dict:
+    from core.database import async_session_maker
+
+    async with async_session_maker() as session:
+        try:
+            result = await TenantScopeBackfillService.run(
+                session,
+                execute=args.execute,
+                limit_per_table=args.limit,
+                expected_tenant_id=args.expected_tenant_id,
+                expected_storefront_id=args.expected_storefront_id,
+                plan_token=args.plan_token,
+            )
+            if args.execute:
+                await session.commit()
+            return result
+        except Exception:
+            if args.execute:
+                await session.rollback()
+            raise
+
+
+def _ids(value: list[int]) -> str:
+    return ",".join(str(item) for item in value) or "-"
+
+
+def _print_report(label: str, report: dict) -> None:
+    print(
+        f"  {label}: total={report['total']} legacy_null={report['legacy_null']} "
+        f"target_scoped={report['target_scoped']} partial={report['partial']} "
+        f"unexpected_scoped={report['unexpected_scoped']} "
+        f"unknown_tenant={report['unknown_tenant']} "
+        f"unknown_storefront={report['unknown_storefront']} "
+        f"cross_tenant={report['cross_tenant']}"
+    )
+
+
+def _execute_command(result: dict) -> str:
+    command = [
+        "python3",
+        "scripts/backfill_lead_order_tenant_scope.py",
+        "--execute",
+        "--limit",
+        str(result["limit_per_table"]),
+        "--expected-tenant-id",
+        str(result["tenant_id"]),
+        "--expected-storefront-id",
+        str(result["storefront_id"]),
+        "--plan-token",
+        result["plan_token"],
+    ]
+    return shlex.join(command)
+
+
+def print_result(result: dict) -> None:
+    print("Lead/Order Tenant Scope Backfill")
+    print(f"  mode={'DRY-RUN' if result['dry_run'] else 'EXECUTE'}")
+    print(
+        f"  scope={result['tenant_slug']}/{result['storefront_slug']} "
+        f"tenant_id={result['tenant_id']} storefront_id={result['storefront_id']}"
+    )
+    print(f"  limit_per_table={result['limit_per_table']}")
+    print("  before:")
+    _print_report("lead", result["before"]["lead"])
+    _print_report("order", result["before"]["order"])
+    print(f"  planned_lead_ids={_ids(result['planned']['lead'])}")
+    print(f"  planned_order_ids={_ids(result['planned']['order'])}")
+    print(f"  plan_token={result['plan_token']}")
+    print(f"  ready_for_backfill={str(result['ready_for_backfill']).lower()}")
+    for blocker in result["blockers"]:
+        print(f"  blocker={blocker}")
+
+    if result["dry_run"]:
+        if result["ready_for_backfill"]:
+            print("  reviewed_execute_command:")
+            print(f"    {_execute_command(result)}")
+        print(f"  contract_ready={str(result['contract_ready']).lower()}")
+        return
+
+    print(
+        f"  updated_leads={result['updated']['lead']} "
+        f"updated_orders={result['updated']['order']}"
+    )
+    print("  after:")
+    _print_report("lead", result["after"]["lead"])
+    _print_report("order", result["after"]["order"])
+    print(f"  contract_ready={str(result['contract_ready']).lower()}")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    validate_args(args, parser)
+    try:
+        result = asyncio.run(run(args))
+        print_result(result)
+    except (
+        TenantScopeBackfillBlockedError,
+        TenantScopeResolutionError,
+        ValueError,
+    ) as exc:
+        print(f"tenant_scope_backfill status=blocked error={exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    if not result["ready_for_backfill"]:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tenant_scope_backfill_service.py
+++ b/services/tenant_scope_backfill_service.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from crud.tenant_scope_backfill import (
+    TenantScopeBackfillDAO,
+    TenantScopeEntityCounts,
+)
+from models import Lead, Order
+from models.tenancy import TenantScope
+from services.tenant_scope_service import SystemTenantScopeResolver
+
+
+class TenantScopeBackfillBlockedError(RuntimeError):
+    """Raised when the reviewed backfill plan is stale or unsafe."""
+
+
+class TenantScopeBackfillService:
+    """Plan or stage one atomic batch; the command handler owns commit/rollback."""
+
+    MIN_LIMIT = 1
+    MAX_LIMIT = 1000
+
+    @classmethod
+    async def run(
+        cls,
+        session: AsyncSession,
+        *,
+        execute: bool,
+        limit_per_table: int = 100,
+        tenant_slug: str = "mvn",
+        storefront_slug: str = "main",
+        expected_tenant_id: int | None = None,
+        expected_storefront_id: int | None = None,
+        plan_token: str | None = None,
+    ) -> dict[str, Any]:
+        limit = cls._validate_limit(limit_per_table)
+        if execute:
+            cls._validate_confirmation(
+                expected_tenant_id=expected_tenant_id,
+                expected_storefront_id=expected_storefront_id,
+                plan_token=plan_token,
+            )
+
+        if execute and not await TenantScopeBackfillDAO.try_acquire_transaction_lock(
+            session
+        ):
+            raise TenantScopeBackfillBlockedError(
+                "Another tenant-scope backfill transaction is already running"
+            )
+
+        tenant_scope = await SystemTenantScopeResolver.resolve(
+            session,
+            tenant_slug=tenant_slug,
+            storefront_slug=storefront_slug,
+        )
+        if execute:
+            cls._assert_expected_scope(
+                tenant_scope,
+                expected_tenant_id=expected_tenant_id,
+                expected_storefront_id=expected_storefront_id,
+            )
+
+        before = await cls._inspect(session, tenant_scope=tenant_scope)
+        candidate_ids = await cls._candidate_ids(
+            session,
+            limit=limit,
+            lock_rows=execute,
+        )
+        blockers = cls._blocking_reasons(before)
+        computed_token = cls._plan_token(
+            tenant_scope=tenant_scope,
+            limit=limit,
+            reports=before,
+            candidate_ids=candidate_ids,
+        )
+        result = {
+            "dry_run": not execute,
+            "tenant_slug": tenant_slug,
+            "storefront_slug": storefront_slug,
+            "tenant_id": tenant_scope.tenant_id,
+            "storefront_id": tenant_scope.storefront_id,
+            "limit_per_table": limit,
+            "before": cls._reports_to_dict(before),
+            "planned": candidate_ids,
+            "planned_counts": {
+                entity: len(ids) for entity, ids in candidate_ids.items()
+            },
+            "plan_token": computed_token,
+            "ready_for_backfill": not blockers,
+            "blockers": blockers,
+            "updated": {"lead": 0, "order": 0},
+            "after": None,
+            "contract_ready": cls._contract_ready(before, blockers=blockers),
+        }
+        if not execute:
+            return result
+
+        if blockers:
+            raise TenantScopeBackfillBlockedError(
+                "Backfill preflight found blocking provenance anomalies: "
+                + "; ".join(blockers)
+            )
+        if not hmac.compare_digest(str(plan_token), computed_token):
+            raise TenantScopeBackfillBlockedError(
+                "Backfill plan token is stale; run a fresh dry-run"
+            )
+
+        updated = {
+            "lead": await TenantScopeBackfillDAO.assign_scope(
+                session,
+                entity=Lead,
+                ids=candidate_ids["lead"],
+                tenant_scope=tenant_scope,
+            ),
+            "order": await TenantScopeBackfillDAO.assign_scope(
+                session,
+                entity=Order,
+                ids=candidate_ids["order"],
+                tenant_scope=tenant_scope,
+            ),
+        }
+        cls._assert_exact_updates(candidate_ids, updated)
+
+        after = await cls._inspect(session, tenant_scope=tenant_scope)
+        after_blockers = cls._blocking_reasons(after)
+        if after_blockers:
+            raise TenantScopeBackfillBlockedError(
+                "Backfill post-check found blocking provenance anomalies: "
+                + "; ".join(after_blockers)
+            )
+
+        return {
+            **result,
+            "updated": {
+                entity: len(ids) for entity, ids in updated.items()
+            },
+            "updated_ids": updated,
+            "after": cls._reports_to_dict(after),
+            "contract_ready": cls._contract_ready(
+                after,
+                blockers=after_blockers,
+            ),
+        }
+
+    @classmethod
+    async def _inspect(
+        cls,
+        session: AsyncSession,
+        *,
+        tenant_scope: TenantScope,
+    ) -> dict[str, TenantScopeEntityCounts]:
+        return {
+            "lead": await TenantScopeBackfillDAO.inspect(
+                session,
+                entity=Lead,
+                tenant_scope=tenant_scope,
+            ),
+            "order": await TenantScopeBackfillDAO.inspect(
+                session,
+                entity=Order,
+                tenant_scope=tenant_scope,
+            ),
+        }
+
+    @classmethod
+    async def _candidate_ids(
+        cls,
+        session: AsyncSession,
+        *,
+        limit: int,
+        lock_rows: bool,
+    ) -> dict[str, list[int]]:
+        return {
+            "lead": await TenantScopeBackfillDAO.list_legacy_ids(
+                session,
+                entity=Lead,
+                limit=limit,
+                lock_rows=lock_rows,
+            ),
+            "order": await TenantScopeBackfillDAO.list_legacy_ids(
+                session,
+                entity=Order,
+                limit=limit,
+                lock_rows=lock_rows,
+            ),
+        }
+
+    @staticmethod
+    def _reports_to_dict(
+        reports: dict[str, TenantScopeEntityCounts],
+    ) -> dict[str, dict[str, int | str]]:
+        return {
+            entity: report.to_dict()
+            for entity, report in reports.items()
+        }
+
+    @staticmethod
+    def _blocking_reasons(
+        reports: dict[str, TenantScopeEntityCounts],
+    ) -> list[str]:
+        blockers: list[str] = []
+        for entity, report in reports.items():
+            classified = (
+                report.legacy_null
+                + report.target_scoped
+                + report.partial
+                + report.unexpected_scoped
+            )
+            if classified != report.total:
+                blockers.append(
+                    f"{entity}: classification mismatch "
+                    f"({classified} classified, {report.total} total)"
+                )
+            for field in (
+                "partial",
+                "unexpected_scoped",
+                "unknown_tenant",
+                "unknown_storefront",
+                "cross_tenant",
+            ):
+                value = int(getattr(report, field))
+                if value:
+                    blockers.append(f"{entity}: {field}={value}")
+        return blockers
+
+    @staticmethod
+    def _contract_ready(
+        reports: dict[str, TenantScopeEntityCounts],
+        *,
+        blockers: list[str],
+    ) -> bool:
+        return not blockers and all(
+            report.legacy_null == 0 for report in reports.values()
+        )
+
+    @staticmethod
+    def _plan_token(
+        *,
+        tenant_scope: TenantScope,
+        limit: int,
+        reports: dict[str, TenantScopeEntityCounts],
+        candidate_ids: dict[str, list[int]],
+    ) -> str:
+        payload = {
+            "version": 1,
+            "tenant_id": tenant_scope.tenant_id,
+            "storefront_id": tenant_scope.storefront_id,
+            "limit_per_table": limit,
+            "legacy_null": {
+                entity: report.legacy_null
+                for entity, report in reports.items()
+            },
+            "anomalies": {
+                entity: {
+                    "partial": report.partial,
+                    "unexpected_scoped": report.unexpected_scoped,
+                    "unknown_tenant": report.unknown_tenant,
+                    "unknown_storefront": report.unknown_storefront,
+                    "cross_tenant": report.cross_tenant,
+                }
+                for entity, report in reports.items()
+            },
+            "candidate_ids": candidate_ids,
+        }
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @classmethod
+    def _validate_limit(cls, value: int) -> int:
+        limit = int(value)
+        if limit < cls.MIN_LIMIT or limit > cls.MAX_LIMIT:
+            raise ValueError(
+                f"limit_per_table must be between {cls.MIN_LIMIT} and {cls.MAX_LIMIT}"
+            )
+        return limit
+
+    @staticmethod
+    def _validate_confirmation(
+        *,
+        expected_tenant_id: int | None,
+        expected_storefront_id: int | None,
+        plan_token: str | None,
+    ) -> None:
+        if not expected_tenant_id or not expected_storefront_id:
+            raise TenantScopeBackfillBlockedError(
+                "Execute requires positive expected tenant and storefront IDs"
+            )
+        if not re.fullmatch(r"[0-9a-f]{64}", str(plan_token or "")):
+            raise TenantScopeBackfillBlockedError(
+                "Execute requires the 64-character plan token from dry-run"
+            )
+
+    @staticmethod
+    def _assert_expected_scope(
+        tenant_scope: TenantScope,
+        *,
+        expected_tenant_id: int | None,
+        expected_storefront_id: int | None,
+    ) -> None:
+        if (
+            tenant_scope.tenant_id != expected_tenant_id
+            or tenant_scope.storefront_id != expected_storefront_id
+        ):
+            raise TenantScopeBackfillBlockedError(
+                "Resolved tenant/storefront IDs do not match the reviewed scope"
+            )
+
+    @staticmethod
+    def _assert_exact_updates(
+        planned: dict[str, list[int]],
+        updated: dict[str, list[int]],
+    ) -> None:
+        for entity in ("lead", "order"):
+            if sorted(planned[entity]) != sorted(updated[entity]):
+                raise TenantScopeBackfillBlockedError(
+                    f"{entity}: updated IDs differ from the reviewed plan"
+                )

--- a/tests/unit/test_tenant_scope_backfill_service.py
+++ b/tests/unit/test_tenant_scope_backfill_service.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import select
+
+from crud.tenant_scope_backfill import TenantScopeBackfillDAO
+from models import Lead, Order, Storefront, Tenant
+from scripts.backfill_lead_order_tenant_scope import build_parser, validate_args
+from services.tenant_scope_backfill_service import (
+    TenantScopeBackfillBlockedError,
+    TenantScopeBackfillService,
+)
+
+
+async def _add_legacy_rows(db, *, leads: int, orders: int) -> tuple[list[Lead], list[Order]]:
+    lead_rows = [Lead(request_text=f"Legacy lead {index}") for index in range(leads)]
+    order_rows = [Order(title=f"Legacy order {index}") for index in range(orders)]
+    db.add_all([*lead_rows, *order_rows])
+    await db.commit()
+    return lead_rows, order_rows
+
+
+@pytest.mark.asyncio
+async def test_dry_run_is_bounded_deterministic_and_read_only(db):
+    legacy_leads, legacy_orders = await _add_legacy_rows(db, leads=2, orders=2)
+    db.add_all(
+        [
+            Lead(request_text="Already scoped lead", tenant_id=1, storefront_id=1),
+            Order(title="Already scoped order", tenant_id=1, storefront_id=1),
+        ]
+    )
+    await db.commit()
+
+    result = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=1,
+    )
+    repeated = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=1,
+    )
+
+    assert result["dry_run"] is True
+    assert result["ready_for_backfill"] is True
+    assert result["contract_ready"] is False
+    assert result["before"]["lead"] == {
+        "entity": "lead",
+        "total": 3,
+        "legacy_null": 2,
+        "target_scoped": 1,
+        "partial": 0,
+        "unexpected_scoped": 0,
+        "unknown_tenant": 0,
+        "unknown_storefront": 0,
+        "cross_tenant": 0,
+    }
+    assert result["before"]["order"]["legacy_null"] == 2
+    assert result["before"]["order"]["target_scoped"] == 1
+    assert result["planned"] == {
+        "lead": [int(legacy_leads[0].id)],
+        "order": [int(legacy_orders[0].id)],
+    }
+    assert len(result["plan_token"]) == 64
+    assert repeated["plan_token"] == result["plan_token"]
+
+    stored_leads = (await db.execute(select(Lead).order_by(Lead.id))).scalars().all()
+    stored_orders = (await db.execute(select(Order).order_by(Order.id))).scalars().all()
+    assert sum(item.tenant_id is None for item in stored_leads) == 2
+    assert sum(item.tenant_id is None for item in stored_orders) == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_backfills_exact_reviewed_batches_and_is_idempotent(db):
+    await _add_legacy_rows(db, leads=2, orders=2)
+
+    canary = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=1,
+    )
+    canary_result = await TenantScopeBackfillService.run(
+        db,
+        execute=True,
+        limit_per_table=1,
+        expected_tenant_id=1,
+        expected_storefront_id=1,
+        plan_token=canary["plan_token"],
+    )
+
+    assert canary_result["updated"] == {"lead": 1, "order": 1}
+    assert canary_result["after"]["lead"]["legacy_null"] == 1
+    assert canary_result["after"]["order"]["legacy_null"] == 1
+    assert canary_result["contract_ready"] is False
+
+    remainder = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+    final_result = await TenantScopeBackfillService.run(
+        db,
+        execute=True,
+        limit_per_table=10,
+        expected_tenant_id=1,
+        expected_storefront_id=1,
+        plan_token=remainder["plan_token"],
+    )
+
+    assert final_result["updated"] == {"lead": 1, "order": 1}
+    assert final_result["after"]["lead"]["legacy_null"] == 0
+    assert final_result["after"]["order"]["legacy_null"] == 0
+    assert final_result["contract_ready"] is True
+
+    no_op_plan = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+    no_op_result = await TenantScopeBackfillService.run(
+        db,
+        execute=True,
+        limit_per_table=10,
+        expected_tenant_id=1,
+        expected_storefront_id=1,
+        plan_token=no_op_plan["plan_token"],
+    )
+    assert no_op_result["updated"] == {"lead": 0, "order": 0}
+    assert no_op_result["contract_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_stale_plan_without_partial_writes(db):
+    await _add_legacy_rows(db, leads=1, orders=1)
+    reviewed = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+    db.add(Lead(request_text="Arrived after review"))
+    await db.commit()
+
+    with pytest.raises(
+        TenantScopeBackfillBlockedError,
+        match="plan token is stale",
+    ):
+        await TenantScopeBackfillService.run(
+            db,
+            execute=True,
+            limit_per_table=10,
+            expected_tenant_id=1,
+            expected_storefront_id=1,
+            plan_token=reviewed["plan_token"],
+        )
+
+    leads = (await db.execute(select(Lead))).scalars().all()
+    orders = (await db.execute(select(Order))).scalars().all()
+    assert all(item.tenant_id is None and item.storefront_id is None for item in leads)
+    assert all(item.tenant_id is None and item.storefront_id is None for item in orders)
+
+
+@pytest.mark.asyncio
+async def test_review_token_allows_concurrent_correctly_scoped_writes(db):
+    await _add_legacy_rows(db, leads=1, orders=1)
+    reviewed = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+    db.add(Order(title="New scoped write", tenant_id=1, storefront_id=1))
+    await db.commit()
+
+    result = await TenantScopeBackfillService.run(
+        db,
+        execute=True,
+        limit_per_table=10,
+        expected_tenant_id=1,
+        expected_storefront_id=1,
+        plan_token=reviewed["plan_token"],
+    )
+
+    assert result["updated"] == {"lead": 1, "order": 1}
+    assert result["after"]["order"]["target_scoped"] == 2
+    assert result["contract_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_blocks_partial_foreign_and_cross_tenant_rows(db):
+    second_tenant = Tenant(
+        id=2,
+        slug="other",
+        display_name="Other tenant",
+        status="active",
+        is_system=False,
+    )
+    db.add(second_tenant)
+    await db.flush()
+    second_storefront = Storefront(
+        id=2,
+        tenant_id=int(second_tenant.id),
+        slug="main",
+        display_name="Other storefront",
+        status="active",
+        is_default=True,
+    )
+    db.add(second_storefront)
+    await db.flush()
+    db.add_all(
+        [
+            Lead(
+                request_text="Partial provenance",
+                tenant_id=1,
+                storefront_id=None,
+            ),
+            Order(
+                title="Foreign valid scope",
+                tenant_id=int(second_tenant.id),
+                storefront_id=int(second_storefront.id),
+            ),
+            Order(
+                title="Cross-tenant pair",
+                tenant_id=1,
+                storefront_id=int(second_storefront.id),
+            ),
+        ]
+    )
+    await db.commit()
+
+    report = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+
+    assert report["ready_for_backfill"] is False
+    assert report["before"]["lead"]["partial"] == 1
+    assert report["before"]["order"]["unexpected_scoped"] == 2
+    assert report["before"]["order"]["cross_tenant"] == 1
+    assert "lead: partial=1" in report["blockers"]
+    assert "order: unexpected_scoped=2" in report["blockers"]
+    assert "order: cross_tenant=1" in report["blockers"]
+
+    with pytest.raises(
+        TenantScopeBackfillBlockedError,
+        match="blocking provenance anomalies",
+    ):
+        await TenantScopeBackfillService.run(
+            db,
+            execute=True,
+            limit_per_table=10,
+            expected_tenant_id=1,
+            expected_storefront_id=1,
+            plan_token=report["plan_token"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_scope_ids_that_differ_from_dry_run(db):
+    await _add_legacy_rows(db, leads=1, orders=1)
+    reviewed = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+
+    with pytest.raises(
+        TenantScopeBackfillBlockedError,
+        match="do not match the reviewed scope",
+    ):
+        await TenantScopeBackfillService.run(
+            db,
+            execute=True,
+            limit_per_table=10,
+            expected_tenant_id=99,
+            expected_storefront_id=1,
+            plan_token=reviewed["plan_token"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_refuses_a_concurrent_backfill_transaction(db_engine):
+    session_factory = sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with session_factory() as lock_owner, session_factory() as contender:
+        assert await TenantScopeBackfillDAO.try_acquire_transaction_lock(lock_owner)
+
+        with pytest.raises(
+            TenantScopeBackfillBlockedError,
+            match="already running",
+        ):
+            await TenantScopeBackfillService.run(
+                contender,
+                execute=True,
+                limit_per_table=10,
+                expected_tenant_id=1,
+                expected_storefront_id=1,
+                plan_token="0" * 64,
+            )
+
+        await contender.rollback()
+        await lock_owner.rollback()
+
+
+@pytest.mark.asyncio
+async def test_limit_is_strictly_bounded():
+    with pytest.raises(ValueError, match="between 1 and 1000"):
+        await TenantScopeBackfillService.run(
+            object(),
+            execute=False,
+            limit_per_table=0,
+        )
+    with pytest.raises(ValueError, match="between 1 and 1000"):
+        await TenantScopeBackfillService.run(
+            object(),
+            execute=False,
+            limit_per_table=1001,
+        )
+
+
+def test_cli_requires_dry_run_confirmation_for_execute():
+    parser = build_parser()
+    args = parser.parse_args(["--execute"])
+
+    with pytest.raises(SystemExit):
+        validate_args(args, parser)
+
+
+def test_cli_does_not_allow_operator_selected_scope():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--tenant-slug", "other"])


### PR DESCRIPTION
## What changed

- add a bounded, dry-run-first Lead/Order tenant-scope backfill
- require the exact SHA-256 plan token and resolved `mvn/main` IDs for execute
- fail closed on partial, unexpected, unknown, or cross-tenant provenance
- serialize execute runs with a PostgreSQL transaction advisory lock and lock selected rows
- document canary, batch, and contract-readiness procedures

## Why

The expand release intentionally left historical Lead and Order rows nullable. This closes the backfill phase reproducibly without a one-off production SQL update and without accepting operator-selected tenant scope.

## Validation

- `2585 passed, 4 skipped` — full unit suite
- `21 passed` — tenant provenance, migration, and Manager integration group
- `10 passed` — final focused backfill suite after CLI hardening
- CLI dry-run and no-op execute verified against local PostgreSQL
- `git diff --check`, compileall, and Alembic single head `a7c8d9e0f1b2`

## Production rollout

After merge and deploy: run a `--limit 1` dry-run/execute canary on the current Patroni primary, verify reports and replication, then process the remaining bounded batch and require final `contract_ready=true`.