### PR TITLE
fix: preserve tenant backfill timestamps

### DIFF
--- a/crud/tenant_scope_backfill.py
+++ b/crud/tenant_scope_backfill.py
@@ -180,6 +180,10 @@ class TenantScopeBackfillDAO:
             .values(
                 tenant_id=tenant_scope.tenant_id,
                 storefront_id=tenant_scope.storefront_id,
+                # Both models define a Python ``onupdate`` value. This explicit
+                # self-assignment prevents a technical provenance backfill from
+                # changing business recency, sorting or archival semantics.
+                updated_at=entity.updated_at,
             )
             .returning(entity.id)
         )

--- a/docs/tenant-scope-rollout.md
+++ b/docs/tenant-scope-rollout.md
@@ -86,7 +86,9 @@ Execute only the `reviewed_execute_command` printed by that dry-run. The
 command includes the resolved tenant/storefront IDs and plan token. Execute
 rebuilds the plan under a transaction-scoped advisory lock, rejects a stale
 token or any provenance anomaly, locks the selected rows and commits Lead and
-Order updates together.
+Order updates together. The technical update preserves each row's existing
+`updated_at`; provenance backfill must not change business recency, sorting or
+archival behavior.
 
 After the canary, repeat dry-run/execute with a larger bounded batch:
 

--- a/tests/unit/test_tenant_scope_backfill_service.py
+++ b/tests/unit/test_tenant_scope_backfill_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import sessionmaker
@@ -130,6 +132,41 @@ async def test_execute_backfills_exact_reviewed_batches_and_is_idempotent(db):
     )
     assert no_op_result["updated"] == {"lead": 0, "order": 0}
     assert no_op_result["contract_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_preserves_business_updated_at_timestamps(db):
+    lead_updated_at = datetime(2024, 2, 3, 4, 5, 6)
+    order_updated_at = datetime(2024, 5, 6, 7, 8, 9)
+    lead = Lead(
+        request_text="Historical lead",
+        updated_at=lead_updated_at,
+    )
+    order = Order(
+        title="Historical order",
+        updated_at=order_updated_at,
+    )
+    db.add_all([lead, order])
+    await db.commit()
+
+    reviewed = await TenantScopeBackfillService.run(
+        db,
+        execute=False,
+        limit_per_table=10,
+    )
+    await TenantScopeBackfillService.run(
+        db,
+        execute=True,
+        limit_per_table=10,
+        expected_tenant_id=1,
+        expected_storefront_id=1,
+        plan_token=reviewed["plan_token"],
+    )
+    await db.refresh(lead)
+    await db.refresh(order)
+
+    assert lead.updated_at == lead_updated_at
+    assert order.updated_at == order_updated_at
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что исправлено

- tenant-scoping backfill явно сохраняет прежний `updated_at`
- добавлен регрессионный тест для Lead и Order
- эксплуатационная инструкция фиксирует инвариант бизнес-времени

## Проверка

- `.venv/bin/pytest tests/unit/test_tenant_scope_backfill_service.py tests/unit/test_tenant_scope_service.py -q` — 18 passed

## Причина

SQLAlchemy применял Python `onupdate` даже к Core UPDATE, из-за чего технический backfill мог менять сортировку и архивную семантику исторических записей.
